### PR TITLE
uri module improvements

### DIFF
--- a/changelogs/fragments/50771-uri-improvements.yml
+++ b/changelogs/fragments/50771-uri-improvements.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- uri - Eliminate multiple requests to determine the final URL for file naming with ``dest``
+- uri - Avoid reading the response body when not needed

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -37,7 +37,6 @@ __metaclass__ = type
 
 import atexit
 import base64
-import cgi
 import email.mime.multipart
 import email.mime.nonmultipart
 import email.mime.application
@@ -762,13 +761,8 @@ def get_response_filename(response):
     filename = os.path.basename(path.rstrip('/')) or None
     if filename:
         filename = unquote(filename)
-    
-    content_disposition = response.headers.get('content-disposition')
-    if content_disposition:
-        mime_type, params = cgi.parse_header(content_disposition)
-        filename = params.get('filename') or filename
-    
-    return filename
+
+    return response.headers.get_param('filename', header='content-disposition') or filename
 
 
 class RequestWithMethod(urllib_request.Request):

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -90,7 +90,7 @@ except ImportError:
 urllib_request.HTTPRedirectHandler.http_error_308 = urllib_request.HTTPRedirectHandler.http_error_307
 
 try:
-    from ansible.module_utils.six.moves.urllib.parse import urlparse, urlunparse, urlsplit, unquote
+    from ansible.module_utils.six.moves.urllib.parse import urlparse, urlunparse, unquote
     HAS_URLPARSE = True
 except Exception:
     HAS_URLPARSE = False
@@ -758,7 +758,7 @@ def extract_pem_certs(b_data):
 
 def get_response_filename(response):
     url = response.geturl()
-    path = urlsplit(url)[2]
+    path = urlparse(url)[2]
     filename = os.path.basename(path.rstrip('/')) or None
     if filename:
         filename = unquote(filename)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -72,7 +72,7 @@ import ansible.module_utils.six.moves.urllib.request as urllib_request
 import ansible.module_utils.six.moves.urllib.error as urllib_error
 
 from ansible.module_utils.common.collections import Mapping
-from ansible.module_utils.six import PY3, string_types
+from ansible.module_utils.six import PY2, PY3, string_types
 from ansible.module_utils.six.moves import cStringIO
 from ansible.module_utils.basic import get_distribution, missing_required_lib
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -763,6 +763,20 @@ def get_response_filename(response):
         filename = unquote(filename)
 
     return response.headers.get_param('filename', header='content-disposition') or filename
+
+
+def parse_content_type(response):
+    if PY2:
+        get_type = response.headers.gettype
+        get_param = response.headers.getparam
+    else:
+        get_type = response.headers.get_content_type
+        get_param = response.headers.get_param
+
+    content_type = (get_type() or 'application/octet-stream').split(',')[0]
+    main_type, sub_type = content_type.split('/')
+    charset = (get_param('charset') or 'utf-8').split(',')[0]
+    return content_type, main_type, sub_type, charset
 
 
 class RequestWithMethod(urllib_request.Request):
@@ -1823,6 +1837,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except MissingModuleError as e:
         module.fail_json(msg=to_text(e), exception=e.import_traceback)
     except urllib_error.HTTPError as e:
+        r = e
         try:
             body = e.read()
         except AttributeError:
@@ -1838,6 +1853,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         info.update({'msg': to_native(e), 'body': body, 'status': e.code})
 
     except urllib_error.URLError as e:
+        r = e
         code = int(getattr(e, 'code', -1))
         info.update(dict(msg="Request failed: %s" % to_native(e), status=code))
     except socket.error as e:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1842,6 +1842,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
             body = e.read()
         except AttributeError:
             body = ''
+        else:
+            e.close()
 
         # Try to add exception info to the output but don't fail if we can't
         try:
@@ -1853,7 +1855,6 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         info.update({'msg': to_native(e), 'body': body, 'status': e.code})
 
     except urllib_error.URLError as e:
-        r = e
         code = int(getattr(e, 'code', -1))
         info.update(dict(msg="Request failed: %s" % to_native(e), status=code))
     except socket.error as e:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -37,6 +37,7 @@ __metaclass__ = type
 
 import atexit
 import base64
