### PR TITLE
fix pacman package state detection

### DIFF
--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -198,7 +198,7 @@ def query_package(module, pacman_path, name, state="present"):
         else:
             # a non-zero exit code doesn't always mean the package is installed
             # for example, if the package name queried is "provided" by another package
-            installed_name = get_name(lstdout)
+            installed_name = get_name(module, lstdout)
             if installed_name != name:
                 return False, False, False
 

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -180,7 +180,7 @@ def get_name(pacman_output):
     """Take pacman -Qi or pacman -Si output and get the package name"""
     lines = pacman_output.split('\n')
     for line in lines:
-        if 'Name' in line:
+        if line.startswith('Name '):
             return line.split(':')[1].strip()
     module.fail_json(msg="get_name: fail to retrieve package name from pacman output")
 

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -175,6 +175,7 @@ def get_version(pacman_output):
             return line.split(':')[1].strip()
     return None
 
+
 def get_name(pacman_output):
     """Take pacman -Qi or pacman -Si output and get the package name"""
     lines = pacman_output.split('\n')
@@ -182,6 +183,7 @@ def get_name(pacman_output):
         if 'Name' in line:
             return line.split(':')[1].strip()
     return None
+
 
 def query_package(module, pacman_path, name, state="present"):
     """Query the package status in both the local system and the repository. Returns a boolean to indicate if the package is installed, a second
@@ -194,11 +196,11 @@ def query_package(module, pacman_path, name, state="present"):
             # package is not installed locally
             return False, False, False
         else:
-          # a non-zero exit code doesn't always mean the package is installed
-          # for example, if the package name queried is "provided" by another package
-          installed_name = get_name(lstdout)
-          if installed_name != name:
-            return False, False, False
+            # a non-zero exit code doesn't always mean the package is installed
+            # for example, if the package name queried is "provided" by another package
+            installed_name = get_name(lstdout)
+            if installed_name != name:
+                return False, False, False
 
         # get the version installed locally (if any)
         lversion = get_version(lstdout)

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -175,6 +175,13 @@ def get_version(pacman_output):
             return line.split(':')[1].strip()
     return None
 
+def get_name(pacman_output):
+    """Take pacman -Qi or pacman -Si output and get the package name"""
+    lines = pacman_output.split('\n')
+    for line in lines:
+        if 'Name' in line:
+            return line.split(':')[1].strip()
+    return None
 
 def query_package(module, pacman_path, name, state="present"):
     """Query the package status in both the local system and the repository. Returns a boolean to indicate if the package is installed, a second
@@ -185,6 +192,12 @@ def query_package(module, pacman_path, name, state="present"):
         lrc, lstdout, lstderr = module.run_command(lcmd, check_rc=False)
         if lrc != 0:
             # package is not installed locally
+            return False, False, False
+        else:
+          # a non-zero exit code doesn't always mean the package is installed
+          # for example, if the package name queried is "provided" by another package
+          installed_name = get_name(lstdout)
+          if installed_name != name:
             return False, False, False
 
         # get the version installed locally (if any)

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -182,7 +182,7 @@ def get_name(pacman_output):
     for line in lines:
         if 'Name' in line:
             return line.split(':')[1].strip()
-    return None
+    module.fail_json(msg="get_name: fail to retrieve package name from pacman output")
 
 
 def query_package(module, pacman_path, name, state="present"):

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -176,7 +176,7 @@ def get_version(pacman_output):
     return None
 
 
-def get_name(pacman_output):
+def get_name(module, pacman_output):
     """Take pacman -Qi or pacman -Si output and get the package name"""
     lines = pacman_output.split('\n')
     for line in lines:

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -171,7 +171,7 @@ def get_version(pacman_output):
     """Take pacman -Qi or pacman -Si output and get the Version"""
     lines = pacman_output.split('\n')
     for line in lines:
-        if 'Version' in line:
+        if line.startswith('Version '):
             return line.split(':')[1].strip()
     return None
 


### PR DESCRIPTION
##### SUMMARY
Fixes #51265 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pacman

##### ADDITIONAL INFORMATION
This is a fix to correctly detect a package's installation status as being absent when it is not installed but another package provides it.