### PR TITLE
Add posibilities to run the integration tests for PowerShell < 5.0

### DIFF
--- a/lib/ansible/modules/windows/win_psrepository.py
+++ b/lib/ansible/modules/windows/win_psrepository.py
@@ -44,7 +44,11 @@ options:
     type: str
     choices: [ trusted, untrusted ]
 notes:
-  - The PowerShellGet module (version 1.6.0 or newer) and the NuGet package provider (version 2.8.5.201 or newer) are required.
+  - PowerShell modules needed
+      - PowerShellGet >= 1.6.0
+      - PackageManagement >= 1.1.7
+  - PowerShell package provider needed
+      - NuGet >= 2.8.5.201
   - See the examples on how to update the NuGet package provider.
   - You can not use C(win_psrepository) to re-register (add) removed PSGallery, use the command C(Register-PSRepository -Default) instead.
 seealso:
@@ -53,10 +57,10 @@ author:
 - Wojciech Sciesinski (@it-praktyk)
 '''
 
-EXAMPLES = r'''
+EXAMPLES = '''
 ---
 - name: Ensure the required NuGet package provider version is installed
-  win_shell: Install-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force
+  win_shell: Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies -Force
 
 - name: Add a PowerShell module and register a repository
   win_psrepository:
@@ -70,5 +74,5 @@ EXAMPLES = r'''
     state: absent
 '''
 
-RETURN = r'''
+RETURN = '''
 '''

--- a/test/integration/targets/win_psrepository/tasks/main.yml
+++ b/test/integration/targets/win_psrepository/tasks/main.yml
@@ -12,20 +12,15 @@
 - name: update PackageManagement and PowerShellGet when PowerShell < 5.0
   when: powershell_major_version.stdout | int < 5
   block:
-    - name: get the TEMP path
-      win_shell: '$env:TEMP'
-      register: temp_path
-
     - name: download PackageManagement
       win_get_url:
-        url: https://download.microsoft.com/download/C/4/1/C41378D4-7F41-4BBE-9D0D-0E4F98585C61/PackageManagement_x64.msi
-        dest: '{{ temp_path.stdout | trim }}\PackageManagement_x64.msi'
+        url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/win_psmodule/PackageManagement_x64.msi
+        dest: '{{ win_output_dir }}\PackageManagement_x64.msi'
 
     - name: install PackageManagement
       win_package:
-        path: '{{ temp_path.stdout | trim }}\PackageManagement_x64.msi'
+        path: '{{ win_output_dir }}\PackageManagement_x64.msi'
         state: present
-        creates_path: 'C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\PowerShellGet.psd1'
 
     - name: create the required folder
       win_file:
@@ -34,21 +29,14 @@
 
     - name: download nuget
       win_get_url:
-        url: https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+        url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/win_psmodule/nuget.exe
         dest: 'C:\Program Files\PackageManagement\ProviderAssemblies\NuGet-anycpu.exe'
 
     - name: update NuGet provider
       win_shell: 'Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies'
 
-    - name: get a random folder path name
-      win_shell: "([System.IO.Path]::GetTempPath()+([System.IO.Path]::GetRandomFileName())).Split('.')[0]"
-      register: random_folder
-
-    - name: create a random folder
-      win_shell: 'New-Item -Path {{ random_folder.stdout | trim }} -ItemType Directory | Out-Null'
-
     - name: download and save the nevest version of the PackageManagement module from PowerShell Gallery
-      win_shell: 'Save-Module -Name PackageManagement, PowerShellGet -Path {{ random_folder.stdout | trim }} -Force'
+      win_shell: 'Save-Module -Name PackageManagement, PowerShellGet -Path {{ win_output_dir }} -Force'
 
     - name: unload PackageManagement and PowerShellGet modules
       win_shell: 'Remove-Module -Name PackageManagement,PowerShellGet -Force -ErrorAction Ignore'
@@ -59,14 +47,23 @@
       register: psmodulepath
 
     - name: remove older versions of the PackageManagement and PowerShellGet
-      win_shell: "Get-ChildItem -Path {{ psmodulepath.stdout | trim }} -Directory | Where { @('PackageManagement','PowerShellGet') -contains $_.Name }  | Remove-Item -Recurse -Force -ErrorAction Ignore"
-      ignore_errors: yes
+      win_file:
+        path: "{{ psmodulepath.stdout | trim }}\\{{ item }}"
+        state: absent
+      with_items:
+        - PackageManagement
+        - PowerShellGet
 
-    - name: create required folder
-      win_shell: 'if ( -not $(Test-Path {{ psmodulepath.stdout | trim }}) ) { New-Item -Path {{ psmodulepath.stdout | trim }} -ItemType Directory | Out-Null }'
+        - name: create required folder
+      win_file:
+        path:  "{{ psmodulepath.stdout | trim }}"
+        state: directory
 
     - name: update PowerShellGet and PackageManagement modules
-      win_shell: 'Copy-Item -Path {{ random_folder.stdout | trim }}\* -Destination {{ psmodulepath.stdout | trim }}\ -Recurse -Force'
+      win_shell: 'Copy-Item -Path {{ win_output_dir }}\{{ item }} -Destination {{ psmodulepath.stdout | trim }}\ -Recurse -Force'
+      with_items:
+        - PackageManagement
+        - PowerShellGet
 
 - name: update NuGet version
   when: powershell_major_version.stdout | int >= 5

