### PR TITLE
win_chocolatey: Fix hang on missing/required base env vars (#51154)

### DIFF
--- a/changelogs/fragments/win_chocolatey.yaml
+++ b/changelogs/fragments/win_chocolatey.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_chocolatey - Fix hang when used with proxy for the first time - https://github.com/ansible/ansible/issues/47669

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -190,6 +190,7 @@ Function Install-Chocolatey {
         if ($proxy_url) {
             # the env values are used in the install.ps1 script when getting
             # external dependencies
+            $environment = [Environment]::GetEnvironmentVariables()
             $environment.chocolateyProxyLocation = $proxy_url
             $web_proxy = New-Object -TypeName System.Net.WebProxy -ArgumentList $proxy_url, $true
             $client.Proxy = $web_proxy


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
* win_chocolatey: Fix hang on missing/required base env vars

* Add changelog fragment

(cherry picked from commit 5540d667476665a2965ecdfca8d37a59a033a4eb)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey