### PR TITLE
conn,buildah: guide users when running rootless

### DIFF
--- a/lib/ansible/plugins/connection/buildah.py
+++ b/lib/ansible/plugins/connection/buildah.py
@@ -28,8 +28,6 @@ DOCUMENTATION = """
         default: inventory_hostname
         vars:
             - name: ansible_host
-#        keyword:
-#            - name: hosts
       remote_user:
         description:
             - User specified via name or ID which is used to execute commands inside the container.
@@ -40,8 +38,6 @@ DOCUMENTATION = """
           - name: ANSIBLE_REMOTE_USER
         vars:
           - name: ansible_user
-#        keyword:
-#            - name: remote_user
     notes:
         - "When you are using rootless buildah containers, you should wrap"
         - "invocation of ansible-playbook in ``buildah unshare`` like this:"


### PR DESCRIPTION
Fixes: #50583

Tested locally, works fine.

There is just this warning which I don't understand:
```
 [WARNING]: Skipping plugin (/home/tt/g/ansible/ansible/lib/ansible/plugins/connection/buildah.py) as it seems to be invalid: mapping values are not allowed in this context
 in "<unicode string>", line 27, column 64
```