+import cgi
 import email.mime.multipart
 import email.mime.nonmultipart
 import email.mime.application

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -719,6 +719,8 @@ def main():
             content = info.pop('body', b'')
     elif r:
         content = r
+    else:
+        content = None
 
     resp = {}
     resp['redirected'] = info['url'] != url

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -437,7 +437,7 @@ import sys
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule, sanitize_keys
-from ansible.module_utils.six import PY2, iteritems, string_types
+from ansible.module_utils.six import PY2, binary_type, iteritems, string_types
 from ansible.module_utils.six.moves.urllib.parse import urlencode, urlsplit
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common._collections_compat import Mapping, Sequence
@@ -458,12 +458,15 @@ def format_message(err, resp):
     return err + (' %s' % msg if msg else '')
 
 
-def write_file(module, url, dest, content, resp):
+def write_file(module, dest, content, resp):
     # create a tempfile with some test content
     fd, tmpsrc = tempfile.mkstemp(dir=module.tmpdir)
-    f = open(tmpsrc, 'wb')
+    f = os.fdopen(fd, 'wb')
     try:
-        f.write(content)
+        if isinstance(content, binary_type):
+            f.write(content)
+        else:
+            shutil.copyfileobj(content, f)
     except Exception as e:
         os.remove(tmpsrc)
         msg = format_message("Failed to create temporary content file: %s" % to_native(e), resp)
@@ -570,9 +573,7 @@ def form_urlencoded(body):
 def uri(module, url, dest, body, body_format, method, headers, socket_timeout, ca_path, unredirected_headers):
     # is dest is set and is a directory, let's check if we get redirected and
     # set the filename from that url
-    redirected = False
-    redir_info = {}
-    r = {}
+
     src = module.params['src']
     if src:
         try:
@@ -586,26 +587,14 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
         data = body
 
     kwargs = {}
-    if dest is not None:
+    if dest is not None and os.path.isfile(dest):
         # if destination file already exist, only download if file newer
-        if os.path.exists(dest):
-            kwargs['last_mod_time'] = datetime.datetime.utcfromtimestamp(os.path.getmtime(dest))
+        kwargs['last_mod_time'] = datetime.datetime.utcfromtimestamp(os.path.getmtime(dest))
 
     resp, info = fetch_url(module, url, data=data, headers=headers,
                            method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],
                            ca_path=ca_path, unredirected_headers=unredirected_headers,
                            **kwargs)
-
-    if dest is not None and os.path.isdir(dest):
-        filename = get_response_filename(resp) or 'index.html'
-        dest = os.path.join(dest, filename)
-
-    try:
-        content = resp.read()
-    except AttributeError:
-        # there was no content, but the error read()
-        # may have been stored in the info as 'body'
-        content = info.pop('body', '')
 
     if src:
         # Try to close the open file handle
@@ -614,11 +603,7 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
         except Exception:
             pass
 
-    r['redirected'] = redirected or info['url'] != url
-    r.update(redir_info)
-    r.update(info)
-
-    return r, content, dest
+    return resp, info
 
 
 def main():
@@ -704,14 +689,42 @@ def main():
 
     # Make the request
     start = datetime.datetime.utcnow()
-    resp, content, dest = uri(module, url, dest, body, body_format, method,
-                              dict_headers, socket_timeout, ca_path, unredirected_headers)
+    r, info = uri(module, url, dest, body, body_format, method,
+                  dict_headers, socket_timeout, ca_path, unredirected_headers)
+
+    if r and dest is not None and os.path.isdir(dest):
+        filename = get_response_filename(r) or 'index.html'
+        dest = os.path.join(dest, filename)
+
+    content_type = info.get('content-type')
+    content_encoding = 'utf-8'
+    if content_type:
+        content_type, params = cgi.parse_header(content_type)
+        content_encoding = params.get('charset') or content_encoding
+
+    maybe_json = content_type and any(candidate in content_type for candidate in JSON_CANDIDATES)
+    maybe_output = maybe_json or return_content or info['status'] not in status_code
+
+    resp = {}
+    resp['redirected'] = info['url'] != url
+    resp.update(info)
+
     resp['elapsed'] = (datetime.datetime.utcnow() - start).seconds
     resp['status'] = int(resp['status'])
     resp['changed'] = False
 
