### PR TITLE
fix hostname module on some platforms

### DIFF
--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -29,9 +29,8 @@ def get_distribution():
     distribution = None
 
     if platform.system() == 'Linux':
-        distribution = distro.name().capitalize()
+        distribution = distro.id().capitalize()
 
-        # FIXME: Would we need to normalize these if we used: id() instead of name()?
         distribution_words = distribution.split()
         if 'Amazon' in distribution_words:
             distribution = 'Amazon'

--- a/test/units/module_utils/basic/test_platform_distribution.py
+++ b/test/units/module_utils/basic/test_platform_distribution.py
@@ -54,19 +54,19 @@ def test_get_distribution_not_linux():
 class TestGetDistribution:
     """ Tests for get_distribution that have to find somethine"""
     def test_distro_known(self):
-        with patch('ansible.module_utils.distro.name', return_value="foo"):
+        with patch('ansible.module_utils.distro.id', return_value="foo"):
             assert get_distribution() == "Foo"
 
     def test_distro_unknown(self):
-        with patch('ansible.module_utils.distro.name', return_value=""):
+        with patch('ansible.module_utils.distro.id', return_value=""):
             assert get_distribution() == "OtherLinux"
 
     def test_distro_amazon_part_of_another_name(self):
-        with patch('ansible.module_utils.distro.name', return_value="AmazonFooBar"):
+        with patch('ansible.module_utils.distro.id', return_value="AmazonFooBar"):
             assert get_distribution() == "Amazonfoobar"
 
     def test_distro_amazon_linux(self):
-        with patch('ansible.module_utils.distro.name', return_value="Amazon Linux AMI"):
+        with patch('ansible.module_utils.distro.id', return_value="Amazon Linux AMI"):
             assert get_distribution() == "Amazon"
 
 

--- a/test/units/module_utils/common/test_sys_info.py
+++ b/test/units/module_utils/common/test_sys_info.py
@@ -41,19 +41,19 @@ def test_get_distribution_not_linux():
 class TestGetDistribution:
     """ Tests for get_distribution that have to find somethine"""
     def test_distro_known(self):
-        with patch('ansible.module_utils.distro.name', return_value="foo"):
+        with patch('ansible.module_utils.distro.id', return_value="foo"):
             assert get_distribution() == "Foo"
 
     def test_distro_unknown(self):
-        with patch('ansible.module_utils.distro.name', return_value=""):
+        with patch('ansible.module_utils.distro.id', return_value=""):
             assert get_distribution() == "OtherLinux"
 
     def test_distro_amazon_part_of_another_name(self):
-        with patch('ansible.module_utils.distro.name', return_value="AmazonFooBar"):
+        with patch('ansible.module_utils.distro.id', return_value="AmazonFooBar"):
             assert get_distribution() == "Amazonfoobar"
 
     def test_distro_amazon_linux(self):
-        with patch('ansible.module_utils.distro.name', return_value="Amazon Linux AMI"):
+        with patch('ansible.module_utils.distro.id', return_value="Amazon Linux AMI"):
             assert get_distribution() == "Amazon"
 
 


### PR DESCRIPTION
##### SUMMARY

Fix #50844 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

hostname module
lib/ansible/module_utils/common/sys_info.py

##### ADDITIONAL INFORMATION

Tested with Alpine Linux, Arch Linux and Ubuntu. Therefore I performed the following steps:

1. Install python3, python3-jinja2 and python3-yaml
1. Download docker container
1. `./bin/ansible localhost -m hostname -a name=foo -C`

Alternative fix: L36 add another elif for Arch Linux, Alpine and Devuan.