### PR TITLE
docker_swarm_service: Add placement_preferences option

### DIFF
--- a/changelogs/fragments/51082-docker_swarm_service-placement-preferences-option.yml
+++ b/changelogs/fragments/51082-docker_swarm_service-placement-preferences-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_swarm_service - Added support for ``placement_preferences`` parameter."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -47,6 +47,13 @@ options:
     description:
     - List of the service constraints.
     - Maps docker service --constraint option.
+  placement_preferences:
+    required: false
+    type: list
+    description:
+    - List of the placement preferences as key value pairs.
+    - Maps docker service --placement-pref option.
+    version_added: 2.8
   hostname:
     required: false
     default: ""
@@ -490,7 +497,6 @@ except Exception:
 class DockerService(DockerBaseClass):
     def __init__(self):
         super(DockerService, self).__init__()
-        self.constraints = []
         self.image = ""
         self.args = []
         self.endpoint_mode = "vip"
@@ -517,6 +523,8 @@ class DockerService(DockerBaseClass):
         self.constraints = []
         self.networks = []
         self.publish = []
+        self.constraints = []
+        self.placement_preferences = None
         self.replicas = -1
         self.service_id = False
         self.service_version = False
@@ -549,6 +557,7 @@ class DockerService(DockerBaseClass):
             'log_driver_options': self.log_driver_options,
             'publish': self.publish,
             'constraints': self.constraints,
+            'placement_preferences': self.placement_preferences,
             'labels': self.labels,
             'container_labels': self.container_labels,
             'mode': self.mode,
@@ -573,6 +582,7 @@ class DockerService(DockerBaseClass):
     def from_ansible_params(ap, old_service):
         s = DockerService()
         s.constraints = ap['constraints']
+        s.placement_preferences = ap['placement_preferences']
         s.image = ap['image']
         s.args = ap['args']
         s.endpoint_mode = ap['endpoint_mode']
@@ -698,6 +708,8 @@ class DockerService(DockerBaseClass):
             differences.add('args', parameter=self.args, active=os.args)
         if self.constraints != os.constraints:
             differences.add('constraints', parameter=self.constraints, active=os.constraints)
+        if self.placement_preferences != os.placement_preferences:
+            differences.add('placement_preferences', parameter=self.placement_preferences, active=os.placement_preferences)
         if self.labels != os.labels:
             differences.add('labels', parameter=self.labels, active=os.labels)
         if self.limit_cpu != os.limit_cpu:
@@ -815,7 +827,14 @@ class DockerService(DockerBaseClass):
 
         log_driver = types.DriverConfig(name=self.log_driver, options=self.log_driver_options)
 
-        placement = types.Placement(constraints=self.constraints)
+        placement = types.Placement(
+            constraints=self.constraints,
+            preferences=[
+                {key.title(): {"SpreadDescriptor": value}}
+                for preference in self.placement_preferences
+                for key, value in preference.items()
+            ] if self.placement_preferences else None,
+        )
 
         restart_policy = types.RestartPolicy(
             condition=self.restart_policy,
@@ -930,7 +949,15 @@ class DockerServiceManager():
         ds.hostname = task_template_data['ContainerSpec'].get('Hostname', '')
         ds.tty = task_template_data['ContainerSpec'].get('TTY', False)
         if 'Placement' in task_template_data.keys():
-            ds.constraints = task_template_data['Placement'].get('Constraints', [])
+            placement = task_template_data['Placement']
+            ds.constraints = placement.get('Constraints', [])
+            placement_preferences = []
+            for preference in placement.get('Preferences', []):
+                placement_preferences.append({
+                    key.lower(): value['SpreadDescriptor'] for key, value in preference.items()
+                })
+            if placement_preferences:
+                ds.placement_preferences = placement_preferences
 
         restart_policy_data = task_template_data.get('RestartPolicy', None)
         if restart_policy_data:
@@ -1161,6 +1188,7 @@ def main():
         log_driver_options=dict(default={}, type='dict'),
         publish=dict(default=[], type='list'),
         constraints=dict(default=[], type='list'),
+        placement_preferences=dict(default=None, type='list'),
         tty=dict(default=False, type='bool'),
         dns=dict(default=[], type='list'),
         dns_search=dict(default=[], type='list'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -959,8 +959,7 @@ class DockerServiceManager():
                         for key, value in preference.items()
                     )
                 )
