### PR TITLE
Adding custom module to get PID of the process

### DIFF
--- a/lib/ansible/modules/system/pids.py
+++ b/lib/ansible/modules/system/pids.py
@@ -52,15 +52,15 @@ except ImportError:
 
 
 def get_pid(name):
-    return [p.info['pid'] for p in psutil.process_iter(attrs=['pid', 'name']) if name in p.info['name']]
+    return [p.info['pid'] for p in psutil.process_iter(attrs=['pid', 'name']) if name == p.info['name']]
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(required= True, type= "str"),
+            name=dict(required=True, type="str"),
         ),
-	supports_check_mode=True,
+        supports_check_mode=True,
     )
     if not HAS_PSUTIL:
         module.fail_json(msg="Missing required 'psutil' python module. Try installing it with: pip install psutil")

--- a/lib/ansible/modules/system/pids.py
+++ b/lib/ansible/modules/system/pids.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+# Copyright 2019, Saranya Sridharan
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: pids
+version_added: 2.8
+description: "Retrieves a list of process IDs (PIDs) of all processes of the given name. Returns an empty list if no process of the given name exists."
+short_description: "Retrieves process IDs list if the process is running otherwise return empty list"
+author:
+  - Saranya Sridharan (@saranyasridharan)
+requirements:
+  - psutil
+options:
+  name:
+    description: the name of the process you want to get PID for
+    required: true
+'''
+
+EXAMPLES = '''
+# Pass the process name
+- name: Getting process IDs of the process
+  pids:
+      name: python
+  register: pids_of_python
+
+- name: Printing the process IDs obtained
+  debug:
+    msg: "PIDS of python:{{pids_of_python.pids|join(',')}}"
+'''
+
+RETURN = '''
+pids:
+  description: Process IDs of the given process
+  returned: list of none, one, or more process IDs
+  type: list
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import sys
+try:
+    import psutil
+    HAS_PSUTIL = True
+except ImportError:
+    HAS_PSUTIL = False
+
+
+def get_pid(name):
+    return [p.info['pid'] for p in psutil.process_iter(attrs=['pid', 'name']) if name in p.info['name']]
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required= True, type= "str"),
+        ),
+	supports_check_mode=True,
+    )
+    if not HAS_PSUTIL:
+        module.fail_json(msg="Missing required 'psutil' python module. Try installing it with: pip install psutil")
+    name = module.params["name"]
+    response = dict(pids=get_pid(name))
+    module.exit_json(**response)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/pids.py
+++ b/lib/ansible/modules/system/pids.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2019, Saranya Sridharan
+# Copyright: (c) 2019, Saranya Sridharan
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -11,16 +11,17 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 module: pids
 version_added: 2.8
-description: "Retrieves a list of process IDs (PIDs) of all processes of the given name. Returns an empty list if no process of the given name exists."
+description: "Retrieves a list of PIDs of given process name in Ansible controller/controlled machines.Returns an empty list if no process in that name exists."
 short_description: "Retrieves process IDs list if the process is running otherwise return empty list"
 author:
   - Saranya Sridharan (@saranyasridharan)
 requirements:
-  - psutil
+  - psutil(python module)
 options:
   name:
-    description: the name of the process you want to get PID for
+    description: the name of the process you want to get PID for.
     required: true
+    type: str
 '''
 
 EXAMPLES = '''
@@ -40,10 +41,10 @@ pids:
   description: Process IDs of the given process
   returned: list of none, one, or more process IDs
   type: list
+  sample: [100,200]
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-import sys
 try:
     import psutil
     HAS_PSUTIL = True

--- a/test/integration/targets/pids/aliases
+++ b/test/integration/targets/pids/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/pids/files/obtainpid.sh
+++ b/test/integration/targets/pids/files/obtainpid.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+"$1" 100 & 
+echo "$!" > "$2"

--- a/test/integration/targets/pids/tasks/main.yml
+++ b/test/integration/targets/pids/tasks/main.yml
@@ -1,0 +1,60 @@
+
+# Test code for the pid module
+# Copyright 2019, Saranya Sridharan
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- name: "Installing the psutil module"
+  pip:
+    name: psutil
+
+- name: "Checking the empty result" 
+  pids: 
+    name: "blahblah"
+  register: emptypids
+
+- name: "Verify that the list of Process IDs (PIDs) returned is empty"
+  assert:
+    that:
+    - emptypids is not changed
+    - emptypids.pids == [] 
+
+- name: "Picking a random process name"
+  command: "echo '{{ 99999999 | random }}'"
+  register: random_name
+
+- name: "finding the 'sleep' binary"
+  command: which sleep
+  register: find_sleep
+
+- name: "copying 'sleep' binary"
+  copy:
+    src: "{{ find_sleep.stdout }}"
+    dest: "{{ output_dir }}/{{ random_name.stdout }}"
+    mode: "777"
+
+- name: "Running the copy of 'sleep' binary"
+  command: "sh {{ role_path }}/files/obtainpid.sh '{{ output_dir }}/{{ random_name.stdout }}' '{{ output_dir }}/obtainpid.txt'"
+
+  async: 100
+  poll: 0
+
+- name: "Checking the process IDs (PIDs) of sleep binary"
+  pids:
+    name: "{{ random_name.stdout }}"
+  register: pids
+
+- name: "Checking that exact non-substring matches are required"
+  pids:
+    name: "{{ random_name.stdout[0:5] }}"
+  register: exactpidmatch
+
+- name: "Reading pid from the file"
+  slurp:
+    src:  "{{ output_dir }}/obtainpid.txt"
+  register: newpid
+
+- name: "Verify that the Process IDs (PIDs) returned is not empty and also equal to the PIDs obtained in console"
+  assert:
+    that:
+    - "pids.pids | join(' ')  == newpid.content | b64decode | trim"
+    - "pids.pids | length > 0"
+    - "exactpidmatch.pids | length == 0"

--- a/test/integration/targets/pids/tasks/main.yml
+++ b/test/integration/targets/pids/tasks/main.yml
@@ -1,5 +1,5 @@
-# Test code for the pid module
-# Copyright 2019, Saranya Sridharan
+# Test code for the pids module
+# Copyright: (c) 2019, Saranya Sridharan
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 - name: "Installing the psutil module"
   pip:

--- a/test/integration/targets/pids/tasks/main.yml
+++ b/test/integration/targets/pids/tasks/main.yml
@@ -1,4 +1,3 @@
-
 # Test code for the pid module
 # Copyright 2019, Saranya Sridharan
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -18,7 +17,7 @@
     - emptypids.pids == [] 
 
 - name: "Picking a random process name"
-  command: "echo '{{ 99999999 | random }}'"
+  command: "echo 'some-random-long-name-{{ 99999999 | random }}'"
   register: random_name
 
 - name: "finding the 'sleep' binary"
@@ -29,7 +28,7 @@
   copy:
     src: "{{ find_sleep.stdout }}"
     dest: "{{ output_dir }}/{{ random_name.stdout }}"
-    mode: "777"
+    mode: "0777"
 
 - name: "Running the copy of 'sleep' binary"
   command: "sh {{ role_path }}/files/obtainpid.sh '{{ output_dir }}/{{ random_name.stdout }}' '{{ output_dir }}/obtainpid.txt'"
@@ -57,4 +56,4 @@
     that:
     - "pids.pids | join(' ')  == newpid.content | b64decode | trim"
     - "pids.pids | length > 0"
-    - "exactpidmatch.pids | length == 0"
+    - "exactpidmatch.pids == []"


### PR DESCRIPTION
SUMMARY
This module will find the pid of the given process name either locally or in remote system, depending on the host parameter.

ISSUE TYPE

New Module Pull Request
COMPONENT NAME
pids

ANSIBLE VERSION
ansible 2.8.0.dev0 last updated 2018/08/07 12:03:58 (GMT +550)
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/home/ansible/newcode/library']
ansible python module location = /home/ansible/lib/ansible
executable location = /home/ansible/bin/ansible
python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

ADDITIONAL INFORMATION
I have used psutil module to find the process IDs(PIDs) of the given process