### PR TITLE
New module postgresql_facts: Gathers facts about PostgreSQL servers.

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -542,7 +542,7 @@ class PgDbConn(object):
                 try:
                     self.cursor.execute('SET ROLE %s' % self.session_role)
                 except Exception as e:
-                    module.fail_json(msg="Could not switch role: %s" % to_native(e))
+                    self.module.fail_json(msg="Could not switch role: %s" % to_native(e))
 
             return self.cursor
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -281,7 +281,7 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_replication_slots')")
-        if not res[0][0]:
+        if not res[0]:
             return 0
 
         query = ("SELECT slot_name, plugin, slot_type, database, "
@@ -375,7 +375,7 @@ class PgClusterFacts(object):
         repl_dict = {}
 
         # If there is no replication:
-        if not res[0][0]:
+        if not res:
             return True
 
         for i in res:

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -144,7 +144,7 @@ class PgClusterFacts(object):
             "roles": {},
         }
 
-    def collect(self, include=[], exclude=[]):
+    def collect(self, include=False, exclude=False):
         subset_map = {
             "version": self.get_pg_version,
             "tablespaces": self.get_tablespaces,

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -893,8 +893,6 @@ def main():
     pg_facts = PgClusterFacts(module, cursor)
 
     if filter_:
-        #val_list = [s.strip(" \'][") for s in filter_.split(',')]
-        #kw['ansible_facts'] = pg_facts.collect(val_list)
         kw['ansible_facts'] = pg_facts.collect(filter_)
 
     else:

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -355,8 +355,8 @@ class PgClusterFacts(object):
         Get information about replication if the server is a master.
         """
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "
-                 "r.client_hostname, r.backend_start::text, r.state, "
-                 "r.replay_lag::text FROM pg_stat_replication AS r "
+                 "r.client_hostname, r.backend_start::text, r.state "
+                 "FROM pg_stat_replication AS r "
                  "JOIN pg_authid AS a ON r.usesysid = a.oid")
         res = self.__exec_sql(query)
         repl_dict = {}
@@ -382,7 +382,6 @@ class PgClusterFacts(object):
 
             repl_info["backend_start"] = i[5]
             repl_info["state"] = i[6]
-            repl_info["reply_lag"] = i[7]
 
             repl_dict[repl_pid] = repl_info
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -33,7 +33,6 @@ options:
     - If you pass including and excluding values to the filter, for example, I(filter=!settings,ver),
       the excluding values will be ignored.
     type: list
-    default: "*"
   db:
     description:
     - Name of database to connect.
@@ -840,7 +839,7 @@ def main():
     argument_spec = postgres_common_argument_spec()
     argument_spec.update(
         db=dict(type='str'),
-        filter=dict(type='str', default="*"),
+        filter=dict(type='list'),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(type='str'),
     )
@@ -893,9 +892,10 @@ def main():
     # Do job:
     pg_facts = PgClusterFacts(module, cursor)
 
-    if filter_ != "*":
-        val_list = [s.strip(" \'][") for s in filter_.split(',')]
-        kw['ansible_facts'] = pg_facts.collect(val_list)
+    if filter_:
+        #val_list = [s.strip(" \'][") for s in filter_.split(',')]
+        #kw['ansible_facts'] = pg_facts.collect(val_list)
+        kw['ansible_facts'] = pg_facts.collect(filter_)
 
     else:
         kw['ansible_facts'] = pg_facts.collect()

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -137,344 +137,339 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-postgresql_facts:
-  description: Dictionary containing the detailed information about the PostgreSQL instance.
+version:
+  description: Database server version U(https://www.postgresql.org/support/versioning/).
   returned: always
-  type: complex
+  type: dict
+  sample: { "version": { "major": 10, "minor": 6 } }
   contains:
-    version:
-      description: Database server version U(https://www.postgresql.org/support/versioning/).
+    major:
+      description: Major server version.
+      returned: always
+      type: int
+      sample: 11
+    minor:
+      description: Minor server version.
+      returned: always
+      type: int
+      sample: 1
+databases:
+  description: Information about databases.
+  returned: always
+  type: dict
+  sample:
+  - { "postgres": { "access_priv": "", "collate": "en_US.UTF-8",
+  "ctype": "en_US.UTF-8", "encoding": "UTF8", "owner": "postgres", "size": "7997 kB" } }
+  contains:
+    database_name:
+      description: Database name.
       returned: always
       type: dict
-      sample: { "version": { "major": 10, "minor": 6 } }
+      sample: template0
+      contains:
+        access_priv:
+          description: Database access privileges.
+          returned: always
+          type: str
+          sample: "=c/postgres_npostgres=CTc/postgres"
+        collate:
+          description:
+          - Database collation U(https://www.postgresql.org/docs/current/collation.html).
+          returned: always
+          type: str
+          sample: en_US.UTF-8
+        ctype:
+          description:
+          - Database LC_CTYPE U(https://www.postgresql.org/docs/current/multibyte.html).
+          returned: always
+          type: str
+          sample: en_US.UTF-8
+        encoding:
+          description:
+          - Database encoding U(https://www.postgresql.org/docs/current/multibyte.html).
+          returned: always
+          type: str
+          sample: UTF8
+        owner:
+          description:
+          - Database owner U(https://www.postgresql.org/docs/current/sql-createdatabase.html).
+          returned: always
+          type: str
+          sample: postgres
+        size:
+          description: Database size in bytes.
+          returned: always
+          type: str
+          sample: 8189415
+extensions:
+  description:
+  - Extensions U(https://www.postgresql.org/docs/current/sql-createextension.html).
+  returned: always
+  type: dict
+  sample:
+  - { "plpgsql": { "description": "PL/pgSQL procedural language",
+    "extversion": { "major": 1, "minor": 0 } } }
+  contains:
+    extdescription:
+      description: Extension description.
+      returned: if existent
+      type: str
+      sample: PL/pgSQL procedural language
+    extversion:
+      description: Extension description.
+      returned: always
+      type: dict
       contains:
         major:
-          description: Major server version.
-          returned: always
-          type: int
-          sample: 11
-        minor:
-          description: Minor server version.
+          description: Extension major version.
           returned: always
           type: int
           sample: 1
-    databases:
-      description: Information about databases.
-      returned: always
-      type: dict
-      sample:
-      - { "postgres": { "access_priv": "", "collate": "en_US.UTF-8",
-      "ctype": "en_US.UTF-8", "encoding": "UTF8", "owner": "postgres", "size": "7997 kB" } }
-      contains:
-        database_name:
-          description: Database name.
+        minor:
+          description: Extension minor version.
           returned: always
-          type: dict
-          sample: template0
-          contains:
-            access_priv:
-              description: Database access privileges.
-              returned: always
-              type: str
-              sample: "=c/postgres_npostgres=CTc/postgres"
-            collate:
-              description:
-              - Database collation U(https://www.postgresql.org/docs/current/collation.html).
-              returned: always
-              type: str
-              sample: en_US.UTF-8
-            ctype:
-              description:
-              - Database LC_CTYPE U(https://www.postgresql.org/docs/current/multibyte.html).
-              returned: always
-              type: str
-              sample: en_US.UTF-8
-            encoding:
-              description:
-              - Database encoding U(https://www.postgresql.org/docs/current/multibyte.html).
-              returned: always
-              type: str
-              sample: UTF8
-            owner:
-              description:
-              - Database owner U(https://www.postgresql.org/docs/current/sql-createdatabase.html).
-              returned: always
-              type: str
-              sample: postgres
-            size:
-              description: Database size in bytes.
-              returned: always
-              type: str
-              sample: 8189415
-    extensions:
-      description:
-      - Extensions U(https://www.postgresql.org/docs/current/sql-createextension.html).
-      returned: always
-      type: dict
-      sample:
-      - { "plpgsql": { "description": "PL/pgSQL procedural language",
-        "extversion": { "major": 1, "minor": 0 } } }
-      contains:
-        extdescription:
-          description: Extension description.
-          returned: if existent
-          type: str
-          sample: PL/pgSQL procedural language
-        extversion:
-          description: Extension description.
-          returned: always
-          type: dict
-          contains:
-            major:
-              description: Extension major version.
-              returned: always
-              type: int
-              sample: 1
-            minor:
-              description: Extension minor version.
-              returned: always
-              type: int
-              sample: 0
-        nspname:
-          description: Namecpase where the extension is.
-          returned: always
-          type: str
-          sample: pg_catalog
-    languages:
-      description: Procedural languages U(https://www.postgresql.org/docs/current/xplang.html).
-      returned: always
-      type: dict
-      sample: { "sql": { "lanacl": "", "lanowner": "postgres" } }
-      contains:
-        lanacl:
-          description:
-          - Language access privileges
-            U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-          returned: always
-          type: str
-          sample: "{postgres=UC/postgres,=U/postgres}"
-        lanowner:
-          description:
-          - Language owner U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-          returned: always
-          type: str
-          sample: postgres
-    namespaces:
-      description:
-      - Namespaces (schema) U(https://www.postgresql.org/docs/current/sql-createschema.html).
-      returned: always
-      type: dict
-      sample: { "pg_catalog": { "nspacl": "{postgres=UC/postgres,=U/postgres}", "nspowner": "postgres" } }
-      contains:
-        nspacl:
-          description:
-          - Assess privileges U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-          returned: always
-          type: str
-          sample: "{postgres=UC/postgres,=U/postgres}"
-        nspowner:
-          description:
-          - Schema owner U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-          returned: always
-          type: str
-          sample: postgres
-    repl_slots:
-      description:
-      - Replication slots (available in 9.4 and later)
-        U(https://www.postgresql.org/docs/current/catalog-pg-replication-slots.html).
-      returned: if existent
-      type: dict
-      sample: { "slot0": { "active": false, "database": null, "plugin": null, "slot_type": "physical" } }
-      contains:
-        active:
-          description: True if this slot is currently actively being used.
-          returned: always
-          type: bool
-          sample: true
-        database:
-          description: Database name this slot is associated with, or null.
-          returned: always
-          type: str
-          sample: acme
-        plugin:
-          description:
-          - The base name of the shared object containing the the output plugin
-            this logical slot is using, or null for physical slots.
-          returned: always
-          type: str
-          sample: pgoutput
-        slot_type:
-          description: The slot type - physical or logical.
-          returned: always
-          type: str
-          sample: logical
-    replications:
-      description:
-      - Information about the current replications by process PIDs
-        U(https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-STATS-VIEWS-TABLE).
-      returned: if pg_stat_replication view existent
-      type: dict
-      sample:
-      - { 76580: { "app_name": "standby1", "backend_start": "2019-02-03 00:14:33.908593+03",
-        "client_addr": "10.10.10.2", "client_hostname": "", "state": "streaming", "usename": "postgres" } }
-      contains:
-        usename:
-          description: Name of the user logged into this WAL sender process.
-          returned: always
-          type: str
-          sample: replication_user
-        app_name:
-          description: Name of the application that is connected to this WAL sender.
-          returned: if existent
-          type: str
-          sample: acme_srv
-        client_addr:
-          description:
-          - IP address of the client connected to this WAL sender.
-          - If this field is null, it indicates that the client is connected
-            via a Unix socket on the server machine.
-          returned: always
-          type: str
-          sample: 10.0.0.101
-        client_hostname:
-          description:
-          - Host name of the connected client, as reported by a reverse DNS lookup of client_addr.
-          - This field will only be non-null for IP connections, and only when log_hostname is enabled.
-          returned: always
-          type: str
-          sample: dbsrv1
-        backend_start:
-          description: Time when this process was started, i.e., when the client connected to this WAL sender.
-          returned: always
-          type: str
-          sample: "2019-02-03 00:14:33.908593+03"
-        state:
-          description: Current WAL sender state.
-          returned: always
-          type: str
-          sample: streaming
-    tablespaces:
-      description:
-      - Information about tablespaces U(https://www.postgresql.org/docs/current/catalog-pg-tablespace.html).
-      returned: always
-      type: dict
-      sample:
-      - { "test": { "spcacl": "{postgres=C/postgres,andreyk=C/postgres}", "spcoptions": [ "seq_page_cost=1" ],
-        "spcowner": "postgres" } }
-      contains:
-        spcacl:
-          description: Tablespace access privileges.
-          returned: always
-          type: str
-          sample: "{postgres=C/postgres,andreyk=C/postgres}"
-        spcoptions:
-          description: Tablespace-level options.
-          returned: always
-          type: list
-          sample: [ "seq_page_cost=1" ]
-        spcowner:
-          description: Owner of the tablespace.
-          returned: always
-          type: str
-          sample: test_user
-    roles:
-      description:
-      - Information about roles U(https://www.postgresql.org/docs/current/user-manag.html).
-      returned: always
-      type: dict
-      sample:
-      - { "test_role": { "canlogin": true, "member_of": [ "user_ro" ], "superuser": false,
-        "valid_until": "9999-12-31T23:59:59.999999+00:00" } }
-      contains:
-        canlogin:
-          description: Login privilege U(https://www.postgresql.org/docs/current/role-attributes.html).
-          returned: always
-          type: bool
-          sample: true
-        member_of:
-          description:
-          - Role membership U(https://www.postgresql.org/docs/current/role-membership.html).
-          returned: always
-          type: list
-          sample: [ "read_only_users" ]
-        superuser:
-          description: User is a superuser or not.
-          returned: always
-          type: bool
-          sample: false
-        valid_until:
-          description:
-          - Password expiration date U(https://www.postgresql.org/docs/current/sql-alterrole.html).
-          returned: always
-          type: str
-          sample: "9999-12-31T23:59:59.999999+00:00"
-    settings:
-      description:
-      - Information about run-time server parameters
-        U(https://www.postgresql.org/docs/current/view-pg-settings.html).
-      returned: always
-      type: dict
-      sample:
-      - { "work_mem": { "boot_val": "4096", "context": "user", "max_val": "2147483647",
-        "min_val": "64", "setting": "8192", "sourcefile": "/var/lib/pgsql/10/data/postgresql.auto.conf",
-        "unit": "kB", "vartype": "integer", "val_in_bytes": 4194304 } }
-      contains:
-        setting:
-          description: Current value of the parameter.
-          returned: always
-          type: str
-          sample: 49152
-        unit:
-          description: Implicit unit of the parameter.
-          returned: always
-          type: str
-          sample: kB
-        boot_val:
-          description:
-          - Parameter value assumed at server startup if the parameter is not otherwise set.
-          returned: always
-          type: str
-          sample: 4096
-        min_val:
-          description:
-          - Minimum allowed value of the parameter (null for non-numeric values).
-          returned: always
-          type: str
-          sample: 64
-        max_val:
-          description:
-          - Maximum allowed value of the parameter (null for non-numeric values).
-          returned: always
-          type: str
-          sample: 2147483647
-        sourcefile:
-          description:
-          - Configuration file the current value was set in.
-          - Null for values set from sources other than configuration files,
-            or when examined by a user who is neither a superuser or a member of pg_read_all_settings.
-          - Helpful when using include directives in configuration files.
-          returned: always
-          type: str
-          sample: /var/lib/pgsql/10/data/postgresql.auto.conf
-        context:
-          description:
-          - Context required to set the parameter's value.
-          - For more information see U(https://www.postgresql.org/docs/current/view-pg-settings.html).
-          returned: always
-          type: str
-          sample: user
-        vartype:
-          description:
-          - Parameter type (bool, enum, integer, real, or string).
-          returned: always
-          type: str
-          sample: integer
-        val_in_bytes:
-          description:
-          - Current value of the parameter in bytes.
-          returned: if supported
           type: int
-          sample: 2147483647
+          sample: 0
+    nspname:
+      description: Namecpase where the extension is.
+      returned: always
+      type: str
+      sample: pg_catalog
+languages:
+  description: Procedural languages U(https://www.postgresql.org/docs/current/xplang.html).
+  returned: always
+  type: dict
+  sample: { "sql": { "lanacl": "", "lanowner": "postgres" } }
+  contains:
+    lanacl:
+      description:
+      - Language access privileges
+        U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
+      returned: always
+      type: str
+      sample: "{postgres=UC/postgres,=U/postgres}"
+    lanowner:
+      description:
+      - Language owner U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
+      returned: always
+      type: str
+      sample: postgres
+namespaces:
+  description:
+  - Namespaces (schema) U(https://www.postgresql.org/docs/current/sql-createschema.html).
+  returned: always
+  type: dict
+  sample: { "pg_catalog": { "nspacl": "{postgres=UC/postgres,=U/postgres}", "nspowner": "postgres" } }
+  contains:
+    nspacl:
+      description:
+      - Assess privileges U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
+      returned: always
+      type: str
+      sample: "{postgres=UC/postgres,=U/postgres}"
+    nspowner:
+      description:
+      - Schema owner U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
+      returned: always
+      type: str
+      sample: postgres
+repl_slots:
+  description:
+  - Replication slots (available in 9.4 and later)
+    U(https://www.postgresql.org/docs/current/catalog-pg-replication-slots.html).
+  returned: if existent
+  type: dict
+  sample: { "slot0": { "active": false, "database": null, "plugin": null, "slot_type": "physical" } }
+  contains:
+    active:
+      description: True if this slot is currently actively being used.
+      returned: always
+      type: bool
+      sample: true
+    database:
+      description: Database name this slot is associated with, or null.
+      returned: always
+      type: str
+      sample: acme
+    plugin:
+      description:
+      - The base name of the shared object containing the the output plugin
+        this logical slot is using, or null for physical slots.
+      returned: always
+      type: str
+      sample: pgoutput
+    slot_type:
+      description: The slot type - physical or logical.
+      returned: always
+      type: str
+      sample: logical
+replications:
+  description:
+  - Information about the current replications by process PIDs
+    U(https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-STATS-VIEWS-TABLE).
+  returned: if pg_stat_replication view existent
+  type: dict
+  sample:
+  - { 76580: { "app_name": "standby1", "backend_start": "2019-02-03 00:14:33.908593+03",
+    "client_addr": "10.10.10.2", "client_hostname": "", "state": "streaming", "usename": "postgres" } }
+  contains:
+    usename:
+      description: Name of the user logged into this WAL sender process.
+      returned: always
+      type: str
+      sample: replication_user
+    app_name:
+      description: Name of the application that is connected to this WAL sender.
+      returned: if existent
+      type: str
+      sample: acme_srv
+    client_addr:
+      description:
+      - IP address of the client connected to this WAL sender.
+      - If this field is null, it indicates that the client is connected
+        via a Unix socket on the server machine.
+      returned: always
+      type: str
+      sample: 10.0.0.101
+    client_hostname:
+      description:
+      - Host name of the connected client, as reported by a reverse DNS lookup of client_addr.
+      - This field will only be non-null for IP connections, and only when log_hostname is enabled.
+      returned: always
+      type: str
+      sample: dbsrv1
+    backend_start:
+      description: Time when this process was started, i.e., when the client connected to this WAL sender.
+      returned: always
+      type: str
+      sample: "2019-02-03 00:14:33.908593+03"
+    state:
+      description: Current WAL sender state.
+      returned: always
+      type: str
+      sample: streaming
+tablespaces:
+  description:
+  - Information about tablespaces U(https://www.postgresql.org/docs/current/catalog-pg-tablespace.html).
+  returned: always
+  type: dict
+  sample:
+  - { "test": { "spcacl": "{postgres=C/postgres,andreyk=C/postgres}", "spcoptions": [ "seq_page_cost=1" ],
+    "spcowner": "postgres" } }
+  contains:
+    spcacl:
+      description: Tablespace access privileges.
+      returned: always
+      type: str
+      sample: "{postgres=C/postgres,andreyk=C/postgres}"
+    spcoptions:
+      description: Tablespace-level options.
+      returned: always
+      type: list
+      sample: [ "seq_page_cost=1" ]
+    spcowner:
+      description: Owner of the tablespace.
+      returned: always
+      type: str
+      sample: test_user
+roles:
+  description:
+  - Information about roles U(https://www.postgresql.org/docs/current/user-manag.html).
+  returned: always
+  type: dict
+  sample:
+  - { "test_role": { "canlogin": true, "member_of": [ "user_ro" ], "superuser": false,
+    "valid_until": "9999-12-31T23:59:59.999999+00:00" } }
+  contains:
+    canlogin:
+      description: Login privilege U(https://www.postgresql.org/docs/current/role-attributes.html).
+      returned: always
+      type: bool
+      sample: true
+    member_of:
+      description:
+      - Role membership U(https://www.postgresql.org/docs/current/role-membership.html).
+      returned: always
+      type: list
+      sample: [ "read_only_users" ]
+    superuser:
+      description: User is a superuser or not.
+      returned: always
+      type: bool
+      sample: false
+    valid_until:
+      description:
+      - Password expiration date U(https://www.postgresql.org/docs/current/sql-alterrole.html).
+      returned: always
+      type: str
+      sample: "9999-12-31T23:59:59.999999+00:00"
+settings:
+  description:
+  - Information about run-time server parameters
+    U(https://www.postgresql.org/docs/current/view-pg-settings.html).
+  returned: always
+  type: dict
+  sample:
+  - { "work_mem": { "boot_val": "4096", "context": "user", "max_val": "2147483647",
+    "min_val": "64", "setting": "8192", "sourcefile": "/var/lib/pgsql/10/data/postgresql.auto.conf",
+    "unit": "kB", "vartype": "integer", "val_in_bytes": 4194304 } }
+  contains:
+    setting:
+      description: Current value of the parameter.
+      returned: always
+      type: str
+      sample: 49152
+    unit:
+      description: Implicit unit of the parameter.
+      returned: always
+      type: str
+      sample: kB
+    boot_val:
+      description:
+      - Parameter value assumed at server startup if the parameter is not otherwise set.
+      returned: always
+      type: str
+      sample: 4096
+    min_val:
+      description:
+      - Minimum allowed value of the parameter (null for non-numeric values).
+      returned: always
+      type: str
+      sample: 64
+    max_val:
+      description:
+      - Maximum allowed value of the parameter (null for non-numeric values).
+      returned: always
+      type: str
+      sample: 2147483647
+    sourcefile:
+      description:
+      - Configuration file the current value was set in.
+      - Null for values set from sources other than configuration files,
+        or when examined by a user who is neither a superuser or a member of pg_read_all_settings.
+      - Helpful when using include directives in configuration files.
+      returned: always
+      type: str
+      sample: /var/lib/pgsql/10/data/postgresql.auto.conf
+    context:
+      description:
+      - Context required to set the parameter's value.
+      - For more information see U(https://www.postgresql.org/docs/current/view-pg-settings.html).
+      returned: always
+      type: str
+      sample: user
+    vartype:
+      description:
+      - Parameter type (bool, enum, integer, real, or string).
+      returned: always
+      type: str
+      sample: integer
+    val_in_bytes:
+      description:
+      - Current value of the parameter in bytes.
+      returned: if supported
+      type: int
+      sample: 2147483647
 '''
 
 from fnmatch import fnmatch
@@ -716,6 +711,9 @@ class PgClusterFacts(object):
 
             elif unit == 'MB':
                 val_in_bytes = int(setting) * 1024 * 1024
+
+            if val_in_bytes < 0:
+                val_in_bytes = 0
 
             set_dict[i[0]] = dict(
                 setting=setting,

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -232,7 +232,7 @@ class PgClusterFacts(object):
             ext_name = i[0]
             ext_info = {}
             ext_info["extversion"] = i[1]
-            ext_info["nspame"] = i[2]
+            ext_info["nspname"] = i[2]
             ext_info["description"] = i[3]
             ext_dict[ext_name] = ext_info
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -310,8 +310,8 @@ class PgClusterFacts(object):
         Get server settings.
         """
         query = ("SELECT name, setting, unit, context, vartype, "
-                 "boot_val, min_val, max_val, sourcefile, "
-                 "pending_restart FROM pg_settings")
+                 "boot_val, min_val, max_val, sourcefile "
+                 "FROM pg_settings")
         res = self.__exec_sql(query)
 
         set_dict = {}
@@ -346,11 +346,6 @@ class PgClusterFacts(object):
                 set_info["sourcefile"] = i[8]
             else:
                 set_info["sourcefile"] = ""
-
-            if i[9]:
-                set_info["pending_restart"] = i[9]
-            else:
-                set_info["pending_restart"] = ""
 
             set_dict[set_name] = set_info
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -68,6 +68,7 @@ options:
         certificate(s). If the file exists, the server's certificate will be
         verified to be signed by one of these authorities.
 notes:
+   - PostgreSQL server must be 9.4 version or later.
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
    - This module uses psycopg2, a Python PostgreSQL database adapter. You must
@@ -355,8 +356,8 @@ class PgClusterFacts(object):
         Get information about replication if the server is a master.
         """
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "
-                 "r.client_hostname, r.backend_start::text, r.state "
-                 "FROM pg_stat_replication AS r "
+                 "r.client_hostname, r.backend_start::text, r.state, "
+                 "r.replay_lag::text FROM pg_stat_replication AS r "
                  "JOIN pg_authid AS a ON r.usesysid = a.oid")
         res = self.__exec_sql(query)
         repl_dict = {}
@@ -382,6 +383,7 @@ class PgClusterFacts(object):
 
             repl_info["backend_start"] = i[5]
             repl_info["state"] = i[6]
+            repl_info["reply_lag"] = i[7]
 
             repl_dict[repl_pid] = repl_info
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -476,6 +476,12 @@ settings:
       returned: if supported
       type: int
       sample: 2147483647
+    pretty_val:
+      description:
+      - Value presented in the pretty form.
+      returned: always
+      type: str
+      sample: 2MB
 '''
 
 from fnmatch import fnmatch
@@ -742,7 +748,10 @@ class PgClusterFacts(object):
             if val_in_bytes is not None and val_in_bytes < 0:
                 val_in_bytes = 0
 
-            set_dict[i[0]] = dict(
+            setting_name = i[0]
+            pretty_val = self.__get_pretty_val(setting_name)
+
+            set_dict[setting_name] = dict(
                 setting=setting,
                 unit=unit,
                 context=i[3],
@@ -751,9 +760,10 @@ class PgClusterFacts(object):
                 min_val=i[6] if i[6] else '',
                 max_val=i[7] if i[7] else '',
                 sourcefile=i[8] if i[8] else '',
+                pretty_val=pretty_val,
             )
             if val_in_bytes is not None:
-                set_dict[i[0]]['val_in_bytes'] = val_in_bytes
+                set_dict[setting_name]['val_in_bytes'] = val_in_bytes
 
         self.pg_facts["settings"] = set_dict
 
@@ -873,6 +883,9 @@ class PgClusterFacts(object):
             db_dict[datname]['languages'] = self.get_lang_info()
 
         self.pg_facts["databases"] = db_dict
+
+    def __get_pretty_val(self, setting):
+        return self.__exec_sql("SHOW %s" % setting)[0][0]
 
     def __exec_sql(self, query):
         try:

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -281,7 +281,7 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_replication_slots')")
-        if res[0] == 'f':
+        if not res[0][0]:
             return 0
 
         query = ("SELECT slot_name, plugin, slot_type, database, "
@@ -364,7 +364,7 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_stat_replication')")
-        if res[0] == 'f':
+        if not res[0][0]:
             return 0
 
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -1,0 +1,565 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+DOCUMENTATION = '''
+---
+module: postgresql_facts
+short_description: Gathers facts about remote PostgreSQL servers.
+description:
+   - Gathers facts about remote PostgreSQL servers.
+version_added: "2.8"
+options:
+  include_subset:
+    description:
+      - Limit collected subsets by comma separated list. Allowable values are C(version),
+        C(databases), C(settings), C(tablespaces), C(languages), C(roles), C(namespaces),
+        C(replications), C(repl_slots). By default, collects all subsets.
+        You can use shell-style (fnmatch) wildcard to pass groups of values (see Examples).
+    default: '*'
+  exclude_subset:
+    description:
+      - Exclude subsets from the collection. Allowable values are similar as in I(include_subset).
+        You can also use shell-style (fnmatch) wildcard. Mutually exclusive with include_subset.
+  db:
+    description:
+      - Name of database to connect.
+  port:
+    description:
+      - Database port to connect.
+    default: 5432
+  login_user:
+    description:
+      - User (role) used to authenticate with PostgreSQL.
+    default: postgres
+  login_password:
+    description:
+      - Password used to authenticate with PostgreSQL.
+  login_host:
+    description:
+      - Host running PostgreSQL.
+  login_unix_socket:
+    description:
+      - Path to a Unix domain socket for local connections.
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection
+        will be negotiated with the server.
+      - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
+        more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    default: prefer
+    choices: ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA)
+        certificate(s). If the file exists, the server's certificate will be
+        verified to be signed by one of these authorities.
+notes:
+   - The default authentication assumes that you are either logging in as or
+     sudo'ing to the postgres account on the host.
+   - This module uses psycopg2, a Python PostgreSQL database adapter. You must
+     ensure that psycopg2 is installed on the host before using this module. If
+     the remote host is the PostgreSQL server (which is the default case), then
+     PostgreSQL must also be installed on the remote host. For Ubuntu-based
+     systems, install the postgresql, libpq-dev, and python-psycopg2 packages
+     on the remote host before using this module.
+requirements: [ psycopg2 ]
+author: "Andrew Klychkov (@Andersson007)"
+'''
+
+EXAMPLES = '''
+# Display facts from postgres hosts.
+# ansible postgres -m postgresql_facts
+
+# Display only databases and roles facts from all hosts using shell-style wildcards:
+# ansible all -m postgresql_facts -a "include_subset=dat*,rol*"
+
+# Display only replications and repl_slots facts from standby hosts using shell-style wildcards:
+# ansible standby -m postgresql_facts -a "include_subset=repl*"
+
+# Display all facts from databases hosts except settings:
+# ansible databases -m postgresql_facts -a "exclude_subset=settings"
+
+- name: Collect PostgreSQL version
+  postgresql_facts:
+    include_subset: ver*
+
+- name: Collect all subsets, excluding settings and roles
+  postgresql_facts:
+    exclude_subset: settings, roles
+'''
+
+RETURN = ''' # '''
+
+
+import traceback
+from fnmatch import fnmatch
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    HAS_PSYCOPG2 = False
+else:
+    HAS_PSYCOPG2 = True
+
+import ansible.module_utils.postgres as pgutils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.database import SQLParseError
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems
+
+
+# ===========================================
+# PostgreSQL module specific support methods.
+#
+
+
+class PgClusterFacts(object):
+    def __init__(self, module, cursor):
+        self.module = module
+        self.cursor = cursor
+        self.pg_facts = {
+            "version": "",
+            "tablespaces": {},
+            "databases": {},
+            "languages": {},
+            "namespaces": {},
+            "replications": {},
+            "repl_slots": {},
+            "settings": {},
+            "roles": {},
+        }
+
+    def collect(self, include=[], exclude=[]):
+        subset_map = {
+            "version": self.get_pg_version,
+            "tablespaces": self.get_tablespaces,
+            "databases": self.get_db_info,
+            "languages": self.get_lang_info,
+            "namespaces": self.get_namespaces,
+            "replications": self.get_repl_info,
+            "repl_slots": self.get_rslot_info,
+            "settings": self.get_settings,
+            "roles": self.get_role_info,
+        }
+
+        if include:
+            # Collect info:
+            for s in subset_map:
+                for i in include:
+                    if fnmatch(s, i):
+                        subset_map[s]()
+                        break
+
+        elif exclude:
+            found = False
+            # Collect info:
+            for s in subset_map:
+                for e in exclude:
+                    if fnmatch(s, e):
+                        found = True
+
+                if not found:
+                    subset_map[s]()
+                else:
+                    found = False
+
+        # Default behaviour, if include or exclude is not passed:
+        else:
+            # Just collect info for each item:
+            for s in subset_map:
+                subset_map[s]()
+
+        return self.pg_facts
+
+    def get_tablespaces(self):
+        """
+        Get information about tablespaces.
+        """
+        query = ("SELECT s.spcname, a.rolname, s.spcacl, s.spcoptions "
+                 "FROM pg_tablespace AS s "
+                 "JOIN pg_authid AS a ON s.spcowner = a.oid")
+        res = self.__exec_sql(query)
+        ts_dict = {}
+        for i in res:
+            ts_name = i[0]
+            ts_info = {}
+            ts_info["spcowner"] = i[1]
+            if i[2]:
+                ts_info["spcacl"] = i[2]
+            else:
+                ts_info["spcacl"] = ""
+
+            if i[3]:
+                ts_info["spcoptions"] = i[3]
+            else:
+                ts_info["spcoptions"] = []
+
+            ts_dict[ts_name] = ts_info
+
+        self.pg_facts["tablespaces"] = ts_dict
+
+    def get_role_info(self):
+        """
+        Get information about roles (in PgSQL groups and users are roles).
+        """
+        query = ("SELECT r.rolname, r.rolsuper, r.rolcanlogin, "
+                 "r.rolvaliduntil, "
+                 "ARRAY(SELECT b.rolname "
+                 "FROM pg_catalog.pg_auth_members AS m "
+                 "JOIN pg_catalog.pg_roles AS b ON (m.roleid = b.oid) "
+                 "WHERE m.member = r.oid) AS memberof "
+                 "FROM pg_catalog.pg_roles AS r "
+                 "WHERE r.rolname !~ '^pg_'")
+
+        res = self.__exec_sql(query)
+        rol_dict = {}
+        for i in res:
+            rol_name = i[0]
+            rol_info = {}
+            rol_info["superuser"] = i[1]
+            rol_info["canlogin"] = i[2]
+
+            if i[3]:
+                rol_info["valid_until"] = i[3]
+            else:
+                rol_info["valid_until"] = ""
+
+            if i[4]:
+                rol_info["member_of"] = i[4]
+            else:
+                rol_info["member_of"] = []
+
+            rol_dict[rol_name] = rol_info
+
+        self.pg_facts["roles"] = rol_dict
+
+    def get_rslot_info(self):
+        """
+        Get information about replication slots if exist.
+        """
+        query = ("SELECT slot_name, plugin, slot_type, database, temporary, "
+                 "active FROM pg_replication_slots")
+        res = self.__exec_sql(query)
+
+        # If there is no replication:
+        if not res:
+            return True
+
+        rslot_dict = {}
+        for i in res:
+            rslot_name = i[0]
+            rslot_info = {}
+            rslot_info["plugin"] = i[1]
+            rslot_info["slot_type"] = i[2]
+            rslot_info["database"] = i[3]
+            rslot_info["temporaty"] = i[4]
+            rslot_info["active"] = i[5]
+
+            rslot_dict[rslot_name] = rslot_info
+
+        self.pg_facts["repl_slots"] = rslot_dict
+
+    def get_settings(self):
+        """
+        Get server settings.
+        """
+        query = ("SELECT name, setting, unit, context, vartype, "
+                 "boot_val, min_val, max_val, sourcefile, "
+                 "pending_restart FROM pg_settings")
+        res = self.__exec_sql(query)
+
+        set_dict = {}
+        for i in res:
+            set_name = i[0]
+            set_info = {}
+            set_info["setting"] = i[1]
+
+            if i[2]:
+                set_info["unit"] = i[2]
+            else:
+                set_info["unit"] = ""
+
+            set_info["context"] = i[3]
+            set_info["vartype"] = i[4]
+            if i[5]:
+                set_info["boot_val"] = i[5]
+            else:
+                set_info["boot_val"] = ""
+
+            if i[6]:
+                set_info["min_val"] = i[6]
+            else:
+                set_info["min_val"] = ""
+
+            if i[7]:
+                set_info["max_val"] = i[7]
+            else:
+                set_info["max_val"] = ""
+
+            if i[8]:
+                set_info["sourcefile"] = i[8]
+            else:
+                set_info["sourcefile"] = ""
+
+            if i[9]:
+                set_info["pending_restart"] = i[9]
+            else:
+                set_info["pending_restart"] = ""
+
+            set_dict[set_name] = set_info
+
+        self.pg_facts["settings"] = set_dict
+
+    def get_repl_info(self):
+        """
+        Get information about replication if the server is a master.
+        """
+        query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "
+                 "r.client_hostname, r.backend_start::text, r.state, "
+                 "r.replay_lag::text FROM pg_stat_replication AS r "
+                 "JOIN pg_authid AS a ON r.usesysid = a.oid")
+        res = self.__exec_sql(query)
+        repl_dict = {}
+
+        # If there is no replication:
+        if not res:
+            return True
+
+        for i in res:
+            repl_pid = i[0]
+            repl_info = {}
+            repl_info["usesysid"] = i[1]
+            if i[2]:
+                repl_info["app_name"] = i[2]
+            else:
+                repl_info["app_name"] = ""
+
+            repl_info["client_addr"] = i[3]
+            if i[4]:
+                repl_info["client_hostname"] = i[4]
+            else:
+                repl_info["client_hostname"] = ""
+
+            repl_info["backend_start"] = i[5]
+            repl_info["state"] = i[6]
+            repl_info["reply_lag"] = i[7]
+
+            repl_dict[repl_pid] = repl_info
+
+        self.pg_facts["replications"] = repl_dict
+
+    def get_lang_info(self):
+        """
+        Get information about current supported languages.
+        """
+        query = ("SELECT l.lanname, a.rolname, l.lanacl "
+                 "FROM pg_language AS l "
+                 "JOIN pg_authid AS a ON l.lanowner = a.oid")
+        res = self.__exec_sql(query)
+        lang_dict = {}
+        for i in res:
+            lang_name = i[0]
+            lang_info = {}
+            lang_info["lanowner"] = i[1]
+            if i[2]:
+                lang_info["lanacl"] = i[2]
+            else:
+                lang_info["lanacl"] = ""
+
+            lang_dict[lang_name] = lang_info
+
+        self.pg_facts["languages"] = lang_dict
+
+    def get_namespaces(self):
+        """
+        Get information about namespaces.
+        """
+        query = ("SELECT n.nspname, a.rolname, n.nspacl "
+                 "FROM pg_catalog.pg_namespace AS n "
+                 "JOIN pg_authid AS a ON a.oid = n.nspowner")
+        res = self.__exec_sql(query)
+        nsp_dict = {}
+        for i in res:
+            nsp_name = i[0]
+            nsp_info = {}
+            nsp_info["nspowner"] = i[1]
+            if i[2]:
+                nsp_info["nspacl"] = i[2]
+            else:
+                nsp_info["nspacl"] = ""
+
+            nsp_dict[nsp_name] = nsp_info
+
+        self.pg_facts["namespaces"] = nsp_dict
+
+    def get_pg_version(self):
+        query = "SELECT version()"
+        raw = self.__exec_sql(query)[0][0]
+        self.pg_facts["version"] = raw.split()[1]
+
+    def get_db_info(self):
+        # Following query returns:
+        # Name, Owner, Encoding, Collate, Ctype, Access Priv, Size
+        query = ("SELECT d.datname, "
+                 "pg_catalog.pg_get_userbyid(d.datdba), "
+                 "pg_catalog.pg_encoding_to_char(d.encoding), "
+                 "d.datcollate, "
+                 "d.datctype, "
+                 "pg_catalog.array_to_string(d.datacl, E'\n'), "
+                 "CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') "
+                 "THEN pg_catalog.pg_size_pretty(pg_catalog.pg_database_size(d.datname)) "
+                 "ELSE 'No Access' END, "
+                 "t.spcname "
+                 "FROM pg_catalog.pg_database AS d "
+                 "JOIN pg_catalog.pg_tablespace t on d.dattablespace = t.oid")
+        res = self.__exec_sql(query)
+        db_dict = {}
+        for i in res:
+            db_name = i[0]
+            db_info = {}
+            db_info['owner'] = i[1]
+            db_info['encoding'] = i[2]
+            db_info['collate'] = i[3]
+            db_info['ctype'] = i[4]
+            db_info['size'] = i[6]
+            if i[5]:
+                db_info['access_priv'] = i[5]
+            else:
+                db_info['access_priv'] = ''
+
+            db_dict[db_name] = db_info
+
+        self.pg_facts["databases"] = db_dict
+
+    def __exec_sql(self, query):
+        try:
+            self.cursor.execute(query)
+            res = self.cursor.fetchall()
+            if res:
+                return res
+        except SQLParseError as e:
+            self.module.fail_json(msg=to_native(e),
+                                  exception=traceback.format_exc())
+            self.cursor.close()
+        except psycopg2.ProgrammingError as e:
+            self.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)),
+                                  exception=traceback.format_exc())
+            self.cursor.close()
+        return False
+
+# ===========================================
+# Module execution.
+#
+
+
+def main():
+    argument_spec = pgutils.postgres_common_argument_spec()
+    argument_spec.update(dict(
+        db=dict(default=''),
+        include_subset=dict(default='*'),
+        exclude_subset=dict(default=''),
+        ssl_mode=dict(default='prefer', choices=[
+            'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
+        ssl_rootcert=dict(default=None),
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    if not HAS_PSYCOPG2:
+        module.fail_json(msg="The python psycopg2 module is required")
+
+    incl_subsets = module.params["include_subset"]
+    excl_subsets = module.params["exclude_subset"]
+    sslrootcert = module.params["ssl_rootcert"]
+
+    if incl_subsets != "*" and excl_subsets:
+        module.fail_json(msg="include_subset and exclude_subset parameters "
+                             "are mutually exclusive")
+
+    # To use defaults values, keyword arguments must be absent, so
+    # check which values are empty and don't include in the **kw
+    # dictionary
+    params_map = {
+        "login_host": "host",
+        "login_user": "user",
+        "login_password": "password",
+        "port": "port",
+        "db": "database",
+        "ssl_mode": "sslmode",
+        "ssl_rootcert": "sslrootcert"
+    }
+    kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
+              if k in params_map and v != "" and v is not None)
+
+    # If a login_unix_socket is specified, incorporate it here.
+    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
+    if is_localhost and module.params["login_unix_socket"] != "":
+        kw["host"] = module.params["login_unix_socket"]
+
+    if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
+        module.fail_json(
+            msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+
+    try:
+        db_connection = psycopg2.connect(**kw)
+
+        cursor = db_connection.cursor(
+            cursor_factory=psycopg2.extras.DictCursor)
+    except TypeError as e:
+        if 'sslrootcert' in e.args[0]:
+            module.fail_json(
+                msg='Postgresql server must be at least version 8.4 to support sslrootcert')
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
+                         exception=traceback.format_exc())
+    except Exception as e:
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
+                         exception=traceback.format_exc())
+
+    # Set defaults:
+    changed = False
+
+    # Do job:
+    pg_facts = PgClusterFacts(module, cursor)
+
+    if incl_subsets != "*":
+        incl_subsets = [s.strip() for s in incl_subsets.split(',')]
+        kw['ansible_facts'] = pg_facts.collect(include=incl_subsets)
+
+    elif excl_subsets:
+        excl_subsets = [s.strip() for s in excl_subsets.split(',')]
+        kw['ansible_facts'] = pg_facts.collect(exclude=excl_subsets)
+
+    else:
+        kw['ansible_facts'] = pg_facts.collect()
+
+    # Rollback transaction, if checkmode.
+    # Otherwise, commit transaction:
+    if changed:
+        if module.check_mode:
+            db_connection.rollback()
+        else:
+            db_connection.commit()
+
+    kw['changed'] = changed
+    module.exit_json(**kw)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -278,7 +278,7 @@ class PgClusterFacts(object):
         """
         Get information about replication slots if exist.
         """
-        query = ("SELECT slot_name, plugin, slot_type, database, temporary, "
+        query = ("SELECT slot_name, plugin, slot_type, database, "
                  "active FROM pg_replication_slots")
         res = self.__exec_sql(query)
 
@@ -293,8 +293,7 @@ class PgClusterFacts(object):
             rslot_info["plugin"] = i[1]
             rslot_info["slot_type"] = i[2]
             rslot_info["database"] = i[3]
-            rslot_info["temporaty"] = i[4]
-            rslot_info["active"] = i[5]
+            rslot_info["active"] = i[4]
 
             rslot_dict[rslot_name] = rslot_info
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -137,7 +137,7 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-ansible_facts:
+postgresql_facts:
   description: Dictionary containing the detailed information about the PostgreSQL instance.
   returned: always
   type: complex
@@ -893,10 +893,10 @@ def main():
     pg_facts = PgClusterFacts(module, cursor)
 
     if filter_:
-        kw['ansible_facts'] = pg_facts.collect(filter_)
+        kw['postgresql_facts'] = pg_facts.collect(filter_)
 
     else:
-        kw['ansible_facts'] = pg_facts.collect()
+        kw['postgresql_facts'] = pg_facts.collect()
 
     module.exit_json(**kw)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -281,7 +281,7 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_replication_slots')")
-        if not res:
+        if not res[0]:
             return 0
 
         query = ("SELECT slot_name, plugin, slot_type, database, "
@@ -364,7 +364,7 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_stat_replication')")
-        if not res:
+        if not res[0]:
             return 0
 
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -295,7 +295,7 @@ ansible_facts:
                     description: Time when this process was started, i.e., when the client connected to this WAL sender.
                     returned: always
                     type: str
-                    sample: 2019-02-03 00:14:33.908593+03
+                    sample: "2019-02-03 00:14:33.908593+03"
                 state:
                     description: Current WAL sender state.
                     returned: always
@@ -315,7 +315,7 @@ ansible_facts:
                     type: str
                     sample: "{postgres=C/postgres,andreyk=C/postgres}"
                 spcoptions:
-                    description: Tablespace-level options, as “keyword=value” strings.
+                    description: Tablespace-level options.
                     returned: always
                     type: list
                     sample: [ "seq_page_cost=1" ]

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -281,8 +281,8 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_replication_slots')")
-        if not res[0]:
-            return 0
+        if not res[0][0]:
+            return True
 
         query = ("SELECT slot_name, plugin, slot_type, database, "
                  "active FROM pg_replication_slots")
@@ -365,7 +365,7 @@ class PgClusterFacts(object):
                               "information_schema.tables "
                               "WHERE table_name = 'pg_stat_replication')")
         if not res[0][0]:
-            return 0
+            return True
 
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "
                  "r.client_hostname, r.backend_start::text, r.state "

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -25,8 +25,8 @@ options:
     description:
     - Limit collected facts by comma separated string or YAML list.
     - Allowable values are C(version),
-      C(databases), C(settings), C(tablespaces), C(languages), C(roles), C(namespaces),
-      C(replications), C(repl_slots), C(extensions).
+      C(databases), C(settings), C(tablespaces), C(roles), 
+      C(replications), C(repl_slots).
     - By default, collects all subsets.
     - You can use shell-style (fnmatch) wildcard to pass groups of values (see Examples).
     - You can use '!' before value (for example, C(!settings)) to exclude it from facts.

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -25,7 +25,7 @@ options:
     description:
     - Limit collected facts by comma separated string or YAML list.
     - Allowable values are C(version),
-      C(databases), C(settings), C(tablespaces), C(roles), 
+      C(databases), C(settings), C(tablespaces), C(roles),
       C(replications), C(repl_slots).
     - By default, collects all subsets.
     - You can use shell-style (fnmatch) wildcard to pass groups of values (see Examples).

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -712,7 +712,7 @@ class PgClusterFacts(object):
             elif unit == 'MB':
                 val_in_bytes = int(setting) * 1024 * 1024
 
-            if val_in_bytes < 0:
+            if val_in_bytes is not None and val_in_bytes < 0:
                 val_in_bytes = 0
 
             set_dict[i[0]] = dict(

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -828,12 +828,12 @@ class PgClusterFacts(object):
 def main():
     argument_spec = pgutils.postgres_common_argument_spec()
     argument_spec.update(dict(
-        db=dict(default=''),
-        incl_subset=dict(default="*"),
-        excl_subset=dict(default=""),
+        db=dict(default='', type=str),
+        incl_subset=dict(default="*", type=str),
+        excl_subset=dict(default="", type=str),
         ssl_mode=dict(default='prefer', choices=[
             'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(default=None),
+        ssl_rootcert=dict(default=None, type=str),
     ))
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -356,8 +356,8 @@ class PgClusterFacts(object):
         Get information about replication if the server is a master.
         """
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "
-                 "r.client_hostname, r.backend_start::text, r.state, "
-                 "r.replay_lag::text FROM pg_stat_replication AS r "
+                 "r.client_hostname, r.backend_start::text, r.state "
+                 "FROM pg_stat_replication AS r "
                  "JOIN pg_authid AS a ON r.usesysid = a.oid")
         res = self.__exec_sql(query)
         repl_dict = {}
