### PR TITLE
docker_node: Docker Swarm node operations module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -584,6 +584,7 @@ files:
     maintainers: $team_windows_core
     support: core
   $module_utils/docker_common.py: *docker
+  $module_utils/docker_swarm.py: *docker
   $module_utils/ec2.py:
     support: core
     labels:
@@ -1337,7 +1338,7 @@ macros:
   team_cumulus: isharacomix jrrivers
   team_cyberark_conjur: jvanderhoof ryanprior
   team_digital_ocean: aluvenko, BondAnthony, mgregson
-  team_docker: akshay196 danihodovic dariko DBendit felixfontein jwitko kassiansun tbouvet
+  team_docker: akshay196 danihodovic dariko DBendit felixfontein jwitko kassiansun tbouvet WojciechowskiPiotr
   team_e_spirit: MatrixCrawler getjack
   team_extreme: bigmstone LindsayHill
   team_fortimanager: Ghilli3 lweighall p4r4n0y1ng Ftntcorecse

--- a/lib/ansible/module_utils/docker_swarm.py
+++ b/lib/ansible/module_utils/docker_swarm.py
@@ -87,6 +87,13 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
         except APIError:
             return False
 
+    def fail_task_if_not_swarm_manager(self):
+        """
+        If host is not a swarm manager then Ansible task on this host should end with 'failed' state
+        """
+        if not self.check_if_swarm_manager():
+            self.client.fail(msg="This node is not a manager.")
+
     def check_if_swarm_worker(self):
         """
         Checks if node role is set as Worker in Swarm. The node is the docker host on which module action

--- a/lib/ansible/module_utils/docker_swarm.py
+++ b/lib/ansible/module_utils/docker_swarm.py
@@ -1,0 +1,142 @@
+# (c) 2019 Piotr Wojciechowski (@wojciechowskipiotr) <piotr@it-playground.pl>
+# (c) Thierry Bouvet (@tbouvet)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+
+try:
+    from docker.errors import APIError
+except ImportError:
+    # missing docker-py handled in ansible.module_utils.docker_common
+    pass
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.docker_common import AnsibleDockerClient
+
+
+class AnsibleDockerSwarmClient(AnsibleDockerClient):
+
+    def __init__(self, **kwargs):
+        super(AnsibleDockerSwarmClient, self).__init__(**kwargs)
+
+    def get_swarm_node_id(self):
+        """
+        Get the 'NodeID' of the Swarm node or 'None' if host is not in Swarm. It returns the NodeID
+        of Docker host the module is executed on
+        :return:
+            NodeID of host or 'None' if not part of Swarm
+        """
+
+        try:
+            info = self.info()
+        except APIError as exc:
+            self.fail(msg="Failed to get node information for %s" % to_native(exc))
+
+        if info:
+            json_str = json.dumps(info, ensure_ascii=False)
+            swarm_info = json.loads(json_str)
+            if swarm_info['Swarm']['NodeID']:
+                return swarm_info['Swarm']['NodeID']
+        return None
+
+    def check_if_swarm_node(self, node_id=None):
+        """
+        Checking if host is part of Docker Swarm. If 'node_id' is not provided it reads the Docker host
+        system information looking if specific key in output exists. If 'node_id' is provided then it tries to
+        read node information assuming it is run on Swarm manager. The get_node_info() method handles exception if
+        it is not executed on Swarm manager
+
+        :param node_id: Node identifier
+        :return:
+            bool: True if node is part of Swarm, False otherwise
+        """
+
+        if node_id is None:
+            try:
+                info = self.info()
+            except APIError:
+                self.fail(msg="Failed to get host information.")
+
+            if info:
+                json_str = json.dumps(info, ensure_ascii=False)
+                swarm_info = json.loads(json_str)
+                if swarm_info['Swarm']['NodeID']:
+                    return True
+            return False
+        else:
+            try:
+                node_info = self.get_node_info(node_id)
+            except APIError:
+                return
+
+            if node_info['ID'] is not None:
+                return True
+            return False
+
+    def check_if_swarm_manager(self):
+        """
+        Checks if node role is set as Manager in Swarm. The node is the docker host on which module action
+        is performed. The inspect_swarm() will fail if node is not a manager
+
+        :return: True if node is Swarm Manager, False otherwise
+        """
+
+        try:
+            self.inspect_swarm()
+            return True
+        except APIError:
+            return False
+
+    def check_if_swarm_worker(self):
+        """
+        Checks if node role is set as Worker in Swarm. The node is the docker host on which module action
+        is performed. Will fail if run on host that is not part of Swarm via check_if_swarm_node()
+
+        :return: True if node is Swarm Worker, False otherwise
+        """
+
+        if self.check_if_swarm_node() and not self.check_if_swarm_manager():
+            return True
+        return False
+
+    def check_if_swarm_node_is_down(self, node_id=None):
+        """
+        Checks if node status on Swarm manager is 'down'. If node_id is provided it query manager about
+        node specified in parameter, otherwise it query manager itself. If run on Swarm Worker node or
+        host that is not part of Swarm it will fail the playbook
+
+        :param node_id: node ID or name, if None then method will try to get node_id of host module run on
+        :return:
+            True if node is part of swarm but its state is down, False otherwise
+        """
+
+        if node_id is None:
+            node_info = self.get_node_info()
+        else:
+            node_info = self.get_node_info(node_id=node_id)
+        if node_info['Status']['State'] == 'down':
+            return True
+        return False
+
+    def get_node_info(self, node_id=None):
+        """
+        Returns Swarm node info as in 'docker node inspect' command or fail the playbook in case of errors
+
+        :param node_id: node ID or name, if None then method will try to get node_id of host module run on
+        :return:
+            Node information structure
+        """
+
+        if node_id is None:
+            node_id = self.get_swarm_node_id()
+
+        if node_id is None:
+            self.fail(msg="Failed to get node information.")
+
+        try:
+            node_info = self.inspect_node(node_id=node_id)
+        except APIError as exc:
+            raise exc
+        json_str = json.dumps(node_info, ensure_ascii=False)
+        node_info = json.loads(json_str)
+        return node_info

--- a/lib/ansible/module_utils/docker_swarm.py
+++ b/lib/ansible/module_utils/docker_swarm.py
@@ -92,7 +92,7 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
         If host is not a swarm manager then Ansible task on this host should end with 'failed' state
         """
         if not self.check_if_swarm_manager():
