### PR TITLE
[WIP] Fieldattribute inheritance with defaults

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -20,17 +20,23 @@ from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, Ansible
 from ansible.module_utils._text import to_text, to_native
 from ansible.playbook.attribute import Attribute, FieldAttribute
 from ansible.parsing.dataloader import DataLoader
-from ansible.utils.vars import combine_vars, isidentifier, get_unique_id
 from ansible.utils.display import Display
+from ansible.utils.sentinel import Sentinel
+from ansible.utils.vars import combine_vars, isidentifier, get_unique_id
 
 display = Display()
 
 
 def _generic_g(prop_name, self):
     try:
-        return self._attributes[prop_name]
+        value = self._attributes[prop_name]
     except KeyError:
         raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, prop_name))
+
+    if value is Sentinel:
+        value = self._attr_defaults[prop_name]
+
+    return value
 
 
 def _generic_g_method(prop_name, self):
@@ -49,11 +55,16 @@ def _generic_g_parent(prop_name, self):
             value = self._attributes[prop_name]
         else:
             try:
+                # Note: _get_parent_attributes(prop_name) should never return Sentinel.  It is
+                # responsible for turning Sentinel into the parent's default prior to returning.
                 value = self._get_parent_attribute(prop_name)
             except AttributeError:
                 value = self._attributes[prop_name]
     except KeyError:
         raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, prop_name))
+
+    if value is Sentinel:
+        value = self._attr_defaults[prop_name]
 
     return value
 
@@ -105,7 +116,8 @@ class BaseMeta(type):
 
                     dst_dict[attr_name] = property(getter, setter, deleter)
                     dst_dict['_valid_attrs'][attr_name] = value
-                    dst_dict['_attributes'][attr_name] = value.default
+                    dst_dict['_attributes'][attr_name] = Sentinel
+                    dst_dict['_attr_defaults'] = value.default
 
                     if value.alias is not None:
                         dst_dict[value.alias] = property(getter, setter, deleter)
@@ -125,9 +137,10 @@ class BaseMeta(type):
                     _process_parents(parent.__bases__, new_dst_dict)
 
         # create some additional class attributes
-        dct['_attributes'] = dict()
-        dct['_valid_attrs'] = dict()
-        dct['_alias_attrs'] = dict()
+        dct['_attributes'] = {}
+        dct['_attr_defaults'] = {}
+        dct['_valid_attrs'] = {}
+        dct['_alias_attrs'] = {}
 
         # now create the attributes based on the FieldAttributes
         # available, including from parent (and grandparent) objects

--- a/lib/ansible/utils/sentinel.py
+++ b/lib/ansible/utils/sentinel.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class Sentinel:
+    """
+    Object which can be used to mark whether an entry as being special
+
+    A sentinel value demarcates a value or marks an entry as having a special meaning.  In C, the
+    Null byte is used as a sentinel for the end of a string.  In Python, None is often used as
+    a Sentinel in optional parameters to mean that the parameter was not set by the user.
+
+    You should use None as a Sentinel value any Python code where None is not a valid entry.  If
+    None is a valid entry, though, then you need to create a different value, which is the purpose
+    of this class.
+
+    Example of using Sentinel as a default parameter value::
+
+        def confirm_big_red_button(tristate=Sentinel):
+            if tristate is Sentinel:
+                print('You must explicitly press the big red button to blow up the base')
+            elif tristate is True:
+                print('Countdown to destruction activated')
+            elif tristate is False:
+                print('Countdown stopped')
+            elif tristate is None:
+                print('Waiting for more input')
+
+    Example of using Sentinel to tell whether a dict which has a default value has been changed::
+
+        values = {'one': Sentinel, 'two': Sentinel}
+        defaults = {'one': 1, 'two': 2}
+
+        # [.. Other code which does things including setting a new value for 'one' ..]
+        values['one'] = None
+        # [..]
+
+        print('You made changes to:')
+        for key, value in values.items():
+            if value is Sentinel:
+                continue
+            print('%s: %s' % (key, value)
+    """
+
+    def __new__(cls):
+        """
+        Return the cls itself.  This makes both equality and identity True for comparing the class
+        to an instance of the class, preventing common usage errors.
+
+        Preferred usage::
+
+            a = Sentinel
+            if a is Sentinel:
+                print('Sentinel value')
+
+        However, these are True as well, eliminating common usage errors::
+
+            if Sentinel is Sentinel():
+                print('Sentinel value')
+
+            if Sentinel == Sentinel():
+                print('Sentinel value')
+        """
+        return cls

