### PR TITLE
Ignore AttributeError when trying to import p paramiko

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -206,8 +206,10 @@ try:
     from ncclient.transport.errors import SSHUnknownHostError
     from ncclient.xml_ import to_ele, to_xml
     HAS_NCCLIENT = True
-except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    NCCLIENT_IMP_ERR = None
+except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
     HAS_NCCLIENT = False
+    NCCLIENT_IMP_ERR = err
 
 logging.getLogger('ncclient').setLevel(logging.INFO)
 
@@ -270,8 +272,8 @@ class Connection(NetworkConnectionBase):
     def _connect(self):
         if not HAS_NCCLIENT:
             raise AnsibleError(
-                'ncclient is required to use the netconf connection type.\n'
-                'Please run pip install ncclient'
+                'ncclient is required to use the netconf connection type: %s.\n'
+                'Please run pip install ncclient' % to_native(NCCLIENT_IMP_ERR)
             )
 
         self.queue_message('log', 'ssh connection done, starting ncclient')

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -206,7 +206,7 @@ try:
     from ncclient.transport.errors import SSHUnknownHostError
     from ncclient.xml_ import to_ele, to_xml
     HAS_NCCLIENT = True
-except ImportError:
+except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
     HAS_NCCLIENT = False
 
 logging.getLogger('ncclient').setLevel(logging.INFO)

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -168,13 +168,14 @@ SETTINGS_REGEX = re.compile(r'(\w+)(?:\s*=\s*|\s+)(.+)')
 
 # prevent paramiko warning noise -- see http://stackoverflow.com/questions/3920502/
 HAVE_PARAMIKO = False
+PARAMIKO_IMP_ERR = None
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     try:
         import paramiko
         HAVE_PARAMIKO = True
-    except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
-        pass
+    except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+        PARAMIKO_IMP_ERR = err
 
 
 class MyAddPolicy(object):
@@ -305,7 +306,7 @@ class Connection(ConnectionBase):
         ''' activates the connection object '''
 
         if not HAVE_PARAMIKO:
-            raise AnsibleError("paramiko is not installed")
+            raise AnsibleError("paramiko is not installed: %s" % to_native(PARAMIKO_IMP_ERR))
 
         port = self._play_context.port or 22
         display.vvv("ESTABLISH PARAMIKO SSH CONNECTION FOR USER: %s on PORT %s TO %s" % (self._play_context.remote_user, port, self._play_context.remote_addr),

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -173,7 +173,7 @@ with warnings.catch_warnings():
     try:
         import paramiko
         HAVE_PARAMIKO = True
-    except ImportError:
+    except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
         pass
 
 


### PR DESCRIPTION
##### SUMMARY
When the [newer gssapi](https://github.com/pythongssapi/python-gssapi) library is installed, paramiko will fail to import and will raise an AttributeError. It is expecting the [older and deprecated gssapi](https://github.com/sigmaris/python-gssapi) library but there is a namespace collision here. There's a PR to support the newer library in paramiko https://github.com/paramiko/paramiko/pull/1311 but this doesn't seem to be going anywhere fast.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
connection/netconf
connection/paramiko_ssh