### PR TITLE
User module - Use correct property name and add missing variable to context manager

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1909,7 +1909,7 @@ class SunOS(User):
                                 fields[5] = str(int(warnweeks) * 7)
                             line = ':'.join(fields)
                             lines.append('%s\n' % line)
-                    with open(self.SHADOWFILE, 'w+'):
+                    with open(self.SHADOWFILE, 'w+') as f:
                         f.writelines(lines)
                     rc = 0
                 except Exception as err:
@@ -1928,7 +1928,7 @@ class SunOS(User):
         with open(self.USER_ATTR, 'r') as file_handler:
             for line in file_handler:
                 lines = line.strip().split('::::')
-                if lines[0] == self.user:
+                if lines[0] == self.name:
                     tmp = dict(x.split('=') for x in lines[1].split(';'))
                     info[0] = tmp.get('profiles', '')
                     info[1] = tmp.get('auths', '')


### PR DESCRIPTION
##### SUMMARY
Reference the correct attribute to get the user name, `self.name` not `self.user`. The later attribute does not exist and causes a `KeyError` exception to be raised.

Add missing variable for storing returned file object when writing the `shadow` file. This prevents an I/O error because the `f.writelines()` call will be against a closed file , `f`, resulting in an empty `shadow` file. 😱 

Fixes #51483

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`user.py`