### PR TITLE
Make Service Plan configurable for AZ Service Functions

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
@@ -34,6 +34,11 @@ options:
     location:
         description:
             - Valid Azure location. Defaults to location of the resource group.
+    plan: 
+        description:
+            - "It can be resource id of existing app service plan. eg.,
+              /subscriptions/<subs_id>/resourceGroups/<resource_group>/providers/Microsoft.Web/serverFarms/<plan_name>"
+        required: false            
     storage_account:
         description:
             - Name of the storage account to use.
@@ -145,6 +150,7 @@ class AzureRMFunctionApp(AzureRMModuleBase):
             name=dict(type='str', required=True),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             location=dict(type='str'),
+            plan=dict(type='str', required=False),
             storage_account=dict(
                 type='str',
                 aliases=['storage', 'storage_account_name']
@@ -160,6 +166,7 @@ class AzureRMFunctionApp(AzureRMModuleBase):
         self.resource_group = None
         self.name = None
         self.state = None
+        self.plan = None
         self.location = None
         self.storage_account = None
         self.app_settings = None
@@ -218,7 +225,8 @@ class AzureRMFunctionApp(AzureRMModuleBase):
                     site_config=SiteConfig(
                         app_settings=self.aggregated_app_settings(),
                         scm_type='LocalGit'
-                    )
+                    ),
+                    server_farm_id=self.plan
                 )
                 self.results['changed'] = True
             else:

--- a/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
@@ -39,7 +39,7 @@ options:
             - "It can be resource id of existing app service plan. eg.,
               /subscriptions/<subs_id>/resourceGroups/<resource_group>/providers/Microsoft.Web/serverFarms/<plan_name>"
         required: false
-        version_added: '2.8'            
+        version_added: '2.8'
     storage_account:
         description:
             - Name of the storage account to use.

--- a/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
@@ -34,11 +34,12 @@ options:
     location:
         description:
             - Valid Azure location. Defaults to location of the resource group.
-    plan: 
+    plan:
         description:
             - "It can be resource id of existing app service plan. eg.,
               /subscriptions/<subs_id>/resourceGroups/<resource_group>/providers/Microsoft.Web/serverFarms/<plan_name>"
-        required: false            
+        required: false
+        version_added: '2.8'            
     storage_account:
         description:
             - Name of the storage account to use.

--- a/test/integration/targets/azure_rm_functionapp/tasks/main.yml
+++ b/test/integration/targets/azure_rm_functionapp/tasks/main.yml
@@ -20,7 +20,7 @@
     resource_group: '{{ resource_group }}'
     name: af{{ fixed_resource_prefix }}
     storage_account: sa{{ fixed_resource_prefix }}
-    plan: '{{outputsp[id]}}'
+    plan: outputsp.id
   register: output
 
 - name: assert the function was created

--- a/test/integration/targets/azure_rm_functionapp/tasks/main.yml
+++ b/test/integration/targets/azure_rm_functionapp/tasks/main.yml
@@ -2,6 +2,12 @@
   set_fact:
     fixed_resource_prefix: "{{ (resource_prefix | replace('-','x'))[-22:] }}"
 
+- name: Create a app service plan
+  azure_rm_appserviceplan:
+    resource_group: '{{ resource_group }}'
+    name: "sp{{ fixed_resource_prefix }}"
+  register: outputsp
+
 - name: create storage account for function apps
   azure_rm_storageaccount:
     resource_group: '{{ resource_group }}'
@@ -13,6 +19,7 @@
     resource_group: '{{ resource_group }}'
     name: af{{ fixed_resource_prefix }}
     storage_account: sa{{ fixed_resource_prefix }}
+    plan: "{{outputsp[id]}}"
   register: output
 
 - name: assert the function was created

--- a/test/integration/targets/azure_rm_functionapp/tasks/main.yml
+++ b/test/integration/targets/azure_rm_functionapp/tasks/main.yml
@@ -6,6 +6,7 @@
   azure_rm_appserviceplan:
     resource_group: '{{ resource_group }}'
     name: "sp{{ fixed_resource_prefix }}"
+    sku: S1
   register: outputsp
 
 - name: create storage account for function apps
@@ -19,7 +20,7 @@
     resource_group: '{{ resource_group }}'
     name: af{{ fixed_resource_prefix }}
     storage_account: sa{{ fixed_resource_prefix }}
-    plan: "{{outputsp[id]}}"
+    plan: '{{outputsp[id]}}'
   register: output
 
 - name: assert the function was created


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make azure app plan configurable for azure functions

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_functionapp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Currently, Azure functions can't be assigned a web app plan during creation. With this change, you can now use other than pay as you go web app plans. 
