### PR TITLE
Add support for multiple IPv6 addresses in nxos_l3_interface module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_l3_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interface.py
@@ -117,7 +117,7 @@ def map_obj_to_commands(updates, module):
             if obj_in_have['name'] == name:
                 if ipv4 and obj_in_have['ipv4']:
                     command.append('no ip address {0}'.format(ipv4))
-                if ipv6 and obj_in_have['ipv6']:
+                if ipv6 and ipv6 in obj_in_have['ipv6']:
                     command.append('no ipv6 address {0}'.format(ipv6))
                 if command:
                     command.append('exit')
@@ -129,7 +129,7 @@ def map_obj_to_commands(updates, module):
             if obj_in_have['name'] == name:
                 if ipv4 and ipv4 != obj_in_have['ipv4']:
                     command.append('ip address {0}'.format(ipv4))
-                if ipv6 and ipv6 != obj_in_have['ipv6']:
+                if ipv6 and ipv6 not in obj_in_have['ipv6']:
                     command.append('ipv6 address {0}'.format(ipv6))
                 if command:
                     command.append('exit')
@@ -174,7 +174,7 @@ def map_config_to_obj(want, module):
     for w in want:
         parents = ['interface {0}'.format(w['name'])]
         config = netcfg.get_section(parents)
-        obj = dict(name=None, ipv4=None, ipv6=None)
+        obj = dict(name=None, ipv4=None, ipv6=[])
 
         if config:
             match_name = re.findall(r'interface (\S+)', config, re.M)
@@ -187,7 +187,7 @@ def map_config_to_obj(want, module):
 
             match_ipv6 = re.findall(r'ipv6 address (\S+)', config, re.M)
             if match_ipv6:
-                obj['ipv6'] = match_ipv6[0]
+                obj['ipv6'] = match_ipv6
 
         objs.append(obj)
     return objs

--- a/lib/ansible/modules/network/nxos/nxos_l3_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interface.py
@@ -115,7 +115,7 @@ def map_obj_to_commands(updates, module):
         if state == 'absent' and obj_in_have:
             command = []
             if obj_in_have['name'] == name:
-                if ipv4 and obj_in_have['ipv4']:
+                if ipv4 and ipv4 == obj_in_have['ipv4']:
                     command.append('no ip address {0}'.format(ipv4))
                 if ipv6 and ipv6 in obj_in_have['ipv6']:
                     command.append('no ipv6 address {0}'.format(ipv6))
@@ -189,7 +189,7 @@ def map_config_to_obj(want, module):
             if match_ipv6:
                 obj['ipv6'] = match_ipv6
 
-        objs.append(obj)
+            objs.append(obj)
     return objs
 
 

--- a/test/units/modules/network/nxos/fixtures/nxos_l3_interface/ethernet_noshut
+++ b/test/units/modules/network/nxos/fixtures/nxos_l3_interface/ethernet_noshut
@@ -1,0 +1,3 @@
+interface Ethernet1/1
+  description Configured by Ansible
+  no shutdown

--- a/test/units/modules/network/nxos/fixtures/nxos_l3_interface/ethernet_noshut_ipv4_ipv6
+++ b/test/units/modules/network/nxos/fixtures/nxos_l3_interface/ethernet_noshut_ipv4_ipv6
@@ -1,0 +1,5 @@
+interface Ethernet1/1
+  description Configured by Ansible
+  ip address 192.168.0.1/24
+  ipv6 address 2001:db8::1/124
+  no shutdown

--- a/test/units/modules/network/nxos/fixtures/nxos_l3_interface/ethernet_noshut_multiple_ipv6
+++ b/test/units/modules/network/nxos/fixtures/nxos_l3_interface/ethernet_noshut_multiple_ipv6
@@ -1,0 +1,7 @@
+interface Ethernet1/1
+  description Configured by Ansible
+  ip address 192.168.0.1/24
+  ipv6 address 2001:db8:1::1/124
+  ipv6 address 2001:db8:2::1/124
+  ipv6 address 2001:db8::1/124
+  no shutdown

--- a/test/units/modules/network/nxos/test_nxos_l3_interface.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interface.py
@@ -210,3 +210,17 @@ class TestNxosL3InterfaceModule(TestNxosModule):
         set_module_args(dict(name='Ethernet1/1'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['interface Ethernet1/1'])
+
+    # Add unknown interface
+    def test_nxos_l3_interface_add_on_unknown_itf(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/2', ipv4='192.168.0.1/24'))
+        result = self.execute_module()
+        self.assertEqual(result['warnings'], ['Unknown interface Ethernet1/2'])
+
+    # Rem unknown interface
+    def test_nxos_l3_interface_rem_on_unknown_itf(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/2', ipv4='192.168.0.1/24', state='absent'))
+        result = self.execute_module()
+        self.assertEqual(result['warnings'], ['Unknown interface Ethernet1/2'])

--- a/test/units/modules/network/nxos/test_nxos_l3_interface.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interface.py
@@ -1,0 +1,212 @@
+# Copyright: (c) 2019, Olivier Blin <olivier.oblin@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat.mock import patch
+from ansible.modules.network.nxos import nxos_l3_interface
+from .nxos_module import TestNxosModule, load_fixture, set_module_args
+
+
+class TestNxosL3InterfaceModule(TestNxosModule):
+
+    module = nxos_l3_interface
+
+    def setUp(self):
+        super(TestNxosL3InterfaceModule, self).setUp()
+
+        self.mock_load_config = patch('ansible.modules.network.nxos.nxos_l3_interface.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_get_config = patch('ansible.modules.network.nxos.nxos_l3_interface.get_config')
+        self.get_config = self.mock_get_config.start()
+
+    def tearDown(self):
+        super(TestNxosL3InterfaceModule, self).tearDown()
+        self.mock_load_config.stop()
+        self.mock_get_config.stop()
+
+    def load_fixtures(self, commands=None, device=''):
+        self.load_config.return_value = None
+        self.get_config.return_value = load_fixture('nxos_l3_interface', self.mode)
+
+    def test_nxos_l3_interface_unknonw_ethernet(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/2', ipv4='192.168.0.1/24'))
+        result = self.execute_module(changed=False)
+
+    # Add when missing
+    def test_nxos_l3_interface_add_missing_ipv4(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'ip address 192.168.0.1/24', 'exit'])
+
+    def test_nxos_l3_interface_add_missing_ipv4_on_e11(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='et1/1', ipv4='192.168.0.1/24'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'ip address 192.168.0.1/24', 'exit'])
+
+    def test_nxos_l3_interface_add_missing_ipv6(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8::1/124'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'ipv6 address 2001:db8::1/124', 'exit'])
+
+    def test_nxos_l3_interface_add_missing_ipv4_and_ipv6(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24', ipv6='2001:db8::1/124'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'ip address 192.168.0.1/24', 'ipv6 address 2001:db8::1/124', 'exit'])
+
+    # Add when existing
+    def test_nxos_l3_interface_add_existing_ipv4(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_add_existing_ipv4_on_e11(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='et1/1', ipv4='192.168.0.1/24'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_add_existing_ipv6(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8::1/124'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_add_existing_ipv4_and_ipv6(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24', ipv6='2001:db8::1/124'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_new_ipv4_and_ipv6(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.2/24', ipv6='2001:db8::2/124'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'ip address 192.168.0.2/24', 'ipv6 address 2001:db8::2/124', 'exit'])
+
+    # Add when existing with multiple IPv6
+    def test_nxos_l3_interface_multiple_ipv6_add_first(self):
+        self.mode = 'ethernet_noshut_multiple_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8::1/124'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_multiple_ipv6_add_last(self):
+        self.mode = 'ethernet_noshut_multiple_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8:2::1/124'))
+        result = self.execute_module()
+
+    # Add aggregate
+    def test_nxos_l3_interface_add_missing_with_empty_aggregate(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(aggregate=[]))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_add_missing_with_aggregate(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(aggregate=[
+            dict(name='Ethernet1/1', ipv4='192.168.0.2/24', ipv6='2001:db8::2/124'),
+            dict(name='Ethernet1/1', ipv6='2001:db8:1::2/124'),
+            dict(name='Ethernet1/1', ipv6='2001:db8:2::2/124')]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], [
+            'interface Ethernet1/1', 'ip address 192.168.0.2/24', 'ipv6 address 2001:db8::2/124', 'exit',
+            'interface Ethernet1/1', 'ipv6 address 2001:db8:1::2/124', 'exit',
+            'interface Ethernet1/1', 'ipv6 address 2001:db8:2::2/124', 'exit'])
+
+    # Rem when missing
+    def test_nxos_l3_interface_rem_missing_ipv4(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24', state='absent'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_rem_missing_ipv4_on_e11(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='et1/1', ipv4='192.168.0.1/24', state='absent'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_rem_missing_ipv6(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8::1/124', state='absent'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_rem_missing_ipv4_and_ipv6(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24', ipv6='2001:db8::1/124', state='absent'))
+        result = self.execute_module()
+
+    # Rem when existing
+    def test_nxos_l3_interface_rem_existing_ipv4(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24', state='absent'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'no ip address 192.168.0.1/24', 'exit'])
+
+    def test_nxos_l3_interface_rem_existing_ipv4_on_e11(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='et1/1', ipv4='192.168.0.1/24', state='absent'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'no ip address 192.168.0.1/24', 'exit'])
+
+    def test_nxos_l3_interface_rem_existing_ipv6(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8::1/124', state='absent'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'no ipv6 address 2001:db8::1/124', 'exit'])
+
+    def test_nxos_l3_interface_rem_existing_ipv4_and_ipv6(self):
+        self.mode = 'ethernet_noshut_ipv4_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv4='192.168.0.1/24', ipv6='2001:db8::1/124', state='absent'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'no ip address 192.168.0.1/24', 'no ipv6 address 2001:db8::1/124', 'exit'])
+
+    # Rem when existing with multiple IPv6
+    def test_nxos_l3_interface_multiple_ipv6_rem_first(self):
+        self.mode = 'ethernet_noshut_multiple_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8::1/124', state='absent'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'no ipv6 address 2001:db8::1/124', 'exit'])
+
+    def test_nxos_l3_interface_multiple_ipv6_rem_last(self):
+        self.mode = 'ethernet_noshut_multiple_ipv6'
+        set_module_args(dict(name='Ethernet1/1', ipv6='2001:db8:2::1/124', state='absent'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1', 'no ipv6 address 2001:db8:2::1/124', 'exit'])
+
+    # Rem when missing with aggregate
+    def test_nxos_l3_interface_rem_with_empty_aggregate(self):
+        self.mode = 'ethernet_noshut_multiple_ipv6'
+        set_module_args(dict(aggregate=[], state='absent'))
+        result = self.execute_module()
+
+    def test_nxos_l3_interface_rem_missing_with_aggregate(self):
+        self.mode = 'ethernet_noshut_multiple_ipv6'
+        set_module_args(dict(state='absent', aggregate=[
+            dict(name='Ethernet1/1', ipv4='192.168.0.2/24', ipv6='2001:db8::2/124'),
+            dict(name='Ethernet1/1', ipv6='2001:db8:1::2/124'),
+            dict(name='Ethernet1/1', ipv6='2001:db8:2::2/124')]))
+        result = self.execute_module()
+
+    # Rem when existing with aggregate
+    def test_nxos_l3_interface_rem_existing_with_aggregate(self):
+        self.mode = 'ethernet_noshut_multiple_ipv6'
+        set_module_args(dict(state='absent', aggregate=[
+            dict(name='Ethernet1/1', ipv4='192.168.0.1/24', ipv6='2001:db8::1/124'),
+            dict(name='Ethernet1/1', ipv6='2001:db8:1::1/124'),
+            dict(name='Ethernet1/1', ipv6='2001:db8:2::1/124')]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], [
+            'interface Ethernet1/1', 'no ip address 192.168.0.1/24', 'no ipv6 address 2001:db8::1/124', 'exit',
+            'interface Ethernet1/1', 'no ipv6 address 2001:db8:1::1/124', 'exit',
+            'interface Ethernet1/1', 'no ipv6 address 2001:db8:2::1/124', 'exit'])
+
+    # Add itf only
+    def test_nxos_l3_interface_add_on_itf_only(self):
+        self.mode = 'ethernet_noshut'
+        set_module_args(dict(name='Ethernet1/1'))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['interface Ethernet1/1'])


### PR DESCRIPTION
##### SUMMARY

Cisco support multiple IPv6 addresses on each interface but only the first IPv6 is considered by this module. There is no impact on the configuration but the module is not idempotent.

* Add internal support for IPv6 list
* Fix module idempotency

This correction does not change module interface, only one IPv6 can be set per module call. Multiple IPv6 can be set with the aggregate option.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_l3_interface

##### ADDITIONAL INFORMATION
System: Cisco nexus9000, version 7.0(3)I7(5a)

I had some difficulties to choose the way to remove the IPv6 address:

```python
if ipv6 and (len(obj_in_have['ipv6']) > 0):
    # Deletion is not idempotent but you are sure that the IPv6 address is deleted.

# VS

if ipv6 and ipv6 in obj_in_have['ipv6']:
    # Deletion is idempotent.
    # To be deleted, the IPv6 address must be in a lowercase compact notation.
    # The filter ipv6('address/prefix') can help to ensure the right notation.
```

I chose the second method but it could cause regressions if IPv6 adresses are not in the right format.
