### PR TITLE
Fix dpkg_selections integration test.

### DIFF
--- a/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
@@ -1,5 +1,5 @@
 - name: download and install old version of hello
-  apt: "deb=https://launchpad.net/ubuntu/+archive/primary/+files/hello_{{ hello_old_version }}_amd64.deb"
+  apt: "deb=https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/dpkg_selections/hello_{{ hello_old_version }}_amd64.deb"
 
 - name: freeze version for hello
   dpkg_selections:


### PR DESCRIPTION
##### SUMMARY

Fix dpkg_selections integration test.

Download package from S3 since the previous location no longer exists.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

dpkg_selections integration test
