### PR TITLE
Update filetree.py to allow lists as input

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -181,7 +181,6 @@ class LookupModule(LookupBase):
                     ret += self.lookup_term(term_l, variables, **kwargs)
             else:
                 ret += self.lookup_term(term, variables, **kwargs)
-
         return ret
 
     def lookup_term(self, term, variables=None, **kwargs):

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -181,6 +181,7 @@ class LookupModule(LookupBase):
                     ret += self.lookup_term(term_l, variables, **kwargs)
             else:
                 ret += self.lookup_term(term, variables, **kwargs)
+                # change that should not affect the results of the tests
         return ret
 
     def lookup_term(self, term, variables=None, **kwargs):

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -169,7 +169,7 @@ def file_props(root, path):
 
     return ret
 
-  
+
 class LookupModule(LookupBase):
     def lookup_term(self, term, variables=None, **kwargs):
         basedir = self.get_basedir(variables)
@@ -191,7 +191,6 @@ class LookupModule(LookupBase):
                         ret.append(props)
         return ret
 
-      
     def run(self, terms, variables=None, **kwargs):
         ret = []
         for term in terms:

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -171,6 +171,19 @@ def file_props(root, path):
 
 
 class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        ret = []
+        for term in terms:
+            display.debug("Walking '{0}'".format(term))
+            if isinstance(term, list):
+                display.debug("List found, walking recursively")
+                for term_l in term:
+                    ret += self.lookup_term(term_l, variables, **kwargs)
+            else:
+                ret += self.lookup_term(term, variables, **kwargs)
+
+        return ret
+
     def lookup_term(self, term, variables=None, **kwargs):
         basedir = self.get_basedir(variables)
         term_file = os.path.basename(term)
@@ -189,17 +202,4 @@ class LookupModule(LookupBase):
                     if props is not None:
                         display.debug("  found '{0}'".format(os.path.join(path, relpath)))
                         ret.append(props)
-        return ret
-
-    def run(self, terms, variables=None, **kwargs):
-        ret = []
-        for term in terms:
-            display.debug("Walking '{0}'".format(term))
-            if isinstance(term, list):
-                display.debug("List found, walking recursively")
-                for term_l in term:
-                    ret += self.lookup_term(term_l, variables, **kwargs)
-            else:
-                ret += self.lookup_term(term, variables, **kwargs)
-
         return ret

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -169,8 +169,8 @@ def file_props(root, path):
 
     return ret
 
+  
 class LookupModule(LookupBase):
-
     def lookup_term(self, term, variables=None, **kwargs):
         basedir = self.get_basedir(variables)
         term_file = os.path.basename(term)
@@ -191,6 +191,7 @@ class LookupModule(LookupBase):
                         ret.append(props)
         return ret
 
+      
     def run(self, terms, variables=None, **kwargs):
         ret = []
         for term in terms:
@@ -203,5 +204,3 @@ class LookupModule(LookupBase):
                 ret += self.lookup_term(term, variables, **kwargs)
 
         return ret
-
-

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -189,22 +189,19 @@ class LookupModule(LookupBase):
                     if props is not None:
                         display.debug("  found '{0}'".format(os.path.join(path, relpath)))
                         ret.append(props)
-      return ret
+        return ret
 
     def run(self, terms, variables=None, **kwargs):
-        basedir = self.get_basedir(variables)
         ret = []
         for term in terms:
             display.debug("Walking '{0}'".format(term))
-            
-            if not isinstance(term, list):
-                t = self.lookup_term(term, variables, **kwargs)
-                if t:
-                        ret += t
+            if isinstance(term, list):
+                display.debug("List found, walking recursively")
+                for term_l in term:
+                    ret += self.lookup_term(term_l, variables, **kwargs)
             else:
-               for term_l in term:
-                   t= self.lookup_term(term_l, variables, **kwargs)
-                   if t:
-                       ret += t
+                ret += self.lookup_term(term, variables, **kwargs)
+
         return ret
+
 


### PR DESCRIPTION
Modified filetree.py to allow a list of elements. 
Issue: When there is a list of elements instead of only an element in the `with_filetree` like: 

```yaml
with_filetree:
  - element/1
  - element/2 
```

The program crashes with an error. Thanks to this patch the program should not crash anymore

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
