### PR TITLE
Fix UnicodeEncodeError for ansible --version.

### DIFF
--- a/lib/ansible/cli/arguments/optparse_helpers.py
+++ b/lib/ansible/cli/arguments/optparse_helpers.py
@@ -15,6 +15,7 @@ import yaml
 import ansible
 from ansible import constants as C
 from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native
 from ansible.release import __version__
 from ansible.utils.path import unfrackpath
 
@@ -192,7 +193,7 @@ def create_base_parser(usage="", desc=None, epilog=None):
     Create an options parser for all ansible scripts
     """
     # base opts
-    parser = SortedOptParser(usage, version=version("%prog"), description=desc, epilog=epilog)
+    parser = SortedOptParser(usage, version=to_native(version("%prog")), description=desc, epilog=epilog)
     parser.remove_option('--version')
     version_help = "show program's version number, config file location, configured module search path," \
                    " module location, executable location and exit"


### PR DESCRIPTION
##### SUMMARY

Fix UnicodeEncodeError for ansible --version.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible

##### ADDITIONAL INFORMATION

The error occurs on Python 2.x when running the following commands:

```
mkdir /tmp/Δ.cfg
ANSIBLE_CONFIG=/tmp/Δ.cfg ansible --version | tee
```

The traceback is as follows:

```
Traceback (most recent call last):
  File "/Users/mclay/code/mattclay/ansible/bin/ansible", line 110, in <module>
    exit_code = cli.run()
  File "/Users/mclay/code/mattclay/ansible/lib/ansible/cli/adhoc.py", line 92, in run
    super(AdHocCLI, self).run()
  File "/Users/mclay/code/mattclay/ansible/lib/ansible/cli/__init__.py", line 102, in run
    self.parse()
  File "/Users/mclay/code/mattclay/ansible/lib/ansible/cli/__init__.py", line 422, in parse
    options, args = self.parser.parse_args(self.args[1:])
  File "/Users/mclay/.pyenv/versions/2.7.14/lib/python2.7/optparse.py", line 1400, in parse_args
    stop = self._process_args(largs, rargs, values)
  File "/Users/mclay/.pyenv/versions/2.7.14/lib/python2.7/optparse.py", line 1440, in _process_args
    self._process_long_opt(rargs, values)
  File "/Users/mclay/.pyenv/versions/2.7.14/lib/python2.7/optparse.py", line 1515, in _process_long_opt
    option.process(opt, value, values, self)
  File "/Users/mclay/.pyenv/versions/2.7.14/lib/python2.7/optparse.py", line 789, in process
    self.action, self.dest, opt, value, values, parser)
  File "/Users/mclay/.pyenv/versions/2.7.14/lib/python2.7/optparse.py", line 814, in take_action
    parser.print_version()
  File "/Users/mclay/.pyenv/versions/2.7.14/lib/python2.7/optparse.py", line 1620, in print_version
    print >>file, self.get_version()
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0394' in position 40: ordinal not in range(128)
```