### PR TITLE
file - allow touch on files not owned by user

### DIFF
--- a/changelogs/fragments/file-touch-non-owner.yaml
+++ b/changelogs/fragments/file-touch-non-owner.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- file - Allow state=touch on file the user does not own https://github.com/ansible/ansible/issues/50943

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -351,7 +351,7 @@ def get_timestamp_for_time(formatted_time, time_format):
     if formatted_time == 'preserve':
         return None
     elif formatted_time == 'now':
-        return Sentinel()
+        return Sentinel
     else:
         try:
             struct = time.strptime(formatted_time, time_format)

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -208,6 +208,11 @@ class ParameterError(AnsibleModuleError):
     pass
 
 
+class Sentinel(object):
+    def __new__(cls, *args, **kwargs):
+        return cls
+
+
 def _ansible_excepthook(exc_type, exc_value, tb):
     # Using an exception allows us to catch it if the calling code knows it can recover
     if issubclass(exc_type, AnsibleModuleError):
@@ -292,7 +297,7 @@ def get_state(path):
 
 
 # This should be moved into the common file utilities
-def recursive_set_attributes(b_path, follow, file_args, timestamps):
+def recursive_set_attributes(b_path, follow, file_args, mtime, atime):
     changed = False
     for b_root, b_dirs, b_files in os.walk(b_path):
         for b_fsobj in b_dirs + b_files:
@@ -301,14 +306,14 @@ def recursive_set_attributes(b_path, follow, file_args, timestamps):
                 tmp_file_args = file_args.copy()
                 tmp_file_args['path'] = to_native(b_fsname, errors='surrogate_or_strict')
                 changed |= module.set_fs_attributes_if_different(tmp_file_args, changed, expand=False)
-                changed |= update_timestamp_for_file(tmp_file_args['path'], timestamps)
+                changed |= update_timestamp_for_file(tmp_file_args['path'], mtime, atime)
 
             else:
                 # Change perms on the link
                 tmp_file_args = file_args.copy()
                 tmp_file_args['path'] = to_native(b_fsname, errors='surrogate_or_strict')
                 changed |= module.set_fs_attributes_if_different(tmp_file_args, changed, expand=False)
-                changed |= update_timestamp_for_file(tmp_file_args['path'], timestamps)
+                changed |= update_timestamp_for_file(tmp_file_args['path'], mtime, atime)
 
                 if follow:
                     b_fsname = os.path.join(b_root, os.readlink(b_fsname))
@@ -316,13 +321,13 @@ def recursive_set_attributes(b_path, follow, file_args, timestamps):
                     if os.path.exists(b_fsname):
                         if os.path.isdir(b_fsname):
                             # Link is a directory so change perms on the directory's contents
-                            changed |= recursive_set_attributes(b_fsname, follow, file_args, timestamps)
+                            changed |= recursive_set_attributes(b_fsname, follow, file_args, mtime, atime)
 
                         # Change perms on the file pointed to by the link
                         tmp_file_args = file_args.copy()
                         tmp_file_args['path'] = to_native(b_fsname, errors='surrogate_or_strict')
                         changed |= module.set_fs_attributes_if_different(tmp_file_args, changed, expand=False)
-                        changed |= update_timestamp_for_file(tmp_file_args['path'], timestamps)
+                        changed |= update_timestamp_for_file(tmp_file_args['path'], mtime, atime)
     return changed
 
 
@@ -346,8 +351,7 @@ def get_timestamp_for_time(formatted_time, time_format):
     if formatted_time == 'preserve':
         return None
     elif formatted_time == 'now':
-        current_time = time.time()
-        return current_time
+        return Sentinel()
     else:
         try:
             struct = time.strptime(formatted_time, time_format)
@@ -359,11 +363,11 @@ def get_timestamp_for_time(formatted_time, time_format):
         return struct_time
 
 
-def update_timestamp_for_file(path, timestamps, diff=None):
+def update_timestamp_for_file(path, mtime, atime, diff=None):
     try:
         # When mtime and atime are set to 'now', rely on utime(path, None) which does not require ownership of the file
         # https://github.com/ansible/ansible/issues/50943
