### PR TITLE
make rax.py py3 compatible

### DIFF
--- a/contrib/inventory/rax.py
+++ b/contrib/inventory/rax.py
@@ -151,7 +151,6 @@ import sys
 import argparse
 import warnings
 import collections
-import ConfigParser
 
 from six import iteritems
 
@@ -168,17 +167,18 @@ from time import time
 from ansible.constants import get_config
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import text_type
+from ansible.module_utils.six.moves import configparser
 
 NON_CALLABLES = (text_type, str, bool, dict, int, list, type(None))
 
 
 def load_config_file():
-    p = ConfigParser.ConfigParser()
+    p = configparser.ConfigParser()
     config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                'rax.ini')
     try:
         p.read(config_file)
-    except ConfigParser.Error:
+    except configparser.Error:
         return None
     else:
         return p


### PR DESCRIPTION
`rax.py` used `ConfigParser` module in py2, which has been renamed
to `configparser` in py3.

Signed-off-by: Guo Qiao <guoqiao@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
