### PR TITLE
[2.7] docker_network IPAM test / general docker test cleanup

### DIFF
--- a/test/integration/targets/docker_network/aliases
+++ b/test/integration/targets/docker_network/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+skip/rhel8.0

--- a/test/integration/targets/setup_docker/tasks/main.yml
+++ b/test/integration/targets/setup_docker/tasks/main.yml
@@ -18,7 +18,12 @@
         name: 'docker{{ extra_packages }}'
         extra_args: "-c {{ role_path }}/../../../runner/requirements/constraints.txt"
 
-    # Detect docker API and docker-py versions
+    # Detect docker CLI, API and docker-py versions
+    - name: Check Docker CLI version
+      command: "docker version -f {% raw %}'{{.Client.Version}}'{% endraw %}"
+      register: docker_cli_version_stdout
+      ignore_errors: yes
+
     - name: Check Docker API version
       command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()[\"ApiVersion\"])'"
       register: docker_api_version_stdout
@@ -30,8 +35,54 @@
       ignore_errors: yes
 
     - set_fact:
+        docker_cli_version: "{{ (docker_cli_version_stdout.stdout | default('0.0')) or '0.0' }}"
         docker_api_version: "{{ docker_api_version_stdout.stdout or '0.0' }}"
         docker_py_version: "{{ docker_py_version_stdout.stdout or '0.0' }}"
 
     - debug:
-        msg: "Docker API version: {{ docker_api_version }}; docker-py library version: {{ docker_py_version }}"
+        msg: "Docker CLI version: {{ docker_cli_version }}; Docker API version: {{ docker_api_version }}; docker-py library version: {{ docker_py_version }}"
+
+    - block:
+      # Cleanup docker daemon
+      - name: "Remove all ansible-test-* docker containers"
+        shell: 'docker ps --no-trunc --format {% raw %}"{{.Names}}"{% endraw %} | grep "^ansible-test-" | xargs -r docker rm -f'
+        register: docker_containers
+      - name: "Remove all ansible-test-* docker volumes"
+        shell: 'docker volume ls --format {% raw %}"{{.Name}}"{% endraw %} | grep "^ansible-test-" | xargs -r docker volume rm -f'
+        register: docker_volumes
+      - name: "Remove all ansible-test-* docker networks"
+        shell: 'docker network ls --no-trunc --format {% raw %}"{{.Name}}"{% endraw %} | grep "^ansible-test-" | xargs -r docker network rm'
+        register: docker_networks
+      - name: Cleaned docker resources
+        debug:
+          var: docker_resources
+        vars:
+          docker_resources:
+            containers: "{{ docker_containers.stdout_lines }}"
+            volumes: "{{ docker_volumes.stdout_lines }}"
+            networks: "{{ docker_networks.stdout_lines }}"
+
+      # List all existing docker resources
+      - name: List all docker containers
+        command: docker ps --no-trunc -a
+        register: docker_containers
+      - name: List all docker volumes
+        command: docker volume ls
+        register: docker_volumes
+      - name: List all docker networks
+        command: docker network ls --no-trunc
+        register: docker_networks
+      - name: List all docker images
+        command: docker images --no-trunc -a
+        register: docker_images
+      - name: Still existing docker resources
+        debug:
+          var: docker_resources
+        vars:
+          docker_resources:
+            containers: "{{ docker_containers.stdout_lines }}"
+            volumes: "{{ docker_volumes.stdout_lines }}"
+            networks: "{{ docker_networks.stdout_lines }}"
+            images: "{{ docker_images.stdout_lines }}"
+
+      when: docker_cli_version is version('0.0', '>')


### PR DESCRIPTION
##### SUMMARY
Backport of #50499 to stable-2.7: improves the docker tests by cleaning up possible left-over parts from cancelled previous docker test runs first.

I'm not sure if the `skip/rhel8.0` is needed for stable-2.7; I've also added it, but if it causes errors I'll remove it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_docker
