### PR TITLE
docker_swarm_service: Fix endpoint mode idempotency

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -117,11 +117,10 @@ options:
     - Dictionary of key value pairs.
     - Maps docker service --container-label option.
   endpoint_mode:
-    required: false
+    type: str
     description:
     - Service endpoint mode.
     - Maps docker service --endpoint-mode option.
-    default: vip
     choices:
     - vip
     - dnsrr
@@ -542,7 +541,7 @@ class DockerService(DockerBaseClass):
         self.image = ""
         self.command = None
         self.args = []
-        self.endpoint_mode = "vip"
+        self.endpoint_mode = None
         self.dns = []
         self.hostname = ""
         self.tty = False
@@ -755,7 +754,7 @@ class DockerService(DockerBaseClass):
         differences = DifferenceTracker()
         needs_rebuild = False
         force_update = False
-        if self.endpoint_mode != os.endpoint_mode:
+        if self.endpoint_mode is not None and self.endpoint_mode != os.endpoint_mode:
             differences.add('endpoint_mode', parameter=self.endpoint_mode, active=os.endpoint_mode)
         if self.env != os.env:
             differences.add('env', parameter=self.env, active=os.env)
@@ -1072,17 +1071,16 @@ class DockerServiceManager():
             ds.restart_policy_attempts = restart_policy_data.get('MaxAttempts')
             ds.restart_policy_window = restart_policy_data.get('Window')
 
-        raw_data_endpoint = raw_data.get('Endpoint', None)
-        if raw_data_endpoint:
-            raw_data_endpoint_spec = raw_data_endpoint.get('Spec', None)
-            if raw_data_endpoint_spec:
-                ds.endpoint_mode = raw_data_endpoint_spec.get('Mode', 'vip')
-                for port in raw_data_endpoint_spec.get('Ports', []):
-                    ds.publish.append({
-                        'protocol': port['Protocol'],
-                        'mode': port.get('PublishMode', None),
-                        'published_port': int(port['PublishedPort']),
-                        'target_port': int(port['TargetPort'])})
+        raw_data_endpoint_spec = raw_data['Spec'].get('EndpointSpec')
+
+        if raw_data_endpoint_spec:
+            ds.endpoint_mode = raw_data_endpoint_spec.get('Mode')
+            for port in raw_data_endpoint_spec.get('Ports', []):
+                ds.publish.append({
+                    'protocol': port['Protocol'],
+                    'mode': port.get('PublishMode', None),
+                    'published_port': int(port['PublishedPort']),
+                    'target_port': int(port['TargetPort'])})
 
         if 'Resources' in task_template_data.keys():
             if 'Limits' in task_template_data['Resources'].keys():
@@ -1288,7 +1286,7 @@ def main():
         container_labels=dict(default={}, type='dict'),
         mode=dict(default="replicated"),
         replicas=dict(default=-1, type='int'),
-        endpoint_mode=dict(default='vip', choices=['vip', 'dnsrr']),
+        endpoint_mode=dict(default=None, choices=['vip', 'dnsrr']),
         restart_policy=dict(default='none', choices=['none', 'on-failure', 'any']),
         limit_cpu=dict(default=0, type='float'),
         limit_memory=dict(default=0, type='str'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1072,7 +1072,6 @@ class DockerServiceManager():
             ds.restart_policy_window = restart_policy_data.get('Window')
 
         raw_data_endpoint_spec = raw_data['Spec'].get('EndpointSpec')
-
         if raw_data_endpoint_spec:
             ds.endpoint_mode = raw_data_endpoint_spec.get('Mode')
             for port in raw_data_endpoint_spec.get('Ports', []):

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -494,14 +494,6 @@
 ## endpoint_mode ###################################################
 ####################################################################
 
-# FIXME: endpoint_mode_2 is not marked as changed
-#fatal: [testhost]: FAILED! => {
-#    "assertion": "endpoint_mode_2 is not changed",
-#    "changed": false,
-#    "evaluated_to": false,
-#    "msg": "Assertion failed"
-#}
-
 - name: endpoint_mode
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -509,19 +501,19 @@
     endpoint_mode: "dnsrr"
   register: endpoint_mode_1
 
-#- name: endpoint_mode (idempotency)
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    endpoint_mode: "dnsrr"
-#  register: endpoint_mode_2
+- name: endpoint_mode (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    endpoint_mode: "dnsrr"
+  register: endpoint_mode_2
 
-#- name: endpoint_mode (changes)
-#  docker_swarm_service:
-#    name: "{{ service_name }}"
-#    image: alpine:3.8
-#    endpoint_mode: "vip"
-#  register: endpoint_mode_3
+- name: endpoint_mode (changes)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    endpoint_mode: "vip"
+  register: endpoint_mode_3
 
 - name: cleanup
   docker_swarm_service:
@@ -532,8 +524,8 @@
 - assert:
     that:
       - endpoint_mode_1 is changed
-#      - endpoint_mode_2 is not changed
-#      - endpoint_mode_3 is changed
+      - endpoint_mode_2 is not changed
+      - endpoint_mode_3 is changed
 
 ####################################################################
 ## env #############################################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

`endpoint_mode` idempotency is broken. The Endpoint-data was fetched from `["Endpoint"]["Spec"]` where only published ports are present. `["Spec"]["EndpointSpec"]` will give both `Ports` and `Mode`.

See:
https://github.com/docker/docker-py/issues/1233
https://docs.docker.com/engine/api/v1.24/#39-services

I've also removed the hardcoded endpoint_mode default of `vip`. This is already the default in docker: https://github.com/docker/docker-py/blob/3.0.0/docker/types/services.py#L448


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
