### PR TITLE
Fix missing and misplaced tracebacks in ansible-inventory

### DIFF
--- a/changelogs/fragments/51136-fix-ansible-inventory-tracebacks.yml
+++ b/changelogs/fragments/51136-fix-ansible-inventory-tracebacks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix bug where some inventory parsing tracebacks were missing or reported under the wrong plugin.

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -21,8 +21,10 @@ __metaclass__ = type
 
 import fnmatch
 import os
+import sys
 import re
 import itertools
+import traceback
 
 from operator import attrgetter
 from random import shuffle
@@ -273,6 +275,9 @@ class InventoryManager(object):
                         break
                     except AnsibleParserError as e:
                         display.debug('%s was not parsable by %s' % (source, plugin_name))
+                        # Ansible error was created before the exception has been processed,
+                        # so traceback can only be obtained within this context
+                        e.tb = ''.join(traceback.format_tb(sys.exc_info()[2]))
                         failures.append({'src': source, 'plugin': plugin_name, 'exc': e})
                     except Exception as e:
                         display.debug('%s failed to parse %s' % (plugin_name, source))


### PR DESCRIPTION
##### SUMMARY
Errors from `ansible-inventory` (applies equally to `ansible-playbook`) were not giving the right traceback corresponding to the right inventory plugin. This would occur under the circumstances:

 - several consecutive plugins tried raised an AnsibleError

The first plugin would be missing a traceback. Then the 2nd plugin would have a traceback corresponding to the 1st plugin, and so-on.

This fixes that by saving the traceback in a context where it is available, and is a fix specific to the inventory manager.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/manager.py

##### ADDITIONAL INFORMATION
I had previously attempted this in another PR, but I've realized my error now, and the correct place to fix this. The comment has my rationale for the fix. Some code will perform:

```python
raise AnsibleError('foo')
```

Then if you catch this in a try-except, the `AnsibleError` class will not be able to capture the relevant traceback information in its `__init__` here:

https://github.com/ansible/ansible/blob/9169b7d2b99613ed112b7adc267a22c2e3d8164b/lib/ansible/errors/__init__.py#L75

This problem _cannot_ be fixed by patching the exception class. The exception object is initialized before the exception is raised. This seems hard to refute, since I could just as easily do:

```python
e = AnsibleError('foo')
# do some other stuff
raise e
```

In this example, it should be very clear that the exception information should not be available on the first line when `e` is created.

Here is a specific example with a particular error case I was investigating with before the fix / after the fix examples:

https://gist.github.com/AlanCoding/6583e251bdd05f6eb496062cc26172e9

In the `before.txt` file, the yaml plugin reports the error from the auto plugin. The ini plugin reports its own error. The yaml plugin is missing correct traceback information.

In the `after.txt` file, the traceback info for the yaml plugin is found, which was not given before, and the auto plugin has its traceback info moved back to the correct place. The ini plugin has its traceback changed, which seems to be because internally the plugin had caught another error before raising the AnsibleError.