### PR TITLE
grammer fix and changed description to iteratively from recursively.

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -141,7 +141,7 @@ Sometimes you would want to retry a task until a certain condition is met.  Here
       retries: 5
       delay: 10
 
-The above example run the shell module recursively till the module's result has "all systems go" in its stdout or the task has
+The above example runs the shell module iteratively until the module's result has "all systems go" in its stdout or the task has
 been retried for 5 times with a delay of 10 seconds. The default value for "retries" is 3 and "delay" is 5.
 
 The task returns the results returned by the last task run. The results of individual retries can be viewed by -vv option.


### PR DESCRIPTION
##### SUMMARY
Grammar fixes:  run -> runs, and till -> until

Semantic fix:  recursively -> iteratively

The shell module is called iteratively, not recursively.  Please correct me if I'm wrong, I did not
dig into the source code to verify.  However, I can't imagine it's actually recursive.

##### ISSUE TYPE

- Docs Pull Request
