### PR TITLE
Make Shippable timing script more resilient.

### DIFF
--- a/test/utils/shippable/timing.py
+++ b/test/utils/shippable/timing.py
@@ -1,9 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.7
 
 import sys
 import time
 
 start = time.time()
+
+sys.stdin.reconfigure(errors='surrogateescape')
+sys.stdout.reconfigure(errors='surrogateescape')
 
 for line in sys.stdin:
     seconds = time.time() - start


### PR DESCRIPTION
##### SUMMARY

Make Shippable timing script more resilient.

This will permit the script to pass through content which could not be previously decoded or encoded. This could occur when running some tests on macOS using file paths with non-ASCII characters.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

timing.py
