### PR TITLE
New module for EC2 ASG Scheduled Actions

### DIFF
--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -227,6 +227,8 @@ groupings:
   - aws
   ec2_asg_lifecycle_hook:
   - aws
+  ec2_asg_scheduled_action:
+  - aws
   ec2_customer_gateway:
   - aws
   ec2_customer_gateway_facts:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
@@ -1,0 +1,244 @@
+#!/usr/bin/python
+# (c) 2016, Mike Mochan <@mmochan>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+# A Munro: 16 Dec 2018
+# Was not working on ansible 2.7, so updated to work, including full state present/absent
+# and reporting changes. More flexibility on settings that can be set in the playbook, etc.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+module: ec2_asg_scheduled_action
+short_description: create, modify and delete AutoScaling Scheduled Actions.
+description:
+  - Read the AWS documentation for Scheduled Actions
+    U(http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-scheduledaction.html
+version_added: "2.10"
+requirements: [ "boto3", "botocore" ]
+options:
+  autoscaling_group_name:
+    description:
+      - The name of the autoscaling group.
+    required: true
+    type: str
+  scheduled_action_name:
+    description:
+      - The name of the scheduled action.
+    required: true
+    type: str
+  state:
+    description:
+      - Whether the schedule is present or absent.
+    required: false
+    default: present
+    choices: ['present', 'absent']
+    type: str
+  desired_capacity:
+    description:
+      - The number of EC2 instances that should be running in the group.
+    required: true
+    type: int
+  recurrence:
+    description:
+      - The recurring schedule for this action, in Unix cron syntax format.
+    required: true
+    type: str
+  min_size:
+    description:
+      - Minimum number of instances in group.
+    type: int
+  max_size:
+    description:
+      - Maximum number of instances in group.
+    type: int
+  start_time:
+    description:
+      - The time for the scheduled action to start.
+    type: str
+  end_time:
+    description:
+      - The time for the recurring schedule to end.
+    type: str
+author: Mike Mochan(@mmochan)
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Create a scheduled action for my autoscaling group.
+- name: create a scheduled action for autoscaling group
+  ec2_asg_scheduled_action:
+    autoscaling_group_name: test_asg
+    scheduled_action_name: mtest_asg_schedule
+    start_time: 2017 August 18 08:00 UTC+10
+    end_time: 2018 August 18 08:00 UTC+10
+    recurrence: 40 22 * * 1-5
+    min_size: 0
+    max_size: 0
+    desired_capacity: 0
+    state: present
+  register: scheduled_action
+
+'''
+
+RETURN = '''
+task:
+  description: The result of the present, and absent actions.
+  returned: success
+  type: dict
+'''
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass  # caught by imported HAS_BOTO3
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import (get_aws_connection_info, boto3_conn, ec2_argument_spec,
+                                      camel_dict_to_snake_dict, AWSRetry, HAS_BOTO3)
+
+
+def get_common_params(module):
+    params = dict()
+    params['aws_retry'] = True
+    params['AutoScalingGroupName'] = module.params.get('autoscaling_group_name')
+    params['ScheduledActionName'] = module.params.get('scheduled_action_name')
+
+    return params
+
+
+def delete_scheduled_action(client, module):
+    changed = False
+    existing = describe_scheduled_actions(client, module)
+
+    if "ScheduledUpdateGroupActions" not in existing:
+        return changed, actions
+
+    actions = existing.get("ScheduledUpdateGroupActions")
+
+    if len(actions) == 0:
+        return changed, actions
+
+    changed = True
+    params = dict()
+    params = get_common_params(module)
+
+    try:
+        actions = client.delete_scheduled_action(**params)
+    except ClientError as e:
+        module.fail_json(msg=str(e))
+
+    return changed, actions
+
+
+def describe_scheduled_actions(client, module):
+    actions = dict()
+    params = get_common_params(module)
+    params['ScheduledActionNames'] = [params.pop('ScheduledActionName')]
+    try:
+        actions = client.describe_scheduled_actions(**params)
+    except ClientError as e:
+        pass
+
+    return actions
+
+
+def put_scheduled_update_group_action(client, module):
+    changed = False
+    params = get_common_params(module)
+
+    params['Recurrence'] = module.params.get('recurrence')
+    params['DesiredCapacity'] = module.params.get('desired_capacity')
+
+    # Some of these are optional
+    if module.params.get('min_size') is not None:
+        params['MinSize'] = module.params.get('min_size')
+
+    if module.params.get('max_size') is not None:
+        params['MaxSize'] = module.params.get('max_size')
+
+    if module.params.get('start_time') is not None:
+        params['StartTime'] = module.params.get('start_time')
+
+    if module.params.get('end_time') is not None:
+        params['EndTime'] = module.params.get('end_time')
+
+    existing = describe_scheduled_actions(client, module)
+    actions = existing.get("ScheduledUpdateGroupActions")
+
+    try:
+        status = client.put_scheduled_update_group_action(**params)
+    except ClientError as e:
+        module.fail_json(msg=str(e))
+
+    if len(actions) == 0:
+        changed = True
+    else:
+        existing = describe_scheduled_actions(client, module)
+        updated = existing.get("ScheduledUpdateGroupActions")[0]
+
+        if actions[0] != updated:
+            changed = True
+
+    return changed, status
+
+
+def main():
+    argument_spec = dict(
+        autoscaling_group_name=dict(type='str', required=True),
+        scheduled_action_name=dict(type='str', required=True),
+        start_time=dict(type='str', default=None),
+        end_time=dict(type='str', default=None),
+        recurrence=dict(type='str', required=True),
+        min_size=dict(type='int', default=None),
+        max_size=dict(type='int', default=None),
+        desired_capacity=dict(type='int', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent'])
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec)
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='json and boto3 required for this module')
+
+    try:
+        client = module.client('autoscaling', retry_decorator=AWSRetry.jittered_backoff())
+    except ClientError as e:
+        module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+    state = module.params.get('state')
+
+    if state == 'present':
+        (changed, results) = put_scheduled_update_group_action(client, module)
+        module.exit_json(changed=changed, results=results)
+    else:
+        (changed, results) = delete_scheduled_action(client, module)
+        module.exit_json(changed=changed, results=results)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
@@ -236,10 +236,10 @@ def main():
 
     if state == 'present':
         (changed, results) = put_scheduled_update_group_action(client, module)
-        module.exit_json(changed=changed, results=results)
     else:
         (changed, results) = delete_scheduled_action(client, module)
-        module.exit_json(changed=changed, results=results)
+
+    module.exit_json(changed=changed, scheduled_action=results)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
@@ -113,7 +113,7 @@ task:
 '''
 
 try:
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by imported HAS_BOTO3
 
@@ -229,8 +229,8 @@ def main():
 
     try:
         client = module.client('autoscaling', retry_decorator=AWSRetry.jittered_backoff())
-    except ClientError as e:
-        module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+    except (ClientError, BotoCoreError) as e:
+        module.fail_json(msg='{0}'.format(e))
 
     state = module.params.get('state')
 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_scheduled_action.py
@@ -132,6 +132,7 @@ def get_common_params(module):
 
 
 def delete_scheduled_action(client, module):
+    actions = []
     changed = False
     existing = describe_scheduled_actions(client, module)
 
@@ -189,6 +190,7 @@ def put_scheduled_update_group_action(client, module):
 
     existing = describe_scheduled_actions(client, module)
     actions = existing.get("ScheduledUpdateGroupActions")
+    status = {}
 
     try:
         status = client.put_scheduled_update_group_action(**params)

--- a/test/integration/targets/ec2_asg_scheduled_action/aliases
+++ b/test/integration/targets/ec2_asg_scheduled_action/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_asg_scheduled_action/aliases
+++ b/test/integration/targets/ec2_asg_scheduled_action/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-shippable/aws/group2
+unsupported

--- a/test/integration/targets/ec2_asg_scheduled_action/defaults/main.yml
+++ b/test/integration/targets/ec2_asg_scheduled_action/defaults/main.yml
@@ -4,6 +4,6 @@
 ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
 scheduled_action_name: "{{ resource_prefix }}-sa"
 autoscaling_group_name: "{{ resource_prefix }}-asg"
-autoscaling_launch_template_name: "{{ resource_prefix }}-lt"
+autoscaling_launch_configuration_name: "{{ resource_prefix }}-lc"
 desired_capacity: 0
 recurrence: '40 22 * * 1-5'

--- a/test/integration/targets/ec2_asg_scheduled_action/defaults/main.yml
+++ b/test/integration/targets/ec2_asg_scheduled_action/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# defaults file for ec2_asg_scheduled_action
+# Amazon Linux 2 AMI 2019.06.12 (HVM), GP2 Volume Type
+ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
+scheduled_action_name: "{{ resource_prefix }}-sa"
+autoscaling_group_name: "{{ resource_prefix }}-asg"
+autoscaling_launch_template_name: "{{ resource_prefix }}-lt"
+desired_capacity: 0
+recurrence: '40 22 * * 1-5'

--- a/test/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
+++ b/test/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
@@ -1,0 +1,203 @@
+---
+# tasks file for test_ec2_asg_scheduled_action
+
+- name: Test incomplete credentials with ec2_asg_scheduled_action
+
+  module_defaults:
+    ec2_asg_scheduled_action:
+        scheduled_action_name: "{{ scheduled_action_name }}"
+        autoscaling_group_name: "{{ autoscaling_group_name }}"
+        desired_capacity: "{{ desired_capacity }}"
+        recurrence: "{{ recurrence }}"
+
+  block:
+
+    # ============================================================
+
+    - name: test invalid profile
+      ec2_asg_scheduled_action:
+        region: "{{ aws_region }}"
+        profile: notavalidprofile
+      ignore_errors: yes
+      register: result
+
+    - name:
+      assert:
+        that:
+          - "'The config profile (notavalidprofile) could not be found' in result.msg"
+
+    - name: test partial credentials
+      ec2_asg_scheduled_action:
+        region: "{{ aws_region }}"
+        aws_access_key: nil
+        aws_secret_key: "{{ aws_secret_key }}"
+      ignore_errors: yes
+      register: result
+
+    - name:
+      assert:
+        that:
+          - "'Partial credentials found in explicit, missing: aws_secret_access_key' in result.msg"
+
+    - name: test without specifying region
+      ec2_asg_scheduled_action:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token | default(omit) }}"
+      ignore_errors: yes
+      register: result
+
+    - name:
+      assert:
+        that:
+          - result.msg == 'The ec2_asg_scheduled_action module requires a region and none was found in configuration, environment variables or module parameters'
+
+    # ============================================================
+
+- name: Test incomplete arguments with ec2_asg_scheduled_action
+
+  block:
+
+    # ============================================================
+
+    - name: test without specifying required module options
+      ec2_asg_scheduled_action:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token | default(omit) }}"
+      ignore_errors: yes
+      register: result
+
+    - name: assert required module options are detected
+      assert:
+        that:
+          - item in result.msg
+      loop:
+        - 'missing required arguments:'
+        - 'autoscaling_group_name'
+        - 'scheduled_action_name'
+        - 'recurrence'
+        - 'desired_capacity'
+
+- name: Run ec2_asg_scheduled_action integration tests.
+
+  module_defaults:
+    ec2_asg:
+      name: "{{ autoscaling_group_name }}"
+      min_size: 0
+      max_size: 0
+    ec2_asg_scheduled_action:
+        scheduled_action_name: "{{ scheduled_action_name }}"
+        autoscaling_group_name: "{{ autoscaling_group_name }}"
+        desired_capacity: "{{ desired_capacity }}"
+        recurrence: "{{ recurrence }}"
+        # start_time: 2020 January 1 08:00 UTC+10
+        # end_time: 2020 December 1 08:00 UTC+10
+        min_size: 0
+        max_size: 1
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+
+  block:
+
+    # ============================================================
+
+    - name: Find AMI to use
+      ec2_ami_info:
+        owners: 'amazon'
+        filters:
+          name: '{{ ec2_ami_name }}'
+      register: ec2_amis
+    - set_fact:
+        ec2_ami_image: '{{ ec2_amis.images[0].image_id }}'
+
+    - name: Create an ec2 launch template
+      ec2_launch_template:
+        name: "{{ autoscaling_launch_template_name }}"
+        image_id: "{{ ec2_ami_image }}"
+        instance_type: t3.micro
+
+    - name: Create asg
+      ec2_asg:
+        launch_template:
+          launch_template_name: "{{ autoscaling_launch_template_name }}"
+        state: present
+        wait_for_instances: no
+      register: ec2_asg
+
+    - name: create a scheduled action for autoscaling group
+      ec2_asg_scheduled_action:
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+    - name: check scheduled action idempotency
+      ec2_asg_scheduled_action:
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+
+    - name: create a second scheduled action (recurrence cannot collide)
+      ec2_asg_scheduled_action:
+        scheduled_action_name: "{{ scheduled_action_name }}-2"
+        recurrence: '0 23 * * *'
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+    - name: remove second scheduled action
+      ec2_asg_scheduled_action:
+        scheduled_action_name: "{{ scheduled_action_name }}-2"
+        state: absent
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+    - name: check idempotency on initial action
+      ec2_asg_scheduled_action:
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+
+    - name: remove initial scheduled action
+      ec2_asg_scheduled_action:
+        state: absent
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+# ============================================================
+
+  always:
+
+    - name: remove asg
+      ec2_asg:
+        state: absent
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove ec2 launch template
+      ec2_launch_template:
+        name: "{{ autoscaling_launch_template_name }}"
+        state: absent
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10

--- a/test/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
+++ b/test/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
@@ -115,16 +115,15 @@
     - set_fact:
         ec2_ami_image: '{{ ec2_amis.images[0].image_id }}'
 
-    - name: Create an ec2 launch template
-      ec2_launch_template:
-        name: "{{ autoscaling_launch_template_name }}"
+    - name: Create an ec2 launch configuration
+      ec2_lc:
+        name: "{{ autoscaling_launch_configuration_name }}"
         image_id: "{{ ec2_ami_image }}"
         instance_type: t3.micro
 
     - name: Create asg
       ec2_asg:
-        launch_template:
-          launch_template_name: "{{ autoscaling_launch_template_name }}"
+        launch_config_name: "{{ autoscaling_launch_configuration_name }}"
         state: present
         wait_for_instances: no
       register: ec2_asg
@@ -194,9 +193,9 @@
       ignore_errors: yes
       retries: 10
 
-    - name: remove ec2 launch template
-      ec2_launch_template:
-        name: "{{ autoscaling_launch_template_name }}"
+    - name: remove ec2 launch config
+      ec2_lc:
+        name: "{{ autoscaling_launch_configuration_name }}"
         state: absent
       register: removed
       until: removed is not failed

--- a/test/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
+++ b/test/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
@@ -37,7 +37,8 @@
     - name:
       assert:
         that:
