### PR TITLE
setup_rabbitmq - fix erlang pinned dependencies

### DIFF
--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -5,11 +5,11 @@
     dest: /etc/apt/preferences.d/erlang
     content: |
         Package: erlang*
-        Pin: version 1:20.1-1
+        Pin: version 1:20.3.8.14-1
         Pin-Priority: 1000
 
         Package: esl-erlang
-        Pin: version 1:20.1.7
+        Pin: version 1:20.3.6
         Pin-Priority: 1000
 
 - name: Install https transport for apt


### PR DESCRIPTION
##### SUMMARY
The dependencies for `rabbitmq-server` have been updated and the ones originally pinned are no longer valid. This updates the pinned erlang versions to the ones in the document https://www.rabbitmq.com/install-debian.html#apt-pinning.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_rabbitmq