### PR TITLE
Rename ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to their post ansible 2.0 versions

### DIFF
--- a/contrib/inventory/vagrant.py
+++ b/contrib/inventory/vagrant.py
@@ -47,10 +47,10 @@ from ansible.module_utils.six.moves import StringIO
 
 
 _group = 'vagrant'  # a default group
-_ssh_to_ansible = [('user', 'ansible_ssh_user'),
-                   ('hostname', 'ansible_ssh_host'),
+_ssh_to_ansible = [('user', 'ansible_user'),
+                   ('hostname', 'ansible_host'),
                    ('identityfile', 'ansible_ssh_private_key_file'),
-                   ('port', 'ansible_ssh_port')]
+                   ('port', 'ansible_port')]
 
 # Options
 # ------------------------------


### PR DESCRIPTION
##### SUMMARY
per https://raw.githubusercontent.com/ansible/ansible/stable-2.0/CHANGELOG.md 

"Ansible 2.0 has deprecated the “ssh” from ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_host, and ansible_port."

##### ISSUE TYPE
- Bugfix Pull Request
I suppose this is a bug.  It appears to mostly still work with the existing deprecated values, but we're 3 years after that deprecation notice.  Its only a matter of time before this rots.

##### COMPONENT NAME
Vagrant inventory contrib script
