### PR TITLE
Allow check_mode with supports_generate_diff capability in cli_config

### DIFF
--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -296,7 +296,8 @@ def run(module, capabilities, connection, candidate, running, rollback_id):
 
             kwargs = {'candidate': candidate, 'commit': commit, 'replace': replace,
                       'comment': commit_comment}
-            connection.edit_config(**kwargs)
+            if commit:
+                connection.edit_config(**kwargs)
             result['changed'] = True
 
         if banner_diff:
@@ -305,7 +306,8 @@ def run(module, capabilities, connection, candidate, running, rollback_id):
             kwargs = {'candidate': candidate, 'commit': commit}
             if multiline_delimiter:
                 kwargs.update({'multiline_delimiter': multiline_delimiter})
-            connection.edit_banner(**kwargs)
+            if commit:
+                connection.edit_banner(**kwargs)
             result['changed'] = True
 
     if module._diff:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* If network cliconf support `supports_generate_diff` in
  that case diff between running and candidate config
  is generated within Ansible and if check_mode is enabled
  in that case, return only diff without actually invoking
  edit_config()
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cli_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
