### PR TITLE
Include materialized views for ALL_IN_SCHEMA

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -365,7 +365,7 @@ class Connection(object):
         query = """SELECT relname
                    FROM pg_catalog.pg_class c
                    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                   WHERE nspname = %s AND relkind in ('r', 'v')"""
+                   WHERE nspname = %s AND relkind in ('r', 'v', 'm')"""
         self.cursor.execute(query, (schema,))
         return [t[0] for t in self.cursor.fetchall()]
 


### PR DESCRIPTION
##### SUMMARY
ALL_IN_SCHEMA currently works only on views and tables because of its condition clause in the function `get_all_tables_in_schema` which only filters tables (relkind='r') and views (relkind='v').

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgresql_privs