### PR TITLE
Fix gcp utils dict replace

### DIFF
--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -69,7 +69,7 @@ def replace_resource_dict(item, value):
             new_item = ast.literal_eval(item)
             return replace_resource_dict(new_item, value)
         except ValueError:
-            return new_item
+            return item
 
 
 # Handles all authentication and HTTP sessions for GCP API calls.

--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -376,7 +376,7 @@ def prefetch_soa_resource(module):
 
     result = fetch_wrapped_resource(resource, 'dns#resourceRecordSet', 'dns#resourceRecordSetsListResponse', 'rrsets')
     if not result:
-        raise ValueError("Google DNS Managed Zone %s not found" % module.params['managed_zone']['name'])
+        raise ValueError("Google DNS Managed Zone %s not found" % replace_resource_dict(module.params['managed_zone'], 'name'))
     return result
 
 


### PR DESCRIPTION
##### SUMMARY
This PR fixes (in gcp_utils.py) `'new_item' referenced before assignment` in case `item` argument to `replace_resource_dict` is a plain string.
Additionally this fixes (in gcp_dns_resource_record_set.py) `TypeError: string indices must be integers, not str` if `managed_zone` parameter is a plain string and a resource cannot be found using the provided parameters.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_utils.py
gcp_dns_resource_record_set.py

##### ADDITIONAL INFORMATION

```python
>>> # current version
...
>>> replace_resource_dict('{"name": "string"}', 'name')
'string'
>>> replace_resource_dict('string', 'name')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 17, in replace_resource_dict
UnboundLocalError: local variable 'new_item' referenced before assignment
>>>
>>> # with this PR merged
...
>>> replace_resource_dict('{"name": "string"}', 'name')
'string'
>>> replace_resource_dict('string', 'name')
'string'

```
