### PR TITLE
jabber: Fix joining group chats

### DIFF
--- a/lib/ansible/modules/notification/jabber.py
+++ b/lib/ansible/modules/notification/jabber.py
@@ -141,7 +141,9 @@ def main():
         if nick:  # sending to room instead of user, need to join
             msg.setType('groupchat')
             msg.setTag('x', namespace='http://jabber.org/protocol/muc#user')
-            conn.send(xmpp.Presence(to=module.params['to']))
+            join = xmpp.Presence(to=module.params['to'])
+            join.setTag('x', namespace='http://jabber.org/protocol/muc')
+            conn.send(join)
             time.sleep(1)
         else:
             msg.setType('chat')


### PR DESCRIPTION
##### SUMMARY

The previous code was using the legacy Group Chat 1.0 (GC1.0) protocol to join [XEP-0045 Multi User Chats][1]. The legacy protocol has not been in active use for more than ten years, and servers are fading out support for it. This commit implements the modern join protocol, restoring functionality. The modern join protocol is, to my knowledge, supported by all XMPP servers which are still in use.

Prosody 0.11 is an example of a server implementation which does not support GC1.0 anymore.

(More extensive description of the issue and background is found below.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
``jabber`` module

##### ADDITIONAL INFORMATION

The previous code was using the legacy Group Chat 1.0 (GC1.0) protocol to join [XEP-0045 Multi User Chats][1]. The legacy protocol is described in § 7.2.1 of that document, the current protocol is described in § 7.2.2.

The legacy protocol has not been in active use for more than ten years, and servers are fading out support for it because its presence (pun not intended) causes issues (see for example the lengthy discussion in [2], particularly the part starting with "A MUC misunderstanding a presence update for a GC1.0 join").

The effect of servers fading out GC1.0 is that jabber.py cannot send messages to rooms on servers which have done that step any more.

This commit implements the modern join protocol, restoring functionality. The modern join protocol is, to my knowledge, supported by all XMPP servers which are still in use.

Prosody 0.11 is an example of a server implementation which does not support GC1.0 anymore.

   [1]: https://xmpp.org/extensions/xep-0045.html
   [2]: https://mail.jabber.org/pipermail/standards/2017-October/033501.html
