### PR TITLE
win_chocolatey: Fix hang on missing/required base env vars

### DIFF
--- a/changelogs/fragments/win_chocolatey.yaml
+++ b/changelogs/fragments/win_chocolatey.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_chocolatey - Fix hang when used with proxy for the first time - https://github.com/ansible/ansible/issues/47669

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -213,6 +213,7 @@ Function Install-Chocolatey {
         if ($proxy_url) {
             # the env values are used in the install.ps1 script when getting
             # external dependencies
+            $environment = [Environment]::GetEnvironmentVariables()
             $environment.chocolateyProxyLocation = $proxy_url
             $web_proxy = New-Object -TypeName System.Net.WebProxy -ArgumentList $proxy_url, $true
             $client.Proxy = $web_proxy


### PR DESCRIPTION
##### SUMMARY
Fixes ansible/ansible#47669

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_chocolatey

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See ansible/ansible#47669 for repro steps.