### PR TITLE
docker_container: userns_mode description updated to mention valid value

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -352,7 +352,7 @@ options:
       - Connect the container to a network. Choices are "bridge", "host", "none" or "container:<name|id>"
   userns_mode:
      description:
-       - Set the usernamespace mode for the container. Only valid value is "host".
+       - Set the user namespace mode for the container. Currently, the only valid value is C(host).
      version_added: "2.5"
   networks:
      description:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -352,7 +352,7 @@ options:
       - Connect the container to a network. Choices are "bridge", "host", "none" or "container:<name|id>"
   userns_mode:
      description:
-       - User namespace to use
+       - Set the usernamespace mode for the container. Only valid value is "host".
      version_added: "2.5"
   networks:
      description:


### PR DESCRIPTION
The only valid value for userns_mode on docker run command is "host". This should be mentioned in description because it is hard to find in docker documentation as well: https://github.com/docker/docker.github.io/issues/7071

##### SUMMARY
I searched for the valid value on userns_mode and had a hard time finding the right one in docker docs. In the end the value is only to be found in docker-code itself. So it would be nice to have a hint on valid values in ansible documentation.

##### ISSUE TYPE
- Documentation Report

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION
