### PR TITLE
setup_rabbitmq - fix erlang pinned dependencies (#51048) - 2.7

### DIFF
--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -6,11 +6,11 @@
     dest: /etc/apt/preferences.d/erlang
     content: |
         Package: erlang*
-        Pin: version 1:20.1-1
+        Pin: version 1:20.3.8.14-1
         Pin-Priority: 1000
 
         Package: esl-erlang
-        Pin: version 1:20.1.7
+        Pin: version 1:20.3.6
         Pin-Priority: 1000
 
 - name: Install https transport for apt


### PR DESCRIPTION
(cherry picked from commit 18c35b69fb8c2eb4314b2cd2e61773496576edcf)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/51048

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_rabbitmq