### PR TITLE
[stable-2.7] Add unstable alias to s3_bucket integration tests (#50508)

### DIFF
--- a/test/integration/targets/s3_bucket/aliases
+++ b/test/integration/targets/s3_bucket/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 shippable/aws/group1
+unstable


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Add unstable alias to s3_bucket integration tests (#50508)

(cherry picked from commit d21ed42f4bdf86aa12394e9bba1aacaf8614d91b)

Co-authored-by: Sloane Hertel <shertel@redhat.com>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

s3_bucket integration test