--- a/test/integration/targets/check_mode/check_mode-not-on-cli.yml
+++ b/test/integration/targets/check_mode/check_mode-not-on-cli.yml
@@ -1,0 +1,37 @@
+---
+# Run withhout --check
+- hosts: localhost
+  gather_facts: False
+  tasks:
+  - command: 'echo ran'
+    register: command_out
+
+  - debug: var=command_out
+  - name: check that this did not run in check mode
+    assert:
+      that:
+      - '"ran" in command_out["stdout"]'
+
+- hosts: localhost
+  gather_facts: False
+  check_mode: True
+  tasks:
+  - command: 'echo ran'
+    register: command_out
+
+  - name: check that play level check_mode overrode the cli
+    assert:
+      that:
+      - '"check mode" in command_out["msg"]'
+
+- hosts: localhost
+  gather_facts: False
+  tasks:
+  - command: 'echo ran'
+    register: command_out
+    check_mode: True
+
+  - name: check that task level check_mode overrode the cli
+    assert:
+      that:
+      - '"check mode" in command_out["msg"]'

--- a/test/integration/targets/check_mode/check_mode-on-cli.yml
+++ b/test/integration/targets/check_mode/check_mode-on-cli.yml
@@ -1,0 +1,36 @@
+---
+# Run with --check
+- hosts: localhost
+  gather_facts: False
+  tasks:
+  - command: 'echo ran'
+    register: command_out
+
+  - name: check that this did not run in check mode
+    assert:
+      that:
+      - '"check mode" in command_out["msg"]'
+
+- hosts: localhost
+  gather_facts: False
+  check_mode: False
+  tasks:
+  - command: 'echo ran'
+    register: command_out
+
+  - name: check that play level check_mode overrode the cli
+    assert:
+      that:
+      - '"ran" in command_out["stdout"]'
+
+- hosts: localhost
+  gather_facts: False
+  tasks:
+  - command: 'echo ran'
+    register: command_out
+    check_mode: False
+
+  - name: check that task level check_mode overrode the cli
+    assert:
+      that:
+      - '"ran" in command_out["stdout"]'

--- a/test/integration/targets/check_mode/check_mode.yml
+++ b/test/integration/targets/check_mode/check_mode.yml
@@ -1,4 +1,5 @@
-- hosts: testhost
+- name: Test that check works with check_mode specified in roles
+  hosts: testhost
   vars:
   - output_dir: .
   roles:

--- a/test/integration/targets/check_mode/runme.sh
+++ b/test/integration/targets/check_mode/runme.sh
@@ -3,3 +3,5 @@
 set -eux
 
 ansible-playbook check_mode.yml -i ../../inventory -v --check "$@"
+ansible-playbook check_mode-on-cli.yml -i ../../inventory -v --check "$@"
+ansible-playbook check_mode-not-on-cli.yml -i ../../inventory -v "$@"


### PR DESCRIPTION
##### SUMMARY
Fixing non-None default FieldAttributes

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py

##### ADDITIONAL INFORMATION
The goal is to be able to write code like this (or a non-ugly workaround which does the same thing):
``` python
    class Base(FieldAttributeBase):
        _check_mode = FieldAttribute([..] default=lambda: context.CLIARGS['check'])
    
    class Play(Base):
        # lambda so that we have a chance to parse the command line args
        # before we get here.  In the future we might be able to restructure
        # this so that the cli parsing code runs before these classes are
        # defined.
    
    class Task(Base):
        pass
 ```   
 And still have a playbook like this function:
 ``` yaml
    ---
    - hosts:
      tasks:
      - command: whoami
        check_mode: True
```