### PR TITLE
Add inhibit_copystat to copy module

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -114,6 +114,7 @@ options:
     - If this is not provided, or no, ansible will preserve historical behaviour of copying stats from src to dest.
     default: no
     type: bool
+    version_added: '2.8'
 extends_documentation_fragment:
 - decrypt
 - files


### PR DESCRIPTION
Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>

##### SUMMARY
Added the inhibit_copystat flag to copy to allow copy to succeed on platforms where stat values cannot be copied from src to dest.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
copy

##### ADDITIONAL INFORMATION
When running playbooks on HPE NonStop platforms, the shutil.copystat operation does not succeed
when copying files between legacy (GUARDIAN) and current file systems (OSS/POSIX). The stat values are incompatible and does not work of the dest file is in the always-three-level GUARDIAN space
(e.g., /G/disk/dir/file). This option will allow the copy operation to succeed. The author considered adding
to the except clause, but felt that the decision to enable this behaviour in general is not desirable, and should by by deliberate choice of the user of the copy module on platforms where this situation applies.