### PR TITLE
User - Create parent directories if they do not exist in the specified home path

### DIFF
--- a/changelogs/fragments/user-home-dir-with-no-parents.yaml
+++ b/changelogs/fragments/user-home-dir-with-no-parents.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - create parent directories when the specified home path has parent directiries that do not exist (https://github.com/ansible/ansible/issues/41393)

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -175,10 +175,6 @@
     path: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
   register: home_with_no_parent_3
 
-- debug:
-    var: home_with_no_parent_3
-  tags: debug
-
 - name: Ensure user with non-existing parent paths was created successfully
   assert:
     that:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -154,6 +154,53 @@
   when: ansible_facts.system != 'Darwin'
 
 
+# https://github.com/ansible/ansible/issues/41393
+# Create a new user account with a path that has parent directories that do not exist
+- name: Create user with home path that has parents that do not exist
+  user:
+    name: ansibulluser2
+    state: present
+    home: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+  register: create_home_with_no_parent_1
+
+- name: Create user with home path that has parents that do not exist again
+  user:
+    name: ansibulluser2
+    state: present
+    home: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+  register: create_home_with_no_parent_2
+
+- name: Check the created home directory
+  stat:
+    path: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+  register: home_with_no_parent_3
+
+- debug:
+    var: home_with_no_parent_3
+  tags: debug
+
+- name: Ensure user with non-existing parent paths was created successfully
+  assert:
+    that:
+      - create_home_with_no_parent_1 is changed
+      - create_home_with_no_parent_1.home == user_home_prefix[ansible_facts.system] ~ '/in2deep/ansibulluser2'
+      - create_home_with_no_parent_2 is not changed
+      - home_with_no_parent_3.stat.uid == create_home_with_no_parent_1.uid
+      - home_with_no_parent_3.stat.gr_name == 'ansibulluser2'
+
+- name: Cleanup test account
+  user:
+    name: ansibulluser2
+    home: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+    state: absent
+    remove: yes
+
+- name: Remove testing dir
+  file:
+    path: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/"
+    state: absent
+
+
 ## user check
 
 - name: run existing user check tests

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -186,7 +186,7 @@
       - create_home_with_no_parent_1.home == user_home_prefix[ansible_facts.system] ~ '/in2deep/ansibulluser2'
       - create_home_with_no_parent_2 is not changed
       - home_with_no_parent_3.stat.uid == create_home_with_no_parent_1.uid
-      - home_with_no_parent_3.stat.gr_name == 'ansibulluser2'
+      - home_with_no_parent_3.stat.gr_name == default_user_group[ansible_facts.distribution] | default('ansibulluser2')
 
 - name: Cleanup test account
   user:

--- a/test/integration/targets/user/vars/main.yml
+++ b/test/integration/targets/user/vars/main.yml
@@ -7,3 +7,7 @@ user_home_prefix:
 status_command:
   OpenBSD: "grep ansibulluser /etc/master.passwd | cut -d ':' -f 2"
   FreeBSD: 'pw user show ansibulluser'
+
+default_user_group:
+  openSUSE Leap: users
+  Darwin: admin

--- a/test/integration/targets/user/vars/main.yml
+++ b/test/integration/targets/user/vars/main.yml
@@ -10,4 +10,4 @@ status_command:
 
 default_user_group:
   openSUSE Leap: users
-  Darwin: admin
+  MacOSX: admin


### PR DESCRIPTION
##### SUMMARY

Fixes #41393 

The `useradd` command line tool does not create parent directories. The PR checks if the specified home path has parents that do not exist. If so, create them prior to running `useradd`, then set the proper permission on the created directory.

This would fail on the first run because the code it was hitting only checked for missing home directories when the user account existed. The first run code was relying on `useradd` to create the home directory if it didn't exist, which it usually does. But when parent directories do not exist, `useradd` simply fails to create the home directory though it does create the account on the system.

Also add integration tests.

Signed-off-by: Sam Doran <sdoran@redhat.com>


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`user.py`