### PR TITLE
Standardize cliconf get_capabilities

### DIFF
--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -165,39 +165,27 @@ from ansible.module_utils.connection import Connection
 from ansible.module_utils._text import to_text
 
 
-def validate_args(module, capabilities):
+def validate_args(module, device_operations):
     """validate param if it is supported on the platform
     """
-    device_operations = capabilities.get('device_operations')
-    if device_operations is None:
-        module.fail_json(msg="Platform does not provide 'device_operations', and cannot be used with cli_config.")
+    feature_list = [
+        'replace', 'rollback', 'commit_comment', 'defaults', 'multiline_delimiter',
+        'diff_replace', 'diff_match', 'diff_ignore_lines',
+    ]
 
-    if (module.params['replace'] and not device_operations['supports_replace']):
-        module.fail_json(msg='replace is not supported on this platform')
-
-    if (module.params['rollback'] is not None and not device_operations['supports_rollback']):
-        module.fail_json(msg='rollback is not supported on this platform')
-
-    if (module.params['commit_comment'] and not device_operations['supports_commit_comment']):
-        module.fail_json(msg='commit_comment is not supported on this platform')
-
-    if (module.params['defaults'] and not device_operations['supports_defaults']):
-        module.fail_json(msg='defaults is not supported on this platform')
-
-    if (module.params['multiline_delimiter'] and not device_operations['supports_multiline_delimiter']):
-        module.fail_json(msg='multiline_delimiter is not supported on this platform')
-
-    if (module.params['diff_replace'] and not device_operations['supports_diff_replace']):
-        module.fail_json(msg='diff_replace is not supported on this platform')
-
-    if (module.params['diff_match'] and not device_operations['supports_diff_match']):
-        module.fail_json(msg='diff_match is not supported on this platform')
-
-    if (module.params['diff_ignore_lines'] and not device_operations['supports_diff_ignore_lines']):
-        module.fail_json(msg='diff_ignore_lines is not supported on this platform')
+    for feature in feature_list:
+        if module.params[feature]:
+            supports_feature = device_operations.get('supports_%s' % feature)
+            if supports_feature is None:
+                module.fail_json(
+                    "This platform does not specify whether %s is supported or not. "
+                    "Please report an issue against this platform's cliconf plugin." % feature
+                )
+            elif not supports_feature:
+                module.fail_json(msg='Option %s is not supported on this platform' % feature)
 
 
-def run(module, capabilities, connection, candidate, running, rollback_id):
+def run(module, device_operations, connection, candidate, running, rollback_id):
     result = {}
     resp = {}
     config_diff = []
@@ -222,7 +210,7 @@ def run(module, capabilities, connection, candidate, running, rollback_id):
         if 'diff' in resp:
             result['changed'] = True
 
-    elif capabilities['device_operations']['supports_onbox_diff']:
+    elif device_operations.get('supports_onbox_diff'):
         if diff_replace:
             module.warn('diff_replace is ignored as the device supports onbox diff')
         if diff_match:
@@ -240,7 +228,7 @@ def run(module, capabilities, connection, candidate, running, rollback_id):
         if 'diff' in resp:
             result['changed'] = True
 
-    elif capabilities['device_operations']['supports_generate_diff']:
+    elif device_operations.get('supports_generate_diff'):
         kwargs = {'candidate': candidate, 'running': running}
         if diff_match:
             kwargs.update({'diff_match': diff_match})
@@ -322,7 +310,10 @@ def main():
     capabilities = module.from_json(connection.get_capabilities())
 
     if capabilities:
-        validate_args(module, capabilities)
+        device_operations = capabilities.get('device_operations', dict())
+        validate_args(module, device_operations)
+    else:
+        device_operations = dict()
 
     if module.params['defaults']:
         if 'get_default_flag' in capabilities.get('rpc'):
@@ -342,7 +333,7 @@ def main():
 
     if candidate or rollback_id:
         try:
-            result.update(run(module, capabilities, connection, candidate, running, rollback_id))
+            result.update(run(module, device_operations, connection, candidate, running, rollback_id))
         except Exception as exc:
             module.fail_json(msg=to_text(exc))
 

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -168,36 +168,32 @@ from ansible.module_utils._text import to_text
 def validate_args(module, capabilities):
     """validate param if it is supported on the platform
     """
-    if (module.params['replace'] and
-            not capabilities['device_operations']['supports_replace']):
+    device_operations = capabilities.get('device_operations')
+    if device_operations is None:
+        module.fail_json(msg="Platform does not provide 'device_operations', and cannot be used with cli_config.")
+
+    if (module.params['replace'] and not device_operations['supports_replace']):
         module.fail_json(msg='replace is not supported on this platform')
 
