### PR TITLE
Fix usetty keyword in example ansible.cfg

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -420,7 +420,7 @@
 
 # The -tt argument is passed to ssh when pipelining is not enabled because sudo 
 # requires a tty by default. 
-#use_tty = True
+#usetty = True
 
 # Number of times to retry an SSH connection to a host, in case of UNREACHABLE.
 # For each retry attempt, there is an exponential backoff,


### PR DESCRIPTION
##### SUMMARY
example fix

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
examples/ansible.cfg

##### ADDITIONAL INFORMATION
The example is incorrect