### PR TITLE
[2.6] docker_volume: revert #47390

### DIFF
--- a/changelogs/fragments/docker_volume-force-change-detection-revert.yaml
+++ b/changelogs/fragments/docker_volume-force-change-detection-revert.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- "docker_volume - reverted changed behavior of ``force``, which was released in Ansible 2.7.1 to 2.7.5, and Ansible 2.6.8 to 2.6.11.
+   Volumes are now only recreated if the parameters changed **and** ``force`` is set to ``true`` (instead of or). This is the behavior
+   which has been described in the documentation all the time."

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -223,7 +223,7 @@ class DockerVolumeManager(object):
         if self.existing_volume:
             differences = self.has_different_config()
 
-        if differences or self.parameters.force:
+        if differences and self.parameters.force:
             self.remove_volume()
             self.existing_volume = None
 


### PR DESCRIPTION
##### SUMMARY
Backport of #50663 to stable-2.6: reverts (backport of) #47390, which caused a bad behavior change in docker_volume (volumes were recreated when parameters changed and `force` was not set to `true`, despite documentation saying that this only happens when parameters change and `force` is `true`).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_volume
