### PR TITLE
Add cmp() for Python 3

### DIFF
--- a/lib/ansible/module_utils/netapp_module.py
+++ b/lib/ansible/module_utils/netapp_module.py
@@ -28,15 +28,7 @@
 
 ''' Support class for NetApp ansible modules '''
 
-
-def cmp(a, b):
-    """
-    Python 3 does not have a cmp function, this will do the cmp.
-    :param a: first object to check
-    :param b: second object to check
-    :return:
-    """
-    return (a > b) - (a < b)
+from ansible.module_utils.six import cmp
 
 
 class NetAppModule(object):

--- a/lib/ansible/module_utils/network/aci/msc.py
+++ b/lib/ansible/module_utils/network/aci/msc.py
@@ -31,15 +31,10 @@
 
 from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule, json
-from ansible.module_utils.six import PY3
+from ansible.module_utils.six import cmp
 from ansible.module_utils.six.moves.urllib.parse import urlencode, urljoin
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils._text import to_native, to_bytes
-
-
-if PY3:
-    def cmp(a, b):
-        return (a > b) - (a < b)
 
 
 def issubset(subset, superset):

--- a/lib/ansible/module_utils/six/__init__.py
+++ b/lib/ansible/module_utils/six/__init__.py
@@ -627,6 +627,11 @@ _add_doc(iteritems,
 _add_doc(iterlists,
          "Return an iterator over the (key, [values]) pairs of a dictionary.")
 
+if PY3:
+    def cmp(a, b):
+        return (a > b) - (a < b)
+else:
+    cmp = cmp
 
 if PY3:
     def b(s):

--- a/lib/ansible/module_utils/six/__init__.py
+++ b/lib/ansible/module_utils/six/__init__.py
@@ -629,6 +629,13 @@ _add_doc(iterlists,
 
 if PY3:
     def cmp(a, b):
+        """
+        Replacement for built-in function cmp that was removed in Python 3
+
+        Compare the two objects a and b and return an integer according to
+        the outcome. The return value is negative if a < b, zero if a == b
+        and strictly positive if a > b.
+        """
         return (a > b) - (a < b)
 else:
     cmp = cmp


### PR DESCRIPTION
##### SUMMARY
In order to be able to use cmp() syntax on both Python 2 and 3 having
this as part of our six library is easiest.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
six