### PR TITLE
docker_swarm_service: Fix crash when using configs parameter

### DIFF
--- a/changelogs/fragments/50606-docker_swarm_service_fix-configs-default.yml
+++ b/changelogs/fragments/50606-docker_swarm_service_fix-configs-default.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - fix problem with ``configs`` which prevented using that option."

--- a/changelogs/fragments/50606-docker_swarm_service_fix-configs-default.yml
+++ b/changelogs/fragments/50606-docker_swarm_service_fix-configs-default.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- "docker_swarm_service - fix problem with ``configs`` which prevented using that option."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -540,7 +540,7 @@ class DockerService(DockerBaseClass):
         self.mode = "replicated"
         self.user = "root"
         self.mounts = []
-        self.configs = None
+        self.configs = []
         self.secrets = []
         self.constraints = []
         self.networks = []

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -672,7 +672,7 @@ class DockerService(DockerBaseClass):
             s.mounts.append(service_m)
 
         s.configs = None
-        if ap['configs']:
+        if ap['configs'] is not None:
             s.configs = []
             for param_m in ap['configs']:
                 service_c = {}

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -713,7 +713,7 @@ class DockerService(DockerBaseClass):
             differences.add('mode', parameter=self.mode, active=os.mode)
         if self.mounts != os.mounts:
             differences.add('mounts', parameter=self.mounts, active=os.mounts)
-        if self.configs != os.configs:
+        if self.configs is not None and self.configs != os.configs:
             differences.add('configs', parameter=self.configs, active=os.configs)
         if self.secrets != os.secrets:
             differences.add('secrets', parameter=self.secrets, active=os.secrets)

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -110,60 +110,58 @@
 ## configs #########################################################
 ####################################################################
 
-# FIXME: Broken until #50606 is merged
+- name: configs
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    configs:
+      - config_id: "{{ config_result_1.config_id }}"
+        config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+  register: configs_1
 
-#- name: configs
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    configs:
-#      - config_id: "{{ config_result_1.config_id }}"
-#        config_name: "{{ config_name_1 }}"
-#        filename: "/tmp/{{ config_name_1 }}.txt"
-#  register: configs_1
-#
-#- name: configs (idempotency)
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    configs:
-#      - config_id: "{{ config_result_1.config_id }}"
-#        config_name: "{{ config_name_1 }}"
-#        filename: "/tmp/{{ config_name_1 }}.txt"
-#  register: configs_2
-#
-#- name: configs (add)
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    configs:
-#      - config_id: "{{ config_result_1.config_id }}"
-#        config_name: "{{ config_name_1 }}"
-#        filename: "/tmp/{{ config_name_1 }}.txt"
-#      - config_id: "{{ config_result_2.config_id }}"
-#        config_name: "{{ config_name_2 }}"
-#        filename: "/tmp/{{ config_name_2 }}.txt"
-#  register: configs_3
-#
+- name: configs (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    configs:
+      - config_id: "{{ config_result_1.config_id }}"
+        config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+  register: configs_2
+
+- name: configs (add)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    configs:
+      - config_id: "{{ config_result_1.config_id }}"
+        config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+      - config_id: "{{ config_result_2.config_id }}"
+        config_name: "{{ config_name_2 }}"
+        filename: "/tmp/{{ config_name_2 }}.txt"
+  register: configs_3
+
 #- name: configs (empty)
 #  docker_swarm_service:
 #    name: "{{ service_name }}"
 #    image: alpine:3.8
 #    configs: []
 #  register: configs_4
-#
-#- assert:
-#    that:
-#    - configs_1 is changed
-#    - configs_2 is not changed
-#    - configs_3 is changed
+
+- assert:
+    that:
+    - configs_1 is changed
+    - configs_2 is not changed
+    - configs_3 is changed
 #    - configs_4 is changed
-#  when: docker_api_version is version('1.30', '>=')
-#- assert:
-#    that:
-#    - configs_1 is failed
-#    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.30') in configs_1.msg"
-#  when: docker_api_version is version('1.30', '<')
+  when: docker_api_version is version('1.30', '>=')
+- assert:
+    that:
+    - configs_1 is failed
+    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.30') in configs_1.msg"
+  when: docker_api_version is version('1.30', '<')
 
 ####################################################################
 ## constraints #####################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -150,6 +150,12 @@
     configs: []
   register: configs_4
 
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
 - assert:
     that:
     - configs_1 is changed
@@ -908,6 +914,12 @@
     mounts: []
   register: mounts_4
 
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
 - assert:
     that:
       - mounts_1 is changed
@@ -941,6 +953,12 @@
     image: alpine:3.8
     networks: []
   register: networks_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
 
 - assert:
     that:
@@ -1019,6 +1037,12 @@
         target_port: 60003
         mode: host
   register: publish_5
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
 
 - assert:
     that:
@@ -1336,6 +1360,12 @@
     image: alpine:3.8
     secrets: []
   register: secrets_4
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
 
 - assert:
     that:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -143,19 +143,19 @@
         filename: "/tmp/{{ config_name_2 }}.txt"
   register: configs_3
 
-#- name: configs (empty)
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    configs: []
-#  register: configs_4
+- name: configs (empty)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    configs: []
+  register: configs_4
 
 - assert:
     that:
     - configs_1 is changed
     - configs_2 is not changed
     - configs_3 is changed
-#    - configs_4 is changed
+    - configs_4 is changed
   when: docker_api_version is version('1.30', '>=')
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #50467

`DockerService.configs` can safely initially be a list. When used it is checked for a boolean value and thus both `None` and `[]` will return `False`.

Examples:
https://github.com/hannseman/ansible/blob/4bfc254ac4dbf31afb0e5fc3d6c11c94bad9785e/lib/ansible/modules/cloud/docker/docker_swarm_service.py#L636
https://github.com/hannseman/ansible/blob/4bfc254ac4dbf31afb0e5fc3d6c11c94bad9785e/lib/ansible/modules/cloud/docker/docker_swarm_service.py#L764

This means that not setting any value in the parameter `configs` will not try and send anything to docker daemons not supporting `configs` (API Version <1.30).

One issue that comes by setting `s.configs` to `None` (See line [#635](https://github.com/hannseman/ansible/blob/4bfc254ac4dbf31afb0e5fc3d6c11c94bad9785e/lib/ansible/modules/cloud/docker/docker_swarm_service.py#L635)) when falsy is that it will incorrectly report state as changed for clients supporting `configs`. This is because the docker client will return an empty list when no `configs` have been set and this is then compared to the nulled value. Since this issue is also present with other parameters (https://github.com/ansible/ansible/issues/49285) I think it should be solved in a separate PR. With this PR the `configs` parameter will at least be useable.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
