### PR TITLE
ansible-test: fix cloud_init_data_facts for Ubuntu 18.04

### DIFF
--- a/test/integration/targets/cloud_init_data_facts/tasks/main.yml
+++ b/test/integration/targets/cloud_init_data_facts/tasks/main.yml
@@ -9,7 +9,9 @@
   block:
   - name: setup install cloud-init
     package:
-      name: cloud-init
+      name:
+      - cloud-init
+      - udev
 
   - name: setup run cloud-init
     service:


### PR DESCRIPTION
##### SUMMARY
Install `udev` in the `cloud_init_data_facts` test to get it working with Ubuntu 18.04.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/cloud_init_data_facts