### PR TITLE
mysql_user: handle either ' or ` quoting in response to show grant command

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -427,7 +427,7 @@ def privileges_get(cursor, user, host):
             return x
 
     for grant in grants:
-        res = re.match("GRANT (.+) ON (.+) TO '.*'@'.*'( IDENTIFIED BY PASSWORD '.+')? ?(.*)", grant[0])
+        res = re.match("GRANT (.+) ON (.+) TO ['`].*['`]@['`].*['`]( IDENTIFIED BY PASSWORD ['`].+['`])? ?(.*)", grant[0])
         if res is None:
             raise InvalidPrivsError('unable to parse the MySQL grant string: %s' % grant[0])
         privileges = res.group(1).split(", ")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Different versions of mysql use different quote characters in the
response to the 'show grants' command.  MySQL 5 and earlier response
like this:

    GRANT USAGE ON *.* TO 'testuser'@'%'

MySQL 8 and later respond like this:

    GRANT USAGE ON *.* TO `testuser`@`%`

This commit updates the privileges_get to handle both quote
characters.

Fixes #51356



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_user
