### PR TITLE
Backport/2.7/docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ docs/docsite/*.html
 docs/docsite/htmlout
 docs/docsite/rst/cli/ansible-*.rst
 docs/docsite/rst/cli/ansible.rst
+docs/docsite/rst/dev_guide/testing/sanity/index.rst.new
 docs/docsite/rst/modules/*.rst
 docs/docsite/rst/playbooks_directives.rst
 docs/docsite/rst/plugins_by_category.rst

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -1,22 +1,9 @@
 #!/usr/bin/env python
-# (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
-# (c) 2012-2014, Michael DeHaan <michael@ansible.com> and others
-# (c) 2017 Ansible Project
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+# Copyright: (c) 2012-2014, Michael DeHaan <michael@ansible.com> and others
+# Copyright: (c) 2017, Ansible Project
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -47,6 +34,7 @@ except ImportError:
 import jinja2
 import yaml
 from jinja2 import Environment, FileSystemLoader
+from jinja2.runtime import Undefined
 from six import iteritems, string_types
 
 from ansible.errors import AnsibleError
@@ -156,6 +144,22 @@ def rst_xline(width, char="="):
     ''' return a restructured text line of a given length '''
 
     return char * width
+
+
+def documented_type(text):
+    ''' Convert any python type to a type for documentation '''
+
+    if isinstance(text, Undefined):
+        return '-'
+    if text == 'str':
+        return 'string'
+    if text == 'bool':
+        return 'boolean'
+    if text == 'int':
+        return 'integer'
+    if text == 'dict':
+        return 'dictionary'
+    return text
 
 
 test_list = partial(is_sequence, include_strings=False)
@@ -367,6 +371,7 @@ def jinja2_environment(template_dir, typ, plugin_type):
         env.filters['html_ify'] = html_ify
         env.filters['fmt'] = rst_fmt
         env.filters['xline'] = rst_xline
+        env.filters['documented_type'] = documented_type
         env.tests['list'] = test_list
         templates['plugin'] = env.get_template('plugin.rst.j2')
 
@@ -464,14 +469,14 @@ def process_plugins(module_map, templates, outputname, output_dir, ansible_versi
             for (k, v) in iteritems(doc['options']):
                 # Error out if there's no description
                 if 'description' not in doc['options'][k]:
-                    raise AnsibleError("Missing required description for option %s in %s " % (k, module))
+                    raise AnsibleError("Missing required description for parameter '%s' in '%s' " % (k, module))
 
                 # Error out if required isn't a boolean (people have been putting
                 # information on when something is required in here.  Those need
                 # to go in the description instead).
                 required_value = doc['options'][k].get('required', False)
                 if not isinstance(required_value, bool):
-                    raise AnsibleError("Invalid required value '%s' for option '%s' in '%s' (must be truthy)" % (required_value, k, module))
+                    raise AnsibleError("Invalid required value '%s' for parameter '%s' in '%s' (must be truthy)" % (required_value, k, module))
 
                 # Strip old version_added information for options
                 if 'version_added' in doc['options'][k] and too_old(doc['options'][k]['version_added']):

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -206,6 +206,7 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
             :aliases: set of aliases to this module name
             :metadata: The modules metadata (as recorded in the module)
             :doc: The documentation structure for the module
+            :seealso: The list of dictionaries with references to related subjects
             :examples: The module's examples
             :returndocs: The module's returndocs
 
@@ -362,7 +363,7 @@ def jinja2_environment(template_dir, typ, plugin_type):
 
     templates = {}
     if typ == 'rst':
-        env.filters['convert_symbols_to_format'] = rst_ify
+        env.filters['rst_ify'] = rst_ify
         env.filters['html_ify'] = html_ify
         env.filters['fmt'] = rst_fmt
         env.filters['xline'] = rst_xline

--- a/docs/docsite/_static/pygments.css
+++ b/docs/docsite/_static/pygments.css
@@ -1,5 +1,5 @@
 .highlight { background: #f8f8f8 }
-.highlight .hll { background-color: #ffffcc; border: 1px solid #ccc; padding: 6px 10px; border-radius: 3px }
+.highlight .hll { background-color: #ffffcc; border: 1px solid #edff00; padding-top: 2px; border-radius: 3px; display: block }
 .highlight .c { color: #6a737d; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2; color: #a61717; border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #007020; font-weight: bold } /* Keyword */

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -224,7 +224,34 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 :notes:
 
   * Details of any important information that doesn't fit in one of the above sections.
