### PR TITLE
Base integration test  for gitlab modules

### DIFF
--- a/test/integration/cloud-config-gitlab.yml.template
+++ b/test/integration/cloud-config-gitlab.yml.template
@@ -1,0 +1,17 @@
+# This is the configuration template for ansible-test Gitlab integration tests.
+#
+# You do not need this template if you are:
+#
+# 1) Running integration tests without using ansible-test.
+# 2) Using the automatically provisioned gitlab docker container in ansible-test.
+#
+# If you do not want to use the automatically provided Gitlab container,
+# fill in the @VAR placeholders below and save this file without the .template extension.
+# This will cause ansible-test to use the given configuration and not launch the simulator.
+#
+# It is recommended that you DO NOT use this template unless you cannot use the simulator.
+
+gitlab_host: http://@HOST:@PORT
+gitlab_login_token: @TOKEN
+gitlab_runner_registration_token: @RUNNER_TOKEN
+timeout: 60

--- a/test/integration/targets/gitlab_deploy_key/aliases
+++ b/test/integration/targets/gitlab_deploy_key/aliases
@@ -1,4 +1,3 @@
-cloud/gitlab
 shippable/gitlab/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_deploy_key/aliases
+++ b/test/integration/targets/gitlab_deploy_key/aliases
@@ -1,3 +1,3 @@
-shippable/gitlab/group1
+shippable/posix/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_deploy_key/aliases
+++ b/test/integration/targets/gitlab_deploy_key/aliases
@@ -1,0 +1,4 @@
+cloud/gitlab
+shippable/gitlab/group1
+gitlab/ci
+disabled

--- a/test/integration/targets/gitlab_deploy_key/defaults/main.yml
+++ b/test/integration/targets/gitlab_deploy_key/defaults/main.yml
@@ -1,0 +1,2 @@
+gitlab_project_name: ansible_test_project
+gitlab_deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJnTYY7CYk1F/wBklpdRxudxN6KeXgfhutkiCigSfPhe ansible_test"

--- a/test/integration/targets/gitlab_deploy_key/tasks/main.yml
+++ b/test/integration/targets/gitlab_deploy_key/tasks/main.yml
@@ -1,0 +1,36 @@
+- name: Install required libs
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Create {{ gitlab_project_name }}
+  gitlab_project:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    name: "{{ gitlab_project_name }}"
+    state: present
+
+- name: Cleanup deploy key to {{ gitlab_project_name }}
+  gitlab_deploy_key:
+    login_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    server_url: "{{ gitlab_host }}"
+    title: "{{ gitlab_project_name }}"
+    key: "{{ gitlab_deploy_key }}"
+    state: absent
+
+
+- name: Add deploy key to {{ gitlab_project_name }}
+  gitlab_deploy_key:
+    login_token: "{{ gitlab_login_token }}"
+    project: "root/{{ gitlab_project_name }}"
+    server_url: "{{ gitlab_host }}"
+    title: "{{ gitlab_project_name }}"
+    key: "{{ gitlab_deploy_key }}"
+    state: present
+  register: deploy_key_status
+
+- assert:
+    that:
+      - deploy_key_status is changed

--- a/test/integration/targets/gitlab_group/aliases
+++ b/test/integration/targets/gitlab_group/aliases
@@ -1,4 +1,3 @@
-cloud/gitlab
 shippable/gitlab/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_group/aliases
+++ b/test/integration/targets/gitlab_group/aliases
@@ -1,3 +1,3 @@
-shippable/gitlab/group1
+shippable/posix/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_group/aliases
+++ b/test/integration/targets/gitlab_group/aliases
@@ -1,0 +1,4 @@
+cloud/gitlab
+shippable/gitlab/group1
+gitlab/ci
+disabled

--- a/test/integration/targets/gitlab_group/defaults/main.yml
+++ b/test/integration/targets/gitlab_group/defaults/main.yml
@@ -1,0 +1,1 @@
+gitlab_group: ansible_test_project

