### PR TITLE
Added support for user-specified log file in win_package

### DIFF
--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -328,10 +328,10 @@ if ($state -eq "absent") {
             if ($program_metadata.msi -eq $true) {
                 # we are uninstalling an msi
                 if ( -Not $log_path ) { 
-                  $temp_path = [System.IO.Path]::GetTempPath()
-                  $log_file = [System.IO.Path]::GetRandomFileName()
-                  $log_path = Join-Path -Path $temp_path -ChildPath $log_file
-                  $cleanup_artifacts += $log_path
+                    $temp_path = [System.IO.Path]::GetTempPath()
+                    $log_file = [System.IO.Path]::GetRandomFileName()
+                    $log_path = Join-Path -Path $temp_path -ChildPath $log_file
+                    $cleanup_artifacts += $log_path
                 }
 
                 if ($program_metadata.product_id -ne $null) {
@@ -422,10 +422,10 @@ if ($state -eq "absent") {
             if ($program_metadata.msi -eq $true) {
                 # we are installing an msi
                 if ( -Not $log_path ) { 
-                  $temp_path = [System.IO.Path]::GetTempPath()
-                  $log_file = [System.IO.Path]::GetRandomFileName()
-                  $log_path = Join-Path -Path $temp_path -ChildPath $log_file
-                  $cleanup_artifacts += $log_path
+                    $temp_path = [System.IO.Path]::GetTempPath()
+                    $log_file = [System.IO.Path]::GetRandomFileName()
+                    $log_path = Join-Path -Path $temp_path -ChildPath $log_file
+                    $cleanup_artifacts += $log_path
                 }
 
                 $install_arguments = @("$env:windir\system32\msiexec.exe", "/i", $local_path, "/L*V", $log_path, "/qn", "/norestart")

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -25,6 +25,7 @@ $validate_certs = Get-AnsibleParam -obj $params -name "validate_certs" -type "bo
 $creates_path = Get-AnsibleParam -obj $params -name "creates_path" -type "path"
 $creates_version = Get-AnsibleParam -obj $params -name "creates_version" -type "str"
 $creates_service = Get-AnsibleParam -obj $params -name "creates_service" -type "str"
+$log_path = Get-AnsibleParam -obj $params -name "log_path" -type "path"
 
 $result = @{
     changed = $false
@@ -326,10 +327,12 @@ if ($state -eq "absent") {
 
             if ($program_metadata.msi -eq $true) {
                 # we are uninstalling an msi
-                $temp_path = [System.IO.Path]::GetTempPath()
-                $log_file = [System.IO.Path]::GetRandomFileName()
-                $log_path = Join-Path -Path $temp_path -ChildPath $log_file
-                $cleanup_artifacts += $log_path
+                if ( -Not $log_path ) { 
+                  $temp_path = [System.IO.Path]::GetTempPath()
+                  $log_file = [System.IO.Path]::GetRandomFileName()
+                  $log_path = Join-Path -Path $temp_path -ChildPath $log_file
+                  $cleanup_artifacts += $log_path
+                }
 
                 if ($program_metadata.product_id -ne $null) {
                     $id = $program_metadata.product_id
@@ -418,11 +421,13 @@ if ($state -eq "absent") {
 
             if ($program_metadata.msi -eq $true) {
                 # we are installing an msi
-                $temp_path = [System.IO.Path]::GetTempPath()
-                $log_file = [System.IO.Path]::GetRandomFileName()
-                $log_path = Join-Path -Path $temp_path -ChildPath $log_file
+                if ( -Not $log_path ) { 
+                  $temp_path = [System.IO.Path]::GetTempPath()
+                  $log_file = [System.IO.Path]::GetRandomFileName()
+                  $log_path = Join-Path -Path $temp_path -ChildPath $log_file
+                  $cleanup_artifacts += $log_path
+                }
 
-                $cleanup_artifacts += $log_path
                 $install_arguments = @("$env:windir\system32\msiexec.exe", "/i", $local_path, "/L*V", $log_path, "/qn", "/norestart")
             } else {
                 $log_path = $null

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -134,7 +134,7 @@ options:
     description:
     - Full path of log file.
     - This file will be kept regardless of overall success or failure
-    type: path
+    type: path.  This is only valid for MSI files, use arguments for other packages.
     version_added: '2.8'
 notes:
 - When C(state=absent) and the product is an exe, the path may be different
@@ -177,7 +177,7 @@ EXAMPLES = r'''
     - /install
     - /passive
     - /norestart
-    log_path: "D:\\logs\\vcredist_x64-exe-{{lookup('pipe', 'date +%Y%m%dT%H%M%S')}}.log"
+    log_path: D:\logs\vcredist_x64-exe-{{lookup('pipe', 'date +%Y%m%dT%H%M%S')}}.log
 
 - name: Install Remote Desktop Connection Manager from msi
   win_package:

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -133,8 +133,9 @@ options:
   log_path:
     description:
     - Full path of log file.
-    - This file will be kept regardless of overall success or failure
-    type: path.  This is only valid for MSI files, use arguments for other packages.
+    - This file will be kept regardless of overall success or failure.
+    - This is only valid for MSI files, use arguments for other packages.
+    type: path
     version_added: '2.8'
 notes:
 - When C(state=absent) and the product is an exe, the path may be different

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -132,9 +132,9 @@ options:
     version_added: '2.4'
   log_path:
     description:
-    - Full path of log file.
-    - This file will be kept regardless of overall success or failure.
-    - This is only valid for MSI files, use arguments for other packages.
+    - Specifies the path to a log file that is persisted after an MSI package is installed or uninstalled.
+    - When omitted, a temporary log file is used for MSI packages.
+    - This is only valid for MSI files, use C(arguments) for other package types.
     type: path
     version_added: '2.8'
 notes:

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -130,6 +130,12 @@ options:
     type: bool
     default: yes
     version_added: '2.4'
+  log_path:
+    description:
+    - Full path of log file.
+    - This file will be kept regardless of overall success or failure
+    type: path
+    version_added: '2.8'
 notes:
 - When C(state=absent) and the product is an exe, the path may be different
   from what was used to install the package originally. If path is not set then
@@ -163,7 +169,7 @@ EXAMPLES = r'''
     product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
     arguments: /install /passive /norestart
 
-- name: Install Visual C thingy with list of arguments instead of a string
+- name: Install Visual C thingy with list of arguments instead of a string, and permanent log
   win_package:
     path: http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
     product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
@@ -171,6 +177,7 @@ EXAMPLES = r'''
     - /install
     - /passive
     - /norestart
+    log_path: "D:\\logs\\vcredist_x64-exe-{{lookup('pipe', 'date +%Y%m%dT%H%M%S')}}.log"
 
 - name: Install Remote Desktop Connection Manager from msi
   win_package:

--- a/test/integration/targets/win_package/defaults/main.yml
+++ b/test/integration/targets/win_package/defaults/main.yml
@@ -2,8 +2,8 @@
 # spaces are tricky, let's have one by default
 test_win_package_path_safe: C:\ansible\win_package
 test_win_package_path: C:\ansible\win package
-test_win_package_log_path_install: C:\ansible\win_package\test-install.log
-test_win_package_log_path_uninstall: C:\ansible\win_package\test-uninstall.log
+test_win_package_log_path_install: C:\ansible\win package\test-install.log
+test_win_package_log_path_uninstall: C:\ansible\win package\test-uninstall.log
 test_win_package_good_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_package/good.msi
 test_win_package_reboot_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_package/reboot.msi
 test_win_package_bad_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_package/bad.msi

--- a/test/integration/targets/win_package/defaults/main.yml
+++ b/test/integration/targets/win_package/defaults/main.yml
@@ -2,6 +2,8 @@
 # spaces are tricky, let's have one by default
 test_win_package_path_safe: C:\ansible\win_package
 test_win_package_path: C:\ansible\win package
+test_win_package_log_path_install: C:\ansible\win_package\test-install.log
+test_win_package_log_path_uninstall: C:\ansible\win_package\test-uninstall.log
 test_win_package_good_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_package/good.msi
 test_win_package_reboot_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_package/reboot.msi
 test_win_package_bad_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_package/bad.msi

--- a/test/integration/targets/win_package/tasks/msi_tests.yml
+++ b/test/integration/targets/win_package/tasks/msi_tests.yml
@@ -25,10 +25,11 @@
     - install_local_msi_check.reboot_required == False
     - install_local_msi_actual_check.exists == False
 
-- name: install local msi
+- name: install local msi with log
   win_package:
     path: '{{test_win_package_path}}\good.msi'
     state: present
+    log_path: "{{test_win_package_log_path_install}}"
   register: install_local_msi
 
 - name: get result of install local msi
@@ -43,6 +44,16 @@
     - install_local_msi.reboot_required == False
     - install_local_msi.rc == 0
     - install_local_msi_actual.exists == True
+
+- name: get result of install local msi log_path
+  win_stat:
+    path: "{{test_win_package_log_path_install}}"
+  register: install_local_msi_actual_log_path
+
+- name: assert install local msi log path
+  assert:
+    that:
+    - install_local_msi_actual_log_path.stat.exists == True
 
 - name: install local msi (idempotent)
   win_package:
@@ -78,6 +89,7 @@
   win_package:
     path: '{{test_win_package_path}}\good.msi'
     state: absent
+    log_path: "{{test_win_package_log_path_uninstall}}"
   register: uninstall_path_local_msi
 
 - name: get result of uninstall local msi with path
@@ -92,6 +104,16 @@
     - uninstall_path_local_msi.reboot_required == False
     - uninstall_path_local_msi.rc == 0
     - uninstall_path_local_msi_actual.exists == False
+
+- name: get result of uninstall local msi with path
+  win_stat:
+    path: "{{test_win_package_log_path_uninstall}}"
+  register: uninstall_path_local_msi_actual_log_path
+
+- name: assert uninstall local msi with path
+  assert:
+    that:
+    - uninstall_path_local_msi_actual_log_path.stat.exists == True  # we expect log to remain
 
 - name: uninstall local msi with path (idempotent)
   win_package:


### PR DESCRIPTION
##### SUMMARY
Users often want the ability to refer back to installer logs long after a deployment is done. This feature provides an optional parameter to win_package to facilitate specifying a log path. Default/existing behaviour for log path is unchanged.

Fixes #38353

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_package

##### ADDITIONAL INFORMATION
Standard behaviour for msiexec seems to overwrite the nominated log file should it already exist.
Additionally, standard msiexec behaviour for a path that does not exist is to fail with 1622.

fatal: [sdcmkt-tstets21]: FAILED! => {
    "changed": false,
    "msg": "unexpected rc from install  C:\\Windows\\system32\\msiexec.exe /i D:\\good.msi /L*V D:\\no\\path\\good-present.log /qn /norestart: see rc, stdout and stderr for more details",
    "rc": 1622,
    "reboot_required": false,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Error opening installation log file.  Verify that the specified log file location exists and is writable.\n\r",
    "stdout_lines": [
        "Error opening installation log file.  Verify that the specified log file location exists and is writable.",
        ""
    ]
}