### PR TITLE
Lookup Plugin: 1Password Documents

### DIFF
--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2019, David Taylor <djtaylor13@gmail.com> (onepassword.py used as a starting point)
+# Copyright: (c) 2019, David Taylor <djtaylor13@gmail.com> (onepassword.py used as a starting point)
 # (c) 2018, Scott Buchanan <sbuchanan@ri.pn>
 # (c) 2016, Andrew Zenk <azenk@umn.edu> (lastpass.py used as starting point)
 # (c) 2018, Ansible Project

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -110,8 +110,7 @@ class OnePassDoc(OnePass):
         return output
 
     def get_document(self, item_id, vault=None):
-        output = self.get_document_raw(item_id, vault)
-        return output
+        return self.get_document_raw(item_id, vault)
 
 class LookupModule(LookupBase):
 

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -49,7 +49,7 @@ DOCUMENTATION = """
         default: None
     notes:
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
-        performed an initial sign in (meaning C(~/.op/config exists)), then only the C(master_password) is required.
+        performed an initial sign in (meaning C(~/.op/config) exists), then only the C(master_password) is required.
         You may optionally specify C(subdomain) in this scenario, otherwise the last used subdomain will be used by C(op).
       - This lookup can perform an initial login by providing C(subdomain), C(username), C(secret_key), and C(master_password).
       - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommeneded that you only pass in the minial credentials

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -19,8 +19,6 @@ DOCUMENTATION = """
       - Scott Buchanan (@scottsb)
       - Andrew Zenk (@azenk)
       - Sam Doran (@samdoran)
-      - Andrew Zenk <@azenk>
-      - Sam Doran<@samdoran>
     version_added: "2.8"
     requirements:
       - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -111,10 +111,7 @@ class OnePassDoc(OnePass):
 
     def get_document(self, item_id, vault=None):
         output = self.get_document_raw(item_id, vault)
-        return self._parse_document_output(output)
-
-    def _parse_document_output(self, doc_data):
-        return doc_data
+        return output
 
 class LookupModule(LookupBase):
 

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -8,7 +8,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -32,18 +32,14 @@ DOCUMENTATION = """
       master_password:
         description: The password used to unlock the specified vault.
         default: None
-        version_added: '2.7'
         aliases: ['vault_password']
       subdomain:
         description: The 1Password subdomain to authenticate against.
         default: None
-        version_added: '2.7'
       username:
         description: The username used to sign in.
-        version_added: '2.7'
       secret_key:
         description: The secret key used when performing an initial sign in.
-        version_added: '2.7'
       vault:
         description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults
         default: None

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -52,7 +52,7 @@ DOCUMENTATION = """
         performed an initial sign in (meaning C(~/.op/config) exists), then only the C(master_password) is required.
         You may optionally specify C(subdomain) in this scenario, otherwise the last used subdomain will be used by C(op).
       - This lookup can perform an initial login by providing C(subdomain), C(username), C(secret_key) and C(master_password).