-    if (module.params['rollback'] is not None and
-            not capabilities['device_operations']['supports_rollback']):
+    if (module.params['rollback'] is not None and not device_operations['supports_rollback']):
         module.fail_json(msg='rollback is not supported on this platform')
 
-    if (module.params['commit_comment'] and
-            not capabilities['device_operations']['supports_commit_comment']):
+    if (module.params['commit_comment'] and not device_operations['supports_commit_comment']):
         module.fail_json(msg='commit_comment is not supported on this platform')
 
-    if (module.params['defaults'] and
-            not capabilities['device_operations']['supports_defaults']):
+    if (module.params['defaults'] and not device_operations['supports_defaults']):
         module.fail_json(msg='defaults is not supported on this platform')
 
-    if (module.params['multiline_delimiter'] and
-            not capabilities['device_operations']['supports_multiline_delimiter']):
+    if (module.params['multiline_delimiter'] and not device_operations['supports_multiline_delimiter']):
         module.fail_json(msg='multiline_delimiter is not supported on this platform')
 
-    if (module.params['diff_replace'] and
-            not capabilities['device_operations']['supports_diff_replace']):
+    if (module.params['diff_replace'] and not device_operations['supports_diff_replace']):
         module.fail_json(msg='diff_replace is not supported on this platform')
 
-    if (module.params['diff_match'] and
-            not capabilities['device_operations']['supports_diff_match']):
+    if (module.params['diff_match'] and not device_operations['supports_diff_match']):
         module.fail_json(msg='diff_match is not supported on this platform')
 
-    if (module.params['diff_ignore_lines'] and
-            not capabilities['device_operations']['supports_diff_ignore_lines']):
+    if (module.params['diff_ignore_lines'] and not device_operations['supports_diff_ignore_lines']):
         module.fail_json(msg='diff_ignore_lines is not supported on this platform')
 
 

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -281,8 +281,21 @@ class CliconfBase(AnsiblePlugin):
         result = {}
         result['rpc'] = self.get_base_rpc()
         result['device_operations'] = self.get_device_operations()
+        result['device_info'] = self.get_device_info()
         result['network_api'] = 'cliconf'
         return result
+
+    @abstractmethod
+    def get_device_info(self):
+        """Returns basic information about the network device.
+
+        This method will provide basic information about the device such as OS version and model
+        name. This data is expected to be used to fill the 'device_info' key in get_capabilities()
+        above.
+
+        :return: dictionary of device information
+        """
+        pass
 
     def get_device_operations(self):
         return {

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -278,7 +278,26 @@ class CliconfBase(AnsiblePlugin):
             }
         :return: capability as json string
         """
-        pass
+        result = {}
+        result['rpc'] = self.get_base_rpc()
+        result['device_operations'] = self.get_device_operations()
+        result['network_api'] = 'cliconf'
+        return result
+
+    def get_device_operations(self):
+        return {
+            'supports_commit': False,
+            'supports_replace': False,
+            'supports_rollback': False,
+            'supports_commit_comment': False,
+            'supports_defaults': False,
+            'supports_multiline_delimiter': False,
+            'supports_diff_replace': False,
+            'supports_diff_match': False,
+            'supports_diff_ignore_lines': False,
+            'supports_onbox_diff': False,
+            'supports_generate_diff': False,
+        }
 
     def commit(self, comment=None):
         """Commit configuration changes

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -280,7 +280,6 @@ class CliconfBase(AnsiblePlugin):
         """
         result = {}
         result['rpc'] = self.get_base_rpc()
-        result['device_operations'] = self.get_device_operations()
         result['device_info'] = self.get_device_info()
         result['network_api'] = 'cliconf'
         return result
@@ -296,21 +295,6 @@ class CliconfBase(AnsiblePlugin):
         :return: dictionary of device information
         """
         pass
