### PR TITLE
Docs: Add yes/no to syntax highlighter

### DIFF
--- a/docs/docsite/_extensions/pygments_lexer.py
+++ b/docs/docsite/_extensions/pygments_lexer.py
@@ -502,7 +502,7 @@ class AnsibleOutputPrimaryLexer(RegexLexer):
 
         # represents a simple terminal value
         'simplevalue': [
-            (r'(true|false|null)\b', token.Keyword.Constant),
+            (r'(true|false|null|yes|no)\b', token.Keyword.Constant),  # NOTE: We added yes/no for Ansible
             (('%(int_part)s(%(frac_part)s%(exp_part)s|'
               '%(exp_part)s|%(frac_part)s)') % vars(),
              token.Number.Float),


### PR DESCRIPTION
##### SUMMARY
As discussed during last Documentation WG we support both true/false and yes/no as boolean values.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite