### PR TITLE
docker_swarm_service: Don’t add difference when update_order is None

### DIFF
--- a/changelogs/fragments/50655-docker_swarm_service-update_order-idempotency.yml
+++ b/changelogs/fragments/50655-docker_swarm_service-update_order-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - fixing falsely reporting ``update_order`` as changed when option is not used."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -719,7 +719,7 @@ class DockerService(DockerBaseClass):
             differences.add('update_monitor', parameter=self.update_monitor, active=os.update_monitor)
         if self.update_max_failure_ratio != os.update_max_failure_ratio:
             differences.add('update_max_failure_ratio', parameter=self.update_max_failure_ratio, active=os.update_max_failure_ratio)
-        if self.update_order != os.update_order:
+        if self.update_order is not None and self.update_order != os.update_order:
             differences.add('update_order', parameter=self.update_order, active=os.update_order)
         if self.image != os.image.split('@')[0]:
             differences.add('image', parameter=self.image, active=os.image.split('@')[0])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

`update_order` is always reported as changed if not set. Docker returns the default value `stop-first`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service