### PR TITLE
[2.7] Fix grafana_dashboard py2/3 compatibility

### DIFF
--- a/changelogs/fragments/49194-grafana_string_handling_fix.yml
+++ b/changelogs/fragments/49194-grafana_string_handling_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - grafana_dashboard - Fix a pair of unicode string handling issues with version checking (https://github.com/ansible/ansible/pull/49194)

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -141,6 +141,7 @@ import string
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_text
 
 __metaclass__ = type
 
@@ -183,8 +184,10 @@ def get_grafana_version(module, grafana_url, headers):
     r, info = fetch_url(module, '%s/api/frontend/settings' % grafana_url, headers=headers, method='GET')
     if info['status'] == 200:
         try:
-            settings = json.loads(r.read())
+            settings = json.loads(to_text(r.read()))
             grafana_version = settings['buildInfo']['version'].split('.')[0]
+        except UnicodeError as e:
+            raise GrafanaAPIException('Unable to decode version string to Unicode')
         except Exception as e:
             raise GrafanaAPIException(e)
     else:

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -184,7 +184,7 @@ def get_grafana_version(module, grafana_url, headers):
     if info['status'] == 200:
         try:
             settings = json.loads(r.read())
-            grafana_version = string.split(settings['buildInfo']['version'], '.')[0]
+            grafana_version = settings['buildInfo']['version'].split('.')[0]
         except Exception as e:
             raise GrafanaAPIException(e)
     else:


### PR DESCRIPTION
##### SUMMARY
Backport of #49194 to stable-2.7: Fix a pair of unicode string handling issues with version checking

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_dashboard