### PR TITLE
docker_host_facts: Get system-wide information about docker host

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -29,6 +29,9 @@ description:
 version_added: "2.8"
 
 options:
+    services:
+        description: List of services for which list of items should be listed in output
+
 extends_documentation_fragment:
     - docker
 
@@ -90,18 +93,80 @@ class DockerHostManager(DockerBaseClass):
         self.client = client
         self.results = results
 
+        listed_objects = ['volumes', 'networks', 'containers', 'images']
+
         self.results['docker_host_facts'] = self.get_docker_host_facts()
+
+        for docker_object in listed_objects:
+            if self.client.module.params[docker_object] is True:
+                returned_name = "docker_" + docker_object + "_list"
+                self.results[returned_name] = self.get_docker_items_list(docker_object)
 
     def get_docker_host_facts(self):
         try:
             return self.client.info()
-        except Exception as exc:
-            self.client.fail_json(msg="Error inspecting docker host: %s" % exc)
+        except APIError as exc:
+            self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))
+
+    def get_docker_items_list(self, object=None):
+        items = None
+        items_list = []
+
+        header_containers = ['Id', 'Image', 'Command', 'Created', 'Status', 'Ports', 'Names']
+        header_volumes = ['Driver', 'Name']
+        header_images = ['Id', 'RepoTags', 'Created', 'Size']
+        header_networks = ['Id', 'Driver', 'Name', 'Scope']
+
+        try:
+            if object == 'containers':
+                items = self.client.containers()
+            if object == 'networks':
+                items = self.client.networks()
+            if object == 'images':
+                items = self.client.images()
+            if object == 'volumes':
+                items = self.client.volumes()
+        except APIError as exc:
+            self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))
+
+        if object != 'volumes':
+            for item in items:
+                item_record = dict()
+
+                if object == 'containers':
+                    for key in header_containers:
+                        item_record[key] = item.get(key)
+                if object == 'networks':
+                    for key in header_networks:
+                        item_record[key] = item.get(key)
+                if object == 'images':
+                    for key in header_images:
+                        item_record[key] = item.get(key)
+
+                items_list.append(item_record)
+
+        else:
+            for item in items['Volumes']:
+                item_record = dict()
+
+                for key in header_volumes:
+                    item_record[key] = item.get(key)
+
+                items_list.append(item_record)
+
+        return items_list
 
 
 def main():
     argument_spec = dict(
-        services=dict(type='list', elements='str'),
+        containers=dict(type='bool', default=False),
+        containers_filters=dict(type='dict'),
+        images=dict(type='bool', default=False),
+        images_filters=dict(type='dict'),
+        networks=dict(type='bool', default=False),
+        networks_filters=dict(type='dict'),
+        volumes=dict(type='bool', default=False),
+        volumes_filters=dict(type='dict'),
     )
 
     client = AnsibleDockerClient(

--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 ---
 module: docker_host_facts
 
-short_description: Retrieves facts about docker host and lists of objects of the services
+short_description: Retrieves facts about docker host and lists of objects of the services.
 
 description:
   - Retrieves facts about a docker host.
@@ -94,7 +94,7 @@ extends_documentation_fragment:
     - docker
 
 author:
-    - Piotr Wojciechowski (@wojciechowskipiotr)
+    - Piotr Wojciechowski (@WojciechowskiPiotr)
 
 requirements:
     - "python >= 2.6"

--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -155,34 +155,34 @@ docker_volumes_list:
         Keys matches the C(docker volume ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(volumes) is C(yes)
-    type: dict
+    type: list
 docker_networks_list:
     description:
       - List of dict objects containing the basic information about each network.
         Keys matches the C(docker network ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(networks) is C(yes)
-    type: dict
+    type: list
 docker_containers_list:
     description:
       - List of dict objects containing the basic information about each container.
         Keys matches the C(docker container ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(containers) is C(yes)
-    type: dict
+    type: list
 docker_images_list:
     description:
       - List of dict objects containing the basic information about each image.
         Keys matches the C(docker image ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(images) is C(yes)
-    type: dict
+    type: list
 docker_disk_usage:
     description:
       - Information on summary disk usage by images, containers and volumes on docker host
         unless I(verbose_output=yes). See description for I(verbose_output).
     returned: When I(disk_usage) is C(yes)
-    type: int
+    type: dict
 
 '''
 
@@ -237,7 +237,7 @@ class DockerHostManager(DockerBaseClass):
             if self.verbose_output:
                 return self.client.df()
             else:
-                return self.client.df()['LayersSize']
+                return dict(LayerSize=self.client.df()['LayersSize'])
         except APIError as exc:
             self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))
 
@@ -260,7 +260,8 @@ class DockerHostManager(DockerBaseClass):
             elif docker_object == 'volumes':
                 items = self.client.volumes(filters=filters)
         except APIError as exc:
-            self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))
+            self.client.fail_json(msg="Error inspecting docker host for object '%s': %s" %
+                                      (docker_object, to_native(exc)))
 
         if self.verbose_output:
             if docker_object != 'volumes':

--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -29,8 +29,58 @@ description:
 version_added: "2.8"
 
 options:
-    services:
-        description: List of services for which list of items should be listed in output
+  containers:
+    description:
+      - Whether to list containers.
+    type: bool
+    default: no
+  containers_filters:
+    description:
+      - A dictionary of filter values used for selecting containers to delete.
+      - "For example, C(until: 24h)."
+      - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/container_prune/#filtering)
+        for more information on possible filters.
+    type: dict
+  images:
+    description:
+      - Whether to list images.
+    type: bool
+    default: no
+  images_filters:
+    description:
+      - A dictionary of filter values used for selecting images to delete.
+      - "For example, C(dangling: true)."
+      - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/image_prune/#filtering)
+        for more information on possible filters.
+    type: dict
+  networks:
+    description:
+      - Whether to list networks.
+    type: bool
+    default: no
+  networks_filters:
+    description:
+      - A dictionary of filter values used for selecting networks to delete.
+      - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/network_prune/#filtering)
+        for more information on possible filters.
+    type: dict
+  volumes:
+    description:
+      - Whether to list volumes.
+    type: bool
+    default: no
+  volumes_filters:
+    description:
+      - A dictionary of filter values used for selecting volumes to delete.
+      - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/volume_prune/#filtering)
+        for more information on possible filters.
+    type: dict
+  disk_usage:
+    description:
+      - Summary information on used disk space by all Docker layers.
+      - The output is a sum of images, volumes, containers and build cache.
+    type: bool
+    default: no
 
 extends_documentation_fragment:
     - docker
@@ -57,20 +107,56 @@ EXAMPLES = '''
   docker_host_facts:
   register: result
 
+- name: Get info on docker host and list images
+  docker_host_facts:
+    images: true
+  register: result
+
+- name: Get info on docker host and list images matching the filter
+  docker_host_facts:
+    images: true
+    images_filters:
+      label: "mylabel"
+  register: result
+
+- name: Get info on docker host and used disk space
+  docker_host_facts:
+    disk_usage: true
+  register: result
+
 '''
 
 RETURN = '''
-exists:
-    description:
-      - Returns whether the node exists in docker swarm cluster.
-    type: bool
-    returned: always
-    sample: true
 docker_host_facts:
     description:
-      - Facts representing the current state of the docker host. Matches the C(docker system info) output.
+      - Facts representing the basic state of the docker host. Matches the C(docker system info) output.
     returned: always
     type: dict
+docker_volumes_list:
+    description:
+      - List of volumes with basic information about each. Matches the C(docker volumes ls) output.
+    returned: on success
+    type: dict
+docker_networks_list:
+    description:
+      - List of networks with basic information about each. Matches the C(docker volumes ls) output.
+    returned: on success
+    type: dict
+docker_containers_list:
+    description:
+      - List of containers with basic information about each. Matches the C(docker volumes ls) output.
+    returned: on success
+    type: dict
+docker_images_list:
+    description:
+      - List of images with basic information about each. Matches the C(docker image ls) output.
+    returned: on success
+    type: dict
+docker_disk_usage:
+    description:
+      - Facts representing the current state of the docker host. Matches the C(docker system info) output.
+    returned: on success
+    type: int
 
 '''
 
@@ -81,6 +167,12 @@ try:
     from docker.errors import APIError, NotFound
 except ImportError:
     # missing docker-py handled in ansible.module_utils.docker_common
+    pass
+
+try:
+    from ansible.module_utils.docker_common import docker_version, clean_dict_booleans_for_docker_api
+except Exception as dummy:
+    # missing docker-py handled in ansible.module_utils.docker
     pass
 
 
@@ -97,10 +189,15 @@ class DockerHostManager(DockerBaseClass):
 
         self.results['docker_host_facts'] = self.get_docker_host_facts()
 
+        if self.client.module.params['disk_usage'] is True:
+            self.results['docker_disk_usage'] = self.get_docker_disk_usage_facts()
+
         for docker_object in listed_objects:
             if self.client.module.params[docker_object] is True:
                 returned_name = "docker_" + docker_object + "_list"
-                self.results[returned_name] = self.get_docker_items_list(docker_object)
+                filter_name = docker_object + "_filters"
+                filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name))
+                self.results[returned_name] = self.get_docker_items_list(docker_object, filters)
 
     def get_docker_host_facts(self):
         try:
@@ -108,7 +205,13 @@ class DockerHostManager(DockerBaseClass):
         except APIError as exc:
             self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))
 
-    def get_docker_items_list(self, object=None):
+    def get_docker_disk_usage_facts(self):
+        try:
+            return self.client.df()['LayersSize']
+        except APIError as exc:
+            self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))
+
+    def get_docker_items_list(self, docker_object=None, filters=None):
         items = None
         items_list = []
 
@@ -118,28 +221,28 @@ class DockerHostManager(DockerBaseClass):
         header_networks = ['Id', 'Driver', 'Name', 'Scope']
 
         try:
-            if object == 'containers':
-                items = self.client.containers()
-            if object == 'networks':
-                items = self.client.networks()
-            if object == 'images':
-                items = self.client.images()
-            if object == 'volumes':
-                items = self.client.volumes()
+            if docker_object == 'containers':
+                items = self.client.containers(filters=filters)
+            if docker_object == 'networks':
+                items = self.client.networks(filters=filters)
+            if docker_object == 'images':
+                items = self.client.images(filters=filters)
+            if docker_object == 'volumes':
+                items = self.client.volumes(filters=filters)
         except APIError as exc:
             self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))
 
-        if object != 'volumes':
+        if docker_object != 'volumes':
             for item in items:
                 item_record = dict()
 
-                if object == 'containers':
+                if docker_object == 'containers':
                     for key in header_containers:
                         item_record[key] = item.get(key)
-                if object == 'networks':
+                if docker_object == 'networks':
                     for key in header_networks:
                         item_record[key] = item.get(key)
-                if object == 'images':
+                if docker_object == 'images':
                     for key in header_images:
                         item_record[key] = item.get(key)
 
@@ -167,6 +270,7 @@ def main():
         networks_filters=dict(type='dict'),
         volumes=dict(type='bool', default=False),
         volumes_filters=dict(type='dict'),
+        disk_usage=dict(type='bool', default=False),
     )
 
     client = AnsibleDockerClient(

--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -123,6 +123,9 @@ EXAMPLES = '''
   docker_host_facts:
     disk_usage: true
   register: result
+  
+- debug:
+    var: result.docker_host_facts
 
 '''
 
@@ -135,27 +138,27 @@ docker_host_facts:
 docker_volumes_list:
     description:
       - List of volumes with basic information about each. Matches the C(docker volumes ls) output.
-    returned: on success
+    returned: When I(volumes) is C(yes)
     type: dict
 docker_networks_list:
     description:
       - List of networks with basic information about each. Matches the C(docker volumes ls) output.
-    returned: on success
+    returned: When I(networks) is C(yes)
     type: dict
 docker_containers_list:
     description:
       - List of containers with basic information about each. Matches the C(docker volumes ls) output.
-    returned: on success
+    returned: When I(containers) is C(yes)
     type: dict
 docker_images_list:
     description:
       - List of images with basic information about each. Matches the C(docker image ls) output.
-    returned: on success
+    returned: When I(images) is C(yes)
     type: dict
 docker_disk_usage:
     description:
-      - Facts representing the current state of the docker host. Matches the C(docker system info) output.
-    returned: on success
+      - Information on summary disk usage by images, containers and volumes on docker host.
+    returned: When I(disk_usage) is C(yes)
     type: int
 
 '''
@@ -189,11 +192,11 @@ class DockerHostManager(DockerBaseClass):
 
         self.results['docker_host_facts'] = self.get_docker_host_facts()
 
-        if self.client.module.params['disk_usage'] is True:
+        if self.client.module.params['disk_usage']:
             self.results['docker_disk_usage'] = self.get_docker_disk_usage_facts()
 
         for docker_object in listed_objects:
-            if self.client.module.params[docker_object] is True:
+            if self.client.module.params[docker_object]:
                 returned_name = "docker_" + docker_object + "_list"
                 filter_name = docker_object + "_filters"
                 filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name))
@@ -223,11 +226,11 @@ class DockerHostManager(DockerBaseClass):
         try:
             if docker_object == 'containers':
                 items = self.client.containers(filters=filters)
-            if docker_object == 'networks':
+            elif docker_object == 'networks':
                 items = self.client.networks(filters=filters)
-            if docker_object == 'images':
+            elif docker_object == 'images':
                 items = self.client.images(filters=filters)
-            if docker_object == 'volumes':
+            elif docker_object == 'volumes':
                 items = self.client.volumes(filters=filters)
         except APIError as exc:
             self.client.fail_json(msg="Error inspecting docker host: %s" % to_native(exc))

--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+#
+# (c) 2019 Piotr Wojciechowski <piotr@it-playground.pl>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: docker_host_facts
+
+short_description: Retrieves facts about docker host and lists of objects of the services
+
+description:
+  - Retrieves facts about a docker host.
+  - Essentially returns the output of C(docker system info).
+  - Returns lists of objects names for the services - images, networks, volumes, containers.
+  - Returns disk usage information.
+  - The output differs depending on API version available on docker host.
+  - Must be executed on a host running a Docker, otherwise the module will fail.
+
+version_added: "2.8"
+
+options:
+extends_documentation_fragment:
+    - docker
+
+author:
+    - Piotr Wojciechowski (@wojciechowskipiotr)
+
+requirements:
+    - "python >= 2.6"
+    - "docker-py >= 1.10.0"
+    - "Please note that the L(docker-py,https://pypi.org/project/docker-py/) Python
+       module has been superseded by L(docker,https://pypi.org/project/docker/)
+       (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
+       For Python 2.6, C(docker-py) must be used. Otherwise, it is recommended to
+       install the C(docker) Python module. Note that both modules should I(not)
+       be installed at the same time. Also note that when both modules are installed
+       and one of them is uninstalled, the other might no longer function and a
+       reinstall of it is required."
+    - "Docker API >= 1.21"
+'''
+
+EXAMPLES = '''
+- name: Get info on docker host
+  docker_host_facts:
+  register: result
+
+'''
+
+RETURN = '''
+exists:
+    description:
+      - Returns whether the node exists in docker swarm cluster.
+    type: bool
+    returned: always
+    sample: true
+docker_host_facts:
+    description:
+      - Facts representing the current state of the docker host. Matches the C(docker system info) output.
+    returned: always
+    type: dict
+
+'''
+
+from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass
+from ansible.module_utils._text import to_native
+
+try:
+    from docker.errors import APIError, NotFound
+except ImportError:
+    # missing docker-py handled in ansible.module_utils.docker_common
+    pass
+
+
+class DockerHostManager(DockerBaseClass):
+
+    def __init__(self, client, results):
+
+        super(DockerHostManager, self).__init__()
+
+        self.client = client
+        self.results = results
+
+        self.results['docker_host_facts'] = self.get_docker_host_facts()
+
+    def get_docker_host_facts(self):
+        try:
+            return self.client.info()
+        except Exception as exc:
+            self.client.fail_json(msg="Error inspecting docker host: %s" % exc)
+
+
+def main():
+    argument_spec = dict(
+        services=dict(type='list', elements='str'),
+    )
+
+    client = AnsibleDockerClient(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        min_docker_version='1.10.0',
+        min_docker_api_version='1.21',
+    )
+
+    results = dict(
+        changed=False,
+        docker_host_facts=[]
+    )
+
+    DockerHostManager(client, results)
+    client.module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Proposal for the new module for Docker. The main purpose of this module is to:
- Gather system-wide information about docker host from the running docker process
- Read the list of containers, volumes, networks, and images on docker host

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
docker_host_facts

##### ADDITIONAL INFORMATION
This PR covers proposal raised in #49267 and let gather information required as an input to other modules or evaluation in conditional. Modules like `docker_container_facts`, `docker_image_facts` or `docker_network_facts` requires the `name` or `id` of object as a parameter to read detailed information on the object. In many playbooks, the list of objects of those types may not be known when playbook starts, neither to get general information on docker process on the host (except parsing the `shell` output which should be the last resort solution). 

By default with no additional parameters, this module will return the system-wide information on docker host (equivalent to `docker system info` CLI command). Using additional options a user can read summary disk usage of volumes, images, containers and build cache objects and get lists of containers, volumes, networks, and images. Each list will contain the same set of information as the output of the equivalent `docker [containers,volumes,images,networks] ls` command. This will provide an easy way to get a list of existing objects and will reduce the requirement of using the `docker_*_facts` for each entry to gather any information. It will be very beneficial for the troubleshooting or maintenance playbooks giving the necessary information as an output of a single task.

I used the naming options convention from the `docker_prune`, also the filters are covered in the same way.

This module does not cover the Docker Swarm - similar implementation for Swarm objects will be included in `docker_swarm_facts` (#50622) 


