### PR TITLE
junos_config documentation missing "update" choice 

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -113,8 +113,14 @@ options:
         it with the loaded configuration.
         C(replace) substitutes each hierarchy level in the loaded configuration
         for the corresponding level.
+        C(update) is similar to the override option. The new configuration completely
+        replaces the existing configuration. The difference comes when the configuration
+        is later committed. This option performs a 'diff' between the new candidate
+        configuration and the existing committed configuration. It then only notifies
+        system processes repsonsible for the changed portions of the configuration, and
+        only marks the actual configuration changes as 'changed'.
     default: merge
-    choices: ['merge', 'override', 'replace']
+    choices: ['merge', 'override', 'replace', 'update']
     version_added: "2.3"
   confirm_commit:
     description:

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -117,7 +117,7 @@ options:
         replaces the existing configuration. The difference comes when the configuration
         is later committed. This option performs a 'diff' between the new candidate
         configuration and the existing committed configuration. It then only notifies
-        system processes repsonsible for the changed portions of the configuration, and
+        system processes responsible for the changed portions of the configuration, and
         only marks the actual configuration changes as 'changed'.
     default: merge
     choices: ['merge', 'override', 'replace', 'update']

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -615,7 +615,6 @@ lib/ansible/modules/network/ironware/ironware_command.py E323
 lib/ansible/modules/network/ironware/ironware_config.py E323
 lib/ansible/modules/network/ironware/ironware_facts.py E323
 lib/ansible/modules/network/junos/junos_command.py E324
-lib/ansible/modules/network/junos/junos_config.py E326
 lib/ansible/modules/network/junos/junos_interface.py E324
 lib/ansible/modules/network/junos/junos_linkagg.py E324
 lib/ansible/modules/network/junos/junos_logging.py E322


### PR DESCRIPTION
##### SUMMARY
The current junos_config module documentation only lists "merge","override" and "replace" as update parameter choices. Looking into junos_python.py "update" is another option which is really helpful and in my opinion the most needed option. 

```
update=dict(default='merge', choices=['merge', 'override', 'replace', 'update'])
```

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
junos_config
