### PR TITLE
[stable-2.5] Fix run.py --branch argument.

### DIFF
--- a/test/utils/shippable/tools/run.py
+++ b/test/utils/shippable/tools/run.py
@@ -103,7 +103,7 @@ def main():
     )
 
     if args.branch:
-        data['branch'] = args.branch
+        data['branchName'] = args.branch
     elif args.run:
         data['runId'] = args.run
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.5] Fix run.py --branch argument.

The API docs state that both `branch` and `branchName` are valid, but only `branchName` appears to work.

(cherry picked from commit 31c1bdd6a84283f407d01b4162e77b9f7e934abc)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/utils/shippable/tools/run.py
