### PR TITLE
Docs: Fix highlight line

### DIFF
--- a/docs/docsite/_static/pygments.css
+++ b/docs/docsite/_static/pygments.css
@@ -1,5 +1,5 @@
 .highlight { background: #f8f8f8 }
-.highlight .hll { background-color: #ffffcc; border: 1px solid #ccc; padding: 6px 10px; border-radius: 3px }
+.highlight .hll { background-color: #ffffcc; border: 1px solid #edff00; padding-top: 2px; border-radius: 3px; display: block }
 .highlight .c { color: #6a737d; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2; color: #a61717; border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #007020; font-weight: bold } /* Keyword */


### PR DESCRIPTION
##### SUMMARY
This PR fixes a visual issue with CSS hll (highlight line)

Before:
![screenshot from 2019-01-10 11-45-34](https://user-images.githubusercontent.com/388198/50963606-7b3da700-14cd-11e9-956d-fbc9868eb275.png)

After:
![screenshot from 2019-01-10 11-45-19](https://user-images.githubusercontent.com/388198/50963633-87c1ff80-14cd-11e9-8642-340a280b906a.png)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite