### PR TITLE
Correct docsite typos: it's -> its

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -198,7 +198,7 @@ Inventory source common format
 ------------------------------
 
 To simplify development, most plugins use a mostly standard configuration file as the inventory source, YAML based and with just one required field ``plugin`` which should contain the name of the plugin that is expected to consume the file.
-Depending on other common features used, other fields might be needed, but each plugin can also add it's own custom options as needed.
+Depending on other common features used, other fields might be needed, but each plugin can also add its own custom options as needed.
 For example, if you use the integrated caching, ``cache_plugin``, ``cache_timeout`` and other cache related fields could be present.
 
 .. _inventory_development_auto:

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -312,7 +312,7 @@ For example:
 
 Suggestions to resolve:
 
-* If you are using the ``provider:`` options ensure that it's suboption ``host:`` is set correctly.
+* If you are using the ``provider:`` options ensure that its suboption ``host:`` is set correctly.
 * If you are not using ``provider:`` nor top-level arguments ensure your inventory file is correct.
 
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -178,7 +178,7 @@ Display class
 -------------
 
 As of Ansible 2.8, the ``Display`` class is now a "singleton". Instead of using ``__main__.display`` each file should
-import and instantiate ``ansible.utils.display.Display`` on it's own.
+import and instantiate ``ansible.utils.display.Display`` on its own.
 
 **OLD** In Ansible 2.7 (and earlier) the following was used to access the ``display`` object:
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -10,7 +10,7 @@ Filters in Ansible are from Jinja2, and are used for transforming data inside a 
 
 Take into account that templating happens on the Ansible controller, **not** on the task's target host, so filters also execute on the controller as they manipulate local data.
 
-In addition the ones provided by Jinja2, Ansible ships with it's own and allows users to add their own custom filters.
+In addition the ones provided by Jinja2, Ansible ships with its own and allows users to add their own custom filters.
 
 .. _filters_for_formatting_data:
 

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -155,7 +155,7 @@ Or, using the newer syntax::
           app_port: 5000
       ...
 
-You can conditionally import a role and execute it's tasks::
+You can conditionally import a role and execute its tasks::
 
     ---
 


### PR DESCRIPTION
##### SUMMARY
Correct some "it's"/"its" mistakes in `docsite`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`docsite`

##### ADDITIONAL INFORMATION
See `docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst` for guidance on "it's" vs "its".