### PR TITLE
Supervisorctl: Support "all" keyword when matching processes

### DIFF
--- a/lib/ansible/modules/web_infrastructure/supervisorctl.py
+++ b/lib/ansible/modules/web_infrastructure/supervisorctl.py
@@ -26,6 +26,7 @@ options:
       - The name of the supervisord program or group to manage.
       - The name will be taken as group name when it ends with a colon I(:)
       - Group support is only available in Ansible version 1.6 or later.
+      - The name I(all) will match all processes
     required: true
   config:
     description:
@@ -70,6 +71,11 @@ EXAMPLES = '''
 # Manage the state of program to be in 'started' state.
 - supervisorctl:
     name: my_app
+    state: started
+
+# Manage the state of all programs to be in 'started' state.
+- supervisorctl:
+    name: all
     state: started
 
 # Manage the state of program group to be in 'started' state.
@@ -177,12 +183,12 @@ def main():
                 # If there is ':', this process must be in a group.
                 if ':' in process_name:
                     group = process_name.split(':')[0]
-                    if group != name:
+                    if group != name and name != "all":
                         continue
-                else:
+                elif name != "all":
                     continue
             else:
-                if process_name != name:
+                if process_name != name and name != "all":
                     continue
 
             matched.append((process_name, status))


### PR DESCRIPTION
##### SUMMARY
The official [supervisorctl.py](https://github.com/Supervisor/supervisor/blob/master/supervisor/supervisorctl.py#L656) supports the `all` keyword to match all tasks. This PR adds this into the ansible module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
supervisor_prod

##### ADDITIONAL INFORMATION
With this change you won't need to know all the job names on a server to change their state, you can simply set `name=all` and all the processes will get matched.
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```shell
# Before the fix:
TASK [ensure all is started] ******************************************************************************************************************************************************
fatal: [1.2.3.4]: FAILED! => {"changed": false, "msg": "ERROR (no such process)", "name": "all"}
fatal: [1.2.3.5]: FAILED! => {"changed": false, "msg": "ERROR (no such process)", "name": "all"}

# After the fix:
TASK [ensure all is started] ******************************************************************************************************************************************************
ok: [1.2.3.4]
ok: [1.2.3.5]
```
