### PR TITLE
ungrouped as a list

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -318,22 +318,24 @@ If you intend to replace an existing static inventory file with an inventory scr
 it must return a JSON object which contains an 'all' group that includes every
 host in the inventory as a member and every group in the inventory as a child.
 It should also include an 'ungrouped' group which contains all hosts which are not members of any other group.
-A skeleton example of this JSON object is::
+A skeleton example of this JSON object is:
 
-	{
-		"_meta": {
-			"hostvars": {}
-		},
-		"all": {
-			"children": [
-				"ungrouped"
-			]
-		},
-		"ungrouped": {
-      "children": [
-      ]
-    }
-	}
+.. code-block:: json
+
+   {
+       "_meta": {
+         "hostvars": {}
+       },
+       "all": {
+         "children": [
+           "ungrouped"
+         ]
+       },
+       "ungrouped": {
+         "children": [
+         ]
+       }
+   }
 
 An easy way to see how this should look is using :ref:`ansible-inventory`, which also supports ``--list`` and ``--host`` parameters like an inventory script would.
 

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -330,7 +330,7 @@ A skeleton example of this JSON object is::
 			]
 		},
 		"ungrouped": {
-      "children":[
+      "children": [
       ]
     }
 	}

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -329,7 +329,10 @@ A skeleton example of this JSON object is::
 				"ungrouped"
 			]
 		},
-		"ungrouped": []
+		"ungrouped": {
+      "children":[
+      ]
+    }
 	}
 
 An easy way to see how this should look is using :ref:`ansible-inventory`, which also supports ``--list`` and ``--host`` parameters like an inventory script would.

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -329,7 +329,7 @@ A skeleton example of this JSON object is::
 				"ungrouped"
 			]
 		},
-		"ungrouped": {}
+		"ungrouped": []
 	}
 
 An easy way to see how this should look is using :ref:`ansible-inventory`, which also supports ``--list`` and ``--host`` parameters like an inventory script would.


### PR DESCRIPTION
When ungrouped is a dict, ansible throws the following warning and in fact treats it as a host

[WARNING]: Found both group and host with same name: ungrouped"

However when it's a list, it seems to work as intended. 
Feel free to reject if I'm missing something.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
