### PR TITLE
k8s: fix handling exceptions for certain modules

### DIFF
--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -75,6 +75,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
 
     def __init__(self, k8s_kind=None, *args, **kwargs):
         self.client = None
+        self.warnings = []
 
         mutually_exclusive = [
             ('resource_definition', 'src'),


### PR DESCRIPTION
##### SUMMARY
k8s modules based on KubernetesRawModule() class will have a code path for handling certain exceptions that assumes `self.warnings` exists. This is true for modules that Do Stuff by utilizing the KubernetesRawModule.execute_module() function, which takes care of setting that variable.

However some k8s modules provide their own execute_module(), which in case of an exception generates lots and lots of lines of backtrace like so:

```
The full traceback is:
(…)
During handling of the above exception, another exception occurred:
(…)
During handling of the above exception, another exception occurred:
(…)
    "msg": "'KubeVirtVM' object has no attribute 'warnings'"
}
```
This patch makes sure `self.warnings` gets created within `__init__`, so that it's lack never causes meltdowns.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

module/k8s_*

##### ADDITIONAL INFORMATION