-
-    def get_device_operations(self):
-        return {
-            'supports_commit': False,
-            'supports_replace': False,
-            'supports_rollback': False,
-            'supports_commit_comment': False,
-            'supports_defaults': False,
-            'supports_multiline_delimiter': False,
-            'supports_diff_replace': False,
-            'supports_diff_match': False,
-            'supports_diff_ignore_lines': False,
-            'supports_onbox_diff': False,
-            'supports_generate_diff': False,
-        }
 
     def commit(self, comment=None):
         """Commit configuration changes

--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -55,7 +55,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -74,5 +74,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -73,8 +73,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -75,5 +75,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -56,7 +56,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -74,8 +74,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/asa.py
+++ b/lib/ansible/plugins/cliconf/asa.py
@@ -71,8 +71,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/asa.py
+++ b/lib/ansible/plugins/cliconf/asa.py
@@ -53,7 +53,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/asa.py
+++ b/lib/ansible/plugins/cliconf/asa.py
@@ -72,5 +72,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/ce.py
+++ b/lib/ansible/plugins/cliconf/ce.py
@@ -87,5 +87,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/ce.py
+++ b/lib/ansible/plugins/cliconf/ce.py
@@ -86,8 +86,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -85,5 +85,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -84,8 +84,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -65,7 +65,7 @@ class Cliconf(CliconfBase):
         return "NA"
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             msg = "fetching configuration from %s is not supported"
             return self.invalid_params(msg % source)

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -76,5 +76,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -75,8 +75,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -57,7 +57,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -76,5 +76,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -57,7 +57,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 #        if source == 'running':

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -75,8 +75,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -76,5 +76,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -57,7 +57,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 #        if source == 'running':

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -75,8 +75,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -61,5 +61,4 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes']
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -38,7 +38,7 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         return self.send_command('show configuration commands')
 
     def edit_config(self, candidate=None, commit=True, replace=False, comment=None):

--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -59,8 +59,7 @@ class Cliconf(CliconfBase):
         self.send_command('discard')
 
     def get_capabilities(self):
-        result = {}
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes']
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -60,5 +60,5 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes']
+        result['rpc'] += ['commit', 'discard_changes']
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/edgeswitch.py
+++ b/lib/ansible/plugins/cliconf/edgeswitch.py
@@ -103,9 +103,8 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = dict()
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['run_commands']
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/edgeswitch.py
+++ b/lib/ansible/plugins/cliconf/edgeswitch.py
@@ -104,7 +104,7 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['run_commands']
+        result['rpc'] += ['run_commands']
         return json.dumps(result)
 
     def run_commands(self, commands=None, check_rc=True):

--- a/lib/ansible/plugins/cliconf/edgeswitch.py
+++ b/lib/ansible/plugins/cliconf/edgeswitch.py
@@ -105,7 +105,6 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['run_commands']
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)
 
     def run_commands(self, commands=None, check_rc=True):

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -71,8 +71,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -52,7 +52,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             msg = "fetching configuration from %s is not supported"
             return self.invalid_params(msg % source)

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -72,5 +72,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -274,6 +274,7 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] += ['commit', 'discard_changes', 'get_diff', 'run_commands', 'supports_sessions']
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
 
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -273,8 +273,7 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        rpc_list = ['commit', 'discard_changes', 'get_diff', 'run_commands', 'supports_sessions']
-        result['rpc'] = self.get_base_rpc() + rpc_list
+        result['rpc'] += ['commit', 'discard_changes', 'get_diff', 'run_commands', 'supports_sessions']
         result.update(self.get_option_values())
 
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -272,13 +272,11 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = {}
+        result = super(Cliconf, self).get_capabilities()
         rpc_list = ['commit', 'discard_changes', 'get_diff', 'run_commands', 'supports_sessions']
         result['rpc'] = self.get_base_rpc() + rpc_list
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
-        result['network_api'] = 'cliconf'
 
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -275,7 +275,6 @@ class Cliconf(CliconfBase):
         result = super(Cliconf, self).get_capabilities()
         rpc_list = ['commit', 'discard_changes', 'get_diff', 'run_commands', 'supports_sessions']
         result['rpc'] = self.get_base_rpc() + rpc_list
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
 
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/exos.py
+++ b/lib/ansible/plugins/cliconf/exos.py
@@ -115,6 +115,5 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/exos.py
+++ b/lib/ansible/plugins/cliconf/exos.py
@@ -114,10 +114,7 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/exos.py
+++ b/lib/ansible/plugins/cliconf/exos.py
@@ -115,5 +115,6 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -231,7 +231,7 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['edit_banner', 'get_diff', 'run_commands', 'get_defaults_flag']
+        result['rpc'] += ['edit_banner', 'get_diff', 'run_commands', 'get_defaults_flag']
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -232,7 +232,6 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['edit_banner', 'get_diff', 'run_commands', 'get_defaults_flag']
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -230,11 +230,9 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = dict()
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['edit_banner', 'get_diff', 'run_commands', 'get_defaults_flag']
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -232,6 +232,7 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] += ['edit_banner', 'get_diff', 'run_commands', 'get_defaults_flag']
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -235,6 +235,6 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'get_diff', 'configure', 'exit']
+        result['rpc'] += ['commit', 'discard_changes', 'get_diff', 'configure', 'exit']
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -236,6 +236,5 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'get_diff', 'configure', 'exit']
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -236,5 +236,6 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] += ['commit', 'discard_changes', 'get_diff', 'configure', 'exit']
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -234,10 +234,8 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = {}
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'get_diff', 'configure', 'exit']
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -75,5 +75,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -74,8 +74,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -231,6 +231,7 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] += ['commit', 'discard_changes', 'run_commands', 'compare_configuration', 'validate', 'get_diff']
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -229,11 +229,9 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = dict()
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'run_commands', 'compare_configuration', 'validate', 'get_diff']
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -231,7 +231,6 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'run_commands', 'compare_configuration', 'validate', 'get_diff']
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -230,7 +230,7 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'run_commands', 'compare_configuration', 'validate', 'get_diff']
+        result['rpc'] += ['commit', 'discard_changes', 'run_commands', 'compare_configuration', 'validate', 'get_diff']
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/nos.py
+++ b/lib/ansible/plugins/cliconf/nos.py
@@ -99,8 +99,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/nos.py
+++ b/lib/ansible/plugins/cliconf/nos.py
@@ -100,5 +100,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -245,7 +245,7 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['get_diff', 'run_commands']
+        result['rpc'] += ['get_diff', 'run_commands']
         result.update(self.get_option_values())
 
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -246,6 +246,7 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] += ['get_diff', 'run_commands']
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
 
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -246,7 +246,6 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['get_diff', 'run_commands']
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
 
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -244,12 +244,10 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = {}
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['get_diff', 'run_commands']
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
-        result['network_api'] = 'cliconf'
 
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/onyx.py
+++ b/lib/ansible/plugins/cliconf/onyx.py
@@ -65,5 +65,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/onyx.py
+++ b/lib/ansible/plugins/cliconf/onyx.py
@@ -64,8 +64,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/onyx.py
+++ b/lib/ansible/plugins/cliconf/onyx.py
@@ -49,7 +49,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format='text'):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running',):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         cmd = b'show running-config'

--- a/lib/ansible/plugins/cliconf/routeros.py
+++ b/lib/ansible/plugins/cliconf/routeros.py
@@ -66,5 +66,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/routeros.py
+++ b/lib/ansible/plugins/cliconf/routeros.py
@@ -65,8 +65,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/slxos.py
+++ b/lib/ansible/plugins/cliconf/slxos.py
@@ -92,5 +92,4 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/slxos.py
+++ b/lib/ansible/plugins/cliconf/slxos.py
@@ -91,8 +91,6 @@ class Cliconf(CliconfBase):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
-        result = {}
-        result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
+        result = super(Cliconf, self).get_capabilities()
         result['device_info'] = self.get_device_info()
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/voss.py
+++ b/lib/ansible/plugins/cliconf/voss.py
@@ -194,7 +194,6 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['get_diff', 'run_commands', 'get_defaults_flag']
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/voss.py
+++ b/lib/ansible/plugins/cliconf/voss.py
@@ -193,7 +193,7 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['get_diff', 'run_commands', 'get_defaults_flag']
+        result['rpc'] += ['get_diff', 'run_commands', 'get_defaults_flag']
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/voss.py
+++ b/lib/ansible/plugins/cliconf/voss.py
@@ -194,6 +194,7 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] += ['get_diff', 'run_commands', 'get_defaults_flag']
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/voss.py
+++ b/lib/ansible/plugins/cliconf/voss.py
@@ -192,11 +192,9 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = dict()
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['get_diff', 'run_commands', 'get_defaults_flag']
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
 

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -243,6 +243,5 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'get_diff', 'run_commands']
-        result['device_info'] = self.get_device_info()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -243,5 +243,6 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         result['rpc'] += ['commit', 'discard_changes', 'get_diff', 'run_commands']
+        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -241,10 +241,8 @@ class Cliconf(CliconfBase):
         }
 
     def get_capabilities(self):
-        result = {}
+        result = super(Cliconf, self).get_capabilities()
         result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'get_diff', 'run_commands']
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
-        result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -242,6 +242,6 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result['rpc'] = self.get_base_rpc() + ['commit', 'discard_changes', 'get_diff', 'run_commands']
+        result['rpc'] += ['commit', 'discard_changes', 'get_diff', 'run_commands']
         result.update(self.get_option_values())
         return json.dumps(result)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Provide default device_operations if not provided, and collect most capabilities automatically.

~~Could replace `result['rpc']` overwrites with appends?~~

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf