### PR TITLE
meraki_admin - Add documentation for tags and network access

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -60,7 +60,7 @@ options:
             access:
                 description:
                 - The privilege of the dashboard administrator on the network
-                - Valid options are C(full), C(read-only), or C(none)
+                - Valid options are C(full), C(read-only), or C(none).
                 type: str
     state:
         description:

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -59,7 +59,7 @@ options:
                 type: str
             access:
                 description:
-                - The privilege of the dashboard administrator on the network
+                - The privilege of the dashboard administrator on the network.
                 - Valid options are C(full), C(read-only), or C(none).
                 type: str
     state:

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -119,7 +119,7 @@ EXAMPLES = r'''
     org_name: YourOrg
     state: absent
     email: jane@doe.com
-    
+
 - name: Create a new administrator with full access to a tag
   meraki_admin:
     auth_key: abc12345
@@ -130,7 +130,7 @@ EXAMPLES = r'''
     email: jane@doe.com
     tags:
         - {"tag": "tenant", "access": "full"}
-        
+
 - name: Create a new administrator with full access to a network
   meraki_admin:
     auth_key: abc12345

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -146,8 +146,10 @@ EXAMPLES = r'''
     orgAccess: read-only
     email: jane@doe.com
     tags:
-        - { "tag": "tenant", "access": "full" }
-        - { "tag": "corporate", "access": "read-only" }
+        - tag: tenant
+          access: full
+        - tag: corporate
+          access: read-only
 
 - name: Create a new administrator with full access to a network
   meraki_admin:
@@ -158,7 +160,8 @@ EXAMPLES = r'''
     orgAccess: read-only
     email: jane@doe.com
     networks:
-        - { "id": "N_12345", "access": "full" }
+        - id: N_12345
+          access: full
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -43,6 +43,8 @@ options:
         description:
         - List of networks the administrator has privileges on.
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
+        - C(id) is the network ID.
+        - C(access) is the access level to be assigned for the network ID.
     state:
         description:
         - Create or modify an organization
@@ -117,6 +119,28 @@ EXAMPLES = r'''
     org_name: YourOrg
     state: absent
     email: jane@doe.com
+    
+- name: Create a new administrator with full access to a tag
+  meraki_admin:
+    auth_key: abc12345
+    org_name: YourOrg
+    state: present
+    name: Jane Doe
+    orgAccess: read-only
+    email: jane@doe.com
+    tags:
+        - {"tag": "tenant", "access": "full"}
+        
+- name: Create a new administrator with full access to a network
+  meraki_admin:
+    auth_key: abc12345
+    org_name: YourOrg
+    state: present
+    name: Jane Doe
+    orgAccess: read-only
+    email: jane@doe.com
+    networks:
+        - {"id": "N_12345", "access": "full"}
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -39,12 +39,29 @@ options:
         - Tags the administrator has privileges on.
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
         - If C(none) is specified, C(network) or C(tags) must be specified.
+        suboptions:
+            tag:
+                description:
+                - Object tag which privileges should be assigned.
+                type: str
+            access:
+                description:
+                - The privilege of the dashboard administrator for the tag.
+                type: str
     networks:
         description:
         - List of networks the administrator has privileges on.
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
-        - C(id) is the network ID.
-        - C(access) is the access level to be assigned for the network ID.
+        suboptions:
+            id:
+                description:
+                - Network ID for which administrator should have privileges assigned.
+                type: str
+            access:
+                description:
+                - The privilege of the dashboard administrator on the network
+                - Valid options are C(full), C(read-only), or C(none)
+                type: str
     state:
         description:
         - Create or modify an organization
@@ -120,7 +137,7 @@ EXAMPLES = r'''
     state: absent
     email: jane@doe.com
 
-- name: Create a new administrator with full access to a tag
+- name: Create a new administrator with full access to two tags
   meraki_admin:
     auth_key: abc12345
     org_name: YourOrg
@@ -129,7 +146,8 @@ EXAMPLES = r'''
     orgAccess: read-only
     email: jane@doe.com
     tags:
-        - {"tag": "tenant", "access": "full"}
+        - { "tag": "tenant", "access": "full" }
+        - { "tag": "corporate", "access": "read-only" }
 
 - name: Create a new administrator with full access to a network
   meraki_admin:
@@ -140,7 +158,7 @@ EXAMPLES = r'''
     orgAccess: read-only
     email: jane@doe.com
     networks:
-        - {"id": "N_12345", "access": "full"}
+        - { "id": "N_12345", "access": "full" }
 '''
 
 RETURN = r'''

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -57,7 +57,8 @@
       orgAccess: none
       tags:
         - { "tag": "production", "access": "read-only" }
-        - { "tag": "beta", "access": "full" }
+        - tag: beta
+          access: full
     delegate_to: localhost
     register: create_tags
 


### PR DESCRIPTION
##### SUMMARY
Documentation now lists examples for the tags and network dictionary structure.

Fixes #42686

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meraki_admin