### PR TITLE
ansible-test: apt cleanup and futher 18.04 fixes

### DIFF
--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -27,8 +27,8 @@
   - block:
       - include: 'repo.yml'
     always:
-      - apt_repository:
-          repo: "deb file:{{ repodir }} ./"
+      - file:
+          path: /etc/apt/sources.list.d/file_tmp_repo.list
           state: absent
       - file:
           name: "{{ repodir }}"

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -135,6 +135,9 @@
   stat: path='/var/cache/apt/pkgcache.bin'
   register: cache_before
 
+- name: ensure ppa key is present before adding repo that requires authentication
+  apt_key: keyserver=keyserver.ubuntu.com id='{{test_ppa_key}}' state=present
+
 - name: 'name=<spec> (expect: pass)'
   apt_repository: repo='{{test_ppa_spec}}' state=present
   register: result
@@ -166,6 +169,9 @@
 - name: 'record apt cache mtime'
   stat: path='/var/cache/apt/pkgcache.bin'
   register: cache_before
+
+- name: ensure ppa key is present before adding repo that requires authentication
+  apt_key: keyserver=keyserver.ubuntu.com id='{{test_ppa_key}}' state=present
 
 - name: 'name=<spec> filename=<filename> (expect: pass)'
   apt_repository: repo='{{test_ppa_spec}}' filename='{{test_ppa_filename}}' state=present


### PR DESCRIPTION
##### SUMMARY
Missed a cleanup step based on changes in https://github.com/ansible/ansible/pull/50795. Also fixes the `apt_repository` integration tests when running on Ubuntu 18.04 as the ppa repository needs to have the key already present for it to refresh its cache.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/apt
test/integration/targets/apt_repository