### PR TITLE
Bugfix plugins/inventory/netbox.py: Virtual machines do not have 'device_roles'

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -243,7 +243,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def extract_device_role(self, host):
         try:
-            return [self.device_roles_lookup[host["device_role"]["id"]]]
+            if 'device_role' in host:
+                return [self.device_roles_lookup[host["device_role"]["id"]]]
+            elif 'role' in host:
+                return [self.device_roles_lookup[host["role"]["id"]]]
         except Exception:
             return
 


### PR DESCRIPTION
##### SUMMARY
Virtual machines do not have 'device_roles', but instead use 'roles'. This commit makes sure that 'roles' show up as 'device_roles' when using virtual machines in Netbox

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
netbox

#####ADDITIONAL INFO
Will be obsolete when this PR is merged at netbox
https://github.com/digitalocean/netbox/issues/2199
