### PR TITLE
Docs: Make module handle its own exit

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -156,7 +156,7 @@ To create a new module:
         # want to make any changes to the environment, just return the current
         # state with no modifications
         if module.check_mode:
-            return result
+            module.exit_json(**result)
 
         # manipulate or modify the state as needed (this is going to be the
         # part where your module will do what it needs to do)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix code for provided sample module when using check mode.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Docs.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->

When I execute the sample module it succeed:

```bash
$ ansible -i inventory -m my_sample_module all -a name=name
localhost | SUCCESS => {
    "changed": false, 
    "message": "goodbye", 
    "original_message": "name"
}
```

But when I execute in `--check` mode I got an error:

```bash
$ ansible -i inventory -m my_sample_module all -a name=name --check
localhost | FAILED! => {
    "changed": false, 
    "msg": "New-style module did not handle its own exit"
}
```

This PR solves this issue.

```bash
$ ansible -i inventory -m my_sample_module all -a name=name --check
localhost | SUCCESS => {
    "changed": false, 
    "message": "", 
    "original_message": ""
}
```
