### PR TITLE
Allow omitting version when upgrading helm chart

### DIFF
--- a/lib/ansible/modules/cloud/misc/helm.py
+++ b/lib/ansible/modules/cloud/misc/helm.py
@@ -128,7 +128,11 @@ def install(module, tserver):
                  if x.name == name and x.namespace == namespace)
     installed_release = next(r_matches, None)
     if installed_release:
-        if installed_release.chart.metadata.version != chart['version']:
+        installed_version = installed_release.chart.metadata.version
+        # Either compare with the version given by the user or with the version
+        # from the latest release.
+        if installed_version != chart.get('version', installed_version) or \
+                installed_version != chartb.get_metadata().version:
             tserver.update_release(chartb.get_helm_chart(), False,
                                    namespace, name=name, values=values)
             changed = True


### PR DESCRIPTION
##### SUMMARY
The helm CLI defaults to using the latest version when upgrading a release. I wanted to replicate that behaviour.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
helm.py

##### ADDITIONAL INFORMATION
With this change you can now keep your helm releases up-to-date by simply omitting the version.
```yaml
helm:
  name: my-memcached
  chart:
    name: memcached
    source:
      type: repo
      location: https://kubernetes-charts.storage.googleapis.com
```
