### PR TITLE
hpilo_boot: fix module doc to match code and logic

### DIFF
--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -39,7 +39,6 @@ options:
   media:
     description:
     - The boot media to boot the system from
-    default: network
     choices: [ "cdrom", "floppy", "hdd", "network", "normal", "usb" ]
   image:
     description:

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -790,7 +790,6 @@ lib/ansible/modules/packaging/os/yum_repository.py E324
 lib/ansible/modules/packaging/os/zypper.py E326
 lib/ansible/modules/remote_management/foreman/foreman.py E322
 lib/ansible/modules/remote_management/foreman/foreman.py E325
-lib/ansible/modules/remote_management/hpilo/hpilo_boot.py E324
 lib/ansible/modules/remote_management/hpilo/hpilo_boot.py E326
 lib/ansible/modules/remote_management/ipmi/ipmi_boot.py E326
 lib/ansible/modules/remote_management/ipmi/ipmi_power.py E326


### PR DESCRIPTION
##### SUMMARY
There is no explicit nor implied value for media.
In fact, not choosing media makes perfect sense.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
hpilo_boot

##### ADDITIONAL INFORMATION
N/A
