### PR TITLE
Add k8s module_defaults group and document

### DIFF
--- a/changelogs/fragments/k8s_module_defaults_group.yml
+++ b/changelogs/fragments/k8s_module_defaults_group.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - A k8s module defaults group has now been added to reduce the amount of parameters required for multiple k8s tasks.
+    This group contains all non-deprecated kubernetes modules - `k8s`, `k8s_facts`, `k8s_scale` and `k8s_service`.

--- a/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
+++ b/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
@@ -78,13 +78,26 @@ Setting a default AWS region for specific EC2-related modules::
 .. _module_defaults_groups:
 
 Module defaults groups
-``````````````````````
+----------------------
 
 .. versionadded:: 2.7
 
 Ansible 2.7 adds a preview-status feature to group together modules that share common sets of parameters. This makes
-it easier to author playbooks making heavy use of API-based modules such as cloud modules. By default Ansible ships
-with groups for AWS and GCP modules that share parameters.
+it easier to author playbooks making heavy use of API-based modules such as cloud modules.
+
++-------+---------------------------+-----------------+
+| Group | Purpose                   | Ansible Version |
++=======+===========================+=================+
+| aws   | Amazon Web Services       | 2.7             |
++-------+---------------------------+-----------------+
+| azure | Azure                     | 2.7             |
++-------+---------------------------+-----------------+
+| gcp   | Google Cloud Platform     | 2.7             |
++-------+---------------------------+-----------------+
+| k8s   | Kubernetes                | 2.8             |
++-------+---------------------------+-----------------+
+
+Use the groups with `module_defaults` by prefixing the group name with `group/` - e.g. `group/aws`
 
 In a playbook, you can set module defaults for whole groups of modules, such as setting a common AWS region.
 

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -594,3 +594,11 @@ groupings:
   - azure
   azure_rm_webapp:
   - azure
+  k8s:
+  - k8s
+  k8s_facts:
+  - k8s
+  k8s_service:
+  - k8s
+  k8s_scale:
+  - k8s


### PR DESCRIPTION
##### SUMMARY
It makes sense to use module_defaults with k8s modules, and thus
have a k8s module_defaults group.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_defaults