### PR TITLE
Fix_dellos6_config module

### DIFF
--- a/lib/ansible/modules/network/dellos6/dellos6_config.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_config.py
@@ -287,7 +287,7 @@ def main():
         result['changed'] = True
         if not module.check_mode:
                 cmd = {'command': 'copy running-config startup-config',
-                       'prompt': r'\(y/n\)\s?$', 'answer': 'yes'}
+                       'prompt': r'\(y/n\)\s?$', 'answer': 'y'}
                 run_commands(module, [cmd])
                 result['saved'] = True
         else:


### PR DESCRIPTION
##### SUMMARY
Fix dellos6_config module

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/dellos6/dellos6_config.py

##### ADDITIONAL INFORMATION
```
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/navm/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/navm/my_ansible/ansible/lib/ansible
  executable location = /home/navm/my_ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
```
