### PR TITLE
docker_swarm_service: Add command option

### DIFF
--- a/changelogs/fragments/50984-docker_swarm_service-command-option.yml
+++ b/changelogs/fragments/50984-docker_swarm_service-command-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_swarm_service - Added support for ``command`` parameter."

--- a/changelogs/fragments/50984-docker_swarm_service-command-option.yml
+++ b/changelogs/fragments/50984-docker_swarm_service-command-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "docker_swarm_service - Added support for ``command`` parameter."
+  - "docker_swarm_service - Added support for ``command`` parameter."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -660,15 +660,29 @@ class DockerService(DockerBaseClass):
         if isinstance(s.command, string_types):
             s.command = shlex.split(s.command)
         elif isinstance(s.command, list):
-            if not all(isinstance(item, string_types) for item in s.command):
+            invalid_items = [
+                (index, item)
+                for index, item in enumerate(s.command)
+                if not isinstance(item, string_types)
+            ]
+            if invalid_items:
+                errors = ', '.join(
+                    [
+                        '%s (%s) at index %s' % (item, type(item), index)
+                        for index, item in invalid_items
+                    ]
+                )
                 raise Exception(
-                    'All items in a command list needs to be strings. Please check quoting.'
+                    'All items in a command list need to be strings. '
+                    'Check quoting. Invalid items: %s.'
+                    % errors
                 )
             s.command = ap['command']
         elif s.command is not None:
             raise ValueError(
-                'Invalid type for command (%s). Only string or list allowed.'
-                % type(s.command)
+                'Invalid type for command %s (%s). '
+                'Only string or list allowed. Check quoting.'
+                % (s.command, type(s.command))
             )
 
         if ap['force_update']:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -659,10 +659,12 @@ class DockerService(DockerBaseClass):
         s.command = ap['command']
         if isinstance(s.command, string_types):
             s.command = shlex.split(s.command)
-        elif s.command is not None and not isinstance(s.command, list):
+        elif isinstance(s.command, list):
+            s.command = ap['command']
+        elif s.command is not None:
             raise ValueError(
-                "Invalid type for command (%s). Only string or list allowed." %
-                type(s.command)
+                'Invalid type for command (%s). Only string or list allowed.'
+                % type(s.command)
             )
 
         if ap['force_update']:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -45,7 +45,8 @@ options:
     required: false
     description:
     - Command to execute when the container starts.
-      A command may be either a string or a list.  
+      A command may be either a string or a list.
+    version_added: 2.8
   constraints:
     required: false
     default: []

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -45,20 +45,20 @@ options:
     required: false
     description:
     - Command to execute when the container starts.
-      A command may be either a string or a list.
+      A command may be either a string or a list or a list of strings.
     version_added: 2.8
   constraints:
     required: false
     default: []
     description:
-    - List of the placement preferences as key value pairs.
-    - Maps docker service C(--placement-pref) option.
+    - List of the service constraints.
+    - Maps docker service --constraint option.
   placement_preferences:
     required: false
     type: list
     description:
-    - Command to execute when the container starts.
-      A command may be either a string or a list of strings.
+    - List of the placement preferences as key value pairs.
+    - Maps docker service C(--placement-pref) option.
     version_added: 2.8
   hostname:
     required: false

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -41,6 +41,11 @@ options:
     description:
     - List comprised of the command and the arguments to be run inside
     - the container
+  command:
+    required: false
+    description:
+    - Command to execute when the container starts.
+      A command may be either a string or a list.  
   constraints:
     required: false
     default: []
@@ -511,6 +516,7 @@ EXAMPLES = '''
 '''
 
 import time
