### PR TITLE
adbotmeta: add windows support to executor/powershell

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1133,6 +1133,11 @@ files:
 ##############################
 # other lib
 
+  lib/ansible/executor/powershell:
+    labels:
+    - windows
+    maintainers: $team_windows_core
+    support: core
   lib/ansible/template:
     keywords:
       - jinja


### PR DESCRIPTION
##### SUMMARY
Add support core and Windows info to the botmeta for files at `lib/ansible/executor/powershell`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml