### PR TITLE
[Backport #50298] fix reference to local variable 'systems_service'

### DIFF
--- a/changelogs/fragments/50298-redfish_utils_fix_reference_to_local_variable_systems_service.yaml
+++ b/changelogs/fragments/50298-redfish_utils_fix_reference_to_local_variable_systems_service.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_utils - fix reference to local variable 'systems_service'

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -128,10 +128,14 @@ class RedfishUtils(object):
             if response['ret'] is False:
                 return response
             data = response['data']
-            for member in data[u'Members']:
-                systems_service = member[u'@odata.id']
-            self.systems_uri = systems_service
-            return {'ret': True}
+            if data.get(u'Members'):
+                for member in data[u'Members']:
+                    systems_service = member[u'@odata.id']
+                    self.systems_uri = systems_service
+                    return {'ret': True}
+            else:
+                return {'ret': False,
+                        'msg': "ComputerSystem's Members array is either empty or missing"}
 
     def _find_updateservice_resource(self, uri):
         response = self.get_request(self.root_uri + uri)


### PR DESCRIPTION
* fixes issue 50296

* fixes the indentation of the return statement

* Adds a conditional test into `_find_systems_resource()` to check the existence
of the Members of System resource

* updates the error message

* harden the conditional test

* Add a changelog

(cherry picked from commit 94a1d86d70f02c1c7fa55426a428e656566c1359)

bugfixes: #50298