-            self.client.fail(msg="This node is not a manager.")
+            self.fail(msg="This node is not a manager.")
 
     def check_if_swarm_worker(self):
         """

--- a/lib/ansible/module_utils/docker_swarm.py
+++ b/lib/ansible/module_utils/docker_swarm.py
@@ -199,6 +199,8 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
                 node_property.update({'Status': node['Status']['State']})
                 node_property.update({'Availability': node['Spec']['Availability']})
                 if 'ManagerStatus' in node:
+                    if node['ManagerStatus']['Leader'] is True:
+                        node_property.update({'Leader': True})
                     node_property.update({'ManagerStatus': node['ManagerStatus']['Reachability']})
                 node_property.update({'EngineVersion': node['Description']['Engine']['EngineVersion']})
 

--- a/lib/ansible/module_utils/docker_swarm.py
+++ b/lib/ansible/module_utils/docker_swarm.py
@@ -171,7 +171,7 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
         node_info = json.loads(json_str)
         return node_info
 
-    def get_all_nodes(self, output='short'):
+    def get_all_nodes_list(self, output='short'):
         """
         Returns list of nodes registered in Swarm
 

--- a/lib/ansible/module_utils/docker_swarm.py
+++ b/lib/ansible/module_utils/docker_swarm.py
@@ -170,3 +170,40 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
         json_str = json.dumps(node_info, ensure_ascii=False)
         node_info = json.loads(json_str)
         return node_info
