### PR TITLE
win_chocolatey.py -  Clarify usage of version-variable

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -195,6 +195,8 @@ options:
     - Specific version of the package to be installed.
     - When I(state) is set to C(absent), will uninstall the specific version
       otherwise all versions of that package will be removed.
+    - If a different version of package is installed, I(state) must be C(latest)
+      or I(force) set to C(yes) to install the desired version.
     - Provide as a string (e.g. C('6.1')), otherwise it is considered to be
       a floating-point number and depending on the locale could become C(6,1),
       which will cause a failure.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated doc for `win_chocolatey` when using `version`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`win_chocolatey`

##### ADDITIONAL INFORMATION
When upgrading from `2.6` to `2.7.5`, we noticed that usage of `win_chocolatey` with `version` startet failing if a _lower_ or _higher_ version of the package was already installed. On `2.6`, it just returned `OK`. The message printet now says (from the `.ps1` script): 
```
Chocolatey package '$package' is already installed with version(s) '$($package_versions -join "', '")' but was expecting '$version'. Either change the expected version, set state=latest, set allow_multiple=yes, or set force=yes to continue"
```

This PR just updates the doc with this information. 

