### PR TITLE
dnf load substitutions from installroot

### DIFF
--- a/changelogs/fragments/51059-dnf-support-substitutions
+++ b/changelogs/fragments/51059-dnf-support-substitutions
@@ -1,0 +1,3 @@
+minor_changes:
+  - dnf module now supports loading substitution overrides from the installroot
+

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -530,6 +530,9 @@ class DnfModule(YumDnf):
         # Set installroot
         conf.installroot = installroot
 
+        # Load substitutions from the filesystem
+        conf.substitutions.update_from_etc(installroot)
+
         # Handle different DNF versions immutable mutable datatypes and
         # dnf v1/v2/v3
         #


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously the ansible `dnf` module was not loading [dnf substituations](https://dnf.readthedocs.io/en/latest/api_conf.html#dnf.conf.Conf.substitutions) from the installroot, this lead to unexpected behavior on systems where arch overrides were defined.

Fixes #51059

Signed-off-by: Adam Miller <admiller@redhat.com>

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf
