### PR TITLE
aws_ec2 Implement the missing 'region discovery'

### DIFF
--- a/changelogs/fragments/allow_regions_aws_invp.yml
+++ b/changelogs/fragments/allow_regions_aws_invp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix aws_ec2 inventory plugin code to automatically populate regions when missing as documentation states, also leverage config system vs self default/type validation

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -48,8 +48,9 @@ DOCUMENTATION = '''
               - name: AWS_SESSION_TOKEN
               - name: EC2_SECURITY_TOKEN
         regions:
-          description: A list of regions in which to describe EC2 instances. By default this is all regions except us-gov-west-1
-              and cn-north-1.
+          description:
+            - A list of regions in which to describe EC2 instances.
+            - If empty (the default) default this will include all regions, except possibly restricted ones like us-gov-west-1 and cn-north-1.
           type: list
           default: []
         hostnames:
@@ -135,9 +136,8 @@ compose:
   ansible_host: private_ip_address
 '''
 
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.six import string_types
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
@@ -328,7 +328,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 # as per https://boto3.amazonaws.com/v1/documentation/api/latest/guide/ec2-example-regions-avail-zones.html
                 client = boto3.client('ec2')
                 resp = client.describe_regions()
-                regions = resp.get('Regions', [])
+                regions = [x['RegionName'] for x in resp.get('Regions', [])]
             except botocore.exceptions.NoRegionError:
                 # above seems to fail depending on boto3 version, ignore and lets try something else
                 pass

--- a/test/units/plugins/inventory/test_aws_ec2.py
+++ b/test/units/plugins/inventory/test_aws_ec2.py
@@ -114,7 +114,9 @@ instances = {
 
 @pytest.fixture(scope="module")
 def inventory():
-    return inventory_loader.get('aws_ec2')
+    i = inventory_loader.get('aws_ec2')
+    i.set_options(direct={'plugin': 'aws_ec2'})
+    return i
 
 
 def test_compile_values(inventory):

--- a/test/units/plugins/inventory/test_aws_ec2.py
+++ b/test/units/plugins/inventory/test_aws_ec2.py
@@ -114,7 +114,9 @@ instances = {
 
 @pytest.fixture(scope="module")
 def inventory():
-    return InventoryModule()
+    i = InventoryModule()
+    setattr(i, '_load_name', 'aws_ec2')
+    return i
 
 
 def test_compile_values(inventory):

--- a/test/units/plugins/inventory/test_aws_ec2.py
+++ b/test/units/plugins/inventory/test_aws_ec2.py
@@ -30,7 +30,7 @@ botocore = pytest.importorskip('botocore')
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible.plugins.inventory.aws_ec2 import InventoryModule
+from ansible.plugins.loader import inventory_loader
 from ansible.plugins.inventory.aws_ec2 import instance_data_filter_to_boto_attr
 
 instances = {
@@ -114,9 +114,7 @@ instances = {
 
 @pytest.fixture(scope="module")
 def inventory():
-    i = InventoryModule()
-    setattr(i, '_load_name', 'aws_ec2')
-    return i
+    return inventory_loader.get('aws_ec2')
 
 
 def test_compile_values(inventory):


### PR DESCRIPTION
  fixes #45288

  tries to use api as documented (which seems to fail in latest boto3 versions)
  and fallback to boto3 'hardcoded' list of regions


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/inventory/aws_ec2
