### PR TITLE
Add force parameter to gem module

### DIFF
--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -95,6 +95,13 @@ options:
       - Allow adding build flags for gem compilation
     required: false
     version_added: "2.0"
+  force:
+    description:
+      - Force gem to install, bypassing dependency checks.
+    required: false
+    default: "no"
+    type: bool
+    version_added: "2.8"
 author:
     - "Ansible Core Team"
     - "Johan Wiren (@johanwiren)"
@@ -247,6 +254,8 @@ def install(module):
     cmd.append(module.params['gem_source'])
     if module.params['build_flags']:
         cmd.extend(['--', module.params['build_flags']])
+    if module.params['force']:
+        cmd.append('--force')
     module.run_command(cmd, check_rc=True)
 
 
@@ -267,6 +276,7 @@ def main():
             env_shebang=dict(required=False, default=False, type='bool'),
             version=dict(required=False, type='str'),
             build_flags=dict(required=False, type='str'),
+            force=dict(required=False, default=False, type='bool'),
         ),
         supports_check_mode=True,
         mutually_exclusive=[['gem_source', 'repository'], ['gem_source', 'version']],

--- a/test/units/modules/packaging/language/test_gem.py
+++ b/test/units/modules/packaging/language/test_gem.py
@@ -119,3 +119,22 @@ class TestGem(ModuleTestCase):
 
         update_environ = run_command.call_args[1].get('environ_update', {})
         assert update_environ.get('GEM_HOME') == '/opt/dummy'
+
+    def test_passes_add_force_option(self):
+        set_module_args({
+            'name': 'dummy',
+            'force': True,
+        })
+
+        self.patch_rubygems_version()
+        self.patch_installed_versions([])
+        run_command = self.patch_run_command()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            gem.main()
+
+        result = exc.value.args[0]
+        assert result['changed']
+        assert run_command.called
+
+        assert '--force' in get_command(run_command)


### PR DESCRIPTION
##### SUMMARY

Add force parameter to gem module.

Sometimes gem install asking "Overwrite ok? [Yn]", it make stuck.
It can bypass `--force` install option.

Fixes #30217

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

gem

##### ADDITIONAL INFORMATION

https://guides.rubygems.org/command-reference/#gem-install
> -f, -​-[no-]force - Force gem to install, bypassing dependency checks

https://github.com/ansible/ansible/issues/30217

