### PR TITLE
Fix IF_ETH_REGEX to allow 1/1 and 1/1/1 interfaces

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_interface.py
@@ -132,7 +132,7 @@ from ansible.module_utils.network.onyx.onyx import get_interfaces_config
 
 
 class OnyxInterfaceModule(BaseOnyxModule):
-    IF_ETH_REGEX = re.compile(r"^Eth(\d+\/\d+|Eth\d+\/\d+\d+)$")
+    IF_ETH_REGEX = re.compile(r"^Eth(\d+\/\d+|\d+\/\d+\/\d+)$")
     IF_VLAN_REGEX = re.compile(r"^Vlan (\d+)$")
     IF_LOOPBACK_REGEX = re.compile(r"^Loopback (\d+)$")
 


### PR DESCRIPTION
##### SUMMARY
I think the original IF_ETH_REGEX was written in mind to allow 1/1 and 1/1/1 type interfaces to match, however I don't think this code path was ever tested fully with break out cables which present as 1/1/1 interface names. The current regex has "\d+\d+", which reads to me wrong as the second '\d+' is unnecessary, as if the '/' was missed. The other issue I see is that the second match, matches Eth rather than "^Eth", meaning that if it did match then Eth would be pulled into the if_id when _get_interface_type is called.

Fixes 51437

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
onyx_interface

##### ADDITIONAL INFORMATION
See https://github.com/ansible/ansible/issues/51437 to reproduce. After this change I get the following working:

```
$ cat test2.yaml 
- hosts: switches
  gather_facts: no
  tasks:
  - onyx_interface:
      name: 'Eth1/1/1'
      description: 'test'
$ ansible-playbook -l melcloudiancol01 test2.yaml

PLAY [switches] ********************************************************************************************************************************

TASK [onyx_interface] **************************************************************************************************************************
changed: [melcloudiancol01]

PLAY RECAP *************************************************************************************************************************************
melcloudiancol01           : ok=1    changed=1    unreachable=0    failed=0   

$ 
```