### PR TITLE
optional attribute arg for min and max filters

### DIFF
--- a/changelogs/fragments/50909-min-max-attrs.yml
+++ b/changelogs/fragments/50909-min-max-attrs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow an attribute to be passed to the min and max filters with Jinja 2.10+

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -882,9 +882,21 @@ To get the minimum value from list of numbers::
 
     {{ list1 | min }}
 
+.. versionadded:: 2.11
+
+To get the minimum value in a list of objects::
+
+    {{ [{'val': 1}, {'val': 2}] | min(attribute='value') }}
+
 To get the maximum value from a list of numbers::
 
     {{ [3, 4, 2] | max }}
+
+.. versionadded:: 2.11
+
+To get the maximum value in a list of objects::
+
+    {{ [{'val': 1}, {'val': 2}] | max(attribute='value') }}
 
 .. versionadded:: 2.5
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -886,7 +886,7 @@ To get the minimum value from list of numbers::
 
 To get the minimum value in a list of objects::
 
-    {{ [{'val': 1}, {'val': 2}] | min(attribute='value') }}
+    {{ [{'val': 1}, {'val': 2}] | min(attribute='val') }}
 
 To get the maximum value from a list of numbers::
 
@@ -896,7 +896,7 @@ To get the maximum value from a list of numbers::
 
 To get the maximum value in a list of objects::
 
-    {{ [{'val': 1}, {'val': 2}] | max(attribute='value') }}
+    {{ [{'val': 1}, {'val': 2}] | max(attribute='val') }}
 
 .. versionadded:: 2.5
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -136,7 +136,7 @@ def min(environment, a, **kwargs):
     else:
         if kwargs:
             raise AnsibleFilterError("Ansible's min filter does not support any keyword arguments. "
-                                     "You need a newer version of Jinja2 that provides their version of the filter.")
+                                     "You need Jinja2 2.10 or later that provides their version of the filter.")
         _min = __builtins__.get('min')
         return _min(a)
 
@@ -148,7 +148,7 @@ def max(environment, a, **kwargs):
     else:
         if kwargs:
             raise AnsibleFilterError("Ansible's max filter does not support any keyword arguments. "
-                                     "You need a newer version of Jinja2 that provides their version of the filter.")
+                                     "You need Jinja2 2.10 or later that provides their version of the filter.")
         _max = __builtins__.get('max')
         return _max(a)
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -53,7 +53,7 @@ try:
     from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
-    display = Display()
+display = Display()
 
 
 @environmentfilter

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -25,7 +25,6 @@ __metaclass__ = type
 
 import itertools
 import math
-from operator import itemgetter
 
 from jinja2.filters import environmentfilter
 
@@ -49,11 +48,7 @@ try:
 except ImportError:
     HAS_MIN_MAX = False
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+display = Display()
 
 
 @environmentfilter

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -25,6 +25,7 @@ __metaclass__ = type
 
 import itertools
 import math
+from operator import itemgetter
 
 from jinja2.filters import environmentfilter
 
@@ -123,14 +124,20 @@ def union(environment, a, b):
     return c
 
 
-def min(a):
+def min(a, attribute=None):
     _min = __builtins__.get('min')
-    return _min(a)
+    if attribute:
+        return _min(a, key=itemgetter(attribute))
+    else:
+        return _min(a)
 
 
-def max(a):
+def max(a, attribute=None):
     _max = __builtins__.get('max')
-    return _max(a)
+    if attribute:
+        return _max(a, key=itemgetter(attribute))
+    else:
+        return _max(a)
 
 
 def logarithm(x, base=math.e):

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -130,25 +130,25 @@ def union(environment, a, b):
 
 
 @environmentfilter
-def min(environment, a, case_sensitive=False, attribute=None):
+def min(environment, a, **kwargs):
     if HAS_MIN_MAX:
-        return do_min(environment, a, case_sensitive=case_sensitive, attribute=attribute)
+        return do_min(environment, a, **kwargs)
     else:
