### PR TITLE
Fix ansible-test handling of empty test targets.

### DIFF
--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -566,7 +566,7 @@ class IntegrationTarget(CompletionTarget):
         elif os.path.isdir(os.path.join(path, 'tasks')) or os.path.isdir(os.path.join(path, 'defaults')):
             self.type = 'role'
         else:
-            self.type = 'unknown'
+            self.type = 'role'  # ansible will consider these empty roles, so ansible-test should as well
 
         # static_aliases
 


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test handling of empty test targets.

Previously empty test targets were ignored by ansible-test.
This would prevent them from participating in dependency analysis.
These targets are actually empty roles, and should be processed as such.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
