### PR TITLE
docker_swarm_service: Fix publish idempotency when mode is None

### DIFF
--- a/changelogs/fragments/50882-docker_swarm_service-fix-publish-idempotency.yml
+++ b/changelogs/fragments/50882-docker_swarm_service-fix-publish-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - fixing falsely reporting ``publish`` as changed when ``publish.mode`` is not set."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -757,12 +757,12 @@ class DockerService(DockerBaseClass):
             ignored_keys = set()
             if not publish_item.get('mode'):
                 ignored_keys.add('mode')
-            filtered_old_publish_item = {
-                k: v for k, v in old_publish_item.items() if k not in ignored_keys
-            }
-            filtered_publish_item = {
-                k: v for k, v in publish_item.items() if k not in ignored_keys
-            }
+            filtered_old_publish_item = dict(
+                (k, v) for k, v in old_publish_item.items() if k not in ignored_keys
+            )
+            filtered_publish_item = dict(
+                (k, v) for k, v in publish_item.items() if k not in ignored_keys
+            )
             if filtered_publish_item != filtered_old_publish_item:
                 return True
         return False

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -650,8 +650,8 @@ class DockerService(DockerBaseClass):
         s.publish = []
         for param_p in ap['publish']:
             service_p = {}
-            service_p['protocol'] = param_p.get('protocol', 'tcp')
-            service_p['mode'] = param_p.get('mode', None)
+            service_p['protocol'] = param_p['protocol']
+            service_p['mode'] = param_p.get('mode')
             service_p['published_port'] = int(param_p['published_port'])
             service_p['target_port'] = int(param_p['target_port'])
             if service_p['protocol'] not in ['tcp', 'udp']:
@@ -1209,7 +1209,7 @@ def main():
         publish=dict(default=[], type='list', elements='dict', options=dict(
             published_port=dict(type='int', required=True),
             target_port=dict(type='int', required=True),
-            protocol=dict(type='str', required=True, choices=('tcp', 'udp')),
+            protocol=dict(default='tcp', type='str', required=False, choices=('tcp', 'udp')),
             mode=dict(type='str', required=False, choices=('ingress', 'host')),
         )),
         constraints=dict(default=[], type='list'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -469,6 +469,7 @@ EXAMPLES = '''
 '''
 
 import time
+import operator
 from ansible.module_utils.docker_common import (
     DockerBaseClass,
     AnsibleDockerClient,
@@ -752,7 +753,10 @@ class DockerService(DockerBaseClass):
     def has_publish_changed(self, old_publish):
         if len(self.publish) != len(old_publish):
             return True
-        for publish_item, old_publish_item in zip(sorted(self.publish), sorted(old_publish)):
+        publish_sorter = operator.itemgetter('published_port', 'target_port', 'protocol', 'mode')
+        publish = sorted(self.publish, key=publish_sorter)
+        old_publish = sorted(old_publish, key=publish_sorter)
+        for publish_item, old_publish_item in zip(publish, old_publish):
             ignored_keys = set()
             if not publish_item.get('mode'):
                 ignored_keys.add('mode')

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1209,8 +1209,8 @@ def main():
         publish=dict(default=[], type='list', elements='dict', options=dict(
             published_port=dict(type='int', required=True),
             target_port=dict(type='int', required=True),
-            protocol=dict(type='str', required=True),
-            mode=dict(type='str', required=False),
+            protocol=dict(type='str', required=True, choices=('tcp', 'udp')),
+            mode=dict(type='str', required=False, choices=('ingress', 'host')),
         )),
         constraints=dict(default=[], type='list'),
         tty=dict(default=False, type='bool'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -710,7 +710,7 @@ class DockerService(DockerBaseClass):
             differences.add('reserve_memory', parameter=self.reserve_memory, active=os.reserve_memory)
         if self.container_labels != os.container_labels:
             differences.add('container_labels', parameter=self.container_labels, active=os.container_labels)
-        if self.is_publish_changed(self.publish, os.publish):
+        if self.has_publish_changed(os.publish):
             differences.add('publish', parameter=self.publish, active=os.publish)
         if self.restart_policy != os.restart_policy:
             differences.add('restart_policy', parameter=self.restart_policy, active=os.restart_policy)
@@ -750,8 +750,8 @@ class DockerService(DockerBaseClass):
             force_update = True
         return not differences.empty or force_update, differences, needs_rebuild, force_update
 
-    def is_publish_changed(self, publish_list, old_publish_list):
-        for publish_item, old_publish_item in zip_longest(publish_list, old_publish_list):
+    def has_publish_changed(self, old_publish):
+        for publish_item, old_publish_item in zip_longest(self.publish, old_publish):
             publish_item = publish_item or {}
             old_publish_item = old_publish_item or {}
             ignored_keys = set()

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -196,8 +196,9 @@ options:
     - List of the service networks names.
     - Maps docker service --network option.
   publish:
-    default: []
+    type: list
     required: false
+    default: []
     description:
     - List of dictionaries describing the service published ports.
     - Only used with api_version >= 1.25

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -215,7 +215,8 @@ options:
            - The port inside the container to expose.
       protocol:
          type: str
-         required: true
+         required: false
+         default: tcp
          description:
            - What protocol to use.
          choices:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -652,7 +652,7 @@ class DockerService(DockerBaseClass):
         for param_p in ap['publish']:
             service_p = {}
             service_p['protocol'] = param_p['protocol']
-            service_p['mode'] = param_p.get('mode')
+            service_p['mode'] = param_p['mode']
             service_p['published_port'] = int(param_p['published_port'])
             service_p['target_port'] = int(param_p['target_port'])
             if service_p['protocol'] not in ['tcp', 'udp']:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -200,9 +200,35 @@ options:
     required: false
     description:
     - List of dictionaries describing the service published ports.
-    - Every item must be a dictionary exposing the keys published_port, target_port, protocol (defaults to 'tcp')
     - Only used with api_version >= 1.25
-    - If API version >= 1.32 and docker python library >= 3.0.0 attribute 'mode' can be set to 'ingress' or 'host' (default 'ingress').
+    suboptions:
+      published_port:
+         type: int
+         required: true
+         description:
+           - The port to make externally available.
+      target_port:
+         type: int
+         required: true
+         description:
+           - The port inside the container to expose.
+      protocol:
+         type: str
+         required: true
+         description:
+           - What protocol to use.
+         choices:
+           - tcp
+           - udp
+      mode:
+        type: str
+        required: false
+        description:
+          - What publish mode to use.
+          - Requires API version >= 1.32 and docker python library >= 3.0.0
+        choices:
+          - ingress
+          - host
   replicas:
     required: false
     default: -1
@@ -1179,7 +1205,12 @@ def main():
         force_update=dict(default=False, type='bool'),
         log_driver=dict(default="json-file", type='str'),
         log_driver_options=dict(default={}, type='dict'),
-        publish=dict(default=[], type='list'),
+        publish=dict(default=[], type='list', elements='dict', options=dict(
+            published_port=dict(type='int', required=True),
+            target_port=dict(type='int', required=True),
+            protocol=dict(type='str', required=True),
+            mode=dict(type='str', required=False),
+        )),
         constraints=dict(default=[], type='list'),
         tty=dict(default=False, type='bool'),
         dns=dict(default=[], type='list'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -752,7 +752,7 @@ class DockerService(DockerBaseClass):
     def has_publish_changed(self, old_publish):
         if len(self.publish) != len(old_publish):
             return True
-        for publish_item, old_publish_item in zip(self.publish, old_publish):
+        for publish_item, old_publish_item in zip(sorted(self.publish), sorted(old_publish)):
             ignored_keys = set()
             if not publish_item.get('mode'):
                 ignored_keys.add('mode')

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -788,6 +788,7 @@ class DockerService(DockerBaseClass):
             ignored_keys = set()
             if not publish_item.get('mode'):
                 ignored_keys.add('mode')
+            # Create copies of publish_item dicts where keys specified in ignored_keys are left out
             filtered_old_publish_item = dict(
                 (k, v) for k, v in old_publish_item.items() if k not in ignored_keys
             )

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -753,7 +753,7 @@ class DockerService(DockerBaseClass):
     def has_publish_changed(self, old_publish):
         if len(self.publish) != len(old_publish):
             return True
-        publish_sorter = operator.itemgetter('published_port', 'target_port', 'protocol', 'mode')
+        publish_sorter = operator.itemgetter('published_port', 'target_port', 'protocol')
         publish = sorted(self.publish, key=publish_sorter)
         old_publish = sorted(old_publish, key=publish_sorter)
         for publish_item, old_publish_item in zip(publish, old_publish):

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -477,7 +477,6 @@ from ansible.module_utils.docker_common import (
 )
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six.moves import zip_longest
 
 try:
     from distutils.version import LooseVersion
@@ -751,9 +750,9 @@ class DockerService(DockerBaseClass):
         return not differences.empty or force_update, differences, needs_rebuild, force_update
 
     def has_publish_changed(self, old_publish):
-        for publish_item, old_publish_item in zip_longest(self.publish, old_publish):
-            publish_item = publish_item or {}
-            old_publish_item = old_publish_item or {}
+        if len(self.publish) != len(old_publish):
+            return True
+        for publish_item, old_publish_item in zip(self.publish, old_publish):
             ignored_keys = set()
             if not publish_item.get('mode'):
                 ignored_keys.add('mode')

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -959,10 +959,10 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - protocol: "tcp"
+      - protocol: tcp
         published_port: 60001
         target_port: 60001
-      - protocol: "udp"
+      - protocol: udp
         published_port: 60002
         target_port: 60002
   register: publish_1
@@ -974,7 +974,7 @@
     publish:
       - published_port: 60001
         target_port: 60001
-      - protocol: "udp"
+      - protocol: udp
         published_port: 60002
         target_port: 60002
   register: publish_2
@@ -984,10 +984,10 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - protocol: "tcp"
+      - protocol: tcp
         published_port: 60002
         target_port: 60003
-      - protocol: "udp"
+      - protocol: udp
         published_port: 60001
         target_port: 60001
   register: publish_3
@@ -997,14 +997,14 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - protocol: "tcp"
+      - protocol: tcp
         published_port: 60002
         target_port: 60003
-        mode: "host"
-      - protocol: "udp"
+        mode: host
+      - protocol: udp
         published_port: 60001
         target_port: 60001
-        mode: "host"
+        mode: host
   register: publish_4
 
 - name: publish (mode idempotency)
@@ -1012,14 +1012,14 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - protocol: "tcp"
+      - protocol: tcp
         published_port: 60002
         target_port: 60003
-        mode: "host"
-      - protocol: "udp"
+        mode: host
+      - protocol: udp
         published_port: 60001
         target_port: 60001
-        mode: "host"
+        mode: host
   register: publish_5
 
 - assert:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -972,11 +972,11 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - published_port: 60001
-        target_port: 60001
       - protocol: udp
         published_port: 60002
         target_port: 60002
+      - published_port: 60001
+        target_port: 60001
   register: publish_2
 
 - name: publish (change)
@@ -1012,13 +1012,13 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - protocol: tcp
-        published_port: 60002
-        target_port: 60003
-        mode: host
       - protocol: udp
         published_port: 60001
         target_port: 60001
+        mode: host
+      - protocol: tcp
+        published_port: 60002
+        target_port: 60003
         mode: host
   register: publish_5
 

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -954,14 +954,6 @@
 ## publish #########################################################
 ####################################################################
 
-# FIXME: publish_2 is not marked as changed
-#fatal: [testhost]: FAILED! => {
-#    "assertion": "publish_2 is not changed",
-#    "changed": false,
-#    "evaluated_to": false,
-#    "msg": "Assertion failed"
-#}
-
 - name: publish
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -975,37 +967,69 @@
         target_port: 60002
   register: publish_1
 
-#- name: publish (idempotency)
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    publish:
-#      - protocol: tcp
-#        published_port: 60001
-#        target_port: 60001
-#      - protocol: udp
-#        published_port: 60001
-#        target_port: 60001
-#  register: publish_2
-#
-#- name: publish (change)
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    publish:
-#      - protocol: tcp
-#        published_port: 60002
-#        target_port: 60001
-#      - protocol: udp
-#        published_port: 60001
-#        target_port: 60001
-#  register: publish_3
-#
+- name: publish (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    publish:
+      - protocol: tcp
+        published_port: 60001
+        target_port: 60001
+      - protocol: udp
+        published_port: 60002
+        target_port: 60002
+  register: publish_2
+
+- name: publish (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    publish:
+      - protocol: "tcp"
+        published_port: 60002
+        target_port: 60003
+      - protocol: "udp"
+        published_port: 60001
+        target_port: 60001
+  register: publish_3
+
+- name: publish (mode)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    publish:
+      - protocol: "tcp"
+        published_port: 60002
+        target_port: 60003
+        mode: "host"
+      - protocol: "udp"
+        published_port: 60001
+        target_port: 60001
+        mode: "host"
+  register: publish_4
+
+- name: publish (mode idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    publish:
+      - protocol: "tcp"
+        published_port: 60002
+        target_port: 60003
+        mode: "host"
+      - protocol: "udp"
+        published_port: 60001
+        target_port: 60001
+        mode: "host"
+  register: publish_5
+
 - assert:
     that:
       - publish_1 is changed
-#      - publish_2 is not changed
-#      - publish_3 is changed
+      - publish_2 is not changed
+      - publish_3 is changed
+      - publish_4 is changed
+      - publish_5 is not changed
   when: docker_api_version is version('1.25', '>=')
 - assert:
     that:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -959,10 +959,10 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - protocol: tcp
+      - protocol: "tcp"
         published_port: 60001
         target_port: 60001
-      - protocol: udp
+      - protocol: "udp"
         published_port: 60002
         target_port: 60002
   register: publish_1
@@ -972,10 +972,9 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     publish:
-      - protocol: tcp
-        published_port: 60001
+      - published_port: 60001
         target_port: 60001
-      - protocol: udp
+      - protocol: "udp"
         published_port: 60002
         target_port: 60002
   register: publish_2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
When `publish.mode` is not set tasks using `publish` will always be marked as changed when a docker-py version supporting `publish.mode` is used. In that case Docker will always return the default `ingress` as `publish.mode`. 

Since `mode` is a key within a list of `publish` a more complex solution had to be implemented. I added this in a new method that is used in `DockerService.compare`.

Fixes #49285 together with the now merged https://github.com/ansible/ansible/pull/50655.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