+import shlex
 import operator
 from ansible.module_utils.docker_common import (
     DockerBaseClass,
@@ -518,6 +524,7 @@ from ansible.module_utils.docker_common import (
     DifferenceTracker,
 )
 from ansible.module_utils.basic import human_to_bytes
+from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_text
 
 try:
@@ -532,6 +539,7 @@ class DockerService(DockerBaseClass):
     def __init__(self):
         super(DockerService, self).__init__()
         self.image = ""
+        self.command = None
         self.args = []
         self.endpoint_mode = "vip"
         self.dns = []
@@ -579,6 +587,7 @@ class DockerService(DockerBaseClass):
             'mounts': self.mounts,
             'configs': self.configs,
             'networks': self.networks,
+            'command': self.command,
             'args': self.args,
             'tty': self.tty,
             'dns': self.dns,
@@ -645,6 +654,10 @@ class DockerService(DockerBaseClass):
         s.update_max_failure_ratio = ap['update_max_failure_ratio']
         s.update_order = ap['update_order']
         s.user = ap['user']
+
+        s.command = ap['command']
+        if isinstance(s.command, string_types):
+            s.command = shlex.split(s.command)
 
         if ap['force_update']:
             s.force_update = int(str(time.time()).replace('.', ''))
@@ -738,6 +751,8 @@ class DockerService(DockerBaseClass):
             needs_rebuild = True
         if self.replicas != os.replicas:
             differences.add('replicas', parameter=self.replicas, active=os.replicas)
+        if self.command is not None and self.command != os.command:
+            differences.add('command', parameter=self.command, active=os.command)
         if self.args != os.args:
             differences.add('args', parameter=self.args, active=os.args)
         if self.constraints != os.constraints:
@@ -866,17 +881,24 @@ class DockerService(DockerBaseClass):
                 )
             )
 
+        dns_config = types.DNSConfig(
+            nameservers=self.dns,
+            search=self.dns_search,
+            options=self.dns_options
+        )
+
         cspec = types.ContainerSpec(
             image=self.image,
-            user=self.user,
-            dns_config=types.DNSConfig(nameservers=self.dns, search=self.dns_search, options=self.dns_options),
+            command=self.command,
             args=self.args,
-            env=self.env,
-            tty=self.tty,
             hostname=self.hostname,
+            env=self.env,
+            user=self.user,
             labels=self.container_labels,
             mounts=mounts,
             secrets=secrets,
+            tty=self.tty,
+            dns_config=dns_config,
             configs=configs
         )
 
@@ -983,6 +1005,7 @@ class DockerServiceManager():
         ds.image = task_template_data['ContainerSpec']['Image']
         ds.user = task_template_data['ContainerSpec'].get('User', 'root')
         ds.env = task_template_data['ContainerSpec'].get('Env', [])
+        ds.command = task_template_data['ContainerSpec'].get('Command')
         ds.args = task_template_data['ContainerSpec'].get('Args', [])
         ds.update_delay = update_config_data['Delay']
         ds.update_parallelism = update_config_data['Parallelism']
@@ -1216,6 +1239,7 @@ def main():
         configs=dict(default=None, type='list'),
         secrets=dict(default=[], type='list'),
         networks=dict(default=[], type='list'),
