### PR TITLE
Fix for iam_role module error with Description key

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -337,7 +337,7 @@ def create_or_update_role(connection, module):
                 connection.add_role_to_instance_profile(InstanceProfileName=params['RoleName'], RoleName=params['RoleName'])
 
     # Check Description update
-    if not role.get('MadeInCheckMode') and params.get('Description') and role['Description'] != params['Description']:
+    if not role.get('MadeInCheckMode') and params.get('Description') and role.get('Description') != params.get('Description'):
         try:
             if not module.check_mode:
                 connection.update_role_description(RoleName=params['RoleName'], Description=params['Description'])


### PR DESCRIPTION
##### SUMMARY
Fixed issue with the iam_role module erroring with KeyError: 'Description' 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iam_role module

##### ADDITIONAL INFORMATION

When running playbook using iam_role and with description parameter, I got this error

```
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/stefan/.ansible/tmp/ansible-tmp-1548070982.8999336-244051620581222/AnsiballZ_iam_role.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/home/stefan/.ansible/tmp/ansible-tmp-1548070982.8999336-244051620581222/AnsiballZ_iam_role.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/stefan/.ansible/tmp/ansible-tmp-1548070982.8999336-244051620581222/AnsiballZ_iam_role.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.5/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.5/imp.py\", line 170, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 626, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 665, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 222, in _call_with_frames_removed\n  File \"/tmp/ansible_iam_role_payload_2h4y3of2/__main__.py\", line 515, in <module>\n  File \"/tmp/ansible_iam_role_payload_2h4y3of2/__main__.py\", line 509, in main\n  File \"/tmp/ansible_iam_role_payload_2h4y3of2/__main__.py\", line 340, in create_or_update_role\nKeyError: 'Description'\n",
```

With ansible --version
```
ansible 2.7.2
  config file = /home/stefan/mediapeers/vod-infrastructure/ansible.cfg
  configured module search path = ['/home/stefan/mediapeers/vod-infrastructure/library']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 12 2018, 13:43:14) [GCC 5.4.0 20160609]
```

Could fix it with attached change.