@@ -383,7 +383,6 @@ class PgClusterFacts(object):
 
             repl_info["backend_start"] = i[5]
             repl_info["state"] = i[6]
-            repl_info["reply_lag"] = i[7]
 
             repl_dict[repl_pid] = repl_info
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -16,9 +16,9 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = r'''
 ---
 module: postgresql_facts
-short_description: Gather facts about remote PostgreSQL servers
+short_description: Gather facts about PostgreSQL servers
 description:
-- Gathers facts about remote PostgreSQL servers.
+- Gathers facts about PostgreSQL servers.
 version_added: "2.8"
 options:
   filter:
@@ -37,11 +37,15 @@ options:
     description:
     - Name of database to connect.
     type: str
+    aliases:
+    - login_db
   port:
     description:
     - Database port to connect.
     type: int
     default: 5432
+    aliases:
+    - login_port
   login_user:
     description:
     - User (role) used to authenticate with PostgreSQL.
@@ -165,7 +169,7 @@ databases:
       description: Database name.
       returned: always
       type: dict
-      sample: template0
+      sample: template1
       contains:
         access_priv:
           description: Database access privileges.
@@ -201,78 +205,78 @@ databases:
           returned: always
           type: str
           sample: 8189415
-extensions:
-  description:
-  - Extensions U(https://www.postgresql.org/docs/current/sql-createextension.html).
-  returned: always
-  type: dict
-  sample:
-  - { "plpgsql": { "description": "PL/pgSQL procedural language",
-    "extversion": { "major": 1, "minor": 0 } } }
-  contains:
-    extdescription:
-      description: Extension description.
-      returned: if existent
-      type: str
-      sample: PL/pgSQL procedural language
-    extversion:
-      description: Extension description.
-      returned: always
-      type: dict
-      contains:
-        major:
-          description: Extension major version.
+        extensions:
+          description:
+          - Extensions U(https://www.postgresql.org/docs/current/sql-createextension.html).
           returned: always
-          type: int
-          sample: 1
-        minor:
-          description: Extension minor version.
+          type: dict
+          sample:
+          - { "plpgsql": { "description": "PL/pgSQL procedural language",
+            "extversion": { "major": 1, "minor": 0 } } }
+          contains:
+            extdescription:
+              description: Extension description.
+              returned: if existent
+              type: str
+              sample: PL/pgSQL procedural language
+            extversion:
+              description: Extension description.
+              returned: always
+              type: dict
+              contains:
+              major:
+                description: Extension major version.
+                returned: always
+                type: int
+                sample: 1
+              minor:
+                description: Extension minor version.
+                returned: always
+                type: int
+                sample: 0
+            nspname:
+              description: Namecpase where the extension is.
+              returned: always
+              type: str
+              sample: pg_catalog
+        languages:
+          description: Procedural languages U(https://www.postgresql.org/docs/current/xplang.html).
           returned: always
-          type: int
-          sample: 0
-    nspname:
-      description: Namecpase where the extension is.
-      returned: always
-      type: str
-      sample: pg_catalog
-languages:
-  description: Procedural languages U(https://www.postgresql.org/docs/current/xplang.html).
-  returned: always
-  type: dict
-  sample: { "sql": { "lanacl": "", "lanowner": "postgres" } }
-  contains:
-    lanacl:
-      description:
-      - Language access privileges
-        U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-      returned: always
-      type: str
-      sample: "{postgres=UC/postgres,=U/postgres}"
-    lanowner:
-      description:
-      - Language owner U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-      returned: always
-      type: str
-      sample: postgres
-namespaces:
-  description:
-  - Namespaces (schema) U(https://www.postgresql.org/docs/current/sql-createschema.html).
-  returned: always
-  type: dict
-  sample: { "pg_catalog": { "nspacl": "{postgres=UC/postgres,=U/postgres}", "nspowner": "postgres" } }
-  contains:
-    nspacl:
-      description:
-      - Assess privileges U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-      returned: always
-      type: str
-      sample: "{postgres=UC/postgres,=U/postgres}"
-    nspowner:
-      description:
-      - Schema owner U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-      returned: always
-      type: str
-      sample: postgres
+          type: dict
+          sample: { "sql": { "lanacl": "", "lanowner": "postgres" } }
+          contains:
+            lanacl:
+              description:
+              - Language access privileges
+                U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
+              returned: always
+              type: str
+              sample: "{postgres=UC/postgres,=U/postgres}"
+            lanowner:
+              description:
+              - Language owner U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
+              returned: always
+              type: str
+              sample: postgres
+        namespaces:
+          description:
+          - Namespaces (schema) U(https://www.postgresql.org/docs/current/sql-createschema.html).
+          returned: always
+          type: dict
+          sample: { "pg_catalog": { "nspacl": "{postgres=UC/postgres,=U/postgres}", "nspowner": "postgres" } }
+          contains:
+            nspacl:
+              description:
+              - Access privileges U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
+              returned: always
+              type: str
+              sample: "{postgres=UC/postgres,=U/postgres}"
+            nspowner:
+              description:
+              - Schema owner U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
+              returned: always
+              type: str
+              sample: postgres
 repl_slots:
   description:
   - Replication slots (available in 9.4 and later)
@@ -282,7 +286,8 @@ repl_slots:
   sample: { "slot0": { "active": false, "database": null, "plugin": null, "slot_type": "physical" } }
   contains:
     active:
-      description: True if this slot is currently actively being used.
+      description:
+      - True means that a receiver has connected to it, and it is currently reserving archives.
       returned: always
       type: bool
       sample: true
@@ -314,7 +319,8 @@ replications:
     "client_addr": "10.10.10.2", "client_hostname": "", "state": "streaming", "usename": "postgres" } }
   contains:
     usename:
-      description: Name of the user logged into this WAL sender process.
+      description:
+      - Name of the user logged into this WAL sender process ('usename' is a column name in pg_stat_replication view).
       returned: always
       type: str
       sample: replication_user
@@ -491,22 +497,46 @@ from ansible.module_utils.six import iteritems
 # PostgreSQL module specific support methods.
 #
 
+class PgDbConn(object):
+    def __init__(self, module, params_dict):
+        self.params_dict = params_dict
+        self.module = module
+        self.db_conn = None
+
+    def connect(self):
+        try:
+            self.db_conn = psycopg2.connect(**self.params_dict)
+            return self.db_conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+        except TypeError as e:
+            if 'sslrootcert' in e.args[0]:
+                self.module.fail_json(msg='PostgreSQL server must be at least version 8.4 '
+                                          'to support sslrootcert')
+            self.module.fail_json(msg="Unable to connect to database: %s" % to_native(e))
+
+        except Exception as e:
+            self.module.fail_json(msg="Unable to connect to database: %s" % to_native(e))
+
+    def reconnect(self, dbname):
+        self.db_conn.close()
+
+        self.params_dict['database'] = dbname
+        return self.connect()
+
 
 class PgClusterFacts(object):
-    def __init__(self, module, cursor):
+    def __init__(self, module, db_conn_obj):
         self.module = module
-        self.cursor = cursor
+        self.db_obj = db_conn_obj
+        self.cursor = db_conn_obj.connect()
         self.pg_facts = {
             "version": {},
             "tablespaces": {},
             "databases": {},
-            "languages": {},
-            "namespaces": {},
             "replications": {},
             "repl_slots": {},
             "settings": {},
             "roles": {},
-            "extensions": {},
         }
 
     def collect(self, val_list=False):
@@ -514,13 +544,10 @@ class PgClusterFacts(object):
             "version": self.get_pg_version,
             "tablespaces": self.get_tablespaces,
             "databases": self.get_db_info,
-            "languages": self.get_lang_info,
-            "namespaces": self.get_namespaces,
             "replications": self.get_repl_info,
             "repl_slots": self.get_rslot_info,
             "settings": self.get_settings,
             "roles": self.get_role_info,
-            "extensions": self.get_ext_info,
         }
 
         incl_list = []
@@ -628,7 +655,7 @@ class PgClusterFacts(object):
                 description=i[3],
             )
 
-        self.pg_facts["extensions"] = ext_dict
+        return ext_dict
 
     def get_role_info(self):
         """
@@ -779,7 +806,7 @@ class PgClusterFacts(object):
                 lanacl=i[2] if i[2] else '',
             )
 
-        self.pg_facts["languages"] = lang_dict
+        return lang_dict
 
     def get_namespaces(self):
         """
@@ -797,7 +824,7 @@ class PgClusterFacts(object):
                 nspacl=i[2] if i[2] else '',
             )
 
-        self.pg_facts["namespaces"] = nsp_dict
+        return nsp_dict
 
     def get_pg_version(self):
         query = "SELECT version()"
@@ -836,6 +863,15 @@ class PgClusterFacts(object):
                 size=i[6],
             )
 
+        for datname in db_dict:
+            if datname == 'template0':
+                continue
+
+            self.cursor = self.db_obj.reconnect(datname)
+            db_dict[datname]['namespaces'] = self.get_namespaces()
+            db_dict[datname]['extensions'] = self.get_ext_info()
+            db_dict[datname]['languages'] = self.get_lang_info()
+
         self.pg_facts["databases"] = db_dict
 
     def __exec_sql(self, query):
@@ -860,7 +896,8 @@ class PgClusterFacts(object):
 def main():
     argument_spec = postgres_common_argument_spec()
     argument_spec.update(
-        db=dict(type='str'),
+        db=dict(type='str', aliases=['login_db']),
+        port=dict(type='int', default=5432, aliases=['login_port']),
         filter=dict(type='list'),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(type='str'),
@@ -900,19 +937,10 @@ def main():
         module.fail_json(msg='psycopg2 must be at least 2.4.3 in order '
                              'to user the ssl_rootcert parameter')
 
-    try:
-        db_connection = psycopg2.connect(**kw)
-        cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    except TypeError as e:
-        if 'sslrootcert' in e.args[0]:
-            module.fail_json(msg='Postgresql server must be at least version 8.4 '
-                                 'to support sslrootcert')
-        module.fail_json(msg="unable to connect to database: %s" % to_native(e))
-    except Exception as e:
-        module.fail_json(msg="unable to connect to database: %s" % to_native(e))
+    db_conn_obj = PgDbConn(module, kw)
 
     # Do job:
-    pg_facts = PgClusterFacts(module, cursor)
+    pg_facts = PgClusterFacts(module, db_conn_obj)
 
     module.exit_json(**pg_facts.collect(filter_))
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -281,7 +281,7 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_replication_slots')")
-        if not res[0]:
+        if res[0] == 'f':
             return 0
 
         query = ("SELECT slot_name, plugin, slot_type, database, "
@@ -364,7 +364,7 @@ class PgClusterFacts(object):
         res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
                               "information_schema.tables "
                               "WHERE table_name = 'pg_stat_replication')")
-        if not res[0]:
+        if res[0] == 'f':
             return 0
 
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -375,7 +375,7 @@ class PgClusterFacts(object):
         repl_dict = {}
 
         # If there is no replication:
-        if not res:
+        if not res[0][0]:
             return True
 
         for i in res:

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -23,17 +23,17 @@ version_added: "2.8"
 options:
   filter:
     description:
-      - Limit collected facts by comma separated string or YAML list.
-      - Allowable values are C(version),
-        C(databases), C(settings), C(tablespaces), C(languages), C(roles), C(namespaces),
-        C(replications), C(repl_slots), C(extensions).
-      - By default, collects all subsets.
-      - You can use shell-style (fnmatch) wildcard to pass groups of values (see Examples).
-      - You can use '!' before value (for example, C(!settings)) to exclude it from facts.
-      - If you pass including and excluding values to the filter, for example, I(filter=!settings,ver),
-        the excluding values will be ignored.
-    default: "*"
+    - Limit collected facts by comma separated string or YAML list.
+    - Allowable values are C(version),
+      C(databases), C(settings), C(tablespaces), C(languages), C(roles), C(namespaces),
+      C(replications), C(repl_slots), C(extensions).
+    - By default, collects all subsets.
+    - You can use shell-style (fnmatch) wildcard to pass groups of values (see Examples).
+    - You can use '!' before value (for example, C(!settings)) to exclude it from facts.
+    - If you pass including and excluding values to the filter, for example, I(filter=!settings,ver),
+      the excluding values will be ignored.
     type: list
+    default: "*"
   db:
     description:
     - Name of database to connect.
@@ -68,8 +68,8 @@ options:
       more information on the modes.
     - Default of C(prefer) matches libpq default.
     type: str
+    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     default: prefer
-    choices: [ disable, allow, prefer, require, verify-ca, verify-full ]
   ssl_rootcert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
@@ -126,368 +126,363 @@ EXAMPLES = r'''
   postgresql_facts:
     db: postgres
     filter:
