### PR TITLE
Fixed broken link in _docker.py

### DIFF
--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -25,7 +25,7 @@ deprecated:
 description:
   - This is the original Ansible module for managing the Docker container life cycle.
   - NOTE - Additional and newer modules are available. For the latest on orchestrating containers with Ansible
-    visit our Getting Started with Docker Guide at U(https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/guide_docker.rst).
+    visit our Getting Started with Docker Guide at U(https://docs.ansible.com/ansible/latest/scenario_guides/guide_docker.html).
 options:
   count:
     description:


### PR DESCRIPTION
##### SUMMARY
There is a broken link in this page: https://docs.ansible.com/ansible/2.5/modules/docker_module.html
This PR fixes the broken link.
The broken link was: https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/guide_docker.rst.
Relaced that with: https://docs.ansible.com/ansible/latest/scenario_guides/guide_docker.html

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request



