### PR TITLE
[stable-2.7] Add AIX support to reboot module (#50353)

### DIFF
--- a/changelogs/fragments/reboot-add-aix-support.yml
+++ b/changelogs/fragments/reboot-add-aix-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - add support for rebooting AIX (https://github.com/ansible/ansible/issues/49712)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -52,6 +52,7 @@ class ActionModule(ActionBase):
         'solaris': 'who -b',
         'sunos': 'who -b',
         'vmkernel': 'grep booted /var/log/vmksummary.log | tail -n 1',
+        'aix': 'who -b',
     }
 
     SHUTDOWN_COMMANDS = {
@@ -68,6 +69,7 @@ class ActionModule(ActionBase):
         'solaris': '-y -g {delay_sec} -i 6 "{message}"',
         'sunos': '-y -g {delay_sec} -i 6 "{message}"',
         'vmkernel': '-d {delay_sec}',
+        'aix': '-Fr',
     }
 
     TEST_COMMANDS = {


### PR DESCRIPTION
##### SUMMARY

* Add ability for reboot module to work for AIX

(cherry picked from commit 1dac10e5c3e362d6eace6ddb7bd42c5de48b6b2d)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`