### PR TITLE
Add backup filename and dir path option for config network modules

### DIFF
--- a/changelogs/fragments/network_configurable_backup_path.yaml
+++ b/changelogs/fragments/network_configurable_backup_path.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add configurable backup path option support for network config modules

--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -134,8 +134,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -145,14 +145,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -65,9 +65,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory.  If the directory does not exist, it is created.
     type: bool
     default: 'no'
   running_config:
@@ -131,6 +131,28 @@ options:
         of the current device's configuration against.  When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -150,6 +172,14 @@ EXAMPLES = """
       - acl rule protocol testACL 1 any
       - acl rule direction testACL 3 in
     before: acl delete testACL
+
+- name: configurable backup path
+  aireos_config:
+    backup: yes
+    lines: sysname testDevice
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -209,6 +239,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -223,6 +257,7 @@ def main():
         intended_config=dict(),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         # save is deprecated as of 2.7, use save_when instead
         save=dict(type='bool', default=False, removed_in_version='2.11'),

--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -155,8 +155,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -166,14 +166,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
-        type: path     
-  type: dict
-  version_added: "2.8"
+        type: path
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -84,9 +84,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   running_config:
@@ -152,6 +152,28 @@ options:
     type: bool
     default: 'yes'
     version_added: "2.5"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path     
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -179,6 +201,14 @@ EXAMPLES = """
     parents: ip access-list standard 1
     before: no ip access-list standard 1
     match: exact
+
+- name: configurable backup path
+  aruba_config:
+    backup: yes
+    lines: hostname {{ inventory_hostname }}
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -241,6 +271,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -257,6 +291,7 @@ def main():
         intended_config=dict(),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 

--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -85,9 +85,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the
+        playbook root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   config:
@@ -119,6 +119,28 @@ options:
         running.  If check mode is specified, this argument is ignored.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -207,6 +229,15 @@ vars:
   debug:
     var: interface
 
+- name: configurable backup path
+  asa_config:
+    lines:
+      - access-group cloud-acl_access_in in interface cloud13
+    provider: "{{ cli }}"
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -282,6 +313,10 @@ def run(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -293,6 +328,7 @@ def main():
 
         match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
         replace=dict(default='line', choices=['line', 'block']),
+        backup_options=dict(type='dict', options=backup_spec),
 
         config=dict(),
         defaults=dict(type='bool', default=False),

--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -122,8 +122,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -133,14 +133,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -121,8 +121,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -132,14 +132,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -49,10 +49,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current running config from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.8"
@@ -118,6 +118,28 @@ options:
         a list of regular expressions or exact line matches.
         Note that this parameter will be ignored if the platform has onbox
         diff support.
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -143,6 +165,14 @@ EXAMPLES = """
   cli_config:
     config: set system host-name foo
     commit_comment: this is a test
+
+- name: configurable backup path
+  cli_config:
+    config: "{{ lookup('template', 'basic/config.j2') }}"
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -299,8 +329,13 @@ def run(module, capabilities, connection, candidate, running):
 def main():
     """main entry point for execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         backup=dict(default=False, type='bool'),
+        backup_options=dict(type='dict', options=backup_spec),
         config=dict(type='str'),
         commit=dict(type='bool'),
         replace=dict(type='str'),

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -92,9 +92,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(current-configuration) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   config:
@@ -125,6 +125,28 @@ options:
         return changed.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -174,6 +196,15 @@ EXAMPLES = """
       before: undo acl 2000
       replace: block
       provider: "{{ cli }}"
+
+  - name: configurable backup path
+    ce_config:
+      lines: sysname {{ inventory_hostname }}
+      provider: "{{ cli }}"
+      backup: yes
+      backup_options:
+        filename: backup.cfg
+        dir_path: /home/user
 """
 
 RETURN = """
@@ -254,6 +285,10 @@ def run(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -269,6 +304,7 @@ def main():
         defaults=dict(type='bool', default=False),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         save=dict(type='bool', default=False),
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -128,8 +128,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -139,14 +139,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/cnos/cnos_config.py
+++ b/lib/ansible/modules/network/cnos/cnos_config.py
@@ -168,8 +168,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -179,14 +179,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/cnos/cnos_config.py
+++ b/lib/ansible/modules/network/cnos/cnos_config.py
@@ -148,9 +148,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   comment:
@@ -165,6 +165,28 @@ options:
         changes to the device.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -185,6 +207,14 @@ Tasks: The following are examples of using the module cnos_config.
   cnos_config:
     src: config.cfg
     backup: yes
+
+- name: configurable backup path
+  cnos_config:
+    src: config.cfg
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -266,6 +296,10 @@ def run(module, result):
 def main():
     """main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -281,6 +315,7 @@ def main():
 
         config=dict(),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         comment=dict(default=DEFAULT_COMMIT_COMMENT),
         admin=dict(type='bool', default=False)
     )

--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -114,11 +114,33 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -145,6 +167,13 @@ EXAMPLES = """
     parents: ['ip access-list test']
     before: ['no ip access-list test']
     replace: block
+
+- dellos10_config:
+    lines: ['hostname {{ inventory_hostname }}']
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -203,6 +232,10 @@ def get_running_config(module):
 
 def main():
 
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         lines=dict(aliases=['commands'], type='list'),
         parents=dict(type='list'),
@@ -219,7 +252,8 @@ def main():
         update=dict(choices=['merge', 'check'], default='merge'),
         save=dict(type='bool', default=False),
         config=dict(),
-        backup=dict(type='bool', default=False)
+        backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec)
     )
 
     argument_spec.update(dellos10_argument_spec)