+        command=dict(default=None, type='raw'),
         args=dict(default=[], type='list'),
         env=dict(default=[], type='list'),
         force_update=dict(default=False, type='bool'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -659,9 +659,11 @@ class DockerService(DockerBaseClass):
         s.command = ap['command']
         if isinstance(s.command, string_types):
             s.command = shlex.split(s.command)
-        elif isinstance(s.command, list) and all(
-            isinstance(item, string_types) for item in s.command
-        ):
+        elif isinstance(s.command, list):
+            if not all(isinstance(item, string_types) for item in s.command):
+                raise Exception(
+                    'All items in a command list needs to be strings. Please check quoting.'
+                )
             s.command = ap['command']
         elif s.command is not None:
             raise ValueError(

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -51,14 +51,14 @@ options:
     required: false
     default: []
     description:
-    - List of the service constraints.
-    - Maps docker service --constraint option.
+    - List of the placement preferences as key value pairs.
+    - Maps docker service C(--placement-pref) option.
   placement_preferences:
     required: false
     type: list
     description:
-    - List of the placement preferences as key value pairs.
-    - Maps docker service C(--placement-pref) option.
+    - Command to execute when the container starts.
+      A command may be either a string or a list of strings.
     version_added: 2.8
   hostname:
     required: false

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -659,6 +659,11 @@ class DockerService(DockerBaseClass):
         s.command = ap['command']
         if isinstance(s.command, string_types):
             s.command = shlex.split(s.command)
+        elif s.command is not None and not isinstance(s.command, list):
+            raise ValueError(
+                "Invalid type for command (%s). Only string or list allowed." %
+                type(s.command)
+            )
 
         if ap['force_update']:
             s.force_update = int(str(time.time()).replace('.', ''))

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -659,7 +659,9 @@ class DockerService(DockerBaseClass):
         s.command = ap['command']
         if isinstance(s.command, string_types):
             s.command = shlex.split(s.command)
-        elif isinstance(s.command, list):
+        elif isinstance(s.command, list) and all(
+            isinstance(item, string_types) for item in s.command
+        ):
             s.command = ap['command']
         elif s.command is not None:
             raise ValueError(

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -237,25 +237,15 @@
     command:
       - "/bin/sh"
       - "-c"
-      - '"sleep 10m"'
+      - "sleep 10m"
   register: command_4
-
-- name: command (as list idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    command:
-      - "/bin/sh"
-      - "-c"
-      - '"sleep 10m"'
-  register: command_5
 
 - name: command (string failure)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
     command: yes
-  register: command_6
+  register: command_5
   ignore_errors: yes
 
 - name: command (list failure)
@@ -265,7 +255,7 @@
     command:
       - "/bin/sh"
       - yes
-  register: command_7
+  register: command_6
   ignore_errors: yes
 
 - name: cleanup
@@ -279,10 +269,9 @@
       - command_1 is changed
       - command_2 is not changed
       - command_3 is changed
-      - command_4 is changed
-      - command_5 is not changed
+      - command_4 is not changed
+      - command_5 is failed
       - command_6 is failed
-      - command_7 is failed
 
 ####################################################################
 ## container_labels ################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -250,6 +250,24 @@
       - '"sleep 10m"'
   register: command_5
 
+- name: command (string failure)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: yes
+  register: command_6
+  ignore_errors: yes
+
+- name: command (list failure)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command:
+      - "/bin/sh"
+      - yes
+  register: command_7
+  ignore_errors: yes
+
 - name: cleanup
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -263,6 +281,8 @@
       - command_3 is changed
       - command_4 is changed
       - command_5 is not changed
+      - command_6 is failed
+      - command_7 is failed
 
 ####################################################################
 ## container_labels ################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -206,6 +206,43 @@
       - constraints_3 is changed
 
 ####################################################################
+## command #########################################################
+####################################################################
+
+- name: command
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+  register: command_1
+
+- name: command (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+  register: command_2
+
+- name: command (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+  register: command_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - command_1 is changed
+      - command_2 is not changed
+      - command_3 is changed
+
+####################################################################
 ## container_labels ################################################
 ####################################################################
 

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -223,7 +223,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_2
 
-- name: command (idempotency)
+- name: command (less parameters)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -230,6 +230,26 @@
     command: '/bin/sh -c "sleep 10m"'
   register: command_3
 
+- name: command (as list)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command:
+      - "/bin/sh"
+      - "-c"
+      - '"sleep 10m"'
+  register: command_4
+
+- name: command (as list idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command:
+      - "/bin/sh"
+      - "-c"
+      - '"sleep 10m"'
+  register: command_5
+
 - name: cleanup
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -241,6 +261,8 @@
       - command_1 is changed
       - command_2 is not changed
       - command_3 is changed
+      - command_4 is changed
+      - command_5 is not changed
 
 ####################################################################
 ## container_labels ################################################

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -5,6 +5,7 @@ service_expected_output:
   configs: null
   constraints: []
   container_labels: {}
+  command: null
   dns: []
   dns_options: []
   dns_search: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

docker_swarm_service is missing an option for `command`. This requires the user to create an image with an empty `ENTRYPOINT` and use `args` to customise what to run. This PR adds a `command` option which can be used to override the `ENTRYPOINT`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
