### PR TITLE
Handle non-target file deps for integration tests.

### DIFF
--- a/test/integration/targets/inventory_foreman_script/aliases
+++ b/test/integration/targets/inventory_foreman_script/aliases
@@ -1,2 +1,3 @@
 shippable/cloud/group1
 cloud/foreman
+needs/file/contrib/inventory/foreman.py

--- a/test/integration/targets/lookup_hashi_vault/aliases
+++ b/test/integration/targets/lookup_hashi_vault/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group2
 destructive
 needs/target/setup_openssl
+needs/file/test/runner/requirements/constraints.txt

--- a/test/integration/targets/setup_docker/aliases
+++ b/test/integration/targets/setup_docker/aliases
@@ -1,4 +1,1 @@
-destructive
-shippable/posix/group1
-needs/httptester
 needs/file/test/runner/requirements/constraints.txt

--- a/test/integration/targets/test_infra/aliases
+++ b/test/integration/targets/test_infra/aliases
@@ -1,1 +1,3 @@
 shippable/posix/group3
+needs/file/hacking/test-module
+needs/file/lib/ansible/modules/system/ping.py

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -626,6 +626,11 @@ class IntegrationTarget(CompletionTarget):
         if self.type not in ('script', 'role'):
             groups.append('hidden')
 
+        # Collect file paths before group expansion to avoid including the directories.
+        # Ignore references to test targets, as those must be defined using `needs/target/*` or other target references.
+        self.needs_file = tuple(sorted(set('/'.join(g.split('/')[2:]) for g in groups if
+                                           g.startswith('needs/file/') and not g.startswith('needs/file/test/integration/targets/'))))
+
         for group in itertools.islice(groups, 0, len(groups)):
             if '/' in group:
                 parts = group.split('/')


### PR DESCRIPTION
##### SUMMARY

Handle non-target file deps for integration tests.

Some integration test targets have dependencies on files outside the `test/integration/targets/` directory tree. Changes to these dependencies can result in unexpected test failures since they do not trigger integration tests which depend on them.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
