### PR TITLE
docker_swarm_service: Remove root as default user

### DIFF
--- a/changelogs/fragments/51110-docker_swarm_service-drop-user-default.yml
+++ b/changelogs/fragments/51110-docker_swarm_service-drop-user-default.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - Don't set ``root`` as the default user."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -162,7 +162,7 @@ Noteworthy module changes
 
 * The ``docker_service`` module was renamed to :ref:`docker_compose <docker_compose_module>`.
 
-* The ``docker_swarm_service`` module will no longer set a default for the user option.
+* The ``docker_swarm_service`` module no longer sets a default for the ``user`` option. Before, the default was ``root``.
 
 Plugins
 =======

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -162,6 +162,8 @@ Noteworthy module changes
 
 * The ``docker_service`` module was renamed to :ref:`docker_compose <docker_compose_module>`.
 
+* The ``docker_swarm_service`` module will no longer set a default for the user option.
+
 Plugins
 =======
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -325,6 +325,8 @@ options:
     required: false
     description:
     - Sets the username or UID used for the specified command.
+    - Before Ansible 2.8, the default value for this option was C(root).
+      The default has been removed so that the user defined in an image is used if no user is specified here.
 extends_documentation_fragment:
 - docker
 requirements:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -321,12 +321,10 @@ options:
     - Maps to docker service --update-order
     - Requires API version >= 1.29
   user:
+    type: str
     required: false
-    default: root
     description:
-    - username or UID.
-    - "If set to C(null) the image provided value (or the one already
-       set for the service) will be used"
+    - Sets the username or UID used for the specified command.
 extends_documentation_fragment:
 - docker
 requirements:
@@ -559,7 +557,7 @@ class DockerService(DockerBaseClass):
         self.reserve_cpu = 0.000
         self.reserve_memory = 0
         self.mode = "replicated"
-        self.user = "root"
+        self.user = None
         self.mounts = []
         self.configs = []
         self.secrets = []
@@ -1303,7 +1301,7 @@ def main():
         update_monitor=dict(default=5000000000, type='int'),
         update_max_failure_ratio=dict(default=0, type='float'),
         update_order=dict(default=None, type='str'),
-        user=dict(default='root'))
+        user=dict(type='str'))
 
     option_minimal_versions = dict(
         dns=dict(docker_py_version='2.6.0', docker_api_version='1.25'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -326,7 +326,7 @@ options:
     description:
     - Sets the username or UID used for the specified command.
     - Before Ansible 2.8, the default value for this option was C(root).
-      The default has been removed so that the user defined in an image is used if no user is specified here.
+      The default has been removed so that the user defined in the image is used if no user is specified here.
 extends_documentation_fragment:
 - docker
 requirements:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
As discussed in #49199 having `root` as the default user is not very good. It will override any user specified in a Dockerfile. It's very easy to miss that the user is overridden by this module and will make containers less secure.

Since this change breaks backwards compatibility some extra consideration needs to be taken in regards of the changelog and porting guide for Ansible 2.8.

Fixes #49199

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service