### PR TITLE
Fix Foreman returning host parameters

### DIFF
--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -166,8 +166,8 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         url = "%s/api/v2/hosts/%s" % (self.foreman_url, hid)
         ret = self._get_json(url, [404])
         if not ret or not isinstance(ret, MutableMapping) or not ret.get('all_parameters', False):
-            ret = {'all_parameters': [{}]}
-        return ret.get('all_parameters')[0]
+            ret = []
+        return ret.get('all_parameters')
 
     def _get_facts_by_id(self, hid):
         url = "%s/api/v2/hosts/%s/facts" % (self.foreman_url, hid)
@@ -220,11 +220,11 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
                 # set host vars from params
                 if self.get_option('want_params'):
-                    for k, v in self._get_all_params_by_id(host['id']).items():
+                    for p in self._get_all_params_by_id(host['id']):
                         try:
-                            self.inventory.set_variable(host['name'], k, v)
+                            self.inventory.set_variable(host['name'], p['name'], p['value'])
                         except ValueError as e:
-                            self.display.warning("Could not set parameter hostvar for %s, skipping %s: %s" % (host, k, to_native(e)))
+                            self.display.warning("Could not set parameter hostvar for %s, skipping %s: %s" % (host, p['name'], to_native(p['value'])))
 
                 # set host vars from facts
                 if self.get_option('want_facts'):


### PR DESCRIPTION
##### SUMMARY

At present, the inventory plugin creates host vars that look like:

```json
"hostvars": {
  "compute001": {
    ...
    "id": 6, 
    "name": "another", 
    "priority": 70, 
    "updated_at": "2019-01-17 17:26:28 UTC", 
    "value": "blah"
  }
}
```

when it should create one like:

```json
"hostvars": {
  "compute001": {
    ...
    "another": "blah", 
  }
}
```

This is because Foreman (1.20) returns the `all_parameters` key as something like:

```yaml
'all_parameters':
[
  {'name': 'another', 'created_at': '2019-01-17 17:26:28 UTC', 'updated_at': '2019-01-17 17:26:28 UTC', 'value': 'blah', 'priority': 70, 'id': 6},
  {'name': 'testing', 'created_at': '2019-01-17 17:07:35 UTC', 'updated_at': '2019-01-17 17:24:36 UTC', 'value': 'foo', 'priority': 70, 'id': 5}
]
```

which is a list of dicts, not a dictionary of key-value pairs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Foreman dynamic inventory plugin