### PR TITLE
ufw: fix spurious integration test breaks

### DIFF
--- a/test/integration/targets/ufw/tasks/main.yml
+++ b/test/integration/targets/ufw/tasks/main.yml
@@ -21,6 +21,12 @@
 
   # Cleanup
   always:
+  - pause:
+      # ufw creates backups of the rule files with a timestamp; if reset is called
+      # twice in a row fast enough (so that both timestamps are taken in the same second),
+      # the second call will notice that the backup files are already there and fail.
+      # Waiting one second fixes this problem.
+      seconds: 1
   - name: Reset ufw to factory defaults and disable
     ufw:
       state: reset

--- a/test/integration/targets/ufw/tasks/run-test.yml
+++ b/test/integration/targets/ufw/tasks/run-test.yml
@@ -1,4 +1,10 @@
 ---
+- pause:
+    # ufw creates backups of the rule files with a timestamp; if reset is called
+    # twice in a row fast enough (so that both timestamps are taken in the same second),
+    # the second call will notice that the backup files are already there and fail.
+    # Waiting one second fixes this problem.
+    seconds: 1
 - name: Reset ufw to factory defaults
   ufw:
     state: reset


### PR DESCRIPTION
##### SUMMARY
Two consecutive `ufw reset` calls can lead to failure (due to same timestamp being used for backup files). This seems to happen spuriously for cleanup (see https://app.shippable.com/github/ansible/ansible/runs/101343/44/tests for an example).

Adding delays should fix and prevent this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
