### PR TITLE
Enable force_handlers for integration tests.

### DIFF
--- a/test/integration/integration.cfg
+++ b/test/integration/integration.cfg
@@ -1,0 +1,3 @@
+[defaults]
+# allow cleanup handlers to run when tests fail
+force_handlers = True

--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -5,6 +5,9 @@
 host_key_checking = False
 log_path = /tmp/ansible-test.out
 
+# allow cleanup handlers to run when tests fail
+force_handlers = True
+
 [ssh_connection]
 ssh_args = '-o UserKnownHostsFile=/dev/null'
 

--- a/test/integration/windows-integration.cfg
+++ b/test/integration/windows-integration.cfg
@@ -1,0 +1,3 @@
+[defaults]
+# allow cleanup handlers to run when tests fail
+force_handlers = True


### PR DESCRIPTION
##### SUMMARY

Enable force_handlers for integration tests.

This will allow cleanup handlers to run when tests fail.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