-      - tablesp*
-      - repl_sl*
+    - tablesp*
+    - repl_sl*
 
 - name: Collect all facts except settings
   become: yes
   become_user: postgres
   postgresql_facts:
     filter:
-      - "!settings"
+    - "!settings"
 '''
 
 RETURN = r'''
 ansible_facts:
-    description: Dictionary containing the detailed information about the PostgreSQL instance.
-    returned: always
-    type: complex
-    contains:
-        version:
-            description: Database server version U(https://www.postgresql.org/support/versioning/).
-            returned: always
-            type: dict
-            sample: { "version": { "major": 10, "minor": 6 } }
-            contains:
-                major:
-                    description: Major server version.
-                    returned: always
-                    type: int
-                    sample: 11
-                minor:
-                    description: Minor server version.
-                    returned: always
-                    type: int
-                    sample: 1
-        databases:
-            description: Information about databases.
-            returned: always
-            type: dict
-            sample:
-            - { "postgres": { "access_priv": "", "collate": "en_US.UTF-8",
-              "ctype": "en_US.UTF-8", "encoding": "UTF8", "owner": "postgres", "size": "7997 kB" } }
-            contains:
-                database_name:
-                    description: Database name.
-                    returned: always
-                    type: dict
-                    sample: template0
-                    contains:
-                        access_priv:
-                            description: Database access privileges.
-                            returned: always
-                            type: str
-                            sample: "=c/postgres_npostgres=CTc/postgres"
-                        collate:
-                            description:
-                            - Database collation U(https://www.postgresql.org/docs/current/collation.html).
-                            returned: always
-                            type: str
-                            sample: en_US.UTF-8
-                        ctype:
-                            description:
-                            - Database LC_CTYPE U(https://www.postgresql.org/docs/current/multibyte.html).
-                            returned: always
-                            type: str
-                            sample: en_US.UTF-8
-                        encoding:
-                            description:
-                            - Database encoding U(https://www.postgresql.org/docs/current/multibyte.html).
-                            returned: always
-                            type: str
-                            sample: UTF8
-                        owner:
-                            description:
-                            - Database owner
-                              U(https://www.postgresql.org/docs/current/sql-createdatabase.html).
-                            returned: always
-                            type: str
-                            sample: postgres
-                        size:
-                            description: Database size.
-                            returned: always
-                            type: str
-                            sample: 7861 kB
-        extensions:
-            description:
-            - Extensions U(https://www.postgresql.org/docs/current/sql-createextension.html).
-            returned: always
-            type: dict
-            sample:
-            - { "plpgsql": { "description": "PL/pgSQL procedural language",
-              "extversion": { "major": 1, "minor": 0 } } }
-            contains:
-                description:
-                    description: Extension description.
-                    returned: if existent
-                    type: str
-                    sample: PL/pgSQL procedural language
-                extversion:
-                    description: Extension description.
-                    returned: always
-                    type: dict
-                    contains:
-                        major:
-                            description: Extension major version.
-                            returned: always
-                            type: int
-                            sample: 1
-                        minor:
-                            description: Extension minor version.
-                            returned: always
-                            type: int
-                            sample: 0
-                nspname:
-                    description: Namecpase where the extension is.
-                    returned: always
-                    type: str
-                    sample: pg_catalog
-        languages:
-            description: Procedural languages U(https://www.postgresql.org/docs/current/xplang.html).
-            returned: always
-            type: dict
-            sample: { "sql": { "lanacl": "", "lanowner": "postgres" } }
-            contains:
-                lanacl:
-                    description:
-                    - Language access privileges
-                      U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-                    returned: always
-                    type: str
-                    sample: "{postgres=UC/postgres,=U/postgres}"
-                lanowner:
-                    description:
-                      - Language owner U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-                    returned: always
-                    type: str
-                    sample: postgres
-        namespaces:
-            description:
-            - Namespaces (schema) U(https://www.postgresql.org/docs/current/sql-createschema.html).
-            returned: always
-            type: dict
-            sample: { "pg_catalog": { "nspacl": "{postgres=UC/postgres,=U/postgres}", "nspowner": "postgres" } }
-            contains:
-                nspacl:
-                    description:
-                    - Assess privileges U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-                    returned: always
-                    type: str
-                    sample: "{postgres=UC/postgres,=U/postgres}"
-                nspowner:
-                    description:
-                    - Schema owner U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-                    returned: always
-                    type: str
-                    sample: postgres
-        repl_slots:
-            description:
-            - Replication slots (available in 9.4 and later)
-              U(https://www.postgresql.org/docs/current/catalog-pg-replication-slots.html).
-            returned: if existent
-            type: dict
-            sample: { "slot0": { "active": false, "database": null, "plugin": null, "slot_type": "physical" } }
-            contains:
-                active:
-                    description: True if this slot is currently actively being used.
-                    returned: always
-                    type: bool
-                    sample: true
-                database:
-                    description: Database name this slot is associated with, or null.
-                    returned: always
-                    type: str
-                    sample: acme
-                plugin:
-                    description:
-                    - The base name of the shared object containing the the output plugin
-                      this logical slot is using, or null for physical slots.
-                    returned: always
-                    type: str
-                    sample: pgoutput
-                slot_type:
-                    description: The slot type - physical or logical.
-                    returned: always
-                    type: str
-                    sample: logical
-        replications:
-            description:
-            - Information about the current replications by process PIDs
-              U(https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-STATS-VIEWS-TABLE).
-            returned: if pg_stat_replication view existent
-            type: dict
-            sample:
-            - { 76580: { "app_name": "standby1", "backend_start": "2019-02-03 00:14:33.908593+03",
-              "client_addr": "10.10.10.2", "client_hostname": "", "state": "streaming", "usename": "postgres" } }
-            contains:
-                usename:
-                    description: Name of the user logged into this WAL sender process.
-                    returned: always
-                    type: str
-                    sample: replication_user
-                app_name:
-                    description: Name of the application that is connected to this WAL sender.
-                    returned: if existent
-                    type: str
-                    sample: acme_srv
-                client_addr:
-                    description:
-                    - IP address of the client connected to this WAL sender.
-                    - If this field is null, it indicates that the client is connected
-                      via a Unix socket on the server machine.
-                    returned: always
-                    type: str
-                    sample: 10.0.0.101
-                client_hostname:
-                    description:
-                    - Host name of the connected client, as reported by a reverse DNS lookup of client_addr.
-                    - This field will only be non-null for IP connections, and only when log_hostname is enabled.
-                    returned: always
-                    type: str
-                    sample: dbsrv1
-                backend_start:
-                    description: Time when this process was started, i.e., when the client connected to this WAL sender.
-                    returned: always
-                    type: str
-                    sample: "2019-02-03 00:14:33.908593+03"
-                state:
-                    description: Current WAL sender state.
-                    returned: always
-                    type: str
-                    sample: streaming
-        tablespaces:
-            description:
-            - Information about tablespaces
-              U(https://www.postgresql.org/docs/current/catalog-pg-tablespace.html).
-            returned: always
-            type: dict
-            sample:
-            - { "test": { "spcacl": "{postgres=C/postgres,andreyk=C/postgres}", "spcoptions": [ "seq_page_cost=1" ],
-              "spcowner": "postgres" } }
-            contains:
-                spcacl:
-                    description: Tablespace access privileges.
-                    returned: always
-                    type: str
-                    sample: "{postgres=C/postgres,andreyk=C/postgres}"
-                spcoptions:
-                    description: Tablespace-level options.
-                    returned: always
-                    type: list
-                    sample: [ "seq_page_cost=1" ]
-                spcowner:
-                    description: Owner of the tablespace.
-                    returned: always
-                    type: str
-                    sample: test_user
-        roles:
-            description:
-            - Information about roles U(https://www.postgresql.org/docs/current/user-manag.html).
-            returned: always
-            type: dict
-            sample:
-            - { "test_role": { "canlogin": true, "member_of": [ "user_ro" ], "superuser": false,
-              "valid_until": "9999-12-31T23:59:59.999999+00:00" } }
-            contains:
-                canlogin:
-                    description: Login privilege U(https://www.postgresql.org/docs/current/role-attributes.html).
-                    returned: always
-                    type: bool
-                    sample: true
-                member_of:
-                    description:
-                    - Role membership U(https://www.postgresql.org/docs/current/role-membership.html).
-                    returned: always
-                    type: list
-                    sample: [ "read_only_users" ]
-                superuser:
-                    description: User is a superuser or not.
-                    returned: always
-                    type: bool
-                    sample: false
-                valid_until:
-                    description:
-                    - Password expiration date U(https://www.postgresql.org/docs/current/sql-alterrole.html).
-                    returned: always
-                    type: str
-                    sample: "9999-12-31T23:59:59.999999+00:00"
-        settings:
-            description:
-            - Information about run-time server parameters
-              U(https://www.postgresql.org/docs/current/view-pg-settings.html).
-            returned: always
-            type: dict
-            sample:
-            - { "work_mem": { "boot_val": "4096", "context": "user", "max_val": "2147483647",
-              "min_val": "64", "setting": "8192", "sourcefile": "/var/lib/pgsql/10/data/postgresql.auto.conf",
-              "unit": "kB", "vartype": "integer" } }
-            contains:
-                setting:
-                    description: Current value of the parameter.
-                    returned: always
-                    type: str
-                    sample: 49152
-                unit:
-                    description: Implicit unit of the parameter.
-                    returned: always
-                    type: str
-                    sample: kB
-                boot_val:
-                    description:
-                    - Parameter value assumed at server startup if the parameter is not otherwise set.
-                    returned: always
-                    type: str
-                    sample: 4096
-                min_val:
-                    description:
-                    - Minimum allowed value of the parameter (null for non-numeric values).
-                    returned: always
-                    type: str
-                    sample: 64
-                max_val:
-                    description:
-                    - Maximum allowed value of the parameter (null for non-numeric values).
-                    returned: always
-                    type: str
-                    sample: 2147483647
-                sourcefile:
-                    description:
-                    - Configuration file the current value was set in.
-                    - Null for values set from sources other than configuration files,
-                      or when examined by a user who is neither a superuser or a member of pg_read_all_settings.
-                    - Helpful when using include directives in configuration files.
-                    returned: always
-                    type: str
-                    sample: /var/lib/pgsql/10/data/postgresql.auto.conf
-                context:
-                    description:
-                    - Context required to set the parameter's value.
-                    - For more information see U(https://www.postgresql.org/docs/current/view-pg-settings.html).
-                    returned: always
-                    type: str
-                    sample: user
-                vartype:
-                    description:
-                    - Parameter type (bool, enum, integer, real, or string).
-                    returned: always
-                    type: str
-                    sample: integer
+  description: Dictionary containing the detailed information about the PostgreSQL instance.
+  returned: always
+  type: complex
+  contains:
+    version:
+      description: Database server version U(https://www.postgresql.org/support/versioning/).
+      returned: always
+      type: dict
+      sample: { "version": { "major": 10, "minor": 6 } }
+      contains:
+        major:
+          description: Major server version.
+          returned: always
+          type: int
+          sample: 11
+        minor:
+          description: Minor server version.
+          returned: always
+          type: int
+          sample: 1
+    databases:
+      description: Information about databases.
+      returned: always
+      type: dict
+      sample:
+      - { "postgres": { "access_priv": "", "collate": "en_US.UTF-8",
+      "ctype": "en_US.UTF-8", "encoding": "UTF8", "owner": "postgres", "size": "7997 kB" } }
+      contains:
+        database_name:
+          description: Database name.
+          returned: always
+          type: dict
+          sample: template0
+          contains:
+            access_priv:
+              description: Database access privileges.
+              returned: always
+              type: str
+              sample: "=c/postgres_npostgres=CTc/postgres"
+            collate:
+              description:
+              - Database collation U(https://www.postgresql.org/docs/current/collation.html).
+              returned: always
+              type: str
+              sample: en_US.UTF-8
+            ctype:
+              description:
+              - Database LC_CTYPE U(https://www.postgresql.org/docs/current/multibyte.html).
+              returned: always
+              type: str
+              sample: en_US.UTF-8
+            encoding:
+              description:
+              - Database encoding U(https://www.postgresql.org/docs/current/multibyte.html).
+              returned: always
+              type: str
+              sample: UTF8
+            owner:
+              description:
+              - Database owner U(https://www.postgresql.org/docs/current/sql-createdatabase.html).
+              returned: always
+              type: str
+              sample: postgres
+            size:
+              description: Database size in bytes.
+              returned: always
+              type: str
+              sample: 8189415
+    extensions:
+      description:
+      - Extensions U(https://www.postgresql.org/docs/current/sql-createextension.html).
+      returned: always
+      type: dict
+      sample:
+      - { "plpgsql": { "description": "PL/pgSQL procedural language",
+        "extversion": { "major": 1, "minor": 0 } } }
+      contains:
+        extdescription:
+          description: Extension description.
+          returned: if existent
+          type: str
+          sample: PL/pgSQL procedural language
+        extversion:
+          description: Extension description.
+          returned: always
+          type: dict
+          contains:
+            major:
+              description: Extension major version.
+              returned: always
+              type: int
+              sample: 1
+            minor:
+              description: Extension minor version.
+              returned: always
+              type: int
+              sample: 0
+        nspname:
+          description: Namecpase where the extension is.
+          returned: always
+          type: str
+          sample: pg_catalog
+    languages:
+      description: Procedural languages U(https://www.postgresql.org/docs/current/xplang.html).
+      returned: always
+      type: dict
+      sample: { "sql": { "lanacl": "", "lanowner": "postgres" } }
+      contains:
+        lanacl:
+          description:
+          - Language access privileges
+            U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
+          returned: always
+          type: str
+          sample: "{postgres=UC/postgres,=U/postgres}"
+        lanowner:
+          description:
+          - Language owner U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
+          returned: always
+          type: str
+          sample: postgres
+    namespaces:
+      description:
+      - Namespaces (schema) U(https://www.postgresql.org/docs/current/sql-createschema.html).
+      returned: always
+      type: dict
+      sample: { "pg_catalog": { "nspacl": "{postgres=UC/postgres,=U/postgres}", "nspowner": "postgres" } }
+      contains:
+        nspacl:
+          description:
+          - Assess privileges U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
+          returned: always
+          type: str
+          sample: "{postgres=UC/postgres,=U/postgres}"
+        nspowner:
+          description:
+          - Schema owner U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
+          returned: always
+          type: str
+          sample: postgres
+    repl_slots:
+      description:
+      - Replication slots (available in 9.4 and later)
+        U(https://www.postgresql.org/docs/current/catalog-pg-replication-slots.html).
+      returned: if existent
+      type: dict
+      sample: { "slot0": { "active": false, "database": null, "plugin": null, "slot_type": "physical" } }
+      contains:
+        active:
+          description: True if this slot is currently actively being used.
+          returned: always
+          type: bool
+          sample: true
+        database:
+          description: Database name this slot is associated with, or null.
+          returned: always
+          type: str
+          sample: acme
+        plugin:
+          description:
+          - The base name of the shared object containing the the output plugin
+            this logical slot is using, or null for physical slots.
+          returned: always
+          type: str
+          sample: pgoutput
+        slot_type:
+          description: The slot type - physical or logical.
+          returned: always
+          type: str
+          sample: logical
+    replications:
+      description:
+      - Information about the current replications by process PIDs
+        U(https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-STATS-VIEWS-TABLE).
+      returned: if pg_stat_replication view existent
+      type: dict
+      sample:
+      - { 76580: { "app_name": "standby1", "backend_start": "2019-02-03 00:14:33.908593+03",
+        "client_addr": "10.10.10.2", "client_hostname": "", "state": "streaming", "usename": "postgres" } }
+      contains:
+        usename:
+          description: Name of the user logged into this WAL sender process.
+          returned: always
+          type: str
+          sample: replication_user
+        app_name:
+          description: Name of the application that is connected to this WAL sender.
+          returned: if existent
+          type: str
+          sample: acme_srv
+        client_addr:
+          description:
+          - IP address of the client connected to this WAL sender.
+          - If this field is null, it indicates that the client is connected
+            via a Unix socket on the server machine.
+          returned: always
+          type: str
+          sample: 10.0.0.101
+        client_hostname:
+          description:
+          - Host name of the connected client, as reported by a reverse DNS lookup of client_addr.
+          - This field will only be non-null for IP connections, and only when log_hostname is enabled.
+          returned: always
+          type: str
+          sample: dbsrv1
+        backend_start:
+          description: Time when this process was started, i.e., when the client connected to this WAL sender.
+          returned: always
+          type: str
+          sample: "2019-02-03 00:14:33.908593+03"
+        state:
+          description: Current WAL sender state.
+          returned: always
+          type: str
+          sample: streaming
+    tablespaces:
+      description:
+      - Information about tablespaces U(https://www.postgresql.org/docs/current/catalog-pg-tablespace.html).
+      returned: always
+      type: dict
+      sample:
+      - { "test": { "spcacl": "{postgres=C/postgres,andreyk=C/postgres}", "spcoptions": [ "seq_page_cost=1" ],
+        "spcowner": "postgres" } }
+      contains:
+        spcacl:
+          description: Tablespace access privileges.
+          returned: always
+          type: str
+          sample: "{postgres=C/postgres,andreyk=C/postgres}"
+        spcoptions:
+          description: Tablespace-level options.
+          returned: always
+          type: list
+          sample: [ "seq_page_cost=1" ]
+        spcowner:
+          description: Owner of the tablespace.
+          returned: always
+          type: str
+          sample: test_user
+    roles:
+      description:
+      - Information about roles U(https://www.postgresql.org/docs/current/user-manag.html).
+      returned: always
+      type: dict
+      sample:
+      - { "test_role": { "canlogin": true, "member_of": [ "user_ro" ], "superuser": false,
+        "valid_until": "9999-12-31T23:59:59.999999+00:00" } }
+      contains:
+        canlogin:
+          description: Login privilege U(https://www.postgresql.org/docs/current/role-attributes.html).
+          returned: always
+          type: bool
+          sample: true
+        member_of:
+          description:
+          - Role membership U(https://www.postgresql.org/docs/current/role-membership.html).
+          returned: always
+          type: list
+          sample: [ "read_only_users" ]
+        superuser:
+          description: User is a superuser or not.
+          returned: always
+          type: bool
+          sample: false
+        valid_until:
+          description:
+          - Password expiration date U(https://www.postgresql.org/docs/current/sql-alterrole.html).
+          returned: always
+          type: str
+          sample: "9999-12-31T23:59:59.999999+00:00"
+    settings:
+      description:
+      - Information about run-time server parameters
+        U(https://www.postgresql.org/docs/current/view-pg-settings.html).
+      returned: always
+      type: dict
+      sample:
+      - { "work_mem": { "boot_val": "4096", "context": "user", "max_val": "2147483647",
+        "min_val": "64", "setting": "8192", "sourcefile": "/var/lib/pgsql/10/data/postgresql.auto.conf",
+        "unit": "kB", "vartype": "integer" } }
+      contains:
+        setting:
+          description: Current value of the parameter.
+          returned: always
+          type: str
+          sample: 49152
+        unit:
+          description: Implicit unit of the parameter.
+          returned: always
+          type: str
+          sample: kB
+        boot_val:
+          description:
+          - Parameter value assumed at server startup if the parameter is not otherwise set.
+          returned: always
+          type: str
+          sample: 4096
+        min_val:
+          description:
+          - Minimum allowed value of the parameter (null for non-numeric values).
+          returned: always
+          type: str
+          sample: 64
+        max_val:
+          description:
+          - Maximum allowed value of the parameter (null for non-numeric values).
+          returned: always
+          type: str
+          sample: 2147483647
+        sourcefile:
+          description:
+          - Configuration file the current value was set in.
+          - Null for values set from sources other than configuration files,
+            or when examined by a user who is neither a superuser or a member of pg_read_all_settings.
+          - Helpful when using include directives in configuration files.
+          returned: always
+          type: str
+          sample: /var/lib/pgsql/10/data/postgresql.auto.conf
+        context:
+          description:
+          - Context required to set the parameter's value.
+          - For more information see U(https://www.postgresql.org/docs/current/view-pg-settings.html).
+          returned: always
+          type: str
+          sample: user
+        vartype:
+          description:
+          - Parameter type (bool, enum, integer, real, or string).
+          returned: always
+          type: str
+          sample: integer
 '''
 
-
-import traceback
 from fnmatch import fnmatch
 
 try:
     import psycopg2
-    import psycopg2.extras
     HAS_PSYCOPG2 = True
 except ImportError:
     HAS_PSYCOPG2 = False
 
-import ansible.module_utils.postgres as pgutils
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import SQLParseError
+from ansible.module_utils.postgres import postgres_common_argument_spec
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 
@@ -829,12 +824,10 @@ class PgClusterFacts(object):
             if res:
                 return res
         except SQLParseError as e:
-            self.module.fail_json(msg=to_native(e),
-                                  exception=traceback.format_exc())
+            self.module.fail_json(msg=to_native(e))
             self.cursor.close()
         except psycopg2.ProgrammingError as e:
-            self.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)),
-                                  exception=traceback.format_exc())
+            self.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
             self.cursor.close()
         return False
 
@@ -844,13 +837,13 @@ class PgClusterFacts(object):
 
 
 def main():
-    argument_spec = pgutils.postgres_common_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = postgres_common_argument_spec()
+    argument_spec.update(
         db=dict(type='str'),
         filter=dict(type='str', default="*"),
-        ssl_mode=dict(type='str', default='prefer', choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
+        ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(type='str'),
-    ))
+    )
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
@@ -893,11 +886,9 @@ def main():
         if 'sslrootcert' in e.args[0]:
             module.fail_json(msg='Postgresql server must be at least version 8.4 '
                                  'to support sslrootcert')
-        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
-                         exception=traceback.format_exc())
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e))
     except Exception as e:
-        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
-                         exception=traceback.format_exc())
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e))
 
     # Do job:
     pg_facts = PgClusterFacts(module, cursor)
@@ -908,14 +899,6 @@ def main():
 
     else:
         kw['ansible_facts'] = pg_facts.collect()
-
-    # Rollback transaction, if checkmode.
-    # Otherwise, commit transaction:
-    # (It doesn't make sense in this praticular case, just for order)
-    if module.check_mode:
-        db_connection.rollback()
-    else:
-        db_connection.commit()
 
     module.exit_json(**kw)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_facts.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_facts.py
@@ -68,7 +68,6 @@ options:
         certificate(s). If the file exists, the server's certificate will be
         verified to be signed by one of these authorities.
 notes:
-   - PostgreSQL server must be 9.4 version or later.
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
    - This module uses psycopg2, a Python PostgreSQL database adapter. You must
@@ -278,6 +277,13 @@ class PgClusterFacts(object):
         """
         Get information about replication slots if exist.
         """
+        # Check that pg_replication_slots exists:
+        res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
+                              "information_schema.tables "
+                              "WHERE table_name = 'pg_replication_slots')")
+        if not res:
+            return 0
+
         query = ("SELECT slot_name, plugin, slot_type, database, "
                  "active FROM pg_replication_slots")
         res = self.__exec_sql(query)
@@ -354,6 +360,13 @@ class PgClusterFacts(object):
         """
         Get information about replication if the server is a master.
         """
+        # Check that pg_replication_slots exists:
+        res = self.__exec_sql("SELECT EXISTS (SELECT 1 FROM "
+                              "information_schema.tables "
+                              "WHERE table_name = 'pg_stat_replication')")
+        if not res:
+            return 0
+
         query = ("SELECT r.pid, a.rolname, r.application_name, r.client_addr, "
                  "r.client_hostname, r.backend_start::text, r.state "
                  "FROM pg_stat_replication AS r "

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -780,6 +780,9 @@
 # Test postgresql_privs
 - include: postgresql_privs.yml
 
+# Test postgresql_facts module:
+- include: postgresql_facts.yml
+
 # dump/restore tests per format
 # ============================================================
 - include: state_dump_restore.yml test_fixture=user file=dbdata.sql

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -13,13 +13,13 @@
 
 - assert:
     that:
-      - result.ansible_facts.version != {}
-      - result.ansible_facts.databases.{{ db_default }}.collate
-      - result.ansible_facts.languages
-      - result.ansible_facts.namespaces.information_schema
-      - result.ansible_facts.settings
-      - result.ansible_facts.tablespaces
-      - result.ansible_facts.roles
+      - result.postgresql_facts.version != {}
+      - result.postgresql_facts.databases.{{ db_default }}.collate
+      - result.postgresql_facts.languages
+      - result.postgresql_facts.namespaces.information_schema
+      - result.postgresql_facts.settings
+      - result.postgresql_facts.tablespaces
+      - result.postgresql_facts.roles
 
 - name: postgresql_facts - check filter param passed by list
   become_user: "{{ pg_user }}"
@@ -35,16 +35,16 @@
 
 - assert:
     that:
-      - result.ansible_facts.version != {}
-      - result.ansible_facts.roles
-      - result.ansible_facts.databases == {}
-      - result.ansible_facts.extensions == {}
-      - result.ansible_facts.namespaces == {}
-      - result.ansible_facts.languages == {}
-      - result.ansible_facts.repl_slots == {}
-      - result.ansible_facts.replications == {}
-      - result.ansible_facts.settings == {}
-      - result.ansible_facts.tablespaces == {}
+      - result.postgresql_facts.version != {}
+      - result.postgresql_facts.roles
+      - result.postgresql_facts.databases == {}
+      - result.postgresql_facts.extensions == {}
+      - result.postgresql_facts.namespaces == {}
+      - result.postgresql_facts.languages == {}
+      - result.postgresql_facts.repl_slots == {}
+      - result.postgresql_facts.replications == {}
+      - result.postgresql_facts.settings == {}
+      - result.postgresql_facts.tablespaces == {}
 
 - name: postgresql_facts - check filter param passed by string
   become_user: "{{ pg_user }}"
@@ -58,16 +58,16 @@
 
 - assert:
     that:
-      - result.ansible_facts.version != {}
-      - result.ansible_facts.roles
-      - result.ansible_facts.databases == {}
-      - result.ansible_facts.extensions == {}
-      - result.ansible_facts.namespaces == {}
-      - result.ansible_facts.languages == {}
-      - result.ansible_facts.repl_slots == {}
-      - result.ansible_facts.replications == {}
-      - result.ansible_facts.settings == {}
-      - result.ansible_facts.tablespaces == {}
+      - result.postgresql_facts.version != {}
+      - result.postgresql_facts.roles
+      - result.postgresql_facts.databases == {}
+      - result.postgresql_facts.extensions == {}
+      - result.postgresql_facts.namespaces == {}
+      - result.postgresql_facts.languages == {}
+      - result.postgresql_facts.repl_slots == {}
+      - result.postgresql_facts.replications == {}
+      - result.postgresql_facts.settings == {}
+      - result.postgresql_facts.tablespaces == {}
 
 - name: postgresql_facts - check filter param passed by string
   become_user: "{{ pg_user }}"
@@ -81,8 +81,8 @@
 
 - assert:
     that:
-      - result.ansible_facts.version
-      - result.ansible_facts.roles == {}
+      - result.postgresql_facts.version
+      - result.postgresql_facts.roles == {}
 
 - name: postgresql_facts - check excluding filter param passed by list
   become_user: "{{ pg_user }}"
@@ -98,6 +98,6 @@
 
 - assert:
     that:
-      - result.ansible_facts.version == {}
-      - result.ansible_facts.roles == {}
-      - result.ansible_facts.databases
+      - result.postgresql_facts.version == {}
+      - result.postgresql_facts.roles == {}
+      - result.postgresql_facts.databases

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -6,6 +6,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_user:
+    db: "{{ db_default }}"
+    login_user: "{{ pg_user }}"
     name: session_superuser
     role_attr_flags: SUPERUSER
 

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -13,11 +13,11 @@
 
 - assert:
     that:
-      - 'result.ansible_facts.version != ""'
-      - 'result.ansible_facts.databases.{{ db_default }}.collate'
-      - 'result.ansible_facts.languages'
-      - 'result.ansible_facts.namespaces.information_schema'
-      - 'result.ansible_facts.settings'
+      - 'result.postgresql_facts.version != ""'
+      - 'result.postgresql_facts.databases.{{ db_default }}.collate'
+      - 'result.postgresql_facts.languages'
+      - 'result.postgresql_facts.namespaces.information_schema'
+      - 'result.postgresql_facts.settings'
 
 - name: "postgresql_facts - test check mode (for order, this module doesn't change anything)"
   become_user: "{{ pg_user }}"
@@ -44,9 +44,9 @@
 
 - assert:
     that:
-      - 'result.ansible_facts.version != ""'
-      - 'result.ansible_facts.roles'
-      - 'result.ansible_facts.namespaces == {}'
+      - 'result.postgresql_facts.version != ""'
+      - 'result.postgresql_facts.roles'
+      - 'result.postgresql_facts.namespaces == {}'
 
 - name: "postgresql_facts - check exclude_subset param"
   become_user: "{{ pg_user }}"
@@ -60,5 +60,5 @@
 
 - assert:
     that:
-      - 'result.ansible_facts.version == ""'
-      - 'result.ansible_facts.roles'
+      - 'result.postgresql_facts.version == ""'
+      - 'result.postgresql_facts.roles'

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -13,52 +13,89 @@
 
 - assert:
     that:
-      - 'result.postgresql_facts.version != ""'
-      - 'result.postgresql_facts.databases.{{ db_default }}.collate'
-      - 'result.postgresql_facts.languages'
-      - 'result.postgresql_facts.namespaces.information_schema'
-      - 'result.postgresql_facts.settings'
+      - 'result.ansible_facts.version != ""'
+      - 'result.ansible_facts.databases.{{ db_default }}.collate'
+      - 'result.ansible_facts.languages'
+      - 'result.ansible_facts.namespaces.information_schema'
+      - 'result.ansible_facts.settings'
 
-- name: "postgresql_facts - test check mode (for order, this module doesn't change anything)"
+- name: "postgresql_facts - check incl_subset param passed by list"
   become_user: "{{ pg_user }}"
   become: True
   postgresql_facts:
     db: "{{ db_default }}"
+    login_user: "{{ pg_user }}"
+    incl_subset:
+      - ver*
+      - rol*
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - 'result.ansible_facts.version != ""'
+      - 'result.ansible_facts.roles'
+      - 'result.ansible_facts.databases == {}'
+      - 'result.ansible_facts.extensions == {}'
+      - 'result.ansible_facts.namespaces == {}'
+      - 'result.ansible_facts.languages == {}'
+      - 'result.ansible_facts.repl_slots == {}'
+      - 'result.ansible_facts.replications == {}'
+      - 'result.ansible_facts.settings == {}'
+      - 'result.ansible_facts.tablespaces == {}'
+
+- name: "postgresql_facts - check incl_subset param passed by string"
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_facts:
+    db: "{{ db_default }}"
+    incl_subset: ver*,role*
     login_user: "{{ pg_user }}"
   register: result
   ignore_errors: True
 
 - assert:
     that:
-      - 'result.changed == False'
+      - 'result.ansible_facts.version != ""'
+      - 'result.ansible_facts.roles'
+      - 'result.ansible_facts.databases == {}'
+      - 'result.ansible_facts.extensions == {}'
+      - 'result.ansible_facts.namespaces == {}'
+      - 'result.ansible_facts.languages == {}'
+      - 'result.ansible_facts.repl_slots == {}'
+      - 'result.ansible_facts.replications == {}'
+      - 'result.ansible_facts.settings == {}'
+      - 'result.ansible_facts.tablespaces == {}'
 
-- name: "postgresql_facts - check include_subset param"
+- name: "postgresql_facts - check excl_subset param passed by string"
   become_user: "{{ pg_user }}"
   become: True
   postgresql_facts:
     db: "{{ db_default }}"
-    include_subset: ver*,role*
+    excl_subset: ver*
     login_user: "{{ pg_user }}"
   register: result
   ignore_errors: True
 
 - assert:
     that:
-      - 'result.postgresql_facts.version != ""'
-      - 'result.postgresql_facts.roles'
-      - 'result.postgresql_facts.namespaces == {}'
+      - 'result.ansible_facts.version == ""'
+      - 'result.ansible_facts.roles'
 
-- name: "postgresql_facts - check exclude_subset param"
+- name: "postgresql_facts - check excl_subset param passed by list"
   become_user: "{{ pg_user }}"
   become: True
   postgresql_facts:
     db: "{{ db_default }}"
-    exclude_subset: ver*
+    excl_subset:
+      - ver*
+      - rol*
     login_user: "{{ pg_user }}"
   register: result
   ignore_errors: True
 
 - assert:
     that:
-      - 'result.postgresql_facts.version == ""'
-      - 'result.postgresql_facts.roles'
+      - 'result.ansible_facts.version == ""'
+      - 'result.ansible_facts.roles == {}'
+      - 'result.ansible_facts.databases'

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -15,8 +15,9 @@
     that:
       - result.version != {}
       - result.databases.{{ db_default }}.collate
-      - result.languages
-      - result.namespaces.information_schema
+      - result.databases.{{ db_default }}.languages
+      - result.databases.{{ db_default }}.namespaces
+      - result.databases.{{ db_default }}.extensions
       - result.settings
       - result.tablespaces
       - result.roles
@@ -38,9 +39,6 @@
       - result.version != {}
       - result.roles
       - result.databases == {}
-      - result.extensions == {}
-      - result.namespaces == {}
-      - result.languages == {}
       - result.repl_slots == {}
       - result.replications == {}
       - result.settings == {}
@@ -61,9 +59,6 @@
       - result.version != {}
       - result.roles
       - result.databases == {}
-      - result.extensions == {}
-      - result.namespaces == {}
-      - result.languages == {}
       - result.repl_slots == {}
       - result.replications == {}
       - result.settings == {}

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -13,13 +13,13 @@
 
 - assert:
     that:
-      - result.postgresql_facts.version != {}
-      - result.postgresql_facts.databases.{{ db_default }}.collate
-      - result.postgresql_facts.languages
-      - result.postgresql_facts.namespaces.information_schema
-      - result.postgresql_facts.settings
-      - result.postgresql_facts.tablespaces
-      - result.postgresql_facts.roles
+      - result.version != {}
+      - result.databases.{{ db_default }}.collate
+      - result.languages
+      - result.namespaces.information_schema
+      - result.settings
+      - result.tablespaces
+      - result.roles
 
 - name: postgresql_facts - check filter param passed by list
   become_user: "{{ pg_user }}"
@@ -35,16 +35,16 @@
 
 - assert:
     that:
-      - result.postgresql_facts.version != {}
-      - result.postgresql_facts.roles
-      - result.postgresql_facts.databases == {}
-      - result.postgresql_facts.extensions == {}
-      - result.postgresql_facts.namespaces == {}
-      - result.postgresql_facts.languages == {}
-      - result.postgresql_facts.repl_slots == {}
-      - result.postgresql_facts.replications == {}
-      - result.postgresql_facts.settings == {}
-      - result.postgresql_facts.tablespaces == {}
+      - result.version != {}
+      - result.roles
+      - result.databases == {}
+      - result.extensions == {}
+      - result.namespaces == {}
+      - result.languages == {}
+      - result.repl_slots == {}
+      - result.replications == {}
+      - result.settings == {}
+      - result.tablespaces == {}
 
 - name: postgresql_facts - check filter param passed by string
   become_user: "{{ pg_user }}"
@@ -58,16 +58,16 @@
 
 - assert:
     that:
-      - result.postgresql_facts.version != {}
-      - result.postgresql_facts.roles
-      - result.postgresql_facts.databases == {}
-      - result.postgresql_facts.extensions == {}
-      - result.postgresql_facts.namespaces == {}
-      - result.postgresql_facts.languages == {}
-      - result.postgresql_facts.repl_slots == {}
-      - result.postgresql_facts.replications == {}
-      - result.postgresql_facts.settings == {}
-      - result.postgresql_facts.tablespaces == {}
+      - result.version != {}
+      - result.roles
+      - result.databases == {}
+      - result.extensions == {}
+      - result.namespaces == {}
+      - result.languages == {}
+      - result.repl_slots == {}
+      - result.replications == {}
+      - result.settings == {}
+      - result.tablespaces == {}
 
 - name: postgresql_facts - check filter param passed by string
   become_user: "{{ pg_user }}"
@@ -81,8 +81,8 @@
 
 - assert:
     that:
-      - result.postgresql_facts.version
-      - result.postgresql_facts.roles == {}
+      - result.version
+      - result.roles == {}
 
 - name: postgresql_facts - check excluding filter param passed by list
   become_user: "{{ pg_user }}"
@@ -98,6 +98,6 @@
 
 - assert:
     that:
-      - result.postgresql_facts.version == {}
-      - result.postgresql_facts.roles == {}
-      - result.postgresql_facts.databases
+      - result.version == {}
+      - result.roles == {}
+      - result.databases

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -2,12 +2,20 @@
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: postgresql_facts - test return values
+- name: postgresql_facts - create role to check session_role
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_user:
+    name: session_superuser
+    role_attr_flags: SUPERUSER
+
+- name: postgresql_facts - test return values and session_role param
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_facts:
     db: "{{ db_default }}"
     login_user: "{{ pg_user }}"
+    session_role: session_superuser
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -2,26 +2,26 @@
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: "postgresql_facts - test return values"
+- name: postgresql_facts - test return values
   become_user: "{{ pg_user }}"
-  become: True
+  become: yes
   postgresql_facts:
     db: "{{ db_default }}"
     login_user: "{{ pg_user }}"
   register: result
-  ignore_errors: True
+  ignore_errors: yes
 
 - assert:
     that:
-      - 'result.ansible_facts.version != ""'
-      - 'result.ansible_facts.databases.{{ db_default }}.collate'
-      - 'result.ansible_facts.languages'
-      - 'result.ansible_facts.namespaces.information_schema'
-      - 'result.ansible_facts.settings'
+      - result.ansible_facts.version != {}
+      - result.ansible_facts.databases.{{ db_default }}.collate
+      - result.ansible_facts.languages
+      - result.ansible_facts.namespaces.information_schema
+      - result.ansible_facts.settings
 
-- name: "postgresql_facts - check incl_subset param passed by list"
+- name: postgresql_facts - check incl_subset param passed by list
   become_user: "{{ pg_user }}"
-  become: True
+  become: yes
   postgresql_facts:
     db: "{{ db_default }}"
     login_user: "{{ pg_user }}"
@@ -29,62 +29,62 @@
       - ver*
       - rol*
   register: result
-  ignore_errors: True
+  ignore_errors: yes
 
 - assert:
     that:
-      - 'result.ansible_facts.version != ""'
-      - 'result.ansible_facts.roles'
-      - 'result.ansible_facts.databases == {}'
-      - 'result.ansible_facts.extensions == {}'
-      - 'result.ansible_facts.namespaces == {}'
-      - 'result.ansible_facts.languages == {}'
-      - 'result.ansible_facts.repl_slots == {}'
-      - 'result.ansible_facts.replications == {}'
-      - 'result.ansible_facts.settings == {}'
-      - 'result.ansible_facts.tablespaces == {}'
+      - result.ansible_facts.version != {}
+      - result.ansible_facts.roles
+      - result.ansible_facts.databases == {}
+      - result.ansible_facts.extensions == {}
+      - result.ansible_facts.namespaces == {}
+      - result.ansible_facts.languages == {}
+      - result.ansible_facts.repl_slots == {}
+      - result.ansible_facts.replications == {}
+      - result.ansible_facts.settings == {}
+      - result.ansible_facts.tablespaces == {}
 
-- name: "postgresql_facts - check incl_subset param passed by string"
+- name: postgresql_facts - check incl_subset param passed by string
   become_user: "{{ pg_user }}"
-  become: True
+  become: yes
   postgresql_facts:
     db: "{{ db_default }}"
     incl_subset: ver*,role*
     login_user: "{{ pg_user }}"
   register: result
-  ignore_errors: True
+  ignore_errors: yes
 
 - assert:
     that:
-      - 'result.ansible_facts.version != ""'
-      - 'result.ansible_facts.roles'
-      - 'result.ansible_facts.databases == {}'
-      - 'result.ansible_facts.extensions == {}'
-      - 'result.ansible_facts.namespaces == {}'
-      - 'result.ansible_facts.languages == {}'
-      - 'result.ansible_facts.repl_slots == {}'
-      - 'result.ansible_facts.replications == {}'
-      - 'result.ansible_facts.settings == {}'
-      - 'result.ansible_facts.tablespaces == {}'
+      - result.ansible_facts.version != {}
+      - result.ansible_facts.roles
+      - result.ansible_facts.databases == {}
+      - result.ansible_facts.extensions == {}
+      - result.ansible_facts.namespaces == {}
+      - result.ansible_facts.languages == {}
+      - result.ansible_facts.repl_slots == {}
+      - result.ansible_facts.replications == {}
+      - result.ansible_facts.settings == {}
+      - result.ansible_facts.tablespaces == {}
 
-- name: "postgresql_facts - check excl_subset param passed by string"
+- name: postgresql_facts - check excl_subset param passed by string
   become_user: "{{ pg_user }}"
-  become: True
+  become: yes
   postgresql_facts:
     db: "{{ db_default }}"
     excl_subset: ver*
     login_user: "{{ pg_user }}"
   register: result
-  ignore_errors: True
+  ignore_errors: yes
 
 - assert:
     that:
-      - 'result.ansible_facts.version == ""'
-      - 'result.ansible_facts.roles'
+      - result.ansible_facts.version == {}
+      - result.ansible_facts.roles
 
-- name: "postgresql_facts - check excl_subset param passed by list"
+- name: postgresql_facts - check excl_subset param passed by list
   become_user: "{{ pg_user }}"
-  become: True
+  become: yes
   postgresql_facts:
     db: "{{ db_default }}"
     excl_subset:
@@ -92,10 +92,10 @@
       - rol*
     login_user: "{{ pg_user }}"
   register: result
-  ignore_errors: True
+  ignore_errors: yes
 
 - assert:
     that:
-      - 'result.ansible_facts.version == ""'
-      - 'result.ansible_facts.roles == {}'
-      - 'result.ansible_facts.databases'
+      - result.ansible_facts.version == {}
+      - result.ansible_facts.roles == {}
+      - result.ansible_facts.databases

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -18,14 +18,16 @@
       - result.ansible_facts.languages
       - result.ansible_facts.namespaces.information_schema
       - result.ansible_facts.settings
+      - result.ansible_facts.tablespaces
+      - result.ansible_facts.roles
 
-- name: postgresql_facts - check incl_subset param passed by list
+- name: postgresql_facts - check filter param passed by list
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_facts:
     db: "{{ db_default }}"
     login_user: "{{ pg_user }}"
-    incl_subset:
+    filter:
       - ver*
       - rol*
   register: result
@@ -44,12 +46,12 @@
       - result.ansible_facts.settings == {}
       - result.ansible_facts.tablespaces == {}
 
-- name: postgresql_facts - check incl_subset param passed by string
+- name: postgresql_facts - check filter param passed by string
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_facts:
     db: "{{ db_default }}"
-    incl_subset: ver*,role*
+    filter: ver*,role*
     login_user: "{{ pg_user }}"
   register: result
   ignore_errors: yes
@@ -67,29 +69,29 @@
       - result.ansible_facts.settings == {}
       - result.ansible_facts.tablespaces == {}
 
-- name: postgresql_facts - check excl_subset param passed by string
+- name: postgresql_facts - check filter param passed by string
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_facts:
     db: "{{ db_default }}"
-    excl_subset: ver*
+    filter: ver*
     login_user: "{{ pg_user }}"
   register: result
   ignore_errors: yes
 
 - assert:
     that:
-      - result.ansible_facts.version == {}
-      - result.ansible_facts.roles
+      - result.ansible_facts.version
+      - result.ansible_facts.roles == {}
 
-- name: postgresql_facts - check excl_subset param passed by list
+- name: postgresql_facts - check excluding filter param passed by list
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_facts:
     db: "{{ db_default }}"
-    excl_subset:
-      - ver*
-      - rol*
+    filter:
+      - "!ver*"
+      - "!rol*"
     login_user: "{{ pg_user }}"
   register: result
   ignore_errors: yes

--- a/test/integration/targets/postgresql/tasks/postgresql_facts.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_facts.yml
@@ -1,0 +1,64 @@
+# Test code for the postgresql_facts module
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: "postgresql_facts - test return values"
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_facts:
+    db: "{{ db_default }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - 'result.ansible_facts.version != ""'
+      - 'result.ansible_facts.databases.{{ db_default }}.collate'
+      - 'result.ansible_facts.languages'
+      - 'result.ansible_facts.namespaces.information_schema'
+      - 'result.ansible_facts.settings'
+
+- name: "postgresql_facts - test check mode (for order, this module doesn't change anything)"
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_facts:
+    db: "{{ db_default }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - 'result.changed == False'
+
+- name: "postgresql_facts - check include_subset param"
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_facts:
+    db: "{{ db_default }}"
+    include_subset: ver*,role*
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - 'result.ansible_facts.version != ""'
+      - 'result.ansible_facts.roles'
+      - 'result.ansible_facts.namespaces == {}'
+
+- name: "postgresql_facts - check exclude_subset param"
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_facts:
+    db: "{{ db_default }}"
+    exclude_subset: ver*
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - 'result.ansible_facts.version == ""'
+      - 'result.ansible_facts.roles'


### PR DESCRIPTION
##### SUMMARY
New module postgresql_facts: Gathers facts about PostgreSQL servers.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
postgresql_facts

##### MAIN PARAMETERS
```yaml
  filter:
    description:
      - Limit collected facts by comma separated string or YAML list.
      - Allowable values are C(version), C(databases), C(settings), C(tablespaces), C(roles),
        C(replications), C(repl_slots).
      - By default, collects all subsets.
      - You can use shell-style (fnmatch) wildcard to pass groups of values (see Examples).
      - You can use '!' before value (for example, C(!settings)) to exclude it from facts.
      - If you pass including and excluding values to the filter, for example, I(filter=!settings,ver),
        the excluding values will be ignored.
```
##### EXAMPLES
```yaml
# Display facts from postgres hosts.
# ansible postgres -m postgresql_facts

# Display only databases and roles facts from all hosts using shell-style wildcards:
# ansible all -m postgresql_facts -a 'filter=dat*,rol*'

# Display only replications and repl_slots facts from standby hosts using shell-style wildcards:
# ansible standby -m postgresql_facts -a 'filter=repl*'

# Display all facts from databases hosts except settings:
# ansible databases -m postgresql_facts -a 'filter=!settings'

- name: Collect PostgreSQL version and extensions
  postgresql_facts:
    filter: ver*,ext*

- name: Collect all subsets, excluding settings and roles
  postgresql_facts:
    filter: "!settings,!roles"

- name: Collect tablespaces and repl_slots facts
  postgresql_facts:
    filter:
      - tablesp*
      - repl_sl*

- name: Collect all facts except settings
  postgresql_facts:
    filter:
      - "!settings"
```
Part of possible returned facts (specially limited):
```json
postgresql_facts": {
        "version": {
            "major": 10, 
            "minor": 6
        },
        "tablespaces": {}, 
        "databases": {
            "mydb": {
                "access_priv": "", 
                "collate": "en_US.UTF-8", 
                "ctype": "en_US.UTF-8", 
                "encoding": "UTF8", 
                "owner": "mydbuser", 
                "size": "45 MB"
                "extensions": {
                    "hstore": {
                        "description": "data type for storing sets of (key, value) pairs", 
                        "extversion": {
                            "major": 1, 
                            "minor": 5
                        }, 
                        "nspname": "public"
                    }, 
                    "plpgsql": {
                        "description": "PL/pgSQL procedural language", 
                        "extversion": {
                            "major": 1, 
                            "minor": 0
                        }, 
                        "nspname": "pg_catalog"
                    }
                }, 
                "languages": {
                    "c": {
                        "lanacl": "", 
                        "lanowner": "postgres"
                    }, 
                    "internal": {
                        "lanacl": "", 
                        "lanowner": "postgres"
                    }, 
                    "plpgsql": {
                        "lanacl": "", 
                        "lanowner": "postgres"
                    }, 
                    "sql": {
                        "lanacl": "", 
                        "lanowner": "postgres"
                    }
                }, 
                "namespaces": {
                    "information_schema": {
                        "nspacl": "{postgres=UC/postgres,=U/postgres}", 
                        "nspowner": "postgres"
                    }, 
                    "pg_catalog": {
                        "nspacl": "{postgres=UC/postgres,=U/postgres}", 
                        "nspowner": "postgres"
                    }, 
                    "pg_temp_1": {
                        "nspacl": "", 
                        "nspowner": "postgres"
                    }, 
                    "pg_toast": {
                        "nspacl": "", 
                        "nspowner": "postgres"
                    }, 
                    "pg_toast_temp_1": {
                        "nspacl": "", 
                        "nspowner": "postgres"
                    }, 
                    "public": {
                        "nspacl": "{postgres=UC/postgres,=UC/postgres}", 
                        "nspowner": "postgres"
                    }
                }, 
            }, 
            "template0": {
                "access_priv": "=c/postgres\npostgres=CTc/postgres", 
                "collate": "en_US.UTF-8", 
                "ctype": "en_US.UTF-8", 
                "encoding": "UTF8", 
                "owner": "postgres", 
                "size": "7729 kB"
            }
        }, 
        "repl_slots": {}, 
        "replications": {}, 
        "roles": {
            "ansible": {
                "canlogin": true, 
                "member_of": [
                    "test"
                ], 
                "superuser": false, 
                "valid_until": ""
            }, 
        "settings": {
           ....,
          "work_mem": {
              "boot_val": "4096", 
              "context": "user", 
              "max_val": "2147483647", 
              "min_val": "64",
              "pretty_val": "4MB",
              "setting": "4096", 
              "sourcefile": "/var/lib/pgsql/11/data/postgresql.auto.conf", 
              "unit": "kB", 
              "val_in_bytes": 4194304, 
              "vartype": "integer",
              "pending_restart": true,
          }, 
           ....,
          "pending_restart_settings": [
            "port", 
            "shared_buffers"
           ],
    }, 
},
```