+
+    def get_all_nodes(self, output='short'):
+        """
+        Returns list of nodes registered in Swarm
+
+        :param output: Defines format of returned data
+        :return:
+            If 'output' is 'short' then return data is list of nodes hostnames registered in Swarm,
+            if 'output' is 'long' then returns data is list of dict containing the attributes as in
+            output of command 'docker node ls'
+        """
+        nodes_list = []
+
+        nodes_inspect = self.get_all_nodes_inspect()
+        if nodes_inspect is None:
+            return None
+
+        if output == 'short':
+            for node in nodes_inspect:
+                nodes_list.append(node['Description']['Hostname'])
+        elif output == 'long':
+            for node in nodes_inspect:
+                node_property = {}
+
+                node_property.update({'ID': node['ID']})
+                node_property.update({'Hostname': node['Description']['Hostname']})
+                node_property.update({'Status': node['Status']['State']})
+                node_property.update({'Availability': node['Spec']['Availability']})
+                if 'ManagerStatus' in node:
+                    node_property.update({'ManagerStatus': node['ManagerStatus']['Reachability']})
+                node_property.update({'EngineVersion': node['Description']['Engine']['EngineVersion']})
+
+                nodes_list.append(node_property)
+        else:
+            return None
+
+        return nodes_list

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -245,7 +245,7 @@ class SwarmNodeManager(DockerBaseClass):
 
 def main():
     argument_spec = dict(
-        state=dict(type='str', choices=['present', 'leave'], default='list'),
+        state=dict(type='str', choices=['list', 'update'], default='list'),
         name=dict(type='str'),
         labels=dict(type='dict'),
         labels_remove=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -229,14 +229,14 @@ class SwarmNodeManager(DockerBaseClass):
                 if node_info['Spec']['Labels']:
                     changed = True
             else:
-                if node_info['Spec']['Labels'].items() != self.parameters.labels.items():
+                if node_info['Spec']['Labels'] != self.parameters.labels:
                     node_spec['Labels'] = self.parameters.labels
                     changed = True
         elif self.parameters.labels_state == 'merge':
             node_spec['Labels'] = dict(node_info['Spec']['Labels'] or {})
             if self.parameters.labels is not None:
                 for key, value in self.parameters.labels.items():
-                    if node_info['Spec']['Labels'].get(key) != value:
+                    if node_spec['Labels'].get(key) != value:
                         node_spec['Labels'][key] = value
                         changed = True
 
@@ -248,7 +248,8 @@ class SwarmNodeManager(DockerBaseClass):
                             changed = True
                     else:
                         self.client.module.warn(
-                            "Label %s listed both in 'labels' and 'labels_to_remove'. Keeping the assigned label value."
+                            "Label '%s' listed both in 'labels' and 'labels_to_remove'. "
+                            "Keeping the assigned label value."
                             % to_native(key))
 
         if changed is True:

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -25,8 +25,10 @@ options:
             - The hostname or ID of node as registered in Swarm.
             - If more than one node is registered using the same hostname the ID must be used,
               otherwise task will fail.
+        required: true
+        type: str
     labels:
-        description: User-defined key/value metadata.
+        description: User-defined key/value metadata. If not provided then labels assigned to node remains unchanged.
         type: dict
     labels_state:
         description:
@@ -45,17 +47,23 @@ options:
           - replace
           - remove
         default: 'merge'
+        required: false
+        type: str
     availability:
-        description: Node availability status to assign.
+        description: Node availability to assign. If not provided then node availability remains unchanged.
         choices:
           - active
           - pause
           - drain
+        required: false
+        type: str
     role:
-        description: Node role to assign.
+        description: Node role to assign. If not provided then node role remains unchanged.
         choices:
           - manager
           - worker
+        required: false
+        type: str
 extends_documentation_fragment:
     - docker
 requirements:
@@ -262,7 +270,7 @@ class SwarmNodeManager(DockerBaseClass):
 
 def main():
     argument_spec = dict(
-        hostname=dict(type='str'),
+        hostname=dict(type='str', required=True),
         labels=dict(type='dict'),
         labels_state=dict(type='str', choices=['merge', 'replace', 'remove'], default='merge'),
         availability=dict(type='str', choices=['active', 'pause', 'drain']),

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -221,7 +221,7 @@ class SwarmNodeManager(DockerBaseClass):
                                     node_spec=node_spec)
         except APIError as exc:
             self.client.fail(msg="Failed to update node : %s" % to_native(exc))
-        self.results['node_facts'] = self.client.get_node_info(node_id=node_info['ID'])
+        self.results['node_facts'] = self.client.get_node_inspect(node_id=node_info['ID'])
         self.results['actions'].append("Node updated")
         self.results['changed'] = True
 
@@ -245,7 +245,7 @@ class SwarmNodeManager(DockerBaseClass):
 
 def main():
     argument_spec = dict(
-        state=dict(type='str', choices=['list', 'update'], default='list'),
+        state=dict(type='str', choices=['present', 'leave'], default='list'),
         name=dict(type='str'),
         labels=dict(type='dict'),
         labels_remove=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -1,0 +1,288 @@
+#!/usr/bin/python
+#
+# (c) 2019 Piotr Wojciechowski <piotr@it-playground.pl>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: docker_node
+short_description: Manage Docker Swarm node
+version_added: "2.8"
+description:
+    - Manages the Docker nodes via Swarm Manager
+    - Change node role
+    - Change node availability
+    - Change or remove node labels
+    - List Swarm nodes
+options:
+    state:
+        description:
+            - Set to C(list) to display swarm nodes names lists.
+            - Set to C(update) to update node labels, availability and role
+        required: true
+        default: list
+        choices:
+          - list
+          - update
+    name:
+        description:
+            - Swarm name of the node.
+            - Used with I(state=update).
+    labels:
+        description:
+            - User-defined key/value metadata. Provided labels will replace existing ones
+    labels_remove:
+        description: If C(True) then labels are removed from mode, the I(label) is ignored
+        type: bool
+        default: 'False'
+    availability:
+        description: Node availability status to assign
+        choices:
+          - active
+          - pause
+          - drain
+    role:
+        description: Node role to assign
+        choices:
+          - manager
+          - worker
+extends_documentation_fragment:
+    - docker
+requirements:
+    - "python >= 2.6"
+    - "docker-py >= 1.10.0"
+    - "Please note that the L(docker-py,https://pypi.org/project/docker-py/) Python
+       module has been superseded by L(docker,https://pypi.org/project/docker/)
+       (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
+       For Python 2.6, C(docker-py) must be used. Otherwise, it is recommended to
+       install the C(docker) Python module. Note that both modules should I(not)
+       be installed at the same time. Also note that when both modules are installed
+       and one of them is uninstalled, the other might no longer function and a
+       reinstall of it is required."
+    - "The docker server >= 1.10.0"
+author:
+  - Piotr Wojciechowski (@wojciechowskipiotr)
+  - Thierry Bouvet (@tbouvet)
+
+'''
+
+EXAMPLES = '''
+- name: List names of registered swarm nodes
+  docker_node:
+    state: list
+
+- name: Set node role
+  docker_node:
+    state: update
+    name: mynode
+    role: manager
+
+- name: Set node availability
+  docker_node:
+    state: update
+    name: mynode
+    availability: drain
+
+- name: Set node labels
+  docker_node:
+    state: update
+    name: mynode
+    labels:
+      key: value
+
+- name: Remove node labels
+  docker_node:
+    state: update
+    name: mynode
+    labels_remove: true
+'''
+
+RETURN = '''
+node_facts:
+  description: Information about node after 'update' operation
+  returned: success
+  type: dict
+nodes:
+  description: List nodes names of swarm cluster.
+  returned: success
+  type: list
+  example: "[ 'node-1', 'node-2', 'node-3']"
+actions:
+  description: Provides the actions done on the swarm.
+  returned: when action failed.
+  type: list
+  example: "['This cluster is already a swarm cluster']"
+
+'''
+
+try:
+    from docker.errors import APIError
+except ImportError:
+    # missing docker-py handled in ansible.module_utils.docker_common
+    pass
+
+from ansible.module_utils.docker_common import (
+    DockerBaseClass,
+)
+
+from ansible.module_utils._text import to_native
+
+from ansible.module_utils.docker_swarm import AnsibleDockerSwarmClient
+
+
+class TaskParameters(DockerBaseClass):
+    def __init__(self, client):
+        super(TaskParameters, self).__init__()
+
+        self.state = None
+        self.force = None
+
+        # Spec
+        self.name = None
+        self.labels = None
+        self.labels_remove = None
+
+        # Node
+        self.availability = None
+        self.role = None
+
+        for key, value in client.module.params.items():
+            setattr(self, key, value)
+
+
+class SwarmNodeManager(DockerBaseClass):
+
+    def __init__(self, client, results):
+
+        super(SwarmNodeManager, self).__init__()
+
+        self.client = client
+        self.results = results
+        self.check_mode = self.client.check_mode
+
+        self.parameters = TaskParameters(client)
+
+    def __call__(self):
+        choice_map = {
+            "list": self.node_list,
+            "update": self.node_update,
+        }
+
+        choice_map.get(self.parameters.state)()
+
+    def node_update(self):
+        if not (self.client.check_if_swarm_manager()):
+            self.client.fail(msg="This node is not a manager.")
+
+        if not (self.client.check_if_swarm_node(node_id=self.parameters.name)):
+            self.results['actions'].append("This node is not part of a swarm.")
+            return
+
+        try:
+            status_down = self.client.check_if_swarm_node_is_down()
+        except APIError:
+            return
+
+        if status_down:
+            self.client.fail(msg="Can not update the node. The status node is down.")
+
+        try:
+            node_info = self.client.inspect_node(node_id=self.parameters.name)
+        except APIError as exc:
+            self.client.fail(msg="Failed to get node information for %s" % to_native(exc))
+
+        if self.parameters.role is None:
+            self.parameters.role = node_info['Spec']['Role']
+
+        if self.parameters.availability is None:
+            self.parameters.availability = node_info['Spec']['Availability']
+
+        if self.parameters.labels is None:
+            self.parameters.labels = node_info['Spec']['Labels']
+
+        if self.parameters.labels_remove is True:
+            self.parameters.labels = {}
+
+        node_spec = dict(
+            Availability=self.parameters.availability,
+            Role=self.parameters.role,
+            Labels=self.parameters.labels,
+        )
+
+        try:
+            self.client.update_node(node_id=node_info['ID'], version=node_info['Version']['Index'],
+                                    node_spec=node_spec)
+        except APIError as exc:
+            self.client.fail(msg="Failed to update node : %s" % to_native(exc))
+        self.results['node_facts'] = self.client.get_node_info(node_id=node_info['ID'])
+        self.results['actions'].append("Node updated")
+        self.results['changed'] = True
+
+    def node_list(self):
+        if not (self.client.check_if_swarm_manager()):
+            self.client.fail(msg="This node is not a manager.")
+
+        try:
+            nodes = self.client.nodes()
+        except APIError as exc:
+            self.client.fail(msg="Failed to get nodes list : %s" % to_native(exc))
+
+        swarm_nodes = []
+
+        for node in nodes:
+            swarm_nodes.append(node['Description']['Hostname'])
+
+        self.results['nodes'] = swarm_nodes
+        self.results['changed'] = False
+
+
+def main():
+    argument_spec = dict(
+        state=dict(type='str', choices=['list', 'update'], default='list'),
+        force=dict(type='bool', default=False),
+        name=dict(type='str'),
+        labels=dict(type='dict'),
+        labels_remove=dict(type='bool', default=False),
+        availability=dict(type='str', choices=['active', 'pause', 'drain']),
+        role=dict(type='str', choices=['worker', 'manager']),
+    )
+
+    required_if = [
+        ('state', 'update', ['name']),
+    ]
+
+    option_minimal_versions = dict(
+        signing_ca_cert=dict(docker_api_version='1.30'),
+        signing_ca_key=dict(docker_api_version='1.30'),
+        ca_force_rotate=dict(docker_api_version='1.30'),
+    )
+
+    client = AnsibleDockerSwarmClient(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=required_if,
+        min_docker_version='1.10.0',
+        min_docker_api_version='1.24',
+        option_minimal_versions=option_minimal_versions,
+    )
+
+    results = dict(
+        changed=False,
+        result='',
+        actions=[],
+    )
+
+    SwarmNodeManager(client, results)()
+    client.module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -28,7 +28,11 @@ options:
         required: true
         type: str
     labels:
-        description: User-defined key/value metadata. If not provided then labels assigned to node remains unchanged.
+        description:
+            - User-defined key/value metadata that will be assigned as node attribute. The actual state of labels
+              assigned to the node when module completes its work depends on I(labels_state) and I(labels_to_remove)
+              parameters values. See description below.
+        required: false
         type: dict
     labels_state:
         description:
@@ -47,9 +51,13 @@ options:
         type: str
     labels_to_remove:
         description:
-            - List of labels that will be removed from the node configuration. If label specified on the list is
-              not assigned to the node then no action will be performed. The remaining labels assigned to the
-              node remains unchanged. The list have to contain only label names, not their values.
+            - List of labels that will be removed from the node configuration. The list has to contain only label
+              names, not their values.
+            - If the label provided on the list is not assigned to the node, the entry is ignored.
+            - If the label is both on the I(labels_to_remove) and I(labels), then value provided in I(labels) remains
+              assigned to the node.
+            - If I(labels_state) is C(replace) and I(labels) is not provided or empty then all labels assigned to
+              node are removed and I(labels_to_remove) is ignored.
         required: false
         type: list
     availability:
@@ -269,7 +277,7 @@ def main():
 
     required_if = [
         ('labels_state', 'merge', ['hostname']),
-        ('labels_state', 'replace', ['hostname', 'labels']),
+        ('labels_state', 'replace', ['hostname']),
     ]
 
     option_minimal_versions = dict(

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -182,14 +182,13 @@ class SwarmNodeManager(DockerBaseClass):
         self.results = results
         self.check_mode = self.client.check_mode
 
+        self.client.fail_task_if_not_swarm_manager()
+
         self.parameters = TaskParameters(client)
 
         self.node_update()
 
     def node_update(self):
-        if not (self.client.check_if_swarm_manager()):
-            self.client.fail(msg="This node is not a manager.")
-
         if not (self.client.check_if_swarm_node(node_id=self.parameters.hostname)):
             self.results['actions'].append("This node is not part of a swarm.")
             return

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -143,7 +143,6 @@ class TaskParameters(DockerBaseClass):
         super(TaskParameters, self).__init__()
 
         self.state = None
-        self.force = None
 
         # Spec
         self.name = None
@@ -247,7 +246,6 @@ class SwarmNodeManager(DockerBaseClass):
 def main():
     argument_spec = dict(
         state=dict(type='str', choices=['list', 'update'], default='list'),
-        force=dict(type='bool', default=False),
         name=dict(type='str'),
         labels=dict(type='dict'),
         labels_remove=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -17,43 +17,42 @@ module: docker_node
 short_description: Manage Docker Swarm node
 version_added: "2.8"
 description:
-    - Manages the Docker nodes via Swarm Manager
-    - Change node role
-    - Change node availability
-    - Change or remove node labels
+    - Manages the Docker nodes via Swarm Manager.
+    - This module allows to change the node's role, its availability, and to modify, add or remove node labels.
 options:
-    state:
+    hostname:
         description:
-            - Set to C(update) to update node labels, availability and role
-        required: true
-        choices:
-          - update
-    name:
-        description:
-            - Swarm name of the node.
-            - Used with I(state=update).
+            - The hostname or ID of node as registered in Swarm.
+            - If more than one node is registered using the same hostname the ID must be used,
+              otherwise task will fail.
     labels:
         description: User-defined key/value metadata.
+        type: dict
     labels_state:
         description:
-            - Defines the operation on the lables assigned to node.
-            - Set to C(merge) to merge provided labels with already assigned ones. It will update existing keys.
-              The I(labels) must be specified.
+            - Defines the operation on the labels assigned to node.
+            - Set to C(merge) to combine labels provided in I(labels) with those already assigned to the node.
+              If no labels are assigned then it will add listed labels. The I(labels) must be specified.
+            - If set as C(merge) for labels that are assigned to node will update their values as specified in I(labels).
+            - If set as C(merge) labels assigned to node that are not specified in I(labels) will remain unchanged.
+            - If set as C(merge) will add new labels specified in I(labels) if labels are not assigned to node.
             - Set to C(replace) to replace assigned labels with provided ones. The I(labels) must be specified.
-            - Set to C(remove) to remove all labels assigned to node.
+            - Set to C(remove) to remove labels specified in I(labels). If I(labels) is not provided then will remove
+              all labels assigned to the node. If I(labels) is specified it will remove only the listed labels.
+              Unassigned labels from I(labels) are ignored.
         choices:
           - merge
           - replace
           - remove
         default: 'merge'
     availability:
-        description: Node availability status to assign
+        description: Node availability status to assign.
         choices:
           - active
           - pause
           - drain
     role:
-        description: Node role to assign
+        description: Node role to assign.
         choices:
           - manager
           - worker
@@ -78,49 +77,45 @@ author:
 '''
 
 EXAMPLES = '''
-- name: List names of registered swarm nodes
-  docker_node:
-    state: list
-
 - name: Set node role
   docker_node:
-    state: update
-    name: mynode
+    hostname: mynode
     role: manager
 
 - name: Set node availability
   docker_node:
-    state: update
-    name: mynode
+    hostname: mynode
     availability: drain
 
 - name: Replace node labels with new labels
   docker_node:
-    state: update
-    name: mynode
+    hostname: mynode
     labels:
       key: value
     labels_state: replace
 
 - name: Merge node labels and new labels
   docker_node:
-    state: update
-    name: mynode
+    hostname: mynode
     labels:
       key: value
 
 - name: Merge node labels and new labels
   docker_node:
-    state: update
-    name: mynode
+    hostname: mynode
     labels:
       key: value
     labels_state: merge
 
+- name: Remove all labels assigned to node
+  docker_node:
+    hostname: mynode
+    labels:
+    labels_state: replace
+
 - name: Remove node labels
   docker_node:
-    state: update
-    name: mynode
+    hostname: mynode
     labels_state: remove
 '''
 
@@ -156,8 +151,6 @@ class TaskParameters(DockerBaseClass):
     def __init__(self, client):
         super(TaskParameters, self).__init__()
 
-        self.state = None
-
         # Spec
         self.name = None
         self.labels = None
@@ -183,18 +176,13 @@ class SwarmNodeManager(DockerBaseClass):
 
         self.parameters = TaskParameters(client)
 
-    def __call__(self):
-        choice_map = {
-            "update": self.node_update,
-        }
-
-        choice_map.get(self.parameters.state)()
+        self.node_update()
 
     def node_update(self):
         if not (self.client.check_if_swarm_manager()):
             self.client.fail(msg="This node is not a manager.")
 
-        if not (self.client.check_if_swarm_node(node_id=self.parameters.name)):
+        if not (self.client.check_if_swarm_node(node_id=self.parameters.hostname)):
             self.results['actions'].append("This node is not part of a swarm.")
             return
 
@@ -207,48 +195,74 @@ class SwarmNodeManager(DockerBaseClass):
             self.client.fail(msg="Can not update the node. The status node is down.")
 
         try:
-            node_info = self.client.inspect_node(node_id=self.parameters.name)
+            node_info = self.client.inspect_node(node_id=self.parameters.hostname)
         except APIError as exc:
             self.client.fail(msg="Failed to get node information for %s" % to_native(exc))
 
-        if self.parameters.role is None:
-            self.parameters.role = node_info['Spec']['Role']
-
-        if self.parameters.availability is None:
-            self.parameters.availability = node_info['Spec']['Availability']
-
-        if self.parameters.labels is None:
-            self.parameters.labels = node_info['Spec']['Labels']
-        else:
-            if self.parameters.labels_state == 'remove':
-                self.parameters.labels = {}
-            if self.parameters.labels_state == 'replace':
-                pass
-            if self.parameters.labels_state == 'merge':
-                for next_key in node_info['Spec']['Labels']:
-                    if next_key not in self.parameters.labels:
-                        self.parameters.labels.update({next_key: node_info['Spec']['Labels'][next_key]})
-
+        __changed = False
         node_spec = dict(
             Availability=self.parameters.availability,
             Role=self.parameters.role,
             Labels=self.parameters.labels,
         )
 
-        try:
-            self.client.update_node(node_id=node_info['ID'], version=node_info['Version']['Index'],
-                                    node_spec=node_spec)
-        except APIError as exc:
-            self.client.fail(msg="Failed to update node : %s" % to_native(exc))
-        self.results['node_facts'] = self.client.get_node_inspect(node_id=node_info['ID'])
-        self.results['actions'].append("Node updated")
-        self.results['changed'] = True
+        if self.parameters.role is None:
+            node_spec['Role'] = node_info['Spec']['Role']
+
+        if self.parameters.availability is None:
+            node_spec['Availability'] = node_info['Spec']['Availability']
+
+        if self.parameters.labels_state == 'replace':
+            node_spec['Labels'] = self.parameters.labels
+            __changed = True
+
+        if self.parameters.labels_state == 'remove':
+            node_spec['Labels'] = node_info['Spec']['Labels']
+
+            if self.parameters.labels is None and node_info['Spec']['Labels'] is not None:
+                node_spec['Labels'] = None
+                __changed = True
+            elif self.parameters.labels is not None and node_info['Spec']['Labels'] is not None:
+                for next_key in self.parameters.labels:
+                    if next_key in node_info['Spec']['Labels']:
+                        try:
+                            node_spec['Labels'].pop(next_key)
+                            __changed = True
+                        except KeyError as exc:
+                            self.client.fail(msg="Failed to remove labels for %s" % to_native(exc))
+
+        if self.parameters.labels_state == 'merge':
+            node_spec['Labels'] = node_info['Spec']['Labels']
+
+            for next_key in self.parameters.labels:
+                if next_key in node_info['Spec']['Labels']:
+                    if self.parameters.labels.get(next_key) == node_info['Spec']['Labels'][next_key]:
+                        pass
+                    else:
+                        node_spec['Labels'].update({next_key: self.parameters.labels.get(next_key)})
+                        __changed = True
+                else:
+                    node_spec['Labels'].update({next_key: self.parameters.labels.get(next_key)})
+                    __changed = True
+
+        if __changed is True:
+            try:
+                self.client.update_node(node_id=node_info['ID'], version=node_info['Version']['Index'],
+                                        node_spec=node_spec)
+            except APIError as exc:
+                self.client.fail(msg="Failed to update node : %s" % to_native(exc))
+            self.results['node_facts'] = self.client.get_node_inspect(node_id=node_info['ID'])
+            self.results['actions'].append("Node updated")
+            self.results['changed'] = __changed
+        else:
+            self.results['node_facts'] = node_info
+            self.results['actions'].append("Nothing to update")
+            self.results['changed'] = __changed
 
 
 def main():
     argument_spec = dict(
-        state=dict(type='str', choices=['update'], required=True),
-        name=dict(type='str'),
+        hostname=dict(type='str'),
         labels=dict(type='dict'),
         labels_state=dict(type='str', choices=['merge', 'replace', 'remove'], default='merge'),
         availability=dict(type='str', choices=['active', 'pause', 'drain']),
@@ -256,9 +270,8 @@ def main():
     )
 
     required_if = [
-        ('state', 'update', ['name']),
-        ('labels_state', 'merge', ['name', 'labels']),
-        ('labels_state', 'replace', ['name', 'labels']),
+        ('labels_state', 'merge', ['hostname', 'labels']),
+        ('labels_state', 'replace', ['hostname', 'labels']),
     ]
 
     option_minimal_versions = dict(
@@ -278,11 +291,10 @@ def main():
 
     results = dict(
         changed=False,
-        result='',
         actions=[],
     )
 
-    SwarmNodeManager(client, results)()
+    SwarmNodeManager(client, results)
     client.module.exit_json(**results)
 
 

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -202,7 +202,7 @@ class SwarmNodeManager(DockerBaseClass):
             return
 
         if self.client.check_if_swarm_node_is_down():
-            self.client.fail(msg="Can not update the node. The status node is down.")
+            self.client.fail(msg="Can not update the node. The node is down.")
 
         try:
             node_info = self.client.inspect_node(node_id=self.parameters.hostname)
@@ -261,11 +261,12 @@ class SwarmNodeManager(DockerBaseClass):
                             changed = True
 
         if changed is True:
-            try:
-                self.client.update_node(node_id=node_info['ID'], version=node_info['Version']['Index'],
-                                        node_spec=node_spec)
-            except APIError as exc:
-                self.client.fail(msg="Failed to update node : %s" % to_native(exc))
+            if not self.check_mode:
+                try:
+                    self.client.update_node(node_id=node_info['ID'], version=node_info['Version']['Index'],
+                                            node_spec=node_spec)
+                except APIError as exc:
+                    self.client.fail(msg="Failed to update node : %s" % to_native(exc))
             self.results['node_facts'] = self.client.get_node_inspect(node_id=node_info['ID'])
             self.results['changed'] = changed
         else:

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -218,9 +218,17 @@ class SwarmNodeManager(DockerBaseClass):
 
         if self.parameters.role is None:
             node_spec['Role'] = node_info['Spec']['Role']
+        else:
+            if not node_info['Spec']['Role'] == self.parameters.role:
+                node_spec['Role'] = self.parameters.role
+                changed = True
 
         if self.parameters.availability is None:
             node_spec['Availability'] = node_info['Spec']['Availability']
+        else:
+            if not node_info['Spec']['Availability'] == self.parameters.availability:
+                node_info['Spec']['Availability'] = self.parameters.availability
+                changed = True
 
         if self.parameters.labels_state == 'replace':
             if self.parameters.labels is None:

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -171,7 +171,6 @@ class SwarmNodeManager(DockerBaseClass):
 
     def __call__(self):
         choice_map = {
-            "list": self.node_list,
             "update": self.node_update,
         }
 
@@ -225,27 +224,10 @@ class SwarmNodeManager(DockerBaseClass):
         self.results['actions'].append("Node updated")
         self.results['changed'] = True
 
-    def node_list(self):
-        if not (self.client.check_if_swarm_manager()):
-            self.client.fail(msg="This node is not a manager.")
-
-        try:
-            nodes = self.client.nodes()
-        except APIError as exc:
-            self.client.fail(msg="Failed to get nodes list : %s" % to_native(exc))
-
-        swarm_nodes = []
-
-        for node in nodes:
-            swarm_nodes.append(node['Description']['Hostname'])
-
-        self.results['nodes'] = swarm_nodes
-        self.results['changed'] = False
-
 
 def main():
     argument_spec = dict(
-        state=dict(type='str', choices=['list', 'update'], default='list'),
+        state=dict(type='str', choices=['update'], required=True),
         name=dict(type='str'),
         labels=dict(type='dict'),
         labels_remove=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -132,11 +132,6 @@ node_facts:
   description: Information about node after 'update' operation
   returned: success
   type: dict
-actions:
-  description: Provides the actions done on the swarm.
-  returned: when action failed.
-  type: list
-  example: "['This cluster is already a swarm cluster']"
 
 '''
 
@@ -190,7 +185,7 @@ class SwarmNodeManager(DockerBaseClass):
 
     def node_update(self):
         if not (self.client.check_if_swarm_node(node_id=self.parameters.hostname)):
-            self.results['actions'].append("This node is not part of a swarm.")
+            self.client.fail(msg="This node is not part of a swarm.")
             return
 
         try:
@@ -259,11 +254,9 @@ class SwarmNodeManager(DockerBaseClass):
             except APIError as exc:
                 self.client.fail(msg="Failed to update node : %s" % to_native(exc))
             self.results['node_facts'] = self.client.get_node_inspect(node_id=node_info['ID'])
-            self.results['actions'].append("Node updated")
             self.results['changed'] = __changed
         else:
             self.results['node_facts'] = node_info
-            self.results['actions'].append("Nothing to update")
             self.results['changed'] = __changed
 
 
@@ -298,7 +291,6 @@ def main():
 
     results = dict(
         changed=False,
-        actions=[],
     )
 
     SwarmNodeManager(client, results)

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -90,7 +90,7 @@ requirements:
        reinstall of it is required."
     - Docker API >= 1.25
 author:
-  - Piotr Wojciechowski (@wojciechowskipiotr)
+  - Piotr Wojciechowski (@WojciechowskiPiotr)
   - Thierry Bouvet (@tbouvet)
 
 '''
@@ -229,7 +229,7 @@ class SwarmNodeManager(DockerBaseClass):
                 if node_info['Spec']['Labels']:
                     changed = True
             else:
-                if node_info['Spec']['Labels'] != self.parameters.labels:
+                if (node_info['Spec']['Labels'] or {}) != self.parameters.labels:
                     node_spec['Labels'] = self.parameters.labels
                     changed = True
         elif self.parameters.labels_state == 'merge':

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -75,8 +75,9 @@ node_facts:
 
 '''
 
-from ansible.module_utils.docker_common import AnsibleDockerClient
 from ansible.module_utils._text import to_native
+
+from ansible.module_utils.docker_swarm import AnsibleDockerSwarmClient
 
 try:
     from docker.errors import APIError, NotFound
@@ -103,7 +104,7 @@ def main():
         name=dict(type='str', required=True),
     )
 
-    client = AnsibleDockerClient(
+    client = AnsibleDockerSwarmClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
         min_docker_version='1.10.0',

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -34,6 +34,7 @@ options:
       - When identifying the node use either the hostname of the node (as registered in Swarm) or node ID.
       - If I(self) is C(true) then this parameter is ignored.
     required: false
+    type: str
   self:
     description:
       - If C(true), queries the node (i.e. the docker daemon) the module communicates with.

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -147,6 +147,8 @@ def main():
         min_docker_api_version='1.24',
     )
 
+    client.fail_task_if_not_swarm_manager()
+
     node = get_node_facts(client)
 
     client.module.exit_json(

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -75,7 +75,7 @@ node_facts:
 
 '''
 
-from ansible.module_utils.docker_common import AnsibleDockerClient
+from ansible.module_utils.docker_swarm import AnsibleDockerSwarmClient
 from ansible.module_utils._text import to_native
 
 try:
@@ -103,7 +103,7 @@ def main():
         name=dict(type='str', required=True),
     )
 
-    client = AnsibleDockerClient(
+    client = AnsibleDockerSwarmClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
         min_docker_version='1.10.0',

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -31,17 +31,17 @@ options:
       - The name of the node to inspect.
       - The list of nodes names to inspect.
       - If empty then return information of all nodes in Swarm cluster.
-      - When identifying an existing node name may either the hostname of the node (as registered in Swarm) or node ID.
-      - If I(self) is C(True) then this parameter is ignored.
+      - When identifying the node use either the hostname of the node (as registered in Swarm) or node ID.
+      - If I(self) is C(true) then this parameter is ignored.
     required: false
   self:
     description:
-      - If C(True) then query the host module run on or one specified as I(docker_host).
-      - If C(True) then I(name) is ignored.
-      - If C(False) then query depends on I(name) presence and value.
+      - If C(true), queries the node (i.e. the docker daemon) the module communicates with.
+      - If C(true) then I(name) is ignored.
+      - If C(false) then query depends on I(name) presence and value.
     required: false
     type: bool
-    default: False
+    default: false
 extends_documentation_fragment:
     - docker
 
@@ -86,25 +86,17 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-exists:
+nodes_facts:
     description:
-      - Returns whether the node exists in docker swarm cluster.
-    type: bool
-    returned: always
-    sample: true
-node_facts:
-    description:
-      - Facts representing the current state of the node. Matches the C(docker node inspect) output.
-      - Will be C(None) if node does not exist.
+      - Facts representing the current state of the nodes. Matches the C(docker node inspect) output.
+      - Will be C(none) if node does not exist.
       - Will contain multiple entries if more than one node provided in I(name).
       - If I(name) contains list of nodes, the output will contain information only about registered nodes.
     returned: always
-    type: dict
-
+    type: list
 '''
 
 from ansible.module_utils.docker_swarm import AnsibleDockerSwarmClient
-from ansible.module_utils._text import to_native
 
 try:
     from docker.errors import APIError, NotFound
@@ -158,8 +150,7 @@ def main():
 
     client.module.exit_json(
         changed=False,
-        exists=(True if node else False),
-        node_facts=node,
+        nodes_facts=node,
     )
 
 

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -29,20 +29,8 @@ options:
   name:
     description:
       - The name of the node to inspect.
-      - The list of nodes names to inspect.
-      - If empty then return information of all nodes in Swarm cluster.
-      - When identifying the node use either the hostname of the node (as registered in Swarm) or node ID.
-      - If I(self) is C(true) then this parameter is ignored.
-    required: false
-    type: str
-  self:
-    description:
-      - If C(true), queries the node (i.e. the docker daemon) the module communicates with.
-      - If C(true) then I(name) is ignored.
-      - If C(false) then query depends on I(name) presence and value.
-    required: false
-    type: bool
-    default: false
+      - When identifying an existing node name may either the hostname of the node (as registered in Swarm) or node ID.
+    required: true
 extends_documentation_fragment:
     - docker
 
@@ -64,40 +52,31 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: Get info on all nodes
-  docker_node_facts:
-  register: result
-
 - name: Get info on node
   docker_node_facts:
     name: mynode
   register: result
 
-- name: Get info on list of nodes
-  docker_node_facts:
-    name:
-      - mynode1
-      - mynode2
-  register: result
-
-- name: Get info on host if it is Swarm Manager
-  docker_node_facts:
-    self: true
-  register: result
 '''
 
 RETURN = '''
-nodes_facts:
+exists:
     description:
-      - Facts representing the current state of the nodes. Matches the C(docker node inspect) output.
-      - Will be C(none) if node does not exist.
-      - Will contain multiple entries if more than one node provided in I(name).
-      - If I(name) contains list of nodes, the output will contain information only about registered nodes.
+      - Returns whether the node exists in docker swarm cluster.
+    type: bool
     returned: always
-    type: list
+    sample: true
+node_facts:
+    description:
+      - Facts representing the current state of the node. Matches the C(docker node inspect) output.
+      - Will be C(None) if node does not exist.
+    returned: always
+    type: dict
+
 '''
 
-from ansible.module_utils.docker_swarm import AnsibleDockerSwarmClient
+from ansible.module_utils.docker_common import AnsibleDockerClient
+from ansible.module_utils._text import to_native
 
 try:
     from docker.errors import APIError, NotFound
@@ -106,54 +85,37 @@ except ImportError:
     pass
 
 
-def get_node_facts(client):
-
-    results = []
-
-    if client.module.params['self'] is True:
-        try:
-            self_node_id = client.get_swarm_node_id()
-        except APIError:
-            return None
-        node_info = client.get_node_inspect(node_id=self_node_id)
-        results.append(node_info)
-        return results
-
-    if client.module.params['name'] is None:
-        node_info = client.get_all_nodes_inspect()
-        return node_info
-
-    nodes = client.module.params['name']
-    if not isinstance(nodes, list):
-        nodes = [nodes]
-
-    for next_node_name in nodes:
-        next_node_info = client.get_node_inspect(node_id=next_node_name, skip_missing=True)
-        if next_node_info:
-            results.append(next_node_info)
-    return results
+def get_node_facts(client, name):
+    try:
+        return client.inspect_node(name)
+    except NotFound:
+        return None
+    except APIError as exc:
+        if exc.status_code == 503:
+            client.fail(msg="Cannot inspect node: To inspect node execute module on Swarm Manager")
+        client.fail(msg="Error while reading from Swarm manager: %s" % to_native(exc))
+    except Exception as exc:
+        client.module.fail_json(msg="Error inspecting swarm node: %s" % exc)
 
 
 def main():
     argument_spec = dict(
-        name=dict(type='list', elements='str'),
-        self=dict(type='bool', default='False'),
+        name=dict(type='str', required=True),
     )
 
-    client = AnsibleDockerSwarmClient(
+    client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
         min_docker_version='1.10.0',
         min_docker_api_version='1.24',
     )
 
-    client.fail_task_if_not_swarm_manager()
-
-    node = get_node_facts(client)
+    node = get_node_facts(client, client.module.params['name'])
 
     client.module.exit_json(
         changed=False,
-        nodes_facts=node,
+        exists=(True if node else False),
+        node_facts=node,
     )
 
 


### PR DESCRIPTION
##### SUMMARY
New module to handle Docker Swarm node operations. It must be executed on Swarm `manager` node and allows changing the node availability, role, and labels (fixes #49547). Part of the commit is also a shared library for all common methods for other Swarm modules.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
docker_node

##### ADDITIONAL INFORMATION
This PR is a copy of #50428, required due to the wrong branch in original PR. The open discussion in old PR is on module name and where put some inspect features, either in `docker_node` or `docker_node_facts` (#50571). The upcoming `docker_swarm_facts` will use the shared code from this PR. 
This module is equivalent of `docker node` CLI command allowing now changing the node availability and role as well as applying or removing the labels from the node. It must be executed on Swarm manager node otherwise exception is raised. 
When RP is merged into `ansible/devel` then we can update `docker_swarm` module so it uses the shared methods from `module_utils/docker_swarm` instead of own local wherever it is possible.