### PR TITLE
Clarify the change made to reverse_inventory

### DIFF
--- a/changelogs/fragments/playbook-order-py3.yaml
+++ b/changelogs/fragments/playbook-order-py3.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- host execution order - Fix ``reverse_inventory`` to work on python3

--- a/changelogs/fragments/playbook-order-reverse_inventory.yaml
+++ b/changelogs/fragments/playbook-order-reverse_inventory.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- host execution order - Fix ``reverse_inventory`` not to change the order of
+  the items before reversing on python2 and to not backtrace on python3


### PR DESCRIPTION
##### SUMMARY

The change to reverse_inventory affects python2 as well as python3, just in a different manner.  Clarify that in the changelog.

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
Okay'd by sivel on slack.