### PR TITLE
[stable-2.5] Fix subversion integration test on Fedora 29. (#51089)

### DIFF
--- a/test/integration/targets/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/tasks/setup.yml
@@ -7,6 +7,13 @@
     name: '{{ subversion_packages }}'
     state: present
 
+- name: upgrade SVN pre-reqs
+  package:
+    name: '{{ upgrade_packages }}'
+    state: latest
+  when:
+    - upgrade_packages | default([])
+
 - name: create SVN home folder
   file:
     path: '{{ subversion_server_dir }}'

--- a/test/integration/targets/subversion/vars/RedHat.yml
+++ b/test/integration/targets/subversion/vars/RedHat.yml
@@ -2,5 +2,9 @@
 subversion_packages:
 - mod_dav_svn
 - subversion
+upgrade_packages:
+# prevent sqlite from being out-of-sync with the version subversion was compiled with
+- subversion
+- sqlite
 apache_user: apache
 apache_group: apache


### PR DESCRIPTION
##### SUMMARY

[stable-2.5] Fix subversion integration test on Fedora 29. (#51089)

* Fix subversion integration test on Fedora 29.

This upgrades the sqlite-libs and subversion packages to make sure
that the version of sqlite expected by subversion is installed.

* Fix compatibility with RHEL and CentOS.

(cherry picked from commit d4dbc7f2e0d963e37e371f3b505152c2e11f1ca6)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

subversion integration test
