### PR TITLE
Make yaml inventory plugin compatible with the auto inventory plugin.

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -101,7 +101,7 @@ class InventoryModule(BaseFileInventoryPlugin):
             raise AnsibleParserError('Parsed empty YAML file')
         elif not isinstance(data, MutableMapping):
             raise AnsibleParserError('YAML inventory has invalid structure, it should be a dictionary, got: %s' % type(data))
-        elif data.get('plugin'):
+        elif data.pop('plugin', self.NAME) != self.NAME:
             raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')
 
         # We expect top level keys to correspond to groups, iterate over them


### PR DESCRIPTION
##### SUMMARY

Without the plugin key the auto plugin errors with `no root 'plugin' key found` meaning that the yaml plugin has to be explicitly loaded in ansible.cfg. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
yaml inventory plugin
