### PR TITLE
Fix mandatory statement error for junos modules (#50074)

### DIFF
--- a/changelogs/fragments/junos_commit_error_fix.yaml
+++ b/changelogs/fragments/junos_commit_error_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix mandatory statement error for junos modules (https://github.com/ansible/ansible/pull/50138)

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -41,7 +41,8 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"unknown command"),
-        re.compile(br"syntax error,")
+        re.compile(br"syntax error"),
+        re.compile(br"[\r\n]error:")
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
* Fix mandatory statement error for junos modules

Fixes #40267

*  Add error regex in junos terminal plugin to error out
   in case of commit fails

*  If commit fails add logic to discard changes before existing
   else next task will result in error

* Add integration test

* Minor update

(cherry picked from commit cc8e90395a9892eb58efac02ae1ac9737853d694)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
