### PR TITLE
tqm._initialize_notified_handlers() is noop now

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -110,26 +110,6 @@ class TaskQueueManager:
         for i in range(num):
             self._workers.append(None)
 
-    def _initialize_notified_handlers(self, play):
-        '''
-        Clears and initializes the shared notified handlers dict with entries
-        for each handler in the play, which is an empty array that will contain
-        inventory hostnames for those hosts triggering the handler.
-        '''
-
-        def _process_block(b):
-            temp_list = []
-            for t in b.block:
-                if isinstance(t, Block):
-                    temp_list.extend(_process_block(t))
-                else:
-                    temp_list.append(t)
-            return temp_list
-
-        handler_list = []
-        for handler_block in play.handlers:
-            handler_list.extend(_process_block(handler_block))
-
     def load_callbacks(self):
         '''
         Loads all available callbacks, with the exception of those which
@@ -225,9 +205,6 @@ class TaskQueueManager:
                 callback_plugin.set_play_context(play_context)
 
         self.send_callback('v2_playbook_on_play_start', new_play)
-
-        # initialize the shared dictionary containing the notified handlers
-        self._initialize_notified_handlers(new_play)
 
         # build the iterator
         iterator = PlayIterator(

--- a/test/units/plugins/strategy/test_strategy_base.py
+++ b/test/units/plugins/strategy/test_strategy_base.py
@@ -525,7 +525,6 @@ class TestStrategyBase(unittest.TestCase):
             forks=5,
         )
         tqm._initialize_processes(3)
-        tqm._initialize_notified_handlers(mock_play)
         tqm.hostvars = dict()
 
         try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Missed in https://github.com/ansible/ansible/pull/49338?
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/executor/task_queue_manager.py
