### PR TITLE
Fix subprocess crash when base/required envvars missing

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1
@@ -259,8 +259,15 @@ namespace Ansible
             if (environment != null && environment.Count > 0)
             {
                 environmentString = new StringBuilder();
+
+                IDictionary existing_environment = Environment.GetEnvironmentVariables();
+                foreach (DictionaryEntry kv in existing_environment)
+                    if (!environment.Contains(kv.Key))
+                        environmentString.AppendFormat("{0}={1}\0", kv.Key, kv.Value);
+
                 foreach (DictionaryEntry kv in environment)
                     environmentString.AppendFormat("{0}={1}\0", kv.Key, kv.Value);
+
                 environmentString.Append('\0');
             }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #47669

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible.ModuleUtils.CommandUtil.psm1

##### ADDITIONAL INFORMATION
Reduced test case:
 1. Copy `lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1` to a temporary location on a Windows machine.
 1. Create the following file in the same folder as step 1 above:
    ```powershell
    Import-Module -Name .\Ansible.ModuleUtils.CommandUtil.psm1
    Run-Command -Command "powershell.exe -" -stdin "Write-Host 'foo'" -Environment @{"MY_VAR" = "abc"}
    ```

Expected result:
```
Name                           Value                                                                                                                                                                                                                             
----                           -----                                                                                                                                                                                                                             
stdout                         foo...                                                                                                                                                                                                                            
rc                             0                                                                                                                                                                                                                                 
stderr                                                                                                                                                                                                                                                           
executable                     C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
```

Result (before change):
```
Name                           Value                                                                                                                                                                                                                             
----                           -----                                                                                                                                                                                                                             
stdout                                                                                                                                                                                                                                                           
rc                             4294901760                                                                                                                                                                                                                        
stderr                         I n t e r n a l   W i n d o w s   P o w e r S h e l l   e r r o r .     L o a d i n g   m a n a g e d   W i n d o w s   P o w e r S h e l l   f a i l e d   w i t h   e r r o r   8 0 0 9 0 0 1 d . ...                           
executable                     C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
```

Result (after change) is as expected.

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
