### PR TITLE
fix Amazon system-release version parsing

### DIFF
--- a/changelogs/fragments/fix-Amazon-system-release-version-parsing.yaml
+++ b/changelogs/fragments/fix-Amazon-system-release-version-parsing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix Amazon system-release version parsing (https://github.com/ansible/ansible/issues/48823)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -228,10 +228,11 @@ class DistributionFiles:
     def parse_distribution_file_Amazon(self, name, data, path, collected_facts):
         amazon_facts = {}
         if 'Amazon' not in data:
-            # return False  # TODO: remove   # huh?
-            return False, amazon_facts  # TODO: remove
+            return False, amazon_facts
         amazon_facts['distribution'] = 'Amazon'
-        amazon_facts['distribution_version'] = data.split()[-1]
+        version = [n for n in data.split() if n.isdigit()]
+        version = version[0] if version else 'NA'
+        amazon_facts['distribution_version'] = version
         return True, amazon_facts
 
     def parse_distribution_file_OpenWrt(self, name, data, path, collected_facts):


### PR DESCRIPTION
Previously it was assumed that the Amazon system-release
number was the final value of the string.  This isn't always
the case.  Some releases have the name at the end.

  Amazon Linux release 2
  Amazon Linux release 2 (Karoo)

Fix by instead looking for a number in the string.

##### SUMMARY

Fixes #48823

##### ISSUE TYPE

- Bugfix Pull Request
