### PR TITLE
Bubble up import exception content for k8s module

### DIFF
--- a/changelogs/fragments/50657-bubble-k8s-import-exception.yml
+++ b/changelogs/fragments/50657-bubble-k8s-import-exception.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- k8s modules and plugins now bubble up error message when the openshift python client fails to import.

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -32,8 +32,10 @@ try:
     from openshift.dynamic import DynamicClient
     from openshift.dynamic.exceptions import ResourceNotFoundError, ResourceNotUniqueError
     HAS_K8S_MODULE_HELPER = True
-except ImportError:
+    k8s_import_exception = None
+except ImportError as e:
     HAS_K8S_MODULE_HELPER = False
+    k8s_import_exception = e
 
 try:
     import yaml
@@ -242,7 +244,7 @@ class KubernetesAnsibleModule(AnsibleModule, K8sAnsibleMixin):
         AnsibleModule.__init__(self, *args, **kwargs)
 
         if not HAS_K8S_MODULE_HELPER:
-            self.fail_json(msg="This module requires the OpenShift Python client. Try `pip install openshift`")
+            self.fail_json(msg="This module requires the OpenShift Python client. Try `pip install openshift`", error=str(k8s_import_exception))
         self.openshift_version = openshift.__version__
 
         if not HAS_YAML:

--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -111,7 +111,7 @@ connections:
 import json
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.k8s.common import K8sAnsibleMixin, HAS_K8S_MODULE_HELPER
+from ansible.module_utils.k8s.common import K8sAnsibleMixin, HAS_K8S_MODULE_HELPER, k8s_import_exception
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
 try:
@@ -151,7 +151,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
 
         if not HAS_K8S_MODULE_HELPER:
             raise K8sInventoryException(
-                "This module requires the OpenShift Python client. Try `pip install openshift`"
+                "This module requires the OpenShift Python client. Try `pip install openshift`. Detail: {0}".format(k8s_import_exception)
             )
 
         source_data = None

--- a/lib/ansible/plugins/lookup/k8s.py
+++ b/lib/ansible/plugins/lookup/k8s.py
@@ -203,8 +203,10 @@ try:
     from openshift.dynamic import DynamicClient
     from openshift.dynamic.exceptions import NotFoundError
     HAS_K8S_MODULE_HELPER = True
-except ImportError as exc:
+    k8s_import_exception = None
+except ImportError as e:
     HAS_K8S_MODULE_HELPER = False
+    k8s_import_exception = e
 
 try:
     import yaml
@@ -219,7 +221,7 @@ class KubernetesLookup(K8sAnsibleMixin):
 
         if not HAS_K8S_MODULE_HELPER:
             raise Exception(
-                "Requires the OpenShift Python client. Try `pip install openshift`"
+                "Requires the OpenShift Python client. Try `pip install openshift`. Detail: {0}".format(k8s_import_exception)
             )
 
         if not HAS_YAML:


### PR DESCRIPTION
Signed-off-by: Fabian von Feilitzsch <fabian@fabianism.us>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Stores the specific exception that caused importing openshift to fail, and bubbles it up to the fail_json message.
Addresses part of #50529, now we can at least see why the import is failing easily.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s

@geerlingguy 