### PR TITLE
Fix exception handling in credtash lookup

### DIFF
--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -113,7 +113,7 @@ class LookupModule(LookupBase):
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {0} not found'.format(term))
             except Exception as e:
-                raise AnsibleError('Encountered exception while fetching {0}: {1}'.format(term, e.message))
+                raise AnsibleError('Encountered exception while fetching {0}: {1}'.format(term, e))
             ret.append(val)
 
         return ret


### PR DESCRIPTION
##### SUMMARY
Exception does not have property `message` and ansible returns completely different exception because of this

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
credstash lookup plugin

##### ADDITIONAL INFORMATION

playbook.yml example:

```yaml
   - set_fact:
          example: '{{ lookup("credstash", "mysql-password") }}'
```

Comparison of error before and after the fix:
```
//command output before
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'credstash'. Error was a <class 'AttributeError'>, original message: 'NoRegionError' object has no attribute 'message'"}

//command output after
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'credstash'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Encountered exception while fetching mysql-password: You must specify a region."}
```
