### PR TITLE
Increase persistent command_timeout default value

### DIFF
--- a/changelogs/fragments/persistent_command_timeout_increase.yaml
+++ b/changelogs/fragments/persistent_command_timeout_increase.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Increase the default persistent command_timeout value from 10 to 30 seconds to reduce frequent timeout issues"

--- a/changelogs/fragments/persistent_command_timeout_increase.yaml
+++ b/changelogs/fragments/persistent_command_timeout_increase.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "Increase the default persistent command_timeout value from 10 to 30 seconds to reduce frequent timeout issues"
+  - "Increase the default persistent command_timeout value from 10 to 30 seconds to reduce frequent timeout issues."

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -240,7 +240,7 @@ If the identified error message from the log file is:
 
 .. code-block:: yaml
 
-   2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 10 secs
+   2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 30 secs
 
 or
 
@@ -472,7 +472,7 @@ For example:
 
 .. code-block:: yaml
 
-   2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 10 secs
+   2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 30 secs
 
 Suggestions to resolve:
 
@@ -481,14 +481,14 @@ Increase value of command timeout in configuration file or by setting environmen
 
 .. code-block:: yaml
 
-   export ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=30
+   export ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=60
 
 To make this a permanent change, add the following to your ``ansible.cfg`` file:
 
 .. code-block:: ini
 
    [persistent_connection]
-   command_timeout = 30
+   command_timeout = 60
 
 Option 2 (Per task command timeout setting):
 Increase command timeout per task basis. All network modules support a
@@ -522,11 +522,11 @@ Suggestions to resolve:
       ios_command:
         commands: copy running-config startup-config
       vars:
-        ansible_command_timeout: 30
+        ansible_command_timeout: 60
 
-Some operations take longer than the default 10 seconds to complete.  One good
+Some operations take longer than the default 30 seconds to complete.  One good
 example is saving the current running config on IOS devices to startup config.
-In this case, changing the timeout value from the default 10 seconds to 30
+In this case, changing the timeout value from the default 30 seconds to 60
 seconds will prevent the task from failing before the command completes
 successfully.
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -435,18 +435,11 @@
 # expires, the connection is shutdown. The default value is 30 seconds.
 #connect_timeout = 30
 
-# Configures the persistent connection retry timeout.  This value configures the
-# the retry timeout that ansible-connection will wait to connect
-# to the local domain socket. This value must be larger than the
-# ssh timeout (timeout) and less than persistent connection idle timeout (connect_timeout).
-# The default value is 15 seconds.
-#connect_retry_timeout = 15
-
 # The command timeout value defines the amount of time to wait for a command
 # or RPC call before timing out. The value for the command timeout must
 # be less than the value of the persistent connection idle timeout (connect_timeout)
-# The default value is 10 second.
-#command_timeout = 10
+# The default value is 30 second.
+#command_timeout = 30
 
 [accelerate]
 #accelerate_port = 5099

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1554,7 +1554,7 @@ PERSISTENT_CONNECT_RETRY_TIMEOUT:
   type: integer
 PERSISTENT_COMMAND_TIMEOUT:
   name: Persistence command timeout
-  default: 10
+  default: 30
   description: This controls the amount of time to wait for response from remote device before timing out presistent connection.
   env: [{name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT}]
   ini:

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -137,7 +137,7 @@ options:
         return from the remote device.  If this timer is exceeded before the
         command returns, the connection plugin will raise an exception and
         close.
-    default: 10
+    default: 30
     ini:
       - section: persistent_connection
         key: command_timeout

--- a/lib/ansible/plugins/connection/napalm.py
+++ b/lib/ansible/plugins/connection/napalm.py
@@ -121,7 +121,7 @@ options:
         return from the remote device.  If this timer is exceeded before the
         command returns, the connection plugin will raise an exception and
         close.
-    default: 10
+    default: 30
     ini:
       - section: persistent_connection
         key: command_timeout

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -149,7 +149,7 @@ options:
         return from the remote device.  If this timer is exceeded before the
         command returns, the connection plugin will raise an exception and
         close.
-    default: 10
+    default: 30
     ini:
       - section: persistent_connection
         key: command_timeout

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -151,7 +151,7 @@ options:
         return from the remote device.  If this timer is exceeded before the
         command returns, the connection plugin will raise an exception and
         close.
-    default: 10
+    default: 30
     ini:
       - section: persistent_connection
         key: command_timeout


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Increase command_timeout default value from 10 to 30 sec
   to reduce frequent timeout issue for network connection
   types (netconf/network_cli/httpapi/napalm)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
