### PR TITLE
Add platform facts in network facts modules

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -185,6 +185,20 @@ class Cli:
             self._module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
         return diff
 
+    def get_capabilities(self):
+        """Returns platform info of the remove device
+        """
+        if hasattr(self._module, '_capabilities'):
+            return self._module._capabilities
+
+        connection = self._get_connection()
+        try:
+            capabilities = connection.get_capabilities()
+        except ConnectionError as exc:
+            self._module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+        self._module._capabilities = json.loads(capabilities)
+        return self._module._capabilities
+
 
 class LocalEapi:
 
@@ -617,3 +631,8 @@ def load_config(module, config, commit=False, replace=False):
 def get_diff(self, candidate=None, running=None, diff_match='line', diff_ignore_lines=None, path=None, diff_replace='line'):
     conn = self.get_connection()
     return conn.get_diff(candidate=candidate, running=running, diff_match=diff_match, diff_ignore_lines=diff_ignore_lines, path=path, diff_replace=diff_replace)
+
+
+def get_capabilities(module):
+    conn = get_connection(module)
+    return conn.get_capabilities()

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -145,7 +145,7 @@ def get_connection(module):
     if hasattr(module, 'connection'):
         return module.connection
 
-    capabilities = get_device_capabilities(module)
+    capabilities = get_capabilities(module)
     network_api = capabilities.get('network_api')
     if network_api == 'cliconf':
         module.connection = Connection(module._socket_path)
@@ -157,7 +157,7 @@ def get_connection(module):
     return module.connection
 
 
-def get_device_capabilities(module):
+def get_capabilities(module):
     if hasattr(module, 'capabilities'):
         return module.capabilities
     try:
@@ -317,12 +317,12 @@ def etree_findall(root, node):
 
 
 def is_cliconf(module):
-    capabilities = get_device_capabilities(module)
+    capabilities = get_capabilities(module)
     return (capabilities.get('network_api') == 'cliconf')
 
 
 def is_netconf(module):
-    capabilities = get_device_capabilities(module)
+    capabilities = get_capabilities(module)
     network_api = capabilities.get('network_api')
     if network_api == 'netconf':
         if not HAS_NCCLIENT:

--- a/lib/ansible/modules/network/eos/eos_facts.py
+++ b/lib/ansible/modules/network/eos/eos_facts.py
@@ -100,6 +100,10 @@ ansible_net_api:
   description: The name of the transport
   returned: always
   type: str
+ansible_net_python_version:
+  description: The Python version Ansible controller is using
+  returned: always
+  type: str
 
 # hardware
 ansible_net_filesystems:

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -103,6 +103,11 @@ ansible_net_stacked_serialnums:
   description: The serial numbers of each device in the stack
   returned: when multiple devices are configured in a stack
   type: list
+ansible_net_api:
+  description: The name of the transport
+  returned: always
+  type: str
+
 
 # hardware
 ansible_net_filesystems:
