### PR TITLE
lxd_container fix to check for snap package install unix.socket #34924

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -292,10 +292,21 @@ class LXDContainerManagement(object):
         self.force_stop = self.module.params['force_stop']
         self.addresses = None
 
-        self.url = self.module.params['url']
         self.key_file = self.module.params.get('key_file', None)
         self.cert_file = self.module.params.get('cert_file', None)
         self.debug = self.module._verbosity >= 4
+
+        try:
+            cmd='/usr/bin/file ' + self.module.params['snap_url']
+            snap_socket_check = os.system(cmd)
+
+            if snap_socket_check == 0:
+                self.url = self.module.params['snap_url']
+            else:
+                self.url = self.module.params['url']
+        except Exception as e:
+            self.module.fail_json(msg=e.msg)
+
         try:
             self.client = LXDClient(
                 self.url, key_file=self.key_file, cert_file=self.cert_file,
@@ -582,6 +593,10 @@ def main():
             url=dict(
                 type='str',
                 default='unix:/var/lib/lxd/unix.socket'
+            ),
+            snap_url=dict(
+                type='str',
+                default='unix:/var/snap/lxd/common/lxd/unix.socket'
             ),
             key_file=dict(
                 type='str',

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -303,7 +303,7 @@ class LXDContainerManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            if os.path.exists(self.module.params['snap_url'].replace('unix:','')):
+            if os.path.exists(self.module.params['snap_url'].replace('unix:', '')):
                 self.url = self.module.params['snap_url']
             else:
                 self.url = self.module.params['url']

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -303,10 +303,7 @@ class LXDContainerManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            cmd = '/usr/bin/file ' + self.module.params['snap_url']
-            snap_socket_check = os.system(cmd)
-
-            if snap_socket_check == 0:
+            if os.path.exists(self.module.params['snap_url'].replace('unix:','')):
                 self.url = self.module.params['snap_url']
             else:
                 self.url = self.module.params['url']

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -111,6 +111,7 @@ options:
           - The unix domain socket path when LXD is installed by snap package manager.
         required: false
         default: unix:/var/snap/lxd/common/lxd/unix.socket
+        version_added: '2.8'
     key_file:
         description:
           - The client certificate key file path.

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -297,7 +297,7 @@ class LXDContainerManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            cmd='/usr/bin/file ' + self.module.params['snap_url']
+            cmd = '/usr/bin/file ' + self.module.params['snap_url']
             snap_socket_check = os.system(cmd)
 
             if snap_socket_check == 0:

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -108,7 +108,7 @@ options:
         default: unix:/var/lib/lxd/unix.socket
     snap_url:
         description:
-          - (SNAP) The unix domain socket path or the https URL for the LXD server.
+          - The unix domain socket path when LXD is installed by snap package manager.
         required: false
         default: unix:/var/snap/lxd/common/lxd/unix.socket
     key_file:

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -106,6 +106,11 @@ options:
           - The unix domain socket path or the https URL for the LXD server.
         required: false
         default: unix:/var/lib/lxd/unix.socket
+    snap_url:
+        description:
+          - (SNAP) The unix domain socket path or the https URL for the LXD server.
+        required: false
+        default: unix:/var/snap/lxd/common/lxd/unix.socket
     key_file:
         description:
           - The client certificate key file path.

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -210,11 +210,7 @@ class LXDProfileManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            cmd = '/usr/bin/file ' + self.module.params['snap_url']
-
-            snap_socket_check = os.system(cmd)
-
-            if snap_socket_check == 0:
+            if os.path.exists(self.module.params['snap_url'].replace('unix:','')):
                 self.url = self.module.params['snap_url']
             else:
                 self.url = self.module.params['url']

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -204,7 +204,7 @@ class LXDProfileManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            cmd='/usr/bin/file ' + self.module.params['snap_url']
+            cmd = '/usr/bin/file ' + self.module.params['snap_url']
 
             snap_socket_check = os.system(cmd)
 

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -64,12 +64,12 @@ options:
         default: present
     url:
         description:
-          - (APT/YUM) The unix domain socket path or the https URL for the LXD server.
+          - The unix domain socket path or the https URL for the LXD server.
         required: false
         default: unix:/var/lib/lxd/unix.socket
     snap_url:
         description:
-          - (SNAP) The unix domain socket path or the https URL for the LXD server. 
+          - (SNAP) The unix domain socket path or the https URL for the LXD server.
         required: false
         default: unix:/var/snap/lxd/common/lxd/unix.socket
     key_file:

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -210,7 +210,7 @@ class LXDProfileManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            if os.path.exists(self.module.params['snap_url'].replace('unix:','')):
+            if os.path.exists(self.module.params['snap_url'].replace('unix:', '')):
                 self.url = self.module.params['snap_url']
             else:
                 self.url = self.module.params['url']

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -69,7 +69,7 @@ options:
         default: unix:/var/lib/lxd/unix.socket
     snap_url:
         description:
-          - (SNAP) The unix domain socket path or the https URL for the LXD server.
+          - The unix domain socket path when LXD is installed by snap package manager.
         required: false
         default: unix:/var/snap/lxd/common/lxd/unix.socket
     key_file:

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -199,10 +199,22 @@ class LXDProfileManagement(object):
         self.state = self.module.params['state']
         self.new_name = self.module.params.get('new_name', None)
 
-        self.url = self.module.params['url']
         self.key_file = self.module.params.get('key_file', None)
         self.cert_file = self.module.params.get('cert_file', None)
         self.debug = self.module._verbosity >= 4
+
+        try:
+            cmd='/usr/bin/file ' + self.module.params['snap_url']
+
+            snap_socket_check = os.system(cmd)
+
+            if snap_socket_check == 0:
+                self.url = self.module.params['snap_url']
+            else:
+                self.url = self.module.params['url']
+        except Exception as e:
+            self.module.fail_json(msg=e.msg)
+
         try:
             self.client = LXDClient(
                 self.url, key_file=self.key_file, cert_file=self.cert_file,
@@ -351,6 +363,10 @@ def main():
             url=dict(
                 type='str',
                 default='unix:/var/lib/lxd/unix.socket'
+            ),
+            snap_url=dict(
+                type='str',
+                default='unix:/var/snap/lxd/common/lxd/unix.socket'
             ),
             key_file=dict(
                 type='str',

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -64,9 +64,14 @@ options:
         default: present
     url:
         description:
-          - The unix domain socket path or the https URL for the LXD server.
+          - (APT/YUM) The unix domain socket path or the https URL for the LXD server.
         required: false
         default: unix:/var/lib/lxd/unix.socket
+    snap_url:
+        description:
+          - (SNAP) The unix domain socket path or the https URL for the LXD server. 
+        required: false
+        default: unix:/var/snap/lxd/common/lxd/unix.socket
     key_file:
         description:
           - The client certificate key file path.

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -72,6 +72,7 @@ options:
           - The unix domain socket path when LXD is installed by snap package manager.
         required: false
         default: unix:/var/snap/lxd/common/lxd/unix.socket
+        version_added: '2.8'
     key_file:
         description:
           - The client certificate key file path.


### PR DESCRIPTION
##### SUMMARY
- added simple fix to lxd module to connect to test if lxd unix.socket is installed with snap package or apt, and will use the snap unix.socket if detected

##### ISSUE TYPE
- Bugfix Pull Request fixes [#34924](https://github.com/ansible/ansible/issues/34924)


##### COMPONENT NAME
lib/ansible/modules/cloud/lxd/lxd_container.py
lib/ansible/modules/cloud/lxd/lxd_profile.py

##### ADDITIONAL INFORMATION
Running ansible playbook to deploy lxd container will fail to create container if the LXD has been installed with snap package manager as default connect url is for apt.

```
ansible-playbook main.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] **************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************
ok: [localhost]

TASK [Create ubuntu base lxd_container] ***************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"actions": [], "changed": false, "msg": "cannot connect to the LXD server"}
	to retry, use: --limit @/home/ubuntu/ansible/roles/lxc/main.retry

PLAY RECAP ********************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   

```