### PR TITLE
Fix subversion integration test on Fedora 29.

### DIFF
--- a/test/integration/targets/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/tasks/setup.yml
@@ -12,6 +12,13 @@
     name: '{{ subversion_packages }}'
     state: present
 
+- name: upgrade SVN pre-reqs
+  package:
+    name: '{{ upgrade_packages }}'
+    state: latest
+  when:
+    - upgrade_packages | default([])
+
 - name: create SVN home folder
   file:
     path: '{{ subversion_server_dir }}'

--- a/test/integration/targets/subversion/vars/RedHat.yml
+++ b/test/integration/targets/subversion/vars/RedHat.yml
@@ -5,6 +5,6 @@ subversion_packages:
 upgrade_packages:
 # prevent sqlite from being out-of-sync with the version subversion was compiled with
 - subversion
-- sqlite-libs
+- sqlite
 apache_user: apache
 apache_group: apache

--- a/test/integration/targets/subversion/vars/RedHat.yml
+++ b/test/integration/targets/subversion/vars/RedHat.yml
@@ -2,5 +2,9 @@
 subversion_packages:
 - mod_dav_svn
 - subversion
+upgrade_packages:
+# prevent sqlite from being out-of-sync with the version subversion was compiled with
+- subversion
+- sqlite-libs
 apache_user: apache
 apache_group: apache


### PR DESCRIPTION
##### SUMMARY

Fix subversion integration test on Fedora 29.

This upgrades the sqlite-libs and subversion packages to make sure that the version of sqlite expected by subversion is installed.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

subversion integration test
