### PR TITLE
flatpak: Open subprocess in text stream mode

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -217,7 +217,7 @@ def _flatpak_command(module, noop, command):
         return ""
 
     process = subprocess.Popen(
-        command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     stdout_data, stderr_data = process.communicate()
     result['rc'] = process.returncode
     result['command'] = command


### PR DESCRIPTION
This sets the return values to be 'str' instead of byte-arrays. Fixes what appears to be a python 3 compatibility problem.

##### SUMMARY
This sets the return values to be 'str' instead of byte-arrays. Fixes what appears to be a python 3 compatibility problem.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`flatpak`
