### PR TITLE
Ovirt vm state running wait false

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -603,6 +603,7 @@ class BaseModule(object):
 
                 def state_condition(entity):
                     return entity and entity.status == result_state
+
             wait(
                 service=entity_service,
                 condition=state_condition,
@@ -741,7 +742,7 @@ class BaseModule(object):
             self.changed = True
 
         post_action(entity)
-        
+
         wait(
             service=self._service.service(entity.id),
             condition=wait_condition,

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -527,6 +527,7 @@ class BaseModule(object):
         fail_condition=lambda e: False,
         search_params=None,
         update_params=None,
+        _wait=None,
         **kwargs
     ):
         """
@@ -602,12 +603,11 @@ class BaseModule(object):
 
                 def state_condition(entity):
                     return entity and entity.status == result_state
-
             wait(
                 service=entity_service,
                 condition=state_condition,
                 fail_condition=fail_condition,
-                wait=self._module.params['wait'],
+                wait=_wait if _wait is not None else self._module.params['wait'],
                 timeout=self._module.params['timeout'],
                 poll_interval=self._module.params['poll_interval'],
             )

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -741,6 +741,7 @@ class BaseModule(object):
             self.changed = True
 
         post_action(entity)
+        
         wait(
             service=self._service.service(entity.id),
             condition=wait_condition,

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -741,7 +741,6 @@ class BaseModule(object):
             self.changed = True
 
         post_action(entity)
-
         wait(
             service=self._service.service(entity.id),
             condition=wait_condition,

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -2075,13 +2075,11 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
-
         vms_module = VmsModule(
             connection=connection,
             module=module,
             service=vms_service,
         )
-
         vm = vms_module.search_entity(list_params={'all_content': True})
 
         control_state(vm, vms_service, module)
@@ -2100,7 +2098,6 @@ def main():
                 clone_permissions=module.params['clone_permissions'],
                 _wait=True if not module.params['wait'] and state == 'running' else module.params['wait'],
             )
-
             # If VM is going to be created and check_mode is on, return now:
             if module.check_mode and ret.get('id') is None:
                 module.exit_json(**ret)
@@ -2148,6 +2145,7 @@ def main():
                         and not module.params.get('cloud_init_persist')
                     ) else None,
                 )
+
                 if module.params['ticket']:
                     vm_service = vms_service.vm_service(ret['id'])
                     graphics_consoles_service = vm_service.graphics_consoles_service()
@@ -2156,6 +2154,7 @@ def main():
                     ticket = console_service.remote_viewer_connection_file()
                     if ticket:
                         ret['vm']['remote_vv_file'] = ticket
+
             if state == 'next_run':
                 # Apply next run configuration, if needed:
                 vm = vms_service.vm_service(ret['id']).get()

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -2077,8 +2077,8 @@ def main():
         vms_service = connection.system_service().vms_service()
 
         #In case of of wait false and state running, waits for VM to be created
-        original_wait=None
-        if not module.params['wait'] and state=='running':
+        original_wait = None
+        if not module.params['wait'] and state == 'running':
             original_wait = module.params['wait']
             module.params['wait'] = True
 
@@ -2105,7 +2105,7 @@ def main():
                 clone_permissions=module.params['clone_permissions'],
             )
 
-            if original_wait != None:
+            if original_wait is not None:
                 vms_module._module.params['wait'] = original_wait
 
             # If VM is going to be created and check_mode is on, return now:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -2076,6 +2076,8 @@ def main():
         connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
 
+        #In case of of wait false and state running, waits for VM to be created
+        original_wait=None
         if not module.params['wait'] and state=='running':
             original_wait = module.params['wait']
             module.params['wait'] = True
@@ -2102,6 +2104,10 @@ def main():
                 clone=module.params['clone'],
                 clone_permissions=module.params['clone_permissions'],
             )
+
+            if original_wait != None:
+                vms_module._module.params['wait'] = original_wait
+
             # If VM is going to be created and check_mode is on, return now:
             if module.check_mode and ret.get('id') is None:
                 module.exit_json(**ret)
@@ -2157,8 +2163,6 @@ def main():
                     ticket = console_service.remote_viewer_connection_file()
                     if ticket:
                         ret['vm']['remote_vv_file'] = ticket
-                if original_wait != None:
-                    vms_module._module.params['wait'] = original_wait
             if state == 'next_run':
                 # Apply next run configuration, if needed:
                 vm = vms_service.vm_service(ret['id']).get()

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -2076,15 +2076,16 @@ def main():
         connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
 
+        if not module.params['wait'] and state=='running':
+            original_wait = module.params['wait']
+            module.params['wait'] = True
+
         vms_module = VmsModule(
             connection=connection,
             module=module,
             service=vms_service,
         )
 
-        if not module.params['wait'] and state=='running':
-            original_wait = module.params['wait']
-            vms_module._module.params['wait'] = True
         vm = vms_module.search_entity(list_params={'all_content': True})
 
         control_state(vm, vms_service, module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Now when you put vm wait=false and state running it will change the wait until the vm is runnnig and then resets the wait again to original val. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #49531
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
