### PR TITLE
Add multiline config example in cli_config docs

### DIFF
--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -147,6 +147,12 @@ EXAMPLES = """
   cli_config:
     config: "{{ lookup('template', 'basic/config.j2') }}"
 
+- name: multiline config
+  cli_config:
+    config: |
+      hostname foo
+      feature nxapi
+
 - name: configure device with config with defaults enabled
   cli_config:
     config: "{{ lookup('template', 'basic/config.j2') }}"


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add multiline config example in cli_config docs
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/network/cli/cli_config.py
