### PR TITLE
Fixed interactions between zabbix_template module options and data wi…

### DIFF
--- a/changelogs/fragments/50834-50833-zabbix_template-json.yaml
+++ b/changelogs/fragments/50834-50833-zabbix_template-json.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - zabbix_template - Module no longer requires ``template_name`` to be provided when importing with ``template_json`` option (https://github.com/ansible/ansible/issues/50833)
+bugfixes:
+  - zabbix_template - Fixed cryptic error when ``template_groups`` option wasn't provided (https://github.com/ansible/ansible/issues/50834)
+  - zabbix_template - Failed template import will no longer leave empty templates configured on Zabbix server


### PR DESCRIPTION
…thin JSON object

##### SUMMARY

Module used weird logic when importing template from `template_json` object by first creating empty template via `template.create` Zabbix API call and then overriding it via `configuration.import` Zabbix API call. This in some cases resulted in inconsistent results (e.g. empty template was created when import failed).

Another problem was that `template_groups` option was not required, but calling Zabbix API without this argument resulted in not well formatted errors. 

Fixes #50833
Fixes #50834

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template