-      - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommeneded that you only pass in the minial credentials
+      - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommended that you only pass in the minimal credentials
         needed at any given time. Also, store these credentials in an Ansible Vault using a key that is equal to or greater in strength
         to the 1Password master password.
       - This lookup stores potentially sensitive data from 1Password as Ansible facts.

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -51,7 +51,7 @@ DOCUMENTATION = """
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
         performed an initial sign in (meaning C(~/.op/config) exists), then only the C(master_password) is required.
         You may optionally specify C(subdomain) in this scenario, otherwise the last used subdomain will be used by C(op).
-      - This lookup can perform an initial login by providing C(subdomain), C(username), C(secret_key), and C(master_password).
+      - This lookup can perform an initial login by providing C(subdomain), C(username), C(secret_key) and C(master_password).
       - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommeneded that you only pass in the minial credentials
         needed at any given time. Also, store these credentials in an Ansible Vault using a key that is equal to or greater in strength
         to the 1Password master password.

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# (c) 2019, David Taylor <djtaylor13@gmail.com> (onepassword.py used as a starting point)
+# (c) 2018, Scott Buchanan <sbuchanan@ri.pn>
+# (c) 2016, Andrew Zenk <azenk@umn.edu> (lastpass.py used as starting point)
+# (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+    lookup: onepassword_doc
+    author:
+      - David Taylor <djtaylor13@gmail.com>
+      - Scott Buchanan <sbuchanan@ri.pn>
+      - Andrew Zenk <azenk@umn.edu>
+      - Sam Doran<sdoran@redhat.com>
+    version_added: "2.7"
+    requirements:
+      - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)
+    short_description: fetch documents from 1Password
+    description:
+      - C(onepassword_doc) wraps the C(op) command line utility to fetch documents from 1Password.
+    options:
+      _terms:
+        description: identifier(s) (UUID, name, or subdomain; case-insensitive) of item(s) to retrieve
+        required: True
+      master_password:
+        description: The password used to unlock the specified vault.
+        default: None
+        version_added: '2.7'
+        aliases: ['vault_password']
+      subdomain:
+        description: The 1Password subdomain to authenticate against.
+        default: None
+        version_added: '2.7'
+      username:
+        description: The username used to sign in.
+        version_added: '2.7'
+      secret_key:
+        description: The secret key used when performing an initial sign in.
+        version_added: '2.7'
+      vault:
+        description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults
+        default: None
+    notes:
+      - This lookup will use an existing 1Password session if one exists. If not, and you have already
+        performed an initial sign in (meaning C(~/.op/config exists)), then only the C(master_password) is required.
+        You may optionally specify C(subdomain) in this scenario, otherwise the last used subdomain will be used by C(op).
+      - This lookup can perform an initial login by providing C(subdomain), C(username), C(secret_key), and C(master_password).
+      - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommeneded that you only pass in the minial credentials
+        needed at any given time. Also, store these credentials in an Ansible Vault using a key that is equal to or greater in strength
+        to the 1Password master password.
+      - This lookup stores potentially sensitive data from 1Password as Ansible facts.
+        Facts are subject to caching if enabled, which means this data could be stored in clear text
+        on disk or in a database.
+      - Tested with C(op) version 0.5.3
+"""
+
+EXAMPLES = """
+# These examples only work when already signed in to 1Password
+- name: Retrieve document contents for MyAwesomeDocument when already signed in to 1Password
+  debug:
+    var: lookup('onepassword_doc', 'MyAwesomeDocument')
+
+- name: Retrieve document contents for MySecureTLSCert from a specific vault
+  debug:
+    var: lookup('onepassword_doc', 'MySecureTLSCert', vault='MyVault')
+
+- name: Retrieve MySecureTLSCert document when not signed in to 1Password
+  debug:
+    var: lookup('onepassword_doc'
+                'MySecureTLSCert'
+                subdomain='MySubdomain'
+                master_password=vault_master_password)
+
+- name: Retrieve MySecureTLSCert document when never signed in to 1Password
+  debug:
+    var: lookup('onepassword_doc'
+                'MySecureTLSCert'
+                subdomain='MySubdomain'
+                master_password=vault_master_password
+                username='tweety@acme.com'
+                secret_key=vault_secret_key)
+"""
+
+RETURN = """
+  _raw:
+    description: document contents requested
+"""
+
+from ansible.plugins.lookup.onepassword import OnePass
+from ansible.plugins.lookup import LookupBase
+from ansible.module_utils._text import to_bytes
+
+
+class OnePassDoc(OnePass):
+
+    def get_document_raw(self, item_id, vault=None):
+        args = ["get", "document", item_id]
+        if vault is not None:
+            args += ['--vault={0}'.format(vault)]
+        if not self.logged_in:
+            args += [to_bytes('--session=') + self.token]
+        rc, output, dummy = self._run(args)
+        return output
+
+    def get_document(self, item_id, vault=None):
+        output = self.get_document_raw(item_id, vault)
+        return self._parse_document_output(output)
+
+    def _parse_document_output(self, doc_data):
+        return doc_data
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        op = OnePassDoc()
+
+        vault = kwargs.get('vault')
+        op.subdomain = kwargs.get('subdomain')
+        op.username = kwargs.get('username')
+        op.secret_key = kwargs.get('secret_key')
+        op.master_password = kwargs.get('master_password', kwargs.get('vault_password'))
+
+        op.assert_logged_in()
+
+        values = []
+        for term in terms:
+            values.append(op.get_document(term, vault))
+        return values

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2019, David Taylor <djtaylor13@gmail.com> (onepassword.py used as a starting point)
-# (c) 2018, Scott Buchanan <sbuchanan@ri.pn>
-# (c) 2016, Andrew Zenk <azenk@umn.edu> (lastpass.py used as starting point)
-# (c) 2018, Ansible Project
+# Copyright: (c) 2018, Scott Buchanan <sbuchanan@ri.pn>
+# Copyright: (c) 2016, Andrew Zenk <azenk@umn.edu> (lastpass.py used as starting point)
+# Copyright: (c) 2018, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -16,9 +16,9 @@ DOCUMENTATION = """
     lookup: onepassword_doc
     author:
       - David Taylor (@djtaylor)
