### PR TITLE
synchronize: fix uninterpolated destination ansible_host

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -216,7 +216,7 @@ class ActionModule(ActionBase):
         inventory_hostname = task_vars.get('inventory_hostname')
         dest_host_inventory_vars = task_vars['hostvars'].get(inventory_hostname)
         try:
-            dest_host = dest_host_inventory_vars['ansible_host']
+            dest_host = self._templar.template(dest_host_inventory_vars['ansible_host'])
         except KeyError:
             dest_host = dest_host_inventory_vars.get('ansible_ssh_host', inventory_hostname)
 


### PR DESCRIPTION
##### SUMMARY
The synchronize module does not interpolate the 'ansible_host' setting of the remote host when it is determining the correct rsync command to use. As a result, rsync treats the destination as an odd local path.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
synchronize

##### ADDITIONAL INFORMATION
I noticed this problem and put together the patch while using the debian-stable backport package of ansible (version 2.7.5+dfsg-1~bpo9+1).

I did not setup a development environment running the ansible devel branch to test the fix, and I'm not familiar enough with the ansible codebase to know if this causes any side-effects.

Example hostlist:
```
---
all:
  vars:
    ansible_host: "{{ hostvars[inventory_hostname]['internal_ip'] | default(hostvars[inventory_hostname]['external_ip'])}}"
  hosts:
    website:
      internal_ip: 192.168.0.2
```
Example task:
```
- name: Copy files
  synchronize:
    dest: "/var/testdir"
    src: "files/testdir/"
    verify_host: true
    recursive: true
    rsync_opts:
      - '--chmod=o-rwx'
  become: true
```
Example error:

> TASK [Copy files] ****************************************************************************************************************************************************************************************************************************************************
> fatal: [website]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh=/usr/bin/ssh -S none --rsync-path=sudo rsync --chmod=o-rwx --out-format=<<CHANGED>>%i %n%L /home/testuser/ansible/files/testdir/ syncuser@{{ hostvars[inventory_hostname]['internal_ip'] | default(hostvars[inventory_hostname]['external_ip'])}}:/var/testdir", "msg": "rsync: mkdir \"/home/testuser/ansible/files/testdir/ syncuser@{{ hostvars[inventory_hostname]['internal_ip'] | default(hostvars[inventory_hostname]['external_ip'])}}:/var/testdir\" failed: No such file or directory (2)\nrsync error: error in file IO (code 11) at main.c(675) [Receiver=3.1.2]\n", "rc": 11}

