### PR TITLE
win_stat - add follow option and fix broken tests

### DIFF
--- a/changelogs/fragments/win_stat-follow.yaml
+++ b/changelogs/fragments/win_stat-follow.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_stat - added the ``follow`` module option to follow ``path`` when getting the file or directory info

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -52,6 +52,14 @@ options:
         default: sha1
         choices: [ md5, sha1, sha256, sha384, sha512 ]
         version_added: "2.3"
+    follow:
+        description:
+            - Whether to follow symlinks or junction points.
+            - In the case of C(path) pointing to another link, then that will
+              be followed until no more links are found.
+        type: bool
+        default no
+        version_added: "2.8"
 seealso:
 - module: stat
 - module: win_file

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -58,7 +58,7 @@ options:
             - In the case of C(path) pointing to another link, then that will
               be followed until no more links are found.
         type: bool
-        default no
+        default: no
         version_added: "2.8"
 seealso:
 - module: stat

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -509,7 +509,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             path=path,
             follow=follow,
             get_checksum=checksum,
-            checksum_algo='sha1',
+            checksum_algorithm='sha1',
         )
         mystat = self._execute_module(module_name='stat', module_args=module_args, task_vars=all_vars,
                                       wrap_async=False)

--- a/test/integration/targets/win_stat/tasks/main.yml
+++ b/test/integration/targets/win_stat/tasks/main.yml
@@ -54,7 +54,8 @@
     cmd.exe /c mklink /H "{{win_stat_dir}}\nested\hard-link.ps1" "{{win_stat_dir}}\nested\hard-target.txt"
     cmd.exe /c mklink /J "{{win_stat_dir}}\junction-link" "{{win_stat_dir}}\junction-dest"
     cmd.exe /c mklink /D "{{win_stat_dir}}\nested\nested\link-rel" "..\..\link-dest"
