### PR TITLE
[2.7] docker_swarm_service: Don’t add difference when update_order is None

### DIFF
--- a/changelogs/fragments/50655-docker_swarm_service-update_order-idempotency.yml
+++ b/changelogs/fragments/50655-docker_swarm_service-update_order-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - fixing falsely reporting ``update_order`` as changed when option is not used."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -717,7 +717,7 @@ class DockerService(DockerBaseClass):
             differences.append('update_monitor')
         if self.update_max_failure_ratio != os.update_max_failure_ratio:
             differences.append('update_max_failure_ratio')
-        if self.update_order != os.update_order:
+        if self.update_order is not None and self.update_order != os.update_order:
             differences.append('update_order')
         if self.image != os.image.split('@')[0]:
             differences.append('image')


### PR DESCRIPTION
##### SUMMARY
Backport of #50655 to stable-2.7: don't add difference if `update_order` is `None` (i.e. improve idempotence).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service
