### PR TITLE
Clarify priority setting in Inventory doc

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -438,6 +438,8 @@ Starting in Ansible version 2.4, users can use the group variable ``ansible_grou
 
 In this example, if both groups have the same priority, the result would normally have been ``testvar == b``, but since we are giving the ``a_group`` a higher priority the result will be ``testvar == a``.
 
+.. note:: ``ansible_group_priority`` can only be set in the inventory source and not in group_vars/ as the variable is used in the loading of group_vars.
+
 
 .. _using_multiple_inventory_sources:
 

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -440,7 +440,6 @@ In this example, if both groups have the same priority, the result would normall
 
 .. note:: ``ansible_group_priority`` can only be set in the inventory source and not in group_vars/ as the variable is used in the loading of group_vars.
 
-
 .. _using_multiple_inventory_sources:
 
 Using multiple inventory sources


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `ansible_group_priority` variable is also described in **Using Variables** and was given a clarification in issue #41512. The variable is also documented in **Working with Inventory** without the caveat that it needs to be declared on the inventory and not a group_vars file. This change adds that as a note

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### Component Name

docs
