### PR TITLE
Add action to task result in json callback

### DIFF
--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -69,6 +69,7 @@ class CallbackModule(CallbackBase):
             'task': {
                 'name': task.get_name(),
                 'id': str(task._uuid),
+                'action': task.action,
                 'duration': {
                     'start': current_time()
                 }


### PR DESCRIPTION
##### SUMMARY
Currently, this information is missing completely, although it's very
useful when somebody wants to analyze the Ansible run based on the
JSON log.

This patch is also proposed for zuul and can be found here:
https://review.openstack.org/#/c/630622/1

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/json.py