### PR TITLE
[2.5] Fixed broken link in _docker.py

### DIFF
--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -25,7 +25,7 @@ deprecated:
 description:
   - This is the original Ansible module for managing the Docker container life cycle.
   - NOTE - Additional and newer modules are available. For the latest on orchestrating containers with Ansible
-    visit our Getting Started with Docker Guide at U(https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/guide_docker.rst).
+    visit our L(Getting Started with Docker Guide,../scenario_guides/guide_docker.html).
 options:
   count:
     description:


### PR DESCRIPTION
##### SUMMARY
Backport of #50950 to stable-2.5. Fixes a broken link to the docker scenario guide in the documentation of the deprecated `docker` module.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker
