### PR TITLE
Don't fail if exos can't configure cli columns

### DIFF
--- a/lib/ansible/plugins/terminal/exos.py
+++ b/lib/ansible/plugins/terminal/exos.py
@@ -23,9 +23,6 @@ import re
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.terminal import TerminalBase
-from ansible.utils.display import Display
-
-display = Display()
 
 
 class TerminalModule(TerminalBase):
@@ -59,4 +56,4 @@ class TerminalModule(TerminalBase):
         try:
             self._exec_cli_command(b'configure cli columns 256')
         except AnsibleConnectionFailure:
-            display.display('WARNING: Unable to configure cli columns, command responses may be truncated')
+            self._connection.queue_message('warning', 'Unable to configure cli columns, command responses may be truncated')

--- a/lib/ansible/plugins/terminal/exos.py
+++ b/lib/ansible/plugins/terminal/exos.py
@@ -23,6 +23,9 @@ import re
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.terminal import TerminalBase
+from ansible.utils.display import Display
+
+display = Display()
 
 
 class TerminalModule(TerminalBase):
@@ -49,7 +52,11 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in (b'disable clipaging', b'configure cli columns 256'):
-                self._exec_cli_command(cmd)
+            self._exec_cli_command(b'disable clipaging')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
+
+        try:
+            self._exec_cli_command(b'configure cli columns 256')
+        except AnsibleConnectionFailure:
+            display.display('WARNING: Unable to configure cli columns, command responses may be truncated')


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51363 

Some exos versions don't have ```configure cli columns``` command, don't fail in this case

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
