### PR TITLE
[stable-2.7] Cleanup integration test inventory. (#50753)

### DIFF
--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -1,52 +1,8 @@
-[local]
-testhost ansible_ssh_host=127.0.0.1 ansible_connection=local host_var_role_name=role3
-testhost2 ansible_ssh_host=127.0.0.1 ansible_connection=local host_var_role_name=role2
-# For testing delegate_to
-testhost3 ansible_ssh_host=127.0.0.3
-testhost4 ansible_ssh_host=127.0.0.4
-# For testing fact gathering
-facthost[0:25] ansible_host=127.0.0.1 ansible_connection=local
+# Do not put test specific entries in this inventory file.
+# For script based test targets (using runme.sh) put the inventory file in the test's directory instead.
 
-[binary_modules]
-testhost_binary_modules ansible_host=127.0.0.1 ansible_connection=local
-
-[local_group]
-kube-pippin.knf.local
-
-# the following inline declarations are accompanied
-# by (preferred) group_vars/ and host_vars/ variables
-# and are used in testing of variable precedence
-
-[inven_overridehosts]
-invenoverride ansible_ssh_host=127.0.0.1 ansible_connection=local
-
-[all:vars]
-extra_var_override=FROM_INVENTORY
-inven_var=inventory_var
-unicode_host_var=CaféEñyei
-
-[inven_overridehosts:vars]
-foo=foo
-var_dir=vars
-
-[arbitrary_parent:children]
-local
-
-[local:vars]
-parent_var=6000
-groups_tree_var=5000
-
-[arbitrary_parent:vars]
-groups_tree_var=4000
-overridden_in_parent=1000
-
-[arbitrary_grandparent:children]
-arbitrary_parent
-
-[arbitrary_grandparent:vars]
-groups_tree_var=3000
-grandparent_var=2000
-overridden_in_parent=2000
+[testgroup]
+testhost ansible_connection=local
 
 [aci:vars]
 aci_hostname=your-apic-1
@@ -57,10 +13,4 @@ aci_use_ssl=yes
 aci_use_proxy=no
 
 [aci]
-localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
-
-[amazon]
-localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
-
-[azure]
 localhost ansible_ssh_host=127.0.0.1 ansible_connection=local

--- a/test/integration/inventory.winrm.template
+++ b/test/integration/inventory.winrm.template
@@ -23,6 +23,6 @@ ansible_winrm_server_cert_validation=ignore
 [winrm:children]
 windows
 
-# support winrm binary module tests (temporary solution)
-[testhost_binary_modules:children]
+# support tests that target testhost
+[testhost:children]
 windows

--- a/test/integration/targets/binary_modules/download_binary_modules.yml
+++ b/test/integration/targets/binary_modules/download_binary_modules.yml
@@ -1,4 +1,4 @@
-- hosts: testhost_binary_modules
+- hosts: testhost
   tasks:
     - debug: var=ansible_system
 

--- a/test/integration/targets/binary_modules/test_binary_modules.yml
+++ b/test/integration/targets/binary_modules/test_binary_modules.yml
@@ -1,4 +1,4 @@
-- hosts: testhost_binary_modules
+- hosts: testhost
   roles:
     - role: test_binary_modules
       tags:

--- a/test/integration/targets/delegate_to/aliases
+++ b/test/integration/targets/delegate_to/aliases
@@ -1,1 +1,2 @@
 shippable/posix/group3
+needs/ssh

--- a/test/integration/targets/delegate_to/inventory
+++ b/test/integration/targets/delegate_to/inventory
@@ -1,0 +1,5 @@
+[local]
+testhost ansible_connection=local
+testhost2 ansible_connection=local
+testhost3 ansible_ssh_host=127.0.0.3
+testhost4 ansible_ssh_host=127.0.0.4

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -3,12 +3,12 @@
 set -eux
 
 ANSIBLE_SSH_ARGS='-C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null' \
-    ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook test_delegate_to.yml -i ../../inventory -v "$@"
+    ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook test_delegate_to.yml -i inventory -v "$@"
 
 ansible-playbook test_loop_control.yml -v "$@"
 
 ansible-playbook test_delegate_to_loop_randomness.yml -v "$@"
 
-ansible-playbook delegate_and_nolog.yml -i ../../inventory -v "$@"
+ansible-playbook delegate_and_nolog.yml -i inventory -v "$@"
 
-ansible-playbook test_delegate_to_loop_caching.yml -i ../../inventory -v "$@"
+ansible-playbook test_delegate_to_loop_caching.yml -i inventory -v "$@"

--- a/test/integration/targets/gathering_facts/inventory
+++ b/test/integration/targets/gathering_facts/inventory
@@ -1,0 +1,2 @@
+[local]
+facthost[0:25] ansible_connection=local

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -2,8 +2,8 @@
 
 set -eux
 
-# ANSIBLE_CACHE_PLUGINS=cache_plugins/ ANSIBLE_CACHE_PLUGIN=none ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
-ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
-#ANSIBLE_CACHE_PLUGIN=base ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
+# ANSIBLE_CACHE_PLUGINS=cache_plugins/ ANSIBLE_CACHE_PLUGIN=none ansible-playbook test_gathering_facts.yml -i inventory -v "$@"
+ansible-playbook test_gathering_facts.yml -i inventory -v "$@"
+# ANSIBLE_CACHE_PLUGIN=base ansible-playbook test_gathering_facts.yml -i inventory -v "$@"
 
-ANSIBLE_GATHERING=smart ansible-playbook test_run_once.yml -i ../../inventory -v "$@"
+ANSIBLE_GATHERING=smart ansible-playbook test_run_once.yml -i inventory -v "$@"

--- a/test/integration/targets/unicode/inventory
+++ b/test/integration/targets/unicode/inventory
@@ -1,0 +1,5 @@
+[local]
+testhost ansible_connection=local
+
+[all:vars]
+unicode_host_var=CaféEñyei

--- a/test/integration/targets/unicode/runme.sh
+++ b/test/integration/targets/unicode/runme.sh
@@ -2,6 +2,6 @@
 
 set -eux
 
-ansible-playbook unicode.yml -i ../../inventory -v -e 'extra_var=café' "$@"
+ansible-playbook unicode.yml -i inventory -v -e 'extra_var=café' "$@"
 # Test the start-at-task flag #9571
-ansible-playbook unicode.yml -i ../../inventory -v --start-at-task '*¶' -e 'start_at_task=True' "$@"
+ansible-playbook unicode.yml -i inventory -v --start-at-task '*¶' -e 'start_at_task=True' "$@"

--- a/test/integration/targets/var_blending/inventory
+++ b/test/integration/targets/var_blending/inventory
@@ -1,0 +1,26 @@
+[local]
+testhost ansible_connection=local
+testhost2 ansible_connection=local
+
+# the following inline declarations are accompanied
+# by (preferred) group_vars/ and host_vars/ variables
+# and are used in testing of variable precedence
+
+[arbitrary_parent:children]
+local
+
+[local:vars]
+parent_var=6000
+groups_tree_var=5000
+
+[arbitrary_parent:vars]
+groups_tree_var=4000
+overridden_in_parent=1000
+
+[arbitrary_grandparent:children]
+arbitrary_parent
+
+[arbitrary_grandparent:vars]
+groups_tree_var=3000
+grandparent_var=2000
+overridden_in_parent=2000

--- a/test/integration/targets/var_blending/runme.sh
+++ b/test/integration/targets/var_blending/runme.sh
@@ -2,4 +2,4 @@
 
 set -eux
 
-ansible-playbook test_var_blending.yml -i ../../inventory -e @integration_config.yml -v "$@"
+ansible-playbook test_var_blending.yml -i inventory -e @integration_config.yml -v "$@"

--- a/test/integration/targets/var_precedence/inventory
+++ b/test/integration/targets/var_precedence/inventory
@@ -1,0 +1,13 @@
+[local]
+testhost ansible_connection=local
+
+[all:vars]
+extra_var_override=FROM_INVENTORY
+inven_var=inventory_var
+
+[inven_overridehosts]
+invenoverride ansible_connection=local
+
+[inven_overridehosts:vars]
+foo=foo
+var_dir=vars

--- a/test/integration/targets/var_precedence/runme.sh
+++ b/test/integration/targets/var_precedence/runme.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-ansible-playbook test_var_precedence.yml -i ../../inventory -v "$@" \
+ansible-playbook test_var_precedence.yml -i inventory -v "$@" \
     -e 'extra_var=extra_var' \
     -e 'extra_var_override=extra_var_override'
 

--- a/test/runner/lib/cloud/aws.py
+++ b/test/runner/lib/cloud/aws.py
@@ -103,10 +103,3 @@ class AwsCloudEnvironment(CloudEnvironment):
         if not tries and self.managed:
             display.notice('If %s failed due to permissions, the IAM test policy may need to be updated. '
                            'For help, consult @mattclay or @gundalow on GitHub or #ansible-devel on IRC.' % target.name)
-
-    @property
-    def inventory_hosts(self):
-        """
-        :rtype: str | None
-        """
-        return 'amazon'

--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -161,13 +161,6 @@ class AzureCloudEnvironment(CloudEnvironment):
             display.notice('If %s failed due to permissions, the test policy may need to be updated. '
                            'For help, consult @mattclay or @gundalow on GitHub or #ansible-devel on IRC.' % target.name)
 
-    @property
-    def inventory_hosts(self):
-        """
-        :rtype: str | None
-        """
-        return 'azure'
-
 
 def get_config(config_path):
     """


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Cleanup integration test inventory. (#50753)

* Move var_blending test inventory into test.
* Remove Amazon specific inventory entry for tests.
* Remove Azure specific inventory entry for tests.
* Move var_precedence test inventory into test.
* Move unicode test inventory into test.
* Remove unused inventory entry.
* Move gathering_facts test inventory into test.
* Move delegate_to test inventory into test.
* Clean up inventory for binary_modules test.
* Clean up integration test inventory..

(cherry picked from commit e5094e8071ad4693089f7345e7aa4715ccfaa429)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
