### PR TITLE
JSON data formatter for nxos

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos_json_formatter.py
+++ b/lib/ansible/module_utils/network/nxos/nxos_json_formatter.py
@@ -1,0 +1,109 @@
+# Copyright: (c) 2019, Olivier Blin <olivier.oblin@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class NxosJsonFormatterError(Exception):
+    pass
+
+
+# Nxos JSON formatter.
+#
+# The nxos JSON outputer return multiple formats for the same data. The regular
+# output structure is { "TABLE_x": "ROW_x": [...] } but, for some specific
+# cases, it changes:
+# * 0 element: missing structure or empty string.
+# * 1 element: ROW_x is a dict instead of a list.
+# * >1 element: regular format.
+# * >1 element alternative: TABLE_x is a list of ROW_x hash.
+#   ex: { "TABLE_x": [ {"ROW_x": {...} }, {"ROW_x": {...} } ] }
+#
+# The TABLE_x.ROW_x stucture can be found on different levels in the nxos JSON
+# output. A list of path describes the position where we should find each
+# TABLE_x.ROW_x structure.
+# With the path "a.*.x":
+# * 'a' is the key of the top level dict.
+# * '*' indicate to iterate on the values of the 'a' key.
+# * 'x', the TABLE_x.ROW_x structure, request a conversion to the regular format:
+#   * if TABLE_x.ROW_x structure is missing, it is created.
+#   * if TABLE_x.ROW_x structure is invalid, it is rewritten in the regular format.
+# The last element of the path is always the TABLE_x.ROW_x structure in a simplified
+# writing. Previous elements are the way to reach it.
+#
+# Examples:
+# * ["a"]: Validate the structure {'TABLE_a': {'ROW_a': [...]}}
+# * ["a.b"]: Validate the structure {'a': {'TABLE_b': {'ROW_b': [...]}}
+# * ["a.*.b"]: Validate the structure {'a': [{'TABLE_b': {'ROW_b': [...]}}, ...]}
+# * ["a", "TABLE_a.ROW_a.*.b"]: Validate the structure {'TABLE_a': {'ROW_a': [{'TABLE_b': {'ROW_b': [...]}}, ...]}}
+#
+# Parameters:
+# * nxos_json: Nxos JSON output.
+# * all_path: list of path to TABLE_x.ROW_x structures to check.
+#
+def nxos_json_formatter(nxos_json, all_path):
+    # First level case: empty string when no elements
+    if nxos_json == '':
+        nxos_json = {}
+
+    for struct_path in all_path:
+        nxos_json_formatter_recursive(nxos_json, struct_path)
+
+    return nxos_json
+
+
+# Apply conversion for the requested path.
+def nxos_json_formatter_recursive(nxos_json_part, struct_path):
+    splitted_path = struct_path.split('.')
+    elem = splitted_path.pop(0)
+    if elem == '*':
+        # Recursive call on each element of the list
+        if isinstance(nxos_json_part, list):
+            for sub_part in nxos_json_part:
+                nxos_json_formatter_recursive(sub_part, '.'.join(splitted_path))
+        else:
+            raise NxosJsonFormatterError("Expected a list (*), got %s" % (str(type(nxos_json_part))))
+    elif len(splitted_path) >= 1:
+        # Move forward in the structure
+        if isinstance(nxos_json_part, dict):
+            if elem in nxos_json_part.keys():
+                nxos_json_formatter_recursive(nxos_json_part[elem], '.'.join(splitted_path))
+            else:
+                raise NxosJsonFormatterError("Missing key '%s'" % (elem))
+        else:
+            raise NxosJsonFormatterError("Expected a dict with key '%s', got %s" % (elem, str(type(nxos_json_part))))
+    else:
+        # Convert last element to the format {'TABLE_ELEMENT': {'ROW_ELEMENT': [ ... ]}}
+        table = "TABLE_" + elem
+        row = "ROW_" + elem
+        if isinstance(nxos_json_part, dict):
+            if table in nxos_json_part.keys():
+                if isinstance(nxos_json_part[table], dict):
+                    if isinstance(nxos_json_part[table][row], list):
+                        pass
+                    else:
+                        # 1 element case
+                        nxos_json_part[table][row] = [nxos_json_part[table][row]]
+                elif isinstance(nxos_json_part[table], list):
+                    # >1 element alternative case
+                    to_reformat = nxos_json_part[table]
+                    nxos_json_part[table] = {}
+                    nxos_json_part[table][row] = []
+
+                    for data_instance in to_reformat:
+                        # Strict structure check before conversion
+                        if not isinstance(data_instance, dict):
+                            raise NxosJsonFormatterError("The last element (%s) must be a list of dict, got list of %s" % (table, str(type(data_instance))))
+                        elif row not in data_instance.keys():
+                            raise NxosJsonFormatterError("The last element (%s) is missing" % (row))
+                        elif not isinstance(data_instance[row], dict):
+                            raise NxosJsonFormatterError("The last element (%s) must be a dict, got %s" % (row, str(type(data_instance[row]))))
+                        else:
+                            nxos_json_part[table][row] += [data_instance[row]]
+                else:
+                    # No other format accepted
+                    raise NxosJsonFormatterError("The last element (%s) must be a dict or a list, got %s" % (table, str(type(nxos_json_part[table]))))
+            else:
+                # 0 element case
+                nxos_json_part[table] = {}
+                nxos_json_part[table][row] = []
+        else:
+            raise NxosJsonFormatterError("The last element must be a dict, got %s" % (str(type(nxos_json_part))))

--- a/test/units/module_utils/network/nxos/test_nxos_json_formatter.py
+++ b/test/units/module_utils/network/nxos/test_nxos_json_formatter.py
@@ -1,0 +1,115 @@
+# Copyright: (c) 2019, Olivier Blin <olivier.oblin@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from ansible.module_utils.network.nxos.nxos_json_formatter import nxos_json_formatter, NxosJsonFormatterError
+
+
+def test_dict_path_with_one_element():
+    data = nxos_json_formatter({}, ['a'])
+    assert data == {'TABLE_a': {'ROW_a': []}}
+
+
+def test_dict_path_with_invalid_struct():
+    with pytest.raises(NxosJsonFormatterError, message="The last element must be a dict, got <type 'list'>"):
+        nxos_json_formatter([], ['a'])
+
+
+def test_empty_string_case():
+    data = nxos_json_formatter("", ['a'])
+    assert data == {'TABLE_a': {'ROW_a': []}}
+
+
+def test_invalid_struct_to_build_nxos_element():
+    with pytest.raises(NxosJsonFormatterError, message="The last element must be a dict, got <type 'str'>"):
+        nxos_json_formatter({'TABLE_a': {'ROW_a': ""}}, ['TABLE_a.ROW_a.b'])
+
+
+def test_dict_path_with_missing_key_after_convert():
+    with pytest.raises(NxosJsonFormatterError, message="Missing key 'a'"):
+        nxos_json_formatter({}, ['a', 'a.b'])
+
+
+def test_long_dict_path():
+    data = nxos_json_formatter({'a': {'b': {}}}, ['a.b.c'])
+    assert data == {'a': {'b': {'TABLE_c': {'ROW_c': []}}}}
+
+
+def test_dict_path_with_missing_key_before_convert():
+    with pytest.raises(NxosJsonFormatterError, message="Missing key 'bad'"):
+        nxos_json_formatter({'a': {'b': {}}}, ['a.bad.c'])
+
+
+def test_long_dict_path_with_invalid_struct():
+    with pytest.raises(NxosJsonFormatterError, message="Expected a dict with key 'b', got <type 'list'>"):
+        nxos_json_formatter({'a': []}, ['a.b.c'])
+
+
+def test_list_path_with_empty_list():
+    data = nxos_json_formatter([], ['*.a'])
+    assert data == []
+
+
+def test_list_path_with_items():
+    data = nxos_json_formatter([{}, {}], ['*.a'])
+    assert data == [{'TABLE_a': {'ROW_a': []}}, {'TABLE_a': {'ROW_a': []}}]
+
+
+def test_list_path_with_complex_items():
+    data = nxos_json_formatter([{'a': {}}, {'a': {}}], ['*.a.b'])
+    assert data == [{'a': {'TABLE_b': {'ROW_b': []}}}, {'a': {'TABLE_b': {'ROW_b': []}}}]
+
+
+def test_double_list_path_with_items():
+    data = nxos_json_formatter([[{}, {}]], ['*.*.a'])
+    assert data == [[{'TABLE_a': {'ROW_a': []}}, {'TABLE_a': {'ROW_a': []}}]]
+
+
+def test_list_path_with_invalid_struct():
+    with pytest.raises(NxosJsonFormatterError, message="Expected a list (*), got <type 'dict'>"):
+        nxos_json_formatter([{}], ['*.*'])
+
+
+def test_rewrite_with_nothing_to_do():
+    data = nxos_json_formatter({'TABLE_a': {'ROW_a': []}}, ['a'])
+    assert data == {'TABLE_a': {'ROW_a': []}}
+
+
+def test_rewrite_with_one_item():
+    data = nxos_json_formatter({'TABLE_a': {'ROW_a': {}}}, ['a'])
+    assert data == {'TABLE_a': {'ROW_a': [{}]}}
+
+
+def test_rewrite_with_nothing_to_do_2():
+    data = nxos_json_formatter({'TABLE_a': {'ROW_a': [{'c': 1, 'd': 2}, {'c': 5, 'd': 4}]}}, ['a'])
+    assert data == {'TABLE_a': {'ROW_a': [{'c': 1, 'd': 2}, {'c': 5, 'd': 4}]}}
+
+
+def test_rewrite_with_one_item_2():
+    data = nxos_json_formatter({'TABLE_a': {'ROW_a': {'c': 1, 'd': 2}}}, ['a'])
+    assert data == {'TABLE_a': {'ROW_a': [{'c': 1, 'd': 2}]}}
+
+
+def test_alternative_format_alternative():
+    data = nxos_json_formatter({'TABLE_a': [{'ROW_a': {'vrf': 1}}, {'ROW_a': {'vrf': 2}}]}, ['a'])
+    assert data == {'TABLE_a': {'ROW_a': [{'vrf': 1}, {'vrf': 2}]}}
+
+
+def test_alternative_format_with_invalid_TABLE():
+    with pytest.raises(NxosJsonFormatterError, message="The last element (TABLE_a) must be a dict or a list, got <type 'int'>"):
+        nxos_json_formatter({'TABLE_a': 5}, ['a'])
+
+
+def test_alternative_format_with_invalid_ROW():
+    with pytest.raises(NxosJsonFormatterError, message="The last element (ROW_a) must be a dict, got <type 'int'>"):
+        nxos_json_formatter({'TABLE_a': [{'ROW_a': {'vrf': 1}}, {'ROW_a': 2}]}, ['a'])
+
+
+def test_alternative_format_with_missing_ROW():
+    with pytest.raises(NxosJsonFormatterError, message="The last element (ROW_a) is missing"):
+        nxos_json_formatter({'TABLE_a': [{'nimp': 2}]}, ['a'])
+
+
+def test_alternative_format_with_invalid_ROW_type():
+    with pytest.raises(NxosJsonFormatterError, message="The last element (TABLE_a) must be a list of dict, got list of <type 'int'>"):
+        nxos_json_formatter({'TABLE_a': [2]}, ['a'])


### PR DESCRIPTION
#### SUMMARY

Working on the nxos system, I had some trouble to use the native JSON output formatter (| json). Depending on some parameters like the number of items, a nxos command can return different JSON structures. This behavior makes it very difficult to work with data in playbooks.

Internally, I developed an Ansible filter to convert the nxos JSON output in a standardized format. With this pull request, I would like to share this functionality and try to get a better integration in Ansible.

I transformed the filter to a nxos module_utils to facilitate its integration.
* It can be used in nxos modules.
* It can be used as an Ansible filter (not integrated here).
* It could be integrated with an option in the nxos_command module (not developed).

#### ISSUE TYPE
- Feature Pull Request

#### COMPONENT NAME
lib/ansible/modules/network/nxos/nxos_command.py
lib/ansible/module_utils/network/nxos/nxos_json_formatter.py
test/units/module_utils/network/nxos/test_nxos_json_formatter.py

#### ADDITIONAL INFORMATION

System: Cisco nexus9000, version 7.0(3)I7(5a)

##### Nexus JSON output cases

All structures cases:
* 0 element: missing structure or empty string.
* 1 element: ROW_x is a dict instead of a list.
* more than 1 element: regular format ```{ "TABLE_x": "ROW_x": [...] }```.
* alternative with more than 1 element: TABLE_x is a list of ROW_x hash ```{ "TABLE_x": [ {"ROW_x": {...} }, {"ROW_x": {...} } ] }```

##### Nexus JSON examples

These examples present the functionality with an Ansible filter (not included in the code). I choose the command ```show port-channel summary``` which has 2 levels of TABLE_x.ROW_x.
* The first level is all channels
* The second level is all members for a channel

Ansible tasks:

```yaml
- register: nexus_port_channels_json
  nxos_command:
    commands:
      - command: "show port-channel summary"
        output: json
- debug:
    var: nexus_port_channels_json.stdout[0]
- debug:
    var: "nexus_port_channels_json.stdout[0] | nxos_json_formatter(['channel', 'TABLE_channel.ROW_channel.*.member'])"
```

###### Zero element

The output is an empty string, iteration will fail.
```
TASK [Original JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0]": ""
}
```
nxos_json_formatter force a minimal structure (empty list) to iterate:
```
TASK [Formatted JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0] | nxos_json_formatter(['channel', 'TABLE_channel.ROW_channel.*.member'])": {
        "TABLE_channel": {
            "ROW_channel": []
        }
    }
}
```

###### One element

With only one port-channel on the system, ROW_channel became a dict, iteration will fail.
There is a similar problem with ROW_member.

```
TASK [Original JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0]": {
        "TABLE_channel": {
            "ROW_channel": {
                "TABLE_member": {
                    "ROW_member": {
                        "port": "Ethernet1/5",
                        "port-status": "D"
                    }
                },
                "group": "10",
                ...
            }
        }
    }
}
```
nxos_json_formatter force ROW_channel and ROW_member to be a list:
```
TASK [Formatted JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0] | nxos_json_formatter(['channel', 'TABLE_channel.ROW_channel.*.member'])": {
        "TABLE_channel": {
            "ROW_channel": [
                {
                    "TABLE_member": {
                        "ROW_member": [
                            {
                                "port": "Ethernet1/5",
                                "port-status": "D"
                            }
                        ]
                    },
                    "group": "10",
                    ...
                }
            ]
        }
    }
}
```

###### More than one element

In the original output, the first ROW_member is a dict, and the second is a list. Impossible to use json_query or jinja2 map on these data.
```
TASK [Original JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0]": {
        "TABLE_channel": {
            "ROW_channel": [
                {
                    "TABLE_member": {
                        "ROW_member": {
                            "port": "Ethernet1/5",
                            "port-status": "D"
                        }
                    },
                    "group": "10",
                    ...
                },
                {
                    "TABLE_member": {
                        "ROW_member": [
                            {
                                "port": "Ethernet1/47",
                                "port-status": "D"
                            },
                            {
                                "port": "Ethernet1/48",
                                "port-status": "D"
                            }
                        ]
                    },
                    "group": "100",
                    ...
                }
            ]
        }
    }
}
```
nxos_json_formatter force all ROW_x to be lists:
```
TASK [Formatted JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0] | nxos_json_formatter(['channel', 'TABLE_channel.ROW_channel.*.member'])": {
        "TABLE_channel": {
            "ROW_channel": [
                {
                    "TABLE_member": {
                        "ROW_member": [
                            {
                                "port": "Ethernet1/5",
                                "port-status": "D"
                            }
                        ]
                    },
                    "group": "10",
                    ...
                },
                {
                    "TABLE_member": {
                        "ROW_member": [
                            {
                                "port": "Ethernet1/47",
                                "port-status": "D"
                            },
                            {
                                "port": "Ethernet1/48",
                                "port-status": "D"
                            }
                        ]
                    },
                    "group": "100",
                    ...
                }
            ]
        }
    }
}
```


