### PR TITLE
Add support for updating projects and inventory sources directly from the resource modules

### DIFF
--- a/test/integration/targets/tower_inventory_source/tasks/main.yml
+++ b/test/integration/targets/tower_inventory_source/tasks/main.yml
@@ -32,3 +32,27 @@
 - assert:
     that:
       - "result is changed"
+
+- name: Update a source inventory
+  tower_inventory_source:
+    name: source-test-inventory
+    inventory: openstack-test-inventory
+    state: updated
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Update a nonexistent inventory
+  tower_inventory_source:
+    name: source-does-not-exist
+    inventory: inventory-does-not-exist-either
+    state: updated
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - "result is failed"
+      - "'could not be found' in result.msg"

--- a/test/integration/targets/tower_project/tasks/main.yml
+++ b/test/integration/targets/tower_project/tasks/main.yml
@@ -77,6 +77,16 @@
     that:
       - "multi_org_cred_project is changed"
 
+- name: Update project
+  tower_project:
+    name: TestProject
+    state: updated
+  register: project_update
+
+- assert:
+    that:
+      - "project_update is changed"
+
 - name: Check module fails with correct msg
   tower_project:
     name: TestProject
@@ -104,3 +114,15 @@
 - assert:
     that:
       - "result.msg =='Failed to update project, credential not found: Non Existing Credential'"
+
+- name: Chcek module fails with correct msg
+  tower_project:
+     name: Non Existing Org
+     state: updated
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result is failed"
+      - "'could not be found' in result.msg"


### PR DESCRIPTION

##### SUMMARY

Allow updating:
- tower/AWX projects
- tower/AWX inventory sources

via passing `state=updated` to the normal resource modules.

This is the same functionality as https://github.com/ansible/ansible/pull/50376, but without making a new module.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

tower_project
tower_inventory_source

##### ADDITIONAL INFORMATION

cc @AlanCoding @john-westcott-iv 
