### PR TITLE
added pipelining for z/OS

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -239,7 +239,7 @@ There are a few common errors that one might run into when trying to execute Ans
 To fix it set `pipelining = True` in `/etc/ansible/ansible.cfg`.
 
   .. error::
-    /usr/bin/python: EDC5129I No such file or directory
+      /usr/bin/python: EDC5129I No such file or directory
 
 To fix this set the path to the python installation in your inventory like so::
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -247,10 +247,12 @@ There are a few common errors that one might run into when trying to execute Ans
 
     zos1 ansible_python_interpreter=/usr/lpp/python/python-2017-04-12-py27/python27/bin/python
 
-.. error::
+* Start of python fails with ``The module libpython2.7.so was not found.``
+
+  .. error::
     EE3501S The module libpython2.7.so was not found.
 
-On z/OS, you must execute python from gnu bash.  If gnu bash is installed at ``/usr/lpp/bash``, you can fix this in your inventory by specifying an ``ansible_shell_executable``::
+  On z/OS, you must execute python from gnu bash.  If gnu bash is installed at ``/usr/lpp/bash``, you can fix this in your inventory by specifying an ``ansible_shell_executable``::
 
     zos1 ansible_shell_executable=/usr/lpp/bash/bin/bash
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -233,7 +233,7 @@ There are a few common errors that one might run into when trying to execute Ans
 
 * When ``pipelining = False`` in `/etc/ansible/ansible.cfg` then Ansible modules are transferred in binary mode via sftp however execution of python fails with 
 
-.. error::
+  .. error::
     SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
   
 To fix it set `pipelining = True` in `/etc/ansible/ansible.cfg`.

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -231,7 +231,7 @@ There are a few common errors that one might run into when trying to execute Ans
 
   To get around this limitation, download and install a later version of `python for z/OS <https://www.rocketsoftware.com/zos-open-source>`_ (2.7.13 or 3.6.1) that represents strings internally as ASCII.  Version 2.7.13 is verified to work.
 
-When `pipelining = False` in `/etc/ansible/ansible.cfg` then Ansible modules are transfered in binary mode via sftp however execution of python fails with 
+* When ``pipelining = False`` in `/etc/ansible/ansible.cfg` then Ansible modules are transferred in binary mode via sftp however execution of python fails with 
 
 .. error::
     SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -238,6 +238,8 @@ There are a few common errors that one might run into when trying to execute Ans
   
   To fix it set ``pipelining = True`` in `/etc/ansible/ansible.cfg`.
 
+* Python interpret cannot be found in default location ``/usr/bin/python`` on target host.
+
   .. error::
       /usr/bin/python: EDC5129I No such file or directory
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -231,8 +231,15 @@ There are a few common errors that one might run into when trying to execute Ans
 
 To get around this limitation, download and install a later version of `python for z/OS <https://www.rocketsoftware.com/zos-open-source>`_ (2.7.13 or 3.6.1) that represents strings internally as ascii.  Version 2.7.13 is verified to work.
 
+When `pipelining = False` in `/etc/ansible/ansible.cfg` then Ansible modules are transfered in binary mode via sftp however execution of python fails with 
+
 .. error::
-  /usr/bin/python: EDC5129I No such file or directory
+    SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
+  
+To fix it set `pipelining = True` in `/etc/ansible/ansible.cfg`.
+
+.. error::
+    /usr/bin/python: EDC5129I No such file or directory
 
 To fix this set the path to the python installation in your inventory like so::
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -229,7 +229,7 @@ There are a few common errors that one might run into when trying to execute Ans
 
 * Version 2.7.6 of python for z/OS will not work with Ansible because it represents strings internally as EBCDIC.
 
-To get around this limitation, download and install a later version of `python for z/OS <https://www.rocketsoftware.com/zos-open-source>`_ (2.7.13 or 3.6.1) that represents strings internally as ascii.  Version 2.7.13 is verified to work.
+  To get around this limitation, download and install a later version of `python for z/OS <https://www.rocketsoftware.com/zos-open-source>`_ (2.7.13 or 3.6.1) that represents strings internally as ASCII.  Version 2.7.13 is verified to work.
 
 When `pipelining = False` in `/etc/ansible/ansible.cfg` then Ansible modules are transfered in binary mode via sftp however execution of python fails with 
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -238,7 +238,7 @@ There are a few common errors that one might run into when trying to execute Ans
   
 To fix it set `pipelining = True` in `/etc/ansible/ansible.cfg`.
 
-.. error::
+  .. error::
     /usr/bin/python: EDC5129I No such file or directory
 
 To fix this set the path to the python installation in your inventory like so::

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -234,7 +234,7 @@ There are a few common errors that one might run into when trying to execute Ans
 * When ``pipelining = False`` in `/etc/ansible/ansible.cfg` then Ansible modules are transferred in binary mode via sftp however execution of python fails with 
 
   .. error::
-    SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
+      SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
   
 To fix it set `pipelining = True` in `/etc/ansible/ansible.cfg`.
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -236,7 +236,7 @@ There are a few common errors that one might run into when trying to execute Ans
   .. error::
       SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
   
-To fix it set `pipelining = True` in `/etc/ansible/ansible.cfg`.
+  To fix it set ``pipelining = True`` in `/etc/ansible/ansible.cfg`.
 
   .. error::
       /usr/bin/python: EDC5129I No such file or directory

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -243,7 +243,7 @@ There are a few common errors that one might run into when trying to execute Ans
   .. error::
       /usr/bin/python: EDC5129I No such file or directory
 
-To fix this set the path to the python installation in your inventory like so::
+  To fix this set the path to the python installation in your inventory like so::
 
     zos1 ansible_python_interpreter=/usr/lpp/python/python-2017-04-12-py27/python27/bin/python
 


### PR DESCRIPTION
##### SUMMARY
Enhanced FAQ for z/OS to enable pipelininig to ensure that transferred ansible module has EBCDIC encoding.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
NA

##### ADDITIONAL INFORMATION
Running 
```shell
ansible -vvv zos -i inv -m copy -a "src=requirements.txt dest=target.txt"
```
against a z/OS target machine while pipelining is disabled causes fails with
```
<zos> ESTABLISH SSH CONNECTION FOR USER: None
<zos> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/user1/.ansible/cp/8550146bb6 -tt ca31 '/bin/sh -c '"'"'/C/zConnect/usr/lpp/IBM/izoda/anaconda/bin/python /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py && sleep 0'"'"''
<zos> (1, '  File "/a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py", line 1\r\nSyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details\r\n', 'Shared connection to zos closed.\r\n')
```
