### PR TITLE
[stable-2.6] Disable failing azure_rm_postgresqlserver test.

### DIFF
--- a/test/integration/targets/azure_rm_postgresqlserver/aliases
+++ b/test/integration/targets/azure_rm_postgresqlserver/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 destructive
 shippable/azure/group4
+disabled


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Disable failing azure_rm_postgresqlserver test.

(cherry picked from commit 37767849ee0aa65d0e683dc67590bba37c344e3f)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_postgresqlserver integration test