--- a/test/integration/targets/gitlab_group/tasks/main.yml
+++ b/test/integration/targets/gitlab_group/tasks/main.yml
@@ -42,4 +42,3 @@
   assert:
     that:
       - gitlab_group_state_again is not changed
-

--- a/test/integration/targets/gitlab_group/tasks/main.yml
+++ b/test/integration/targets/gitlab_group/tasks/main.yml
@@ -1,0 +1,45 @@
+- name: Install required libs
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Cleanup Gitlab Group
+  gitlab_group:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    name: ansible_test_group
+    path: ansible_test_group
+    state: absent
+
+- name: Create Gitlab Group
+  gitlab_group:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    name: ansible_test_group
+    path: ansible_test_group
+    state: present
+  register: gitlab_group_state
+
+- name: Test group created
+  assert:
+    that:
+      - gitlab_group_state is changed
+
+
+- name: Create Gitlab Group ( Idempotency test )
+  gitlab_group:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    name: ansible_test_group
+    path: ansible_test_group
+    state: present
+  register: gitlab_group_state_again
+
+- name: Test module is idempotent
+  assert:
+    that:
+      - gitlab_group_state_again is not changed
+

--- a/test/integration/targets/gitlab_hooks/aliases
+++ b/test/integration/targets/gitlab_hooks/aliases
@@ -1,4 +1,3 @@
-cloud/gitlab
 shippable/gitlab/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_hooks/aliases
+++ b/test/integration/targets/gitlab_hooks/aliases
@@ -1,3 +1,3 @@
-shippable/gitlab/group1
+shippable/posix/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_hooks/aliases
+++ b/test/integration/targets/gitlab_hooks/aliases
@@ -1,0 +1,4 @@
+cloud/gitlab
+shippable/gitlab/group1
+gitlab/ci
+disabled

--- a/test/integration/targets/gitlab_hooks/defaults/main.yml
+++ b/test/integration/targets/gitlab_hooks/defaults/main.yml
@@ -1,0 +1,2 @@
+gitlab_project_name: ansible_test_project
+gitlab_hook_url: http://gitlab.example.com/hook

--- a/test/integration/targets/gitlab_hooks/tasks/main.yml
+++ b/test/integration/targets/gitlab_hooks/tasks/main.yml
@@ -65,4 +65,3 @@
   assert:
     that:
       - gitlab_hook_state_absent is changed
-

--- a/test/integration/targets/gitlab_hooks/tasks/main.yml
+++ b/test/integration/targets/gitlab_hooks/tasks/main.yml
@@ -1,0 +1,68 @@
+- name: Install required libs
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Create {{ gitlab_project_name }}
+  gitlab_project:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    name: "{{ gitlab_project_name }}"
+    state: present
+
+- name: Cleanup Gitlab hook
+  gitlab_hooks:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    hook_url: "{{ gitlab_hook_url }}"
+    project: "{{ gitlab_project_name }}"
+    state: absent
+
+- name: Create Gitlab Hook
+  gitlab_hooks:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    hook_url: "{{ gitlab_hook_url }}"
+    project: "{{ gitlab_project_name }}"
+    state: present
+  register: gitlab_hook_state
+
+- name: Test group created
+  assert:
+    that:
+      - gitlab_hook_state is changed
+
+
+- name: Create Gitlab Hook ( Idempotency test )
+  gitlab_hooks:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    hook_url: "{{ gitlab_hook_url }}"
+    project: "{{ gitlab_project_name }}"
+    state: present
+  register: gitlab_hook_state_again
+
+- name: Test module is idempotent
+  assert:
+    that:
+      - gitlab_hook_state_again is not changed
+
+- name: Remove Gitlab hook
+  gitlab_hooks:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    hook_url: "{{ gitlab_hook_url }}"
+    project: "{{ gitlab_project_name }}"
+    state: absent
+  register: gitlab_hook_state_absent
+
+- name: Assert hook has been removed
+  assert:
+    that:
+      - gitlab_hook_state_absent is changed
+

