### PR TITLE
Add the "probe" filter to dig into an array or a hash

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -514,9 +514,9 @@ def probe(data, *args):
     path = 'probed_object'
     for i in args:
         if isinstance(i, int):
-            path += "[{}]".format(str(i))
+            path += "[{0}]".format(str(i))
         else:
-            path += "['{}']".format(str(i))
+            path += "['{0}']".format(str(i))
         try:
             result = result[i]
         except (TypeError, IndexError, KeyError) as e:

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- include_tasks: probe.yml
+
 - name: a dummy task to test the changed and success filters
   shell: echo hi
   register: some_registered_var

--- a/test/integration/targets/filters/tasks/probe.yml
+++ b/test/integration/targets/filters/tasks/probe.yml
@@ -1,21 +1,14 @@
 ---
-- name: a dummy variable to test the filter probe
-  set_fact:
-    some_var:
-      key1: begin
-      key2:
-        - foo
-        - bar
-        - subkey1: v1
-          subkey2: v2
-      key3: end
-
-- name: check that the value v2 is well reached
+- name: some checks on the probe() filter
+  some_var:
+    key1: begin
+    key2:
+      - foo
+      - bar
+      - subkey1: v1
+        subkey2: v2
+    key3: end
   assert:
     that:
       - some_var | probe('key2', 2, 'subkey2') == 'v2'
-
-- name: check it's OK with a bad path and the default() filter
-  assert:
-    that:
       - some_var | probe('key2', 4, 'subkey2') | default('N/A') == 'N/A'

--- a/test/integration/targets/filters/tasks/probe.yml
+++ b/test/integration/targets/filters/tasks/probe.yml
@@ -1,0 +1,19 @@
+---
+- name: a dummy variable to test the filter probe
+  set_fact:
+    some_var:
+      key1: begin
+      key2:
+        - foo
+        - bar
+        - subkey1: v1
+          subkey2: v2
+      key3: end
+
+- name: check that the value v2 is well reached
+  assert:
+    that:
+      - "some_var | probe('key2', 2, 'subkey2') == 'v2'"
+
+- name: check it's OK with a bad path and the default() filter
+      - "some_var | probe('key2', 4, 'subkey2') | default('N/A') == 'N/A'"

--- a/test/integration/targets/filters/tasks/probe.yml
+++ b/test/integration/targets/filters/tasks/probe.yml
@@ -13,9 +13,9 @@
 - name: check that the value v2 is well reached
   assert:
     that:
-      - "some_var | probe('key2', 2, 'subkey2') == 'v2'"
+      - some_var | probe('key2', 2, 'subkey2') == 'v2'
 
 - name: check it's OK with a bad path and the default() filter
   assert:
     that:
-      - "some_var | probe('key2', 4, 'subkey2') | default('N/A') == 'N/A'"
+      - some_var | probe('key2', 4, 'subkey2') | default('N/A') == 'N/A'

--- a/test/integration/targets/filters/tasks/probe.yml
+++ b/test/integration/targets/filters/tasks/probe.yml
@@ -1,14 +1,15 @@
 ---
-- name: some checks on the probe() filter
-  some_var:
-    key1: begin
-    key2:
-      - foo
-      - bar
-      - subkey1: v1
-        subkey2: v2
-    key3: end
+- name: Test the probe() filter
   assert:
     that:
       - some_var | probe('key2', 2, 'subkey2') == 'v2'
       - some_var | probe('key2', 4, 'subkey2') | default('N/A') == 'N/A'
+  vars:
+    some_var:
+      key1: begin
+      key2:
+        - foo
+        - bar
+        - subkey1: v1
+          subkey2: v2
+      key3: end

--- a/test/integration/targets/filters/tasks/probe.yml
+++ b/test/integration/targets/filters/tasks/probe.yml
@@ -16,4 +16,6 @@
       - "some_var | probe('key2', 2, 'subkey2') == 'v2'"
 
 - name: check it's OK with a bad path and the default() filter
+  assert:
+    that:
       - "some_var | probe('key2', 4, 'subkey2') | default('N/A') == 'N/A'"


### PR DESCRIPTION
##### SUMMARY

This PR adds the ~`dig`~ `probe` filter in native filters.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Ansible core.

##### ADDITIONAL INFORMATION

The ~`dig`~ `probe` filter returns a value for a sequence of given keys/indexes into a structure, such as an array or hash. The first encountered undefined value or key stops the dig and None is returned. For instance:

    {{ data | probe("key1", 2, "b" }}

is roughly equivalent to:

    {{ data["key1"][2]["b"] }}

However a standard index will return an error if any parent of the final key
"b" is undefined, the function will just return `Undefined` in this case, without to handle any error.