### PR TITLE
Update the NuGet package provider when needed

### DIFF
--- a/lib/ansible/modules/windows/win_psrepository.ps1
+++ b/lib/ansible/modules/windows/win_psrepository.ps1
@@ -1,7 +1,7 @@
 #!powershell
 
-# Copyright: (c) 2017, Daniele Lazzari <lazzari@mailup.com>
 # Copyright: (c) 2018, Wojciech Sciesinski <wojciech[at]sciesinski[dot]net>
+# Copyright: (c) 2017, Daniele Lazzari <lazzari@mailup.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
@@ -18,9 +18,14 @@ $installationpolicy = Get-AnsibleParam -obj $params -name "installation_policy" 
 
 $result = @{"changed" = $false}
 
+$PackageProvider = Get-PackageProvider -ListAvailable | Where-Object { ($_.name -eq 'Nuget') -and ($_.version -ge "2.8.5.201") }
+if ($null -eq $PackageProvider) {
+    Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies -Force | Out-Null
+}
+
 $Repo = Get-PSRepository -Name $name -ErrorAction Ignore
 if ($state -eq "present") {
-    if ($null -eq $Repo){
+    if ($null -eq $Repo) {
         if ($null -eq $installationpolicy) {
             $installationpolicy = "trusted"
         }

--- a/test/integration/targets/win_psrepository/tasks/main.yml
+++ b/test/integration/targets/win_psrepository/tasks/main.yml
@@ -13,18 +13,6 @@
   when: powershell_major_version.stdout | int >= 5
   block:
 
-    - name: update NuGet version
-      win_shell: |
-        $nuget_exists = (Get-PackageProvider | Where-Object { $_.Name -eq 'Nuget' } | Measure-Object).Count -eq 1
-
-        if ( $nuget_exists ) {
-          $nuget_outdated = (Get-PackageProvider -Name NuGet -ErrorAction Ignore).Version -lt [Version]"2.8.5.201"
-        }
-
-        if ( -not $nuget_exists -or $nuget_outdated ) {
-          Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-        }
-
     - name: ensure test repository is deleted
       win_psrepository:
         name: '{{ repository_name }}'


### PR DESCRIPTION
##### SUMMARY
Under adding a repository the NuGet package provider in the version 2.8.5.201 or newer is required. When it's not available the win_psrepository fails.

The operations of check and update the NuGet are added to the code to resolve that.

Fixes partially #50332 - for Ansible 2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psrepository