### PR TITLE
Fix: lxca_nodes misspelled in the lxca_common.py

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/lxca_common.py
+++ b/lib/ansible/utils/module_docs_fragments/lxca_common.py
@@ -53,7 +53,7 @@ options:
       lxca https full web address
     required: true
 
-requirement:
+requirements:
   - pylxca
 
 notes:


### PR DESCRIPTION
##### SUMMARY

In the `lib/ansible/modules/remote_management/lxca/lxca_nodes.py`,
`requirements:` misspelled as `requirement:`

* [Module format and documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html)

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- lxca_nodes
