### PR TITLE
docker_service/docker_compose rename: update porting guide

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -160,6 +160,8 @@ Noteworthy module changes
 * The ``digital_ocean`` module has been deprecated in favor of modules that do not require external dependencies.
   This allows for more flexibility and better module support.
 
+* The ``docker_service`` module was renamed to :ref:`docker_compose <docker_compose_module>`.
+
 Plugins
 =======
 


### PR DESCRIPTION
##### SUMMARY
Updating 2.8 porting guide to include module rename `docker_service` → `docker_compose` (rename done in #51035).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guides/porting_guide_2.8.rst
