### PR TITLE
Match VLAN ID as whole line instead of searching for digits in line

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -580,7 +580,7 @@ def map_config_to_obj(module):
                 if len(line) > 0:
                     line = line.strip()
                     if line[0].isdigit():
-                        match = re.search(r'(\d+)', line, re.M)
+                        match = re.search(r'^(\d+)$', line, re.M)
                         if match:
                             v = match.group(1)
                             pos1 = splitted_line.index(v)


### PR DESCRIPTION
##### SUMMARY
Searching for digits somewhere in the output line will also match VLAN name (lines) starting with digits.

Fixes issue #50998

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

nxos_vlan

##### ADDITIONAL INFORMATION
