### PR TITLE
[2.7] openssl_pkcs12: fix ca_certificates path expansion

### DIFF
--- a/changelogs/fragments/50697-openssl_pkcs12-ca_certificates.yaml
+++ b/changelogs/fragments/50697-openssl_pkcs12-ca_certificates.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_pkcs12 - now does proper path expansion for ``ca_certificates``."

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -222,7 +222,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
             module.fail_json(msg=to_native(exc))
 
         if self.ca_certificates:
-            ca_certs = [crypto_utils.load_certificate(ca_cert) for ca_cert
+            ca_certs = [crypto_utils.load_certificate(os.path.expanduser(os.path.expandvars(ca_cert))) for ca_cert
                         in self.ca_certificates]
             self.pkcs12.set_ca_certificates(ca_certs)
 

--- a/test/sanity/code-smell/use-argspec-type-path.py
+++ b/test/sanity/code-smell/use-argspec-type-path.py
@@ -23,6 +23,7 @@ def main():
         'lib/ansible/modules/web_infrastructure/jenkins_plugin.py',
         'lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py',
         'lib/ansible/modules/crypto/certificate_complete_chain.py',  # would need something like type=list(path)
+        'lib/ansible/modules/crypto/openssl_pkcs12.py',  # would need something like type=list(path)
         # fix uses of expanduser in the following modules and remove them from the following list
         'lib/ansible/modules/cloud/rackspace/rax.py',
         'lib/ansible/modules/cloud/rackspace/rax_scaling_group.py',


### PR DESCRIPTION
##### SUMMARY
Fixes #50424 directly for stable-2.7 (as suggested by @ganeshrn), since this will be fixed for 2.8 via #48473. (The fix is similar to related code in `certificate_complete_chain`.)

CC @MarkusTeufelberger

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12
