### PR TITLE
#50632 use describe_stream_summary to avoid iterating all shards

### DIFF
--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -352,15 +352,13 @@ def find_stream(client, stream_name, check_mode=False):
             results = client.describe_stream_summary(**params)['StreamDescriptionSummary']
         else:
             results = {
-                'OpenShardsCount': 5,
-                'ClosedShardsCount': 0,
-                'ShardsCount': 5,
-                'HasMoreShards': True,
-                'RetentionPeriodHours': 24,
                 'StreamName': stream_name,
                 'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/{0}'.format(stream_name),
                 'StreamStatus': 'ACTIVE',
-                'EncryptionType': 'NONE'
+                'RetentionPeriodHours': 24,
+                'EncryptionType': 'NONE',
+                'OpenShardCount': 5,
+                'ConsumerCount': 0
             }
         success = True
     except botocore.exceptions.ClientError as e:

--- a/test/units/modules/cloud/amazon/test_kinesis_stream.py
+++ b/test/units/modules/cloud/amazon/test_kinesis_stream.py
@@ -98,15 +98,13 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
             kinesis_stream.find_stream(client, 'test', check_mode=True)
         )
         should_return = {
-            'OpenShardsCount': 5,
-            'ClosedShardsCount': 0,
-            'ShardsCount': 5,
-            'HasMoreShards': True,
-            'RetentionPeriodHours': 24,
             'StreamName': 'test',
             'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/test',
             'StreamStatus': 'ACTIVE',
-            'EncryptionType': 'NONE'
+            'RetentionPeriodHours': 24,
+            'EncryptionType': 'NONE',
+            'OpenShardCount': 5,
+            'ConsumerCount': 0
         }
         self.assertTrue(success)
         self.assertEqual(stream, should_return)
@@ -119,15 +117,13 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
             )
         )
         should_return = {
-            'OpenShardsCount': 5,
-            'ClosedShardsCount': 0,
-            'ShardsCount': 5,
-            'HasMoreShards': True,
-            'RetentionPeriodHours': 24,
             'StreamName': 'test',
             'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/test',
             'StreamStatus': 'ACTIVE',
-            'EncryptionType': 'NONE'
+            'RetentionPeriodHours': 24,
+            'EncryptionType': 'NONE',
+            'OpenShardCount': 5,
+            'ConsumerCount': 0
         }
         self.assertTrue(success)
         self.assertEqual(stream, should_return)
@@ -250,15 +246,13 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
     def test_update(self):
         client = boto3.client('kinesis', region_name=aws_region)
         current_stream = {
-            'OpenShardsCount': 5,
-            'ClosedShardsCount': 0,
-            'ShardsCount': 1,
-            'HasMoreShards': True,
-            'RetentionPeriodHours': 24,
             'StreamName': 'test',
             'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/test',
             'StreamStatus': 'ACTIVE',
-            'EncryptionType': 'NONE'
+            'RetentionPeriodHours': 24,
+            'EncryptionType': 'NONE',
+            'OpenShardCount': 5,
+            'ConsumerCount': 0
         }
         tags = {
             'env': 'development',
@@ -287,15 +281,13 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
             )
         )
         should_return = {
-            'open_shards_count': 5,
-            'closed_shards_count': 0,
-            'shards_count': 5,
-            'has_more_shards': True,
-            'retention_period_hours': 24,
             'stream_name': 'test',
             'stream_arn': 'arn:aws:kinesis:east-side:123456789:stream/test',
             'stream_status': 'ACTIVE',
+            'retention_period_hours': 24,
             'encryption_type': 'NONE',
+            'open_shard_count': 5,
+            'consumer_count': 0,
             'tags': tags,
         }
         self.assertTrue(success)


### PR DESCRIPTION
##### SUMMARY
* Fixes #50632 by avoiding paging or iterating over a streams shards at all. `describe_shard_summary` returns all the required information for the module and is much faster.
* Removes incorrect logic that prevented `update` from resharding a stream.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
kinesis_stream

##### ADDITIONAL INFORMATION

I've worked through simple functional testing with these changes.

1. Created a new kinesis stream with 110 shards.
1. Enabled SSE for the stream.
1. Ensured no-op passes OK.
1. Reduced stream shard count from 110 to 109.
1. Ensure no-op passes OK again after resharding.