-            if placement_preferences:
-                ds.placement_preferences = placement_preferences
+            ds.placement_preferences = placement_preferences or None
 
         restart_policy_data = task_template_data.get('RestartPolicy', None)
         if restart_policy_data:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -953,9 +953,12 @@ class DockerServiceManager():
             ds.constraints = placement.get('Constraints', [])
             placement_preferences = []
             for preference in placement.get('Preferences', []):
-                placement_preferences.append({
-                    key.lower(): value['SpreadDescriptor'] for key, value in preference.items()
-                })
+                placement_preferences.append(
+                    dict(
+                        (key.lower(), value["SpreadDescriptor"])
+                        for key, value in preference.items()
+                    )
+                )
             if placement_preferences:
                 ds.placement_preferences = placement_preferences
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -473,6 +473,12 @@ EXAMPLES = '''
     docker_swarm_service:
         name: myservice
         state: absent
+-   name: set placement preferences
+    docker_swarm_service:
+        name: myservice
+        image: alpine:edge
+        placement_preferences:
+          - spread: "node.labels.mylabel"
 '''
 
 import time

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -52,7 +52,7 @@ options:
     type: list
     description:
     - List of the placement preferences as key value pairs.
-    - Maps docker service --placement-pref option.
+    - Maps docker service C(--placement-pref) option.
     version_added: 2.8
   hostname:
     required: false

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -708,7 +708,7 @@ class DockerService(DockerBaseClass):
             differences.add('args', parameter=self.args, active=os.args)
         if self.constraints != os.constraints:
             differences.add('constraints', parameter=self.constraints, active=os.constraints)
-        if self.placement_preferences != os.placement_preferences:
+        if self.placement_preferences is not None and self.placement_preferences != os.placement_preferences:
             differences.add('placement_preferences', parameter=self.placement_preferences, active=os.placement_preferences)
         if self.labels != os.labels:
             differences.add('labels', parameter=self.labels, active=os.labels)

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -951,6 +951,46 @@
       - networks_3 is changed
 
 ####################################################################
+## placement_preferences ###########################################
+####################################################################
+
+- name: placement_preferences
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    placement_preferences:
+      - spread: "node.labels.test"
+  register: placement_preferences_1
+
+- name: placement_preferences (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    placement_preferences:
+      - spread: "node.labels.test"
+  register: placement_preferences_2
+
+- name: placement_preferences (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    placement_preferences:
+      - spread: "node.labels.test2"
+  register: placement_preferences_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - placement_preferences_1 is changed
+      - placement_preferences_2 is not changed
+      - placement_preferences_3 is changed
+
+####################################################################
 ## publish #########################################################
 ####################################################################
 

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -21,6 +21,7 @@ service_expected_output:
   mode: global
   mounts: []
   networks: []
+  placement_preferences: null
   publish:
     - {mode: null, protocol: tcp, published_port: 60001, target_port: 60001}
     - {mode: null, protocol: udp, published_port: 60001, target_port: 60001}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
docker_swarm_service is missing an option for setting placement preferences.

 It was added in Docker API 1.27 and docker-py 2.4. `types.PlacementPreference` recently got added to docker-py but is broken at the moment, see: https://github.com/docker/docker-py/pull/2234. Until that is fixed we'll have to pass the preferences context as a python dict. 

I haven't specified any minimum versions as it's easier to wait for #50609 to be merged first.

Fixes #49246

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service