### PR TITLE
Add 'duplicate' to the set theory filters

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -185,6 +185,11 @@ To get the symmetric difference of 2 lists (items exclusive to each list)::
 
     {{ list1 | symmetric_difference(list2) }}
 
+.. versionadded:: 2.x
+
+To get the duplicate values from a lists (the resulting list contains unique duplicates)::
+
+    {{ list1 | duplicate }}
 
 .. _dict_filter:
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -254,6 +254,7 @@ class FilterModule(object):
 
             # set theory
             'unique': unique,
+            'duplicate': duplicate,
             'intersect': intersect,
             'difference': difference,
             'symmetric_difference': symmetric_difference,

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -87,6 +87,23 @@ def unique(environment, a, case_sensitive=False, attribute=None):
 
 
 @environmentfilter
+def duplicate(environment, a):
+    if isinstance(a, Hashable):
+        c = set(a)
+    else:
+        s = {}
+        c = []
+        for x in a:
+            if x not in s:
+                s[x] = 1
+            else:
+                if s[x] == 1:
+                    c.append(x)
+                s[x] += 1
+    return c
+
+
+@environmentfilter
 def intersect(environment, a, b):
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) & set(b)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
'duplicate' will take a list of values, and return all duplicate values found within it, if any.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
duplicate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- debug:
    msg: '{{ [1, 1, 1, 2, 3, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8] | duplicate }}'

...

MSG:

[1, 3, 8]
```