--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -122,8 +122,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -133,14 +133,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/dellos6/dellos6_config.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_config.py
@@ -120,8 +120,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -131,14 +131,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/dellos6/dellos6_config.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_config.py
@@ -112,11 +112,33 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -144,6 +166,12 @@ EXAMPLES = """
     before: ['no ip access-list test']
     replace: block
 
+- dellos6_config:
+    lines: ['hostname {{ inventory_hostname }}']
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -205,6 +233,10 @@ def get_running_config(module):
 
 def main():
 
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         lines=dict(aliases=['commands'], type='list'),
         parents=dict(type='list'),
@@ -221,7 +253,8 @@ def main():
         update=dict(choices=['merge', 'check'], default='merge'),
         save=dict(type='bool', default=False),
         config=dict(),
-        backup=dict(type='bool', default=False)
+        backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec)
     )
 
     argument_spec.update(dellos6_argument_spec)

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -121,8 +121,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -132,14 +132,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 notes:
   - This module requires Dell OS9 version 9.10.0.1P13 or above.
 

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -113,11 +113,33 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 notes:
   - This module requires Dell OS9 version 9.10.0.1P13 or above.
 
@@ -152,6 +174,14 @@ EXAMPLES = """
     parents: ['ip access-list extended test']
     before: ['no ip access-list extended test']
     replace: block
+
+- dellos9_config:
+    lines: ['hostname {{ inventory_hostname }}']
+    provider: "{{ cli }}"
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -210,6 +240,10 @@ def get_running_config(module):
 
 def main():
 
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         lines=dict(aliases=['commands'], type='list'),
         parents=dict(type='list'),
@@ -226,7 +260,8 @@ def main():
         update=dict(choices=['merge', 'check'], default='merge'),
         save=dict(type='bool', default=False),
         config=dict(),
-        backup=dict(type='bool', default=False)
+        backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec)
     )
 
     argument_spec.update(dellos9_argument_spec)

--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -59,10 +59,10 @@ options:
     description:
       - The C(backup) argument will backup the current device's active
         configuration to the Ansible control host prior to making any
-        changes. The backup file will be located in the backup folder
-        in the playbook root directory or role root directory if the
-        playbook is part of an ansible role. If the directory does not
-        exist, it is created.
+        changes. If the C(backup_options) value is not given, the backup
+        file will be located in the backup folder in the playbook root
+        directory or role root directory if the playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   comment:
@@ -85,6 +85,28 @@ options:
         active configuration is saved.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -99,6 +121,14 @@ EXAMPLES = """
   edgeos_config:
     src: edgeos.cfg
     backup: yes
+
+- name: configurable backup path
+  edgeos_config:
+    src: edgeos.cfg
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -241,6 +271,11 @@ def run(module, result):
 
 
 def main():
+
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     spec = dict(
         src=dict(type='path'),
         lines=dict(type='list'),
@@ -252,6 +287,7 @@ def main():
         config=dict(),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         save=dict(type='bool', default=False),
     )
 

--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -88,8 +88,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -99,14 +99,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -109,9 +109,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   comment:
@@ -126,6 +126,28 @@ options:
         changes to the device.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -144,6 +166,14 @@ EXAMPLES = """
   enos_config:
     src: config.cfg
     backup: yes
+
+- name: configurable backup path
+  enos_config:
+    src: config.cfg
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -225,6 +255,10 @@ def run(module, result):
 def main():
     """main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -239,6 +273,7 @@ def main():
 
         config=dict(),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         comment=dict(default=DEFAULT_COMMIT_COMMENT),
         admin=dict(type='bool', default=False)
     )

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -129,8 +129,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -140,14 +140,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -209,8 +209,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -220,14 +220,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -114,10 +114,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.2"
@@ -206,6 +206,28 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -245,6 +267,14 @@ EXAMPLES = """
       - shutdown
     # parents: int eth1
     parents: interface Ethernet1
+
+- name: configurable backup path
+  eos_config:
+    src: eos_template.j2
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -310,6 +340,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -324,6 +358,7 @@ def main():
 
         defaults=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 

