### PR TITLE
Pass optional elb names to boto call for getting elbs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb.py
@@ -261,9 +261,10 @@ class ElbManager:
 
         elbs = []
         marker = None
+        ec2_elbs = ec2_elbs if ec2_elbs else None
         while True:
             try:
-                newelbs = elb.get_all_load_balancers(marker=marker)
+                newelbs = elb.get_all_load_balancers(load_balancer_names=ec2_elbs, marker=marker)
                 marker = newelbs.next_marker
                 elbs.extend(newelbs)
                 if not marker:

--- a/lib/ansible/modules/cloud/amazon/elb_instance.py
+++ b/lib/ansible/modules/cloud/amazon/elb_instance.py
@@ -257,9 +257,10 @@ class ElbManager:
 
         elbs = []
         marker = None
+        ec2_elbs = ec2_elbs if ec2_elbs else None
         while True:
             try:
-                newelbs = elb.get_all_load_balancers(marker=marker)
+                newelbs = elb.get_all_load_balancers(load_balancer_names=ec2_elbs, marker=marker)
                 marker = newelbs.next_marker
                 elbs.extend(newelbs)
                 if not marker:


### PR DESCRIPTION
##### SUMMARY
The [get_all_load_balancers](http://boto.cloudhackers.com/en/latest/ref/elb.html?highlight=get_all_load_balancers#boto.ec2.elb.ELBConnection.get_all_load_balancers) API in boto provides an optional argument to fetch a specific list of load balancers. This property was not used when `ec2_elbs` is defined. This results in fetching all load balancers, by multiple pagination calls, which contributes to the throttling error.

Contributes to #30229

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ec2_elb
- elb_instance

##### ADDITIONAL INFORMATION

