### PR TITLE
Fix dictionary access in os_floating_ip module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_floating_ip.py
+++ b/lib/ansible/modules/cloud/openstack/os_floating_ip.py
@@ -185,7 +185,7 @@ def main():
                 if nat_destination:
                     nat_floating_addrs = [addr for addr in server.addresses.get(
                         cloud.get_network(nat_destination)['name'], [])
-                        if addr.addr == public_ip and
+                        if addr['addr'] == public_ip and
                         addr['OS-EXT-IPS:type'] == 'floating']
 
                     if len(nat_floating_addrs) == 0:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When using `nat_destination` parameter of `os_floating_ip` module, dot
syntax (`addr.addr`) is used to access a value in a dictionary,
resulting in the module crashing with this error:

AttributeError: 'dict' object has no attribute 'addr'

This is now fixed, when using correct syntax (`addr['addr']`), the
module seems to work fine.

Fixes #51443
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_floating_ip

##### ADDITIONAL INFORMATION
It was a syntax error -- invalid Python. The invalid code path was exercised only when `nat_destination` and `server` parameters were provided to the module, and the server already had some floating IP assigned.