--- a/test/integration/targets/gitlab_project/aliases
+++ b/test/integration/targets/gitlab_project/aliases
@@ -1,4 +1,3 @@
-cloud/gitlab
 shippable/gitlab/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_project/aliases
+++ b/test/integration/targets/gitlab_project/aliases
@@ -1,3 +1,3 @@
-shippable/gitlab/group1
+shippable/posix/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_project/aliases
+++ b/test/integration/targets/gitlab_project/aliases
@@ -1,0 +1,4 @@
+cloud/gitlab
+shippable/gitlab/group1
+gitlab/ci
+disabled

--- a/test/integration/targets/gitlab_project/defaults/main.yml
+++ b/test/integration/targets/gitlab_project/defaults/main.yml
@@ -1,0 +1,2 @@
+gitlab_project_name: ansible_test_project
+gitlab_deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJnTYY7CYk1F/wBklpdRxudxN6KeXgfhutkiCigSfPhe ansible_test"

--- a/test/integration/targets/gitlab_project/tasks/main.yml
+++ b/test/integration/targets/gitlab_project/tasks/main.yml
@@ -1,0 +1,40 @@
+- name: Install required libs
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Clean up {{ gitlab_project_name }}
+  gitlab_project:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    name: "{{ gitlab_project_name }}"
+    state: absent
+
+- name: Create {{ gitlab_project_name }}
+  gitlab_project:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    name: "{{ gitlab_project_name }}"
+    state: present
+  register: gitlab_project_state
+
+
+- assert:
+    that:
+      - gitlab_project_state is changed
+
+- name: Create {{ gitlab_project_name }} (Test idempotency)
+  gitlab_project:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    name: "{{ gitlab_project_name }}"
+    state: present
+  register: gitlab_project_state_again
+
+
+- assert:
+    that:
+      - gitlab_project_state_again is not changed

--- a/test/integration/targets/gitlab_runner/aliases
+++ b/test/integration/targets/gitlab_runner/aliases
@@ -1,4 +1,3 @@
-cloud/gitlab
 shippable/gitlab/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_runner/aliases
+++ b/test/integration/targets/gitlab_runner/aliases
@@ -1,3 +1,3 @@
-shippable/gitlab/group1
+shippable/posix/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_runner/aliases
+++ b/test/integration/targets/gitlab_runner/aliases
@@ -1,0 +1,4 @@
+cloud/gitlab
+shippable/gitlab/group1
+gitlab/ci
+disabled

--- a/test/integration/targets/gitlab_runner/defaults/main.yml
+++ b/test/integration/targets/gitlab_runner/defaults/main.yml
@@ -1,0 +1,3 @@
+gitlab_project_name: ansible_test_project
+gitlab_hook_url: http://gitlab.example.com/hook
+gitlab_runner_name: ansible_test_runner

