### PR TITLE
reboot - Fix connection timeout reset

### DIFF
--- a/changelogs/fragments/reboot-conn-timeout-reset.yaml
+++ b/changelogs/fragments/reboot-conn-timeout-reset.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- reboot - Fix bug where the connection timeout was not reset in the same task after rebooting

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -309,17 +309,17 @@ class ActionModule(ActionBase):
                 connect_timeout = self._connection.get_option('connection_timeout')
             except AnsibleError:
                 pass
-
-            if original_connection_timeout != connect_timeout:
-                try:
-                    display.debug("{action}: setting connect_timeout back to original value of {value}".format(
-                        action=self._task.action,
-                        value=original_connection_timeout))
-                    self._connection.set_option("connection_timeout", original_connection_timeout)
-                    self._connection.reset()
-                except (AnsibleError, AttributeError) as e:
-                    # reset the connection to clear the custom connection timeout
-                    display.debug("{action}: failed to reset connection_timeout back to default: {error}".format(action=self._task.action, error=to_text(e)))
+            else:
+                if original_connection_timeout != connect_timeout:
+                    try:
+                        display.debug("{action}: setting connect_timeout back to original value of {value}".format(
+                            action=self._task.action,
+                            value=original_connection_timeout))
+                        self._connection.set_option("connection_timeout", original_connection_timeout)
+                        self._connection.reset()
+                    except (AnsibleError, AttributeError) as e:
+                        # reset the connection to clear the custom connection timeout
+                        display.debug("{action}: failed to reset connection_timeout back to default: {error}".format(action=self._task.action, error=to_text(e)))
 
             # finally run test command to ensure everything is working
             # FUTURE: add a stability check (system must remain up for N seconds) to deal with self-multi-reboot updates

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -319,7 +319,8 @@ class ActionModule(ActionBase):
                         self._connection.reset()
                     except (AnsibleError, AttributeError) as e:
                         # reset the connection to clear the custom connection timeout
-                        display.debug("{action}: failed to reset connection_timeout back to default: {error}".format(action=self._task.action, error=to_text(e)))
+                        display.debug("{action}: failed to reset connection_timeout back to default: {error}".format(action=self._task.action,
+                                                                                                                     error=to_text(e)))
 
             # finally run test command to ensure everything is working
             # FUTURE: add a stability check (system must remain up for N seconds) to deal with self-multi-reboot updates

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -296,7 +296,6 @@ class ActionModule(ActionBase):
         try:
             # keep on checking system boot_time with short connection responses
             reboot_timeout = int(self._task.args.get('reboot_timeout', self._task.args.get('reboot_timeout_sec', self.DEFAULT_REBOOT_TIMEOUT)))
-            connect_timeout = self._task.args.get('connect_timeout', self._task.args.get('connect_timeout_sec', self.DEFAULT_CONNECT_TIMEOUT))
 
             self.do_until_success_or_timeout(
                 action=self.check_boot_time,
@@ -305,7 +304,13 @@ class ActionModule(ActionBase):
                 distribution=distribution,
                 action_kwargs=action_kwargs)
 
-            if connect_timeout and original_connection_timeout:
+            # Get the connect_timeout set on the connection to compare to the original
+            try:
+                connect_timeout = self._connection.get_option('connection_timeout')
+            except AnsibleError:
+                pass
+
+            if original_connection_timeout != connect_timeout:
                 try:
                     display.debug("{action}: setting connect_timeout back to original value of {value}".format(
                         action=self._task.action,


### PR DESCRIPTION
##### SUMMARY
The current logic to reset the connection timeout is not correct as it won't run if the original connection timeout (connection plugin) was never set. This PR changes the logic to compare the previous value with the current value instead to detect if there were any changes.

Fixes https://github.com/ansible/ansible/issues/48665.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
reboot