### PR TITLE
hiera version4 and version5 are not supported

### DIFF
--- a/lib/ansible/plugins/lookup/hiera.py
+++ b/lib/ansible/plugins/lookup/hiera.py
@@ -12,6 +12,7 @@ DOCUMENTATION = '''
     short_description: get info from hiera data
     requirements:
       - hiera (command line utility)
+      - hieradata format up to vesrsion 3
     description:
         - Retrieves data from an Puppetmaster node using Hiera as ENC
     options:


### PR DESCRIPTION
hiera tool is deprecated and should not be used anymore with
latest hieradata formats.

- https://puppet.com/docs/hiera/3.3/command_line.html#important-this-is-old-documentation-read-the-new-version-instead
- https://puppet.com/docs/hiera/3.3/command_line.html#important-this-is-old-documentation-read-the-new-version-instead

