### PR TITLE
docker_swarm_service: use exact name match when finding services

### DIFF
--- a/changelogs/fragments/50654-docker-swarm-service-docker-api-fix.yaml
+++ b/changelogs/fragments/50654-docker-swarm-service-docker-api-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - fix use of Docker API so that services are not detected as present if there is an existing service whose name is a substring of the desired service"


### PR DESCRIPTION
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Address docker_swarm_service corner-case described in #50654 using the fix from that issues.

<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

<!--- Write the short name of the module, plugin, task or feature below -->

docker_swarm_service

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

> Opening this PR after confirmation on the issue by @felixfontein.

The Docker API's filtering support allows filtering for substring
matches which means that when we filter the list of running services we
may accidentally match a service called "foobar" when looking for a
service named "foo".

Fix this by filtering the list of services returned from the Docker API
so that name matches are exact. It is still worth passing the filter
parameter to the Docker API because it reduces the number of results
passed back which may be important for remote Docker connections.

Closes #50654.