### PR TITLE
Add missing parameters in get_config vyos

### DIFF
--- a/lib/ansible/module_utils/network/vyos/vyos.py
+++ b/lib/ansible/module_utils/network/vyos/vyos.py
@@ -90,7 +90,8 @@ def get_capabilities(module):
     return module._vyos_capabilities
 
 
-def get_config(module):
+def get_config(module, flags=None, format=None):
+    flags = [] if flags is None else flags
     global _DEVICE_CONFIGS
 
     if _DEVICE_CONFIGS != {}:
@@ -98,7 +99,7 @@ def get_config(module):
     else:
         connection = get_connection(module)
         try:
-            out = connection.get_config()
+            out = connection.get_config(flags=flags, format=format)
         except ConnectionError as exc:
             module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
         cfg = to_text(out, errors='surrogate_then_replace').strip()


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add missing parameters in get_config vyos
The parameters are present in cliconf https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/cliconf/vyos.py#L57
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/vyos/vyos.py