### PR TITLE
Pluribus Networks admin syslog modules with unit tests

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_admin_syslog.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_syslog.py
@@ -1,0 +1,227 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_admin_syslog
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to create/modify/delete admin-syslog
+description:
+  - C(present): create the scope and other parameters of syslog event collection.
+  - C(update): modify parameters of syslog event collection.
+  - C(absent): delete the scope and other parameters of syslog event collection.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use C(present) to create admin-syslog and
+        C(absent) to delete admin-syslog C(update) to modify the admin-syslog.
+    required: True
+    type: str
+    choices: ['present', 'absent', 'update']
+  pn_scope:
+    description:
+      - Scope of the system log.
+    required: False
+    type: str
+    choices: ['local', 'fabric']
+  pn_host:
+    description:
+      - Hostname to log system events.
+    required: False
+    type: str
+  pn_port:
+    description:
+      - Host port.
+    required: False
+    type: str
+  pn_transport:
+    description:
+      - Transport for log events - tcp/tls or udp.
+    required: False
+    choices: ['tcp-tls', 'udp']
+    default: 'udp'
+  pn_message_format:
+    description:
+      - message-format for log events - structured or legacy.
+    required: False
+    choices: ['structured', 'legacy']
+  pn_name:
+    description:
+      - name of the system log.
+    required: False
+    type: str
+"""
+
+EXAMPLES = """
+- name: admin-syslog functionality
+  pn_admin_syslog:
+    pn_cliswitch: sw01
+    state: "absent"
+    pn_name: "foo"
+    pn_scope: "local"
+
+- name: admin-syslog functionality
+  pn_admin_syslog:
+    pn_cliswitch: "sw01"
+    state: "present"
+    pn_name: "foo"
+    pn_scope: "local"
+    pn_host: "166.68.224.46"
+    pn_message_format: "structured"
+
+- name: admin-syslog functionality
+  pn_admin_syslog:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_name: "foo"
+    pn_host: "166.68.224.10"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the admin-syslog command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the admin-syslog command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the admin-syslog-show command.
+    If a user with given name exists, return as True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    """
+
+    name = module.params['pn_name']
+
+    cli += ' admin-syslog-show format name no-show-headers'
+    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+
+    out = out.split()
+
+    return True if name in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        present='admin-syslog-create',
+        absent='admin-syslog-delete',
+        update='admin-syslog-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_scope=dict(required=False, type='str',
+                          choices=['local', 'fabric']),
+            pn_host=dict(required=False, type='str'),
+            pn_port=dict(required=False, type='str'),
+            pn_transport=dict(required=False, type='str',
+                              choices=['tcp-tls', 'udp'], default='udp'),
+            pn_message_format=dict(required=False, type='str',
+                                   choices=['structured', 'legacy']),
+            pn_name=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ['state', 'present', ['pn_name', 'pn_host', 'pn_scope']],
+            ['state', 'absent', ['pn_name']],
+            ['state', 'update', ['pn_name']]
+        ),
+        required_one_of=[['pn_port', 'pn_message_format',
+                          'pn_host', 'pn_transport', 'pn_scope']]
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    scope = module.params['pn_scope']
+    host = module.params['pn_host']
+    port = module.params['pn_port']
+    transport = module.params['pn_transport']
+    message_format = module.params['pn_message_format']
+    name = module.params['pn_name']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    SYSLOG_EXISTS = check_cli(module, cli)
+    cli += ' %s name %s ' % (command, name)
+
+    if command == 'admin-syslog-modify':
+        if SYSLOG_EXISTS is False:
+            module.fail_json(
+                failed=True,
+                msg='admin syslog with name %s does not exist' % name
+            )
+
+    if command == 'admin-syslog-delete':
+        if SYSLOG_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='admin syslog with name %s does not exist' % name
+            )
+
+    if command == 'admin-syslog-create':
+        if SYSLOG_EXISTS is True:
+            module.exit_json(
+                skipped=True,
+                msg='admin syslog user with name %s already exists' % name
+            )
+
+    if command == 'admin-syslog-create':
+        if scope:
+            cli += ' scope ' + scope
+
+    if command != 'admin-syslog-delete':
+        if host:
+            cli += ' host ' + host
+        if port:
+            cli += ' port ' + port
+        if transport:
+            cli += ' transport ' + transport
+        if message_format:
+            cli += ' message-format ' + message_format
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/netvisor/pn_admin_syslog.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_syslog.py
@@ -18,9 +18,9 @@ author: "Pluribus Networks (@rajaspachipulusu17)"
 version_added: "2.8"
 short_description: CLI command to create/modify/delete admin-syslog
 description:
-  - C(present): create the scope and other parameters of syslog event collection.
-  - C(update): modify parameters of syslog event collection.
-  - C(absent): delete the scope and other parameters of syslog event collection.
+  - This module can be used to create the scope and other parameters of syslog event collection.
+  - This module can be used to modify parameters of syslog event collection.
+  - This module can be used to delete the scope and other parameters of syslog event collection.
 options:
   pn_cliswitch:
     description:
@@ -54,6 +54,7 @@ options:
     description:
       - Transport for log events - tcp/tls or udp.
     required: False
+    type: str
     choices: ['tcp-tls', 'udp']
     default: 'udp'
   pn_message_format:
@@ -61,6 +62,7 @@ options:
       - message-format for log events - structured or legacy.
     required: False
     choices: ['structured', 'legacy']
+    type: str
   pn_name:
     description:
       - name of the system log.

--- a/test/units/modules/network/netvisor/test_pn_admin_syslog.py
+++ b/test/units/modules/network/netvisor/test_pn_admin_syslog.py
@@ -1,0 +1,76 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_admin_syslog
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestAdminSyslogModule(TestNvosModule):
+
+    module = pn_admin_syslog
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_admin_syslog.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_admin_syslog.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'admin-syslog-create':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'admin-syslog-delete':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['update'] == 'admin-syslog-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = False
+        if state == 'absent':
+            self.run_check_cli.return_value = True
+        if state == 'update':
+            self.run_check_cli.return_value = True
+
+    def test_admin_syslog_create(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_scope': 'local', 'pn_host': '166.68.224.46', 'pn_message_format': 'structured', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-syslog-create name foo  scope local host 166.68.224.46 '
+        expected_cmd += 'transport udp message-format structured'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_admin_syslog_delete(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'state': 'absent'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-syslog-delete name foo '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_admin_syslog_update(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'state': 'update'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-syslog-modify name foo  transport udp'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of admin syslog for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_admin_syslog.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```