### PR TITLE
Updated test constraints for mock assert_called(), assert_called_once()

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -21,6 +21,8 @@ virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later requi
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pycparser < 2.19 ; python_version < '2.7' # pycparser 2.19 and later require python 2.7 or later
+mock >= 2.0.0 # needed for features backported from Python 3.6 unittest.mock (assert_called, assert_called_once...)
+pytest-mock >= 1.4.0 # needed for mock_use_standalone_module pytest option
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.0.4

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
 [pytest]
 xfail_strict = true
 cache_dir = .pytest_cache
+mock_use_standalone_module = true
 
 [flake8]
 # These are things that the devs don't agree make the code more readable


### PR DESCRIPTION
##### SUMMARY
Some current (and some future) unit tests are using Mock methods assert_called() and assert_called_once() which imposes constraints on version of mock library.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/units

##### ADDITIONAL INFORMATION
assert_called() and assert_called_once() methods were introduced in Python 3.6 unittest.mock and were backported to mock 2.0.0. This PR ups the constraints for mock to version >= 2.0.0. It also ups constraints for pytest-mock to version >= 1.4.0 and puts pytest configuration option "mock_use_standalone_module = true" to tox.ini so that mock will be used instead of unittest.mock in pytest-mock. This is needed for Python versions that don't have native support for assert_called() and assert_called_once() methods (e.g. Python 3.5).