### PR TITLE
Use different test package in pip test.

### DIFF
--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -1,13 +1,13 @@
 pip_test_package: sampleproject
 pip_test_packages:
   - sampleproject
-  - decorator
+  - jiphy
 pip_test_pkg_ver:
   - sampleproject<=100, !=9.0.0,>=0.0.1 
-  - decorator<100 ,!=9,>=0.0.1
+  - jiphy<100 ,!=9,>=0.0.1
 pip_test_pkg_ver_unsatisfied:
   - sampleproject>= 999.0.0
-  - decorator >999.0
+  - jiphy >999.0
 pip_test_modules:
   - sample
-  - decorator
+  - jiphy


### PR DESCRIPTION
##### SUMMARY

Use different test package in pip test.

This avoids conflicts with other tests such as firewalld, which use the decorator package installed using OS packages.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip integration test