@@ -148,9 +153,10 @@ ansible_net_neighbors:
   returned: when interfaces is configured
   type: dict
 """
+import platform
 import re
 
-from ansible.module_utils.network.ios.ios import run_commands
+from ansible.module_utils.network.ios.ios import run_commands, get_capabilities
 from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
 from ansible.module_utils.network.ios.ios import normalize_interface
 from ansible.module_utils.basic import AnsibleModule
@@ -180,20 +186,12 @@ class Default(FactsBase):
 
     def populate(self):
         super(Default, self).populate()
+        self.facts.update(self.platform_facts())
         data = self.responses[0]
         if data:
-            self.facts['version'] = self.parse_version(data)
             self.facts['iostype'] = self.parse_iostype(data)
             self.facts['serialnum'] = self.parse_serialnum(data)
-            self.facts['model'] = self.parse_model(data)
-            self.facts['image'] = self.parse_image(data)
-            self.facts['hostname'] = self.parse_hostname(data)
             self.parse_stacks(data)
-
-    def parse_version(self, data):
-        match = re.search(r'Version (\S+?)(?:,\s|\s)', data)
-        if match:
-            return match.group(1)
 
     def parse_iostype(self, data):
         match = re.search(r'\S+(X86_64_LINUX_IOSD-UNIVERSALK9-M)(\S+)', data)
@@ -201,21 +199,6 @@ class Default(FactsBase):
             return "IOS-XE"
         else:
             return "IOS"
-
-    def parse_hostname(self, data):
-        match = re.search(r'^(.+) uptime', data, re.M)
-        if match:
-            return match.group(1)
-
-    def parse_model(self, data):
-        match = re.search(r'^[Cc]isco (\S+).+bytes of .*memory', data, re.M)
-        if match:
-            return match.group(1)
-
-    def parse_image(self, data):
-        match = re.search(r'image file is "(.+)"', data)
-        if match:
-            return match.group(1)
 
     def parse_serialnum(self, data):
         match = re.search(r'board ID (\S+)', data)
@@ -230,6 +213,24 @@ class Default(FactsBase):
         match = re.findall(r'^System [Ss]erial [Nn]umber\s+: (\S+)', data, re.M)
         if match:
             self.facts['stacked_serialnums'] = match
+
+    def platform_facts(self):
+        platform_facts = {}
+
+        resp = get_capabilities(self.module)
+        device_info = resp['device_info']
+
+        platform_facts['system'] = device_info['network_os']
+
+        for item in ('model', 'image', 'version', 'platform', 'hostname'):
+            val = device_info.get('network_os_%s' % item)
+            if val:
+                platform_facts[item] = val
+
+        platform_facts['api'] = resp['network_api']
+        platform_facts['python_version'] = platform.python_version()
+
+        return platform_facts
 
 
 class Hardware(FactsBase):

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -107,7 +107,10 @@ ansible_net_api:
   description: The name of the transport
   returned: always
   type: str
-
+ansible_net_python_version:
+  description: The Python version Ansible controller is using
+  returned: always
+  type: str
 
 # hardware
 ansible_net_filesystems:

--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -169,6 +169,7 @@ class Default(FactsBase):
 
         return platform_facts
 
+
 class Hardware(FactsBase):
 
     COMMANDS = [

--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -92,7 +92,7 @@ import platform
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.netconf import exec_rpc
 from ansible.module_utils.network.junos.junos import junos_argument_spec, get_param, tostring
-from ansible.module_utils.network.junos.junos import get_configuration, get_connection, get_capabilities
+from ansible.module_utils.network.junos.junos import get_configuration, get_capabilities
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 
@@ -332,7 +332,6 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
-    get_connection(module)
     warnings = list()
     gather_subset = module.params['gather_subset']
 

--- a/lib/ansible/modules/network/vyos/vyos_facts.py
+++ b/lib/ansible/modules/network/vyos/vyos_facts.py
@@ -95,12 +95,22 @@ ansible_net_gather_subset:
   description: The list of subsets gathered by the module
   returned: always
   type: list
+ansible_net_api:
+  description: The name of the transport
+  returned: always
+  type: str
+ansible_net_python_version:
+  description: The Python version Ansible controller is using
+  returned: always
+  type: str
 """
+
+import platform
 import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.network.vyos.vyos import run_commands
+from ansible.module_utils.network.vyos.vyos import run_commands, get_capabilities
 from ansible.module_utils.network.vyos.vyos import vyos_argument_spec
 
 
@@ -121,33 +131,36 @@ class Default(FactsBase):
 
     COMMANDS = [
         'show version',
-        'show host name',
     ]
 
     def populate(self):
         super(Default, self).populate()
         data = self.responses[0]
-
-        self.facts['version'] = self.parse_version(data)
         self.facts['serialnum'] = self.parse_serialnum(data)
-        self.facts['model'] = self.parse_model(data)
-
-        self.facts['hostname'] = self.responses[1]
-
-    def parse_version(self, data):
-        match = re.search(r'Version:\s*(.*)', data)
-        if match:
-            return match.group(1)
-
-    def parse_model(self, data):
-        match = re.search(r'HW model:\s*(\S+)', data)
-        if match:
-            return match.group(1)
+        self.facts.update(self.platform_facts())
 
     def parse_serialnum(self, data):
         match = re.search(r'HW S/N:\s+(\S+)', data)
         if match:
             return match.group(1)
+
+    def platform_facts(self):
+        platform_facts = {}
+
+        resp = get_capabilities(self.module)
+        device_info = resp['device_info']
+
+        platform_facts['system'] = device_info['network_os']
+
+        for item in ('model', 'image', 'version', 'platform', 'hostname'):
+            val = device_info.get('network_os_%s' % item)
+            if val:
+                platform_facts[item] = val
+
+        platform_facts['api'] = resp['network_api']
+        platform_facts['python_version'] = platform.python_version()
+
+        return platform_facts
 
 
 class Config(FactsBase):

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -43,6 +43,7 @@ options:
 
 import json
 import time
+import re
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
@@ -245,6 +246,11 @@ class Cliconf(CliconfBase):
         data = json.loads(reply)
 
         device_info['network_os_hostname'] = data['hostname']
