### PR TITLE
Fix 'defaults' option in the nxos_config module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -286,16 +286,12 @@ from ansible.module_utils.network.nxos.nxos import check_args as nxos_check_args
 from ansible.module_utils.network.common.utils import to_list
 
 
-def get_running_config(module, config=None):
+def get_running_config(module, config=None, flags=None):
     contents = module.params['running_config']
     if not contents:
-        if not module.params['defaults'] and config:
-            # Optimization: The running-config has already been recovered by the backup
+        if config:
             contents = config
         else:
-            flags = []
-            if module.params['defaults']:
-                flags = ['all']
             contents = get_config(module, flags=flags)
     return contents
 
@@ -398,13 +394,14 @@ def main():
     path = module.params['parents']
     connection = get_connection(module)
     contents = None
+    flags = ['all'] if module.params['defaults'] else []
     replace_src = module.params['replace_src']
     if replace_src:
         if module.params['replace'] != 'config':
             module.fail_json(msg='replace: config is required with replace_src')
 
     if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
-        contents = get_config(module)
+        contents = get_config(module, flags=flags)
         config = NetworkConfig(indent=2, contents=contents)
         if module.params['backup']:
             result['__backup__'] = contents
@@ -415,7 +412,7 @@ def main():
 
         commit = not module.check_mode
         candidate = get_candidate(module)
-        running = get_running_config(module, contents)
+        running = get_running_config(module, contents, flags=flags)
         if replace_src:
             commands = candidate.split('\n')
             result['commands'] = result['updates'] = commands

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -290,9 +290,12 @@ def get_running_config(module, config=None):
     contents = module.params['running_config']
     if not contents:
         if not module.params['defaults'] and config:
+            # Optimization: The running-config has already been recovered by the backup
             contents = config
         else:
-            flags = ['all']
+            flags = []
+            if module.params['defaults']:
+                flags = ['all']
             contents = get_config(module, flags=flags)
     return contents
 

--- a/test/units/modules/network/nxos/test_nxos_config.py
+++ b/test/units/modules/network/nxos/test_nxos_config.py
@@ -215,13 +215,10 @@ class TestNxosConfigModule(TestNxosModule):
         set_module_args(dict(lines=['hostname localhost'], defaults=False, backup=True))
         result = self.execute_module(changed=True)
         self.assertEqual(self.get_config.call_count, 1)
-        self.assertEqual(self.get_config.call_args[1], dict())
+        self.assertEqual(self.get_config.call_args[1], dict(flags=[]))
 
     def test_nxos_config_defaults_true_backup_true(self):
         set_module_args(dict(lines=['hostname localhost'], defaults=True, backup=True))
         result = self.execute_module(changed=True)
-        self.assertEqual(self.get_config.call_count, 2)
-        # get_config call for backup
-        self.assertEqual(self.get_config.call_args_list[0][1], dict())
-        # get_config call to get running-config with the 'all' option
-        self.assertEqual(self.get_config.call_args_list[1][1], dict(flags=['all']))
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.get_config.call_args[1], dict(flags=['all']))

--- a/test/units/modules/network/nxos/test_nxos_config.py
+++ b/test/units/modules/network/nxos/test_nxos_config.py
@@ -198,3 +198,30 @@ class TestNxosConfigModule(TestNxosModule):
         self.assertEqual(self.save_config.call_count, 0)
         self.assertEqual(self.get_config.call_count, 0)
         self.assertEqual(self.load_config.call_count, 0)
+
+    def test_nxos_config_defaults_false(self):
+        set_module_args(dict(lines=['hostname localhost'], defaults=False))
+        result = self.execute_module(changed=True)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.get_config.call_args[1], dict(flags=[]))
+
+    def test_nxos_config_defaults_true(self):
+        set_module_args(dict(lines=['hostname localhost'], defaults=True))
+        result = self.execute_module(changed=True)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.get_config.call_args[1], dict(flags=['all']))
+
+    def test_nxos_config_defaults_false_backup_true(self):
+        set_module_args(dict(lines=['hostname localhost'], defaults=False, backup=True))
+        result = self.execute_module(changed=True)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.get_config.call_args[1], dict())
+
+    def test_nxos_config_defaults_true_backup_true(self):
+        set_module_args(dict(lines=['hostname localhost'], defaults=True, backup=True))
+        result = self.execute_module(changed=True)
+        self.assertEqual(self.get_config.call_count, 2)
+        # get_config call for backup
+        self.assertEqual(self.get_config.call_args_list[0][1], dict())
+        # get_config call to get running-config with the 'all' option
+        self.assertEqual(self.get_config.call_args_list[1][1], dict(flags=['all']))


### PR DESCRIPTION
##### SUMMARY
Nxos get_config is allways called with the 'all' option.
* Fix flag's calculation
* Add tests

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_config

##### ADDITIONAL INFORMATION

* This issue seems to be added in the PR #26565.
* The eos_config module has already been fixed:
  * #26798 logic fix.
  * #42300 functional change: 'all' option is used on the backup config.

I have not changed the backup behavior as in the eos_config module.