### PR TITLE
ansible-test git: kill gpg-agent to remove locks

### DIFF
--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -182,6 +182,7 @@
 
 - name: GPG-VERIFICATION | Stop gpg-agent so we can remove any locks on the GnuPG dir
   command: gpgconf --kill gpg-agent
+  when: ansible_os_family != 'Suse'  # OpenSUSE ships with an older version of gpg-agent that doesn't support this
 
 - name: GPG-VERIFICATION | Remove GnuPG verification workdir
   file:

--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -180,6 +180,9 @@
       - git_verify is failed
       - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
 
+- name: GPG-VERIFICATION | Stop gpg-agent so we can remove any locks on the GnuPG dir
+  command: gpgconf --kill gpg-agent
+
 - name: GPG-VERIFICATION | Remove GnuPG verification workdir
   file:
     path: "{{ git_gpg_workdir.path }}"


### PR DESCRIPTION
##### SUMMARY
On Ubuntu 18.04 sometimes the gpg-agent locks a file in the gpg working dir causing a failure further down. This PR makes sure we kill the agent before removing the working dir to avoid this scenario.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/git