### PR TITLE
Fix ansible-test dependency processing.

### DIFF
--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -389,7 +389,6 @@ def analyze_integration_target_dependencies(integration_targets):
                         if new_target_name not in dependent_target_names:
                             dependent_target_names.add(new_target_name)
                             changes += 1
-                    dependent_target_names.remove(dependent_target_name)
 
         if not changes:
             break


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test dependency processing.

Previously, the following dependencies:

A used by B
B used by C

Would have been converted to:

A used by C
B used by C

Intead of being expanded to:

A used by B
A used by C
B used by C

This change preserves the existing dependency when expanding it.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
