### PR TITLE
Fixed bug in the error checking mechanism.  Use variable instead hardcode

### DIFF
--- a/lib/ansible/modules/system/selinux.py
+++ b/lib/ansible/modules/system/selinux.py
@@ -148,7 +148,7 @@ def set_state(module, state):
 
 
 def set_config_policy(module, policy, configfile):
-    if not os.path.exists(configfile):):
+    if not os.path.exists(configfile):
         module.fail_json(msg='Specified policy file %s does not exist' % configfile)
 
     # edit config file with state value

--- a/lib/ansible/modules/system/selinux.py
+++ b/lib/ansible/modules/system/selinux.py
@@ -148,8 +148,8 @@ def set_state(module, state):
 
 
 def set_config_policy(module, policy, configfile):
-    if not os.path.exists('/etc/selinux/%s/policy' % policy):
-        module.fail_json(msg='Policy %s does not exist in /etc/selinux/' % policy)
+    if not os.path.exists(configfile):):
+        module.fail_json(msg='Specified policy file %s does not exist' % configfile)
 
     # edit config file with state value
     # SELINUXTYPE=targeted


### PR DESCRIPTION
By default module is working and expect configuration to be at /etc/selinux/config. It also allow the operator to override this file by passing `config: /path/to/file` parameter.

Even the operator is passing different config the error checking in the set_config_policy function entry is using hardcoded value '/etc/selinux/%s/policy'

In this way on systems where such file/dir does not exist check will always file regardless of the operator-specified config file

Fix is simple. Just check for configfile instead of /etc/selinux/%s/policy

