### PR TITLE
Fix: test if "Label" exists in the spec

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -373,7 +373,7 @@ class SwarmManager(DockerBaseClass):
             self.parameters.name = spec['Name']
 
         if (self.parameters.labels is None):
-            if (spec['Labels'] is not None):
+            if spec.get('Labels') is not None:
                 self.parameters.labels = spec['Labels']
 
         if 'LogDriver' in spec['TaskDefaults']:

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -373,7 +373,8 @@ class SwarmManager(DockerBaseClass):
             self.parameters.name = spec['Name']
 
         if (self.parameters.labels is None):
-            self.parameters.labels = spec['Labels']
+            if (spec['Labels'] is not None):
+                self.parameters.labels = spec['Labels']
 
         if 'LogDriver' in spec['TaskDefaults']:
             self.parameters.log_driver = spec['TaskDefaults']['LogDriver']


### PR DESCRIPTION
Fix: test if "Label" exists in the spec

Fixes: ansible/ansible#51175

<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Related: ansible/ansible#51175

<!--- Write the short name of the module, plugin, task or feature below -->

`docker_swarm`

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```