### PR TITLE
Ansible.Basic - make choices validate case insensitive

### DIFF
--- a/test/integration/targets/win_certificate_store/tasks/test.yml
+++ b/test/integration/targets/win_certificate_store/tasks/test.yml
@@ -5,7 +5,7 @@
     path: '{{win_cert_dir}}\subj-cert.pem'
     store_location: FakeLocation
   register: fail_fake_location
-  failed_when: "fail_fake_location.msg != 'value of store_location must be one of: CurrentUser, LocalMachine, got: FakeLocation'"
+  failed_when: "fail_fake_location.msg != 'value of store_location must be one of: CurrentUser, LocalMachine. Got no match for: FakeLocation'"
 
 - name: fail with invalid store name
   win_certificate_store:
@@ -13,7 +13,7 @@
     path: '{{win_cert_dir}}\subj-cert.pem'
     store_name: FakeName
   register: fail_fake_name
-  failed_when: "fail_fake_name.msg != 'value of store_name must be one of: AddressBook, AuthRoot, CertificateAuthority, Disallowed, My, Root, TrustedPeople, TrustedPublisher, got: FakeName'"
+  failed_when: "fail_fake_name.msg != 'value of store_name must be one of: AddressBook, AuthRoot, CertificateAuthority, Disallowed, My, Root, TrustedPeople, TrustedPublisher. Got no match for: FakeName'"
 
 - name: fail when state=present and no path is set
   win_certificate_store:

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -1172,7 +1172,7 @@ test_no_log - Invoked with:
         $expected_msg = "internal error: argument spec entry contains an invalid key 'invalid', valid keys: apply_defaults, "
         $expected_msg += "aliases, choices, default, elements, mutually_exclusive, no_log, options, removed_in_version, "
         $expected_msg += "required, required_if, required_one_of, required_together, supports_check_mode, type - "
-        $expected_msg += "found in option_key -> sub_option_key."
+        $expected_msg += "found in option_key -> sub_option_key"
 
         $actual.Keys.Count | Assert-Equals -Expected 3
         $actual.failed | Assert-Equals -Expected $true
@@ -1446,6 +1446,114 @@ test_no_log - Invoked with:
         $actual.invocation | Assert-DictionaryEquals -Expected @{module_args = $complex_args}
     }
 
+    "Numeric choices" = {
+        $spec = @{
+            options = @{
+                option_key = @{
+                    choices = 1, 2, 3
+                    type = "int"
+                }
+            }
+        }
+        $complex_args = @{
+            option_key = "2"
+        }
+
+        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+        try {
+            $m.ExitJson()
+        } catch [System.Management.Automation.RuntimeException] {
+            $output = [Ansible.Basic.AnsibleModule]::FromJson($_test_out)
+        }
+        $output.Keys.Count | Assert-Equals -Expected 2
+        $output.changed | Assert-Equals -Expected $false
+        $output.invocation | Assert-DictionaryEquals -Expected @{module_args = @{option_key = 2}}
+    }
+
+    "Case insensitive choice" = {
+        $spec = @{
+            options = @{
+                option_key = @{
+                    choices = "abc", "def"
+                }
+            }
+        }
+        $complex_args = @{
+            option_key = "ABC"
+        }
+
+        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+        try {
+            $m.ExitJson()
+        } catch [System.Management.Automation.RuntimeException] {
+            $output = [Ansible.Basic.AnsibleModule]::FromJson($_test_out)
+        }
+        $expected_warning = "value of option_key was a case insensitive match of one of: abc, def. "
+        $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
+        $expected_warning += "Case insensitive matches were: ABC"
+
+        $output.invocation | Assert-DictionaryEquals -Expected @{module_args = @{option_key = "ABC"}}
+        $output.warnings.Count | Assert-Equals -Expected 1
+        $output.warnings[0] | Assert-Equals -Expected $expected_warning
+    }
+
+    "Case insensitive choice no_log" = {
+        $spec = @{
+            options = @{
+                option_key = @{
+                    choices = "abc", "def"
+                    no_log = $true
+                }
+            }
+        }
+        $complex_args = @{
+            option_key = "ABC"
+        }
+
+        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+        try {
+            $m.ExitJson()
+        } catch [System.Management.Automation.RuntimeException] {
+            $output = [Ansible.Basic.AnsibleModule]::FromJson($_test_out)
+        }
+        $expected_warning = "value of option_key was a case insensitive match of one of: abc, def. "
+        $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
+        $expected_warning += "Case insensitive matches were: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+
+        $output.invocation | Assert-DictionaryEquals -Expected @{module_args = @{option_key = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}}
+        $output.warnings.Count | Assert-Equals -Expected 1
+        $output.warnings[0] | Assert-Equals -Expected $expected_warning
+    }
+
+    "Case insentitive choice as list" = {
+        $spec = @{
+            options = @{
+                option_key = @{
+                    choices = "abc", "def", "ghi", "JKL"
+                    type = "list"
+                    elements = "str"
+                }
+            }
+        }
+        $complex_args = @{
+            option_key = "AbC", "ghi", "jkl"
+        }
+
+        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+        try {
+            $m.ExitJson()
+        } catch [System.Management.Automation.RuntimeException] {
+            $output = [Ansible.Basic.AnsibleModule]::FromJson($_test_out)
+        }
+        $expected_warning = "value of option_key was a case insensitive match of one or more of: abc, def, ghi, JKL. "
+        $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
+        $expected_warning += "Case insensitive matches were: AbC, jkl"
+
+        $output.invocation | Assert-DictionaryEquals -Expected @{module_args = $complex_args}
+        $output.warnings.Count | Assert-Equals -Expected 1
+        $output.warnings[0] | Assert-Equals -Expected $expected_warning
+    }
+
     "Invalid choice" = {
         $spec = @{
             options = @{
@@ -1468,7 +1576,7 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equals -Expected $true
 
-        $expected_msg = "value of option_key must be one of: a, b, got: c"
+        $expected_msg = "value of option_key must be one of: a, b. Got no match for: c"
 
         $actual.Keys.Count | Assert-Equals -Expected 4
         $actual.changed | Assert-Equals -Expected $false
@@ -1500,7 +1608,7 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equals -Expected $true
 
-        $expected_msg = "value of option_key must be one of: a, b, got: ***"
+        $expected_msg = "value of option_key must be one of: a, b. Got no match for: ***"
 
         $actual.Keys.Count | Assert-Equals -Expected 4
         $actual.changed | Assert-Equals -Expected $false


### PR DESCRIPTION
##### SUMMARY
Currently the choice validation for Ansible.Basic in Windows is case sensitive which is a break from the choice validation in the existing PowerShell util. This change makes things case insensitive for backwards compatibility but also adds a warning saying this will change sometime in the future. Also slightly refactors the options context message to a shared implementation.

Fixes https://github.com/ansible/ansible/issues/51063

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs