### PR TITLE
Documentation Mistake rule_desc

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -187,7 +187,7 @@ EXAMPLES = '''
         cidr_ipv6: 64:ff9b::/96
         group_name: example-other
         # description to use if example-other needs to be created
-        group_desc: other example EC2 group
+        rule_desc: other example EC2 group
 
 - name: example2 ec2 group
   ec2_group:


### PR DESCRIPTION
The documentation shows group_desc under a rule which is incorrect. The correct name is rule_desc

+label: docsite_pr

##### SUMMARY
The documentation shows group_desc under a rule which is incorrect. The correct name is rule_desc


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_group

##### ADDITIONAL INFORMATION
Simple documentation mistake. The usage error reflects the correct usage which is how I figured out the mistake.
