### PR TITLE
Fix stray string in network_cli

### DIFF
--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -35,7 +35,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'aireos'
-        reply = self.get(b'show sysinfo')
+        reply = self.get('show sysinfo')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'Product Version\.* (.*)', data)
@@ -46,7 +46,7 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_hostname'] = match.group(1)
 
-        reply = self.get(b'show inventory')
+        reply = self.get('show inventory')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'DESCR: \"(.*)\"', data, re.M)
@@ -59,14 +59,14 @@ class Cliconf(CliconfBase):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':
-            cmd = b'show run-config commands'
+            cmd = 'show run-config commands'
         else:
-            cmd = b'show run-config startup-commands'
+            cmd = 'show run-config startup-commands'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'config'], to_list(command), [b'end']):
+        for cmd in chain(['config'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -35,7 +35,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'aruba'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'Version (\S+)', data)
@@ -46,7 +46,7 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_model'] = match.group(1)
 
-        reply = self.get(b'show hostname')
+        reply = self.get('show hostname')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'^Hostname is (.+)', data, re.M)
@@ -60,14 +60,14 @@ class Cliconf(CliconfBase):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':
-            cmd = b'show running-config all'
+            cmd = 'show running-config all'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+        for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/asa.py
+++ b/lib/ansible/plugins/cliconf/asa.py
@@ -35,7 +35,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'asa'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'Version (\S+),', data)
@@ -57,14 +57,14 @@ class Cliconf(CliconfBase):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':
-            cmd = b'show running-config all'
+            cmd = 'show running-config all'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+        for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/ce.py
+++ b/lib/ansible/plugins/cliconf/ce.py
@@ -35,7 +35,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'ce'
-        reply = self.get(b'display version')
+        reply = self.get('display version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'^Huawei.+\n.+\Version\s+(\S+)', data)

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -32,9 +32,9 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'cnos'
-        reply = self.get(b'show sys-info')
+        reply = self.get('show sys-info')
         data = to_text(reply, errors='surrogate_or_strict').strip()
-        host = self.get(b'show hostname')
+        host = self.get('show hostname')
         hostname = to_text(host, errors='surrogate_or_strict').strip()
         if data:
             device_info['network_os_version'] = self.parse_version(data)
@@ -70,14 +70,14 @@ class Cliconf(CliconfBase):
             msg = "fetching configuration from %s is not supported"
             return self.invalid_params(msg % source)
         if source == 'running':
-            cmd = b'show running-config'
+            cmd = 'show running-config'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+        for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -37,7 +37,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'dellos10'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'OS Version (\S+)', data)
@@ -48,7 +48,7 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_model'] = match.group(1)
 
-        reply = self.get(b'show running-configuration | grep hostname')
+        reply = self.get('show running-configuration | grep hostname')
         data = to_text(reply, errors='surrogate_or_strict').strip()
         match = re.search(r'^hostname (.+)', data, re.M)
         if match:
@@ -61,9 +61,9 @@ class Cliconf(CliconfBase):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':
-            cmd = b'show running-config all'
+            cmd = 'show running-config all'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
         return self.send_command(cmd)
 
     @enable_mode

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -37,7 +37,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'dellos6'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'Software Version (\S+)', data)
@@ -48,7 +48,7 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_model'] = match.group(1)
 
-        reply = self.get(b'show running-config | grep hostname')
+        reply = self.get('show running-config | grep hostname')
         data = to_text(reply, errors='surrogate_or_strict').strip()
         match = re.search(r'^hostname (.+)', data, re.M)
         if match:
@@ -61,14 +61,14 @@ class Cliconf(CliconfBase):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 #        if source == 'running':
-#            cmd = b'show running-config all'
+#            cmd = 'show running-config all'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+        for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -37,7 +37,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'dellos9'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'Software Version (\S+)', data)
@@ -48,7 +48,7 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_model'] = match.group(1)
 
-        reply = self.get(b'show running-config | grep hostname')
+        reply = self.get('show running-config | grep hostname')
         data = to_text(reply, errors='surrogate_or_strict').strip()
         match = re.search(r'^hostname (.+)', data, re.M)
         if match:
@@ -61,14 +61,14 @@ class Cliconf(CliconfBase):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 #        if source == 'running':
-#            cmd = b'show running-config all'
+#            cmd = 'show running-config all'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+        for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -32,7 +32,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'enos'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'^Software Version (.*?) ', data, re.M | re.I)
@@ -57,14 +57,14 @@ class Cliconf(CliconfBase):
             msg = "fetching configuration from %s is not supported"
             return self.invalid_params(msg % source)
         if source == 'running':
-            cmd = b'show running-config'
+            cmd = 'show running-config'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+        for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/exos.py
+++ b/lib/ansible/plugins/cliconf/exos.py
@@ -35,7 +35,7 @@ class Cliconf(CliconfBase):
         device_info = {}
         device_info['network_os'] = 'exos'
 
-        reply = self.get(b'show switch detail')
+        reply = self.get('show switch detail')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'ExtremeXOS version  (\S+)', data)
@@ -59,7 +59,7 @@ class Cliconf(CliconfBase):
             cmd = 'show configuration'
         else:
             cmd = 'debug cfgmgr show configuration file'