--- a/lib/ansible/modules/network/exos/exos_config.py
+++ b/lib/ansible/modules/network/exos/exos_config.py
@@ -145,8 +145,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -156,14 +156,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/exos/exos_config.py
+++ b/lib/ansible/modules/network/exos/exos_config.py
@@ -76,9 +76,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   running_config:
@@ -142,6 +142,28 @@ options:
         of the current device's configuration against.  When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -169,6 +191,15 @@ EXAMPLES = """
 - name: save running to startup when modified
   exos_config:
     save_when: modified
+
+- name: configurable backup path
+  exos_config:
+    lines:
+      - configure ports 2 description-string "Master Uplink"
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -256,6 +287,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -272,6 +307,7 @@ def main():
 
         defaults=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 

--- a/lib/ansible/modules/network/f5/bigip_imish_config.py
+++ b/lib/ansible/modules/network/f5/bigip_imish_config.py
@@ -153,6 +153,28 @@ options:
         configuration against.
       - When specifying this argument, the task should also modify the
         C(diff_against) value and set it to I(intended).
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 notes:
   - Abbreviated commands are NOT idempotent, see
     L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
@@ -223,6 +245,19 @@ EXAMPLES = r'''
       user: admin
       password: secret
       server: lb.mydomain.com
+  delegate_to: localhost
+
+- name: configurable backup path
+  bigip_imish_config:
+    lines: bfd slow-timer 2000
+    backup: yes
+    provider:
+      user: admin
+      password: secret
+      server: lb.mydomain.com
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
   delegate_to: localhost
 '''
 
