### PR TITLE
Fix example, clarify "macro_name" syntax

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -33,7 +33,7 @@ options:
         required: true
     macro_name:
         description:
-            - Name of the host macro.
+            - Name of the host macro without the enclosing curly braces and the leading dollar sign.
         required: true
     macro_value:
         description:
@@ -66,7 +66,7 @@ EXAMPLES = '''
     login_user: username
     login_password: password
     host_name: ExampleHost
-    macro_name: Example macro
+    macro_name: EXAMPLE.MACRO
     macro_value: Example value
     state: present
 '''


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
* Fix the macro name in example to use allowed characters.
* Clarify on the syntax for the "macro_name" parameter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_hostmacro