### PR TITLE
Check correct data for clear linux fact population

### DIFF
--- a/changelogs/fragments/50009-facts-fix-debian-family-kde-neon-clearlinux.yml
+++ b/changelogs/fragments/50009-facts-fix-debian-family-kde-neon-clearlinux.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - resolve issue where KDE neon wasn not properly detected as a debian derivative and fix clearlinux false positive

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -403,7 +403,7 @@ class DistributionFiles:
 
     def parse_distribution_file_ClearLinux(self, name, data, path, collected_facts):
         clear_facts = {}
-        if "clearlinux" not in name.lower():
+        if "clearlinux" not in data.lower():
             return False, clear_facts
 
         pname = re.search('NAME="(.*)"', data)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -351,6 +351,8 @@ class DistributionFiles:
             if version:
                 debian_facts['distribution_version'] = version.group(1)
                 debian_facts['distribution_major_version'] = version.group(1).split('.')[0]
+        elif 'KDE neon' in data:
+            debian_facts['distribution'] = 'KDE neon'
         else:
             return False, debian_facts
 
@@ -461,6 +463,7 @@ class Distribution(object):
         'Altlinux': 'ALT Linux',
         'ClearLinux': 'Clear Linux Software for Intel Architecture',
         'SMGL': 'Source Mage GNU/Linux',
+        'Neon': 'KDE neon',
     }
 
     # keep keys in sync with Conditionals page of docs
@@ -483,7 +486,7 @@ class Distribution(object):
                      'HP-UX': ['HPUX'],
                      'Darwin': ['MacOSX'],
                      'FreeBSD': ['FreeBSD', 'TrueOS'],
-                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix']}
+                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix', 'ClearLinux']}
 
     OS_FAMILY = {}
     for family, names in OS_FAMILY_MAP.items():

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1252,9 +1252,40 @@ TESTSETS = [
         "neon"
     ],
     "input": {
-        "/etc/os-release": "NAME=\"KDE neon\"\nVERSION=\"5.14\"\nID=neon\nID_LIKE=\"ubuntu debian\"\nPRETTY_NAME=\"KDE neon User Edition 5.14\"\nVERSION_ID=\"18.04\"\nHOME_URL=\"http://neon.kde.org/\"\nSUPPORT_URL=\"http://neon.kde.org/\"\nBUG_REPORT_URL=\"http://bugs.kde.org/\"\nPRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"\nVERSION_CODENAME=bionic\nUBUNTU_CODENAME=bionic\n",
-        "/usr/lib/os-release": "NAME=\"KDE neon\"\nVERSION=\"5.14\"\nID=neon\nID_LIKE=\"ubuntu debian\"\nPRETTY_NAME=\"KDE neon User Edition 5.14\"\nVERSION_ID=\"18.04\"\nHOME_URL=\"http://neon.kde.org/\"\nSUPPORT_URL=\"http://neon.kde.org/\"\nBUG_REPORT_URL=\"http://bugs.kde.org/\"\nPRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"\nVERSION_CODENAME=bionic\nUBUNTU_CODENAME=bionic\n",
-        "/etc/lsb-release": "DISTRIB_ID=neon\nDISTRIB_RELEASE=18.04\nDISTRIB_CODENAME=bionic\nDISTRIB_DESCRIPTION=\"KDE neon User Edition 5.14\"\n"
+        "/etc/os-release": '''
+NAME="KDE neon"
+VERSION="5.14"
+ID=neon
+ID_LIKE="ubuntu debian"
+PRETTY_NAME="KDE neon User Edition 5.14"
+VERSION_ID="18.04"
+HOME_URL="http://neon.kde.org/"
+SUPPORT_URL="http://neon.kde.org/"
+BUG_REPORT_URL="http://bugs.kde.org/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=bionic
+UBUNTU_CODENAME=bionic
+''',
+        "/usr/lib/os-release": '''
+NAME="KDE neon"
+VERSION="5.14"
+ID=neon
+ID_LIKE="ubuntu debian"
+PRETTY_NAME="KDE neon User Edition 5.14"
+VERSION_ID="18.04"
+HOME_URL="http://neon.kde.org/"
+SUPPORT_URL="http://neon.kde.org/"
+BUG_REPORT_URL="http://bugs.kde.org/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=bionic
+UBUNTU_CODENAME=bionic
+''',
+        "/etc/lsb-release": '''
+DISTRIB_ID=neon
+DISTRIB_RELEASE=18.04
+DISTRIB_CODENAME=bionic
+DISTRIB_DESCRIPTION="KDE neon User Edition 5.14"
+'''
     },
     "name": "KDE neon",
     "result": {

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1235,6 +1235,36 @@ TESTSETS = [
             "distribution_version": "26580"
         }
     },
+    "name": "ClearLinux 26580",
+    "result": {
+        "distribution_release": "clear-linux-os",
+        "distribution": "Clear Linux OS",
+        "distribution_major_version": "26580",
+        "os_family": "ClearLinux",
+        "distribution_version": "26580"
+    }
+},
+    # KDE Neon
+{
+    "platform.dist": [
+        "neon",
+        "18.04",
+        "neon"
+    ],
+    "input": {
+        "/etc/os-release": "NAME=\"KDE neon\"\nVERSION=\"5.14\"\nID=neon\nID_LIKE=\"ubuntu debian\"\nPRETTY_NAME=\"KDE neon User Edition 5.14\"\nVERSION_ID=\"18.04\"\nHOME_URL=\"http://neon.kde.org/\"\nSUPPORT_URL=\"http://neon.kde.org/\"\nBUG_REPORT_URL=\"http://bugs.kde.org/\"\nPRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"\nVERSION_CODENAME=bionic\nUBUNTU_CODENAME=bionic\n",
+        "/usr/lib/os-release": "NAME=\"KDE neon\"\nVERSION=\"5.14\"\nID=neon\nID_LIKE=\"ubuntu debian\"\nPRETTY_NAME=\"KDE neon User Edition 5.14\"\nVERSION_ID=\"18.04\"\nHOME_URL=\"http://neon.kde.org/\"\nSUPPORT_URL=\"http://neon.kde.org/\"\nBUG_REPORT_URL=\"http://bugs.kde.org/\"\nPRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"\nVERSION_CODENAME=bionic\nUBUNTU_CODENAME=bionic\n",
+        "/etc/lsb-release": "DISTRIB_ID=neon\nDISTRIB_RELEASE=18.04\nDISTRIB_CODENAME=bionic\nDISTRIB_DESCRIPTION=\"KDE neon User Edition 5.14\"\n"
+    },
+    "name": "KDE neon",
+    "result": {
+        "distribution_release": "neon",
+        "distribution": "KDE neon",
+        "distribution_major_version": "18",
+        "os_family": "Debian",
+        "distribution_version": "18.04"
+    }
+},
     # ArchLinux with no /etc/arch-release but with a /etc/os-release with NAME=Arch Linux
     # The fact needs to map 'Arch Linux' to 'Archlinux' for compat with 2.3 and earlier facts
     {


### PR DESCRIPTION
##### SUMMARY
Previously the setup module was checking the incorrect arg to the
clear linux fact parsing function leading to a conditional that was
never false and therefore applying ClearLinux facts to distributions
other than ClearLinux

Fixes #50009

Signed-off-by: Adam Miller <admiller@redhat.com>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup
