### PR TITLE
docker_swarm_service: Compare image by digest

### DIFF
--- a/changelogs/fragments/51134-docker_swarm_service-change-on-updated-image.yml
+++ b/changelogs/fragments/51134-docker_swarm_service-change-on-updated-image.yml
@@ -1,2 +1,2 @@
-bugfixes:
-  - "docker_swarm_service - Trigger a change when an image changes in a service."
+minor_changes:
+  - "docker_swarm_service - Resolve image digest from registry to detect and deploy changed images. This behaviour can be turned of by using the new option ``resolve_image: false``"

--- a/changelogs/fragments/51134-docker_swarm_service-change-on-updated-image.yml
+++ b/changelogs/fragments/51134-docker_swarm_service-change-on-updated-image.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - Trigger a change when an image changes in a service."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -331,6 +331,9 @@ requirements:
    (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
    Version 2.1.0 or newer is only available with the C(docker) module."
 - "Docker API >= 1.24"
+notes:
+- Images will only resolve to the latest digest when using Docker API >= 1.30 and docker-py >= 3.2.0. 
+  When using older versions use `force_update: true` to trigger the swarm to resolve a new image.
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -629,7 +629,6 @@ class DockerService(DockerBaseClass):
     def from_ansible_params(ap, old_service, image_digest):
         s = DockerService()
         s.image = image_digest
-        s.resolve_image = ap['resolve_image']
         s.constraints = ap['constraints']
         s.placement_preferences = ap['placement_preferences']
         s.args = ap['args']

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -332,8 +332,8 @@ requirements:
    Version 2.1.0 or newer is only available with the C(docker) module."
 - "Docker API >= 1.24"
 notes:
-- Images will only resolve to the latest digest when using Docker API >= 1.30 and docker-py >= 3.2.0. 
-  When using older versions use `force_update: true` to trigger the swarm to resolve a new image.
+  - "Images will only resolve to the latest digest when using Docker API >= 1.30 and docker-py >= 3.2.0.
+     When using older versions use C(force_update: true) to trigger the swarm to resolve a new image."
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -517,7 +517,6 @@ from ansible.module_utils.docker_common import (
     AnsibleDockerClient,
     DifferenceTracker,
     DockerBaseClass,
-    docker_version,
 )
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -34,6 +34,7 @@ options:
     default: true
     description:
       - If the current image digest should be resolved from registry and updated if changed.
+    version_added: 2.8      
   state:
     required: true
     default: present

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -575,7 +575,6 @@ class DockerService(DockerBaseClass):
         self.replicas = -1
         self.service_id = False
         self.service_version = False
-        self.resolve_image = None
         self.restart_policy = None
         self.restart_policy_attempts = None
         self.restart_policy_delay = None

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1138,7 +1138,11 @@ class DockerServiceManager():
         self.client.remove_service(name)
 
     def get_image_digest(self, name):
-        if not name or self.client.docker_py_version < LooseVersion('1.30'):
+        if (
+            not name
+            or self.client.docker_py_version < LooseVersion('3.2')
+            or self.client.docker_api_version < LooseVersion('1.30')
+        ):
             return name
         repo, tag = parse_repository_tag(name)
         if not tag:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -34,7 +34,7 @@ options:
     default: true
     description:
       - If the current image digest should be resolved from registry and updated if changed.
-    version_added: 2.8      
+    version_added: 2.8
   state:
     required: true
     default: present

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -624,7 +624,6 @@ class DockerService(DockerBaseClass):
         s.image = image_digest
         s.constraints = ap['constraints']
         s.placement_preferences = ap['placement_preferences']
-        s.image = ap['image']
         s.args = ap['args']
         s.endpoint_mode = ap['endpoint_mode']
         s.dns = ap['dns']

--- a/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
@@ -86,10 +86,14 @@
         published_port: 60001
         target_port: 60001
 
+- name: fake image key as it is not predictable
+  set_fact:
+    ansible_docker_service_output: "{{ output.ansible_docker_service|combine({'image': 'busybox'}) }}"
+
 - name: assert service matches expectations
   assert:
     that:
-      - output.ansible_docker_service == service_expected_output
+      - ansible_docker_service_output == service_expected_output
 
 - name: delete sample service
   register: output

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1188,6 +1188,43 @@
       - reserve_memory_3 is changed
 
 ###################################################################
+# resolve_image ###################################################
+###################################################################
+
+- name: resolve_image (false)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: false
+  register: resolve_image_1
+
+- name: resolve_image (false idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: false
+  register: resolve_image_2
+
+- name: resolve_image (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: true
+  register: resolve_image_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - resolve_image_1 is changed
+      - resolve_image_2 is not changed
+      - resolve_image_3 is changed
+
+###################################################################
 # restart_policy ##################################################
 ###################################################################
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR fixes so that a `docker_swarm_service` task will be marked as changed when the image is updated on the service. In the current version setting something like `image: hello-world:latest` will never be marked as changed after the first run. This is because we just compare the `user/repo:tag` and discards the image repo digest when comparing. This causes service_update to never be run and requires users to use `force_update:true` to actually update the image.

To fix this I use `APIClient.inspect_distribution(image_name)` to fetch the current digest of an image and then compare it with the value returned in `ContainerSpec['Image']`. 

This behaviour can be turned off by setting `resolve_image: false`.

`APIClient.inspect_distribution` is not available in docker api versions less than 1.30 or docker-py versions less than 3.2.0, for these users we'll fall back to the old behaviour. See:
https://docker-py.readthedocs.io/en/stable/change-log.html
https://github.com/docker/docker-py/blob/master/docker/api/image.py#L248


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service