-        if timestamps['modification_time'] == 'now' and timestamps['access_time'] == 'now':
+        if mtime is Sentinel and atime is Sentinel:
             # It's not exact but we can't rely on os.stat(path).st_mtime after setting os.utime(path, None) as it may
             # not be updated. Just use the current time for the diff values
             mtime = atime = time.time()
@@ -373,10 +377,7 @@ def update_timestamp_for_file(path, timestamps, diff=None):
 
             set_time = None
         else:
-            mtime = get_timestamp_for_time(timestamps['modification_time'], timestamps['modification_time_format'])
-            atime = get_timestamp_for_time(timestamps['access_time'], timestamps['access_time_format'])
-
-            # If both parameters are None, nothing to do
+            # If both parameters are None 'preserve', nothing to do
             if mtime is None and atime is None:
                 return False
 
@@ -385,9 +386,13 @@ def update_timestamp_for_file(path, timestamps, diff=None):
 
             if mtime is None:
                 mtime = previous_mtime
+            elif mtime is Sentinel:
+                mtime = time.time()
 
             if atime is None:
                 atime = previous_atime
+            elif atime is Sentinel:
+                atime = time.time()
 
             # If both timestamps are already ok, nothing to do
             if mtime == previous_mtime and atime == previous_atime:
@@ -473,6 +478,8 @@ def execute_touch(path, follow, timestamps):
     prev_state = get_state(b_path)
     changed = False
     result = {'dest': path}
+    mtime = get_timestamp_for_time(timestamps['modification_time'], timestamps['modification_time_format'])
+    atime = get_timestamp_for_time(timestamps['access_time'], timestamps['access_time_format'])
 
     if not module.check_mode:
         if prev_state == 'absent':
@@ -490,7 +497,7 @@ def execute_touch(path, follow, timestamps):
         file_args = module.load_file_common_arguments(module.params)
         try:
             changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
-            changed |= update_timestamp_for_file(file_args['path'], timestamps, diff)
+            changed |= update_timestamp_for_file(file_args['path'], mtime, atime, diff)
         except SystemExit as e:
             if e.code:
                 # We take this to mean that fail_json() was called from