-        if case_sensitive or attribute:
-            raise AnsibleFilterError("Ansible's min filter does not support case_sensitive nor attribute parameters, "
-                                     "you need a newer version of Jinja2 that provides their version of the filter.")
+        if kwargs:
+            raise AnsibleFilterError("Ansible's min filter does not support any keyword arguments. "
+                                     "You need a newer version of Jinja2 that provides their version of the filter.")
         _min = __builtins__.get('min')
         return _min(a)
 
 
 @environmentfilter
-def max(environment, a, case_sensitive=False, attribute=None):
+def max(environment, a, **kwargs):
     if HAS_MIN_MAX:
-        return do_max(environment, a, case_sensitive=case_sensitive, attribute=attribute)
+        return do_max(environment, a, **kwargs)
     else:
-        if case_sensitive or attribute:
-            raise AnsibleFilterError("Ansible's max filter does not support case_sensitive nor attribute parameters, "
-                                     "you need a newer version of Jinja2 that provides their version of the filter.")
+        if kwargs:
+            raise AnsibleFilterError("Ansible's max filter does not support any keyword arguments. "
+                                     "You need a newer version of Jinja2 that provides their version of the filter.")
         _max = __builtins__.get('max')
         return _max(a)
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -53,7 +53,7 @@ try:
     from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
-display = Display()
+    display = Display()
 
 
 @environmentfilter

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -64,16 +64,22 @@ class TestSymmetricDifference:
 
 class TestMin:
     def test_min(self):
-        assert ms.min((1, 2)) == 1
-        assert ms.min((2, 1)) == 1
-        assert ms.min(('p', 'a', 'w', 'b', 'p')) == 'a'
+        assert ms.min(env, (1, 2)) == 1
+        assert ms.min(env, (2, 1)) == 1
+        assert ms.min(env, ('p', 'a', 'w', 'b', 'p')) == 'a'
+        assert ms.min(env, ({'key': 'a'}, {'key': 'b'}, {'key': 'c'}), attribute='key') == {'key': 'a'}
+        assert ms.min(env, ({'key': 1}, {'key': 2}, {'key': 3}), attribute='key') == {'key': 1}
+        assert ms.min(env, ('a', 'A', 'b', 'B'), case_sensitive=True) == 'A'
 
 
 class TestMax:
     def test_max(self):
-        assert ms.max((1, 2)) == 2
-        assert ms.max((2, 1)) == 2
-        assert ms.max(('p', 'a', 'w', 'b', 'p')) == 'w'
+        assert ms.max(env, (1, 2)) == 2
+        assert ms.max(env, (2, 1)) == 2
+        assert ms.max(env, ('p', 'a', 'w', 'b', 'p')) == 'w'
+        assert ms.max(env, ({'key': 'a'}, {'key': 'b'}, {'key': 'c'}), attribute='key') == {'key': 'c'}
+        assert ms.max(env, ({'key': 1}, {'key': 2}, {'key': 3}), attribute='key') == {'key': 3}
+        assert ms.max(env, ('a', 'A', 'b', 'B'), case_sensitive=True) == 'b'
 
 
 class TestLogarithm:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow an optional parameter for the key in a list of objects to get the min/max of, similar to the [Jinja2 filter](http://jinja.pocoo.org/docs/2.10/templates/#max).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #50669

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/filter/core.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Sample playbook using the `min` and `max` filters:
```yaml
---
- hosts: ['localhost']
  vars:
    foo: [{'key':  1}, {'key': 2}, {'key': 3}]
  tasks:
    - debug:
        msg: "{{ foo | max(attribute='key') }}"
    - debug:
        msg:  "{{ foo | min(attribute='key') }}"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY [localhost] ************************************************************************

TASK [Gathering Facts] ******************************************************************
ok: [localhost]

TASK [debug] ****************************************************************************
ok: [localhost] => {
    "msg": {
        "key": 3
    }
}

TASK [debug] ****************************************************************************
ok: [localhost] => {
    "msg": {
        "key": 1
    }
}

PLAY RECAP ******************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0
```