### PR TITLE
setup_deb_repo: Support Ubuntu 18.04

### DIFF
--- a/test/integration/targets/setup_deb_repo/tasks/main.yml
+++ b/test/integration/targets/setup_deb_repo/tasks/main.yml
@@ -28,9 +28,22 @@
     args:
       chdir: "{{ repodir }}"
 
+  # Can't use apt_repository as it doesn't expose a trusted=yes option
   - name: Install the repo
-    apt_repository:
-      repo: "deb file:{{ repodir }} ./"
-      validate_certs: no
+    copy:
+      content: deb [trusted=yes] file:{{ repodir }} ./
+      dest: /etc/apt/sources.list.d/file_tmp_repo.list
+
+  # Need to uncomment the deb-src for the universe component for build-dep state
+  - name: Ensure deb-src for the universe component
+    lineinfile:
+      path: /etc/apt/sources.list
+      backrefs: True
+      regexp: ^#\s*deb-src http://archive\.ubuntu\.com/ubuntu/ (\w*){{ item }} universe$
+      line: deb-src http://archive.ubuntu.com/ubuntu \1{{ item }} universe
+      state: present
+    with_items:
+    - ''
+    - -updates
 
   when: ansible_distribution in ['Ubuntu', 'Debian']


### PR DESCRIPTION
##### SUMMARY
Currently the `setup_dep_repo` will fail on Ubuntu 18.04 with the error `E: The repository 'file:/tmp/repo ./ Release' does not have a Release file.`. It is expecting the test repo to be signed with a Release file which this PR attempts to do.

The steps to create the GPG key and sign the local repo are currently only working on Ubuntu 18.04. Not sure if we should try and run it for the older versions in ansible-test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_dep_repo