### PR TITLE
Backport #50448 that will fix "Authentication timeout" errors.

### DIFF
--- a/changelogs/fragments/50448-paramiko_ssh_add_auth_timeout.yaml
+++ b/changelogs/fragments/50448-paramiko_ssh_add_auth_timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - paramiko_ssh - add auth_timeout parameter to ssh.connect when supported by installed paramiko version. This will prevent "Authentication timeout" errors when a slow authentication step (>30s) happens with a host (https://github.com/ansible/ansible/issues/42596)

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -137,6 +137,7 @@ import sys
 import re
 
 from termios import tcflush, TCIFLUSH
+from distutils.version import LooseVersion
 from binascii import hexlify
 
 from ansible import constants as C
@@ -326,7 +327,7 @@ class Connection(ConnectionBase):
                     pass  # file was not found, but not required to function
             ssh.load_system_host_keys()
 
-        sock_kwarg = self._parse_proxy_command(port)
+        ssh_connect_kwargs = self._parse_proxy_command(port)
 
         ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
 
@@ -340,6 +341,10 @@ class Connection(ConnectionBase):
             if self._play_context.private_key_file:
                 key_filename = os.path.expanduser(self._play_context.private_key_file)
 
+            # paramiko 2.2 introduced auth_timeout parameter
+            if LooseVersion(paramiko.__version__) >= LooseVersion('2.2.0'):
+                ssh_connect_kwargs['auth_timeout'] = self._play_context.timeout
+
             ssh.connect(
                 self._play_context.remote_addr.lower(),
                 username=self._play_context.remote_user,
@@ -349,7 +354,7 @@ class Connection(ConnectionBase):
                 password=self._play_context.password,
                 timeout=self._play_context.timeout,
                 port=port,
-                **sock_kwarg
+                **ssh_connect_kwargs
             )
         except paramiko.ssh_exception.BadHostKeyException as e:
             raise AnsibleConnectionFailure('host key mismatch for %s' % e.hostname)


### PR DESCRIPTION
Backport of #50448

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add auth_timeout parameter when supported

Paramiko 2.2 introduces the auth_timeout parameter. This will set the
parameter to the same value of the timeout parameter to prevent
"Authentication timeout" errors.

(cherry picked from commit e7f21dd1af2429a09c698e0fc5914e1656cd48a3)

Conditionally add auth_timeout to ssh.connect

Renamed sock_kwarg to ssh_connect_kwargs and conditionally added the
auth_timeout parameter based on the installed paramiko version.

(cherry picked from commit 6c41e97eeedf123e4aa88c5b42b4214c419fc70f)

Add changelog fragment

(cherry picked from commit 7679a92db74801dd8f404abb2d9cd2c973e9d8cf)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
paramiko_ssh


