### PR TITLE
copy module "dest" parameter is not only absolute

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -38,9 +38,10 @@ options:
     version_added: '1.1'
   dest:
     description:
-    - Remote absolute path where the file should be copied to.
+    - Remote path where the file should be copied to.
     - If I(src) is a directory, this must be a directory too.
     - If I(dest) is a non-existent path and if either I(dest) ends with "/" or I(src) is a directory, I(dest) is created.
+    - If I(dest) is a relative path, the starting directory is determined by the remote host.
     - If I(src) and I(dest) are files, the parent directory of I(dest) is not created and the task fails if it does not already exist.
     required: yes
   backup:


### PR DESCRIPTION
##### SUMMARY
I've been using the `copy` module with relative destinations, and it works fine. This should be documented, as the docs currently say `dest` must be an absolute path. Note that I've only copied to "." on linux targets, which points to the user's home directory. If this feature is fully working, can we state that relative paths are fine? (If the feature is partially working, we should say what type of relative paths are allowed.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
copy module

##### ADDITIONAL INFORMATION
Working example code:
```
copy:
  src: "files/{{ tmux_server_script }}"
  dest: .
```

+label: docsite_pr