### PR TITLE
meraki_device - Support for creating and modifying device notes

### DIFF
--- a/changelogs/fragments/49037-digital_ocean_tag_facts_keyerror.yaml
+++ b/changelogs/fragments/49037-digital_ocean_tag_facts_keyerror.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "digital_ocean_tag_facts - Fixed KeyError exception when using tag_name parameter"

--- a/changelogs/fragments/49037-digital_ocean_tag_facts_keyerror.yaml
+++ b/changelogs/fragments/49037-digital_ocean_tag_facts_keyerror.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- "digital_ocean_tag_facts - Fixed KeyError exception when using tag_name parameter"

--- a/changelogs/fragments/51100-meraki_device-notes-support.yml
+++ b/changelogs/fragments/51100-meraki_device-notes-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "meraki_device - Add support for attaching notes to a device."

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -90,6 +90,7 @@ options:
     	description:
     	- Informational notes about a device.
     	- Limited to 255 characters.
+        version_added: '2.8'
 
 
 author:

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -86,7 +86,7 @@ options:
     serial_uplink:
         description:
         - Serial number of device to query uplink information from.
-    notes:
+    note:
     	description:
     	- Informational notes about a device.
     	- Limited to 255 characters.
@@ -242,7 +242,7 @@ def main():
                          lng=dict(type='float', aliases=['longitude']),
                          address=dict(type='str'),
                          move_map_marker=dict(type='bool'),
-                         notes=dict(type='str'),
+                         note=dict(type='str'),
                          )
 
     # seed the result dict in the object
@@ -366,7 +366,7 @@ def main():
                            'lng': meraki.params['lng'],
                            'address': meraki.params['address'],
                            'moveMapMarker': meraki.params['move_map_marker'],
-                           'notes': meraki.params['notes'],
+                           'notes': meraki.params['note'],
                            }
                 query_path = meraki.construct_path('get_device', net_id=net_id) + meraki.params['serial']
                 device_data = meraki.request(query_path, method='GET')

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -86,6 +86,10 @@ options:
     serial_uplink:
         description:
         - Serial number of device to query uplink information from.
+    notes:
+    	description:
+    	- Informational notes about a device.
+    	- Limited to 255 characters.
 
 
 author:
@@ -238,6 +242,7 @@ def main():
                          lng=dict(type='float', aliases=['longitude']),
                          address=dict(type='str'),
                          move_map_marker=dict(type='bool'),
+                         notes=dict(type='str'),
                          )
 
     # seed the result dict in the object
@@ -361,6 +366,7 @@ def main():
                            'lng': meraki.params['lng'],
                            'address': meraki.params['address'],
                            'moveMapMarker': meraki.params['move_map_marker'],
+                           'notes': meraki.params['notes'],
                            }
                 query_path = meraki.construct_path('get_device', net_id=net_id) + meraki.params['serial']
                 device_data = meraki.request(query_path, method='GET')

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -87,9 +87,9 @@ options:
         description:
         - Serial number of device to query uplink information from.
     note:
-    	description:
-    	- Informational notes about a device.
-    	- Limited to 255 characters.
+        description:
+        - Informational notes about a device.
+        - Limited to 255 characters.
         version_added: '2.8'
 
 

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - block:
-  - name: Claim a device into an organization
-    meraki_device:
-      auth_key: '{{auth_key}}'
-      org_name: '{{test_org_name}}'
-      serial: '{{serial}}'
-      state: present
-    delegate_to: localhost
-    register: claim_device_org
+  # - name: Claim a device into an organization
+  #   meraki_device:
+  #     auth_key: '{{auth_key}}'
+  #     org_name: '{{test_org_name}}'
+  #     serial: '{{serial}}'
+  #     state: present
+  #   delegate_to: localhost
+  #   register: claim_device_org
 
-  - assert:
-      that:
-        - claim_device_org.changed == true
+  # - assert:
+  #     that:
+  #       - claim_device_org.changed == true
 
   - name: Query status of all devices in an organization
     meraki_device:
@@ -163,9 +163,6 @@
       note: Test device notes
     delegate_to: localhost
     register: update_device
-
-  - debug:
-      msg: '{{update_device.data.0.notes}}'
 
   - assert:
       that:

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -165,16 +165,16 @@
     register: update_device
 
   - debug:
-      msg: '{{update_device}}'
+      msg: '{{update_device.data.0.notes}}'
 
   - assert:
       that:
-        - update_device.data.note == "Test device notes"
+        - update_device.data.0.notes == "Test device notes"
 
-  # - assert:
-  #     that:
-  #       - update_device.changed == true
-  #       - '"1060 W. Addison St., Chicago, IL" in update_device.data.0.address'
+  - assert:
+      that:
+        - update_device.changed == true
+        - '"1060 W. Addison St., Chicago, IL" in update_device.data.0.address'
 
   - name: Update a device with idempotency
     meraki_device:

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -160,11 +160,16 @@
       tags: recently-added
       state: present
       move_map_marker: True
+      note: Test device notes
     delegate_to: localhost
     register: update_device
 
   - debug:
       msg: '{{update_device}}'
+
+  - assert:
+      that:
+        - update_device.data.note == "Test device notes"
 
   # - assert:
   #     that:

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -166,11 +166,8 @@
 
   - assert:
       that:
-        - update_device.data.0.notes == "Test device notes"
-
-  - assert:
-      that:
         - update_device.changed == true
+        - update_device.data.0.notes == "Test device notes"
         - '"1060 W. Addison St., Chicago, IL" in update_device.data.0.address'
 
   - name: Update a device with idempotency


### PR DESCRIPTION
##### SUMMARY
Meraki added support for adding device notes to a device via API. This PR adds a `note` parameter which allows assigning notes to a device.

Fixes #50962

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meraki_device