### PR TITLE
expect: utf-8' codec can't decode byte 0x80 enhancement #46556

### DIFF
--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -142,7 +142,7 @@ def main():
             responses=dict(type='dict', required=True),
             timeout=dict(type='int', default=30),
             echo=dict(type='bool', default=False),
-            codec_errors=dict(type='str'),
+            codec_errors=dict(type='str', choices=['strict','replace']),
         )
     )
 

--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -57,7 +57,11 @@ options:
     description:
       - Used to avoid the utf-8 codec error, options are strict,replace
     default: false
+    choices:
+      - strict
+      - replace
     type: str
+    version_added: "2.8"
 requirements:
   - python >= 2.6
   - pexpect >= 3.3

--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -133,6 +133,7 @@ def main():
             responses=dict(type='dict', required=True),
             timeout=dict(type='int', default=30),
             echo=dict(type='bool', default=False),
+            codec_errors=dict(type='str'),
         )
     )
 
@@ -146,6 +147,7 @@ def main():
     responses = module.params['responses']
     timeout = module.params['timeout']
     echo = module.params['echo']
+    codec_errors = module.params['codec_errors']
 
     events = dict()
     for key, value in responses.items():
@@ -194,11 +196,11 @@ def main():
             # Prefer pexpect.run from pexpect>=4
             out, rc = pexpect.run(args, timeout=timeout, withexitstatus=True,
                                   events=events, cwd=chdir, echo=echo,
-                                  encoding='utf-8')
+                                  encoding='utf-8', codec_errors=codec_errors)
         except TypeError:
             # Use pexpect.runu in pexpect>=3.3,<4
             out, rc = pexpect.runu(args, timeout=timeout, withexitstatus=True,
-                                   events=events, cwd=chdir, echo=echo)
+                                   events=events, cwd=chdir, echo=echo, codec_errors=codec_errors)
     except (TypeError, AttributeError) as e:
         # This should catch all insufficient versions of pexpect
         # We deem them insufficient for their lack of ability to specify

--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -53,6 +53,11 @@ options:
       - Whether or not to echo out your response strings.
     default: false
     type: bool
+  codec_errors:
+    description:
+      - Used to avoid the utf-8 codec error, options are strict,replace
+    default: false
+    type: str
 requirements:
   - python >= 2.6
   - pexpect >= 3.3


### PR DESCRIPTION
##### SUMMARY
Modified the expect.py script to handle the utf-8 codec error


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
lib/ansible/modules/commands/expect.py

##### ADDITIONAL INFORMATION
If the reload is called after the telnet, it will show the utf-8 codec error. If I do the codec_error as replace option, the error is not seen. The example is shown below.

```
- name: Telnet to the switch to get the prompt
  delegate_to: localhost
  become: no
  expect:
    command: telnet {{ ansible_console }} {{ console_port }} -e {{ telnet_esc }}
    timeout: "{{ timeout|default(30) }}"
    responses: "{{ exp | default({}) | combine(default_exp) | combine(extra_exp) }}"
    echo: no
    codec_errors: replace
  register: output

```
