### PR TITLE
Update galaxy cli metadata file templates

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -210,7 +210,7 @@ class GalaxyCLI(CLI):
             author='your name',
             description='your description',
             company='your company (optional)',
-            license='license (GPLv2, CC-BY, etc)',
+            license='license (GPL-2.0-or-later, MIT, etc)',
             issue_tracker_url='http://example.com/issue/tracker',
             min_ansible_version='2.4',
             role_type=context.CLIARGS['role_type']

--- a/lib/ansible/galaxy/data/apb/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/meta/main.yml.j2
@@ -7,13 +7,13 @@ galaxy_info:
   # next line and provide a value
   # issue_tracker_url: {{ issue_tracker_url }}
 
-  # Some suggested licenses:
-  # - BSD (default)
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
   license: {{ license }}
 
   #

--- a/lib/ansible/galaxy/data/apb/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/meta/main.yml.j2
@@ -16,14 +16,6 @@ galaxy_info:
   # - CC-BY
   license: {{ license }}
 
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
   #
   # platforms is a list of platforms, and each platform has a name and a list of versions.
   #

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -7,13 +7,13 @@ galaxy_info:
   # next line and provide a value
   # issue_tracker_url: {{ issue_tracker_url }}
 
-  # Some suggested licenses:
-  # - BSD (default)
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
   license: {{ license }}
 
   min_ansible_container_version: 0.2.0

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -21,14 +21,6 @@ galaxy_info:
   # If Ansible is required outside of the build container, provide the minimum version:
   # min_ansible_version:
 
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
   #
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.

--- a/lib/ansible/galaxy/data/default/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/meta/main.yml.j2
@@ -21,14 +21,6 @@ galaxy_info:
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
 
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
   #
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.

--- a/lib/ansible/galaxy/data/default/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/meta/main.yml.j2
@@ -7,13 +7,13 @@ galaxy_info:
   # next line and provide a value
   # issue_tracker_url: {{ issue_tracker_url }}
 
-  # Some suggested licenses:
-  # - BSD (default)
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
   license: {{ license }}
 
   min_ansible_version: {{ min_ansible_version }}

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -21,14 +21,6 @@ galaxy_info:
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
 
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
   #
   # platforms is a list of platforms, and each platform has a name and a list of versions.
   #

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -7,13 +7,13 @@ galaxy_info:
   # next line and provide a value
   # issue_tracker_url: {{ issue_tracker_url }}
 
-  # Some suggested licenses:
-  # - BSD (default)
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
   license: {{ license }}
 
   min_ansible_version: {{ min_ansible_version }}


### PR DESCRIPTION
##### SUMMARY
Update galaxy cli metadata file templates to match current functionality:
1. Remove `github_branch` from galaxy meta file templates, since the galaxy import process no longer uses this
2. Update galaxy meta license examples to valid SPDX IDs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`ansible-galaxy init`
