### PR TITLE
#50877: add support to postgresql_privs to use "FOR { ROLE | USER } target_role" in "ALTER DEFAULT PRIVILEGES"

### DIFF
--- a/changelogs/fragments/50877-postgresql_privs_add-support-for-target_role.yaml
+++ b/changelogs/fragments/50877-postgresql_privs_add-support-for-target_role.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "postgresql_privs - introduces support to postgresql_privs to use 'FOR { ROLE | USER } target_role' in 'ALTER DEFAULT PRIVILEGES'. (https://github.com/ansible/ansible/issues/50877)"

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -87,6 +87,7 @@ options:
   target_roles:
     description:
       - Comma separated list of role (user/group) names to set as the default permissions.
+    version_added: 2.8
   grant_option:
     description:
       - Whether C(role) may grant/revoke the specified privileges/group
@@ -729,8 +730,8 @@ class QueryBuilder(object):
             else:
                 self.query.append(
                     'ALTER DEFAULT PRIVILEGES FOR ROLE {0} IN SCHEMA {1} REVOKE ALL ON {2} FROM {3};'.format(self._as_who,
-                                                                                                self._schema, obj,
-                                                                                                self._for_whom))
+                                                                                                             self._schema, obj,
+                                                                                                             self._for_whom))
 
     def add_grant_option(self):
         if self._grant_option:
@@ -756,10 +757,10 @@ class QueryBuilder(object):
             else:
                 self.query.append(
                     'ALTER DEFAULT PRIVILEGES FOR ROLE {0} IN SCHEMA {1} GRANT {2} ON {3} TO {4}'.format(self._as_who,
-                                                                                                    self._schema,
-                                                                                                    self._set_what,
-                                                                                                    obj,
-                                                                                                    self._for_whom))
+                                                                                                         self._schema,
+                                                                                                         self._set_what,
+                                                                                                         obj,
+                                                                                                         self._for_whom))
             self.add_grant_option()
         if not self._as_who:
             self.query.append(
@@ -767,8 +768,8 @@ class QueryBuilder(object):
         else:
             self.query.append(
                 'ALTER DEFAULT PRIVILEGES FOR ROLE {0} IN SCHEMA {1} GRANT USAGE ON TYPES TO {2}'.format(self._as_who,
-                                                                                                    self._schema,
-                                                                                                    self._for_whom))
+                                                                                                         self._schema,
+                                                                                                         self._for_whom))
         self.add_grant_option()
 
     def build_present(self):
@@ -938,7 +939,7 @@ def main():
             privs=privs,
             objs=objs,
             roles=roles,
-            target_roles= target_roles,
+            target_roles=target_roles,
             state=p.state,
             grant_option=p.grant_option,
             schema_qualifier=p.schema,

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -811,9 +811,15 @@ class QueryBuilder(object):
         if self._obj_type == 'default_privs':
             self.query = []
             for obj in ['TABLES', 'SEQUENCES', 'TYPES']:
-                self.query.append(
-                    'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} REVOKE ALL ON {1} FROM {2};'.format(self._schema, obj,
-                                                                                                self._for_whom))
+                if not self._as_who:
+                    self.query.append(
+                        'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} REVOKE ALL ON {1} FROM {2};'.format(self._schema, obj,
+                                                                                                    self._for_whom))
+                else:
+                    self.query.append(
+                        'ALTER DEFAULT PRIVILEGES FOR ROLE {0} IN SCHEMA {1} REVOKE ALL ON {2} FROM {3};'.format(self._as_who,
+                                                                                                                 self._schema, obj,
+                                                                                                                 self._for_whom))
         else:
             self.query.append('REVOKE {0} FROM {1};'.format(self._set_what, self._for_whom))
 

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -89,7 +89,6 @@ options:
     - A list of existing role (user/group) names to set as the
       default permissions for database objects subsequently created by them.
     - Parameter I(target_roles) is only available with C(type=default_privs).
-    type: list
     version_added: '2.8'
   grant_option:
     description:

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -86,10 +86,11 @@ options:
       Permissions checking for SQL commands is carried out as though the session_role were the one that had logged in originally.
   target_roles:
     description:
-      - Comma-separated list of existing role (user/group) names to set as the
-        default permissions for database objects subsequently created by them.
-        I(target_roles) is only available with I(type=default_privs)."
-    version_added: 2.8
+    - A list of existing role (user/group) names to set as the
+      default permissions for database objects subsequently created by them.
+    - Parameter I(target_roles) is only available with C(type=default_privs).
+    type: list
+    version_added: '2.8'
   grant_option:
     description:
       - Whether C(role) may grant/revoke the specified privileges/group

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -84,6 +84,9 @@ options:
     description: |
       Switch to session_role after connecting. The specified session_role must be a role that the current login_user is a member of.
       Permissions checking for SQL commands is carried out as though the session_role were the one that had logged in originally.
+  target_roles:
+    description:
+      - Comma separated list of role (user/group) names to set as the default permissions.
   grant_option:
     description:
       - Whether C(role) may grant/revoke the specified privileges/group
