### PR TITLE
Do not add state: absent when a non-existent path is returned in "path" or "dest"

### DIFF
--- a/changelogs/fragments/basic-no-state-absent-when-path-or-dest.yaml
+++ b/changelogs/fragments/basic-no-state-absent-when-path-or-dest.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - 'do not return ``state: absent`` when the module returns either ``path`` or ``dest`` but the file does not exists (https://github.com/ansible/ansible/issues/35382)'

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1555,8 +1555,6 @@ class AnsibleModule(object):
             if HAVE_SELINUX and self.selinux_enabled():
                 kwargs['secontext'] = ':'.join(self.selinux_context(path))
             kwargs['size'] = st[stat.ST_SIZE]
-        else:
-            kwargs['state'] = 'absent'
         return kwargs
 
     def _check_locale(self):

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -470,9 +470,9 @@ def ensure_absent(path):
                                                           'path': path})
 
         diff = initial_diff(path, 'absent', prev_state)
-        result.update({'path': path, 'changed': True, 'diff': diff})
+        result.update({'path': path, 'changed': True, 'diff': diff, 'state': 'absent'})
     else:
-        result.update({'path': path, 'changed': False})
+        result.update({'path': path, 'changed': False, 'state': 'absent'})
 
     return result
 


### PR DESCRIPTION
##### SUMMARY
Leave it up to the module to return the state in the results.

I went through all the modules in `lib/ansible/modules/files/` and only found one case where the module needed to return `state: absent`. No other modules return paths that do not exists and will therefore get the correct file type added by `AnsibleModule.add_path_info()`.

Signed-off-by: Sam Doran <sdoran@redhat.com>

Fixes #35382

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/module_utils/basic.py`
`lib/ansible/modules/files/file.py`