### PR TITLE
Remove obsolete alias from nios_txt_record test.

### DIFF
--- a/test/integration/targets/nios_txt_record/aliases
+++ b/test/integration/targets/nios_txt_record/aliases
@@ -1,4 +1,3 @@
 shippable/cloud/group1
-posix/ci/cloud/group4/nios
 cloud/nios
 destructive


### PR DESCRIPTION
##### SUMMARY

Remove obsolete alias from nios_txt_record test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

nios_txt_record integration test