@@ -538,8 +541,13 @@ class Connection(object):
 
     # Manipulating privileges
 
+<<<<<<< HEAD
     def manipulate_privs(self, obj_type, privs, objs, roles,
                          state, grant_option, schema_qualifier=None, fail_on_role=True):
+=======
+    def manipulate_privs(self, obj_type, privs, objs, roles, target_roles,
+                         state, grant_option, schema_qualifier=None):
+>>>>>>> #50877:
         """Manipulate database object privileges.
 
         :param obj_type: Type of database object to grant/revoke
@@ -550,6 +558,8 @@ class Connection(object):
                      privileges for.
         :param roles: Either a list of role names or "PUBLIC"
                       for the implicitly defined "PUBLIC" group
+        :param target_roles: List of role names to grant/revoke
+                             default privileges as.
         :param state: "present" to grant privileges, "absent" to revoke.
         :param grant_option: Only for state "present": If True, set
                              grant/admin option. If False, revoke it.
@@ -639,12 +649,18 @@ class Connection(object):
 
             for_whom = ','.join(for_whom)
 
+        if target_roles:
+            as_who = ','.join(pg_quote_identifier(r, 'role') for r in target_roles)
+        else:
+            as_who = target_roles
+
         status_before = get_status(objs)
 
         query = QueryBuilder(state) \
             .for_objtype(obj_type) \
             .with_grant_option(grant_option) \
             .for_whom(for_whom) \
+            .as_who(as_who) \
             .for_schema(schema_qualifier) \
             .set_what(set_what) \
             .for_objs(objs) \
@@ -659,6 +675,7 @@ class QueryBuilder(object):
     def __init__(self, state):
         self._grant_option = None
         self._for_whom = None
+        self._as_who = None
         self._set_what = None
         self._obj_type = None
         self._state = state
@@ -682,6 +699,10 @@ class QueryBuilder(object):
         self._for_whom = who
         return self
 
+    def as_who(self, target_roles):
+        self._as_who = target_roles
+        return self
+
     def set_what(self, what):
         self._set_what = what
         return self
@@ -701,9 +722,15 @@ class QueryBuilder(object):
 
     def add_default_revoke(self):
         for obj in self._objs:
-            self.query.append(
-                'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} REVOKE ALL ON {1} FROM {2};'.format(self._schema, obj,
-                                                                                            self._for_whom))
+            if not self._as_who:
+                self.query.append(
+                    'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} REVOKE ALL ON {1} FROM {2};'.format(self._schema, obj,
+                                                                                                self._for_whom))
+            else:
+                self.query.append(
+                    'ALTER DEFAULT PRIVILEGES FOR ROLE {0} IN SCHEMA {1} REVOKE ALL ON {2} FROM {3};'.format(self._as_who,
+                                                                                                self._schema, obj,
+                                                                                                self._for_whom))
 
     def add_grant_option(self):
         if self._grant_option:
@@ -720,13 +747,28 @@ class QueryBuilder(object):
 
     def add_default_priv(self):
         for obj in self._objs:
-            self.query.append(
-                'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} GRANT {1} ON {2} TO {3}'.format(self._schema, self._set_what,
-                                                                                        obj,
-                                                                                        self._for_whom))
+            if not self._as_who:
+                self.query.append(
+                    'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} GRANT {1} ON {2} TO {3}'.format(self._schema,
+                                                                                            self._set_what,
+                                                                                            obj,
+                                                                                            self._for_whom))
+            else:
+                self.query.append(
+                    'ALTER DEFAULT PRIVILEGES FOR ROLE {0} IN SCHEMA {1} GRANT {2} ON {3} TO {4}'.format(self._as_who,
+                                                                                                    self._schema,
+                                                                                                    self._set_what,
+                                                                                                    obj,
+                                                                                                    self._for_whom))
             self.add_grant_option()
-        self.query.append(
-            'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} GRANT USAGE ON TYPES TO {1}'.format(self._schema, self._for_whom))
+        if not self._as_who:
+            self.query.append(
+                'ALTER DEFAULT PRIVILEGES IN SCHEMA {0} GRANT USAGE ON TYPES TO {1}'.format(self._schema, self._for_whom))
+        else:
+            self.query.append(
+                'ALTER DEFAULT PRIVILEGES FOR ROLE {0} IN SCHEMA {1} GRANT USAGE ON TYPES TO {2}'.format(self._as_who,
+                                                                                                    self._schema,
+                                                                                                    self._for_whom))
         self.add_grant_option()
 
     def build_present(self):
@@ -770,6 +812,7 @@ def main():
             schema=dict(required=False),
             roles=dict(required=True, aliases=['role']),
             session_role=dict(required=False),
+            target_roles=dict(required=False),
             grant_option=dict(required=False, type='bool',
                               aliases=['admin_option']),
             host=dict(default='', aliases=['login_host']),
@@ -884,11 +927,18 @@ def main():
                 else:
                     module.warn("Role '%s' does not exist, nothing to do" % roles[0].strip())
 
+        # target roles
+        if p.target_roles:
+            target_roles = p.target_roles.split(',')
+        else:
+            target_roles = None
+
         changed = conn.manipulate_privs(
             obj_type=p.type,
             privs=privs,
             objs=objs,
             roles=roles,
+            target_roles= target_roles,
             state=p.state,
             grant_option=p.grant_option,
             schema_qualifier=p.schema,

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -88,6 +88,7 @@ options:
     description:
       - Comma-separated list of existing role (user/group) names to set as the
         default permissions for database objects subsequently created by them.
+        I(target_roles) is only available with I(type=default_privs)."
     version_added: 2.8
   grant_option:
     description:

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -787,6 +787,9 @@
 # Test postgresql_facts module:
 - include: postgresql_facts.yml
 
+# Test default_privs with target_role
+- include: test_target_role.yml
+
 # dump/restore tests per format
 # ============================================================
 - include: state_dump_restore.yml test_fixture=user file=dbdata.sql

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -789,6 +789,7 @@
 
 # Test default_privs with target_role
 - include: test_target_role.yml
+  when: postgres_version_resp.stdout is version('9.1', '>=')
 
 # dump/restore tests per format
 # ============================================================

--- a/test/integration/targets/postgresql/tasks/test_target_role.yml
+++ b/test/integration/targets/postgresql/tasks/test_target_role.yml
@@ -35,6 +35,7 @@
     type: default_privs
     role: "{{ db_user2 }}"
     target_roles: "{{ db_user1 }}"
+    login_user: "{{ pg_user }}"
   register: result
 
 # Checks
@@ -62,6 +63,7 @@
     type: default_privs
     role: "{{ db_user2 }}"
     target_roles: "{{ db_user1 }}"
+    login_user: "{{ pg_user }}"
   register: result
 
 # Checks

--- a/test/integration/targets/postgresql/tasks/test_target_role.yml
+++ b/test/integration/targets/postgresql/tasks/test_target_role.yml
@@ -1,0 +1,92 @@
+---
+
+# Setup
+- name: Create DB
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_db:
+    state: present
+    name: "{{ db_name }}"
+    owner: "{{ db_user1 }}"
+    login_user: "{{ pg_user }}"
+
+- name: Create a user to be given permissions and other tests
+  postgresql_user:
+    name: "{{ db_user2 }}"
+    state: present
+    encrypted: yes
+    password: password
+    role_attr_flags: LOGIN
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+
+#######################################
+# Test default_privs with target_role #
+#######################################
+
+# Test
+- name: Grant default privileges for new table objects
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_privs:
+    db: "{{ db_name }}"
+    objs: TABLES
+    privs: SELECT
+    type: default_privs
+    role: "{{ db_user2 }}"
+    target_roles: "{{ db_user1 }}"
+  register: result
+
+# Checks
+- assert:
+    that: result.changed == true
+
+- name: Check that default privileges are set
+  become: yes
+  become_user: "{{ pg_user }}"
+  shell: psql {{ db_name }} -c "SELECT defaclrole, defaclobjtype, defaclacl FROM pg_default_acl a JOIN pg_roles b ON a.defaclrole=b.oid;" -t
+  register: result
+
+- assert:
+    that: "'{{ db_user2 }}=r/{{ db_user1 }}' in '{{ result.stdout_lines[0] }}'"
+
+# Test
+- name: Revoke default privileges for new table objects
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_privs:
+    db: "{{ db_name }}"
+    state: absent
+    objs: TABLES
+    privs: SELECT
+    type: default_privs
+    role: "{{ db_user2 }}"
+    target_roles: "{{ db_user1 }}"
+  register: result
+
+# Checks
+- assert:
+    that: result.changed == true
+
+# Cleanup
+- name: Remove user given permissions
+  postgresql_user:
+    name: "{{ db_user2 }}"
+    state: absent
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+
+- name: Remove user owner of objects
+  postgresql_user:
+    name: "{{ db_user3 }}"
+    state: absent
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+
+- name: Destroy DB
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_db:
+    state: absent
+    name: "{{ db_name }}"
+    login_user: "{{ pg_user }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* add support to postgresql_privs to use "FOR { ROLE | USER } target_role" in "ALTER DEFAULT PRIVILEGES"
* Fixes #50877 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
ATM only a workaround (See [#32987)](https://github.com/ansible/ansible/pull/32987#issuecomment-451026860) exists to use the [FOR { ROLE | USER } target_role [, ...]](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html).
I implement a new parameter **target_roles** like the roles parameter to configure the target_role in the default privilege context.
If you don't set the target_roles or either not use the [FOR ROLE ...] option, the default privileges will be set for the user who is running the command (this will be the login_user or if you use become_user in your playbook this user).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- postgresql_privs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

A possible playbook could look like this:
```paste below
- name: set default privs
  become_user: postgres
  postgresql_privs:
    db: library
    objs: TABLES,SEQUENCES
    privs: SELECT
    type: default_privs
    role: group_reader
    role_target: reader
    schema: reader
```
