### PR TITLE
fix(rabbitmq_plugin): fixed an issue, when module successfully reports installation of non existing plugins

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_plugin.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_plugin.py
@@ -113,14 +113,21 @@ class RabbitMqPlugins(object):
         return list()
 
     def get_all(self):
-        list_output = self._exec(['list', '-E', '-m'], True)
-        plugins = []
+        list_output = self._exec(['-q', 'list', '--enabled', '--minimal'], True)
+        enabled_plugins = []
         for plugin in list_output:
             if not plugin:
                 break
-            plugins.append(plugin)
+            enabled_plugins.append(plugin)
 
-        return plugins
+        list_output = self._exec(['-q', 'list', '--minimal'], True)
+        available_plugins = []
+        for plugin in list_output:
+            if not plugin:
+                break
+            available_plugins.append(plugin)
+
+        return enabled_plugins, available_plugins
 
     def enable(self, name):
         self._exec(['enable', name])
@@ -147,11 +154,15 @@ def main():
     state = module.params['state']
 
     rabbitmq_plugins = RabbitMqPlugins(module)
-    enabled_plugins = rabbitmq_plugins.get_all()
+    enabled_plugins, available_plugins = rabbitmq_plugins.get_all()
 
     enabled = []
     disabled = []
     if state == 'enabled':
+        for name in names:
+            if name not in available_plugins:
+                module.fail_json(msg='{} plugin is not available'.format(name))
+
         if not new_only:
             for plugin in enabled_plugins:
                 if plugin not in names:

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_plugin.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_plugin.py
@@ -161,7 +161,7 @@ def main():
     if state == 'enabled':
         for name in names:
             if name not in available_plugins:
-                module.fail_json(msg='{} plugin is not available'.format(name))
+                module.fail_json(msg='{name} plugin is not available'.format(name=name))
 
         if not new_only:
             for plugin in enabled_plugins:


### PR DESCRIPTION
##### SUMMARY
- added additional check on list of available rmq plugins
- fail when trying to enable missing plugin
- added `-q` flag to exec (prevents header printing to output)
- renamed rabbitmq-plugins args to full form for better readability

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_plugin

