### PR TITLE
[WIP] any_errors_fatal: stop after a block containing error once rescue/always tasks have run

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -407,9 +407,12 @@ class StrategyModule(StrategyBase):
                         failed_hosts.append(res._host.name)
                     elif res.is_unreachable():
                         unreachable_hosts.append(res._host.name)
+                    elif any_errors_fatal and res.is_failed() and not iterator.is_failed(res._host):
+                        failed_hosts.append(res._host.name)
 
                 # if any_errors_fatal and we had an error, mark all hosts as failed
-                if any_errors_fatal and (len(failed_hosts) > 0 or len(unreachable_hosts) > 0):
+                # check TQM failed hosts in case a rescue/always was used after a failure in a block as failed_hosts may be empty
+                if any_errors_fatal and (len(failed_hosts) > 0 or len(unreachable_hosts) > 0 or len(self._tqm._failed_hosts) > 0):
                     dont_fail_states = frozenset([iterator.ITERATING_RESCUE, iterator.ITERATING_ALWAYS])
                     for host in hosts_left:
                         (s, _) = iterator.get_next_task_for_host(host, peek=True)

--- a/test/integration/targets/any_errors_fatal/runme.sh
+++ b/test/integration/targets/any_errors_fatal/runme.sh
@@ -15,6 +15,17 @@ if [ "${res}" -eq 0 ] ; then
 	exit 1
 fi
 
+ansible-playbook -i inventory -e @../../integration_config.yml "$@" tasks_after_always_block.yml | tee out.txt | grep 'task_after_block_should_not_run'
+res=$?
+cat out.txt
+if [ "${res}" -eq 0 ] ; then
+    exit 1
+fi
+grep "continue executing after recovering from failure" out.txt
+if [ $? -eq 1 ] ; then
+    exit 1
+fi
+
 set -ux
 
 ansible-playbook -i inventory -e @../../integration_config.yml "$@" always_block.yml | tee out.txt | grep 'any_errors_fatal_always_block_start'

--- a/test/integration/targets/any_errors_fatal/tasks_after_always_block.yml
+++ b/test/integration/targets/any_errors_fatal/tasks_after_always_block.yml
@@ -1,0 +1,27 @@
+- hosts: testhost,testhost2
+  gather_facts: no
+  tasks:
+  - block:
+    - fail:
+      when: inventory_hostname == 'testhost'
+    - debug: msg="still executing in block"
+    rescue:
+    - meta: clear_host_errors
+    always:
+    - debug: msg="executing in always"
+    any_errors_fatal: yes
+
+  - debug: msg="continue executing after recovering from failure"
+
+- hosts: testhost,testhost2
+  gather_facts: no
+  tasks:
+  - block:
+    - fail:
+      when: inventory_hostname == 'testhost'
+    - debug: msg="still executing in block"
+    always:
+    - debug: msg="executing in always"
+    any_errors_fatal: yes
+
+  - debug: msg="task_after_block_should_not_run"

--- a/test/integration/targets/any_errors_fatal/tasks_after_always_block.yml
+++ b/test/integration/targets/any_errors_fatal/tasks_after_always_block.yml
@@ -2,7 +2,8 @@
   gather_facts: no
   tasks:
   - block:
-    - fail:
+    - name: EXPECTED FAILURE fail on testhost
+      fail:
       when: inventory_hostname == 'testhost'
     - debug: msg="still executing in block"
     rescue:
@@ -17,7 +18,8 @@
   gather_facts: no
   tasks:
   - block:
-    - fail:
+    - name: EXPECTED FAILURE fail on testhost
+      fail:
       when: inventory_hostname == 'testhost'
     - debug: msg="still executing in block"
     always:


### PR DESCRIPTION
Tasks following a block with a failure should not run for hosts without failures if any_errors_fatal is true

Add a test for clear_host_errors

##### SUMMARY
Fixes #31543

~Interestingly, inventory_hostnames that are a subset of another host don't trigger this bug, hence not using testhost and adding a testhost1 to the test inventory instead. Still digging into that.~ Not true, was butchering something else.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
any_errors_fatal

