### PR TITLE
[WIP] Fix copy module to reset filesystem acls

### DIFF
--- a/changelogs/fragments/44412-copy-fix-unwanted-acls.yaml
+++ b/changelogs/fragments/44412-copy-fix-unwanted-acls.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix unwanted ACLs when using copy module (https://github.com/ansible/ansible/issues/44412)

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -300,11 +300,11 @@ def del_facl(path, acl_tag, acl_qualifier=None):
         if acl_tag == 'g':
             raise ValueError('acl_qualifier must be set to a groupname or groupid when acl_tag is "g"')
 
-    setfacl = get_bin_path('setfacl', True)
-    if acl_qualifier:
-        acl_string = '{0}:{1}:'.format(acl_tag, acl_qualifier)
-    else:
         acl_string = acl_tag
+    else:
+        acl_string = '{0}:{1}:'.format(acl_tag, acl_qualifier)
+
+    setfacl = get_bin_path('setfacl', True)
     # Like: ['/usr/bin/setfacl', '-x', 'u:1000:', '/etc/config.cfg']
     acl_command = [setfacl, '-x', acl_string, path]
     rc, out, err = module.run_command(acl_command)

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -687,20 +687,21 @@ def main():
                             raise
                     except RuntimeError as e:
                         # setfacl failed.
+
                         # FIXME: separate out the following cases and do the appropriate thing:
                         # * If any of the following raise errors, they can be ignored
                         #   * If we're running on python2 therefore the facls were not copied
-                        #   * If there were no facls to clear (because we we're not becoming an
-                        #     unprivileged user, for instance)
                         #   * If the directory we copied into has a default acl, on python2, the
                         #     file ends up with the directory's default acl.  On python3, if the
                         #     file did not start with any acl, it will end up with the default acl.
                         #     A failure to remove 'm' can be ignored.
+
                         # * Treatment of default acls are a related bug.  On Python2, default acls
                         #   are applied to the copied file.  On Python3, the default acls won't
                         #   apply because we copied metadata that tells what the acls are.  Should
                         #   we fix Python2 to not apply default acls (easier)? or fix Python3 to
                         #   apply the default acls?
+
                         # Perhaps it will be easier to:
                         # * Make a clear_facl() function instead of del_facl().  It looks like Linux
                         #   and freebsd support setfacl -b for this but other platforms (z/OS) do not.
@@ -708,7 +709,11 @@ def main():
                         #   * Does the source file have acls?
                         #   * Does the destination file have acls for the default acl and nothing
                         #     else?
-                        if 'Operation not supported' in to_native(e):
+                        native_exc = to_native(e)
+                        if 'Operation not supported' in native_exc:
+                            # noacl file system
+                            pass
+                        elif 'cannot remove non-existent ACL entry' in native_exc:
                             pass
                         else:
                             raise

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -300,9 +300,9 @@ def del_facl(path, acl_tag, acl_qualifier=None):
         if acl_tag == 'g':
             raise ValueError('acl_qualifier must be set to a groupname or groupid when acl_tag is "g"')
 
-        acl_string = acl_tag
-    else:
-        acl_string = '{0}:{1}:'.format(acl_tag, acl_qualifier)
+        acl_qualifier = ''
+
+    acl_string = '{0}:{1}:'.format(acl_tag, acl_qualifier)
 
     setfacl = get_bin_path('setfacl', True)
     # Like: ['/usr/bin/setfacl', '-x', 'u:1000:', '/etc/config.cfg']
@@ -694,7 +694,7 @@ def main():
                         #   * If the directory we copied into has a default acl, on python2, the
                         #     file ends up with the directory's default acl.  On python3, if the
                         #     file did not start with any acl, it will end up with the default acl.
-                        #     A failure to remove 'm' can be ignored.
+                        #   * A failure to remove 'm' can be ignored.
 
                         # * Treatment of default acls are a related bug.  On Python2, default acls
                         #   are applied to the copied file.  On Python3, the default acls won't

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -294,7 +294,7 @@ def del_facl(path, acl_tag, acl_qualifier=None):
     if acl_tag not in ('u', 'g', 'o', 'm'):
         raise ValueError('acl_tag must be one of "u", "g", "o", or "m"')
 
-    if not acl_qualifier:
+    if acl_qualifier in (None, ''):
         if acl_tag == 'u':
             raise ValueError('acl_qualifier must be set to a username or userid when acl_tag is "u"')
         if acl_tag == 'g':

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -307,7 +307,8 @@ def del_facl(path, acl_tag, acl_qualifier=None):
     setfacl = get_bin_path('setfacl', True)
     # Like: ['/usr/bin/setfacl', '-x', 'u:1000:', '/etc/config.cfg']
     acl_command = [setfacl, '-x', acl_string, path]
-    rc, out, err = module.run_command(acl_command)
+    b_acl_command = [to_bytes(x) for x in acl_command]
+    rc, out, err = module.run_command(b_acl_command)
     if rc != 0:
         raise RuntimeError('Error running setfacl: stdout: {0}; stderr: {1}'.format(out, err))
 

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -308,7 +308,7 @@ def del_facl(path, acl_tag, acl_qualifier=None):
     # Like: ['/usr/bin/setfacl', '-x', 'u:1000:', '/etc/config.cfg']
     acl_command = [setfacl, '-x', acl_string, path]
     b_acl_command = [to_bytes(x) for x in acl_command]
-    rc, out, err = module.run_command(b_acl_command)
+    rc, out, err = module.run_command(b_acl_command, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
     if rc != 0:
         raise RuntimeError('Error running setfacl: stdout: {0}; stderr: {1}'.format(out, err))
 

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -302,10 +302,10 @@ def del_facl(path, acl_tag, acl_qualifier=None):
 
     setfacl = get_bin_path('setfacl', True)
     if acl_qualifier:
-        acl_string = '{0}:{1}'.format(acl_tag, acl_qualifier)
+        acl_string = '{0}:{1}:'.format(acl_tag, acl_qualifier)
     else:
         acl_string = acl_tag
-    # Like: ['/usr/bin/setfacl', '-x', 'u:1000', '/etc/config.cfg']
+    # Like: ['/usr/bin/setfacl', '-x', 'u:1000:', '/etc/config.cfg']
     acl_command = [setfacl, '-x', acl_string, path]
     rc, out, err = module.run_command(acl_command)
     if rc != 0:

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -688,7 +688,6 @@ def main():
                         # setfacl failed.
                         # FIXME: separate out the following cases and do the appropriate thing:
                         # * If any of the following raise errors, they can be ignored
-                        #   * If the filesystem we're copying to does not support facls
                         #   * If we're running on python2 therefore the facls were not copied
                         #   * If there were no facls to clear (because we we're not becoming an
                         #     unprivileged user, for instance)
@@ -708,7 +707,10 @@ def main():
                         #   * Does the source file have acls?
                         #   * Does the destination file have acls for the default acl and nothing
                         #     else?
-                        pass
+                        if 'Operation not supported' in to_native(e):
+                            pass
+                        else:
+                            raise
 
             except (IOError, OSError):
                 module.fail_json(msg="failed to copy: %s to %s" % (src, dest), traceback=traceback.format_exc())

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -356,6 +356,22 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 self._connection._shell.tmpdir = None
 
     def _transfer_file(self, local_path, remote_path):
+        """
+        Copy a file from the controller to a remote path
+
+        :arg local_path: Path on controller to transfer
+        :arg remote_path: Path on the remote system to transfer into
+
+        .. warning::
+            * When you use this function you likely want to use use fixup_perms2() on the
+              remote_path to make sure that the remote file is readable when the user becomes
+              a non-privileged user.
+            * If you use fixup_perms2() on the file and copy or move the file into place, you will
+              need to then remove filesystem acls on the file once it has been copied into place by
+              the module.  See how the copy module implements this for help.
+        """
+        # FIXME: find all the action plugins that use _transfer_files() and make sure they obey the
+        # above two raning notes.
         self._connection.put_file(local_path, remote_path)
         return remote_path
 

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -302,6 +302,10 @@ class ActionModule(ActionBase):
             self._remove_tempfile_if_content_defined(content, content_tempfile)
             self._loader.cleanup_tmp_file(source_full)
 
+            # FIXME: I don't think this is needed when PIPELINING=0 because the source is created
+            # world readable.  Access to the directory itself is controlled via fixup_perms2() as
+            # part of executing the module. Check that umask with scp/sftp/piped doesn't cause
+            # a problem before acting on this idea. (This idea would save a round-trip)
             # fix file permissions when the copy is done as a different user
             if remote_path:
                 self._fixup_perms2((self._connection._shell.tmpdir, remote_path))

--- a/test/integration/targets/copy/tasks/acls.yml
+++ b/test/integration/targets/copy/tasks/acls.yml
@@ -1,28 +1,49 @@
 - block:
+  - set_fact:
+      testing_copy_user: testing_copy_user
+
+  - user:
+      name: "{{ testing_copy_user }}"
+      state: present
+
   - block:
     - file:
         path: "{{ remote_dir }}"
         state: directory
 
-    - copy:
+    - command: "setfacl -d -m u:{{ testing_copy_user }}:rw {{ remote_dir }}"
+
+    - name: Testing ACLs
+      copy:
         content: "TEST"
         dest: "{{ remote_dir }}/test.txt"
-        remote_src: "{{ remote_src_toggle | default('no') }}"
 
     - command: "getfacl {{ remote_dir }}/test.txt"
       register: acls
-
+    - debug:
+        var: acls
     become: yes
     become_user: "{{ remote_unprivileged_user }}"
 
-  - assert:
+  - name: Check that there are no ACLs leftovers
+    assert:
       that:
         - "'user:{{ remote_unprivileged_user }}:r-x\t#effective:r--' not in acls.stdout_lines"
 
+  - name: Check that default ACLs are preserved - FIXME decide what we want to do
+    assert:
+      that:
+        - "'user:{{ testing_copy_user }}:rw-' in acls.stdout_lines"
+
   always:
     - name: Clean up
-      file:
-        path: "{{ remote_dir }}/test.txt"
-        state: absent
-      become: yes
-      become_user: "{{ remote_unprivileged_user }}"
+      block:
+       - file:
+           path: "{{ remote_dir }}/test.txt"
+           state: absent
+         become: yes
+         become_user: "{{ remote_unprivileged_user }}"
+
+       - user:
+           name: "{{ testing_copy_user }}"
+           state: absent

--- a/test/integration/targets/copy/tasks/acls.yml
+++ b/test/integration/targets/copy/tasks/acls.yml
@@ -1,0 +1,21 @@
+- file:
+    path: "{{ remote_dir }}"
+    state: directory
+  become: yes
+  become_user: '{{ remote_unprivileged_user }}'
+
+- copy:
+    content: "TEST"
+    dest: "{{ remote_dir }}/test.txt"
+  become: yes
+  become_user: "{{ remote_unprivileged_user }}"
+
+- command: "getfacl {{ remote_dir }}/test.txt"
+  register: acls
+  become: yes
+  become_user: '{{ remote_unprivileged_user }}'
+- debug:
+    var: acls
+- assert:
+    that:
+      - "'user:{{ remote_unprivileged_user }}:r-x\t#effective:r--' not in acls.stdout_lines"

--- a/test/integration/targets/copy/tasks/acls.yml
+++ b/test/integration/targets/copy/tasks/acls.yml
@@ -1,21 +1,28 @@
-- file:
-    path: "{{ remote_dir }}"
-    state: directory
-  become: yes
-  become_user: '{{ remote_unprivileged_user }}'
+- block:
+  - block:
+    - file:
+        path: "{{ remote_dir }}"
+        state: directory
 
-- copy:
-    content: "TEST"
-    dest: "{{ remote_dir }}/test.txt"
-  become: yes
-  become_user: "{{ remote_unprivileged_user }}"
+    - copy:
+        content: "TEST"
+        dest: "{{ remote_dir }}/test.txt"
+        remote_src: "{{ remote_src_toggle | default('no') }}"
 
-- command: "getfacl {{ remote_dir }}/test.txt"
-  register: acls
-  become: yes
-  become_user: '{{ remote_unprivileged_user }}'
-- debug:
-    var: acls
-- assert:
-    that:
-      - "'user:{{ remote_unprivileged_user }}:r-x\t#effective:r--' not in acls.stdout_lines"
+    - command: "getfacl {{ remote_dir }}/test.txt"
+      register: acls
+
+    become: yes
+    become_user: "{{ remote_unprivileged_user }}"
+
+  - assert:
+      that:
+        - "'user:{{ remote_unprivileged_user }}:r-x\t#effective:r--' not in acls.stdout_lines"
+
+  always:
+    - name: Clean up
+      file:
+        path: "{{ remote_dir }}/test.txt"
+        state: absent
+      become: yes
+      become_user: "{{ remote_unprivileged_user }}"

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -58,10 +58,7 @@
     - import_tasks: tests.yml
       remote_user: '{{ remote_unprivileged_user }}'
 
-    - include: "acls.yml remote_src_toggle={{ item }}"
-      loop:
-        - no
-        - yes
+    - import_tasks: acls.yml
 
   always:
     - name: Cleaning

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -55,8 +55,8 @@
 
     # execute tests tasks using an unprivileged user, this is useful to avoid
     # local/remote ambiguity when controller and managed hosts are identical.
-    #- import_tasks: tests.yml
-    #  remote_user: '{{ remote_unprivileged_user }}'
+    - import_tasks: tests.yml
+      remote_user: '{{ remote_unprivileged_user }}'
 
     - include: "acls.yml remote_src_toggle={{ item }}"
       loop:

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -58,7 +58,10 @@
     #- import_tasks: tests.yml
     #  remote_user: '{{ remote_unprivileged_user }}'
 
-    - import_tasks: acls.yml
+    - include: "acls.yml remote_src_toggle={{ item }}"
+      loop:
+        - no
+        - yes
 
   always:
     - name: Cleaning

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -55,8 +55,10 @@
 
     # execute tests tasks using an unprivileged user, this is useful to avoid
     # local/remote ambiguity when controller and managed hosts are identical.
-    - import_tasks: tests.yml
-      remote_user: '{{ remote_unprivileged_user }}'
+    #- import_tasks: tests.yml
+    #  remote_user: '{{ remote_unprivileged_user }}'
+
+    - import_tasks: acls.yml
 
   always:
     - name: Cleaning


### PR DESCRIPTION
##### SUMMARY

Taking over work from https://github.com/ansible/ansible/pull/50419

The controller's fixup_perms2 uses filesystem acls to make the temporary
file for copy readable by an unprivileged become user.  On Python3, the
acls are then copied to the destination filename so we have to remove
them from there.

We can't remove them prior to the copy because we may not have
permission to read the file if the acls are not present.  We can't
remove them in atomic_move() because the move function shouldn't know
anything about controller features.  We may want to genrealize this into
a helper function, though.

Fixes #44412


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
copy
