### PR TITLE
Enable pip integration test on RHEL 8.0.

### DIFF
--- a/test/integration/targets/pip/aliases
+++ b/test/integration/targets/pip/aliases
@@ -1,3 +1,2 @@
 destructive
 shippable/posix/group1
-skip/rhel8.0


### PR DESCRIPTION
##### SUMMARY

Enable pip integration test on RHEL 8.0.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip integration test
