### PR TITLE
Toshio is now release manager for 2.8 and future 2.6

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -25,7 +25,8 @@ Actual
 
 Release Manager
 ---------------
-Matt Clay (IRC/GitHub: @mattclay)
+* 2.6.0-2.6.12 Matt Clay (IRC/GitHub: @mattclay)
+* 2.6.13+ Toshio Kuratomi (IRC: abadger1999; GitHub: @abadger)
 
 
 Engine improvements

--- a/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
@@ -31,7 +31,7 @@ PRs must be raised well in advance of the dates below to have a chance of being 
 Release Manager
 ---------------
 
-Adam Miller (IRC: maxamillion; GitHub: @maxamillion)
+Toshio Kuratomi (IRC: abadger1999; GitHub: @abadger)
 
 Planned work
 ============


### PR DESCRIPTION
##### SUMMARY
Fix Roadmap docs for Toshio taking over release management duty

In the future, we might not want to list the RM by name (since it will be a dedicated person/team who is doing RM work).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
