### PR TITLE
Allows usage of public ip, private ip or hostname in Linode inventory

### DIFF
--- a/lib/ansible/plugins/inventory/linode.py
+++ b/lib/ansible/plugins/inventory/linode.py
@@ -143,6 +143,10 @@ class InventoryModule(BaseInventoryPlugin):
                     result_ip = ip
             if result_ip:
                 return result_ip
+            else:
+                raise AnsibleError(
+                    'Expected IPv4 address not found'
+                )
         else:
             raise AnsibleError(
                 'Instance IPv4 address is missing or empty'

--- a/test/units/plugins/inventory/test_linode.py
+++ b/test/units/plugins/inventory/test_linode.py
@@ -147,7 +147,7 @@ def test_validation_option_bad_option(inventory):
 def test_empty_config_query_options(inventory):
     regions, types, instance_access = inventory._get_user_options({})
     assert regions == types == []
-    assert instance_access == 'hostname'
+    assert instance_access == 'label'
 
 
 def test_config_user_options(inventory):

--- a/test/units/plugins/inventory/test_linode.py
+++ b/test/units/plugins/inventory/test_linode.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 
 import pytest
 import sys
-import os
 import json
 from collections import namedtuple
 
@@ -122,6 +121,7 @@ instances_json = """
 # converts instance_json dict into python objects
 instances = json.loads(instances_json, object_hook=lambda d: namedtuple('X', d.keys())(*d.values()))
 
+
 @pytest.fixture(scope="module")
 def inventory():
     return InventoryModule()
@@ -166,10 +166,12 @@ def test_config_user_options(inventory):
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('foobar.linde.yml') is False
 
-def test_get_instance_public_ip(inventory):
-    instance = instances.data[0]
-    assert inventory._get_instance_public_ip(instance) == '123.45.67.89'
 
-def test_get_instance_private_ip(inventory):
+def test_get_instance_ip_public(inventory):
     instance = instances.data[0]
-    assert inventory._get_instance_private_ip(instance) == '192.168.45.67'
+    assert inventory._get_instance_ip(instance, private=False) == '123.45.67.89'
+
+
+def test_get_instance_ip_private(inventory):
+    instance = instances.data[0]
+    assert inventory._get_instance_ip(instance, private=True) == '192.168.45.67'

--- a/test/units/plugins/inventory/test_linode.py
+++ b/test/units/plugins/inventory/test_linode.py
@@ -107,8 +107,7 @@ instances_json = """
       "created": "2017-01-01T00:00:00",
       "region": "us-east-1a",
       "ipv4": [
-        "123.45.67.89",
-        "192.168.45.68"
+        "123.45.67.89"
       ],
       "updated": "2017-01-01T00:00:00",
       "image": "linode/debian9",
@@ -175,3 +174,10 @@ def test_get_instance_ip_public(inventory):
 def test_get_instance_ip_private(inventory):
     instance = instances.data[0]
     assert inventory._get_instance_ip(instance, private=True) == '192.168.45.67'
+
+
+def test_get_instance_ip_private_missing(inventory):
+    instance = instances.data[1]
+    with pytest.raises(AnsibleError) as error_message:
+        inventory._get_instance_ip(instance, private=True)
+        assert 'Expected IPv4 address not found' in error_message

--- a/test/units/plugins/inventory/test_linode.py
+++ b/test/units/plugins/inventory/test_linode.py
@@ -58,18 +58,21 @@ def test_validation_option_bad_option(inventory):
 
 
 def test_empty_config_query_options(inventory):
-    regions, types = inventory._get_query_options({})
+    regions, types, instance_access = inventory._get_user_options({})
     assert regions == types == []
+    assert instance_access == 'hostname'
 
 
-def test_conig_query_options(inventory):
-    regions, types = inventory._get_query_options({
+def test_config_user_options(inventory):
+    regions, types, instance_access = inventory._get_user_options({
         'regions': ['eu-west', 'us-east'],
         'types': ['g5-standard-2', 'g6-standard-2'],
+        'instance_access': 'public_ip',
     })
 
     assert regions == ['eu-west', 'us-east']
     assert types == ['g5-standard-2', 'g6-standard-2']
+    assert instance_access == 'public_ip'
 
 
 def test_verify_file_bad_config(inventory):

--- a/test/units/plugins/inventory/test_linode.py
+++ b/test/units/plugins/inventory/test_linode.py
@@ -145,21 +145,18 @@ def test_validation_option_bad_option(inventory):
 
 
 def test_empty_config_query_options(inventory):
-    regions, types, instance_access = inventory._get_user_options({})
+    regions, types = inventory._get_user_options({})
     assert regions == types == []
-    assert instance_access == 'label'
 
 
 def test_config_user_options(inventory):
-    regions, types, instance_access = inventory._get_user_options({
+    regions, types = inventory._get_user_options({
         'regions': ['eu-west', 'us-east'],
         'types': ['g5-standard-2', 'g6-standard-2'],
-        'instance_access': 'public_ip',
     })
 
     assert regions == ['eu-west', 'us-east']
     assert types == ['g5-standard-2', 'g6-standard-2']
-    assert instance_access == 'public_ip'
 
 
 def test_verify_file_bad_config(inventory):


### PR DESCRIPTION
The older linode inventory plugin supported using the public IP as well as the
instances label. This change enables using public IP, private IP or hostname. It also injects public_ip and private_ip into `hostvars` for easy access(also as the old plugin).

##### SUMMARY
Fixes #51195 

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
`lib/ansible/plugins/inventory/linode.py`
