### PR TITLE
[backport/2.7] Update vmware.py minor typo

### DIFF
--- a/changelogs/fragments/vmware_guest-documentation_fix.yaml
+++ b/changelogs/fragments/vmware_guest-documentation_fix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Fixed typo in vmware documentation fragment. Changed "supported added" to "support added".

--- a/lib/ansible/utils/module_docs_fragments/vmware.py
+++ b/lib/ansible/utils/module_docs_fragments/vmware.py
@@ -11,27 +11,27 @@ options:
       description:
       - The hostname or IP address of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_HOST) will be used instead.
-      - Environment variable supported added in version 2.6.
+      - Environment variable support added in version 2.6.
       type: str
     username:
       description:
       - The username of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_USER) will be used instead.
-      - Environment variable supported added in version 2.6.
+      - Environment variable support added in version 2.6.
       type: str
       aliases: [ admin, user ]
     password:
       description:
       - The password of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_PASSWORD) will be used instead.
-      - Environment variable supported added in version 2.6.
+      - Environment variable support added in version 2.6.
       type: str
       aliases: [ pass, pwd ]
     validate_certs:
       description:
       - Allows connection when SSL certificates are not valid. Set to C(false) when certificates are not trusted.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_VALIDATE_CERTS) will be used instead.
-      - Environment variable supported added in version 2.6.
+      - Environment variable support added in version 2.6.
       - If set to C(yes), please make sure Python >= 2.7.9 is installed on the given machine.
       type: bool
       default: 'yes'
@@ -39,7 +39,7 @@ options:
       description:
       - The port number of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_PORT) will be used instead.
-      - Environment variable supported added in version 2.6.
+      - Environment variable support added in version 2.6.
       type: int
       default: 443
       version_added: 2.5


### PR DESCRIPTION
##### SUMMARY
"supported added" changed to "support added"

(cherry picked from commit 0d97629e4d19586a3546eb573cf71781f737edc0)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_guest-documentation_fix.yaml
lib/ansible/utils/module_docs_fragments/vmware.py