--- a/test/integration/targets/gitlab_runner/tasks/main.yml
+++ b/test/integration/targets/gitlab_runner/tasks/main.yml
@@ -1,0 +1,69 @@
+- name: Install required libs
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Create {{ gitlab_project_name }}
+  gitlab_project:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    name: "{{ gitlab_project_name }}"
+    state: present
+
+- name: Cleanup Gitlab runner
+  gitlab_runner:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    description: "{{ gitlab_runner_name }}"
+    registration_token: "{{ gitlab_runner_registration_token }}"
+    state: absent
+
+- name: Create Gitlab Runner
+  gitlab_runner:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    description: "{{ gitlab_runner_name }}"
+    registration_token: "{{ gitlab_runner_registration_token }}"
+    state: present
+  register: gitlab_runner_state
+
+- name: Test group created
+  assert:
+    that:
+      - gitlab_runner_state is changed
+
+
+#### COMMENTED AS MODULE WILL UPDATE THE RUNNER IF EXISTS. TO BE DISCUSSED ####
+# - name: Create Gitlab Runner ( Idempotency test )
+#   gitlab_runner:
+#     server_url: "{{ gitlab_host }}"
+#     validate_certs: false
+#     login_token: "{{ gitlab_login_token }}"
+#     description: "{{ gitlab_runner_name }}"
+#     registration_token: "{{ gitlab_runner_registration_token }}"
+#     state: present
+#   register: gitlab_runner_state_again
+
+# - name: Test module is idempotent
+#   assert:
+#     that:
+#       - gitlab_runner_state_again is not changed
+
+- name: Remove Gitlab Runner
+  gitlab_runner:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    description: "{{ gitlab_runner_name }}"
+    registration_token: "{{ gitlab_runner_registration_token }}"
+    state: absent
+  register: gitlab_runner_state_absent
+
+- name: Assert runner has been removed
+  assert:
+    that:
+      - gitlab_runner_state_absent is changed
+

--- a/test/integration/targets/gitlab_runner/tasks/main.yml
+++ b/test/integration/targets/gitlab_runner/tasks/main.yml
@@ -66,4 +66,3 @@
   assert:
     that:
       - gitlab_runner_state_absent is changed
-

--- a/test/integration/targets/gitlab_user/aliases
+++ b/test/integration/targets/gitlab_user/aliases
@@ -1,4 +1,3 @@
-cloud/gitlab
 shippable/gitlab/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_user/aliases
+++ b/test/integration/targets/gitlab_user/aliases
@@ -1,3 +1,3 @@
-shippable/gitlab/group1
+shippable/posix/group1
 gitlab/ci
 disabled

--- a/test/integration/targets/gitlab_user/aliases
+++ b/test/integration/targets/gitlab_user/aliases
@@ -1,0 +1,4 @@
+cloud/gitlab
+shippable/gitlab/group1
+gitlab/ci
+disabled

--- a/test/integration/targets/gitlab_user/defaults/main.yml
+++ b/test/integration/targets/gitlab_user/defaults/main.yml
@@ -1,0 +1,3 @@
+gitlab_user: ansible_test_user
+gitlab_user_pass: Secr3tPassw00rd
+gitlab_user_email: root@localhost

--- a/test/integration/targets/gitlab_user/tasks/main.yml
+++ b/test/integration/targets/gitlab_user/tasks/main.yml
@@ -1,0 +1,51 @@
+- name: Install required libs
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Clean up gitlab user
+  gitlab_user:
+    server_url: "{{ gitlab_host }}"
+    name: ansible_test_user
+    username: ansible_test_user
+    password: Secr3tPassw00rd
+    email: root@localhost
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    state: absent
+
+
+- name: Create gitlab user
+  gitlab_user:
+    server_url: "{{ gitlab_host }}"
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    password: "{{ gitlab_user_pass }}"
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check user has been created correctly
+  assert:
+    that:
+      - gitlab_user_state is changed
+
+- name: Create gitlab user again
+  gitlab_user:
+    server_url: "{{ gitlab_host }}"
+    email: root@localhost
+    name: ansible_test_user
+    username: ansible_test_user
+    password: Secr3tPassw00rd
+    validate_certs: False
+    login_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state_again
+
+- name: Check state is not changed
+  assert:
+    that:
+      - gitlab_user_state_again is not changed
+

--- a/test/integration/targets/gitlab_user/tasks/main.yml
+++ b/test/integration/targets/gitlab_user/tasks/main.yml
@@ -48,4 +48,3 @@
   assert:
     that:
       - gitlab_user_state_again is not changed
-


### PR DESCRIPTION
##### SUMMARY
This adds a first round of integration tests for the gitlab modules. They are disabled by default for now as they require a gitlab instance available to run. 
I have set some foundation for ansible-test to spin up a gitlab container, but will be added in a separate PR as it requires a bit/lot more work. 
 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
N/A