+    if maybe_output:
+        try:
+            content = r.read()
+        except AttributeError:
+            # there was no content, but the error read()
+            # may have been stored in the info as 'body'
+            content = info.pop('body', '')
+    elif r:
+        content = r
+
     # Write the file out if requested
-    if dest is not None:
+    if r and dest is not None:
         if resp['status'] in status_code and resp['status'] != 304:
             write_file(module, url, dest, content, resp)
             # allow file attribute changes
@@ -734,42 +747,20 @@ def main():
         uresp['location'] = absolute_location(url, uresp['location'])
 
     # Default content_encoding to try
-    content_encoding = 'utf-8'
-    if 'content_type' in uresp:
-        # Handle multiple Content-Type headers
-        charsets = []
-        content_types = []
-        for value in uresp['content_type'].split(','):
-            ct, params = cgi.parse_header(value)
-            if ct not in content_types:
-                content_types.append(ct)
-            if 'charset' in params:
-                if params['charset'] not in charsets:
-                    charsets.append(params['charset'])
-
-        if content_types:
-            content_type = content_types[0]
-            if len(content_types) > 1:
-                module.warn(
-                    'Received multiple conflicting Content-Type values (%s), using %s' % (', '.join(content_types), content_type)
-                )
-        if charsets:
-            content_encoding = charsets[0]
-            if len(charsets) > 1:
-                module.warn(
-                    'Received multiple conflicting charset values (%s), using %s' % (', '.join(charsets), content_encoding)
-                )
-
-        u_content = to_text(content, encoding=content_encoding)
-        if any(candidate in content_type for candidate in JSON_CANDIDATES):
-            try:
-                js = json.loads(u_content)
-                uresp['json'] = js
-            except Exception:
-                if PY2:
-                    sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
+    if maybe_output:
+        if content_type:
+            u_content = to_text(content, encoding=content_encoding)
+            if maybe_json:
+                try:
+                    js = json.loads(u_content)
+                    uresp['json'] = js
+                except Exception:
+                    if PY2:
+                        sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
+        else:
+            u_content = to_text(content, encoding=content_encoding)
     else:
-        u_content = to_text(content, encoding=content_encoding)
+        u_content = None
 
     if module.no_log_values:
         uresp = sanitize_keys(uresp, module.no_log_values, NO_MODIFY_KEYS)

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -726,7 +726,7 @@ def main():
     # Write the file out if requested
     if r and dest is not None:
         if resp['status'] in status_code and resp['status'] != 304:
-            write_file(module, url, dest, content, resp)
+            write_file(module, dest, content, resp)
             # allow file attribute changes
             resp['changed'] = True
             module.params['path'] = dest

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -695,7 +695,6 @@ def main():
         filename = get_response_filename(r) or 'index.html'
         dest = os.path.join(dest, filename)
 
-
     if r:
         content_type, main_type, sub_type, content_encoding = parse_content_type(r)
     else:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -64,7 +64,6 @@ lib/ansible/modules/systemd.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd.py validate-modules:return-syntax-error
 lib/ansible/modules/sysvinit.py validate-modules:return-syntax-error
 lib/ansible/modules/unarchive.py validate-modules:nonexistent-parameter-documented
-lib/ansible/modules/uri.py pylint:disallowed-name
 lib/ansible/modules/uri.py validate-modules:doc-required-mismatch
 lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/user.py validate-modules:doc-default-incompatible-type


### PR DESCRIPTION
##### SUMMARY
Don't perform double requests when dest is a dir

Currently when `dest` is supplied to the `uri` module, and `dest` is a dir, we do some weird double request to try and figure out what the resulting filename will be. Don't do this, instead try to infer from the final URL or headers of the request after the single request is made.

There may be more work to be done here, to dedupe some code in `get_url` as well.

I'd also like to improve `dest` handling to not read the data into a var when not necessary.  Such as only doing it when the `Content-Type` matches a suspected JSON type, or when `return_content` is supplied.

The primary reason for `uri` supporting downloads, is to support request methods other than `GET`, so we may want to recommend `get_url` explicitly for `GET` requests in the `uri` docs as may be more performant.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py
lib/ansible/modules/net_tools/basic/uri.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```