+
+        reply = self.get('bash timeout 5 cat /mnt/flash/boot-config')
+        match = re.search(r'SWI=(.+)$', reply, re.M)
+        if match:
+            device_info['network_os_image'] = match.group(1)
 
         return device_info
 

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -216,6 +216,10 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_hostname'] = match.group(1)
 
+        match = re.search(r'image file is "(.+)"', data)
+        if match:
+            device_info['network_os_image'] = match.group(1)
+
         return device_info
 
     def get_device_operations(self):

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -80,9 +80,9 @@ class Cliconf(CliconfBase):
             if match_sys_ver:
                 device_info['network_os_version'] = match_sys_ver.group(1)
 
-        match_chassis_id = re.search(r'Hardware\n\s+cisco\s*(\S+\s+\S+)', reply, re.M)
+        match_chassis_id = re.search(r'Hardware\n\s+cisco(.+)$', reply, re.M)
         if match_chassis_id:
-            device_info['network_os_model'] = match_chassis_id.group(1)
+            device_info['network_os_model'] = match_chassis_id.group(1).strip()
 
         match_host_name = re.search(r'\s+Device name:\s*(\S+)', reply, re.M)
         if match_host_name:

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -52,7 +52,7 @@ class Cliconf(CliconfBase):
         reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
-        match = re.search(r'Version:\s*(\S+)', data)
+        match = re.search(r'Version:\s*(.*)', data)
         if match:
             device_info['network_os_version'] = match.group(1)
 

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -35,7 +35,7 @@ class TestIosFactsModule(TestIosModule):
 
         self.mock_get_capabilities = patch('ansible.modules.network.ios.ios_facts.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'network_api': 'cliconf'}
+        self.get_capabilities.return_value = {'device_info': {'network_os': 'ios', 'network_os_hostname': 'an-ios-01', 'network_os_image': 'flash0:/vios-adventerprisek9-m', 'network_os_model': 'WS-C3750-24TS', 'network_os_version': '15.6(3)M2'}, 'network_api': 'cliconf'}
 
     def tearDown(self):
         super(TestIosFactsModule, self).tearDown()

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -33,9 +33,14 @@ class TestIosFactsModule(TestIosModule):
         self.mock_run_commands = patch('ansible.modules.network.ios.ios_facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
+        self.mock_get_capabilities = patch('ansible.modules.network.ios.ios_facts.get_capabilities')
+        self.get_capabilities = self.mock_get_capabilities.start()
+        self.get_capabilities.return_value = {'network_api': 'cliconf'}
+
     def tearDown(self):
         super(TestIosFactsModule, self).tearDown()
         self.mock_run_commands.stop()
+        self.mock_get_capabilities.stop()
 
     def load_fixtures(self, commands=None):
         def load_from_file(*args, **kwargs):

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -35,7 +35,16 @@ class TestIosFactsModule(TestIosModule):
 
         self.mock_get_capabilities = patch('ansible.modules.network.ios.ios_facts.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'device_info': {'network_os': 'ios', 'network_os_hostname': 'an-ios-01', 'network_os_image': 'flash0:/vios-adventerprisek9-m', 'network_os_model': 'WS-C3750-24TS', 'network_os_version': '15.6(3)M2'}, 'network_api': 'cliconf'}
+        self.get_capabilities.return_value = {
+            'device_info': {
+                'network_os': 'ios',
+                'network_os_hostname': 'an-ios-01',
+                'network_os_image': 'flash0:/vios-adventerprisek9-m',
+                'network_os_model': 'WS-C3750-24TS',
+                'network_os_version': '15.6(3)M2'
+            },
+            'network_api': 'cliconf'
+        }
 
     def tearDown(self):
         super(TestIosFactsModule, self).tearDown()

--- a/test/units/modules/network/iosxr/test_iosxr_facts.py
+++ b/test/units/modules/network/iosxr/test_iosxr_facts.py
@@ -40,7 +40,7 @@ class TestIosxrFacts(TestIosxrModule):
 
         self.mock_get_capabilities = patch('ansible.modules.network.iosxr.iosxr_facts.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'network_api': 'cliconf'}
+        self.get_capabilities.return_value = {'device_info': {'network_os': 'iosxr', 'network_os_hostname': 'iosxr01', 'network_os_image': 'bootflash:disk0/xrvr-os-mbi-6.1.3/mbixrvr-rp.vm', 'network_os_version': '6.1.3[Default]'}, 'network_api': 'cliconf'}
 
     def tearDown(self):
         super(TestIosxrFacts, self).tearDown()

--- a/test/units/modules/network/iosxr/test_iosxr_facts.py
+++ b/test/units/modules/network/iosxr/test_iosxr_facts.py
@@ -38,10 +38,15 @@ class TestIosxrFacts(TestIosxrModule):
             'ansible.modules.network.iosxr.iosxr_facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
+        self.mock_get_capabilities = patch('ansible.modules.network.iosxr.iosxr_facts.get_capabilities')
+        self.get_capabilities = self.mock_get_capabilities.start()
+        self.get_capabilities.return_value = {'network_api': 'cliconf'}
+
     def tearDown(self):
         super(TestIosxrFacts, self).tearDown()
 
         self.mock_run_commands.stop()
+        self.mock_get_capabilities.stop()
 
     def load_fixtures(self, commands=None):
 

--- a/test/units/modules/network/iosxr/test_iosxr_facts.py
+++ b/test/units/modules/network/iosxr/test_iosxr_facts.py
@@ -40,7 +40,15 @@ class TestIosxrFacts(TestIosxrModule):
 
         self.mock_get_capabilities = patch('ansible.modules.network.iosxr.iosxr_facts.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'device_info': {'network_os': 'iosxr', 'network_os_hostname': 'iosxr01', 'network_os_image': 'bootflash:disk0/xrvr-os-mbi-6.1.3/mbixrvr-rp.vm', 'network_os_version': '6.1.3[Default]'}, 'network_api': 'cliconf'}
+        self.get_capabilities.return_value = {
+            'device_info': {
+                'network_os': 'iosxr',
+                'network_os_hostname': 'iosxr01',
+                'network_os_image': 'bootflash:disk0/xrvr-os-mbi-6.1.3/mbixrvr-rp.vm',
+                'network_os_version': '6.1.3[Default]'
+            },
+            'network_api': 'cliconf'
+        }
 
     def tearDown(self):
         super(TestIosxrFacts, self).tearDown()

--- a/test/units/modules/network/junos/test_junos_facts.py
+++ b/test/units/modules/network/junos/test_junos_facts.py
@@ -63,7 +63,15 @@ class TestJunosCommandModule(TestJunosModule):
 
         self.mock_get_capabilities = patch('ansible.module_utils.network.junos.junos.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'network_api': 'netconf'}
+        self.get_capabilities.return_value = {
+            'device_info': {
+                'network_os': 'junos',
+                'network_os_hostname': 'vsrx01',
+                'network_os_model': 'vsrx',
+                'network_os_version': '17.3R1.10'
+            },
+            'network_api': 'netconf'
+        }
 
     def tearDown(self):
         super(TestJunosCommandModule, self).tearDown()

--- a/test/units/modules/network/junos/test_junos_facts.py
+++ b/test/units/modules/network/junos/test_junos_facts.py
@@ -49,9 +49,6 @@ class TestJunosCommandModule(TestJunosModule):
         self.mock_get_config = patch('ansible.modules.network.junos.junos_facts.get_configuration')
         self.get_config = self.mock_get_config.start()
 
-        self.mock_conn = patch('ansible.module_utils.connection.Connection')
-        self.conn = self.mock_conn.start()
-
         self.mock_netconf = patch('ansible.module_utils.network.junos.junos.NetconfConnection')
         self.netconf_conn = self.mock_netconf.start()
 
@@ -61,7 +58,7 @@ class TestJunosCommandModule(TestJunosModule):
         self.mock_netconf_rpc = patch('ansible.module_utils.network.common.netconf.NetconfConnection')
         self.netconf_rpc = self.mock_netconf_rpc.start()
 
-        self.mock_get_capabilities = patch('ansible.module_utils.network.junos.junos.get_capabilities')
+        self.mock_get_capabilities = patch('ansible.modules.network.junos.junos_facts.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
         self.get_capabilities.return_value = {
             'device_info': {
@@ -75,7 +72,6 @@ class TestJunosCommandModule(TestJunosModule):
 
     def tearDown(self):
         super(TestJunosCommandModule, self).tearDown()
-        self.mock_conn.stop()
         self.mock_netconf.stop()
         self.mock_exec_rpc.stop()
         self.mock_netconf_rpc.stop()

--- a/test/units/modules/network/vyos/test_vyos_facts.py
+++ b/test/units/modules/network/vyos/test_vyos_facts.py
@@ -38,7 +38,7 @@ class TestVyosFactsModule(TestVyosModule):
 
         self.mock_get_capabilities = patch('ansible.modules.network.vyos.vyos_facts.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'network_api': 'cliconf'}
+        self.get_capabilities.return_value = {'device_info': {'network_os': 'vyos', 'network_os_hostname': 'vyos01', 'network_os_model': 'VMware', 'network_os_version': 'VyOS 1.1.7'}, 'network_api': 'cliconf'}
 
     def tearDown(self):
         super(TestVyosFactsModule, self).tearDown()
@@ -66,7 +66,7 @@ class TestVyosFactsModule(TestVyosModule):
         set_module_args(dict(gather_subset='default'))
         result = self.execute_module()
         facts = result.get('ansible_facts')
-        self.assertEqual(len(facts), 5)
+        self.assertEqual(len(facts), 8)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
         self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
@@ -74,7 +74,7 @@ class TestVyosFactsModule(TestVyosModule):
         set_module_args(dict(gather_subset='!all'))
         result = self.execute_module()
         facts = result.get('ansible_facts')
-        self.assertEqual(len(facts), 5)
+        self.assertEqual(len(facts), 8)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
         self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
@@ -82,7 +82,7 @@ class TestVyosFactsModule(TestVyosModule):
         set_module_args(dict(gather_subset=['!neighbors', '!config']))
         result = self.execute_module()
         facts = result.get('ansible_facts')
-        self.assertEqual(len(facts), 5)
+        self.assertEqual(len(facts), 8)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
         self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 

--- a/test/units/modules/network/vyos/test_vyos_facts.py
+++ b/test/units/modules/network/vyos/test_vyos_facts.py
@@ -38,7 +38,15 @@ class TestVyosFactsModule(TestVyosModule):
 
         self.mock_get_capabilities = patch('ansible.modules.network.vyos.vyos_facts.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'device_info': {'network_os': 'vyos', 'network_os_hostname': 'vyos01', 'network_os_model': 'VMware', 'network_os_version': 'VyOS 1.1.7'}, 'network_api': 'cliconf'}
+        self.get_capabilities.return_value = {
+            'device_info': {
+                'network_os': 'vyos',
+                'network_os_hostname': 'vyos01',
+                'network_os_model': 'VMware',
+                'network_os_version': 'VyOS 1.1.7'
+            },
+            'network_api': 'cliconf'
+        }
 
     def tearDown(self):
         super(TestVyosFactsModule, self).tearDown()

--- a/test/units/modules/network/vyos/test_vyos_facts.py
+++ b/test/units/modules/network/vyos/test_vyos_facts.py
@@ -36,9 +36,14 @@ class TestVyosFactsModule(TestVyosModule):
         self.mock_run_commands = patch('ansible.modules.network.vyos.vyos_facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
+        self.mock_get_capabilities = patch('ansible.modules.network.vyos.vyos_facts.get_capabilities')
+        self.get_capabilities = self.mock_get_capabilities.start()
+        self.get_capabilities.return_value = {'network_api': 'cliconf'}
+
     def tearDown(self):
         super(TestVyosFactsModule, self).tearDown()
         self.mock_run_commands.stop()
+        self.mock_get_capabilities.stop()
 
     def load_fixtures(self, commands=None):
         def load_from_file(*args, **kwargs):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR gets in if Facts gathering PR https://github.com/ansible/ansible/pull/49399 gets in 2.8
Add platform facts in network facts modules

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/cliconf/{eos,ios,nxos,vyos}.py
module_utils//network/eos/eos.py
module_utils//network/iosxr/iosxr.py
modules/network/eos/eos_facts.py
modules/network/nxos/nxos_facts.py
modules/network/ios/ios_facts.py
modules/network/iosxr/iosxr_facts.py
modules/network/junos/junos_facts.py
modules/network/vyos/vyos_facts.py
test/units/modules/network/ios/test_ios_facts.py
test/units/modules/network/iosxr/test_iosxr_facts.py
test/units/modules/network/vyos/test_vyos_facts.py


**OUTPUT:**
```
- nxos_facts:
    gather_subset: default


    "ansible_facts": {
        "ansible_net_api": "cliconf", 
        "ansible_net_gather_subset": [
            "default"
        ], 
        "ansible_net_hostname": "test", 
        "ansible_net_image": "bootflash:///nxos.7.0.3.I7.3.bin",  
        "ansible_net_model": "Nexus9000 9000v Chassis", 
        "ansible_net_platform": "N9K-9000v", 
        "ansible_net_python_version": "2.7.14", 
        "ansible_net_serialnum": "97J3P1UQ5NR", 
        "ansible_net_system": "nxos", 
        "ansible_net_version": "7.0(3)I7(3)"
    }
```