### PR TITLE
Fixes and refactor netbox device module

### DIFF
--- a/lib/ansible/modules/net_tools/netbox/netbox_device.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_device.py
@@ -161,10 +161,14 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-meta:
-  description: Message indicating failure or returns results with the object created within Netbox
+device:
+  description: Serialized object as created or already existent within Netbox
+  returned: on creation
+  type: dict
+msg:
+  description: Message indicating failure or info about what has been achieved
   returned: always
-  type: list
+  type: str
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -175,28 +179,6 @@ try:
     HAS_PYNETBOX = True
 except ImportError:
     HAS_PYNETBOX = False
-
-
-def netbox_create_device(nb, nb_endpoint, data):
-    norm_data = normalize_data(data)
-    if norm_data.get("status"):
-            norm_data["status"] = DEVICE_STATUS.get(norm_data["status"].lower(), 0)
-    if norm_data.get("face"):
-        norm_data["face"] = FACE_ID.get(norm_data["face"].lower(), 0)
-    data = find_ids(nb, norm_data)
-    return nb_endpoint.create(norm_data)
-
-
-def netbox_delete_device(nb_endpoint, data):
-    norm_data = normalize_data(data)
-    endpoint = nb_endpoint.get(name=norm_data["name"])
-    result = []
-    try:
-        if endpoint.delete():
-            result.append({'success': '%s deleted from Netbox' % (norm_data["name"])})
-    except AttributeError:
-        result.append({'failed': '%s not found' % (norm_data["name"])})
-    return result
 
 
 def main():
@@ -219,7 +201,6 @@ def main():
         module.fail_json(msg='pynetbox is required for this module')
 
     # Assign variables to be used with module
-    changed = False
     app = 'dcim'
     endpoint = 'devices'
     url = module.params["netbox_url"]
@@ -239,21 +220,62 @@ def main():
         module.fail_json(msg="Incorrect application specified: %s" % (app))
 
     nb_endpoint = getattr(nb_app, endpoint)
-    if 'present' in state:
-        try:
-            response = (
-                netbox_create_device(nb, nb_endpoint, data).serialize()
+    norm_data = normalize_data(data)
+    try:
+        if 'present' in state:
+            return module.exit_json(
+                **ensure_device_present(nb, nb_endpoint, norm_data)
             )
-            changed = True
-        except pynetbox.RequestError as e:
-            response = json.loads(e.error)
+        else:
+            return module.exit_json(
+                **ensure_device_absent(nb_endpoint, norm_data)
+            )
+    except pynetbox.RequestError as e:
+        return module.fail_json(msg=json.loads(e.error))
+
+
+def ensure_device_present(nb, nb_endpoint, data):
+    '''
+    :returns dict(device, msg, changed): dictionary resulting of the request,
+        where `device` is the serialized device fetched or newly created in
+        Netbox
+    '''
+    nb_device = nb_endpoint.get(name=data["name"])
+    if not nb_device:
+        device = _netbox_create_device(nb, nb_endpoint, data).serialize()
+        changed = True
+        msg = "Device %s created" % (data["name"])
     else:
-        try:
-            response = netbox_delete_device(nb_endpoint, data)[0].serialize()
-            changed = True
-        except pynetbox.RequestError as e:
-            response = json.loads(e.error)
-    module.exit_json(changed=changed, meta=response)
+        msg = "Device %s already exists" % (data["name"])
+        device = nb_device.serialize()
+        changed = False
+
+    return {"device": device, "msg": msg, "changed": changed}
+
+
+def _netbox_create_device(nb, nb_endpoint, data):
+    if data.get("status"):
+        data["status"] = DEVICE_STATUS.get(data["status"].lower(), 0)
+    if data.get("face"):
+        data["face"] = FACE_ID.get(data["face"].lower(), 0)
+    data = find_ids(nb, data)
+    return nb_endpoint.create(data)
+
+
+def ensure_device_absent(nb_endpoint, data):
+    '''
+    :returns dict(msg, changed)
+    '''
+    device = nb_endpoint.get(name=data["name"])
+    if device:
+        device.delete()
+        msg = 'Device %s deleted' % (data["name"])
+        changed = True
+    else:
+        msg = 'Device %s already absent' % (data["name"])
+        changed = False
+
+    return {"msg": msg, "changed": changed}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### SUMMARY

The `netbox_device` module, meant to create or delete a device in the Netbox DCIM, relies on the pynetbox library to interact with Netbox. was broken since Pynetbox changed its API. My first commit fixes that.

I also refactored the module for better error handling. The module did not indicate correctly if a failure occurred, and the returned values were not really clear. I proposed my changes in a 2nd commit.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
netbox_device

##### ADDITIONAL INFORMATION

Here are the different returned values depending on the action and context.

Setting the status to "present":
```
{
    "device": {"last_updated": "2019-01-09T00:18:59.793071Z", "site": 2, "asset_tag": null, "cluster": null, "device_type": 154, "serial": "", "id": 152957, "display_name": "Test", "local_context_data": null, "comments": "", "platform": null, "status": 1, "device_role": 4, "primary_ip": null, "tags": [], "vc_priority": null, "parent_device": null, "primary_ip4": null, "primary_ip6": null, "tenant": null, "virtual_chassis": null, "name": "Test", "created": "2019-01-09", "face": null, "vc_position": null, "position": null, "rack": null}, 
    "msg": "Device Test created",
    "changed": true
}
```

Setting the status to "present" on an already existing device:
```
{
    "device": {"last_updated": "2019-01-09T00:18:59.793071Z", "site": 2, "asset_tag": null, "cluster": null, "device_type": 154, "serial": "", "id": 152957, "custom_fields": {"os_version": null, "legacy_console_id": null}, "display_name": "Test", "local_context_data": null, "comments": "", "platform": null, "status": 1, "device_role": 4, "primary_ip": null, "tags": [], "vc_priority": null, "parent_device": null, "primary_ip4": null, "primary_ip6": null, "tenant": null, "virtual_chassis": null, "name": "Test", "created": "2019-01-09", "face": null, "vc_position": null, "position": null, "rack": null},
    "msg": "Device Test already exists",
    "changed": false
}
```

Setting the status to "absent":
```
{"msg": "Device Test deleted", "changed": true}
```

Setting the status to "absent" on a non existing device:
```
{"msg": "Device Test already absent", "changed": false}
```

Thanks a lot!