-  
+    cmd.exe /c mklink /D "{{win_stat_dir}}\outer-link" "{{win_stat_dir}}\nested\nested\link-rel"
+
     $date = Get-Date -Year 2016 -Month 11 -Day 1 -Hour 7 -Minute 10 -Second 5 -Millisecond 0
     Get-ChildItem -Path "{{win_stat_dir}}" -Recurse | ForEach-Object {
         $_.CreationTime = $date

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -140,6 +140,7 @@
 - name: test win_stat on hard link file
   win_stat:
     path: '{{win_stat_dir}}\nested\hard-link.ps1'
+    follow: True  # just verifies we don't do any weird follow logic for hard links
   register: stat_hard_link
 
 - name: check actual for hard link file
@@ -386,6 +387,37 @@
     - stat_file_symlink.stat.owner == 'BUILTIN\\Administrators'
     - stat_file_symlink.stat.path == win_stat_dir + '\\file-link.txt'
 
+- name: test win_stat of file symlink with follow
+  win_stat:
+    path: '{{win_stat_dir}}\file-link.txt'
+    follow: True
+  register: stat_file_symlink_follow
+
+- name: assert file system with follow actual
+  assert:
+    that:
+    - stat_file_symlink_follow.stat.attributes == 'Archive'
+    - stat_file_symlink_follow.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_file_symlink_follow.stat.creationtime is defined
+    - stat_file_symlink_follow.stat.exists == True
+    - stat_file_symlink_follow.stat.extension == '.ps1'
+    - stat_file_symlink_follow.stat.filename == 'file.ps1'
+    - stat_file_symlink_follow.stat.hlnk_targets == []
+    - stat_file_symlink_follow.stat.isarchive == True
+    - stat_file_symlink_follow.stat.isdir == False
+    - stat_file_symlink_follow.stat.ishidden == False
+    - stat_file_symlink_follow.stat.isjunction == False
+    - stat_file_symlink_follow.stat.islnk == False
+    - stat_file_symlink_follow.stat.isreadonly == False
+    - stat_file_symlink_follow.stat.isreg == True
+    - stat_file_symlink_follow.stat.isshared == False
+    - stat_file_symlink_follow.stat.lastaccesstime is defined
+    - stat_file_symlink_follow.stat.lastwritetime is defined
+    - stat_file_symlink_follow.stat.md5 is not defined
+    - stat_file_symlink_follow.stat.nlink == 1
+    - stat_file_symlink_follow.stat.owner == 'BUILTIN\\Administrators'
+    - stat_file_symlink_follow.stat.path == win_stat_dir + '\\nested\\file.ps1'
+
 - name: test win_stat on relative symlink
   win_stat:
     path: '{{win_stat_dir}}\nested\nested\link-rel'
@@ -417,6 +449,36 @@
     - stat_rel_symlink.stat.checksum is not defined
     - stat_rel_symlink.stat.md5 is not defined
 
+- name: test win_stat on relative multiple symlink with follow
+  win_stat:
+    path: '{{win_stat_dir}}\outer-link'
+    follow: True
+  register: stat_symlink_follow
+
+- name: assert directory relative symlink actual
+  assert:
+    that:
+    - stat_symlink_follow.stat.attributes == 'Directory'
+    - stat_symlink_follow.stat.creationtime is defined
+    - stat_symlink_follow.stat.exists == True
+    - stat_symlink_follow.stat.filename == 'link-dest'
+    - stat_symlink_follow.stat.hlnk_targets == []
+    - stat_symlink_follow.stat.isarchive == False
+    - stat_symlink_follow.stat.isdir == True
+    - stat_symlink_follow.stat.ishidden == False
+    - stat_symlink_follow.stat.isjunction == False
+    - stat_symlink_follow.stat.islnk == False
+    - stat_symlink_follow.stat.isreadonly == False
+    - stat_symlink_follow.stat.isreg == False
+    - stat_symlink_follow.stat.isshared == False
+    - stat_symlink_follow.stat.lastaccesstime is defined
+    - stat_symlink_follow.stat.lastwritetime is defined
+    - stat_symlink_follow.stat.nlink == 1
+    - stat_symlink_follow.stat.owner == 'BUILTIN\\Administrators'
+    - stat_symlink_follow.stat.path == win_stat_dir + '\\link-dest'
+    - stat_symlink_follow.stat.checksum is not defined
+    - stat_symlink_follow.stat.md5 is not defined
+
 - name: test win_stat on junction
   win_stat:
     path: '{{win_stat_dir}}\junction-link'
@@ -446,6 +508,35 @@
     - stat_junction_point.stat.owner == 'BUILTIN\\Administrators'
     - stat_junction_point.stat.path == win_stat_dir + '\\junction-link'
     - stat_junction_point.stat.size == 0
+
+- name: test win_stat on junction with follow
+  win_stat:
+    path: '{{win_stat_dir}}\junction-link'
+    follow: True
+  register: stat_junction_point_follow
+
+- name: assert junction with follow actual
+  assert:
+    that:
+    - stat_junction_point_follow.stat.attributes == 'Directory'
+    - stat_junction_point_follow.stat.creationtime is defined
+    - stat_junction_point_follow.stat.exists == True
+    - stat_junction_point_follow.stat.filename == 'junction-dest'
+    - stat_junction_point_follow.stat.hlnk_targets == []
+    - stat_junction_point_follow.stat.isarchive == False
+    - stat_junction_point_follow.stat.isdir == True
+    - stat_junction_point_follow.stat.ishidden == False
+    - stat_junction_point_follow.stat.isjunction == False
+    - stat_junction_point_follow.stat.islnk == False
+    - stat_junction_point_follow.stat.isreadonly == False
+    - stat_junction_point_follow.stat.isreg == False
+    - stat_junction_point_follow.stat.isshared == False
+    - stat_junction_point_follow.stat.lastaccesstime is defined
+    - stat_junction_point_follow.stat.lastwritetime is defined
+    - stat_junction_point_follow.stat.nlink == 1
+    - stat_junction_point_follow.stat.owner == 'BUILTIN\\Administrators'
+    - stat_junction_point_follow.stat.path == win_stat_dir + '\\junction-dest'
+    - stat_junction_point_follow.stat.size == 0
 
 - name: test win_stat module non-existent path
   win_stat:

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -66,8 +66,6 @@ lib/ansible/modules/windows/win_security_policy.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_security_policy.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_shell.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_shell.ps1 PSUseApprovedVerbs
-lib/ansible/modules/windows/win_stat.ps1 PSAvoidUsingWMICmdlet
-lib/ansible/modules/windows/win_stat.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_unzip.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_unzip.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_uri.ps1 PSAvoidUsingEmptyCatchBlock


### PR DESCRIPTION
##### SUMMARY
Fixes an issue where the _execute_remote_stat would send module args with `follow` and `checksum_algo` which is not supported by win_stat. A recent change to win_stat meant it will fail if invalid options are passed in so this PR adds support for `follow` and changes the module arg from `checksum_algo` to `checksum_algorithm` that's supported by both stat and win_stat.

Also fixes some pslint issues that we were ignoring.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
win_stat