### PR TITLE
[stable-2.6] Disable retry files for integration tests.

### DIFF
--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -40,6 +40,7 @@ def ansible_environment(args, color=True):
         ANSIBLE_FORCE_COLOR='%s' % 'true' if args.color and color else 'false',
         ANSIBLE_DEPRECATION_WARNINGS='false',
         ANSIBLE_HOST_KEY_CHECKING='false',
+        ANSIBLE_RETRY_FILES_ENABLED='false',
         ANSIBLE_CONFIG=os.path.abspath(ansible_config),
         ANSIBLE_LIBRARY='/dev/null',
         PYTHONPATH=os.path.abspath('lib'),


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Disable retry files for integration tests.

(cherry picked from commit 39824f50b10f7deb6be2a31eac01cc6393d7248e)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