@@ -509,6 +516,8 @@ def ensure_file_attributes(path, follow, timestamps):
     b_path = to_bytes(path, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     file_args = module.load_file_common_arguments(module.params)
+    mtime = get_timestamp_for_time(timestamps['modification_time'], timestamps['modification_time_format'])
+    atime = get_timestamp_for_time(timestamps['access_time'], timestamps['access_time_format'])
 
     if prev_state != 'file':
         if follow and prev_state == 'link':
@@ -525,7 +534,7 @@ def ensure_file_attributes(path, follow, timestamps):
 
     diff = initial_diff(path, 'file', prev_state)
     changed = module.set_fs_attributes_if_different(file_args, False, diff, expand=False)
-    changed |= update_timestamp_for_file(file_args['path'], timestamps, diff)
+    changed |= update_timestamp_for_file(file_args['path'], mtime, atime, diff)
     return {'path': path, 'changed': changed, 'diff': diff}
 
 
@@ -533,6 +542,8 @@ def ensure_directory(path, follow, recurse, timestamps):
     b_path = to_bytes(path, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     file_args = module.load_file_common_arguments(module.params)
+    mtime = get_timestamp_for_time(timestamps['modification_time'], timestamps['modification_time_format'])
+    atime = get_timestamp_for_time(timestamps['access_time'], timestamps['access_time_format'])
 
     # For followed symlinks, we need to operate on the target of the link
     if follow and prev_state == 'link':
@@ -574,7 +585,7 @@ def ensure_directory(path, follow, recurse, timestamps):
                     tmp_file_args = file_args.copy()
                     tmp_file_args['path'] = curpath
                     changed = module.set_fs_attributes_if_different(tmp_file_args, changed, diff, expand=False)
-                    changed |= update_timestamp_for_file(file_args['path'], timestamps, diff)
+                    changed |= update_timestamp_for_file(file_args['path'], mtime, atime, diff)
         except Exception as e:
             raise AnsibleModuleError(results={'msg': 'There was an issue creating %s as requested:'
                                                      ' %s' % (curpath, to_native(e)),
@@ -591,9 +602,9 @@ def ensure_directory(path, follow, recurse, timestamps):
     #
 
     changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
-    changed |= update_timestamp_for_file(file_args['path'], timestamps, diff)
+    changed |= update_timestamp_for_file(file_args['path'], mtime, atime, diff)
     if recurse:
-        changed |= recursive_set_attributes(b_path, follow, file_args, timestamps)
+        changed |= recursive_set_attributes(b_path, follow, file_args, mtime, atime)
 
     return {'path': path, 'changed': changed, 'diff': diff}
 
@@ -603,6 +614,8 @@ def ensure_symlink(path, src, follow, force, timestamps):
     b_src = to_bytes(src, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     file_args = module.load_file_common_arguments(module.params)
+    mtime = get_timestamp_for_time(timestamps['modification_time'], timestamps['modification_time_format'])
+    atime = get_timestamp_for_time(timestamps['access_time'], timestamps['access_time_format'])
     # source is both the source of a symlink or an informational passing of the src for a template module
     # or copy module, even if this module never uses it, it is needed to key off some things
     if src is None:
@@ -705,7 +718,7 @@ def ensure_symlink(path, src, follow, force, timestamps):
                     ' set to False to avoid this.')
     else:
         changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
-        changed |= update_timestamp_for_file(file_args['path'], timestamps, diff)
+        changed |= update_timestamp_for_file(file_args['path'], mtime, atime, diff)
 
     return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 
@@ -715,6 +728,8 @@ def ensure_hardlink(path, src, follow, force, timestamps):
     b_src = to_bytes(src, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     file_args = module.load_file_common_arguments(module.params)
+    mtime = get_timestamp_for_time(timestamps['modification_time'], timestamps['modification_time_format'])
+    atime = get_timestamp_for_time(timestamps['access_time'], timestamps['access_time_format'])
 
     # src is the source of a hardlink.  We require it if we are creating a new hardlink
     if src is None and not os.path.exists(b_path):
@@ -813,7 +828,7 @@ def ensure_hardlink(path, src, follow, force, timestamps):
         return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 
     changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
-    changed |= update_timestamp_for_file(file_args['path'], timestamps, diff)
+    changed |= update_timestamp_for_file(file_args['path'], mtime, atime, diff)
 
     return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -488,6 +488,37 @@
     that:
     - result.mode == '0444'
 
+# https://github.com/ansible/ansible/issues/50943
+# Need to use /tmp as nobody can't access output_dir at all
+- name: create file as root with all write permissions
+  file: dest=/tmp/write_utime state=touch mode=0666 owner={{ansible_user}}
+
+- block:
+  - name: get previous time
+    stat: path=/tmp/write_utime
+    register: previous_time
+
+  - name: touch file as nobody
+    file: dest=/tmp/write_utime state=touch
+    become: True
+    become_user: nobody
+    register: result
+
+  - name: get new time
+    stat: path=/tmp/write_utime
+    register: current_time
+
+  always:
+  - name: remove test utime file
+    file: path=/tmp/write_utime state=absent
+
+- name: assert touch file as nobody
+  assert:
+    that:
+    - result is changed
+    - current_time.stat.atime > previous_time.stat.atime
+    - current_time.stat.mtime > previous_time.stat.mtime
+
 # Follow + recursive tests
 - name: create a toplevel directory
   file: path={{output_dir}}/test_follow_rec state=directory mode=0755


### PR DESCRIPTION
##### SUMMARY
Recent changes to `state=touch` broke the scenario of touching a file not owned by the current user but the user still had write access. This PR brings back that old behaviour as well as adding a test to ensure it doesn't revert accidentally in the future.

Fixes https://github.com/ansible/ansible/issues/50943

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
file