### PR TITLE
ovirt_disk: Support ISO image uploads.

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -75,6 +75,12 @@ options:
             - Specify format of the disk.
             - Note that this option isn't idempotent as it's not currently possible to change format of the disk via API.
         choices: ['raw', 'cow']
+    content_type:
+        description:
+            - Specify if the disk is a data disk or ISO image
+        choices: ['data', 'iso']
+        default: 'data'
+        version_added: "2.8"
     sparse:
         required: False
         type: bool
@@ -247,6 +253,18 @@ EXAMPLES = '''
     storage_domain: data
     description: somedescriptionhere
     quota_id: "{{ ovirt_quotas[0]['id'] }}"
+
+# Upload an ISO image
+# Since Ansible 2.8
+-  ovirt_disk:
+     name: myiso
+     upload_image_path: /path/to/iso/image
+     storage_domain: data
+     size: 4 GiB
+     wait: true
+     bootable: true
+     format: raw
+     content_type: iso
 '''
 
 
@@ -448,6 +466,9 @@ class DisksModule(BaseModule):
             format=otypes.DiskFormat(
                 self._module.params.get('format')
             ) if self._module.params.get('format') else None,
+            content_type=otypes.DiskContentType(
+                self._module.params.get('content_type')
+            ) if self._module.params.get('content_type') else None,
             sparse=self._module.params.get(
                 'sparse'
             ) if self._module.params.get(
@@ -593,6 +614,7 @@ def main():
         profile=dict(default=None),
         quota_id=dict(default=None),
         format=dict(default='cow', choices=['raw', 'cow']),
+        content_type=dict(default='data', choices=['data','iso']),
         sparse=dict(default=None, type='bool'),
         bootable=dict(default=None, type='bool'),
         shareable=dict(default=None, type='bool'),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -614,7 +614,7 @@ def main():
         profile=dict(default=None),
         quota_id=dict(default=None),
         format=dict(default='cow', choices=['raw', 'cow']),
-        content_type=dict(default='data', choices=['data','iso']),
+        content_type=dict(default='data', choices=['data', 'iso']),
         sparse=dict(default=None, type='bool'),
         bootable=dict(default=None, type='bool'),
         shareable=dict(default=None, type='bool'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
oVirt will only recognize ISO images if DiskContentType is set to "iso". This change implements content_type parameter in ovirt_disk to allow the upload of ISO images.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_disk
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
If content_type is not set, the default value will be "data", avoiding change in behaviour.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
