### PR TITLE
ansible-test: fix dpkg_selections on Ubuntu 18.04

### DIFF
--- a/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
@@ -30,7 +30,7 @@
 - name: ensure hello was not upgraded
   assert:
     that:
-      - "{{ hello_version.stdout }} == {{ hello_old_version }}"
+    - hello_version.stdout == hello_old_version
 
 - name: remove version freeze
   dpkg_selections:
@@ -49,7 +49,7 @@
 - name: check that old version upgraded correctly
   assert:
     that:
-      - "{{ hello_version.stdout }}!={{ hello_old_version }}"
+    - hello_version.stdout != hello_old_version
 
 - name: set hello to deinstall
   dpkg_selections:


### PR DESCRIPTION
##### SUMMARY
On Ubuntu 18.04 the version string is slightly different, this PR changes the assertion to work in the usual manner.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/dpkg_selections