### PR TITLE
docker_volume: revert #47390

### DIFF
--- a/changelogs/fragments/docker_volume-force-change-detection-revert.yaml
+++ b/changelogs/fragments/docker_volume-force-change-detection-revert.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- "docker_volume - reverted changed behavior of ``force``, which was released in Ansible 2.7.1 to 2.7.5, and Ansible 2.6.8 to 2.6.11.
+   Volumes are now only recreated if the parameters changed **and** ``force`` is set to ``true`` (instead of or). This is the behavior
+   which has been described in the documentation all the time."

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -249,7 +249,7 @@ class DockerVolumeManager(object):
             differences = self.has_different_config()
 
         self.diff_tracker.add('exists', parameter=True, active=self.existing_volume is not None)
-        if not differences.empty or self.parameters.force:
+        if not differences.empty and self.parameters.force:
             self.remove_volume()
             self.existing_volume = None
 

--- a/test/integration/targets/docker_volume/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_volume/tasks/tests/basic.yml
@@ -42,7 +42,7 @@
     that:
     - create_1 is changed
     - create_2 is not changed
-    - create_3 is changed
+    - create_3 is not changed
     - absent_1 is changed
     - absent_2 is not changed
 
@@ -80,6 +80,17 @@
       o: size=200m,uid=1000
   register: driver_options_3
 
+- name: Create a volume with options (changed, force)
+  docker_volume:
+    name: "{{ vname }}"
+    driver: local
+    driver_options:
+      type: tempfs
+      device: tmpfs
+      o: size=200m,uid=1000
+    force: yes
+  register: driver_options_4
+
 - name: Cleanup
   docker_volume:
     name: "{{ vname }}"
@@ -89,7 +100,8 @@
     that:
     - driver_options_1 is changed
     - driver_options_2 is not changed
-    - driver_options_3 is changed
+    - driver_options_3 is not changed
+    - driver_options_4 is changed
 
 ####################################################################
 ## labels ##########################################################
@@ -118,13 +130,30 @@
       ansible.test.1: hello
   register: driver_labels_3
 
+- name: Create a volume with labels (less, force)
+  docker_volume:
+    name: "{{ vname }}"
+    labels:
+      ansible.test.1: hello
+    force: yes
+  register: driver_labels_4
+
 - name: Create a volume with labels (more)
   docker_volume:
     name: "{{ vname }}"
     labels:
       ansible.test.1: hello
       ansible.test.3: ansible
-  register: driver_labels_4
+  register: driver_labels_5
+
+- name: Create a volume with labels (more, force)
+  docker_volume:
+    name: "{{ vname }}"
+    labels:
+      ansible.test.1: hello
+      ansible.test.3: ansible
+    force: yes
+  register: driver_labels_6
 
 - name: Cleanup
   docker_volume:
@@ -136,4 +165,6 @@
     - driver_labels_1 is changed
     - driver_labels_2 is not changed
     - driver_labels_3 is not changed
-    - driver_labels_4 is changed
+    - driver_labels_4 is not changed
+    - driver_labels_5 is not changed
+    - driver_labels_6 is changed


### PR DESCRIPTION
##### SUMMARY
Reverts #47390, which caused a bad behavior change in `docker_volume` (volumes were recreated when parameters changed and `force` was not set to `true`, despite documentation saying that this only happens when parameters change **and** `force` is `true`).

Thanks to @valentin-krasontovitsch for pointing this out!

CC @mattclay @abadger (quick question: should I get rid of the old changelog fragment, or keep it? I've added the new changelog fragment into the old file and commented the old fragment out)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_volume
