### PR TITLE
Allow check_mode with supports_generate_diff capability in cli_config…

### DIFF
--- a/changelogs/fragments/cli_config_diff_fix.yaml
+++ b/changelogs/fragments/cli_config_diff_fix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Allow check_mode with supports_generate_diff capability in cli_config. (https://github.com/ansible/ansible/pull/51417)

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -251,7 +251,8 @@ def run(module, capabilities, connection, candidate, running):
 
             kwargs = {'candidate': candidate, 'commit': commit, 'replace': replace,
                       'comment': commit_comment}
-            connection.edit_config(**kwargs)
+            if commit:
+                connection.edit_config(**kwargs)
             result['changed'] = True
 
         if banner_diff:
@@ -260,7 +261,8 @@ def run(module, capabilities, connection, candidate, running):
             kwargs = {'candidate': candidate, 'commit': commit}
             if multiline_delimiter:
                 kwargs.update({'multiline_delimiter': multiline_delimiter})
-            connection.edit_banner(**kwargs)
+            if commit:
+                connection.edit_banner(**kwargs)
             result['changed'] = True
 
     if module._diff:


### PR DESCRIPTION
… (#51384)


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

* If network cliconf support `supports_generate_diff` in
  that case diff between running and cnadidate config
  is generated within Ansible and if check_mode is enabled
  in that case, return only diff without actually invoking
  edit_config()

(cherry picked from commit 8f5cd049d677e56648da3a6fc1c790a30d4a90f5)
Merged to devel https://github.com/ansible/ansible/pull/51384
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cli_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
