### PR TITLE
win_updates - fix category return value to be a list

### DIFF
--- a/lib/ansible/modules/windows/win_updates.ps1
+++ b/lib/ansible/modules/windows/win_updates.ps1
@@ -112,7 +112,7 @@ $update_script_block = {
                 kb = $update.KBArticleIDs
                 id = $update.Identity.UpdateId
                 installed = $false
-                categories = ($update.Categories | ForEach-Object { $_.Name })
+                categories = @($update.Categories | ForEach-Object { $_.Name })
             }
 
             # validate update again blacklist/whitelist/post_category_names/hidden

--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -134,14 +134,6 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        category_names = self._task.args.get('category_names', [
-            'CriticalUpdates',
-            'SecurityUpdates',
-            'UpdateRollups',
-        ])
-        if isinstance(category_names, AnsibleUnicode):
-            category_names = [cat.strip() for cat in category_names.split(",")]
-
         state = self._task.args.get('state', 'installed')
         reboot = self._task.args.get('reboot', False)
         reboot_timeout = self._task.args.get('reboot_timeout',

--- a/test/integration/targets/win_updates/aliases
+++ b/test/integration/targets/win_updates/aliases
@@ -1,2 +1,1 @@
 shippable/windows/group2
-unstable


### PR DESCRIPTION
##### SUMMARY
Makes sure the `categories` return value is always a list, even if there is only 1 category for the update. Also removes some unseeded code now that category_names is a free form list. This doesn't need a changelog fragment or back porting as it hasn't be included in a release yet.

Also removes the unstable test alias, the test may still be unstable but we will add it back in the future if that's the case.

Fixes https://github.com/ansible/ansible/issues/38710

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates