### PR TITLE
User module - Check local database when local is specified in the task

### DIFF
--- a/changelogs/user-read-passwd-when-local.yaml
+++ b/changelogs/user-read-passwd-when-local.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix a bug when checking if a local user account exists on a system using directory authentication (https://github.com/ansible/ansible/issues/50947, https://github.com/ansible/ansible/issues/38206)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -847,13 +847,7 @@ class User(object):
         # It's output cannot be used to determine whether or not an account exists locally.
         # It returns True if the account exists locally or in the directory, so instead
         # look in the local PASSWORD file for an existing account.
-        if not self.local:
-            try:
-                if pwd.getpwnam(self.name):
-                    return True
-            except KeyError:
-                return False
-        else:
+        if self.local:
             if not os.path.exists(self.PASSWORDFILE):
                 self.module.fail_json(msg="'local: true' specified but unable to find local account file {0} to parse.".format(self.PASSWORDFILE))
 
@@ -871,6 +865,13 @@ class User(object):
                 "The local user account may already exist if the local account database exists somewhere other than {file}.".format(file=self.PASSWORDFILE))
 
             return exists
+
+        else:
+            try:
+                if pwd.getpwnam(self.name):
+                    return True
+            except KeyError:
+                return False
 
     def get_pwd_info(self):
         if not self.user_exists():

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -206,7 +206,9 @@ options:
             - Forces the use of "local" command alternatives on platforms that implement it.
             - This is useful in environments that use centralized authentification when you want to manipulate the local users
               (i.e. it uses C(luseradd) instead of C(useradd)).
-            - This requires that these commands exist on the targeted host, otherwise it will be a fatal error.
+            - This will check C(/etc/passwd) for an existing account before invoking commands. If the local account database
+              exists somewhere other than C(/etc/passwd), this setting will not work properly.
+            - This requires that the above commands as well as C(/etc/passwd) must exist on the target host, otherwise it will be a fatal error.
         type: bool
         default: no
         version_added: "2.4"
@@ -843,7 +845,8 @@ class User(object):
     def user_exists(self):
         # The pwd module does not distinguish between local and directory accounts.
         # It's output cannot be used to determine whether or not an account exists locally.
-        # It returns True if the account exists locally or in the directory.
+        # It returns True if the account exists locally or in the directory, so instead
+        # look in the local PASSWORD file for an existing account.
         if not self.local:
             try:
                 if pwd.getpwnam(self.name):
@@ -851,6 +854,9 @@ class User(object):
             except KeyError:
                 return False
         else:
+            if not os.path.exists(self.PASSWORDFILE):
+                self.module.fail_json(msg="'local: true' specified but unable to find local account file {0} to parse.".format(self.PASSWORDFILE))
+
             exists = False
             name_test = '{0}:'.format(self.name)
             with open(self.PASSWORDFILE, 'rb') as f:
@@ -859,6 +865,10 @@ class User(object):
                     if line.startswith(to_bytes(name_test)):
                         exists = True
                         break
+
+            self.module.warn(
+                "'local: true' specified and user was not found in {file}. "
+                "The local user account may already exist if the local account database exists somewhere other than {file}.".format(file=self.PASSWORDFILE))
 
             return exists
 

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -255,7 +255,7 @@
         mode = oct(0o777 & ~umask)
         print(str(mode).replace('o', ''))
       args:
-        executable: python
+        executable: "{{ ansible_facts.python.executable }}"
       register: user_login_defs_umask
 
     - name: validate that user home dir is created
@@ -782,6 +782,27 @@
   # to run with local: true to exercise the code path that reads through the local
   # user database file.
   # https://github.com/ansible/ansible/issues/50947