-          - "'Partial credentials found in explicit, missing: aws_secret_access_key' in result.msg"
+          - "'The security token included in the request is invalid.' in result.msg or
+             'Partial credentials found in explicit, missing: aws_secret_access_key' in result.msg"
 
     - name: test without specifying region
       ec2_asg_scheduled_action:

--- a/test/units/modules/cloud/amazon/test_ec2_asg_scheduled_action.py
+++ b/test/units/modules/cloud/amazon/test_ec2_asg_scheduled_action.py
@@ -66,7 +66,7 @@ class TestModule(ModuleTestCase):
         result = scheduled_action.get_common_params(module)
         assert result['AutoScalingGroupName'] == 'group'
         assert result['ScheduledActionName'] == 'action'
-        assert result['aws_retry'] == True
+        assert result['aws_retry'] is True
 
     @patch.object(scheduled_action, 'get_common_params')
     def test_describe_scheduled_actions(self, get_common_params_mock):
@@ -103,21 +103,21 @@ class TestModule(ModuleTestCase):
 
     @patch.object(scheduled_action, 'describe_scheduled_actions')
     def test_delete_scheduled_action_empty(self, describe_scheduled_actions_mock):
-        describe_scheduled_actions_mock.return_value ={}
+        describe_scheduled_actions_mock.return_value = {}
         module = MagicMock()
         client = MagicMock()
         (changed, results) = scheduled_action.delete_scheduled_action(client, module)
