### PR TITLE
Please make the build reproducible

### DIFF
--- a/lib/ansible/cli/arguments/optparse_helpers.py
+++ b/lib/ansible/cli/arguments/optparse_helpers.py
@@ -281,8 +281,9 @@ def add_meta_options(parser):
 
 def add_module_options(parser):
     """Add options for commands that load modules"""
+    default = str(C.DEFAULT_MODULE_PATH).replace(os.path.expanduser('~'), '~')
     parser.add_option('-M', '--module-path', dest='module_path', default=None,
-                      help="prepend colon-separated path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
+                      help="prepend colon-separated path(s) to module library (default=%s)" % default,
                       action="callback", callback=unfrack_paths, type='str')
 
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, we noticed that ansible could not be built reproducibly, mostly due to variations in the documentation between successive builds.

This pull request includes a number of changes to make it build in a determinstic manner. Currently it still varies a bit even with this patch, presumably due to nondetermistic filesystem ordering but it will be easier to see after these are merged.