### PR TITLE
reboot - Fix connection timeout reset (#51000) - 2.7

### DIFF
--- a/changelogs/fragments/reboot-conn-timeout-reset.yaml
+++ b/changelogs/fragments/reboot-conn-timeout-reset.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- reboot - Fix bug where the connection timeout was not reset in the same task after rebooting

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -302,7 +302,6 @@ class ActionModule(ActionBase):
         try:
             # keep on checking system boot_time with short connection responses
             reboot_timeout = int(self._task.args.get('reboot_timeout', self._task.args.get('reboot_timeout_sec', self.DEFAULT_REBOOT_TIMEOUT)))
-            connect_timeout = self._task.args.get('connect_timeout', self._task.args.get('connect_timeout_sec', self.DEFAULT_CONNECT_TIMEOUT))
 
             self.do_until_success_or_timeout(
                 action=self.check_boot_time,
@@ -311,16 +310,23 @@ class ActionModule(ActionBase):
                 distribution=distribution,
                 action_kwargs=action_kwargs)
 
-            if connect_timeout and original_connection_timeout:
-                try:
-                    display.debug("{action}: setting connect_timeout back to original value of {value}".format(
-                        action=self._task.action,
-                        value=original_connection_timeout))
-                    self._connection.set_option("connection_timeout", original_connection_timeout)
-                    self._connection.reset()
-                except (AnsibleError, AttributeError) as e:
-                    # reset the connection to clear the custom connection timeout
-                    display.debug("{action}: failed to reset connection_timeout back to default: {error}".format(action=self._task.action, error=to_text(e)))
+            # Get the connect_timeout set on the connection to compare to the original
+            try:
+                connect_timeout = self._connection.get_option('connection_timeout')
+            except AnsibleError:
+                pass
+            else:
+                if original_connection_timeout != connect_timeout:
+                    try:
+                        display.debug("{action}: setting connect_timeout back to original value of {value}".format(
+                            action=self._task.action,
+                            value=original_connection_timeout))
+                        self._connection.set_option("connection_timeout", original_connection_timeout)
+                        self._connection.reset()
+                    except (AnsibleError, AttributeError) as e:
+                        # reset the connection to clear the custom connection timeout
+                        display.debug("{action}: failed to reset connection_timeout back to default: {error}".format(action=self._task.action,
+                                                                                                                     error=to_text(e)))
 
             # finally run test command to ensure everything is working
             # FUTURE: add a stability check (system must remain up for N seconds) to deal with self-multi-reboot updates


### PR DESCRIPTION
(cherry picked from commit 9fa46e7f946bfe244d0e126bd96588b460592826)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/51000

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
reboot
win_reboot