### PR TITLE
[stable-2.6] 🚸 🐍 🍒 ⛏ Integrate cherry picker (#41403)

### DIFF
--- a/.cherry_picker.toml
+++ b/.cherry_picker.toml
@@ -1,0 +1,5 @@
+team = "ansible"
+repo = "ansible"
+check_sha = "f31421576b00f0b167cdbe61217c31c21a41ac02"  # the very first commit in repo
+fix_commit_msg = false  # Don't replace "#" with "GH-"
+default_branch = "devel"

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -82,6 +82,13 @@ pull request to backport the change to a previous stable branch.
     but it can be helpful, especially when making multiple backport PRs for
     multiple stable branches.
 
+.. note::
+
+    If you prefer, you can use CPython's cherry-picker tool to backport commits
+    from devel to stable branches in Ansible. Take a look at the `cherry-picker
+    documentation <https://pypi.org/p/cherry-picker#cherry-picking>`_ for
+    details on installing, configuring, and using it.
+
 
 Ansibullbot
 ===========


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] 🚸 🐍 🍒 ⛏ Integrate cherry picker (#41403)

This enables developers to use cherry-picker for backporting purposes.
This tool originally comes from Core Python Development Workflow.

Ref: https://pypi.org/p/cherry-picker
Ref: https://github.com/python/core-workflow/tree/master/cherry_picker

Also:
* 📝 Add docs about supporting cherry-picker
(cherry picked from commit 97cc0cce7f53b704f8541530e42d5e515584cd95)

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

cherry picker
