### PR TITLE
Change | section to | begin to support older versions of ios

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -344,7 +344,7 @@ def parse_password_type(data):
 
 
 def map_config_to_obj(module):
-    data = get_config(module, flags=['| section username'])
+    data = get_config(module, flags=['| begin username'])
 
     match = re.findall(r'(?:^(?:u|\s{2}u))sername (\S+)', data, re.M)
     if not match:


### PR DESCRIPTION

##### SUMMARY

Changed | section to | begin to support older versions of ios

Older versions of ios don't support the | section command.  Changing it to | begin should allow those older versions to work with this module as well as newer versions that do have the | section command.


##### ISSUE TYPE

- Bugfix Pull Request



##### COMPONENT NAME

ios_user.py

