### PR TITLE
docker scenario guide: add $team_docker as maintainer and label docker

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1244,6 +1244,9 @@ files:
     maintainers:
       - samccann
   docs/docsite/rst/scenario_guides/guide_aci.rst: *aci
+  docs/docsite/rst/scenario_guides/guide_docker.rst:
+    maintainers: $team_docker
+    labels: docker
   docs/docsite/rst/user_guide/intro_bsd.rst: *bsd
 ###############################
 # 'test' is a component path, then 'test' label will be automatically added


### PR DESCRIPTION
##### SUMMARY
So docker maintainers see changes to docker scenario guide and affecting PRs are labelled with `docker`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
