### PR TITLE
Pluribus Networks snmp community module with unit tests

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_snmp_community.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_community.py
@@ -44,24 +44,24 @@ options:
 """
 
 EXAMPLES = """
-- name: snmp-community functionality
+- name: Create snmp community
   pn_snmp_community:
     pn_cliswitch: "sw01"
     state: "present"
     pn_community_string: "foo"
     pn_community_type: "read-write"
 
-- name: snmp-community functionality
+- name: Delete snmp community
   pn_snmp_community:
     pn_cliswitch: "sw01"
     state: "absent"
     pn_community_string: "foo"
 
-- name: snmp-community functionality
+- name: Modify snmp community
   pn_snmp_community:
     pn_cliswitch: "sw01"
     state: "update"
-    pn_community_string: "F4u1tMgmt"
+    pn_community_string: "foo"
     pn_community_type: "read-only"
 """
 

--- a/lib/ansible/modules/network/netvisor/pn_snmp_community.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_community.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_snmp_community
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to create/modify/delete snmp-community
+description:
+  - This module can be used to create SNMP communities for SNMPv1 or
+    delete SNMP communities for SNMPv1 or modify SNMP communities for SNMPv1.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: false
+  state:
+    description:
+      - State the action to perform. Use C(present) to create snmp-community and
+        C(absent) to delete snmp-community C(update) to update snmp-community.
+    required: true
+    type: str
+    choices: ['present', 'absent', 'update']
+  pn_community_type:
+    description:
+      - community type.
+    type: str
+    choices: ['read-only', 'read-write']
+  pn_community_string:
+    description:
+      - community name.
+    type: str
+"""
+
+EXAMPLES = """
+- name: snmp-community functionality
+  pn_snmp_community:
+    pn_cliswitch: "sw01"
+    state: "present"
+    pn_community_string: "foo"
+    pn_community_type: "read-write"
+
+- name: snmp-community functionality
+  pn_snmp_community:
+    pn_cliswitch: "sw01"
+    state: "absent"
+    pn_community_string: "foo"
+
+- name: snmp-community functionality
+  pn_snmp_community:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_community_string: "F4u1tMgmt"
+    pn_community_type: "read-only"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the snmp-community command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the snmp-community command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the snmp-community-show command.
+    If a user with given name exists, return as True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    """
+    comm_str = module.params['pn_community_string']
+
+    cli += ' snmp-community-show format community-string no-show-headers'
+    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+
+    out = out.split()
+
+    return True if comm_str in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        present='snmp-community-create',
+        absent='snmp-community-delete',
+        update='snmp-community-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_community_type=dict(required=False, type='str',
+                                   choices=['read-only', 'read-write']),
+            pn_community_string=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ["state", "present", ["pn_community_type", "pn_community_string"]],
+            ["state", "absent", ["pn_community_string"]],
+            ["state", "update", ["pn_community_type", "pn_community_string"]],
+        )
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    community_type = module.params['pn_community_type']
+    comm_str = module.params['pn_community_string']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    COMMUNITY_EXISTS = check_cli(module, cli)
+
+    if command == 'snmp-community-modify':
+        if COMMUNITY_EXISTS is False:
+            module.fail_json(
+                failed=True,
+                msg='snmp community name %s does not exist' % comm_str
+            )
+
+    if command == 'snmp-community-delete':
+        if COMMUNITY_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='snmp community name %s does not exist' % comm_str
+            )
+
+    if command == 'snmp-community-create':
+        if COMMUNITY_EXISTS is True:
+            module.exit_json(
+                skipped=True,
+                msg='snmp community with name %s already exists' % comm_str
+            )
+
+    cli += ' %s community-string %s ' % (command, comm_str)
+
+    if command != 'snmp-community-delete' and community_type:
+            cli += ' community-type ' + community_type
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/netvisor/test_pn_snmp_community.py
+++ b/test/units/modules/network/netvisor/test_pn_snmp_community.py
@@ -1,0 +1,75 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_snmp_community
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestSnmpCommunityModule(TestNvosModule):
+
+    module = pn_snmp_community
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_snmp_community.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_snmp_community.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'snmp-community-create':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'snmp-community-delete':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['update'] == 'snmp-community-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = False
+        if state == 'absent':
+            self.run_check_cli.return_value = True
+        if state == 'update':
+            self.run_check_cli.return_value = True
+
+    def test_snmp_community_create(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_community_string': 'foo',
+                         'pn_community_type': 'read-write', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-community-create community-string foo  community-type read-write'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_snmp_community_delete(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_community_string': 'foo',
+                         'state': 'absent'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-community-delete community-string foo '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_snmp_community_update(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_community_string': 'foo',
+                         'pn_community_type': 'read-only', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-community-modify community-string foo  community-type read-only'
+        self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_snmp_community.py
+++ b/test/units/modules/network/netvisor/test_pn_snmp_community.py
@@ -25,6 +25,7 @@ class TestSnmpCommunityModule(TestNvosModule):
 
     def tearDown(self):
         self.mock_run_nvos_commands.stop()
+        self.run_check_cli.stop()
 
     def run_cli_patch(self, module, cli, state_map):
         if state_map['present'] == 'snmp-community-create':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of snmp community for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_snmp_community.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```