-  * For example, whether ``check_mode`` is or is not supported, or links to external documentation.
+  * For example, whether ``check_mode`` is or is not supported.
+
+:seealso:
+
+  * A list of references to other modules, documentation or Internet resources
+  * A reference can be one of the following formats:
+
+
+    .. code-block:: yaml+jinja
+
+        seealso::
+
+        # Reference by module name
+        - module: aci_tenant
+
+        # Reference by module name, including description
+        - module: aci_tenant
+          description: ACI module to create tenants on a Cisco ACI fabric.
+
+        # Reference by rST documentation anchor
+        - ref: aci_guide
+          description: Detailed information on how to manage your ACI infrastructure using Ansible.
+
+        # Reference by Internet resource
+        - name: APIC Management Information Model reference
+          description: Complete reference of the APIC object model.
+          link: https://developer.cisco.com/docs/apic-mim-ref/
+
 
 Linking within module documentation
 -----------------------------------
@@ -239,7 +266,8 @@ You can link from your module documentation to other module docs, other resource
 
 .. note::
 
-  To refer a collection of modules, use ``C(..)``, e.g. ``Refer to the C(win_*) modules.``
+    - To refer a collection of modules, use ``C(..)``, e.g. ``Refer to the C(win_*) modules.``
+    - Because it stands out better, using ``seealso`` is preferred for general references over the use of notes or adding links to the description.
 
 Documentation fragments
 -----------------------
@@ -248,9 +276,12 @@ If you're writing multiple related modules, they may share common documentation,
 
 For example, all AWS modules should include::
 
+.. code-block:: yaml+jinja
+
     extends_documentation_fragment:
         - aws
         - ec2
+
 
 You can find more examples by searching for ``extends_documentation_fragment`` under the Ansible source tree.
 

--- a/docs/templates/list_of_CATEGORY_modules.rst.j2
+++ b/docs/templates/list_of_CATEGORY_modules.rst.j2
@@ -1,3 +1,6 @@
+{# avoids rST "isn't included in any toctree" errors for module docs #}
+:orphan:
+
 .. _@{ title.lower() + '_' + plugin_type + 's' }@:
 
 @{ title }@ @{ plugin_type + 's' }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -196,9 +196,9 @@ Parameters
             </tr>
             {% if value.suboptions %}
                 {% if value.suboptions.items %}
-                    @{ loop(value.suboptions.items()) }@
+                    @{ loop(value.suboptions|dictsort) }@
                 {% elif value.suboptions[0].items %}
-                    @{ loop(value.suboptions[0].items()) }@
+                    @{ loop(value.suboptions[0]|dictsort) }@
                 {% endif %}
             {% endif %}
         {% endfor %}
@@ -324,9 +324,9 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
              # ---------------------------------------------------------#}
             {% if value.contains %}
                 {% if value.contains.items %}
-                    @{ loop(value.contains.items()) }@
+                    @{ loop(value.contains|dictsort) }@
                 {% elif value.contains[0].items %}
-                    @{ loop(value.contains[0].items()) }@
+                    @{ loop(value.contains[0]|dictsort) }@
                 {% endif %}
             {% endif %}
         {% endfor %}
@@ -394,9 +394,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
              # ---------------------------------------------------------#}
             {% if value.contains %}
                 {% if value.contains.items %}
-                    @{ loop(value.contains.items()) }@
+                    @{ loop(value.contains|dictsort) }@
                 {% elif value.contains[0].items %}
-                    @{ loop(value.contains[0].items()) }@
+                    @{ loop(value.contains[0]|dictsort) }@
                 {% endif %}
             {% endif %}
         {% endfor %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -11,7 +11,7 @@
 {% endfor %}
 
 {% if short_description %}
-{%   set title = module + ' - ' + short_description | rst_ify %}
+{%   set title = module + ' -- ' + short_description | rst_ify %}
 {% else %}
 {%   set title = module %}
 {% endif %}
@@ -25,7 +25,7 @@
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 {# ------------------------------------------
  #
@@ -67,7 +67,7 @@ Aliases: @{ ','.join(aliases) }@
 {% if requirements -%}
 
 Requirements
-~~~~~~~~~~~~
+------------
 {%   if plugin_type == 'module' %}
 The below requirements are needed on the host that executes this @{ plugin_type }@.
 {%   else %}
@@ -118,9 +118,11 @@ Parameters
                 {# parameter name with required and/or introduced label #}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
-                    {% if value.get('type', None) %}<br/><div style="font-size: small; color: red">@{ value.type }@</div>{% endif %}
-                    {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
-                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
+                    <div style="font-size: small">
+                        <span style="color: purple">@{ value.type | documented_type }@</span>
+                        {% if value.get('required', False) %} / <span style="color: red">required</span>{% endif %}
+                    </div>
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 {# default / choices #}
                 <td>
@@ -135,7 +137,7 @@ Parameters
                     {% endif %}
                     {# Show possible choices and highlight details #}
                     {% if value.choices %}
-                        <ul><b>Choices:</b>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
                             {% for choice in value.choices %}
                                 {# Turn boolean values in 'yes' and 'no' values #}
                                 {% if choice is sameas true %}
@@ -293,8 +295,8 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
-                    <br/><div style="font-size: small; color: red">@{ value.type }@</div>
-                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
+                    <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
@@ -365,8 +367,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
-                    <br/><div style="font-size: small; color: red">@{ value.type }@</div>
-                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
+                    <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
@@ -405,53 +407,46 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
 Status
 ------
-{% if not deprecated %}
+
+{% if deprecated %}
+
+- This @{ plugin_type }@ will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+{% else %}
 
 {%   set support = { 'core': 'the Ansible Core Team', 'network': 'the Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'the Ansible Community', 'curated': 'a Third Party'} %}
-{%   set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
+{%   set module_states = { 'preview': 'not guaranteed to have a backwards compatible interface', 'stableinterface': 'guaranteed to have no backward incompatible interface changes going forward'} %}
 
 {%   if metadata %}
 {%     if metadata.status %}
 
 {%       for cur_state in metadata.status %}
-This @{ plugin_type }@ is flagged as **@{cur_state}@** which means that @{module_states[cur_state]}@.
+- This @{ plugin_type }@ is @{ module_states[cur_state] }@. *[@{ cur_state }@]*
 {%       endfor %}
 
 {%     endif %}
 
 {%     if metadata.supported_by %}
-
-Maintenance
------------
-
 {%       set supported_by = support[metadata.supported_by] %}
-This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is maintained by @{ supported_by }@. See :ref:`Module Maintenance & Support <modules_support>` for more info.
-
-For a list of other modules that are also maintained by @{ supported_by }@, see :ref:`here <@{ metadata.supported_by }@_supported>`.
+- This @{ plugin_type }@ is :ref:`maintained by @{ supported_by }@ <modules_support>`. *[@{ metadata.supported_by }@]*
 
 {%       if metadata.supported_by in ('core', 'network') %}
+Red Hat Support
+~~~~~~~~~~~~~~~
 
-Support
-~~~~~~~
-
-For more information about Red Hat's support of this @{ plugin_type }@,
-please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
+More information about Red Hat's support of this @{ plugin_type }@ is available from this `Red Hat Knowledge Base article <https://access.redhat.com/articles/3166901>`_.
 {%       endif %}
 
 {%     endif %}
 
 {%   endif %}
 
-{% else %}
-
-This @{ plugin_type }@ is flagged as **deprecated** and will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. For more information see `DEPRECATED`_.
-
 {% endif %}
 
 {% if author is defined -%}
-
-Author
-~~~~~~
+Authors
+~~~~~~~
 
 {%   for author_name in author %}
 - @{ author_name }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -11,7 +11,7 @@
 {% endfor %}
 
 {% if short_description %}
-{%   set title = module + ' - ' + short_description|convert_symbols_to_format %}
+{%   set title = module + ' - ' + short_description | rst_ify %}
 {% else %}
 {%   set title = module %}
 {% endif %}
@@ -39,9 +39,9 @@
 DEPRECATED
 ----------
 {# use unknown here? skip the fields? #}
-:Removed in Ansible: version: @{ deprecated['removed_in'] | default('') | string | convert_symbols_to_format }@
-:Why: @{ deprecated['why'] | default('') | convert_symbols_to_format }@
-:Alternative: @{ deprecated['alternative'] | default('')|  convert_symbols_to_format }@
+:Removed in Ansible: version: @{ deprecated['removed_in'] | default('') | string | rst_ify }@
+:Why: @{ deprecated['why'] | default('') | rst_ify }@
+:Alternative: @{ deprecated['alternative'] | default('') | rst_ify }@
 
 
 {% endif %}
@@ -51,10 +51,10 @@ Synopsis
 {% if description -%}
 
 {%   if description is string -%}
-- @{ description | convert_symbols_to_format }@
+- @{ description | rst_ify }@
 {%   else %}
 {%     for desc in description %}
-- @{ desc | convert_symbols_to_format }@
+- @{ desc | rst_ify }@
 {%     endfor %}
 {%   endif %}
 
@@ -75,7 +75,7 @@ The below requirements are needed on the local master node that executes this @{
 {%   endif %}
 
 {%   for req in requirements %}
-- @{ req | convert_symbols_to_format }@
+- @{ req | rst_ify }@
 {%   endfor %}
 
 {% endif %}
@@ -206,14 +206,37 @@ Parameters
 {% endif %}
 
 {% if notes -%}
-
 Notes
 -----
 
 .. note::
 {%   for note in notes %}
-    - @{ note | convert_symbols_to_format }@
+   - @{ note | rst_ify }@
 {%   endfor %}
+
+{% endif %}
+
+{% if seealso -%}
+See Also
+--------
+
+.. seealso::
+
+{% for item in seealso %}
+{%   if item.module is defined and item.description is defined %}
+   :ref:`Module @{ item.module }@ <@{ item.module }@_module>`
+       @{ item.description | rst_ify }@
+{%   elif item.module is defined %}
+   :ref:`@{ item.module }@_module`
+      The official documentation on the **@{ item.module }@** module.
+{%   elif item.name is defined and item.link is defined and item.description is defined %}
+   `@{ item.name }@ <@{ item.link }@>`_
+       @{ item.description | rst_ify }@
+{%   elif item.ref is defined and item.description is defined %}
+   :ref:`@{ item.ref }@`
+       @{ item.description | rst_ify }@
+{%   endif %}
+{% endfor %}
 
 {% endif %}
 
@@ -421,7 +444,7 @@ please refer to this `Knowledge Base article <https://access.redhat.com/articles
 
 {% else %}
 
-This @{ plugin_type }@ is flagged as **deprecated** and will be removed in version @{ deprecated['removed_in'] | default('') | string | convert_symbols_to_format }@. For more information see `DEPRECATED`_.
+This @{ plugin_type }@ is flagged as **deprecated** and will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. For more information see `DEPRECATED`_.
 
 {% endif %}
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1,17 +1,5 @@
-# (c) 2014, James Tanner <tanner.jc@gmail.com>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2014, James Tanner <tanner.jc@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -580,7 +568,44 @@ class DocCLI(CLI):
             for note in doc['notes']:
                 text.append(textwrap.fill(CLI.tty_ify(note), limit - 6, initial_indent=opt_indent[:-2] + "* ", subsequent_indent=opt_indent))
             text.append('')
+            text.append('')
             del doc['notes']
+
+        if 'seealso' in doc and doc['seealso']:
+            text.append("SEE ALSO:")
+            for item in doc['seealso']:
+                if 'module' in item and 'description' in item:
+                    text.append(textwrap.fill(CLI.tty_ify('Module %s' % item['module']),
+                                limit - 6, initial_indent=opt_indent[:-2] + "* ", subsequent_indent=opt_indent))
+                    text.append(textwrap.fill(CLI.tty_ify(item['description']),
+                                limit - 6, initial_indent=opt_indent, subsequent_indent=opt_indent))
+                    text.append(textwrap.fill(CLI.tty_ify('https://docs.ansible.com/ansible/latest/modules/%s_module.html' % item['module']),
+                                limit - 6, initial_indent=opt_indent + '   ', subsequent_indent=opt_indent))
+                elif 'module' in item:
+                    text.append(textwrap.fill(CLI.tty_ify('Module %s' % item['module']),
+                                limit - 6, initial_indent=opt_indent[:-2] + "* ", subsequent_indent=opt_indent))
+                    text.append(textwrap.fill(CLI.tty_ify('The official documentation on the %s module.' % item['module']),
+                                limit - 6, initial_indent=opt_indent + '   ', subsequent_indent=opt_indent + '   '))
+                    text.append(textwrap.fill(CLI.tty_ify('https://docs.ansible.com/ansible/latest/modules/%s_module.html' % item['module']),
+                                limit - 6, initial_indent=opt_indent + '   ', subsequent_indent=opt_indent))
+                elif 'name' in item and 'link' in item and 'description' in item:
+                    text.append(textwrap.fill(CLI.tty_ify(item['name']),
+                                limit - 6, initial_indent=opt_indent[:-2] + "* ", subsequent_indent=opt_indent))
+                    text.append(textwrap.fill(CLI.tty_ify(item['description']),
+                                limit - 6, initial_indent=opt_indent + '   ', subsequent_indent=opt_indent + '   '))
+                    text.append(textwrap.fill(CLI.tty_ify(item['link']),
+                                limit - 6, initial_indent=opt_indent + '   ', subsequent_indent=opt_indent + '   '))
+                elif 'ref' in item and 'description' in item:
+                    text.append(textwrap.fill(CLI.tty_ify('Ansible documentation [%s]' % item['ref']),
+                                limit - 6, initial_indent=opt_indent[:-2] + "* ", subsequent_indent=opt_indent))
+                    text.append(textwrap.fill(CLI.tty_ify(item['description']),
+                                limit - 6, initial_indent=opt_indent + '   ', subsequent_indent=opt_indent + '   '))
+                    text.append(textwrap.fill(CLI.tty_ify('https://docs.ansible.com/ansible/latest/#stq=%s&stp=1' % item['ref']),
+                                limit - 6, initial_indent=opt_indent + '   ', subsequent_indent=opt_indent + '   '))
+
+            text.append('')
+            text.append('')
+            del doc['seealso']
 
         if 'requirements' in doc and doc['requirements'] is not None and len(doc['requirements']) > 0:
             req = ", ".join(doc.pop('requirements'))
@@ -601,14 +626,16 @@ class DocCLI(CLI):
 
         if 'plainexamples' in doc and doc['plainexamples'] is not None:
             text.append("EXAMPLES:")
+            text.append('')
             if isinstance(doc['plainexamples'], string_types):
                 text.append(doc.pop('plainexamples').strip())
             else:
                 text.append(yaml.dump(doc.pop('plainexamples'), indent=2, default_flow_style=False))
             text.append('')
+            text.append('')
 
         if 'returndocs' in doc and doc['returndocs'] is not None:
-            text.append("RETURN VALUES:\n")
+            text.append("RETURN VALUES:")
             if isinstance(doc['returndocs'], string_types):
                 text.append(doc.pop('returndocs'))
             else:

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -21,8 +21,9 @@ notes:
   is required when the state is C(absent) or C(present).
 - The C(tenant) and C(bd) used must exist before using this module in your playbook.
   The M(aci_tenant) module and M(aci_bd) can be used for these.
-- More information about the internal APIC class B(fv:Subnet) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_bd
+- module: aci_tenant
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -1,7 +1,6 @@
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -29,7 +28,8 @@ def read_docstring(filename, verbose=True, ignore_errors=True):
         'doc': None,
         'plainexamples': None,
         'returndocs': None,
-        'metadata': None
+        'metadata': None,
+        'seealso': None,
     }
 
     string_to_vars = {

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -2,7 +2,6 @@
 
 # Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
 # Copyright: (c) 2017, Swetha Chunduri (@schunduri)
-
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
@@ -70,6 +69,9 @@ options:
     - This should only set to C(no) when used on personally controlled sites using self-signed certificates.
     type: bool
     default: 'yes'
-notes:
-- Please read the :ref:`aci_guide` for more detailed information on how to manage your ACI infrastructure using Ansible.
+seealso:
+- ref: aci_guide
+  description: Detailed information on how to manage your ACI infrastructure using Ansible.
+- ref: aci_dev_guide
+  description: Detailed guide on how to write your own Cisco ACI modules to contribute.
 '''

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -89,6 +89,13 @@ def add_fragments(doc, filename, fragment_loader):
                     doc['notes'] = []
                 doc['notes'].extend(notes)
 
+        if 'seealso' in fragment:
+            seealso = fragment.pop('seealso')
+            if seealso:
+                if 'seealso' not in doc:
+                    doc['seealso'] = []
+                doc['seealso'].extend(seealso)
+
         if 'options' not in fragment:
             raise Exception("missing options in fragment (%s), possibly misformatted?: %s" % (fragment_name, filename))
 

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -1,20 +1,8 @@
 # -*- coding: utf-8 -*-
-#
-# Copyright (C) 2015 Matt Martz <matt@sivel.net>
-# Copyright (C) 2015 Rackspace US, Inc.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright: (c) 2015, Matt Martz <matt@sivel.net>
+# Copyright: (c) 2015, Rackspace US, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from voluptuous import PREVENT_EXTRA, All, Any, Length, Required, Schema, Self
 from ansible.module_utils.six import string_types
@@ -35,6 +23,26 @@ def sequence_of_sequences(min=None, max=None):
         ),
     )
 
+
+seealso_schema = Schema(
+    [
+        Any(
+            {
+                Required('module'): Any(*string_types),
+                'description': Any(*string_types),
+            },
+            {
+                Required('ref'): Any(*string_types),
+                Required('description'): Any(*string_types),
+            },
+            {
+                Required('name'): Any(*string_types),
+                Required('link'): Any(*string_types),
+                Required('description'): Any(*string_types),
+            },
+        ),
+    ]
+)
 
 ansible_module_kwargs_schema = Schema(
     {
@@ -147,6 +155,7 @@ def doc_schema(module_name):
         Required('version_added'): Any(float, *string_types),
         Required('author'): Any(None, list_string_types, *string_types),
         'notes': Any(None, list_string_types),
+        'seealso': Any(None, seealso_schema),
         'requirements': list_string_types,
         'todo': Any(None, list_string_types, *string_types),
         'options': Any(None, *list_dict_option_schema),


### PR DESCRIPTION
##### SUMMARY
Backports five changes to the docsite mechanics:
#47518 adding a build artifact to .gitignore
#45949 adding a "see also" section to module docs
#49966 showing parameter types (string, boolean, etc.) in purple on module docs
#50315 sorting (alphabetizing) suboptions/subparameters/nested content in module docs
#50756 fixing the style for highlighted lines in rST

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

