### PR TITLE
Update ec2_asg.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -123,7 +123,7 @@ options:
     description:
       - Length of time in seconds after a new EC2 instance comes into service that Auto Scaling starts checking its health.
     required: false
-    default: 500 seconds
+    default: 300 seconds
     version_added: "1.7"
   health_check_type:
     description:


### PR DESCRIPTION
The documentation states that the health_check_period parameter value defaults to 500 when it actually defaults to 300. 

##### SUMMARY
Updating the documentation to reflect the actual default value

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
health_check_period

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