###### More than one element (alternative)

For this case, I use the ```show ip interface vrf all``` command with the filter ```nexus_port_channels_json.stdout[0] | nxos_json_formatter(['vrf', 'intf'])```

I don't know why this command has this specific JSON structure which is quite hard to work with:
```
TASK [Original JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0]": {
        "TABLE_intf": [
            {
                "ROW_intf": {
                    "admin-state": "up",
                    "bbyte-consumed": "0",
                    ...
                  }
            },
            {
            "ROW_intf": {
               "admin-state": "up",
               "bbyte-consumed": "0",
               ...
             },
             ...
        ],
        "TABLE_vrf": [
            {
                "ROW_vrf": {
                    "vrf-name-out": "default"
                }
            },
            {
                "ROW_vrf": {
                    "vrf-name-out": "default"
                }
            },
            ...
        ]
    }
}
```
nxos_json_formatter applies the regular format:
```
TASK [Formatted JSON output] ***************************
ok: [leaf-2-prod] => {
    "nexus_port_channels_json.stdout[0] | nxos_json_formatter(['vrf', 'intf'])": {
        "TABLE_intf": {
            "ROW_intf": [
                {
                    "admin-state": "up",
                    "bbyte-consumed": "0",
                    ...
                },
                {
                    "admin-state": "up",
                    "bbyte-consumed": "0",
                    ...
                },
                ...
            ]
        },
        "TABLE_vrf": {
            "ROW_vrf": [
                {
                    "vrf-name-out": "default"
                },
                {
                    "vrf-name-out": "default"
                },
            ]
        }
    }
}
```

##### Integration in nxos modules

Most of the nxos_* modules implement checks for each case. The nxos_json_formatter could replace all these checks.

Random example with the nxos_vrf module:
```python
#lib/ansible/modules/network/nxos/nxos_vrf.py
def get_existing_vrfs(module):
    objs = list()
    command = "show vrf all"
    try:
        body = execute_show_command(command, module)[0]
    except IndexError:
        return list()
    try:
        vrf_table = body['TABLE_vrf']['ROW_vrf']
    except (TypeError, IndexError, KeyError):
        return list()

    if isinstance(vrf_table, list):
        for vrf in vrf_table:
            obj = {}
            obj['name'] = vrf['vrf_name']
            objs.append(obj)

    elif isinstance(vrf_table, dict):
        obj = {}
        obj['name'] = vrf_table['vrf_name']
        objs.append(obj)

    return objs
```

with nxos_json_formatter, it is possible to remove KeyError exception, and instance type checks:
```python
def get_existing_vrfs(module):
    objs = list()
    command = "show vrf all"
    try:
        body = execute_show_command(command, module)[0]
    except IndexError:
        return list()

    formatted_data = nxos_json_formatter(body, ['vrf'])
    for vrf in formatted_data['TABLE_vrf']['ROW_vrf']:
        obj = {}
        obj['name'] = vrf['vrf_name']
        objs.append(obj)

    return objs
```

##### Next step

Are you interested ?

An integration in the nxos_command module could be great to avoid a set_fact and reduce the code to one Ansible task.

Real code sample with an Ansible filter:
```yaml
- block:
    - name: "{{ caller_main }} > Port-channel > Get Nexus PO"
      register: nexus_port_channels_json
      nxos_command:
        commands:
          - command: "show port-channel database"
            output: json
    - name: "{{ caller_main }} > Port-channel > Select managed PO"
      set_fact:
        local_managed_port_channels_json: "{{
          nexus_port_channels_json.stdout[0]
          | alpha_nxos_json_formatter(['interface', 'TABLE_interface.ROW_interface.*.member'])
          | json_query('TABLE_interface.ROW_interface')
          | selectattr('interface', 'in', local_managed_port_channels_names)
          | list
          }}"
```
