### PR TITLE
Pluribus Networks point features for snmp vacm with UT's

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
@@ -1,0 +1,223 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_snmp_vacm
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to create/modify/delete snmp-vacm
+description:
+  - This module can be used to create View Access Control Models (VACM),
+    modify VACM and delete VACM.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    type: str
+    required: false
+  state:
+    description:
+      - State the action to perform. Use C(present) to create snmp-vacm and
+        C(absent) to delete snmp-vacm and C(update) to modify snmp-vacm.
+    type: str
+    required: true
+  pn_oid_restrict:
+    description:
+      - restrict OID.
+    type: str
+  pn_priv:
+    description:
+      - privileges.
+    type: str
+  pn_auth:
+    description:
+      - authentication required.
+    type: str
+  pn_user_type:
+    description:
+      - SNMP user type.
+    type: str
+    choices: ['rouser', 'rwuser']
+  pn_user_name:
+    description:
+      - SNMP administrator name.
+    type: str
+"""
+
+EXAMPLES = """
+- name: snmp vacm functionality
+  pn_snmp_vacm:
+    state: "present"
+    pn_user_name: "foo"
+    pn_user_type: "rouser"
+
+- name: snmp vacm functionality
+  pn_snmp_vacm:
+    state: "update"
+    pn_user_name: "foo"
+    pn_user_type: "rwuser"
+
+- name: snmp vacm functionality
+  pn_snmp_vacm:
+    state: "absent"
+    pn_user_name: "foo"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the snmp-vacm command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the snmp-vacm command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli, booleanArgs
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the snmp-vacm-show command.
+    If a user with given name exists, return True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    """
+    user_name = module.params['pn_user_name']
+    show = cli
+
+    cli += ' snmp-user-show user-name %s format user-name no-show-headers' % user_name
+    rc, out, err = module.run_command(cli, use_unsafe_shell=True)
+    if out:
+        pass
+    else:
+        return None
+
+    cli = show
+    cli += ' snmp-vacm-show format user-name no-show-headers'
+    out = module.run_command(cli, use_unsafe_shell=True)[1]
+
+    out = out.split()
+
+    return True if user_name in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        present='snmp-vacm-create',
+        absent='snmp-vacm-delete',
+        update='snmp-vacm-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_oid_restrict=dict(required=False, type='str'),
+            pn_priv=dict(required=False, type='bool'),
+            pn_auth=dict(required=False, type='bool'),
+            pn_user_type=dict(required=False, type='str',
+                              choices=['rouser', 'rwuser']),
+            pn_user_name=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ["state", "present", ["pn_user_name"]],
+            ["state", "absent", ["pn_user_name"]],
+            ["state", "update", ["pn_user_name"]]
+        )
+
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    oid_restrict = module.params['pn_oid_restrict']
+    priv = module.params['pn_priv']
+    auth = module.params['pn_auth']
+    user_type = module.params['pn_user_type']
+    user_name = module.params['pn_user_name']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    USER_EXISTS = check_cli(module, cli)
+    cli += ' %s user-name %s ' % (command, user_name)
+
+    if command == 'snmp-vacm-modify':
+        if USER_EXISTS is None:
+            module.fail_json(
+                failed=True,
+                msg='snmp user with name %s does not exists' % user_name
+            )
+        if USER_EXISTS is False:
+            module.fail_json(
+                failed=True,
+                msg='snmp vacm with name %s does not exists' % user_name
+            )
+
+    if command == 'snmp-vacm-delete':
+        if USER_EXISTS is None:
+            module.fail_json(
+                failed=True,
+                msg='snmp user with name %s does not exists' % user_name
+            )
+
+        if USER_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='snmp vacm with name %s does not exist' % user_name
+            )
+
+    if command == 'snmp-vacm-create':
+        if USER_EXISTS is None:
+            module.fail_json(
+                failed=True,
+                msg='snmp user with name %s does not exists' % user_name
+            )
+        if USER_EXISTS is True:
+            module.exit_json(
+                skipped=True,
+                msg='snmp vacm with name %s already exists' % user_name
+            )
+
+    if command != 'snmp-vacm-delete':
+        if oid_restrict:
+            cli += ' oid-restrict ' + oid_restrict
+        if user_type:
+            cli += ' user-type ' + user_type
+
+        cli += booleanArgs(auth, 'auth', 'no-auth')
+        cli += booleanArgs(priv, 'priv', 'no-priv')
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
@@ -32,6 +32,7 @@ options:
         C(absent) to delete snmp-vacm and C(update) to modify snmp-vacm.
     type: str
     required: true
+    choices: ['present', 'absent', 'update']
   pn_oid_restrict:
     description:
       - restrict OID.

--- a/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
@@ -39,11 +39,11 @@ options:
   pn_priv:
     description:
       - privileges.
-    type: str
+    type: bool
   pn_auth:
     description:
       - authentication required.
-    type: str
+    type: bool
   pn_user_type:
     description:
       - SNMP user type.

--- a/test/units/modules/network/netvisor/test_pn_snmp_vacm.py
+++ b/test/units/modules/network/netvisor/test_pn_snmp_vacm.py
@@ -1,0 +1,76 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_snmp_vacm
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestSnmpVacmModule(TestNvosModule):
+
+    module = pn_snmp_vacm
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_snmp_vacm.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_snmp_vacm.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+        self.run_check_cli.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'snmp-vacm-create':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'snmp-vacm-delete':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['update'] == 'snmp-vacm-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = False
+        if state == 'absent':
+            self.run_check_cli.return_value = True
+        if state == 'update':
+            self.run_check_cli.return_value = True
+
+    def test_snmp_vacm_create(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
+                         'pn_user_type': 'rouser', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-create user-name foo  user-type rouser'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_snmp_vacm_delete(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
+                         'pn_user_name': 'foo', 'state': 'absent'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-delete user-name foo '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_snmp_vacm_modify(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
+                         'pn_user_name': 'foo', 'pn_user_type': 'rwuser', 'state': 'absent'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-delete user-name foo '
+        self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_snmp_vacm.py
+++ b/test/units/modules/network/netvisor/test_pn_snmp_vacm.py
@@ -63,14 +63,14 @@ class TestSnmpVacmModule(TestNvosModule):
 
     def test_snmp_vacm_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
-                         'pn_user_name': 'foo', 'state': 'absent'})
+                         'state': 'absent'})
         result = self.execute_module(changed=True, state='update')
         expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-delete user-name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_snmp_vacm_modify(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
-                         'pn_user_name': 'foo', 'pn_user_type': 'rwuser', 'state': 'absent'})
+                         'pn_user_type': 'rwuser', 'state': 'absent'})
         result = self.execute_module(changed=True, state='update')
         expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-delete user-name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of snmp vacm for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_snmp_vacm.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```