### PR TITLE
Fix assign_public_ip: no disregarded (#29691) (#43954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Ansible Changes By Release
 * Fix setting of environment in a task that uses a loop:
   https://github.com/ansible/ansible/issues/32685
 * Fix https retrieval with TLSv1.2: https://github.com/ansible/ansible/pull/32053
+* Backported the AWS EC2 assign_public_ip fix for when a setting of "no" is ignored: https://github.com/ansible/ansible/pull/43954
 
 
 <a id="2.3.3"></a>

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1079,7 +1079,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                     module.fail_json(
                         msg="instance_profile_name parameter requires Boto version 2.5.0 or higher")
 
-            if assign_public_ip:
+            if assign_public_ip is not None:
                 if not boto_supports_associate_public_ip_address(ec2):
                     module.fail_json(
                         msg="assign_public_ip parameter requires Boto version 2.13.0 or higher.")


### PR DESCRIPTION
in case assign_public_ip is False, it is not handled.

(cherry picked from commit 4bea004a4ec2c83aeac4784e42fd1133f010cc4e)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
AWS EC2 module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When launching an EC2 instance in a subnet which has been configured to automatically assign public IPs to new instances, we want to be able to disable this feature by setting assign_public_ip to "no"; a use-case is if we want to associate our instance with an elastic IP.
This PR is just a backport of the fix in devel to 2.3.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