-            reply = self.get(b'show switch | include "Config Selected"')
+            reply = self.get('show switch | include "Config Selected"')
             data = to_text(reply, errors='surrogate_or_strict').strip()
             match = re.search(r': +(\S+)\.cfg', data)
             if match:

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -35,7 +35,7 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'ironware'
-        reply = self.send_command(b'show version')
+        reply = self.send_command('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'IronWare : Version (\S+),', data)
@@ -54,12 +54,12 @@ class Cliconf(CliconfBase):
             raise ValueError("fetching configuration from %s is not supported" % source)
 
         if source == 'running':
-            cmd = b'show running-config'
+            cmd = 'show running-config'
             if flags is not None:
                 cmd += ' ' + ' '.join(flags)
 
         else:
-            cmd = b'show configuration'
+            cmd = 'show configuration'
             if flags is not None:
                 raise ValueError("flags are only supported with running-config")
 
@@ -67,7 +67,7 @@ class Cliconf(CliconfBase):
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+        for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/nos.py
+++ b/lib/ansible/plugins/cliconf/nos.py
@@ -33,21 +33,21 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'nos'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'Network Operating System Version: (\S+)', data)
         if match:
             device_info['network_os_version'] = match.group(1)
 
-        reply = self.get(b'show chassis')
+        reply = self.get('show chassis')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'^Chassis Name:(\s+)(\S+)', data, re.M)
         if match:
             device_info['network_os_model'] = match.group(2)
 
-        reply = self.get(b'show running-config | inc "switch-attributes host-name"')
+        reply = self.get('show running-config | inc "switch-attributes host-name"')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'switch-attributes host-name (\S+)', data, re.M)

--- a/lib/ansible/plugins/cliconf/onyx.py
+++ b/lib/ansible/plugins/cliconf/onyx.py
@@ -33,14 +33,14 @@ class Cliconf(CliconfBase):
     def get_device_info(self):
         device_info = {}
 
-        reply = self.get(b'show version | json-print')
+        reply = self.get('show version | json-print')
         data = json.loads(reply)
         device_info['network_os'] = data['Product name']
         device_info['network_os_version'] = data['Product release']
         device_info['network_os_version_summary'] = data['Version summary']
         device_info['network_os_model'] = data['Product model']
 
-        reply = self.get(b'show hosts | include Hostname')
+        reply = self.get('show hosts | include Hostname')
         data = to_text(reply, errors='surrogate_or_strict').strip()
         hostname = data.split(':')[1]
         hostname = hostname.strip()
@@ -52,12 +52,12 @@ class Cliconf(CliconfBase):
     def get_config(self, source='running', format='text'):
         if source not in ('running',):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
-        cmd = b'show running-config'
+        cmd = 'show running-config'
         return self.send_command(cmd)
 
     @enable_mode
     def edit_config(self, command):
-        for cmd in chain([b'configure terminal'], to_list(command), [b'exit']):
+        for cmd in chain(['configure terminal'], to_list(command), ['exit']):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):

--- a/lib/ansible/plugins/cliconf/routeros.py
+++ b/lib/ansible/plugins/cliconf/routeros.py
@@ -35,19 +35,19 @@ class Cliconf(CliconfBase):
         device_info = {}
         device_info['network_os'] = 'RouterOS'
 
-        resource = self.get(b'/system resource print')
+        resource = self.get('/system resource print')
         data = to_text(resource, errors='surrogate_or_strict').strip()
         match = re.search(r'version: (\S+)', data)
         if match:
             device_info['network_os_version'] = match.group(1)
 
-        routerboard = self.get(b'/system routerboard print')
+        routerboard = self.get('/system routerboard print')
         data = to_text(routerboard, errors='surrogate_or_strict').strip()
         match = re.search(r'model: (.+)$', data, re.M)
         if match:
             device_info['network_os_model'] = match.group(1)
 
-        identity = self.get(b'/system identity print')
+        identity = self.get('/system identity print')
         data = to_text(identity, errors='surrogate_or_strict').strip()
         match = re.search(r'name: (.+)$', data, re.M)
         if match:

--- a/lib/ansible/plugins/cliconf/slxos.py
+++ b/lib/ansible/plugins/cliconf/slxos.py
@@ -35,21 +35,21 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'slxos'
-        reply = self.get(b'show version')
+        reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'SLX\-OS Operating System Version: (\S+)', data)
         if match:
             device_info['network_os_version'] = match.group(1)
 
-        reply = self.get(b'show chassis')
+        reply = self.get('show chassis')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'^Chassis Name:(\s+)(\S+)', data, re.M)
         if match:
             device_info['network_os_model'] = match.group(2)
 
-        reply = self.get(b'show running-config | inc "switch-attributes host-name"')
+        reply = self.get('show running-config | inc "switch-attributes host-name"')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'switch-attributes host-name (\S+)', data, re.M)

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -523,7 +523,7 @@ class Connection(NetworkConnectionBase):
                     self._ssh_shell.sendall(b'%s' % prompt_answer)
                     if newline:
                         self._ssh_shell.sendall(b'\r')
-                        prompt_answer += '\r'
+                        prompt_answer += b'\r'
                     self._log_messages("matched command prompt answer: %s" % prompt_answer)
                 if check_all and prompts and not single_prompt:
                     prompts.pop(0)

--- a/lib/ansible/plugins/terminal/ironware.py
+++ b/lib/ansible/plugins/terminal/ironware.py
@@ -30,12 +30,12 @@ from ansible.plugins.terminal import TerminalBase
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(r"[\r\n]?(?:\w+@)?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$")
+        re.compile(br"[\r\n]?(?:\w+@)?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$")
     ]
 
     terminal_stderr_re = [
-        re.compile(r"[\r\n]Error - "),
-        re.compile(r"[\r\n](?:incomplete|ambiguous|unrecognised|invalid) (?:command|input)", re.I)
+        re.compile(br"[\r\n]Error - "),
+        re.compile(br"[\r\n](?:incomplete|ambiguous|unrecognised|invalid) (?:command|input)", re.I)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This only hits on Python 3 when trying to use prompts which expect to be sent with a newline.

Also remove a lot of unnecessary `b'` string markers 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli