### PR TITLE
Ansible.Become - fix 32 bit incompatibility

### DIFF
--- a/lib/ansible/module_utils/csharp/Ansible.Become.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Become.cs
@@ -793,7 +793,7 @@ namespace Ansible.Become
             using (sessionPtr)
             {
                 for (IntPtr p = sessionPtr.DangerousGetHandle();
-                    p != IntPtr.Add(sessionPtr.DangerousGetHandle(), (int)(IntPtr.Size * sessionCount));
+                    p != IntPtr.Add(sessionPtr.DangerousGetHandle(), (int)(Marshal.SizeOf(typeof(NativeHelpers.LUID)) * sessionCount));
                     p = IntPtr.Add(p, Marshal.SizeOf(typeof(NativeHelpers.LUID))))
                 {
                     SafeLsaMemoryBuffer sessionDataPtr;


### PR DESCRIPTION
##### SUMMARY
The output of [LsaEnumerateLogonSessions](https://docs.microsoft.com/en-us/windows/desktop/api/ntsecapi/nf-ntsecapi-lsaenumeratelogonsessions) is a list of LUIDs and not a list of pointers. This is not an issue on 64-bit OS' as a pointer is 8 bytes which is the same as a LUID but on a 32 bit OS a pointer is only 4 bytes. This results in the for loop to exit early potentially before it finds the session it is looking for.

The change makes sure we enumerate all the logon sessions which is essential when trying to impersonate SYSTEM for higher privileges.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/csharp/Ansible.Become.cs