### PR TITLE
Implemented usage of /etc/os-release for amazon linux 2 facts

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -307,8 +307,7 @@ class DistributionFiles:
                     release = re.search('PATCHLEVEL = ([0-9]+)', line)  # SLES doesn't got funny release names
                     if release:
                         suse_facts['distribution_release'] = release.group(1)
-                        suse_facts['distribution_version'] = collected_facts[
-                                                                 'distribution_version'] + '.' + release.group(1)
+                        suse_facts['distribution_version'] = collected_facts['distribution_version'] + '.' + release.group(1)
 
         return True, suse_facts
 

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -435,6 +435,7 @@ class Distribution(object):
         {'path': '/etc/redhat-release', 'name': 'RedHat'},
         {'path': '/etc/vmware-release', 'name': 'VMwareESX', 'allowempty': True},
         {'path': '/etc/openwrt_release', 'name': 'OpenWrt'},
+        {'path': '/etc/os-release', 'name': 'Amazon', 'allowempty': True},
         {'path': '/etc/system-release', 'name': 'Amazon'},
         {'path': '/etc/alpine-release', 'name': 'Alpine'},
         {'path': '/etc/arch-release', 'name': 'Archlinux', 'allowempty': True},

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -229,12 +229,11 @@ class DistributionFiles:
         if 'Amazon' not in data:
             # return False  # TODO: remove   # huh?
             return False, amazon_facts  # TODO: remove
+        amazon_facts['distribution'] = "Amazon"
         if path == '/etc/os-release':
-            for line in data.splitlines():
-                amazon_facts['distribution'] = re.search("^NAME=(.*)", line)
-                amazon_facts['distribution_version'] = re.search("^VERSION=(.*)", line)
+            # amazon_facts['distribution'] = re.search("^NAME=(.*)", data))split()[0]
+            amazon_facts['distribution_version'] = re.search("^VERSION=(.*)", data)
         else:
-            amazon_facts['distribution'] = data.split()[0] + ' ' + data.split()[1]
             amazon_facts['distribution_version'] = data.split()[-1] if (data.split()[-1]).isdigit() else data.split[-2]
         return True, amazon_facts
 

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1079,6 +1079,75 @@ PRIVACY_POLICY_URL="http://www.intel.com/privacy"
             "os_family": "Archlinux",
             "distribution_version": "NA"
         }
+    },
+    # Amazonlinux with no /etc/os-release but with a /etc/system-release with NAME=Arch Linux
+    {
+        "platform.dist": [
+            "",
+            "",
+            ""
+        ],
+        "input": {
+            "/etc/system-release": "Amazon Linux release 2 (Karoo)",
+            "/etc/os-release": "",
+        },
+        "name": "Amazon",
+        "result": {
+            "distribution_release": "NA",
+            "distribution": "Amazon Linux",
+            "distribution_major_version": "NA",
+            "os_family": "RedHat",
+            "distribution_version": "2"
+        }
+    },
+    {
+        "platform.dist": [
+            "",
+            "",
+            ""
+        ],
+        "input": {
+            "/etc/system-release": "Amazon Linux release 2",
+            "/etc/os-release": "",
+        },
+        "name": "Amazon",
+        "result": {
+            "distribution_release": "NA",
+            "distribution": "Amazon Linux",
+            "distribution_major_version": "NA",
+            "os_family": "RedHat",
+            "distribution_version": "2"
+        }
+    },
+    # Amazonlinux with /etc/os-release. This file should be used
+    {
+        "platform.dist": [
+            "",
+            "",
+            ""
+        ],
+        "input": {
+            "/etc/system-release": "Amazon Linux release 2 (Karoo)",
+            "/etc/os-release": '''
+NAME="Amazon Linux"
+VERSION="3"
+ID="amzn"
+ID_LIKE="centos rhel fedora"
+VERSION_ID="2"
+PRETTY_NAME="Amazon Linux 2"
+ANSI_COLOR="0;33"
+CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
+HOME_URL="https://amazonlinux.com/"
+''',
+        },
+        "name": "Amazon",
+        "result": {
+            "distribution_release": "NA",
+            "distribution": "Amazon Linux",
+            "distribution_major_version": "NA",
+            "os_family": "RedHat",
+            "distribution_version": "3"
+        }
     }
 ]
 


### PR DESCRIPTION
##### SUMMARY
Implemented usage of /etc/os-release for amazon linux 2 facts
Fixes #48823

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
facts

##### ANSIBLE VERSION
```
ansible 2.7.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jul 26 2018, 19:59:38) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```