### PR TITLE
Added filters option to openstack inventory plugin.

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -209,7 +209,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             expand_hostvars = self._config_data.get('expand_hostvars', False)
             fail_on_errors = self._config_data.get('fail_on_errors', False)
-            filters = self._config_data.get('filters', None)
+            filters = self.templar.template(self._config_data.get('filters', None))
 
             if isinstance(filters, dict) or isinstance(filters, string_types):
                 source_data = cloud_inventory.search_hosts(

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -105,6 +105,7 @@ DOCUMENTATION = '''
                 note: fail_on_errors is always True when using filters
             type: dictionary or string
             default: None
+            version_added: "2.9"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Added support for OpenStack SDK filters option to inventory plugin.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
OpenStack inventory plugin

##### ADDITIONAL INFORMATION
I use our case as example:

We want to create automatically environment from pull request (multiple virtual machines, networks etc.). Our and 3rd party software are installed and configured with Ansible. We use Heat templates to describe resources and use unique identifier for each environment.

With filters implementation we can use metadata to get only those virtual machine belonging to one pull request:
```
filters:
  metadata:
    stack_identifier: 'PR-123'
```