### PR TITLE
[Backport 2.7] VMware: Fix vmware_vm_inventory

### DIFF
--- a/changelogs/fragments/50249-vmware_vm_inventory-fix_host_ip.yaml
+++ b/changelogs/fragments/50249-vmware_vm_inventory-fix_host_ip.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- Added documentation about using VMware dynamic inventory plugin.
+- Fixed bug around populating host_ip in hostvars in vmware_vm_inventory.

--- a/docs/docsite/rst/vmware/index.rst
+++ b/docs/docsite/rst/vmware/index.rst
@@ -18,6 +18,7 @@ To get started, please select one of the following topics.
    vmware_concepts
    vmware_requirements
    vmware_getting_started
+   vmware_inventory
    vmware_scenarios
    vmware_module_reference
    vmware_troubleshooting

--- a/docs/docsite/rst/vmware/vmware_inventory.rst
+++ b/docs/docsite/rst/vmware/vmware_inventory.rst
@@ -1,0 +1,51 @@
+.. _vmware_ansible_inventory:
+
+*************************************
+Using VMware dynamic inventory plugin
+*************************************
+
+.. contents:: Topics
+
+VMware Dynamic Inventory Plugin
+===============================
+
+
+The best way to interact with your hosts is to use the VMware dynamic inventory plugin, which dynamically queries VMware APIs and
+tells Ansible what nodes can be managed.
+
+To be able to use this VMware dynamic inventory plugin, you need to enable it first by specifying the following in the ``ansible.cfg`` file:
+
+.. code-block:: ini
+
+  [inventory]
+  enable_plugins = vmware_vm_inventory
+
+Then, create a file that ends in ``.vmware.yml`` or ``.vmware.yaml`` in your working directory.
+
+The ``vmware_vm_inventory`` script takes in the same authentication information as any VMware module.
+
+Here's an example of a valid inventory file:
+
+.. code-block:: yaml
+
+    plugin: vmware_vm_inventory
+    strict: False
+    hostname: 10.65.223.31
+    username: administrator@vsphere.local
+    password: Esxi@123$%
+    validate_certs: False
+    with_tags: True
+
+
+Executing ``ansible-inventory --list -i <filename>.vmware.yml`` will create a list of VMware instances that are ready to be configured using Ansible.
+
+
+.. seealso::
+
+    `pyVmomi <https://github.com/vmware/pyvmomi>`_
+        The GitHub Page of pyVmomi
+    `pyVmomi Issue Tracker <https://github.com/vmware/pyvmomi/issues>`_
+        The issue tracker for the pyVmomi project
+    :ref:`working_with_playbooks`
+        An introduction to playbooks
+

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -12,6 +12,8 @@ DOCUMENTATION = '''
     plugin_type: inventory
     short_description: VMware Guest inventory source
     version_added: "2.6"
+    author:
+      - Abhijeet Kasurde (@Akasurde)
     description:
         - Get virtual machines as inventory hosts from VMware environment.
         - Uses any file which ends with vmware.yml or vmware.yaml as a YAML configuration file.
@@ -62,7 +64,7 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-    # Sample configuration file for VMware Guest dynamic inventory
+# Sample configuration file for VMware Guest dynamic inventory
     plugin: vmware_vm_inventory
     strict: False
     hostname: 10.65.223.31
@@ -303,6 +305,17 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             for host in hostvars:
                 self.inventory.add_host(host)
 
+    @staticmethod
+    def _get_vm_prop(vm, attributes):
+        """Safely get a property or return None"""
+        result = vm
+        for attribute in attributes:
+            try:
+                result = getattr(result, attribute)
+            except (AttributeError, IndexError):
+                return None
+        return result
+
     def _populate_from_source(self, source_data, using_current_cache):
         """
         Populate inventory data from direct source
@@ -339,7 +352,29 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 if current_host not in hostvars:
                     hostvars[current_host] = {}
                     self.inventory.add_host(current_host)
+                    host_ip = temp_vm_object.obj.guest.ipAddress
+                    if host_ip:
+                        self.inventory.set_variable(current_host, 'ansible_host', host_ip)
 
+                    # Load VM properties in host_vars
+                    vm_properties = [
+                        'name',
+                        'config.cpuHotAddEnabled',
+                        'config.cpuHotRemoveEnabled',
+                        'config.instanceUuid',
+                        'config.hardware.numCPU',
+                        'config.template',
+                        'config.name',
+                        'guest.hostName',
+                        'guest.ipAddress',
+                        'guest.guestId',
+                        'guest.guestState',
+                        'runtime.maxMemoryUsage',
+                        'customValue',
+                    ]
+                    for vm_prop in vm_properties:
+                        vm_value = self._get_vm_prop(temp_vm_object.obj, vm_prop.split("."))
+                        self.inventory.set_variable(current_host, vm_prop, vm_value)
                     # Only gather facts related to tag if vCloud and vSphere is installed.
                     if HAS_VCLOUD and HAS_VSPHERE and self.with_tags:
                         # Add virtual machine to appropriate tag group


### PR DESCRIPTION
##### SUMMARY
* Added documentation around using vmware dynamic inventory plugin
* Fixed bug for populating host_ip in hostvars for given inventory host
* VMware: Add properties in vmware_vm_inventory

Fixes: #50249

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit af914695e6eb38ff7c1d4585b9218e9b7915756f)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/50249-vmware_vm_inventory-fix_host_ip.yaml
docs/docsite/rst/vmware/index.rst
docs/docsite/rst/vmware/vmware_inventory.rst
lib/ansible/plugins/inventory/vmware_vm_inventory.py
