### PR TITLE
docker_swarm_service: Documentation fixes

### DIFF
--- a/changelogs/fragments/50861-docker_swarm_service-documentation-fixes.yml
+++ b/changelogs/fragments/50861-docker_swarm_service-documentation-fixes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "docker_swarm_service - Document minimal api_version for ``configs`` and ``secrets``."
+  - "docker_swarm_service - Document ``labels`` and ``container_labels`` with correct type."
+  - "docker_swarm_service - Document ``limit_memory`` and ``reserve_memory`` correctly on how to specify sizes."

--- a/changelogs/fragments/50861-docker_swarm_service-documentation-fixes.yml
+++ b/changelogs/fragments/50861-docker_swarm_service-documentation-fixes.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - "docker_swarm_service - Document minimal api_version for ``configs`` and ``secrets``."
+  - "docker_swarm_service - Document minimal API version for ``configs`` and ``secrets``."
   - "docker_swarm_service - Document ``labels`` and ``container_labels`` with correct type."
   - "docker_swarm_service - Document ``limit_memory`` and ``reserve_memory`` correctly on how to specify sizes."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -101,7 +101,6 @@ options:
     description:
     - Dictionary of key value pairs.
     - Maps docker service --container-label option.
-    default: []
   endpoint_mode:
     required: false
     description:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -173,6 +173,7 @@ options:
     - List of dictionaries describing the service secrets.
     - Every item must be a dictionary exposing the keys secret_id, secret_name, filename, uid (defaults to 0), gid (defaults to 0), mode (defaults to 0o444)
     - Maps docker service --secret option.
+    - Requires api_version >= 1.25
     default: []
   configs:
     required: false
@@ -180,6 +181,7 @@ options:
     - List of dictionaries describing the service configs.
     - Every item must be a dictionary exposing the keys config_id, config_name, filename, uid (defaults to 0), gid (defaults to 0), mode (defaults to 0o444)
     - Maps docker service --config option.
+    - Requires api_version >= 1.30
     default: null
   networks:
     required: false

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -93,11 +93,13 @@ options:
     - Requires api_version >= 1.25
   labels:
     required: false
+    type: dict
     description:
     - Dictionary of key value pairs.
     - Maps docker service --label option.
   container_labels:
     required: false
+    type: dict
     description:
     - Dictionary of key value pairs.
     - Maps docker service --container-label option.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -94,12 +94,12 @@ options:
   labels:
     required: false
     description:
-    - List of the service labels.
+    - Dictionary of key value pairs.
     - Maps docker service --label option.
   container_labels:
     required: false
     description:
-    - List of the service containers labels.
+    - Dictionary of key value pairs.
     - Maps docker service --container-label option.
     default: []
   endpoint_mode:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -145,7 +145,8 @@ options:
     default: 0
     description:
     - "Service memory limit (format: C(<number>[<unit>])). Number is a positive integer.
-      Unit can be C(b) (byte), C(k) (kilobytes, 1024b), C(m) (megabytes), C(g) (gigabyte)."
+      Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+      C(T) (tebibyte), or C(P) (pebibyte). Minimum is C(4M)."
     - 0 equals no limit.
     - Omitting the unit defaults to bytes.
     - Maps docker service --limit-memory option.
@@ -154,7 +155,8 @@ options:
     default: 0
     description:
     - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
-      Unit can be C(b) (byte), C(k) (kilobytes, 1024b), C(m) (megabytes), C(g) (gigabyte)."
+      Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+      C(T) (tebibyte), or C(P) (pebibyte)."
     - 0 equals no reservation.
     - Omitting the unit defaults to bytes.
     - Maps docker service --reserve-memory option.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -143,13 +143,17 @@ options:
     required: false
     default: 0
     description:
-    - Service memory limit in MB. 0 equals no limit.
+    - Service memory limit. 0 equals no limit. Accepts a float value 
+      representing bytes or a string value with a units identification 
+      char (100000b, 1000k, 128m, 1g).
     - Maps docker service --limit-memory option.
   reserve_memory:
     required: false
     default: 0
     description:
-    - Service memory reservation in MB. 0 equals no reservation.
+    - Service memory reservation. 0 equals no limit. Accepts a float value 
+      representing bytes or a string value with a units identification 
+      char (100000b, 1000k, 128m, 1g).
     - Maps docker service --reserve-memory option.
   mode:
     required: false

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -144,17 +144,19 @@ options:
     required: false
     default: 0
     description:
-    - Service memory limit. 0 equals no limit. Accepts a float value
-      representing bytes or a string value with a units identification
-      char (100000b, 1000k, 128m, 1g).
+    - "Service memory limit (format: C(<number>[<unit>])). Number is a positive integer.
+      Unit can be C(b) (byte), C(k) (kilobytes, 1024b), C(m) (megabytes), C(g) (gigabyte)."
+    - 0 equals no limit.
+    - Omitting the unit defaults to bytes.
     - Maps docker service --limit-memory option.
   reserve_memory:
     required: false
     default: 0
     description:
-    - Service memory reservation. 0 equals no limit. Accepts a float value
-      representing bytes or a string value with a units identification
-      char (100000b, 1000k, 128m, 1g).
+    - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
+      Unit can be C(b) (byte), C(k) (kilobytes, 1024b), C(m) (megabytes), C(g) (gigabyte)."
+    - 0 equals no reservation.
+    - Omitting the unit defaults to bytes.
     - Maps docker service --reserve-memory option.
   mode:
     required: false

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -146,7 +146,7 @@ options:
     description:
     - "Service memory limit (format: C(<number>[<unit>])). Number is a positive integer.
       Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-      C(T) (tebibyte), or C(P) (pebibyte). Minimum is C(4M)."
+      C(T) (tebibyte), or C(P) (pebibyte)."
     - 0 equals no limit.
     - Omitting the unit defaults to bytes.
     - Maps docker service --limit-memory option.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -53,7 +53,7 @@ options:
     description:
     - Container hostname
     - Maps docker service --hostname option.
-    - Requires api_version >= 1.25
+    - Requires API version >= 1.25
   tty:
     required: false
     type: bool
@@ -61,28 +61,28 @@ options:
     description:
     - Allocate a pseudo-TTY
     - Maps docker service --tty option.
-    - Requires api_version >= 1.25
+    - Requires API version >= 1.25
   dns:
     required: false
     default: []
     description:
     - List of custom DNS servers.
     - Maps docker service --dns option.
-    - Requires api_version >= 1.25
+    - Requires API version >= 1.25
   dns_search:
     required: false
     default: []
     description:
     - List of custom DNS search domains.
     - Maps docker service --dns-search option.
-    - Requires api_version >= 1.25
+    - Requires API version >= 1.25
   dns_options:
     required: false
     default: []
     description:
     - List of custom DNS options.
     - Maps docker service --dns-option option.
-    - Requires api_version >= 1.25
+    - Requires API version >= 1.25
   force_update:
     required: false
     type: bool
@@ -90,7 +90,7 @@ options:
     description:
     - Force update even if no changes require it.
     - Maps to docker service update --force option.
-    - Requires api_version >= 1.25
+    - Requires API version >= 1.25
   labels:
     required: false
     type: dict
@@ -175,7 +175,7 @@ options:
     - List of dictionaries describing the service secrets.
     - Every item must be a dictionary exposing the keys secret_id, secret_name, filename, uid (defaults to 0), gid (defaults to 0), mode (defaults to 0o444)
     - Maps docker service --secret option.
-    - Requires api_version >= 1.25
+    - Requires API version >= 1.25
     default: []
   configs:
     required: false
@@ -183,7 +183,7 @@ options:
     - List of dictionaries describing the service configs.
     - Every item must be a dictionary exposing the keys config_id, config_name, filename, uid (defaults to 0), gid (defaults to 0), mode (defaults to 0o444)
     - Maps docker service --config option.
-    - Requires api_version >= 1.30
+    - Requires API version >= 1.30
     default: null
   networks:
     required: false
@@ -198,7 +198,7 @@ options:
     - List of dictionaries describing the service published ports.
     - Every item must be a dictionary exposing the keys published_port, target_port, protocol (defaults to 'tcp')
     - Only used with api_version >= 1.25
-    - If api_version >= 1.32 and docker python library >= 3.0.0 attribute 'mode' can be set to 'ingress' or 'host' (default 'ingress').
+    - If API version >= 1.32 and docker python library >= 3.0.0 attribute 'mode' can be set to 'ingress' or 'host' (default 'ingress').
   replicas:
     required: false
     default: -1
@@ -274,7 +274,7 @@ options:
     description:
     - Specifies the order of operations when rolling out an updated task.
     - Maps to docker service --update-order
-    - Requires docker api version >= 1.29
+    - Requires API version >= 1.29
   user:
     required: false
     default: root

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -142,16 +142,16 @@ options:
     required: false
     default: 0
     description:
-    - Service memory limit. 0 equals no limit. Accepts a float value 
-      representing bytes or a string value with a units identification 
+    - Service memory limit. 0 equals no limit. Accepts a float value
+      representing bytes or a string value with a units identification
       char (100000b, 1000k, 128m, 1g).
     - Maps docker service --limit-memory option.
   reserve_memory:
     required: false
     default: 0
     description:
-    - Service memory reservation. 0 equals no limit. Accepts a float value 
-      representing bytes or a string value with a units identification 
+    - Service memory reservation. 0 equals no limit. Accepts a float value
+      representing bytes or a string value with a units identification
       char (100000b, 1000k, 128m, 1g).
     - Maps docker service --reserve-memory option.
   mode:


### PR DESCRIPTION
##### SUMMARY
This PR fixes three issues in the documentation. 

* The minimal docker API version is not documented for `secrets` and `configs`.
* `labels` and `container_labels` are described as they accept lists but in reality they expect dicts.
* `limit_memory` and `reserve_memory` describes that they accept values in "MB" but in reality it is in bytes if not suffixed by unit identifiers.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
