### PR TITLE
check for chroot in systemd module (#43904)

### DIFF
--- a/changelogs/fragments/systemd-warn-on-chroot.yaml
+++ b/changelogs/fragments/systemd-warn-on-chroot.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - systemd - warn when exeuting in a chroot environment rather than failing (https://github.com/ansible/ansible/pull/43904)

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -251,6 +251,7 @@ status:
 import os
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.facts.system.chroot import is_chroot
 from ansible.module_utils.service import sysv_exists, sysv_is_enabled, fail_if_missing
 from ansible.module_utils._text import to_native
 
@@ -486,6 +487,9 @@ def main():
                         (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
+            # check for chroot
+            elif is_chroot():
+                module.warn("Target is a chroot. This can lead to false positives or prevent the init system tools from working.")
             else:
                 # this should not happen?
                 module.fail_json(msg="Service is in unknown state", status=result['status'])


### PR DESCRIPTION
* check for result['status'] in systemd module

* instead of checking for result['state'], actually check for chroot and warn

* allow systemctl status to work if in a chroot, update warn text

* simply change warning message


(cherry picked from commit 37960ccc87fb3711893d986e6d512920e095044f)

##### SUMMARY
Checks for chroot and warn when managing service state w/ systemd module.

In a chrooted environment, `result['status']` doesn't exist, so basic service/systemd tasks w/ `state: started` fail.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
