### PR TITLE
iam_role tags support

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -507,7 +507,7 @@ def update_role_tags(connection, module):
         return False, {}
 
     if not hasattr(connection, 'list_role_tags'):
-        module.fail_json(msg='You need at least boto3 1.9.54 to manage IAM role tags')
+        module.fail_json(msg='You need at least boto3 1.9.83 to manage IAM role tags')
 
     role_name = module.params.get('name')
     purge_tags = module.params.get('purge_tags')

--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -504,7 +504,7 @@ def get_attached_policy_list(connection, module, name):
 def update_role_tags(connection, module):
     new_tags = module.params.get('tags')
     if new_tags is None:
-        return False
+        return False, {}
 
     if not hasattr(connection, 'list_role_tags'):
         module.fail_json(msg='You need at least boto3 1.9.54 to manage IAM role tags')


### PR DESCRIPTION
##### SUMMARY
Added tags support to `iam_role`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib.ansible.modules.cloud.amazon.iam_role`

##### ADDITIONAL INFORMATION
```yaml
- name: Create a role with description and tags
  iam_role:
    name: mynewrole
    assume_role_policy_document: "{{ lookup('file','policy.json') }}"
    description: This is My New Role
    tags:
      env: dev
```
