### PR TITLE
Add limited config commands in aireos_command to support prompts

### DIFF
--- a/lib/ansible/module_utils/network/aireos/aireos.py
+++ b/lib/ansible/module_utils/network/aireos/aireos.py
@@ -54,9 +54,22 @@ aireos_top_spec = {
 }
 aireos_argument_spec.update(aireos_top_spec)
 
+# Modify aireos_command documentation when you update this list
+# Be as specific as necessary to not exclude other commands
 aireos_config_exclusions = [
-    'config ap reset',
+    'config 802.11b 11gSupport',
+    'config ap bridgegroupname',
     'config ap group-name',
+    'config ap reset',
+    'config ap role',
+    'config auto-configure voice',
+    'config ipv6 capwap udplite',
+    'config lag',
+    'config mesh client-access',
+    'config mesh linktest',
+    'config mesh public-safety',
+    'config mesh security lsc-only-auth',
+    'config mesh range',
 ]
 
 

--- a/lib/ansible/module_utils/network/aireos/aireos.py
+++ b/lib/ansible/module_utils/network/aireos/aireos.py
@@ -54,6 +54,10 @@ aireos_top_spec = {
 }
 aireos_argument_spec.update(aireos_top_spec)
 
+aireos_config_exclusions = [
+    'config ap reset',
+    'config ap group-name',
+]
 
 def sanitize(resp):
     # Takes response from device and strips whitespace from all lines

--- a/lib/ansible/module_utils/network/aireos/aireos.py
+++ b/lib/ansible/module_utils/network/aireos/aireos.py
@@ -59,6 +59,7 @@ aireos_config_exclusions = [
     'config ap group-name',
 ]
 
+
 def sanitize(resp):
     # Takes response from device and strips whitespace from all lines
     # Aireos adds in extra preceding whitespace which netcfg parses as children/parents, which Aireos does not do

--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -116,6 +116,7 @@ import time
 
 from ansible.module_utils.network.aireos.aireos import run_commands
 from ansible.module_utils.network.aireos.aireos import aireos_argument_spec, check_args
+from ansible.module_utils.network.aireos.aireos import aireos_config_exclusions
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.network.common.parsing import Conditional
@@ -143,10 +144,14 @@ def parse_commands(module, warnings):
                 'executing `%s`' % item['command']
             )
         elif item['command'].startswith('conf'):
-            module.fail_json(
-                msg='aireos_command does not support running config mode '
-                    'commands.  Please use aireos_config instead'
-            )
+            for exclusion in aireos_config_exclusions:
+                if item['command'].startswith(exclusion):
+                    break
+            else:
+                module.fail_json(
+                    msg='aireos_command does not support running config mode '
+                        'commands.  Please use aireos_config instead'
+                )
     return commands
 
 

--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -22,8 +22,9 @@ description:
     read from the device. This module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.
-  - This module does not support running commands in configuration mode.
-    Please use M(aireos_config) to configure WLC devices.
+  - This module only supports a limited number of configuration commands
+    that utilize prompts (commands listed below). Please use M(aireos_config)
+    for all other commands.
 extends_documentation_fragment: aireos
 options:
   commands:
@@ -32,7 +33,13 @@ options:
         configured provider. The resulting output from the command
         is returned. If the I(wait_for) argument is provided, the
         module is not returned until the condition is satisfied or
-        the number of retries has expired.
+        the number of retries has expired. Supported config commands:
+        C(config 802.11b 11gSupport), C(config ap bridgegroupname),
+        C(config ap group-name), C(config ap reset), C(config ap role),
+        C(config auto-configure voice), C(config ipv6 capwap udplite),
+        C(config lag), C(config mesh client-access), C(config mesh linktest),
+        C(config mesh public-safety), C(config mesh security lsc-only-auth),
+        C(config mesh range)
     required: true
   wait_for:
     description:
@@ -149,8 +156,10 @@ def parse_commands(module, warnings):
                     break
             else:
                 module.fail_json(
-                    msg='aireos_command does not support running config mode '
-                        'commands.  Please use aireos_config instead'
+                    msg='aireos_command only supports a limited number of '
+                        'config mode commands(`%s`). See documentation for '
+                        'more details. Please use aireos_config instead'
+                        % '`, `'.join(aireos_config_exclusions)
                 )
     return commands
 

--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -33,13 +33,14 @@ options:
         configured provider. The resulting output from the command
         is returned. If the I(wait_for) argument is provided, the
         module is not returned until the condition is satisfied or
-        the number of retries has expired. Supported config commands:
+        the number of retries has expired.
+      - Supported config commands = (
         C(config 802.11b 11gSupport), C(config ap bridgegroupname),
         C(config ap group-name), C(config ap reset), C(config ap role),
         C(config auto-configure voice), C(config ipv6 capwap udplite),
         C(config lag), C(config mesh client-access), C(config mesh linktest),
         C(config mesh public-safety), C(config mesh security lsc-only-auth),
-        C(config mesh range)
+        C(config mesh range) )
     required: true
   wait_for:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Alternative to fixing #35622 as generally alluded to by @ganeshrn in #41579. Allowing specific config operations under aireos_command with a simple list and for loop. Keeps aireos_config idempotent while supporting prompts where necessary.

Leaving first check against "conf" since it prevents loop check against other commands. Could incorporate regex checks but I sense simpler solutions would be desired by maintainers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aireos.py
aireos_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```Playbook command
- name: Configure Access Points to Reboot
  aireos_command:
    provider:
      host: '{{ inventory_hostname }}'
      timeout: 60
    commands:
      - command: config ap reset {{ item }}
        prompt: "Would you like to reset"
        answer: y
  with_items: "{{ ap_list }}"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
__Output before:__   
```
failed: [x.x.x.x] (item=AP_NAME) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "commands": [
                {
                    "answer": "y", 
                    "command": "config ap reset AP_NAME", 
                    "prompt": "Would you like to reset"
                }
            ], 
            "host": null, 
            "interval": 1, 
            "match": "all", 
            "password": null, 
            "port": null, 
            "provider": {
                "host": "x.x.x.x", 
                "password": null, 
                "port": null, 
                "ssh_keyfile": null, 
                "timeout": 60, 
                "username": null
            }, 
            "retries": 10, 
            "ssh_keyfile": null, 
            "timeout": null, 
            "username": null, 
            "wait_for": null
        }
    }, 
    "item": "AP_NAME", 
    "msg": "aireos_command does not support running config mode commands.  Please use aireos_config instead"
}

```
__Output after:__  
```
ok: [x.x.x.x] => (item=AP_NAME) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "commands": [
                {
                    "answer": "y", 
                    "command": "config ap reset AP_NAME", 
                    "prompt": "Would you like to reset"
                }
            ], 
            "host": null, 
            "interval": 1, 
            "match": "all", 
            "password": null, 
            "port": null, 
            "provider": {
                "host": "x.x.x.x", 
                "password": null, 
                "port": null, 
                "ssh_keyfile": null, 
                "timeout": 60, 
                "username": null
            }, 
            "retries": 10, 
            "ssh_keyfile": null, 
            "timeout": null, 
            "username": null, 
            "wait_for": null
        }
    }, 
    "item": "AP_NAME", 
    "stdout": [
        "Would you like to reset AP_NAME ? (y/n)y"
    ], 
    "stdout_lines": [
        [
            "Would you like to reset AP_NAME ? (y/n)y"
        ]
    ]
}

```