### PR TITLE
mso_schema: Improvements to docs

### DIFF
--- a/lib/ansible/modules/network/aci/mso_schema.py
+++ b/lib/ansible/modules/network/aci/mso_schema.py
@@ -46,6 +46,12 @@ options:
     type: str
     choices: [ absent, present, query ]
     default: present
+notes:
+- This module cannot create empty schemas (i.e. schemas without templates).
+  Use the M(mso_schema_template) to automatically create schemas with templates.
+seealso:
+- module: mso_schema_site
+- module: mso_schema_template
 extends_documentation_fragment: mso
 '''
 
@@ -126,7 +132,7 @@ def main():
         supports_check_mode=True,
         required_if=[
             ['state', 'absent', ['schema']],
-            ['state', 'present', ['schema']],
+            ['state', 'present', ['schema', 'templates']],
         ],
     )
 


### PR DESCRIPTION
##### SUMMARY
Due to restrictions in the MSO backend, the **mso_schema** module can only be used to create templates, but not an empty schema container. This means most users will want to use **mso_schema_template** instead.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
mso_schema