### PR TITLE
Meraki performance fixes for net and org lookups

### DIFF
--- a/changelogs/fragments/meraki_orgnet_fix.yml
+++ b/changelogs/fragments/meraki_orgnet_fix.yml
@@ -1,0 +1,2 @@
+bugfix:
+    - Meraki - Lookups using org_name or net_name no longer query Meraki twice, only once. Major performance improvements.

--- a/changelogs/fragments/meraki_orgnet_fix.yml
+++ b/changelogs/fragments/meraki_orgnet_fix.yml
@@ -1,2 +1,2 @@
-bugfix:
-    - Meraki - Lookups using org_name or net_name no longer query Meraki twice, only once. Major performance improvements.
+bugfixes:
+  - Meraki - Lookups using org_name or net_name no longer query Meraki twice, only once. Major performance improvements.

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -157,7 +157,7 @@ class MerakiModule(object):
         response = self.request('/organizations', method='GET')
         if self.status != 200:
             self.fail_json(msg='Organization lookup failed')
-        self.orgs = self.request('/organizations', method='GET')
+        self.orgs = response
         return self.orgs
 
     def is_org_valid(self, data, org_name=None, org_id=None):
@@ -205,7 +205,7 @@ class MerakiModule(object):
         r = self.request(path, method='GET')
         if self.status != 200:
             self.fail_json(msg='Network lookup failed')
-        self.nets = self.request(path, method='GET')
+        self.nets = r
         templates = self.get_config_templates(org_id)
         for t in templates:
             self.nets.append(t)


### PR DESCRIPTION
##### SUMMARY
Large performance increases due to duplicate lookups
- Both methods had duplicate lookups
- This should significantly improve performance

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki
