### PR TITLE
fix ansible_connect_timeout variable in network_cli,httpapi and nxos_install_os timeout check

### DIFF
--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -55,7 +55,8 @@ class ActionModule(ActionNetworkModule):
                 self._task.args['username'] = self._play_context.connection_user
 
         if self._task.action == 'nxos_install_os':
-            if C.PERSISTENT_COMMAND_TIMEOUT < 600 or C.PERSISTENT_CONNECT_TIMEOUT < 600:
+            connection = self._connection
+            if connection.get_option('persistent_command_timeout') < 600 or connection.get_option('persistent_connect_timeout') < 600:
                 msg = 'PERSISTENT_COMMAND_TIMEOUT and PERSISTENT_CONNECT_TIMEOUT'
                 msg += ' must be set to 600 seconds or higher when using nxos_install_os module'
                 return {'failed': True, 'msg': msg}

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -128,6 +128,8 @@ options:
         key: connect_timeout
     env:
       - name: ANSIBLE_PERSISTENT_CONNECT_TIMEOUT
+    vars:
+      - name: ansible_connect_timeout
   persistent_command_timeout:
     type: int
     description:

--- a/lib/ansible/plugins/connection/napalm.py
+++ b/lib/ansible/plugins/connection/napalm.py
@@ -112,6 +112,8 @@ options:
         key: connect_timeout
     env:
       - name: ANSIBLE_PERSISTENT_CONNECT_TIMEOUT
+    vars:
+      - name: ansible_connect_timeout
   persistent_command_timeout:
     type: int
     description:

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -140,6 +140,8 @@ options:
         key: connect_timeout
     env:
       - name: ANSIBLE_PERSISTENT_CONNECT_TIMEOUT
+    vars:
+      - name: ansible_connect_timeout
   persistent_command_timeout:
     type: int
     description:

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -142,6 +142,8 @@ options:
         key: connect_timeout
     env:
       - name: ANSIBLE_PERSISTENT_CONNECT_TIMEOUT
+    vars:
+      - name: ansible_connect_timeout
   persistent_command_timeout:
     type: int
     description:


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/50626
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
nxos action plugin was only checking for the variable set as environment variable or via ansible.cfg, connection plugins have been ignoring the persistent connect timeout values if set as variables or passed as extra vars.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/nxos.py
plugins/connection/{network_cli,netconf,napalm,httpapi}.py