### PR TITLE
[GCP DNS] fix resource record set comparison

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -326,7 +326,7 @@ def is_different(module, response):
 # Remove unnecessary properties from the response.
 # This is for doing comparisons with Ansible's current parameters.
 def response_to_hash(module, response):
-    return {u'name': response.get(u'name'), u'type': response.get(u'type'), u'ttl': response.get(u'ttl'), u'rrdatas': response.get(u'target')}
+    return {u'name': response.get(u'name'), u'type': response.get(u'type'), u'ttl': response.get(u'ttl'), u'rrdatas': response.get(u'rrdatas')}
 
 
 def updated_record(module):


### PR DESCRIPTION
##### SUMMARY
This PR fixes comparison between current and to-be state of a resource record set.
The response variable contains properties as returned by GCP (https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets) which holds rrdata in a "rrdata" field rather than "target" (which is the name of the Ansible parameter for rrdata).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_dns_resource_record_set.py
