### PR TITLE
WIP: cloudscale: add new module cloudscale_server_facts

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server_facts.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server_facts.py
@@ -1,0 +1,178 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017, Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>
+# Copyright (c) 2019, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: cloudscale_server_facts
+short_description: Gather server facts on cloudscale.ch IaaS service
+description:
+  - Gather facts about servers available.
+  - If more than one server with the name given by the I(name) option exists, execution is aborted.
+author:
+  - "Gaudenz Steinlin (@gaudenz)"
+  - "René Moser (@resmo)"
+version_added: "2.8"
+options:
+  name:
+    description:
+      - Name of the server.
+      - Either I(name) or I(uuid) are required. These options are mutually exclusive.
+  uuid:
+    description:
+      - UUID of the server.
+      - Either I(name) or I(uuid) are required. These options are mutually exclusive.
+extends_documentation_fragment: cloudscale
+'''
+
+EXAMPLES = '''
+- name: Get facts of a server by its name
+  cloudscale_server:
+    name: my-name
+    api_token: xxxxxx
+
+- name: Get facts of a server by its uuid
+  cloudscale_server:
+    uuid: "{{ my_uuid }}"
+    api_token: xxxxxx
+'''
+
+RETURN = '''
+href:
+  description: API URL to get details about this server
+  returned: if available
+  type: str
+  sample: https://api.cloudscale.ch/v1/servers/cfde831a-4e87-4a75-960f-89b0148aa2cc
+uuid:
+  description: The unique identifier for this server
+  returned: success
+  type: str
+  sample: cfde831a-4e87-4a75-960f-89b0148aa2cc
+name:
+  description: The display name of the server
+  returned: success
+  type: str
+  sample: its-a-me-mario.cloudscale.ch
+state:
+  description: The current status of the server
+  returned: success
+  type: str
+  sample: running
+flavor:
+  description: The flavor that has been used for this server
+  returned: if available
+  type: str
+  sample: flex-8
+image:
+  description: The image used for booting this server
+  returned: if available
+  type: str
+  sample: debian-8
+volumes:
+  description: List of volumes attached to the server
+  returned: if available
+  type: list
+  sample: [ {"type": "ssd", "device": "/dev/vda", "size_gb": "50"} ]
+interfaces:
+  description: List of network ports attached to the server
+  returned: if available
+  type: list
+  sample: [ { "type": "public", "addresses": [ ... ] } ]
+ssh_fingerprints:
+  description: A list of SSH host key fingerprints. Will be null until the host keys could be retrieved from the server.
+  returned: if available
+  type: list
+  sample: ["ecdsa-sha2-nistp256 SHA256:XXXX", ... ]
+ssh_host_keys:
+  description: A list of SSH host keys. Will be null until the host keys could be retrieved from the server.
+  returned: if available
+  type: list
+  sample: ["ecdsa-sha2-nistp256 XXXXX", ... ]
+anti_affinity_with:
+  description: List of servers in the same anti-affinity group
+  returned: if available
+  type: str
+  sample: []
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudscale import AnsibleCloudscaleBase, cloudscale_argument_spec
+
+
+class AnsibleCloudscaleServerFacts(AnsibleCloudscaleBase):
+
+    def __init__(self, module):
+        super(AnsibleCloudscaleServerFacts, self).__init__(module)
+
+        # Check if server already exists and load properties
+        uuid = self._module.params['uuid']
+        name = self._module.params['name']
+
+        # Initialize server dictionary
+        self.info = {'uuid': uuid, 'name': name, 'state': 'absent'}
+
+        servers = self._get('servers') or []
+        matching_server = []
+        for s in servers:
+            if uuid:
+                # Look for server by UUID if given
+                if s['uuid'] == uuid:
+                    self.info = self._transform_state(s)
+                    break
+            else:
+                # Look for server by name
+                if s['name'] == name:
+                    matching_server.append(s)
+        else:
+            if len(matching_server) == 1:
+                self.info = self._transform_state(matching_server[0])
+            elif len(matching_server) > 1:
+                self._module.fail_json(msg="More than one server with name '%s' exists. "
+                                       "Use the 'uuid' parameter to identify the server." % name)
+
+    @staticmethod
+    def _transform_state(server):
+        if 'status' in server:
+            server['state'] = server['status']
+            del server['status']
+        else:
+            server['state'] = 'absent'
+        return server
+
+
+def main():
+    argument_spec = cloudscale_argument_spec()
+    argument_spec.update(dict(
+        name=dict(),
+        uuid=dict(),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=(('name', 'uuid'),),
+        mutually_exclusive=(('name', 'uuid'),),
+        supports_check_mode=True,
+    )
+
+    server = AnsibleCloudscaleServerFacts(module)
+    ansible_facts = {
+        'cloudscale_server': server.info,
+    }
+    module.exit_json(ansible_facts=ansible_facts, **server.info)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/doc_fragments/cloudscale.py
+++ b/lib/ansible/plugins/doc_fragments/cloudscale.py
@@ -20,5 +20,6 @@ notes:
   - Instead of the api_token parameter the C(CLOUDSCALE_API_TOKEN) environment variable can be used.
   - All operations are performed using the cloudscale.ch public API v1.
   - "For details consult the full API documentation: U(https://www.cloudscale.ch/en/api/v1)."
-  - A valid API token is required for all operations. You can create as many tokens as you like using the cloudscale.ch control panel at U(https://control.cloudscale.ch).
+  - A valid API token is required for all operations. You can create as many tokens as you like using the cloudscale.ch control panel at
+    U(https://control.cloudscale.ch).
 '''

--- a/lib/ansible/plugins/doc_fragments/cloudscale.py
+++ b/lib/ansible/plugins/doc_fragments/cloudscale.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+
+    # Standard cloudstack documentation fragment
+    DOCUMENTATION = '''
+options:
+  api_token:
+    description:
+      - cloudscale.ch API token.
+      - This can also be passed in the C(CLOUDSCALE_API_TOKEN) environment variable.
+  api_timeout:
+    description:
+      - Timeout in seconds for calls to the cloudscale.ch API.
+    default: 30
+notes:
+  - Instead of the api_token parameter the C(CLOUDSCALE_API_TOKEN) environment variable can be used.
+  - All operations are performed using the cloudscale.ch public API v1.
+  - "For details consult the full API documentation: U(https://www.cloudscale.ch/en/api/v1)."
+  - A valid API token is required for all operations. You can create as many tokens as you like using the cloudscale.ch control panel at U(https://control.cloudscale.ch).
+'''

--- a/test/integration/targets/cloudscale_server_facts/aliases
+++ b/test/integration/targets/cloudscale_server_facts/aliases
@@ -1,0 +1,2 @@
+cloud/cloudscale
+unsupported

--- a/test/integration/targets/cloudscale_server_facts/defaults/main.yml
+++ b/test/integration/targets/cloudscale_server_facts/defaults/main.yml
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+cloudscale_server_facts_flavor: flex-2
+cloudscale_server_facts_image: debian-9
+cloudscale_server_facts_ssh_key: |
+  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPmiqkvDH1/+MDAVDZT8381aYqp73Odz8cnD5hegNhqtXajqtiH0umVg7HybX3wt1HjcrwKJovZURcIbbcDvzdH2bnYbF93T4OLXA0bIfuIp6M86x1iutFtXdpN3TTicINrmSXEE2Ydm51iMu77B08ZERjVaToya2F7vC+egfoPvibf7OLxE336a5tPCywavvNihQjL8sjgpDT5AAScjb3YqK/6VLeQ18Ggt8/ufINsYkb+9/Ji/3OcGFeflnDXq80vPUyF3u4iIylob6RSZenC38cXmQB05tRNxS1B6BXCjMRdy0v4pa7oKM2GA4ADKpNrr0RI9ed+peRFwmsclH test@ansible

--- a/test/integration/targets/cloudscale_server_facts/meta/main.yml
+++ b/test/integration/targets/cloudscale_server_facts/meta/main.yml
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+dependencies:
+  - cloudscale_common

--- a/test/integration/targets/cloudscale_server_facts/tasks/main.yml
+++ b/test/integration/targets/cloudscale_server_facts/tasks/main.yml
@@ -98,18 +98,6 @@
       - cloudscale_server.image.slug == '{{ cloudscale_server_facts_image }}'
       - cloudscale_server.state == 'running'
 
-# TODO: Why we need to stop manually before absent?
-- name: Stop server
-  cloudscale_server:
-    name: '{{ cloudscale_resource_prefix }}-test-facts'
-    state: stopped
-  register: server
-- name: Verify stop server
-  assert:
-    that:
-      - server is successful
-      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
-
 - name: Cleanup server
   cloudscale_server:
     name: '{{ cloudscale_resource_prefix }}-test-facts'

--- a/test/integration/targets/cloudscale_server_facts/tasks/main.yml
+++ b/test/integration/targets/cloudscale_server_facts/tasks/main.yml
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Gather facts of non existing server
+  cloudscale_server_facts:
+    name: '{{ cloudscale_resource_prefix }}-test-facts'
+  register: server
+- name: Verify setup create server
+  assert:
+    that:
+      - server is not changed
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - server.state == 'absent'
+
+- name: Setup create server
+  cloudscale_server:
+    name: '{{ cloudscale_resource_prefix }}-test-facts'
+    flavor: '{{ cloudscale_server_facts_flavor }}'
+    image: '{{ cloudscale_server_facts_image }}'
+    ssh_keys: '{{ cloudscale_server_facts_ssh_key }}'
+    state: running
+  register: server
+- name: Verify setup create server
+  assert:
+    that:
+      - server is changed
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - server.state == 'running'
+
+- name: Test gather facts of a server in check mode
+  cloudscale_server_facts:
+    name: '{{ cloudscale_resource_prefix }}-test-facts'
+  register: server
+  check_mode: yes
+- name: Verify gather facts of a server in check mode
+  assert:
+    that:
+      - server is not changed
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - server.state == 'running'
+      - cloudscale_server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - cloudscale_server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - cloudscale_server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - cloudscale_server.state == 'running'
+
+- name: Test gather facts of a server
+  cloudscale_server_facts:
+    name: '{{ cloudscale_resource_prefix }}-test-facts'
+  register: server
+- name: Verify gather facts of a server
+  assert:
+    that:
+      - server is not changed
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - server.state == 'running'
+      - cloudscale_server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - cloudscale_server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - cloudscale_server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - cloudscale_server.state == 'running'
+
+- name: Test gather facts of a server by uuid in check mode
+  cloudscale_server_facts:
+    uuid: '{{ server.uuid }}'
+  register: server
+  check_mode: yes
+- name: Verify gather facts of a server by uuid in check mode
+  assert:
+    that:
+      - server is not changed
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - server.state == 'running'
+      - cloudscale_server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - cloudscale_server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - cloudscale_server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - cloudscale_server.state == 'running'
+
+- name: Test gather facts of a server by uuid
+  cloudscale_server_facts:
+    uuid: '{{ server.uuid }}'
+  register: server
+- name: Verify gather facts of a server by uuid
+  assert:
+    that:
+      - server is not changed
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - server.state == 'running'
+      - cloudscale_server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+      - cloudscale_server.flavor.slug == '{{ cloudscale_server_facts_flavor }}'
+      - cloudscale_server.image.slug == '{{ cloudscale_server_facts_image }}'
+      - cloudscale_server.state == 'running'
+
+# TODO: Why we need to stop manually before absent?
+- name: Stop server
+  cloudscale_server:
+    name: '{{ cloudscale_resource_prefix }}-test-facts'
+    state: stopped
+  register: server
+- name: Verify stop server
+  assert:
+    that:
+      - server is successful
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'
+
+- name: Cleanup server
+  cloudscale_server:
+    name: '{{ cloudscale_resource_prefix }}-test-facts'
+    state: absent
+  register: server
+- name: Verify cleanup server
+  assert:
+    that:
+      - server is successful
+      - server.name == '{{ cloudscale_resource_prefix }}-test-facts'


### PR DESCRIPTION
##### SUMMARY
new module for gathering server facts on cloudscale

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudscale_server_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
 $ ansible-test integration cloud/cloudscale/cloudscale_server_facts  -v --diff --allow-unsupported

Using existing cloudscale cloud config: test/integration/cloud-config-cloudscale.ini
WARNING: A Python 2.7 interpreter was found at "/usr/bin/python2.7", yet a matching pip was not found.
WARNING: A Python 3.7 interpreter was found at "/usr/bin/python3.7", yet a matching pip was not found.
Running cloudscale_server_facts integration test role
Run command: ansible-playbook cloudscale_server_facts-Hx65XL.yml -i inventory -e @integration_config.yml --diff -v -e cloudscale_resource_prefix=ansible-test-titan-76111193
Using /home/resmo/.ansible/test/tmp/cloudscale_server_facts-HMhkSt-ÅÑŚÌβŁÈ/test/integration/integration.cfg as config file
 [WARNING]: The `junit_xml` python module is not installed. Disabling the `junit` callback plugin.


PLAY [testhost] *****************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************
ok: [testhost]

TASK [cloudscale_server_facts : Gather facts of non existing server] ************************************************************************************************************
ok: [testhost] => {"ansible_facts": {"cloudscale_server": {"name": "ansible-test-titan-76111193-test-facts", "state": "absent", "uuid": null}}, "changed": false, "name": "ansible-test-titan-76111193-test-facts", "state": "absent", "uuid": null}

TASK [cloudscale_server_facts : Verify setup create server] *********************************************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [cloudscale_server_facts : Setup create server] ****************************************************************************************************************************
changed: [testhost] => {"anti_affinity_with": [], "changed": true, "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}

TASK [cloudscale_server_facts : Verify setup create server] *********************************************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [cloudscale_server_facts : Test gather facts of a server in check mode] ****************************************************************************************************
ok: [testhost] => {"ansible_facts": {"cloudscale_server": {"anti_affinity_with": [], "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}}, "anti_affinity_with": [], "changed": false, "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}

TASK [cloudscale_server_facts : Verify gather facts of a server in check mode] **************************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [cloudscale_server_facts : Test gather facts of a server] ******************************************************************************************************************
ok: [testhost] => {"ansible_facts": {"cloudscale_server": {"anti_affinity_with": [], "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}}, "anti_affinity_with": [], "changed": false, "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}

TASK [cloudscale_server_facts : Verify gather facts of a server] ****************************************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [cloudscale_server_facts : Test gather facts of a server by uuid in check mode] ********************************************************************************************
ok: [testhost] => {"ansible_facts": {"cloudscale_server": {"anti_affinity_with": [], "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}}, "anti_affinity_with": [], "changed": false, "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}

TASK [cloudscale_server_facts : Verify gather facts of a server by uuid in check mode] ******************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [cloudscale_server_facts : Test gather facts of a server by uuid] **********************************************************************************************************
ok: [testhost] => {"ansible_facts": {"cloudscale_server": {"anti_affinity_with": [], "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}}, "anti_affinity_with": [], "changed": false, "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": null, "ssh_host_keys": null, "state": "running", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}

TASK [cloudscale_server_facts : Verify gather facts of a server by uuid] ********************************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [cloudscale_server_facts : Stop server] ************************************************************************************************************************************
changed: [testhost] => {"anti_affinity_with": [], "changed": true, "flavor": {"memory_gb": 2, "name": "Flex-2", "slug": "flex-2", "vcpu_count": 1}, "href": "https://api.cloudscale.ch/v1/servers/6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "image": {"default_username": "debian", "name": "Debian 9.0", "operating_system": "Debian", "slug": "debian-9"}, "interfaces": [{"addresses": [{"address": "5.102.145.82", "gateway": "5.102.145.1", "prefix_length": 24, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 4}, {"address": "2a06:c01:1:1102::9152:82", "gateway": "fe80::1", "prefix_length": 64, "reverse_ptr": "5-102-145-82.cust.cloudscale.ch", "version": 6}], "type": "public"}], "name": "ansible-test-titan-76111193-test-facts", "ssh_fingerprints": ["ecdsa-sha2-nistp256 SHA256:bYsodoTE+yIX9CIrba4UehbDIZGMcFPJ3jjdl6NPDxk", "ecdsa-sha2-nistp256 5c:ea:21:8c:69:be:3b:8d:02:73:7d:e5:df:5c:f1:42", "ssh-rsa SHA256:giG3A1OIOtvDzYBUrjyqZvaRhO26PbLMEG8ZHbwTZm0", "ssh-rsa a1:9c:9b:c9:b2:55:0c:94:b1:d9:e6:c1:fe:77:a1:eb", "ssh-ed25519 SHA256:5ai013dAR1tM5smrMkR3LkybOzWDXlrYc8eevF4XgKc", "ssh-ed25519 00:95:dc:db:18:f3:f3:df:54:26:3d:4a:6c:47:71:8a", "ssh-dss SHA256:7SONoGV21TjCqcVD/UaOVnP7TplZ2XyVaJQrF/j6p30", "ssh-dss f2:2f:aa:14:00:57:1b:45:35:90:20:4c:cf:95:4e:38"], "ssh_host_keys": ["ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmplQwHQJtrYoZuJK8xMUmkEcuEq3PVNB2m1r37iuegEVK2mmG2x20WJQNC9HDURYeG/DpNRgUc9OJ1YfrvRDI=", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC13vdbd2fkqdR0EJnNh5inVREXDIUFl6rqpOkxc9kGW307iAr7xH69jTRDn88Ui0/Tb4F2Y20AQ51v6ZbKLkDdSJM/FNZJoOO3PfSGGESZhwKsPi0Sh6kdEc5gQdhfl12PyCx04MsLR27RRK4sfkDRr68mXYiMJ20WXde7Of3z1jOXctxmFvsQUYRVAyD2N0BH+L9GeJVwG6TG0sgAVLMcfm65/69N2wGEbAwsZu3LbBg5xsBZkrobNQAu0g1cMFWrtKW3Xh5tRUMOCx1odoU9woWWO8q9ojWMb2jYifKjaaAnlCqknuwF82VVJ/msBx8k5Jm95nBIP83zbX1UQiKv", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJjHy4VDkqVyy5dPaCQEWh77RCWOOZhSpCrBxwoTZ01u", "ssh-dss AAAAB3NzaC1kc3MAAACBAJw/oJrMOK5vRAhPpPWJKm3see5cbvKHK7i/CjTPHJOIzhCI4sAkApfkyUi4rEEKrrjrXBQlyptIzK1zkHVVfz72BnSsUM6t5yOCducVtGunyyz50kIa7nh1bBTZzqyz+ELfO0x+7ZXYhEFUF4GvND1j70wSl+kXMLYVrdUuFRolAAAAFQDMC3FWszpdQGmIMr3nyCbqQ0sqEQAAAIEAmc17HNsqkmnRhJadcm6kIEZ2nzFPgTQrgDsjAaQ3qhYfjo6a03kbm7E13uUOXNkn9DK1IPGIZkojgBIogckA89t1SShPCROEtZxUnlHbUfiAzA2lJCZ1co05ZkJJbWImEeFe3EKnfZs4JbLyrEnkjHpqZYzquDn+5nAmxgC95xIAAACAMatGt3QOJQ46TF4GsBPkG74Q26+5jJT9zrbUAzJPUGVRIxnsBp5YegkMTB2m6NQJ2Vuq44lob+yA7jpIh38DEZyK0fAiDe1FfgvmuodGS2arwWcSeKxsMi1xhdrWQji3u9Aj8bdV0nvHtcPUU7HaiFu3Z3fBW6/vbUiNt+dYh4A="], "state": "stopped", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e", "volumes": [{"name": "ansible-test-titan-76111193-test-facts-root", "size_gb": 10, "type": "ssd", "uuid": "c6a5802a-1965-4e43-82a8-2b1cb6c0347f"}]}

TASK [cloudscale_server_facts : Verify stop server] *****************************************************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [cloudscale_server_facts : Cleanup server] *********************************************************************************************************************************
changed: [testhost] => {"changed": true, "name": "ansible-test-titan-76111193-test-facts", "state": "absent", "uuid": "6f61ca30-e8fe-4051-a18c-1a4bd38a4f0e"}

TASK [cloudscale_server_facts : Verify cleanup server] **************************************************************************************************************************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

PLAY RECAP **********************************************************************************************************************************************************************
testhost                   : ok=17   changed=3    unreachable=0    failed=0    skipped=0   

```