+
+- name: Create /etc/gshadow
+  file:
+    path: /etc/gshadow
+    state: touch
+  when: ansible_facts.os_family == 'Suse'
+
+- name: Create /etc/libuser.conf
+  file:
+    path: /etc/libuser.conf
+    state: touch
+  when:
+    - ansible_facts.distribution == 'Ubuntu'
+    - ansible_facts.distribution_major_version is version_compare('16', '==')
+
+- name: Ensure luseradd is present
+  action: "{{ ansible_facts.pkg_mgr }}"
+  args:
+    name: libuser
+    state: present
+  when: ansible_facts.system in ['Linux']
 
 - name: Create local_ansibulluser
   user:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -788,6 +788,8 @@
     path: /etc/gshadow
     state: touch
   when: ansible_facts.os_family == 'Suse'
+  tags:
+    - user_test_local_mode
 
 - name: Create /etc/libuser.conf
   file:
@@ -796,6 +798,8 @@
   when:
     - ansible_facts.distribution == 'Ubuntu'
     - ansible_facts.distribution_major_version is version_compare('16', '==')
+  tags:
+    - user_test_local_mode
 
 - name: Ensure luseradd is present
   action: "{{ ansible_facts.pkg_mgr }}"
@@ -803,6 +807,8 @@
     name: libuser
     state: present
   when: ansible_facts.system in ['Linux']
+  tags:
+    - user_test_local_mode
 
 - name: Create local_ansibulluser
   user:
@@ -810,6 +816,8 @@
     state: present
     local: yes
   register: local_user_test_1
+  tags:
+    - user_test_local_mode
 
 - name: Create local_ansibulluser again
   user:
@@ -817,6 +825,8 @@
     state: present
     local: yes
   register: local_user_test_2
+  tags:
+    - user_test_local_mode
 
 - name: Remove local_ansibulluser
   user:
@@ -825,6 +835,8 @@
     remove: yes
     local: yes
   register: local_user_test_3
+  tags:
+    - user_test_local_mode
 
 - name: Remove local_ansibulluser again
   user:
@@ -833,6 +845,8 @@
     remove: yes
     local: yes
   register: local_user_test_4
+  tags:
+    - user_test_local_mode
 
 - name: Ensure local user accounts were created
   assert:
@@ -841,3 +855,5 @@
       - local_user_test_2 is not changed
       - local_user_test_3 is changed
       - local_user_test_4 is not changed
+  tags:
+    - user_test_local_mode

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -775,3 +775,48 @@
         password_lock: no
 
   when: ansible_facts['system'] in ['FreeBSD', 'OpenBSD', 'Linux']
+
+
+  ## Check local mode
+  # Even if we don't have a system that is bound to a directory, it's useful
+  # to run with local: true to exercise the code path that reads through the local
+  # user database file.
+  # https://github.com/ansible/ansible/issues/50947
+
+- name: Create local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+  register: local_user_test_1
+
+- name: Create local_ansibulluser again
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+  register: local_user_test_2
+
+- name: Remove local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+  register: local_user_test_3
+
+- name: Remove local_ansibulluser again
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+  register: local_user_test_4
+
+- name: Ensure local user accounts were created
+  assert:
+    that:
+      - local_user_test_1 is changed
+      - local_user_test_2 is not changed
+      - local_user_test_3 is changed
+      - local_user_test_4 is not changed


### PR DESCRIPTION
##### SUMMARY

The output of `pw.getpwnam()` does not distinguish between local and remote accounts. It will return a result if an account exists locally or in the directory. This PR changes `User.user_exists()` so that when local is set to `True`, it looks through the local password database explicitly instead of using `pw.getpwnam()`.

Signed-off-by: Sam Doran <sdoran@redhat.com>

Fixes #50947 
Fixes #38206

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`user.py`

##### ADDITIONAL INFORMATION

I tested on Linux, FreeBSD, and OpenBSD and looked at Solaris and AIX. Seems that they all store their user data in `/etc/passwd` with colon delimited fields. We have the ability to override the `PASSWORD` file per class. The search string is hard coded but that could also be turned into a variable as well if it needs to be different on different platforms.