### PR TITLE
ansible-pull: Add --module-args to expose all SCM module args and deprecate old argument specific CLI options. (#48678)

### DIFF
--- a/changelogs/fragments/48678-ansible-pull.yml
+++ b/changelogs/fragments/48678-ansible-pull.yml
@@ -1,0 +1,11 @@
+---
+
+deprecated_features:
+  - ansible-pull - --full CLI argument is deprecated in favor of using depth or export in --module-args (https://github.com/ansible/ansible/issues/48678)
+  - ansible-pull - -C and --checkout CLI arguments are deprecated, use --module-args 'version=<checkout>' or --module-args 'revision=<checkout>' (https://github.com/ansible/ansible/issues/48678)
+  - ansible-pull - --accept-host-key CLI argument is deprecated, use --module-args 'accept_hostkey=yes' (https://github.com/ansible/ansible/issues/48678)
+  - ansible-pull - --verify-commit CLI argument is deprecated, use --module-args 'verify_commit=yes' (https://github.com/ansible/ansible/issues/48678)
+  - ansible-pull - --track-subs CLI argument is deprecated, use --module-args 'track_submodules=yes' (https://github.com/ansible/ansible/issues/48678)
+
+minor_changes:
+  - ansible-pull - Adds -a and --module-args arguments for creating a generic method to pass arguments to the underlying SCM module (https://github.com/ansible/ansible/issues/48678)

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -225,23 +225,16 @@ class PullCLI(CLI):
 
             if checkout_key in repo_opts:
                 display.warning("--module-args '%s' argument was provided but is being overridden because of deprecated -C or --checkout" % checkout_key)
-            else:
-                display.warning("-C and --checkout are deprecated, use --module-args '%s=<%s>'" % (checkout_key, checkout_key))
 
             repo_opts[checkout_key] = context.CLIARGS['checkout']
 
         if context.CLIARGS['clean']:
             repo_opts['force'] = 'yes'
 
-        if context.CLIARGS['fullclone'] and context.CLIARGS['module_name'] in ['git', 'subversion']:
-            display.warning('--full is deprecated')
-
         if context.CLIARGS['module_name'] == 'git':
             if context.CLIARGS['accept_host_key']:
                 if 'accept_hostkey' in repo_opts:
                     display.warning("--module-args 'accept_hostkey' argument was provided but is being overridden because of deprecated --accept-host-key")
-                else:
-                    display.warning("--accept-host-key is deprecated, use --module-args 'accept_hostkey=yes'")
 
                 repo_opts['accept_hostkey'] = 'yes'
 
@@ -261,16 +254,12 @@ class PullCLI(CLI):
             if context.CLIARGS['tracksubs']:
                 if 'track_submodules' in repo_opts:
                     display.warning("--module-args 'track_submodules' argument was provided but is being overridden because of deprecated --track-subs")
-                else:
-                    display.warning("--track-subs is deprecated use --module-args 'track_submodules=yes'")
 
                 repo_opts['track_submodules'] = 'yes'
 
             if context.CLIARGS['verify']:
                 if 'verify_commit' in repo_opts:
                     display.warning("--module-args 'verify_commit' argument was provided but is being overridden because of deprecated --verify-commit")
-                else:
-                    display.warning("--verify-commit is deprecated, use --module-args 'verify_commit=yes'")
 
                 repo_opts['verify_commit'] = 'yes'
         elif context.CLIARGS['module_name'] == 'subversion':

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -238,7 +238,7 @@ class PullCLI(CLI):
 
                 repo_opts['accept_hostkey'] = 'yes'
 
-            if not context.CLIARGS['fullclone'] and 'depth' not in repo_opts:
+            if not context.CLIARGS['module_args'] and not context.CLIARGS['fullclone'] and 'depth' not in repo_opts:
                 repo_opts['depth'] = '1'
             elif context.CLIARGS['fullclone'] and 'depth' in repo_opts:
                 display.warning("--module-args 'depth' argument was provided but is being ignored because of --full")

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -102,7 +102,7 @@ class PullCLI(CLI):
                                  help='Do a full clone, instead of a shallow one. (deprecated in favor of using depth or export in --module-args)')
         self.parser.add_argument('-C', '--checkout', dest='checkout',
                                  help="".join(["branch/tag/commit to checkout. Defaults to behavior of repository module.",
-                                             "(deprecated, use --module-args 'version=<checkout>' or --module-args 'revision=<checkout>')"]))
+                                               "(deprecated, use --module-args 'version=<checkout>' or --module-args 'revision=<checkout>')"]))
         self.parser.add_argument('--accept-host-key', default=False, dest='accept_host_key', action='store_true',
                                  help="adds the hostkey for the repo url if not already added (deprecated, use --module-args 'accept_hostkey=yes')")
         self.parser.add_argument('-a', '--module-args', dest='module_args', default=None,
@@ -112,14 +112,14 @@ class PullCLI(CLI):
                                       % (self.REPO_CHOICES, self.DEFAULT_REPO_TYPE))
         self.parser.add_argument('--verify-commit', dest='verify', default=False, action='store_true',
                                  help="".join(['verify GPG signature of checked out commit, if it fails abort running the playbook. ',
-                                             'This needs the corresponding VCS module to support such an operation.',
-                                             " (deprecated, use --module-args 'verify_commit=yes')"]))
+                                               'This needs the corresponding VCS module to support such an operation.',
+                                               " (deprecated, use --module-args 'verify_commit=yes')"]))
         self.parser.add_argument('--clean', dest='clean', default=False, action='store_true',
                                  help='modified files in the working repository will be discarded')
         self.parser.add_argument('--track-subs', dest='tracksubs', default=False, action='store_true',
                                  help="".join(["submodules will track the latest changes. This is equivalent to specifying",
-                                             " the --remote flag to git submodule update.",
-                                             " (deprecated, use --module-args 'track_submodules=yes')"]))
+                                               " the --remote flag to git submodule update.",
+                                               " (deprecated, use --module-args 'track_submodules=yes')"]))
         # add a subset of the check_opts flag group manually, as the full set's
         # shortcodes conflict with above --checkout/-C
         self.parser.add_argument("--check", default=False, dest='check', action='store_true',

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -225,16 +225,23 @@ class PullCLI(CLI):
 
             if checkout_key in repo_opts:
                 display.warning("--module-args '%s' argument was provided but is being overridden because of deprecated -C or --checkout" % checkout_key)
+            else:
+                display.warning("-C and --checkout are deprecated, use --module-args '%s=<%s>'" % (checkout_key, checkout_key))
 
             repo_opts[checkout_key] = context.CLIARGS['checkout']
 
         if context.CLIARGS['clean']:
             repo_opts['force'] = 'yes'
 
+        if context.CLIARGS['fullclone'] and context.CLIARGS['module_name'] in ['git', 'subversion']:
+            display.warning('--full is deprecated')
+
         if context.CLIARGS['module_name'] == 'git':
             if context.CLIARGS['accept_host_key']:
                 if 'accept_hostkey' in repo_opts:
                     display.warning("--module-args 'accept_hostkey' argument was provided but is being overridden because of deprecated --accept-host-key")
+                else:
+                    display.warning("--accept-host-key is deprecated, use --module-args 'accept_hostkey=yes'")
 
                 repo_opts['accept_hostkey'] = 'yes'
 
@@ -254,12 +261,16 @@ class PullCLI(CLI):
             if context.CLIARGS['tracksubs']:
                 if 'track_submodules' in repo_opts:
                     display.warning("--module-args 'track_submodules' argument was provided but is being overridden because of deprecated --track-subs")
+                else:
+                    display.warning("--track-subs is deprecated use --module-args 'track_submodules=yes'")
 
                 repo_opts['track_submodules'] = 'yes'
 
             if context.CLIARGS['verify']:
                 if 'verify_commit' in repo_opts:
                     display.warning("--module-args 'verify_commit' argument was provided but is being overridden because of deprecated --verify-commit")
+                else:
+                    display.warning("--verify-commit is deprecated, use --module-args 'verify_commit=yes'")
 
                 repo_opts['verify_commit'] = 'yes'
         elif context.CLIARGS['module_name'] == 'subversion':

--- a/test/integration/targets/git_config/tasks/main.yml
+++ b/test/integration/targets/git_config/tasks/main.yml
@@ -19,5 +19,9 @@
     - import_tasks: precedence_between_unset_and_value.yml
     # testing state=absent with check mode
     - import_tasks: unset_check_mode.yml
+  always:
+    # Always renove git config
+    - import_tasks: setup_no_value.yml
   when: git_installed is succeeded and git_version.stdout is version(git_version_supporting_includes, ">=")
+
 ...

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -308,10 +308,10 @@ submodule_full_cloned
 
 rm -rf "${pull_dir}"
 
-# Run ansible-pull with --checkout at tag 1.2.0 and accept GH host key
-ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.2.0' "$@" | tee "${temp_log}"
+# Run ansible-pull with --checkout at tag 1.3.0 and accept GH host key
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.3.0' "$@" | tee "${temp_log}"
 
-main_repo_at_tag '1.2.0'
+main_repo_at_tag '1.3.0'
 main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized
@@ -339,10 +339,10 @@ submodule_full_cloned
 
 rm -rf "${pull_dir}"
 
-# Run ansible-pull with checkout at tag 1.2.0 and accept GH host key using --module-args
-ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.2.0' "$@" | tee "${temp_log}"
+# Run ansible-pull with checkout at tag 1.3.0 and accept GH host key using --module-args
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.3.0' "$@" | tee "${temp_log}"
 
-main_repo_at_tag '1.2.0'
+main_repo_at_tag '1.3.0'
 main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -31,18 +31,18 @@ cd "${repo_dir}"
 
 function localhost_only
 {
-  local ansible_output=''
+  local ansible_output_log=''
 
   if [[ $# -ne 1 ]]; then
-    echo 'Usage: localhost_only <ansible_output>' 1>&2
+    echo 'Usage: localhost_only <ansible_output_log>' 1>&2
 
     return 1
   fi
 
-  ansible_output="$1"
+  ansible_output_log="$1"
 
   # test for https://github.com/ansible/ansible/issues/13681
-  if egrep '127\.0\.0\.1.*ok=' <<< "${ansible_output}"; then
+  if egrep '127\.0\.0\.1.*ok=' < "${ansible_output_log}"; then
     echo "Found host 127.0.0.1 in output. Only localhost should be present." 1>&2
 
     return 1
@@ -53,18 +53,18 @@ function localhost_only
 
 function localhost_ran
 {
-  local ansible_output=''
+  local ansible_output_log=''
 
   if [[ $# -ne 1 ]]; then
-    echo 'Usage: localhost_ran <ansible_output>' 1>&2
+    echo 'Usage: localhost_ran <ansible_output_log>' 1>&2
 
     return 1
   fi
 
-  ansible_output="$1"
+  ansible_output_log="$1"
 
   # make sure one host was run
-  if ! egrep 'localhost.*ok=' <<< "${ansible_output}"; then
+  if ! egrep 'localhost.*ok=' < "${ansible_output_log}"; then
     echo "Did not find host localhost in output." 1>&2
 
     return 1
@@ -75,18 +75,18 @@ function localhost_ran
 
 function magickeyword_in_output
 {
-  local ansible_output=''
+  local ansible_output_log=''
 
   if [[ $# -ne 1 ]]; then
-    echo 'Usage: magickeyword_in_output <ansible_output>' 1>&2
+    echo 'Usage: magickeyword_in_output <ansible_output_log>' 1>&2
 
     return 1
   fi
 
-  ansible_output="$1"
+  ansible_output_log="$1"
 
   # test for https://github.com/ansible/ansible/issues/13688
-  if ! grep MAGICKEYWORD <<< "${ansible_output}"; then
+  if ! grep MAGICKEYWORD < "${ansible_output_log}"; then
     echo "Missing MAGICKEYWORD in output." 1>&2
 
     return 1
@@ -108,7 +108,7 @@ function main_repo_at_tag
 
   tag="$1"
 
-  cd "${pull_dir}"
+  pushd "${pull_dir}"
 
   set +x
 
@@ -122,14 +122,14 @@ function main_repo_at_tag
     return 1
   fi
 
-  cd -
+  popd
 
   return 0
 }
 
 function main_repo_full_cloned()
 {
-  cd "${pull_dir}"
+  pushd "${pull_dir}"
 
   if [[ "$(git log --oneline | wc -l)" -eq 1 ]]; then
     echo "Main ansible-pull repo was not full cloned by git" 1>&2
@@ -137,29 +137,29 @@ function main_repo_full_cloned()
     return 1
   fi
 
-  cd -
+  popd
 
   return 0
 }
 
 function main_repo_shallow_cloned
 {
-  local ansible_output=''
+  local ansible_output_log=''
 
   if [[ $# -ne 1 ]]; then
-    echo 'Usage: main_repo_shallow_cloned <ansible_output>' 1>&2
+    echo 'Usage: main_repo_shallow_cloned <ansible_output_log>' 1>&2
 
     return 1
   fi
 
-  ansible_output="$1"
+  ansible_output_log="$1"
 
-  if grep '\[WARNING]: Your git version is too old to fully support the depth argument.' <<< "${ansible_output}"; then
+  if grep '\[WARNING]: Your git version is too old to fully support the depth argument.' < "${ansible_output_log}"; then
     main_repo_full_cloned
 
     return $?
   else
-    cd "${pull_dir}"
+    pushd "${pull_dir}"
 
     if [[ "$(git log --oneline | wc -l)" -gt 1 ]]; then
       echo "Main ansible-pull repo was not shallow cloned by git" 1>&2
@@ -167,7 +167,7 @@ function main_repo_shallow_cloned
       return 1
     fi
 
-    cd -
+    popd
   fi
 
   return 0
@@ -175,7 +175,7 @@ function main_repo_shallow_cloned
 
 function submodule_initialized()
 {
-  cd "${pull_dir}"
+  pushd "${pull_dir}"
 
   if [[ -z "$(ls roles/test_submodules/)" ]]; then
     echo "Primary submodule for role test_submodules was not initialized" 1>&2
@@ -183,12 +183,12 @@ function submodule_initialized()
     return 1
   fi
 
-  cd -
+  popd
 }
 
 function submodule_recursively_initialized()
 {
-  cd "${pull_dir}"
+  pushd "${pull_dir}"
 
   if ! [[ -d "roles/test_submodules/submodule1/submodule2" ]]; then
     echo "Recursive submodules for role test_submodules were not initialized" 1>&2
@@ -196,14 +196,14 @@ function submodule_recursively_initialized()
     return 1
   fi
 
-  cd -
+  popd
 
   return 0
 }
 
 function submodule_full_cloned()
 {
-  cd "${pull_dir}/roles/test_submodules"
+  pushd "${pull_dir}/roles/test_submodules"
 
   if [[ "$(git log --oneline | wc -l)" -eq 1 ]]; then
     echo "Primary submodule for role test_submodules was not full cloned by git" 1>&2
@@ -211,29 +211,29 @@ function submodule_full_cloned()
     return 1
   fi
 
-  cd -
+  popd
 
   return 0
 }
 
 function submodule_shallow_cloned
 {
-  local ansible_output=''
+  local ansible_output_log=''
 
   if [[ $# -ne 1 ]]; then
-    echo 'Usage: main_repo_shallow_cloned <ansible_output>' 1>&2
+    echo 'Usage: main_repo_shallow_cloned <ansible_output_log>' 1>&2
 
     return 1
   fi
 
-  ansible_output="$1"
+  ansible_output_log="$1"
 
-  if grep '\[WARNING]: Your git version is too old to fully support the depth argument.' <<< "${ansible_output}"; then
+  if grep '\[WARNING]: Your git version is too old to fully support the depth argument.' < "${ansible_output_log}"; then
     submodule_full_cloned
 
     return $?
   else
-    cd "${pull_dir}/roles/test_submodules"
+    pushd "${pull_dir}/roles/test_submodules"
 
     if [[ "$(git log --oneline | wc -l)" -gt 1 ]]; then
       echo "Primary submodule for role test_submodules was not shallow cloned by git" 1>&2
@@ -241,23 +241,17 @@ function submodule_shallow_cloned
       return 1
     fi
 
-    cd -
+    popd
   fi
 
   return 0
 }
 
-set +x
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" 2>&1 | tee "${temp_log}"
 
-output="$(ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" 2>&1 | tee "${temp_log}")"
-
-echo -n "${output}"
-
-set -x
-
-localhost_only "${output}"
-localhost_ran "${output}"
-magickeyword_in_output "${output}"
+localhost_only "${temp_log}"
+localhost_ran "${temp_log}"
+magickeyword_in_output "${temp_log}"
 
 rm -rf "${pull_dir}"
 
@@ -266,30 +260,18 @@ PASSWORD='test'
 USER=${USER:-'broken_docker'}
 JSON_EXTRA_ARGS='{"docker_registries_login": [{ "docker_password": "'"${PASSWORD}"'", "docker_username": "'"${USER}"'", "docker_registry_url":"repository-manager.company.com:5001"}], "docker_registries_logout": [{ "docker_password": "'"${PASSWORD}"'", "docker_username": "'"${USER}"'", "docker_registry_url":"repository-manager.company.com:5001"}] }'
 
-set +x
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" -e "${JSON_EXTRA_ARGS}" "$@" --tags untagged,test_ev 2>&1 | tee "${temp_log}"
 
-output="$(ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" -e "${JSON_EXTRA_ARGS}" "$@" --tags untagged,test_ev 2>&1 | tee "${temp_log}")"
-
-echo -n "${output}"
-
-set -x
-
-localhost_only "${output}"
-localhost_ran "${output}"
-magickeyword_in_output "${output}"
+localhost_only "${temp_log}"
+localhost_ran "${temp_log}"
+magickeyword_in_output "${temp_log}"
 
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with defaults (which is shallow clone on main repository and recursive full clone on submodules) and accept GH host key
-set +x
+ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key "$@" 2>&1 | tee "${temp_log}"
 
-output="$(ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key "$@" 2>&1 | tee "${temp_log}")"
-
-echo -n "${output}"
-
-set -x
-
-main_repo_shallow_cloned "${output}"
+main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned
@@ -307,16 +289,10 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with --checkout at tag 1.0.0 and accept GH host key
-set +x
-
-output="$(ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.0.0' "$@" 2>&1 | tee "${temp_log}")"
-
-echo -n "${output}"
-
-set -x
+ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.0.0' "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_at_tag '1.0.0'
-main_repo_shallow_cloned "${output}"
+main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned
@@ -324,15 +300,9 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with depth of 1 and accept GH host key using --module-args
-set +x
+ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1' "$@" 2>&1 | tee "${temp_log}"
 
-output="$(ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1' "$@" 2>&1 | tee "${temp_log}")"
-
-echo -n "${output}"
-
-set -x
-
-main_repo_shallow_cloned "${output}"
+main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned
@@ -350,16 +320,10 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with checkout at tag 1.0.0 and accept GH host key using --module-args
-set +x
-
-output="$(ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.0.0' "$@" 2>&1 | tee "${temp_log}")"
-
-echo -n "${output}"
-
-set -x
+ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.0.0' "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_at_tag '1.0.0'
-main_repo_shallow_cloned "${output}"
+main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -32,8 +32,15 @@ cd "${repo_dir}"
 function git_supports_depth()
 {
   # Output boolean 1 for true if git supports --depth or 0 for false
+  local git_version=''
 
-  if [[ -z "$(git clone -h | grep '\--depth')" ]]; then
+  set +x
+
+  git_version="$(git --version | grep 'git version' | sed 's/git version //')"
+
+  set -x
+
+  if [[ "${git_version}" == '1.8.3.1' ]] || ! grep -q '\--depth' <<< "$(git clone -h)"; then
     echo -n '0'
   else
     echo -n '1'
@@ -301,10 +308,10 @@ submodule_full_cloned
 
 rm -rf "${pull_dir}"
 
-# Run ansible-pull with --checkout at tag 1.0.0 and accept GH host key
-ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.0.0' "$@" | tee "${temp_log}"
+# Run ansible-pull with --checkout at tag 1.2.0 and accept GH host key
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.2.0' "$@" | tee "${temp_log}"
 
-main_repo_at_tag '1.0.0'
+main_repo_at_tag '1.2.0'
 main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized
@@ -332,10 +339,10 @@ submodule_full_cloned
 
 rm -rf "${pull_dir}"
 
-# Run ansible-pull with checkout at tag 1.0.0 and accept GH host key using --module-args
-ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.0.0' "$@" | tee "${temp_log}"
+# Run ansible-pull with checkout at tag 1.2.0 and accept GH host key using --module-args
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.2.0' "$@" | tee "${temp_log}"
 
-main_repo_at_tag '1.0.0'
+main_repo_at_tag '1.2.0'
 main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
 submodule_recursively_initialized

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -279,6 +279,8 @@ submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned
 
+rm -rf "${pull_dir}"
+
 # Run ansbible-pull with --module-args and no depth to emulate --full and accept GH host key using --module-args
 ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes' "$@" | tee "${temp_log}"
 

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -269,7 +269,7 @@ magickeyword_in_output "${temp_log}"
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with defaults (which is shallow clone on main repository and recursive full clone on submodules) and accept GH host key
-ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key "$@" 2>&1 | tee "${temp_log}"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
@@ -279,7 +279,7 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with --full for full clone and accept GH host key
-ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --full "$@" 2>&1 | tee "${temp_log}"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --full "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_full_cloned
 submodule_initialized
@@ -289,7 +289,7 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with --checkout at tag 1.0.0 and accept GH host key
-ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.0.0' "$@" 2>&1 | tee "${temp_log}"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.0.0' "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_at_tag '1.0.0'
 main_repo_shallow_cloned "${temp_log}"
@@ -300,7 +300,7 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with depth of 1 and accept GH host key using --module-args
-ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1' "$@" 2>&1 | tee "${temp_log}"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1' "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_shallow_cloned "${temp_log}"
 submodule_initialized
@@ -310,7 +310,7 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansbible-pull with --module-args and no depth to emulate --full and accept GH host key using --module-args
-ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes' "$@" 2>&1 | tee "${temp_log}"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes' "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_full_cloned
 submodule_initialized
@@ -320,7 +320,7 @@ submodule_full_cloned
 rm -rf "${pull_dir}"
 
 # Run ansible-pull with checkout at tag 1.0.0 and accept GH host key using --module-args
-ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.0.0' "$@" 2>&1 | tee "${temp_log}"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.0.0' "$@" 2>&1 | tee "${temp_log}"
 
 main_repo_at_tag '1.0.0'
 main_repo_shallow_cloned "${temp_log}"

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -42,7 +42,7 @@ function localhost_only
   ansible_output="$1"
 
   # test for https://github.com/ansible/ansible/issues/13681
-  if egrep '127\.0\.0\.1.*ok' <<< "${ansible_output}"; then
+  if egrep '127\.0\.0\.1.*ok=' <<< "${ansible_output}"; then
     echo "Found host 127.0.0.1 in output. Only localhost should be present." 1>&2
 
     return 1
@@ -64,7 +64,7 @@ function localhost_ran
   ansible_output="$1"
 
   # make sure one host was run
-  if ! egrep 'localhost.*ok' <<< "${ansible_output}"; then
+  if ! egrep 'localhost.*ok=' <<< "${ansible_output}"; then
     echo "Did not find host localhost in output." 1>&2
 
     return 1
@@ -215,9 +215,13 @@ function submodule_shallow_cloned()
   return 0
 }
 
+set +x
+
 output="$(ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" | tee "${temp_log}")"
 
 echo -n "${output}"
+
+set -x
 
 localhost_only "${output}"
 localhost_ran "${output}"
@@ -230,9 +234,13 @@ PASSWORD='test'
 USER=${USER:-'broken_docker'}
 JSON_EXTRA_ARGS='{"docker_registries_login": [{ "docker_password": "'"${PASSWORD}"'", "docker_username": "'"${USER}"'", "docker_registry_url":"repository-manager.company.com:5001"}], "docker_registries_logout": [{ "docker_password": "'"${PASSWORD}"'", "docker_username": "'"${USER}"'", "docker_registry_url":"repository-manager.company.com:5001"}] }'
 
+set +x
+
 output="$(ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" -e "${JSON_EXTRA_ARGS}" "$@" --tags untagged,test_ev | tee "${temp_log}")"
 
 echo -n "${output}"
+
+set -x
 
 localhost_only "${output}"
 localhost_ran "${output}"

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -162,18 +162,8 @@ function main_repo_full_cloned()
   return 0
 }
 
-function main_repo_shallow_cloned
+function main_repo_shallow_cloned()
 {
-  local ansible_output_log=''
-
-  if [[ $# -ne 1 ]]; then
-    echo 'Usage: main_repo_shallow_cloned <ansible_output_log>' 1>&2
-
-    return 1
-  fi
-
-  ansible_output_log="$1"
-
   if [[ "$(git_supports_depth)" -eq 0 ]]; then
     main_repo_full_cloned
 
@@ -236,18 +226,8 @@ function submodule_full_cloned()
   return 0
 }
 
-function submodule_shallow_cloned
+function submodule_shallow_cloned()
 {
-  local ansible_output_log=''
-
-  if [[ $# -ne 1 ]]; then
-    echo 'Usage: main_repo_shallow_cloned <ansible_output_log>' 1>&2
-
-    return 1
-  fi
-
-  ansible_output_log="$1"
-
   if [[ "$(git_supports_depth)" -eq 0 ]]; then
     submodule_full_cloned
 
@@ -291,7 +271,7 @@ rm -rf "${pull_dir}"
 # Run ansible-pull with defaults (which is shallow clone on main repository and recursive full clone on submodules) and accept GH host key
 ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key "$@" | tee "${temp_log}"
 
-main_repo_shallow_cloned "${temp_log}"
+main_repo_shallow_cloned
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned
@@ -312,7 +292,7 @@ rm -rf "${pull_dir}"
 ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --accept-host-key --checkout '1.3.0' "$@" | tee "${temp_log}"
 
 main_repo_at_tag '1.3.0'
-main_repo_shallow_cloned "${temp_log}"
+main_repo_shallow_cloned
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned
@@ -322,7 +302,7 @@ rm -rf "${pull_dir}"
 # Run ansible-pull with depth of 1 and accept GH host key using --module-args
 ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1' "$@" | tee "${temp_log}"
 
-main_repo_shallow_cloned "${temp_log}"
+main_repo_shallow_cloned
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned
@@ -343,7 +323,7 @@ rm -rf "${pull_dir}"
 ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${remote_repo}" --module-args 'accept_hostkey=yes depth=1 version=1.3.0' "$@" | tee "${temp_log}"
 
 main_repo_at_tag '1.3.0'
-main_repo_shallow_cloned "${temp_log}"
+main_repo_shallow_cloned
 submodule_initialized
 submodule_recursively_initialized
 submodule_full_cloned


### PR DESCRIPTION
- Second PR to complete #48678

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds a generic --module-args parameter that allows ansible-pull to pass parameters to the underlying SCM module used to checkout the repo without requiring the addition of CLI flags specific to options of each SCM module.

All existing CLI options that correspond to a specific SCM module parameter are deprecated and a warning has been added when behavior is being overridden to preserve backwards compatibility.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-pull
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
