### PR TITLE
PR to implement support feature for creating NIOS network container

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -59,6 +59,8 @@ NIOS_NSGROUP = 'nsgroup'
 NIOS_IPV4_FIXED_ADDRESS = 'fixedaddress'
 NIOS_IPV6_FIXED_ADDRESS = 'ipv6fixedaddress'
 NIOS_NEXT_AVAILABLE_IP = 'func:nextavailableip'
+NIOS_IPV4_NETWORK_CONTAINER = 'networkcontainer'
+NIOS_IPV6_NETWORK_CONTAINER = 'ipv6networkcontainer'
 
 NIOS_PROVIDER_SPEC = {
     'host': dict(fallback=(env_fallback, ['INFOBLOX_HOST'])),

--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -82,6 +82,7 @@ options:
     description:
       - If set to true it'll create the network container to be added or removed
         from the system.
+    type: bool
     version_added: '2.8'
   state:
     description:

--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -78,6 +78,12 @@ options:
       - Configures a text string comment to be associated with the instance
         of this object.  The provided text string will be configured on the
         object instance.
+  container:
+    description:
+      - If set to true it'll create the network container to be added or removed
+        from the system.
+    default: false
+    version_added: '2.8'
   state:
     description:
       - Configures the intended state of the instance of the object on
@@ -133,6 +139,39 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
+- name: configure a ipv4 network container
+  nios_network:
+    network: 192.168.10.0/24
+    container: true
+    comment: test network container
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: configure a ipv6 network container
+  nios_network:
+    network: fe80::/64
+    container: true
+    comment: test network container
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: remove a ipv4 network container
+  nios_network:
+    networkr: 192.168.10.0/24
+    container: true
+    comment: test network container
+    state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
 '''
 
 RETURN = ''' # '''
@@ -141,8 +180,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.net_tools.nios.api import WapiModule
 from ansible.module_utils.network.common.utils import validate_ip_address, validate_ip_v6_address
-from ansible.module_utils.net_tools.nios.api import NIOS_IPV4_NETWORK
-from ansible.module_utils.net_tools.nios.api import NIOS_IPV6_NETWORK
+from ansible.module_utils.net_tools.nios.api import NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK
+from ansible.module_utils.net_tools.nios.api import NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER
 
 
 def options(module):
@@ -170,15 +209,27 @@ def options(module):
     return options
 
 
-def check_ip_addr_type(ip):
-    '''This function will check if the argument ip is type v4/v6 and return appropriate infoblox network type
+def check_ip_addr_type(obj_filter, ib_spec):
+    '''This function will check if the argument ip is type v4/v6 and return appropriate infoblox
+       network/networkcontainer type
     '''
-    check_ip = ip.split('/')
 
-    if validate_ip_address(check_ip[0]):
-        return NIOS_IPV4_NETWORK
-    elif validate_ip_v6_address(check_ip[0]):
-        return NIOS_IPV6_NETWORK
+    ip = obj_filter['network']
+    if 'container' in obj_filter and obj_filter['container']:
+        check_ip = ip.split('/')
+        del ib_spec['container'] #removing the container key from post arguments
+        del ib_spec['options'] #removing option argument as for network container it's not supported
+        if validate_ip_address(check_ip[0]):
+            return NIOS_IPV4_NETWORK_CONTAINER, ib_spec
+        elif validate_ip_v6_address(check_ip[0]):
+            return NIOS_IPV6_NETWORK_CONTAINER, ib_spec
+    else:
+        check_ip = ip.split('/')
+
+        if validate_ip_address(check_ip[0]):
+            return NIOS_IPV4_NETWORK, ib_spec
+        elif validate_ip_v6_address(check_ip[0]):
+            return NIOS_IPV6_NETWORK, ib_spec
 
 
 def check_vendor_specific_dhcp_option(module, ib_spec):
@@ -215,7 +266,8 @@ def main():
         options=dict(type='list', elements='dict', options=option_spec, transform=options),
 
         extattrs=dict(type='dict'),
-        comment=dict()
+        comment=dict(),
+        container=dict(type='bool', default=False, ib_req=True)
     )
 
     argument_spec = dict(
@@ -231,7 +283,7 @@ def main():
 
     # to get the argument ipaddr
     obj_filter = dict([(k, module.params[k]) for k, v in iteritems(ib_spec) if v.get('ib_req')])
-    network_type = check_ip_addr_type(obj_filter['network'])
+    network_type, ib_spec = check_ip_addr_type(obj_filter, ib_spec)
 
     wapi = WapiModule(module)
     # to check for vendor specific dhcp option

--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -82,7 +82,6 @@ options:
     description:
       - If set to true it'll create the network container to be added or removed
         from the system.
-    default: false
     version_added: '2.8'
   state:
     description:
@@ -217,15 +216,15 @@ def check_ip_addr_type(obj_filter, ib_spec):
     ip = obj_filter['network']
     if 'container' in obj_filter and obj_filter['container']:
         check_ip = ip.split('/')
-        del ib_spec['container'] #removing the container key from post arguments
-        del ib_spec['options'] #removing option argument as for network container it's not supported
+        del ib_spec['container']  # removing the container key from post arguments
+        del ib_spec['options']  # removing option argument as for network container it's not supported
         if validate_ip_address(check_ip[0]):
             return NIOS_IPV4_NETWORK_CONTAINER, ib_spec
         elif validate_ip_v6_address(check_ip[0]):
             return NIOS_IPV6_NETWORK_CONTAINER, ib_spec
     else:
         check_ip = ip.split('/')
-
+        del ib_spec['container']  # removing the container key from post arguments
         if validate_ip_address(check_ip[0]):
             return NIOS_IPV4_NETWORK, ib_spec
         elif validate_ip_v6_address(check_ip[0]):
@@ -267,7 +266,7 @@ def main():
 
         extattrs=dict(type='dict'),
         comment=dict(),
-        container=dict(type='bool', default=False, ib_req=True)
+        container=dict(type='bool', ib_req=True)
     )
 
     argument_spec = dict(

--- a/test/units/modules/net_tools/nios/test_nios_network.py
+++ b/test/units/modules/net_tools/nios/test_nios_network.py
@@ -160,7 +160,6 @@ class TestNiosNetworkModule(TestNiosModule):
         }
 
         wapi = self._get_wapi(test_object)
-        print("WAPI: ", wapi)
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
@@ -190,3 +189,61 @@ class TestNiosNetworkModule(TestNiosModule):
 
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ref)
+
+    def test_nios_networkcontainer_ipv4_create(self):
+        self.module.params = {'provider': None, 'state': 'present', 'networkcontainer': '192.168.10.0/24',
+                              'comment': None, 'extattrs': None}
+
+        test_object = None
+        test_spec = {
+            "networkcontainer": {"ib_req": True},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with('testobject', {'networkcontainer': '192.168.10.0/24'})
+
+    def test_nios_networkcontainer_ipv4_remove(self):
+        self.module.params = {'provider': None, 'state': 'absent', 'networkcontainer': '192.168.10.0/24',
+                              'comment': None, 'extattrs': None}
+
+        ref = "networkcontainer/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/false"
+
+        test_object = [{
+            "comment": "test comment",
+            "_ref": ref,
+            "networkcontainer": "192.168.10.0/24"
+        }]
+
+        test_spec = {
+            "networkcontainer": {"ib_req": True},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+
+    def test_nios_networkcontainer_ipv6_create(self):
+        self.module.params = {'provider': None, 'state': 'present', 'ipv6networkcontainer': 'fe80::/64',
+                              'comment': None, 'extattrs': None}
+
+        test_object = None
+        test_spec = {
+            "ipv6networkcontainer": {"ib_req": True},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with('testobject', {'ipv6networkcontainer': 'fe80::/64'})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR raised to include feature request raised in issue #51161 in ansible version `2.8`, with this change user can now create network containers in NIOS via available `nios_network` ansible module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
