### PR TITLE
test - skip dnf on RHEL 8 until test is fixed

### DIFF
--- a/test/integration/targets/dnf/aliases
+++ b/test/integration/targets/dnf/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group1
 skip/freebsd
 skip/osx
+skip/rhel8.0


### PR DESCRIPTION
##### SUMMARY
Until the issue between dnf and postgresql tests on RHEL 8 is sorted we will disable the test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/dnf