### PR TITLE
Fix integration test shebangs and update tests.

### DIFF
--- a/test/integration/targets/inventory_foreman_script/foreman.sh
+++ b/test/integration/targets/inventory_foreman_script/foreman.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wrapper to use the correct Python interpreter and support code coverage.
 
 REL_SCRIPT="../../../../contrib/inventory/foreman.py"

--- a/test/integration/targets/vault/runme_change_pip_installed.sh
+++ b/test/integration/targets/vault/runme_change_pip_installed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # start by removing pycrypto and cryptography
 

--- a/test/sanity/code-smell/shebang.py
+++ b/test/sanity/code-smell/shebang.py
@@ -6,16 +6,21 @@ import sys
 
 
 def main():
-    allowed = set([
+    standard_shebangs = set([
         b'#!/bin/bash -eu',
         b'#!/bin/bash -eux',
-        b'#!/bin/bash',
         b'#!/bin/sh',
         b'#!/usr/bin/env bash',
         b'#!/usr/bin/env fish',
         b'#!/usr/bin/env pwsh',
         b'#!/usr/bin/env python',
         b'#!/usr/bin/make -f',
+    ])
+
+    integration_shebangs = set([
+        b'#!/bin/sh',
+        b'#!/usr/bin/env bash',
+        b'#!/usr/bin/env python',
     ])
 
     module_shebangs = {
@@ -61,6 +66,7 @@ def main():
                 continue
 
             is_module = False
+            is_integration = False
 
             if path.startswith('lib/ansible/modules/'):
                 is_module = True
@@ -73,6 +79,8 @@ def main():
 
                 continue
             elif path.startswith('test/integration/targets/'):
+                is_integration = True
+
                 dirname = os.path.dirname(path)
 
                 if dirname.endswith('/library') or dirname in (
@@ -98,6 +106,11 @@ def main():
                 else:
                     print('%s:%d:%d: expected module extension %s but found: %s' % (path, 0, 0, expected_ext, ext))
             else:
+                if is_integration:
+                    allowed = integration_shebangs
+                else:
+                    allowed = standard_shebangs
+
                 if shebang not in allowed:
                     print('%s:%d:%d: unexpected non-module shebang: %s' % (path, 1, 1, shebang))
 


### PR DESCRIPTION
##### SUMMARY

Fix integration test shebangs and update tests.

* Integration tests now have their own list of allowed shebangs.
* Use `#!/usr/bin/env bash` instead of `#!/bin/bash` since the location is different on various platforms.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shebang sanity test, integration tests
