### PR TITLE
Ignore WinRMOperationTimeoutError in WinRM Send operation

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -135,6 +135,7 @@ else:
 try:
     import winrm
     from winrm import Response
+    from winrm.exceptions import WinRMOperationTimeoutError
     from winrm.protocol import Protocol
     HAS_WINRM = True
 except ImportError as e:
@@ -453,6 +454,15 @@ class Connection(ConnectionBase):
                 if stdin_iterator:
                     for (data, is_last) in stdin_iterator:
                         self._winrm_send_input(self.protocol, self.shell_id, command_id, data, eof=is_last)
+
+            except WinRMOperationTimeoutError as ex:
+                # This exception seems to be a non-error and could make Ansible tasks fail even so they
+                # completed successfully and returned a valid result.
+                # Usually, this exception should only be raised during a Receive operation, not during a Send.
+                # The Receive operation is implemented in winrm.get_command_output()
+                # which polls the result asynchronously and already handles this case.
+                # Thus, we should ignore this exception here.
+                display.warning("IGNORING WINRM OPERATION TIMEOUT ERROR: %s" % to_text(ex))
 
             except Exception as ex:
                 display.warning("FATAL ERROR DURING FILE TRANSFER: %s" % to_text(ex))


### PR DESCRIPTION
##### SUMMARY
We see quite frequently Ansible runs failing with a `winrm send_input failed` error.

After some investigation, we discovered that this is actually a `WinRMOperationTimeoutError` which is raised in the underlying `winrm.send_message()`:
https://github.com/diyan/pywinrm/blob/v0.3.0/winrm/protocol.py#L256

According to the comment in the code and also https://msdn.microsoft.com/en-us/library/cc251676.aspx this is a "normal" return code for the Receive operation of WinRM.
Somehow we manage to get this on a Send operation where this is not expected (at least not documented: https://msdn.microsoft.com/en-us/library/cc251702.aspx).

The `get_command_output()` implementation in winrm is doing the retry/polling for this error in case for the Receive: https://github.com/diyan/pywinrm/blob/v0.3.0/winrm/protocol.py#L401
We still seem to get the task result even in case we hit that timeout, since the result is retrieved asynchronously by `winrm.get_command_output()`.

As this seems to be a non-error, we tried to just catch this error and ignore it to continue with the Ansible run which worked quite well in our scenario. I assume, that if the response is not complete, the retrieval will most likely fail anyways and make the task fail.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Could be related to #48290 and #27556

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/connection/winrm.py`