### PR TITLE
vmware_guest: Enable setting mac address when cloning from VM or template 

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1328,10 +1328,6 @@ class PyVmomiHelper(PyVmomi):
                         self.module.fail_json(msg="Changing the device type is not possible when interface is already present. "
                                                   "The failing device type is %s" % network_devices[key]['device_type'])
                 if 'mac' in network_devices[key] and nic.device.macAddress != network_devices[key]['mac']:
-                    if not PyVmomiDeviceHelper.is_valid_mac_addr(network_devices[key]['mac']):
-                        self.module.fail_json(msg="Device MAC address '%s' is invalid."
-                                                  " Please provide correct MAC address." % network_devices[key]['mac'])
-
                     nic.device.addressType = 'manual'
                     nic.device.macAddress = network_devices[key]['mac']
                     nic_change_detected = True

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1328,6 +1328,9 @@ class PyVmomiHelper(PyVmomi):
                         self.module.fail_json(msg="Changing the device type is not possible when interface is already present. "
                                                   "The failing device type is %s" % network_devices[key]['device_type'])
                 if 'mac' in network_devices[key] and nic.device.macAddress != network_devices[key]['mac']:
+                    if vm_obj and vm_obj.runtime.powerState == vim.VirtualMachinePowerState.poweredOn:
+                        self.module.fail_json(msg="Changing the device MAC address is not "
+                                                  "possible when the guest is powered on.")
                     nic.device.addressType = 'manual'
                     nic.device.macAddress = network_devices[key]['mac']
                     nic_change_detected = True

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2151,6 +2151,8 @@ class PyVmomiHelper(PyVmomi):
 
         if self.params['template']:
             is_clone = True
+        else:
+            is_clone = False
 
         self.configspec = vim.vm.ConfigSpec()
         self.configspec.deviceChange = []

--- a/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
@@ -1,0 +1,31 @@
+- name: clone VM from template and set manual mac address
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ 'mac_manual_' + item.name }}"
+    template: "{{ item.name }}"
+    datacenter: "{{ dc1 }}"
+    state: poweredoff
+    folder: "{{ item.folder }}"
+    networks:
+        - name: VM Network
+          ip: "192.168.10.1{{ index }}"
+          netmask: 255.255.255.0
+          gateway: 192.168.10.254
+          mac: "aa:bb:cc:dd:aa:b{{ index }}"
+  loop: "{{ virtual_machines }}"
+  loop_control:
+    index_var: index
+  register: clone_manual_mac_address
+
+- debug:
+    var: clone_manual_mac_address
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "clone_with_mac_addr.results|map(attribute='changed')|unique|list == [true]"
+        - "clone_with_mac_addr.results[0]['instance']['hw_eth0']['addresstype'] == 'manual'"
+        - "clone_with_mac_addr.results[0]['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:b0'"

--- a/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
@@ -38,6 +38,6 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_with_mac_addr.results|map(attribute='changed')|unique|list == [true]"
-        - "clone_with_mac_addr.results[0]['instance']['hw_eth0']['addresstype'] == 'manual'"
-        - "clone_with_mac_addr.results[0]['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:b0'"
+        - "clone_manual_mac_address.results|map(attribute='changed')|unique|list == [true]"
+        - "clone_manual_mac_address.results[0]['instance']['hw_eth0']['addresstype'] == 'manual'"
+        - "clone_manual_mac_address.results[0]['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:b0'"

--- a/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
@@ -1,3 +1,15 @@
+- name: Power off clone source VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ item.name }}"
+    datacenter: "{{ dc1 }}"
+    folder: "{{ item.folder }}"
+    state: poweredoff
+  loop: "{{ virtual_machines }}"
+
 - name: clone VM from template and set manual mac address
   vmware_guest:
     validate_certs: False

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -90,6 +90,7 @@
     - include: boot_firmware_d1_c1_f0.yml
     - include: clone_with_convert.yml
     - include: clone_customize_guest_test.yml
+    - include: clone_set_manual_mac_address.yml
   always:
     - name: Remove VM
       vmware_guest:
@@ -114,3 +115,5 @@
         - eagerzeroedthick_DC0_H0_VM1
         - net_customize_DC0_H0_VM0
         - net_customize_DC0_H0_VM1
+        - mac_manual_DC0_H0_VM0
+        - mac_manual_DC0_H0_VM1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The method previously used for device changes when cloning was [deprecated in vCenter 6.0](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.CloneSpec.html). Even though it still works on vCenter 6.5.0, the vcsim did not apply these changes (resolved in govmomi master now, but not released).

For future proofing and testability,  the new method of implementing device changes on clone is used when applying device changes when vCenter version 6.0 or greater is detected.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51123 and fixes #51124 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

