### PR TITLE
win_psexec: added the pid return value to the docs

### DIFF
--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -149,6 +149,11 @@ cmd:
     returned: always
     type: str
     sample: psexec.exe -nobanner \\remote_server -u "DOMAIN\Administrator" -p "some_password" -accepteula E:\setup.exe
+pid:
+    description: The PID of the async process created by PsExec.
+    returned: when C(wait=False)
+    type: int
+    sample: 1532
 rc:
     description: The return code for the command.
     returned: always


### PR DESCRIPTION
##### SUMMARY
Adds the `pid` return value to the docs which is used when `wait: False`. This value is the process ID of the async process spawned by PsExec.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_psexec
