### PR TITLE
tower modules: check that 'verify_ssl' defined in ~/.tower_cli.cfg isn't ignored

### DIFF
--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -89,7 +89,7 @@ class TowerModule(AnsibleModule):
             tower_host=dict(),
             tower_username=dict(),
             tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
+            tower_verify_ssl=dict(type='bool'),
             tower_config_file=dict(type='path'),
         )
         args.update(argument_spec)

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -44,7 +44,7 @@ def tower_auth_config(module):
     '''tower_auth_config attempts to load the tower-cli.cfg file
     specified from the `tower_config_file` parameter. If found,
     if returns the contents of the file as a dictionary, else
-    it will attempt to fetch values from the module pararms and
+    it will attempt to fetch values from the module params and
     only pass those values that have been set.
     '''
     config_file = module.params.pop('tower_config_file', None)

--- a/lib/ansible/plugins/doc_fragments/tower.py
+++ b/lib/ansible/plugins/doc_fragments/tower.py
@@ -36,7 +36,6 @@ options:
           - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
             This should only be used on personally controlled sites using self-signed certificates.
         type: bool
-        default: 'yes'
     tower_config_file:
       description:
         - Path to the Tower config file. See notes.

--- a/test/integration/targets/tower_common/aliases
+++ b/test/integration/targets/tower_common/aliases
@@ -1,0 +1,2 @@
+cloud/tower
+shippable/tower/group1

--- a/test/integration/targets/tower_common/tasks/main.yml
+++ b/test/integration/targets/tower_common/tasks/main.yml
@@ -1,0 +1,51 @@
+# Test behaviour common to all tower modules
+- name: Check that SSL is available
+  tower_organization:
+    name: Default
+  environment:
+    TOWER_HOST: "https://{{ lookup('env', 'TOWER_HOST') }}"
+  register: result
+
+- name: Check we haven't changed anything
+  assert:
+    that: result is not changed
+
+- name: Check that SSL is available and verify_ssl is enabled (task must fail)
+  tower_organization:
+    name: Default
+  environment:
+    TOWER_HOST: "https://{{ lookup('env', 'TOWER_HOST') }}"
+    TOWER_CERTIFICATE: /dev/null  # force check failure
+  ignore_errors: true
+  register: check_ssl_is_used
+
+- name: Check that connection failed
+  assert:
+    that:
+      - check_ssl_is_used is failed
+      - >
+          'Could not establish a secure connection' in check_ssl_is_used.module_stderr
+          or 'OpenSSL.SSL.Error' in check_ssl_is_used.module_stderr
+        # 'Could not establish a secure connection': when pyOpenSSL isn't available
+        # 'OpenSSL.SSL.Error': with pyOpenSSL, see https://github.com/urllib3/urllib3/pull/1517
+
+- name: Disable verify_ssl in ~/.tower_cli.cfg
+  copy:
+    dest: ~/.tower_cli.cfg
+    content: |
+      [general]
+      verify_ssl = False
+    force: false  # ensure remote file doesn't exist
+
+- block:
+    - name: Check that verify_ssl is disabled (task must not fail)
+      tower_organization:
+        name: Default
+      environment:
+        TOWER_HOST: "https://{{ lookup('env', 'TOWER_HOST') }}"
+        TOWER_CERTIFICATE: /dev/null  # should not fail because verify_ssl is disabled
+  always:
+    - name: Delete ~/.tower_cli.cfg
+      file:
+        path: ~/.tower_cli.cfg
+        state: absent


### PR DESCRIPTION
##### SUMMARY

Tower modules: check that `verify_ssl` defined in `~/.tower_cli.cfg` isn't ignored

By default, `tower-cli` library [enables SSL certificates check](https://github.com/ansible/tower-cli/blob/867164ed42a3a28d953cb005b70c601d874f5f20/tower_cli/conf.py#L131). But `verify_ssl` `false` value defined in [config files read by default by tower-cli library](https://tower-cli.readthedocs.io/en/latest/api_ref/conf.html?highlight=tower_cli.cfg#tower_cli.conf.Settings) (for example `/etc/tower/tower_cli.cfg`) was ignored because overriden by the `tower_verify_ssl` parameter default value.

Integration test provided.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/module_docs_fragments/tower.py

##### ADDITIONAL INFORMATION
