### PR TITLE
identity: Autodetect FreeIPA server with DNS

### DIFF
--- a/lib/ansible/plugins/doc_fragments/ipa.py
+++ b/lib/ansible/plugins/doc_fragments/ipa.py
@@ -18,7 +18,9 @@ options:
     description:
     - IP or hostname of IPA server.
     - If the value is not specified in the task, the value of environment variable C(IPA_HOST) will be used instead.
-    - If both the environment variable C(IPA_HOST) and the value are not specified in the task, then default value is set.
+    - If both the environment variable C(IPA_HOST) and the value are not specified in the task, then DNS will be used to try to discover the FreeIPA server.
+    - The relevant entry needed in FreeIPA is the 'ipa-ca' entry.
+    - If neither the DNS entry, nor the environment C(IPA_HOST), nor the value are available in the task, then the default value will be used.
     - 'Environment variable fallback mechanism is added in version 2.5.'
     default: ipa.example.com
   ipa_user:


### PR DESCRIPTION
##### SUMMARY
This adds the ability for the freeIPA related modules to be able to
auto-detect the IPA server through DNS.

This takes advantage of the fact that a lot of FreeIPA deployments
configure their hosts to use IPA as the nameserver.

This check is only used if we didn't set neither the ipa_host parameter,
nor the environment variable IPA_HOST.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
identity

##### ADDITIONAL INFORMATION
This makes it easier to use the IPA-related modules in the sense that one no longer needs to include the hostname of the IPA server if the nodes are enrolled to it and use IPA as the nameserver. This way, the module can be shared between deployments in a more general fashion.

So, instead of always adding the host to create a service, like this:
```
- hosts: localhost 
  tasks:
  - ipa_service:
      name: beer/some-host.mydomain.example.com
      state: present
      force: true
      ipa_host: ipa.mydomain.example.com
      ipa_user: admin
      ipa_pass: my-super-secret-password
```
you can now merely omit it as follows:
```
- hosts: localhost 
  tasks:
  - ipa_service:
      name: beer/some-host.mydomain.example.com
      state: present
      force: true
      ipa_user: admin
      ipa_pass: my-super-secret-password
```
Assuming that the host that runs this resolves the appropriate DNS entries.