@@ -707,6 +742,10 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
+        backup_spec = dict(
+            filename=dict(),
+            dir_path=dict(type='path')
+        )
         argument_spec = dict(
             route_domain=dict(default=0),
             src=dict(type='path'),
@@ -723,6 +762,7 @@ class ArgumentSpec(object):
             intended_config=dict(),
 
             backup=dict(type='bool', default=False),
+            backup_options=dict(type='dict', options=backup_spec),
 
             save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 

--- a/lib/ansible/modules/network/f5/bigip_imish_config.py
+++ b/lib/ansible/modules/network/f5/bigip_imish_config.py
@@ -156,8 +156,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -167,14 +167,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 notes:
   - Abbreviated commands are NOT idempotent, see
     L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -206,8 +206,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -217,14 +217,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -88,7 +88,7 @@ options:
   replace:
     description:
       - Instructs the module on the way to perform the configuration
-        on the device.  If the replace argument is set to I(line) then
+        on the device. If the replace argument is set to I(line) then
         the modified lines are pushed to the device in configuration
         mode.  If the replace argument is set to I(block) then the entire
         command block is pushed to the device in configuration mode if any
@@ -118,10 +118,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.2"
@@ -129,7 +129,7 @@ options:
     description:
       - The module, by default, will connect to the remote device and
         retrieve the current running-config to use as a base for comparing
-        against the contents of source.  There are times when it is not
+        against the contents of source. There are times when it is not
         desirable to have the task get the current running-config for
         every task in a playbook.  The I(running_config) argument allows the
         implementer to pass in the configuration to use as the base
@@ -197,12 +197,34 @@ options:
     description:
       - The C(intended_config) provides the master configuration that
         the node should conform to and is used to check the final
-        running-config against.   This argument will not modify any settings
+        running-config against. This argument will not modify any settings
         on the remote device and is strictly used to check the compliance
         of the current device's configuration against.  When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -287,6 +309,14 @@ EXAMPLES = """
   ios_config:
     backup: yes
     src: ios_template.j2
+
+- name: configurable backup path
+  ios_config:
+    src: ios_template.j2
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -371,6 +401,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -389,7 +423,7 @@ def main():
 
         defaults=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
-
+        backup_options=dict(type='dict', options=backup_spec),
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 
         diff_against=dict(choices=['startup', 'intended', 'running']),

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -114,10 +114,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.2"
@@ -143,6 +143,28 @@ options:
         underscores are allowed. If the configuration is not changed or
         committed, this argument is ignored.
     version_added: "2.7"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -170,6 +192,14 @@ EXAMPLES = """
       - shutdown
     # parents: int g0/0/0/1
     parents: interface GigabitEthernet0/0/0/1
+
+- name: configurable backup path
+  iosxr_config:
+    src: config.cfg
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -312,6 +342,10 @@ def run(module, result):
 def main():
     """main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -330,6 +364,7 @@ def main():
 
         config=dict(),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         comment=dict(default=DEFAULT_COMMIT_COMMENT),
         admin=dict(type='bool', default=False),
         label=dict()

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -146,8 +146,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -157,14 +157,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -105,9 +105,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory.  If the directory does not exist, it is created.
     type: bool
     default: 'no'
   config:
@@ -131,6 +131,28 @@ options:
     default: never
     choices: ['always', 'never', 'modified']
     version_added: "2.4"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path   
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -217,6 +239,10 @@ def run(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -232,6 +258,7 @@ def main():
         config=dict(),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         save_when=dict(choices=['always', 'never', 'modified'], default='never')
 
     )

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -134,8 +134,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -145,14 +145,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
-        type: path   
-  type: dict
-  version_added: "2.8"
+        type: path
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -92,10 +92,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.2"
@@ -130,6 +130,28 @@ options:
     type: bool
     default: 'no'
     version_added: "2.8"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 requirements:
   - ncclient (>=v0.5.2)
 notes:
@@ -193,6 +215,14 @@ EXAMPLES = """
     lines:
       # - set int ge-0/0/1 unit 0 desc "Test interface"
       - set interfaces ge-0/0/1 unit 0 description "Test interface"
+
+- name: configurable backup path
+  junos_config:
+    src: srx.cfg
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -310,6 +340,10 @@ def configure_device(module, warnings, candidate):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         lines=dict(type='list'),
 
@@ -329,6 +363,7 @@ def main():
 
         # config operations
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         rollback=dict(type='int'),
 
         zeroize=dict(default=False, type='bool'),

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -133,8 +133,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -144,14 +144,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 requirements:
   - ncclient (>=v0.5.2)
 notes:

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -146,8 +146,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -157,14 +157,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 requirements:
   - "ncclient"
 notes:

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -108,10 +108,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.7"
@@ -143,6 +143,28 @@ options:
       to load. The path to the source file can either be the full path on the Ansible control host or
       a relative path from the playbook or role root directory. This argument is mutually exclusive with I(xml).
     version_added: "2.4"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 requirements:
   - "ncclient"
 notes:
@@ -193,6 +215,13 @@ EXAMPLES = '''
   register: backup_junos_location
   vars:
     ansible_private_key_file: /home/admin/.ssh/newprivatekeyfile
+
+- name: configurable backup path
+  netconf_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 '''
 
 RETURN = '''
@@ -225,6 +254,10 @@ from ansible.module_utils.network.netconf.netconf import get_capabilities, get_c
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         content=dict(aliases=['xml']),
         target=dict(choices=['auto', 'candidate', 'running'], default='auto', aliases=['datastore']),
@@ -236,6 +269,7 @@ def main():
         confirm_commit=dict(type='bool', default=False),
         error_option=dict(choices=['stop-on-error', 'continue-on-error', 'rollback-on-error'], default='stop-on-error'),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         save=dict(type='bool', default=False),
         delete=dict(type='bool', default=False),
         commit=dict(type='bool', default=True),

--- a/lib/ansible/modules/network/nos/nos_config.py
+++ b/lib/ansible/modules/network/nos/nos_config.py
@@ -90,9 +90,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made. The backup file is written to the C(backup)
-        folder in the playbook root directory. If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   running_config:
@@ -131,6 +131,28 @@ options:
         of the current device's configuration against. When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -171,6 +193,14 @@ EXAMPLES = """
   nos_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
+
+- name: configurable backup path
+  nos_config:
+    lines: logging raslog console INFO
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -232,6 +262,10 @@ def get_candidate(module):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -249,6 +283,7 @@ def main():
         intended_config=dict(),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         diff_against=dict(choices=['intended', 'running']),
         diff_ignore_lines=dict(type='list'),

--- a/lib/ansible/modules/network/nos/nos_config.py
+++ b/lib/ansible/modules/network/nos/nos_config.py
@@ -134,8 +134,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -145,14 +145,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -227,8 +227,8 @@ options:
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 notes:
   - Abbreviated commands are NOT idempotent, see
     L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -118,10 +118,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.2"
@@ -207,6 +207,28 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 notes:
   - Abbreviated commands are NOT idempotent, see
     L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
@@ -257,6 +279,13 @@ EXAMPLES = """
       - shutdown
     # parents: int eth1/1
     parents: interface Ethernet1/1
+
+- name: configurable backup path
+  nxos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -337,6 +366,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
         replace_src=dict(),
@@ -354,6 +387,7 @@ def main():
 
         defaults=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 

--- a/lib/ansible/modules/network/onyx/onyx_config.py
+++ b/lib/ansible/modules/network/onyx/onyx_config.py
@@ -83,9 +83,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory.  If the directory does not exist, it is created.
     default: no
     type: bool
   config:
@@ -101,6 +101,28 @@ options:
         running.  If check mode is specified, this argument is ignored.
     default: no
     type: bool
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -184,6 +206,10 @@ def run(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -199,6 +225,7 @@ def main():
         config=dict(),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         save=dict(type='bool', default=False),
     )
 

--- a/lib/ansible/modules/network/onyx/onyx_config.py
+++ b/lib/ansible/modules/network/onyx/onyx_config.py
@@ -104,8 +104,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -115,14 +115,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -159,8 +159,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -170,14 +170,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -90,9 +90,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   running_config:
@@ -156,6 +156,28 @@ options:
         of the current device's configuration against.  When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -205,6 +227,14 @@ EXAMPLES = """
 - name: save running to startup when modified
   slxos_config:
     save_when: modified
+
+- name: configurable backup path
+  slxos_config:
+    lines: hostname {{ inventory_hostname }}
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -282,6 +312,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -300,6 +334,7 @@ def main():
 
         defaults=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 

--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -130,8 +130,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -141,14 +141,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -96,9 +96,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made. f the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
     type: bool
     default: 'no'
     version_added: "2.2"
@@ -127,6 +127,28 @@ options:
     type: bool
     default: 'no'
     version_added: "2.2"
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -184,6 +206,13 @@ vars:
       - service
       - vpls 1000 customer foo 1 create
     provider: "{{ cli }}"
+
+- name: configurable backup path
+  sros_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -258,6 +287,10 @@ def run(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -270,6 +303,7 @@ def main():
         defaults=dict(type='bool', default=False, aliases=['detail']),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         save=dict(type='bool', default=False),
     )
 

--- a/lib/ansible/modules/network/voss/voss_config.py
+++ b/lib/ansible/modules/network/voss/voss_config.py
@@ -85,10 +85,10 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made. The backup file is written to the C(backup)
-        folder in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not exist,
-        it is created.
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   running_config:
@@ -151,6 +151,28 @@ options:
         of the current device's configuration against. When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -179,6 +201,13 @@ EXAMPLES = """
 - name: save running to startup when modified
   voss_config:
     save_when: modified
+
+- name: configurable backup path
+  voss_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -247,6 +276,10 @@ def save_config(module, result):
 def main():
     """ main entry point for module execution
     """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
 
@@ -264,6 +297,7 @@ def main():
 
         defaults=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
 
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 

--- a/lib/ansible/modules/network/voss/voss_config.py
+++ b/lib/ansible/modules/network/voss/voss_config.py
@@ -154,8 +154,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -165,14 +165,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -29,7 +29,7 @@ author: "Nathaniel Case (@qalthos)"
 short_description: Manage VyOS configuration on remote device
 description:
   - This module provides configuration file management of VyOS
-    devices.  It provides arguments for managing both the
+    devices. It provides arguments for managing both the
     configuration file and state of the active configuration.   All
     configuration statements are based on `set` and `delete` commands
     in the device configuration.
@@ -64,10 +64,10 @@ options:
     description:
       - The C(backup) argument will backup the current devices active
         configuration to the Ansible control host prior to making any
-        changes.  The backup file will be located in the backup folder
-        in the playbook root directory or role root directory, if
-        playbook is part of an ansible role. If the directory does not
-        exist, it is created.
+        changes. If the C(backup_options) value is not given, the
+        backup file will be located in the backup folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
     type: bool
     default: 'no'
   comment:
@@ -90,6 +90,28 @@ options:
         active configuration is saved.
     type: bool
     default: 'no'
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
+        to I(false) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exit it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+  type: dict
+  version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -114,6 +136,13 @@ EXAMPLES = """
     lines:
       # - set int eth eth2 description 'OUTSIDE'
       - set interface ethernet eth2 description 'OUTSIDE'
+
+- name: configurable backup path
+  vyos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
 """
 
 RETURN = """
@@ -242,6 +271,10 @@ def run(module, result):
 
 
 def main():
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
     argument_spec = dict(
         src=dict(type='path'),
         lines=dict(type='list'),
@@ -253,6 +286,7 @@ def main():
         config=dict(),
 
         backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
         save=dict(type='bool', default=False),
     )
 

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -30,7 +30,7 @@ short_description: Manage VyOS configuration on remote device
 description:
   - This module provides configuration file management of VyOS
     devices. It provides arguments for managing both the
-    configuration file and state of the active configuration.   All
+    configuration file and state of the active configuration. All
     configuration statements are based on `set` and `delete` commands
     in the device configuration.
 extends_documentation_fragment: vyos
@@ -93,8 +93,8 @@ options:
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(True), if C(backup) is set
-        to I(false) this option will be silently ignored.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
     suboptions:
       filename:
         description:
@@ -104,14 +104,14 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be first
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory
             and backup configuration will be copied in C(filename) within I(backup) directory.
         type: path
-  type: dict
-  version_added: "2.8"
+    type: dict
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -41,6 +41,7 @@ display = Display()
 class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
+        del tmp  # tmp no longer has any effect
 
         self._config_module = True if self._task.action == 'bigip_imish_config' else False
         socket_path = None

--- a/lib/ansible/plugins/action/network.py
+++ b/lib/ansible/plugins/action/network.py
@@ -25,7 +25,7 @@ import glob
 import re
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.display import Display
@@ -44,8 +44,8 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 
-        if config_module and self._task.args.get('backup'):
-            self._handle_backup_option(result, task_vars['inventory_hostname'], result.get('__backup__', False))
+        if config_module and self._task.args.get('backup') and not result.get('failed'):
+            self._handle_backup_option(result, task_vars)
 
         return result
 
@@ -55,12 +55,60 @@ class ActionModule(_ActionModule):
         except ValueError as exc:
             return dict(failed=True, msg=to_text(exc))
 
-    def _handle_backup_option(self, result, hostname, backup):
-        if backup:
-            # User requested backup and no error occurred in module.
-            # NOTE: If there is a parameter error, _backup key may not be in results.
-            filepath = self._write_backup(hostname, backup)
-            result['backup_path'] = filepath
+    def _handle_backup_option(self, result, task_vars):
+
+        filename = None
+        backup_path = None
+        try:
+            content = result['__backup__']
+        except KeyError:
+            raise AnsibleError('Failed while reading configuration backup')
+
+        backup_options = self._task.args.get('backup_options')
+        if backup_options:
+            filename = backup_options.get('filename')
+            backup_path = backup_options.get('dir_path')
+
+        if not backup_path:
+            cwd = self._get_working_path()
+            backup_path = os.path.join(cwd, 'backup')
+        if not filename:
+            tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+            filename = '%s_config.%s' % (task_vars['inventory_hostname'], tstamp)
+
+        dest = os.path.join(backup_path, filename)
+        backup_path = os.path.expanduser(os.path.expandvars(to_bytes(backup_path, errors='surrogate_or_strict')))
+
+        if not os.path.exists(backup_path):
+            os.makedirs(backup_path)
+
+        new_task = self._task.copy()
+        for item in self._task.args:
+            if not item.startswith('_'):
+                new_task.args.pop(item, None)
+
+        new_task.args.update(
+            dict(
+                content=content,
+                dest=dest,
+            ),
+        )
+        copy_action = self._shared_loader_obj.action_loader.get('copy',
+                                                                task=new_task,
+                                                                connection=self._connection,
+                                                                play_context=self._play_context,
+                                                                loader=self._loader,
+                                                                templar=self._templar,
+                                                                shared_loader_obj=self._shared_loader_obj)
+        copy_result = copy_action.run(task_vars=task_vars)
+        if copy_result.get('failed'):
+            result['failed'] = copy_result['failed']
+            result['msg'] = copy_result.get('msg')
+            return
+
+        result['backup_path'] = copy_result['dest']
+        if copy_result.get('changed', False):
+            result['changed'] = copy_result['changed']
 
         # strip out any keys that have two leading and two trailing
         # underscore characters
@@ -73,20 +121,6 @@ class ActionModule(_ActionModule):
         if self._task._role is not None:
             cwd = self._task._role._role_path
         return cwd
-
-    def _write_backup(self, host, contents, encoding='utf-8'):
-        cwd = self._get_working_path()
-
-        backup_path = os.path.join(cwd, 'backup')
-        if not os.path.exists(backup_path):
-            os.mkdir(backup_path)
-        for existing_backup in glob.glob('%s/%s_config.*' % (backup_path, host)):
-            os.remove(existing_backup)
-        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
-        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
-        open(filename, 'w').write(to_text(contents, encoding=encoding))
-
-        return filename
 
     def _handle_template(self, convert_data=True):
         src = self._task.args.get('src')

--- a/test/integration/targets/eos_config/tests/cli/backup.yaml
+++ b/test/integration/targets/eos_config/tests/cli/backup.yaml
@@ -1,6 +1,14 @@
 ---
 - debug: msg="START cli/backup.yaml on connection={{ ansible_connection }}"
 
+- name: collect any backup files
+  find:
+    paths: "{{ role_path }}/backup"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_files
+  connection: local
+
+
 - name: setup
   eos_config:
     commands:
@@ -46,5 +54,81 @@
 - assert:
     that:
       - "backup_files.files is defined"
+
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
+
+- name: take configuration backup in custom filename and directory path
+  eos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-1 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom filename
+  eos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-2 exist
+  find:
+    paths: "{{ role_path }}/backup/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom path and default filename
+  eos_config:
+    backup: yes
+    backup_options:
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-3 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
 
 - debug: msg="END cli/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_config/tests/cli_config/cli_backup.yaml
+++ b/test/integration/targets/eos_config/tests/cli_config/cli_backup.yaml
@@ -1,14 +1,12 @@
----
-- debug: msg="START cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
 
-- name: setup
-  ios_config:
-    commands:
-      - no description
-      - no shutdown
-    parents:
-      - interface Loopback999
-    match: none
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
 
 - name: collect any backup files
   find:
@@ -23,17 +21,15 @@
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
-  ios_config:
-    src: basic/config.j2
+- name: take config backup
+  cli_config:
     backup: yes
+  become: yes
   register: result
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME Bug https://github.com/ansible/ansible/issues/19382
-#      - "result.updates is not defined"
 
 - name: collect any backup files
   find:
@@ -46,16 +42,8 @@
     that:
       - "backup_files.files is defined"
 
-- name: delete configurable backup file path
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ role_path }}/backup_test_dir/"
-    - "{{ role_path }}/backup/backup.cfg"
-
 - name: take configuration backup in custom filename and directory path
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -78,7 +66,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -100,7 +88,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom path and default filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
@@ -122,4 +110,4 @@
     that:
       - "backup_file.files is defined"
 
-- debug: msg="END cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli_config/cli_backup.yaml
+++ b/test/integration/targets/ios_config/tests/cli_config/cli_backup.yaml
@@ -1,14 +1,12 @@
----
-- debug: msg="START cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
 
-- name: setup
-  ios_config:
-    commands:
-      - no description
-      - no shutdown
-    parents:
-      - interface Loopback999
-    match: none
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
 
 - name: collect any backup files
   find:
@@ -23,17 +21,15 @@
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
-  ios_config:
-    src: basic/config.j2
+- name: take config backup
+  cli_config:
     backup: yes
+  become: yes
   register: result
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME Bug https://github.com/ansible/ansible/issues/19382
-#      - "result.updates is not defined"
 
 - name: collect any backup files
   find:
@@ -46,16 +42,8 @@
     that:
       - "backup_files.files is defined"
 
-- name: delete configurable backup file path
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ role_path }}/backup_test_dir/"
-    - "{{ role_path }}/backup/backup.cfg"
-
 - name: take configuration backup in custom filename and directory path
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -78,7 +66,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -100,7 +88,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom path and default filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
@@ -122,4 +110,4 @@
     that:
       - "backup_file.files is defined"
 
-- debug: msg="END cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_config/tests/cli/backup.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/backup.yaml
@@ -45,4 +45,79 @@
     that:
       - "backup_files.files is defined"
 
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
+
+- name: take configuration backup in custom filename and directory path
+  iosxr_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-1 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom filename
+  iosxr_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-2 exist
+  find:
+    paths: "{{ role_path }}/backup/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom path and default filename
+  iosxr_config:
+    backup: yes
+    backup_options:
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-3 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
 - debug: msg="END cli/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_config/tests/cli_config/cli_backup.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli_config/cli_backup.yaml
@@ -1,14 +1,12 @@
----
-- debug: msg="START cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
 
-- name: setup
-  ios_config:
-    commands:
-      - no description
-      - no shutdown
-    parents:
-      - interface Loopback999
-    match: none
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
 
 - name: collect any backup files
   find:
@@ -23,17 +21,15 @@
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
-  ios_config:
-    src: basic/config.j2
+- name: take config backup
+  cli_config:
     backup: yes
+  become: yes
   register: result
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME Bug https://github.com/ansible/ansible/issues/19382
-#      - "result.updates is not defined"
 
 - name: collect any backup files
   find:
@@ -46,16 +42,8 @@
     that:
       - "backup_files.files is defined"
 
-- name: delete configurable backup file path
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ role_path }}/backup_test_dir/"
-    - "{{ role_path }}/backup/backup.cfg"
-
 - name: take configuration backup in custom filename and directory path
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -78,7 +66,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -100,7 +88,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom path and default filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
@@ -122,4 +110,4 @@
     that:
       - "backup_file.files is defined"
 
-- debug: msg="END cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/cli_config/cli_backup.yaml
+++ b/test/integration/targets/junos_config/tests/cli_config/cli_backup.yaml
@@ -1,14 +1,12 @@
----
-- debug: msg="START cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
 
-- name: setup
-  ios_config:
-    commands:
-      - no description
-      - no shutdown
-    parents:
-      - interface Loopback999
-    match: none
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
 
 - name: collect any backup files
   find:
@@ -23,17 +21,15 @@
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
-  ios_config:
-    src: basic/config.j2
+- name: take config backup
+  cli_config:
     backup: yes
+  become: yes
   register: result
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME Bug https://github.com/ansible/ansible/issues/19382
-#      - "result.updates is not defined"
 
 - name: collect any backup files
   find:
@@ -46,16 +42,8 @@
     that:
       - "backup_files.files is defined"
 
-- name: delete configurable backup file path
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ role_path }}/backup_test_dir/"
-    - "{{ role_path }}/backup/backup.cfg"
-
 - name: take configuration backup in custom filename and directory path
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -78,7 +66,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -100,7 +88,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom path and default filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
@@ -122,4 +110,4 @@
     that:
       - "backup_file.files is defined"
 
-- debug: msg="END cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/netconf/backup.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/backup.yaml
@@ -45,4 +45,80 @@
     that:
       - "backup_files.files is defined"
 
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
+
+- name: take configuration backup in custom filename and directory path
+  junos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-1 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom filename
+  junos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-2 exist
+  find:
+    paths: "{{ role_path }}/backup/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom path and default filename
+  junos_config:
+    backup: yes
+    backup_options:
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-3 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
 - debug: msg="END netconf/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_config/tests/cli_config/cli_backup.yaml
+++ b/test/integration/targets/nxos_config/tests/cli_config/cli_backup.yaml
@@ -1,14 +1,12 @@
----
-- debug: msg="START cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
 
-- name: setup
-  ios_config:
-    commands:
-      - no description
-      - no shutdown
-    parents:
-      - interface Loopback999
-    match: none
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
 
 - name: collect any backup files
   find:
@@ -23,17 +21,15 @@
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
-  ios_config:
-    src: basic/config.j2
+- name: take config backup
+  cli_config:
     backup: yes
+  become: yes
   register: result
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME Bug https://github.com/ansible/ansible/issues/19382
-#      - "result.updates is not defined"
 
 - name: collect any backup files
   find:
@@ -46,16 +42,8 @@
     that:
       - "backup_files.files is defined"
 
-- name: delete configurable backup file path
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ role_path }}/backup_test_dir/"
-    - "{{ role_path }}/backup/backup.cfg"
-
 - name: take configuration backup in custom filename and directory path
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -78,7 +66,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -100,7 +88,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom path and default filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
@@ -122,4 +110,4 @@
     that:
       - "backup_file.files is defined"
 
-- debug: msg="END cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/common/backup.yaml
@@ -52,4 +52,80 @@
     that:
       - "backup_files.files is defined"
 
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
+
+- name: take configuration backup in custom filename and directory path
+  nxos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-1 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom filename
+  nxos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-2 exist
+  find:
+    paths: "{{ role_path }}/backup/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- name: take configuration backup in custom path and default filename
+  nxos_config:
+    backup: yes
+    backup_options:
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-3 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
 - debug: msg="END common/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/vyos_config/tests/cli/backup.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/backup.yaml
@@ -1,14 +1,5 @@
 ---
-- debug: msg="START cli/cli_backup.yaml on connection={{ ansible_connection }}"
-
-- name: setup
-  ios_config:
-    commands:
-      - no description
-      - no shutdown
-    parents:
-      - interface Loopback999
-    match: none
+- debug: msg="START vyos/backup.yaml on connection={{ ansible_connection }}"
 
 - name: collect any backup files
   find:
@@ -23,17 +14,14 @@
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
-  ios_config:
-    src: basic/config.j2
+- name: take configure backup
+  vyos_config:
     backup: yes
   register: result
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME Bug https://github.com/ansible/ansible/issues/19382
-#      - "result.updates is not defined"
 
 - name: collect any backup files
   find:
@@ -55,7 +43,7 @@
     - "{{ role_path }}/backup/backup.cfg"
 
 - name: take configuration backup in custom filename and directory path
-  ios_config:
+  vyos_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -78,7 +66,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom filename
-  ios_config:
+  vyos_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -100,7 +88,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom path and default filename
-  ios_config:
+  vyos_config:
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
@@ -122,4 +110,4 @@
     that:
       - "backup_file.files is defined"
 
-- debug: msg="END cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END vyos/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/vyos_config/tests/cli_config/cli_backup.yaml
+++ b/test/integration/targets/vyos_config/tests/cli_config/cli_backup.yaml
@@ -1,14 +1,12 @@
----
-- debug: msg="START cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
 
-- name: setup
-  ios_config:
-    commands:
-      - no description
-      - no shutdown
-    parents:
-      - interface Loopback999
-    match: none
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
 
 - name: collect any backup files
   find:
@@ -23,17 +21,15 @@
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
-  ios_config:
-    src: basic/config.j2
+- name: take config backup
+  cli_config:
     backup: yes
+  become: yes
   register: result
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME Bug https://github.com/ansible/ansible/issues/19382
-#      - "result.updates is not defined"
 
 - name: collect any backup files
   find:
@@ -46,16 +42,8 @@
     that:
       - "backup_files.files is defined"
 
-- name: delete configurable backup file path
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ role_path }}/backup_test_dir/"
-    - "{{ role_path }}/backup/backup.cfg"
-
 - name: take configuration backup in custom filename and directory path
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -78,7 +66,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       filename: backup.cfg
@@ -100,7 +88,7 @@
       - "backup_file.files is defined"
 
 - name: take configuration backup in custom path and default filename
-  ios_config:
+  cli_config:
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
@@ -122,4 +110,4 @@
     that:
       - "backup_file.files is defined"
 
-- debug: msg="END cli/cli_backup.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #50283
Fixes #32724

*  Add back_options in network config module argspec to allow backup filename and directory path
   to be configurable.
*  Handle backup path options in network action plugin
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aireos_config
aruba_config
asa_config
cli_config
ce_config
cnos_config
dellos10_config
dellos6_config
dellos9_config
edgeos_config
enos_config
eos_config
exos_config
bigip_imish_config
ios_config
iosxr_config
ironware_config
junos_config
netconf_config
nos_config
nxos_config
onyx_config
slxos_config
sros_config
voss_config
vyos_config
plugins/action/bigip.py
plugins/action/network.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
