### PR TITLE
Fix ansible-test target dependency issues.

### DIFF
--- a/test/integration/targets/binary_modules_posix/aliases
+++ b/test/integration/targets/binary_modules_posix/aliases
@@ -1,1 +1,2 @@
 shippable/posix/group3
+needs/target/binary_modules

--- a/test/integration/targets/binary_modules_winrm/aliases
+++ b/test/integration/targets/binary_modules_winrm/aliases
@@ -1,3 +1,4 @@
 shippable/windows/group1
 shippable/windows/smoketest
 windows
+needs/target/binary_modules

--- a/test/integration/targets/connection_posix/aliases
+++ b/test/integration/targets/connection_posix/aliases
@@ -1,0 +1,1 @@
+needs/target/connection

--- a/test/integration/targets/connection_psrp/aliases
+++ b/test/integration/targets/connection_psrp/aliases
@@ -1,3 +1,4 @@
 windows
 shippable/windows/group1
 shippable/windows/smoketest
+needs/target/connection

--- a/test/integration/targets/connection_winrm/aliases
+++ b/test/integration/targets/connection_winrm/aliases
@@ -1,3 +1,4 @@
 windows
 shippable/windows/group1
 shippable/windows/smoketest
+needs/target/connection

--- a/test/integration/targets/lookup_hashi_vault/aliases
+++ b/test/integration/targets/lookup_hashi_vault/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 destructive
+needs/target/setup_openssl

--- a/test/integration/targets/template_jinja2_latest/aliases
+++ b/test/integration/targets/template_jinja2_latest/aliases
@@ -1,2 +1,3 @@
 needs/root
 shippable/posix/group2
+needs/target/template

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -378,8 +378,9 @@ def analyze_integration_target_dependencies(integration_targets):
                 dependencies[link_target].add(target.name)
 
     # intentionally primitive analysis of role meta to avoid a dependency on pyyaml
-    for role_target in role_targets:
-        meta_dir = os.path.join(role_target.path, 'meta')
+    # script based targets are scanned as they may execute a playbook with role dependencies
+    for target in integration_targets:
+        meta_dir = os.path.join(target.path, 'meta')
 
         if not os.path.isdir(meta_dir):
             continue
@@ -400,7 +401,7 @@ def analyze_integration_target_dependencies(integration_targets):
 
                     for hidden_target_name in hidden_role_target_names:
                         if hidden_target_name in meta_line:
-                            dependencies[hidden_target_name].add(role_target.name)
+                            dependencies[hidden_target_name].add(target.name)
 
     while True:
         changes = 0

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -12,6 +12,7 @@ import sys
 
 from lib.util import (
     ApplicationError,
+    display,
     read_lines_without_comments,
 )
 
@@ -392,6 +393,17 @@ def analyze_integration_target_dependencies(integration_targets):
 
         if not changes:
             break
+
+    for target_name in sorted(dependencies):
+        consumers = dependencies[target_name]
+
+        if not consumers:
+            continue
+
+        display.info('%s:' % target_name, verbosity=4)
+
+        for consumer in sorted(consumers):
+            display.info('  %s' % consumer, verbosity=4)
 
     return dependencies
 

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -355,6 +355,11 @@ def analyze_integration_target_dependencies(integration_targets):
         for setup_target_name in target.setup_always + target.setup_once:
             dependencies[setup_target_name].add(target.name)
 
+    # handle target dependencies
+    for target in integration_targets:
+        for need_target in target.needs_target:
+            dependencies[need_target].add(target.name)
+
     # handle symlink dependencies between targets
     # this use case is supported, but discouraged
     for target in integration_targets:
@@ -645,6 +650,7 @@ class IntegrationTarget(CompletionTarget):
 
         self.setup_once = tuple(sorted(set(g.split('/')[2] for g in groups if g.startswith('setup/once/'))))
         self.setup_always = tuple(sorted(set(g.split('/')[2] for g in groups if g.startswith('setup/always/'))))
+        self.needs_target = tuple(sorted(set(g.split('/')[2] for g in groups if g.startswith('needs/target/'))))
 
 
 class TargetPatternsNotMatched(ApplicationError):


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test target dependency issues:

* Log dependencies at verbosity level 4.
* Scan symlinks for target dependencies.
* Scan meta dependencies in script targets.
* Track missing target deps with `needs/target/*`

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
