### PR TITLE
Add timeout parameter to post_request() in redfish_utils and 60-second timeout to set_bios_default_settings()

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -41,14 +41,14 @@ class RedfishUtils(object):
                     'msg': 'Failed GET operation against Redfish API server: %s' % to_text(e)}
         return {'ret': True, 'data': data}
 
-    def post_request(self, uri, pyld, hdrs):
+    def post_request(self, uri, pyld, hdrs, timeout=10):
         try:
             resp = open_url(uri, data=json.dumps(pyld),
                             headers=hdrs, method="POST",
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
-                            follow_redirects='all',
+                            follow_redirects='all', timeout=timeout,
                             use_proxy=False)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -646,7 +646,7 @@ class RedfishUtils(object):
         data = response['data']
         reset_bios_settings_uri = data["Actions"]["#Bios.ResetBios"]["target"]
 
-        response = self.post_request(self.root_uri + reset_bios_settings_uri, {}, HEADERS)
+        response = self.post_request(self.root_uri + reset_bios_settings_uri, {}, HEADERS, timeout=60)
         if response['ret'] is False:
             return response
         return {'ret': True, 'changed': True, 'msg': "Set BIOS to default settings"}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I discovered that the redfish_config module's command SetBiosDefaultSettings was failing due to atimeout, but the equivalent POST request works outside of Ansible. I determined that this was due to the default timeout (10 seconds) being too short for such an operation. I added a timeout parameter to post_request() so that commands that may take longer to run successfully can be customized to accommodate longer runtimes. In order to resolve this particular timeout issue, I provided a 60-second timeout to set_bios_default_settings()'s post_request command, which is used in SetBiosDefaultSettings.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.243.5.31
    user: USERID
    password: PASSW0RD

  tasks:
    - name: Set BIOS to defaults
      redfish_config:
        category: Systems
        command: SetBiosDefaultSettings
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before - The code times out and returns a failure, despite the rest of the code being functional. The default timeout used under the covers is 10 seconds.
```paste below
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible
  executable location = bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_config.yml ****************************************************************************************************************************************************************************************************Positional arguments: ../test_redfish_config.yml
become_user: root
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
tags: (u'all',)
forks: 5
verbosity: 5
connection: smart
timeout: 10
1 plays in ../test_redfish_config.yml

PLAY [Test Redfish modules] *********************************************************************************************************************************************************************************************************META: ran handlers

TASK [Set BIOS to defaults] *****************************************************************************************************************************************************************************task path: /mnt/c/Users/amadsen/Coding/redfish/test_redfish_config.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1547572504.15-99136087233708 `" && echo ansible-tmp-1547572504.15-99136087233708="` echo /home/xander/.ansible/tmp/ansible-tmp-1547572504.15-99136087233708 `" ) && sleep 0'
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/_text.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/basic.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/redfish_utils.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/six/__init__.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/parsing/convert_bool.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/common/_collections_compat.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/common/sys_info.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/parsing/__init__.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/pycompat24.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/common/_utils.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/common/process.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/common/__init__.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/common/file.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/distro/__init__.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/distro/_distro.py
Using module_utils file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/module_utils/urls.py
Using module file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/modules/remote_management/redfish/redfish_config.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-13642ZSO1Z/tmpbX3jST TO /home/xander/.ansible/tmp/ansible-tmp-1547572504.15-99136087233708/AnsiballZ_redfish_config.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1547572504.15-99136087233708/ /home/xander/.ansible/tmp/ansible-tmp-1547572504.15-99136087233708/AnsiballZ_redfish_config.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1547572504.15-99136087233708/AnsiballZ_redfish_config.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1547572504.15-99136087233708/ > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31",
            "bios_attribute_name": "null",
            "bios_attribute_value": "null",
            "category": "Systems",
            "command": [
                "SetBiosDefaultSettings"
            ],
            "manager_attribute_name": "null",
            "manager_attribute_value": "null",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "username": "USERID"
        }
    },
    "msg": "Failed POST operation against Redfish API server: ('The read operation timed out',)"
}
        to retry, use: --limit @/mnt/c/Users/amadsen/Coding/redfish/test_redfish_config.retry

PLAY RECAP **************************************************************************************************************************************************************************************************************************localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0
```

After - The code does not time out, since this operation typically takes ~30 seconds to work, and the timeout has been set to 60 seconds.
```
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible
  executable location = bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_config.yml ********************************************************************************************************************Positional arguments: ../test_redfish_config.yml
become_user: root
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
tags: (u'all',)
forks: 5
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_config.yml

PLAY [Test Redfish modules] *************************************************************************************************************************META: ran handlers

TASK [Set BIOS to defaults] *********************************************************************************************task path: /mnt/c/Users/amadsen/Coding/redfish/test_redfish_config.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1547576089.09-163240987942368 `" && echo ansible-tmp-1547576089.09-163240987942368="` echo /home/xander/.ansible/tmp/ansible-tmp-1547576089.09-163240987942368 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/modules/remote_management/redfish/redfish_config.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-1667O0PtOO/tmpPX7tBf TO /home/xander/.ansible/tmp/ansible-tmp-1547576089.09-163240987942368/AnsiballZ_redfish_config.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1547576089.09-163240987942368/ /home/xander/.ansible/tmp/ansible-tmp-1547576089.09-163240987942368/AnsiballZ_redfish_config.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1547576089.09-163240987942368/AnsiballZ_redfish_config.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1547576089.09-163240987942368/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31",
            "bios_attribute_name": "null",
            "bios_attribute_value": "null",
            "category": "Systems",
            "command": [
                "SetBiosDefaultSettings"
            ],
            "manager_attribute_name": "null",
            "manager_attribute_value": "null",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "username": "USERID"
        }
    },
    "msg": "Set BIOS to default settings"
}

PLAY RECAP ******************************************************************************************************************************************localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0
```
