### PR TITLE
Enable paramiko connection tests on RHEL 8.0.

### DIFF
--- a/test/integration/targets/connection_paramiko_ssh/aliases
+++ b/test/integration/targets/connection_paramiko_ssh/aliases
@@ -1,3 +1,2 @@
 needs/ssh
 shippable/posix/group3
-skip/rhel8.0

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -98,7 +98,7 @@ fi
 # We also need to add localhost's server keys to known_hosts.
 
 if [ ! -f "${HOME}/.ssh/id_rsa.pub" ]; then
-    ssh-keygen -q -t rsa -N '' -f "${HOME}/.ssh/id_rsa"
+    ssh-keygen -m PEM -q -t rsa -N '' -f "${HOME}/.ssh/id_rsa"
     cp "${HOME}/.ssh/id_rsa.pub" "${HOME}/.ssh/authorized_keys"
     for key in /etc/ssh/ssh_host_*_key.pub; do
         pk=$(cat "${key}")


### PR DESCRIPTION
##### SUMMARY

Enable paramiko connection tests on RHEL 8.0.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

connection_paramiko_ssh integration tests
