### PR TITLE
[stable-2.7] Toshio is now release manager for 2.8 and future 2.6 (#51452)

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -29,7 +29,8 @@ Expected
 
 Release Manager
 ---------------
-Matt Clay (IRC/GitHub: @mattclay)
+* 2.6.0-2.6.12 Matt Clay (IRC/GitHub: @mattclay)
+* 2.6.13+ Toshio Kuratomi (IRC: abadger1999; GitHub: @abadger)
 
 
 Engine improvements


### PR DESCRIPTION

(cherry picked from commit b0ac7d96525c155446d6c452045c788a1fffb7f8)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION
