### PR TITLE
use list instead of tuple and remove md5 on ValueError

### DIFF
--- a/changelogs/fragments/51357-module_utils-basic.yml
+++ b/changelogs/fragments/51357-module_utils-basic.yml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
     - ansible.module_utils.basic - fix handling of md5 in algorithms tuple for FIPS compatibility (https://github.com/ansible/ansible/issues/51355)
-

--- a/changelogs/fragments/51357-module_utils-basic.yml
+++ b/changelogs/fragments/51357-module_utils-basic.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+    - ansible.module_utils.basic - fix handling of md5 in algorithms tuple for FIPS compatibility (https://github.com/ansible/ansible/issues/51355)
+

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -131,7 +131,7 @@ try:
             break
     if algorithms is None:
         # python 2.5+
-        algorithms = ('md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512')
+        algorithms = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
     for algorithm in algorithms:
         AVAILABLE_HASH_ALGORITHMS[algorithm] = getattr(hashlib, algorithm)
 
@@ -139,7 +139,7 @@ try:
     try:
         hashlib.md5()
     except ValueError:
-        algorithms.pop('md5', None)
+        algorithms.remove('md5')
 except Exception:
     import sha
     AVAILABLE_HASH_ALGORITHMS = {'sha1': sha.sha}

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -126,7 +126,8 @@ try:
 
     # python 2.7.9+ and 2.7.0+
     for attribute in ('available_algorithms', 'algorithms'):
-        algorithms = getattr(hashlib, attribute, None)
+        # algorithms needs to be a list instead of immutable tuple so md5 can be removed if not available
+        algorithms = list(getattr(hashlib, attribute, None))
         if algorithms:
             break
     if algorithms is None:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -126,9 +126,10 @@ try:
 
     # python 2.7.9+ and 2.7.0+
     for attribute in ('available_algorithms', 'algorithms'):
-        # algorithms needs to be a list instead of immutable tuple so md5 can be removed if not available
-        algorithms = list(getattr(hashlib, attribute, None))
+        algorithms = getattr(hashlib, attribute, None)
         if algorithms:
+            # convert algorithms to list instead of immutable tuple so md5 can be removed if not available
+            algorithms = list(algorithms)
             break
     if algorithms is None:
         # python 2.5+


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Error was generated because algorithms tuple is immutable and pop does not work on tuples.  To maintain existing process, defined algorithms as list and used remove method to remove md5 from list by name.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51355 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils basic

