### PR TITLE
add support for hostname on Raspbian

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -721,6 +721,12 @@ class DevuanHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class RaspbianHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Raspbian gnu/linux'
+    strategy_class = DebianStrategy
+
+
 class GentooHostname(Hostname):
     platform = 'Linux'
     distribution = 'Gentoo base system'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR adds support for the hostname module on Raspbian

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hostname

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

So far, the hostname module does not work on Raspbian:
```
TASK [network : Set hostname] ***********************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux (Raspbian gnu/linux)"}
```
After testing the code change, I get the following output:
```
TASK [network : Set hostname] ***********************************************************************************************************************************************************
ok: [localhost]
```
