### PR TITLE
make missing pattern ansibleerror

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -558,7 +558,7 @@ class InventoryManager(object):
             if C.HOST_PATTERN_MISMATCH == 'warning':
                 display.warning(msg)
             elif C.HOST_PATTERN_MISMATCH == 'error':
-                raise AnsibleOptionsError(msg)
+                raise AnsibleError(msg)
             # no need to write 'ignore' state
 
         return results


### PR DESCRIPTION
  ansibleoptionserror should be limited to cli options
 (technically --limit makes this a bit grey but hosts: should not trigger the same error)



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
inventory