--- a/test/integration/targets/win_psrepository/tasks/main.yml
+++ b/test/integration/targets/win_psrepository/tasks/main.yml
@@ -54,7 +54,7 @@
         - PackageManagement
         - PowerShellGet
 
-        - name: create required folder
+    - name: create required folder
       win_file:
         path:  "{{ psmodulepath.stdout | trim }}"
         state: directory

--- a/test/integration/targets/win_psrepository/tasks/main.yml
+++ b/test/integration/targets/win_psrepository/tasks/main.yml
@@ -9,21 +9,81 @@
   win_shell: '$PSVersionTable.PSVersion.Major'
   register: powershell_major_version
 
-- name: Perform integration tests for Powershell 5+
-  when: powershell_major_version.stdout | int >= 5
+- name: update PackageManagement and PowerShellGet when PowerShell < 5.0
+  when: powershell_major_version.stdout | int < 5
   block:
+    - name: get the TEMP path
+      win_shell: '$env:TEMP'
+      register: temp_path
 
-    - name: ensure test repository is deleted
-      win_psrepository:
-        name: '{{ repository_name }}'
-        state: absent
+    - name: download PackageManagement
+      win_get_url:
+        url: https://download.microsoft.com/download/C/4/1/C41378D4-7F41-4BBE-9D0D-0E4F98585C61/PackageManagement_x64.msi
+        dest: '{{ temp_path.stdout | trim }}\PackageManagement_x64.msi'
 
-    - name: run all tests
-      include_tasks: tests.yml
+    - name: install PackageManagement
+      win_package:
+        path: '{{ temp_path.stdout | trim }}\PackageManagement_x64.msi'
+        state: present
+        creates_path: 'C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\PowerShellGet.psd1'
 
-  always:
+    - name: create the required folder
+      win_file:
+        path: 'C:\Program Files\PackageManagement\ProviderAssemblies'
+        state: directory
 
-  - name: ensure test repository is deleted after tests run
-    win_psrepository:
-      name: '{{ repository_name }}'
-      state: absent
+    - name: download nuget
+      win_get_url:
+        url: https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+        dest: 'C:\Program Files\PackageManagement\ProviderAssemblies\NuGet-anycpu.exe'
+
+    - name: update NuGet provider
+      win_shell: 'Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies'
+
+    - name: get a random folder path name
+      win_shell: "([System.IO.Path]::GetTempPath()+([System.IO.Path]::GetRandomFileName())).Split('.')[0]"
+      register: random_folder
+
+    - name: create a random folder
+      win_shell: 'New-Item -Path {{ random_folder.stdout | trim }} -ItemType Directory | Out-Null'
+
+    - name: download and save the nevest version of the PackageManagement module from PowerShell Gallery
+      win_shell: 'Save-Module -Name PackageManagement, PowerShellGet -Path {{ random_folder.stdout | trim }} -Force'
+
+    - name: unload PackageManagement and PowerShellGet modules
+      win_shell: 'Remove-Module -Name PackageManagement,PowerShellGet -Force -ErrorAction Ignore'
+      ignore_errors: yes
+
+    - name: get PSModulePath
+      win_shell: "$($Env:PSModulePath -Split ';')[0]"
+      register: psmodulepath
+
+    - name: remove older versions of the PackageManagement and PowerShellGet
+      win_shell: "Get-ChildItem -Path {{ psmodulepath.stdout | trim }} -Directory | Where { @('PackageManagement','PowerShellGet') -contains $_.Name }  | Remove-Item -Recurse -Force -ErrorAction Ignore"
+      ignore_errors: yes
+
+    - name: create required folder
+      win_shell: 'if ( -not $(Test-Path {{ psmodulepath.stdout | trim }}) ) { New-Item -Path {{ psmodulepath.stdout | trim }} -ItemType Directory | Out-Null }'
+
+    - name: update PowerShellGet and PackageManagement modules
+      win_shell: 'Copy-Item -Path {{ random_folder.stdout | trim }}\* -Destination {{ psmodulepath.stdout | trim }}\ -Recurse -Force'
+
+- name: update NuGet version
+  when: powershell_major_version.stdout | int >= 5
+  win_shell: |
+    $nuget_exists = (Get-PackageProvider | Where-Object { $_.Name -eq 'Nuget' } | Measure-Object).Count -eq 1
+
+    if ( $nuget_exists ) {
+      $nuget_outdated = (Get-PackageProvider -Name NuGet -ErrorAction Ignore).Version -lt [Version]"2.8.5.201"
+    }
+
+    if ( -not $nuget_exists -or $nuget_outdated ) {
+      Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies -Force
+    }
+
+- name: unregister the repository
+  win_shell: 'Unregister-PSRepository {{ repository_name | quote }} -ErrorAction Ignore'
+  changed_when: false
+
+- name: run all tests
+  include_tasks: tests.yml


### PR DESCRIPTION
##### SUMMARY
Currently, the integration tests for the win_psrepository module are run only for some supported Windows versions - for which PowerShell in version >=5.0 is installed.

The pull request extends testing also for Windows versions with PowerShell < 5.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_psrepository
