### PR TITLE
docker_swarm_service: temporarily disable tests

### DIFF
--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -3,3 +3,4 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+unstable


### PR DESCRIPTION
##### SUMMARY
There seem to be problems with the `docker_swarm_service` tests; see [here](https://github.com/ansible/ansible/pull/51145#issuecomment-456199128) or [here](https://github.com/ansible/ansible/pull/51110#issuecomment-456194320).

Temporarily disabling the tests until this problem is fixed.

CC @hannseman

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service