-      - Scott Buchanan <sbuchanan@ri.pn>
-      - Andrew Zenk <azenk@umn.edu>
-      - Sam Doran<sdoran@redhat.com>
+      - Scott Buchanan <@scottsb>
+      - Andrew Zenk <@azenk>
+      - Sam Doran<@samdoran>
     version_added: "2.8"
     requirements:
       - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -16,7 +16,9 @@ DOCUMENTATION = """
     lookup: onepassword_doc
     author:
       - David Taylor (@djtaylor)
-      - Scott Buchanan <@scottsb>
+      - Scott Buchanan (@scottsb)
+      - Andrew Zenk (@azenk)
+      - Sam Doran (@samdoran)
       - Andrew Zenk <@azenk>
       - Sam Doran<@samdoran>
     version_added: "2.8"

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -19,7 +19,7 @@ DOCUMENTATION = """
       - Scott Buchanan <sbuchanan@ri.pn>
       - Andrew Zenk <azenk@umn.edu>
       - Sam Doran<sdoran@redhat.com>
-    version_added: "2.7"
+    version_added: "2.8"
     requirements:
       - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)
     short_description: fetch documents from 1Password

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -108,6 +108,7 @@ class OnePassDoc(OnePass):
     def get_document(self, doc_id, vault=None):
         return self.get_document_raw(doc_id, vault)
 
+
 class LookupModule(LookupBase):
 
     def run(self, doc_id, variables=None, **kwargs):

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
     lookup: onepassword_doc
     author:
-      - David Taylor <djtaylor13@gmail.com>
+      - David Taylor (@djtaylor)
       - Scott Buchanan <sbuchanan@ri.pn>
       - Andrew Zenk <azenk@umn.edu>
       - Sam Doran<sdoran@redhat.com>

--- a/lib/ansible/plugins/lookup/onepassword_doc.py
+++ b/lib/ansible/plugins/lookup/onepassword_doc.py
@@ -100,8 +100,8 @@ from ansible.module_utils._text import to_bytes
 
 class OnePassDoc(OnePass):
 
-    def get_document_raw(self, item_id, vault=None):
-        args = ["get", "document", item_id]
+    def get_document_raw(self, doc_id, vault=None):
+        args = ["get", "document", doc_id]
         if vault is not None:
             args += ['--vault={0}'.format(vault)]
         if not self.logged_in:
@@ -109,12 +109,12 @@ class OnePassDoc(OnePass):
         rc, output, dummy = self._run(args)
         return output
 
-    def get_document(self, item_id, vault=None):
-        return self.get_document_raw(item_id, vault)
+    def get_document(self, doc_id, vault=None):
+        return self.get_document_raw(doc_id, vault)
 
 class LookupModule(LookupBase):
 
-    def run(self, terms, variables=None, **kwargs):
+    def run(self, doc_id, variables=None, **kwargs):
         op = OnePassDoc()
 
         vault = kwargs.get('vault')
@@ -125,7 +125,4 @@ class LookupModule(LookupBase):
 
         op.assert_logged_in()
 
-        values = []
-        for term in terms:
-            values.append(op.get_document(term, vault))
-        return values
+        return op.get_document(doc_id, vault)

--- a/test/units/plugins/lookup/test_onepassword.py
+++ b/test/units/plugins/lookup/test_onepassword.py
@@ -241,7 +241,7 @@ class MockOnePass(OnePass):
                 mock_entry = self._lookup_mock_document(args.item_id, args.vault)
 
                 if mock_entry is None:
-                    return mock_exit(error='Document {0} not found'.format(args.item_id))
+                    return mock_exit(error='Document {0} not found'.format(args.item_id), rc=1)
 
                 return mock_exit(output=mock_entry)
 
@@ -388,6 +388,12 @@ class TestOnePasswordRawLookup(unittest.TestCase):
 
 @patch('ansible.plugins.lookup.onepassword_doc.OnePassDoc', MockOnePassDoc)
 class TestOnePasswordDocLookup(unittest.TestCase):
+
+    def test_onepassword_doc_not_found(self):
+        doc_lookup_plugin = OnePasswordDocLookup()
+
+        with self.assertRaises(AnsibleError):
+            doc_lookup_plugin.run('NotRealDoc')
 
     def test_onepassword_doc(self):
         doc_lookup_plugin = OnePasswordDocLookup()


### PR DESCRIPTION
##### SUMMARY
This PR looks to extend 1password functionality by looking up secure documents stored in 1password. The existing `onepassword` lookup plugin seems to require fields, a document has no fields, only its raw content. The `onepassword_raw` plugin returns a JSON object that describes the document, but not the actual document content. This PR uses `op get document` to retrieve a document's contents.

As an example, when using the F5 plugin, I would like to be able to provision TLS certificates on the load balancer without having to store the contents encrypted in the repository, or have a local copy where the path is dependent on the user.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/onepassword_doc.py

##### ADDITIONAL INFORMATION
This PR creates a subclass of the `lib/ansible/plugins/lookup/onepassword.py` plugin to query 1password for a document's contents.

This is my first attempted contribution to Ansible, so I expect I will need to make revisions. Any guidance or feedback is appreciated.
