### PR TITLE
[2.7] [docker_container] Failing on non-string env values

### DIFF
--- a/changelogs/fragments/49843-docker_container-wrap-env.yaml
+++ b/changelogs/fragments/49843-docker_container-wrap-env.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'docker_container - fail when non-string env values are found, avoiding YAML parsing issues. (https://github.com/ansible/ansible/issues/49802)'

--- a/changelogs/fragments/49843-docker_container-wrap-env.yaml
+++ b/changelogs/fragments/49843-docker_container-wrap-env.yaml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
-  - 'docker_container - fail when non-string env values are found, avoiding YAML parsing issues. (https://github.com/ansible/ansible/issues/49802)'
+  - "docker_container - warning when non-string env values are found, avoiding YAML parsing issues.
+     Will be made an error in Ansible 2.8. (https://github.com/ansible/ansible/issues/49802)"

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1229,8 +1229,11 @@ class TaskParameters(DockerBaseClass):
         if self.env:
             for name, value in self.env.items():
                 if not isinstance(value, string_types):
-                    self.fail("Non-string value found for env option. "
-                              "Ambiguous env options must be wrapped in quotes to avoid YAML parsing. Key: %s" % (name, ))
+                    self.client.module.warn(
+                        "Non-string value found for env option. "
+                        "Ambiguous env options should be wrapped in quotes to avoid YAML parsing. "
+                        "This will become an error in Ansible 2.8. "
+                        "Key: %s; value will be treated as: %s" % (name, str(value)))
                 final_env[name] = str(value)
         return final_env
 

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -93,6 +93,8 @@ options:
   env:
     description:
       - Dictionary of key,value pairs.
+      - Values which might be parsed as numbers, booleans or other types by the YAML parser must be quoted (e.g. C("true")) in order to avoid data loss.
+    type: dict
   env_file:
     version_added: "2.2"
     description:
@@ -489,7 +491,9 @@ EXAMPLES = '''
      - "8080:9000"
      - "127.0.0.1:8081:9001/udp"
     env:
-        SECRET_KEY: ssssh
+        SECRET_KEY: "ssssh"
+        # Values which might be parsed as numbers, booleans or other types by the YAML parser need to be quoted
+        BOOLEAN_KEY: "yes"
 
 - name: Container present
   docker_container:
@@ -1224,6 +1228,9 @@ class TaskParameters(DockerBaseClass):
                 final_env[name] = str(value)
         if self.env:
             for name, value in self.env.items():
+                if not isinstance(value, string_types):
+                    self.fail("Non-string value found for env option. "
+                              "Ambiguous env options must be wrapped in quotes to avoid YAML parsing. Key: %s" % (name, ))
                 final_env[name] = str(value)
         return final_env
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1000,8 +1000,8 @@
     - env_2 is not changed
     - env_3 is not changed
     - env_4 is changed
-    - env_5 is failed
-    - "('Non-string value found for env option.') in env_5.msg"
+    - '"warnings" in env_5'
+    - "'Non-string value found for env option.' in env_5.warnings[0]"
 
 ####################################################################
 ## env_file #########################################################

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -935,6 +935,9 @@
     env:
       TEST1: val1
       TEST2: val2
+      TEST3: "False"
+      TEST4: "true"
+      TEST5: "yes"
   register: env_1
 
 - name: env (idempotency)
@@ -946,6 +949,9 @@
     env:
       TEST2: val2
       TEST1: val1
+      TEST5: "yes"
+      TEST3: "False"
+      TEST4: "true"
   register: env_2
 
 - name: env (less environment variables)
@@ -970,6 +976,18 @@
     stop_timeout: 1
   register: env_4
 
+- name: env (fail unwrapped values)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    env:
+      TEST1: true
+    force_kill: yes
+  register: env_5
+  ignore_errors: yes
+
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
@@ -982,6 +1000,8 @@
     - env_2 is not changed
     - env_3 is not changed
     - env_4 is changed
+    - env_5 is failed
+    - "('Non-string value found for env option.') in env_5.msg"
 
 ####################################################################
 ## env_file #########################################################


### PR DESCRIPTION
##### SUMMARY
Backport of #49843 to stable-2.7: failing on non-string environment value (instead of converting them to `str` and passing them to Docker daemon, resulting in rather random behavior as values such as `y` or `true` would be changed to `True`).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
