### PR TITLE
docker_service: rename to docker_compose.

### DIFF
--- a/changelogs/fragments/51035-docker_service-docker_compose-rename.yaml
+++ b/changelogs/fragments/51035-docker_service-docker_compose-rename.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- The ``docker_service`` module has been renamed to ``docker_compose``.

--- a/docs/docsite/rst/scenario_guides/guide_docker.rst
+++ b/docs/docsite/rst/scenario_guides/guide_docker.rst
@@ -3,7 +3,7 @@ Getting Started with Docker
 
 Ansible offers the following modules for orchestrating Docker containers:
 
-    docker_service
+    docker_compose
         Use your existing Docker compose files to orchestrate containers on a single Docker daemon or on
         Swarm. Supports compose versions 1 and 2.
 
@@ -66,7 +66,7 @@ a broken installation. If this happens, Ansible will detect it and inform you ab
     for Python 2.6 is required. Please note that simply uninstalling one of the modules can leave the
     other module in a broken state.
 
-The docker_service module also requires `docker-compose <https://github.com/docker/compose>`_
+The docker_compose module also requires `docker-compose <https://github.com/docker/compose>`_
 
 .. code-block:: bash
 

--- a/lib/ansible/modules/cloud/docker/_docker_service.py
+++ b/lib/ansible/modules/cloud/docker/_docker_service.py
@@ -1,0 +1,1 @@
+docker_compose.py

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -504,8 +504,8 @@ def stderr_redirector(path_name):
 
 
 def make_redirection_tempfiles():
-    _, out_redir_name = tempfile.mkstemp(prefix="ansible")
-    _, err_redir_name = tempfile.mkstemp(prefix="ansible")
+    dummy, out_redir_name = tempfile.mkstemp(prefix="ansible")
+    dummy, err_redir_name = tempfile.mkstemp(prefix="ansible")
     return (out_redir_name, err_redir_name)
 
 

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 
-module: docker_service
+module: docker_compose
 
 short_description: Manage docker services and containers.
 
@@ -28,6 +28,7 @@ description:
   - Compose can be read from a docker-compose.yml (or .yaml) file or inline using the C(definition) option.
   - See the examples for more details.
   - Supports check mode.
+  - This module was called C(docker_service) before Ansible 2.8. The usage did not change.
 
 options:
   project_src:
@@ -166,18 +167,18 @@ EXAMPLES = '''
   connection: local
   gather_facts: no
   tasks:
-    - docker_service:
+    - docker_compose:
         project_src: flask
         state: absent
 
-    - docker_service:
+    - docker_compose:
         project_src: flask
       register: output
 
     - debug:
         var: output
 
-    - docker_service:
+    - docker_compose:
         project_src: flask
         build: no
       register: output
@@ -188,7 +189,7 @@ EXAMPLES = '''
     - assert:
         that: "not output.changed "
 
-    - docker_service:
+    - docker_compose:
         project_src: flask
         build: no
         stopped: true
@@ -202,7 +203,7 @@ EXAMPLES = '''
           - "not web.flask_web_1.state.running"
           - "not db.flask_db_1.state.running"
 
-    - docker_service:
+    - docker_compose:
         project_src: flask
         build: no
         restarted: true
@@ -221,7 +222,7 @@ EXAMPLES = '''
   connection: local
   gather_facts: no
   tasks:
-    - docker_service:
+    - docker_compose:
         project_src: flask
         scale:
           web: 2
@@ -235,11 +236,11 @@ EXAMPLES = '''
   connection: local
   gather_facts: no
   tasks:
-    - docker_service:
+    - docker_compose:
         project_src: flask
         state: absent
 
-    - docker_service:
+    - docker_compose:
         project_name: flask
         definition:
           version: '2'
@@ -270,11 +271,11 @@ EXAMPLES = '''
   connection: local
   gather_facts: no
   tasks:
-    - docker_service:
+    - docker_compose:
         project_src: flask
         state: absent
 
-    - docker_service:
+    - docker_compose:
         project_name: flask
         definition:
             db:
@@ -1064,6 +1065,8 @@ def main():
         supports_check_mode=True,
         min_docker_api_version='1.20',
     )
+    if client.module._name == 'docker_service':
+        client.module.deprecate("The 'docker_service' module has been renamed to 'docker_compose'.", version='2.12')
 
     result = ContainerManager(client).exec_module()
     client.module.exit_json(**result)

--- a/test/sanity/code-smell/no-underscore-variable.py
+++ b/test/sanity/code-smell/no-underscore-variable.py
@@ -33,7 +33,6 @@ def main():
         'lib/ansible/modules/cloud/amazon/route53_zone.py',
         'lib/ansible/modules/cloud/amazon/s3_sync.py',
         'lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py',
-        'lib/ansible/modules/cloud/docker/docker_service.py',
         'lib/ansible/modules/cloud/google/gce.py',
         'lib/ansible/modules/cloud/google/gce_eip.py',
         'lib/ansible/modules/cloud/google/gce_img.py',


### PR DESCRIPTION
##### SUMMARY
As discussed in #408 ([original suggestion](https://github.com/ansible/ansible/pull/50428#issuecomment-451687999) by @WojciechowskiPiotr), this PR renames the `docker_service` module to `docker_compose`.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
docker_service
docker_compose