-        assert changed == False
+        assert changed is False
         assert results == []
         assert client.describe_scheduled_actions.call_count == 0
 
     @patch.object(scheduled_action, 'describe_scheduled_actions')
     def test_delete_scheduled_action_no_actions(self, describe_scheduled_actions_mock):
-        describe_scheduled_actions_mock.return_value ={ 'ScheduledUpdateGroupActions': [] }
+        describe_scheduled_actions_mock.return_value = {'ScheduledUpdateGroupActions': []}
         module = MagicMock()
         client = MagicMock()
         (changed, results) = scheduled_action.delete_scheduled_action(client, module)
-        assert changed == False
+        assert changed is False
         assert results == []
         assert client.describe_scheduled_actions.call_count == 0
 
@@ -130,14 +130,14 @@ class TestModule(ModuleTestCase):
         describe = {
             'ScheduledUpdateGroupActions': [params['ScheduledActionName']]
         }
-        expect = { 'client': 'success' }
+        expect = {'client': 'success'}
         get_common_params_mock.return_value = params
         describe_scheduled_actions_mock.return_value = describe
         module = MagicMock()
         client = MagicMock()
         client.delete_scheduled_action.return_value = expect
         (changed, results) = scheduled_action.delete_scheduled_action(client, module)
-        assert changed == True
+        assert changed is True
         assert results == expect
         client.delete_scheduled_action.assert_called_once_with(**params)
 
@@ -187,7 +187,7 @@ class TestModule(ModuleTestCase):
         client = MagicMock()
         (changed, results) = scheduled_action.put_scheduled_update_group_action(client, module)
         client.put_scheduled_update_group_action.assert_called_once_with(**expect)
-        assert changed == True
+        assert changed is True
 
     @patch.object(scheduled_action, 'describe_scheduled_actions')
     @patch.object(scheduled_action, 'get_common_params')
@@ -198,7 +198,7 @@ class TestModule(ModuleTestCase):
         client = MagicMock()
         (changed, results) = scheduled_action.put_scheduled_update_group_action(client, module)
         assert describe_scheduled_actions_mock.call_count == 2
-        assert changed == False
+        assert changed is False
 
     @patch.object(scheduled_action, 'describe_scheduled_actions')
     @patch.object(scheduled_action, 'get_common_params')

--- a/test/units/modules/cloud/amazon/test_ec2_asg_scheduled_action.py
+++ b/test/units/modules/cloud/amazon/test_ec2_asg_scheduled_action.py
@@ -1,0 +1,213 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from units.compat.mock import MagicMock, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+from ansible.module_utils.ec2 import HAS_BOTO3
+
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip("ec2_asg_scheduled_action.py requires the `boto3` and `botocore` modules")
+else:
+    import boto3
+    from ansible.modules.cloud.amazon import ec2_asg_scheduled_action as scheduled_action
+    from botocore.exceptions import ClientError
+
+
+class TestModule(ModuleTestCase):
+
+    def get_valid_args(self):
+        return dict({
+            'autoscaling_group_name': 'foo',
+            'desired_capacity': '2',
+            'recurrence': "daily",
+            'region': 'up-north-1',
+            'scheduled_action_name': 'bar',
+        })
+
+    def get_error(self):
+        error_response = {"Error": {"Code": "Bad"}}
+        return ClientError(error_response, "test")
+
+    def test_module_fail_when_required_args_missing(self):
+        with pytest.raises(AnsibleFailJson):
+            set_module_args({})
+            scheduled_action.main()
+
+    @patch('ansible.modules.cloud.amazon.ec2_asg_scheduled_action.AnsibleAWSModule.client')
+    def test_module_exit_when_required_args_present(self, aws_client):
+        with pytest.raises(AnsibleExitJson):
+            set_module_args(self.get_valid_args())
+            scheduled_action.main()
+
+    @patch('ansible.module_utils.aws.core.HAS_BOTO3', new=False)
+    @patch('ansible.modules.cloud.amazon.ec2_asg_scheduled_action.AnsibleAWSModule.client')
+    def test_module_fail_when_boto_absent(self, aws_client):
+        with pytest.raises(AnsibleFailJson):
+            set_module_args(self.get_valid_args())
+            scheduled_action.main()
+
+    @patch('ansible.modules.cloud.amazon.ec2_asg_scheduled_action.AnsibleAWSModule.client')
+    def test_module_fail_when_client_error(self, client):
+        client.side_effect = self.get_error()
+        with pytest.raises(AnsibleFailJson):
+            set_module_args(self.get_valid_args())
+            scheduled_action.main()
+
+    def test_get_common_params(self):
+        module = MagicMock()
+        module.params = {
+            'autoscaling_group_name': 'group',
+            'scheduled_action_name': 'action'
+        }
+        result = scheduled_action.get_common_params(module)
+        assert result['AutoScalingGroupName'] == 'group'
+        assert result['ScheduledActionName'] == 'action'
+        assert result['aws_retry'] == True
+
+    @patch.object(scheduled_action, 'get_common_params')
+    def test_describe_scheduled_actions(self, get_common_params_mock):
+        params = {
+            'ScheduledActionName': 'foo'
+        }
+        describe = {
+            'ScheduledActionNames': [params['ScheduledActionName']]
+        }
+        actions = ['action']
+        get_common_params_mock.return_value = params
+        module = MagicMock()
+        client = MagicMock()
+        client.describe_scheduled_actions.return_value = actions
+        result = scheduled_action.describe_scheduled_actions(client, module)
+        assert result == actions
+        client.describe_scheduled_actions.assert_called_once_with(**describe)
+
+    @patch.object(scheduled_action, 'get_common_params')
+    def test_describe_scheduled_actions_empty(self, get_common_params_mock):
+        params = {
+            'ScheduledActionName': 'foo'
+        }
+        describe = {
+            'ScheduledActionNames': [params['ScheduledActionName']]
+        }
+        get_common_params_mock.return_value = params
+        module = MagicMock()
+        client = MagicMock()
+        client.describe_scheduled_actions.side_effect = self.get_error()
+        result = scheduled_action.describe_scheduled_actions(client, module)
+        assert result == {}
+        client.describe_scheduled_actions.assert_called_once_with(**describe)
+
+    @patch.object(scheduled_action, 'describe_scheduled_actions')
+    def test_delete_scheduled_action_empty(self, describe_scheduled_actions_mock):
+        describe_scheduled_actions_mock.return_value ={}
+        module = MagicMock()
+        client = MagicMock()
+        (changed, results) = scheduled_action.delete_scheduled_action(client, module)
+        assert changed == False
+        assert results == []
+        assert client.describe_scheduled_actions.call_count == 0
+
+    @patch.object(scheduled_action, 'describe_scheduled_actions')
+    def test_delete_scheduled_action_no_actions(self, describe_scheduled_actions_mock):
+        describe_scheduled_actions_mock.return_value ={ 'ScheduledUpdateGroupActions': [] }
+        module = MagicMock()
+        client = MagicMock()
+        (changed, results) = scheduled_action.delete_scheduled_action(client, module)
+        assert changed == False
+        assert results == []
+        assert client.describe_scheduled_actions.call_count == 0
+
+    @patch.object(scheduled_action, 'describe_scheduled_actions')
+    @patch.object(scheduled_action, 'get_common_params')
+    def test_delete_scheduled_action_deleted(self, get_common_params_mock, describe_scheduled_actions_mock):
+        params = {
+            'ScheduledActionName': 'bar'
+        }
+        describe = {
+            'ScheduledUpdateGroupActions': [params['ScheduledActionName']]
+        }
+        expect = { 'client': 'success' }
+        get_common_params_mock.return_value = params
+        describe_scheduled_actions_mock.return_value = describe
+        module = MagicMock()
+        client = MagicMock()
+        client.delete_scheduled_action.return_value = expect
+        (changed, results) = scheduled_action.delete_scheduled_action(client, module)
+        assert changed == True
+        assert results == expect
+        client.delete_scheduled_action.assert_called_once_with(**params)
+
+    @patch.object(scheduled_action, 'describe_scheduled_actions')
+    @patch.object(scheduled_action, 'get_common_params')
+    def test_delete_scheduled_action_fail(self, get_common_params_mock, describe_scheduled_actions_mock):
+        params = {
+            'ScheduledActionName': 'bar'
+        }
+        describe = {
+            'ScheduledUpdateGroupActions': [params['ScheduledActionName']]
+        }
+        get_common_params_mock.return_value = params
+        describe_scheduled_actions_mock.return_value = describe
+        module = MagicMock()
+        client = MagicMock()
+        error = self.get_error()
+        client.delete_scheduled_action.side_effect = error
+        scheduled_action.delete_scheduled_action(client, module)
+        client.delete_scheduled_action.assert_called_once_with(**params)
+        module.fail_json.assert_called_once_with(msg=str(error))
+
+    @patch.object(scheduled_action, 'describe_scheduled_actions')
+    @patch.object(scheduled_action, 'get_common_params')
+    def test_put_scheduled_update_group_action_params(self, get_common_params_mock, describe_scheduled_actions_mock):
+        get_common_params_mock.return_value = {'aws_retry': True}
+        module = MagicMock()
+        module.params = {
+            'autoscaling_group_name': 'group',
+            'scheduled_action_name': 'action',
+            'recurrence': 'daily',
+            'desired_capacity': '1',
+            'min_size': '0',
+            'max_size': '2',
+            'start_time': 'now',
+            'end_time': 'never'
+        }
+        expect = {
+            'aws_retry': True,
+            'Recurrence': module.params['recurrence'],
+            'DesiredCapacity': module.params['desired_capacity'],
+            'MinSize': module.params['min_size'],
+            'MaxSize': module.params['max_size'],
+            'StartTime': module.params['start_time'],
+            'EndTime': module.params['end_time']
+        }
+        client = MagicMock()
+        (changed, results) = scheduled_action.put_scheduled_update_group_action(client, module)
+        client.put_scheduled_update_group_action.assert_called_once_with(**expect)
+        assert changed == True
+
+    @patch.object(scheduled_action, 'describe_scheduled_actions')
+    @patch.object(scheduled_action, 'get_common_params')
+    def test_put_scheduled_update_group_action_unchanged(self, get_common_params_mock, describe_scheduled_actions_mock):
+        get_common_params_mock.return_value = {}
+        describe_scheduled_actions_mock.return_value = {'ScheduledUpdateGroupActions': ['existing']}
+        module = MagicMock()
+        client = MagicMock()
+        (changed, results) = scheduled_action.put_scheduled_update_group_action(client, module)
+        assert describe_scheduled_actions_mock.call_count == 2
+        assert changed == False
+
+    @patch.object(scheduled_action, 'describe_scheduled_actions')
+    @patch.object(scheduled_action, 'get_common_params')
+    def test_put_scheduled_update_group_action_error(self, get_common_params_mock, describe_scheduled_actions_mock):
+        get_common_params_mock.return_value = {}
+        describe_scheduled_actions_mock.return_value = {'ScheduledUpdateGroupActions': []}
+        module = MagicMock()
+        client = MagicMock()
+        error = self.get_error()
+        client.put_scheduled_update_group_action.side_effect = error
+        scheduled_action.put_scheduled_update_group_action(client, module)
+        module.fail_json.assert_called_once_with(msg=str(error))


### PR DESCRIPTION
##### SUMMARY
New module for AWS autoscaling group scheduled actions 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
ec2_asg_scheduled_action

##### ADDITIONAL INFORMATION

Originally from https://github.com/mmochan/ansible-aws-ec2-asg-scheduled-actions/pull/1

Unit test example:
```
source hacking/env-setup
ansible-test units --docker --python 2.7 -v test/units/modules/cloud/amazon/test_ec2_asg_scheduled_action.py
```

Integration test example:
```
source hacking/env-setup
ansible-test integration -v ec2_asg_scheduled_action --docker ubuntu1604 --allow-unsupported
```
Integration test requires 
```AWS ACTIONS: ['autoscaling:DeleteScheduledAction', 'autoscaling:DescribeScheduledActions', 'autoscaling:PutScheduledUpdateGroupAction', 'ec2:DescribeImages']```