### PR TITLE
Foreman facts uploading correctly merges facts

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -238,10 +238,10 @@ class CallbackModule(CallbackBase):
     def v2_runner_on_unreachable(self, result):
         self.append_result(result)
 
-    def v2_runner_on_async_ok(self, result, jid):
+    def v2_runner_on_async_ok(self, result):
         self.append_result(result)
 
-    def v2_runner_on_async_failed(self, result, jid):
+    def v2_runner_on_async_failed(self, result):
         self.append_result(result)
 
     def v2_playbook_on_stats(self, stats):

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -196,10 +196,10 @@ class CallbackModule(CallbackBase):
         metrics = {}
 
         for host in stats.processed.keys():
-            sum = stats.summarize(host)
-            status["applied"] = sum['changed']
-            status["failed"] = sum['failures'] + sum['unreachable']
-            status["skipped"] = sum['skipped']
+            total = stats.summarize(host)
+            status["applied"] = total['changed']
+            status["failed"] = total['failures'] + total['unreachable']
+            status["skipped"] = total['skipped']
             log = self._build_log(self.items[host])
             metrics["time"] = {"total": int(time.time()) - self.start_time}
             now = datetime.now().strftime(self.TIME_FORMAT)

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -86,10 +86,6 @@ class CallbackModule(CallbackBase):
     CALLBACK_NAME = 'foreman'
     CALLBACK_NEEDS_WHITELIST = True
 
-    FOREMAN_HEADERS = {
-        "Content-Type": "application/json",
-        "Accept": "application/json"
-    }
     TIME_FORMAT = "%Y-%m-%d %H:%M:%S %f"
 
     def __init__(self):
@@ -109,8 +105,8 @@ class CallbackModule(CallbackBase):
         self.ssl_verify = self._ssl_verify()
 
         if HAS_REQUESTS:
-            requests_major = int(requests.__version__.split('.')[0])
-            if requests_major < 2:
+            requests_version = requests.__version__.split('.')
+            if int(requests_version[0]) < 2 or int(requests_version[1]) < 14:
                 self._disable_plugin('The `requests` python module is too old.')
         else:
             self._disable_plugin('The `requests` python module is not installed.')
@@ -159,8 +155,7 @@ class CallbackModule(CallbackBase):
 
             try:
                 r = requests.post(url=self.FOREMAN_URL + '/api/v2/hosts/facts',
-                                  data=json.dumps(facts),
-                                  headers=self.FOREMAN_HEADERS,
+                                  json=facts,
                                   cert=self.FOREMAN_SSL_CERT,
                                   verify=self.ssl_verify)
                 r.raise_for_status()
@@ -219,8 +214,7 @@ class CallbackModule(CallbackBase):
             }
             try:
                 r = requests.post(url=self.FOREMAN_URL + '/api/v2/config_reports',
-                                  data=json.dumps(report),
-                                  headers=self.FOREMAN_HEADERS,
+                                  json=report,
                                   cert=self.FOREMAN_SSL_CERT,
                                   verify=self.ssl_verify)
                 r.raise_for_status()

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -106,6 +106,17 @@ def build_log(data):
         }
 
 
+def get_time():
+    """
+    Return the time for measuring duration. Prefers monotonic time but
+    falls back to the regular time on older Python versions.
+    """
+    try:
+        return time.monotonic()
+    except AttributeError:
+        return time.time()
+
+
 class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'notification'
@@ -118,7 +129,7 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).__init__()
         self.items = defaultdict(list)
         self.facts = defaultdict(dict)
-        self.start_time = int(time.time())
+        self.start_time = get_time()
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
 
@@ -204,7 +215,7 @@ class CallbackModule(CallbackBase):
             status["failed"] = total['failures'] + total['unreachable']
             status["skipped"] = total['skipped']
             log = list(build_log(self.items[host]))
-            metrics["time"] = {"total": int(time.time()) - self.start_time}
+            metrics["time"] = {"total": int(get_time() - self.start_time)}
             now = datetime.now().strftime(self.TIME_FORMAT)
             report = {
                 "config_report": {

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -120,7 +120,7 @@ def get_now():
     """
     Return the current timestamp as a string to be sent over the network.
     """
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S %f")
+    return datetime.utcnow().isoformat()
 
 
 class CallbackModule(CallbackBase):

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -116,14 +116,18 @@ def get_time():
     except AttributeError:
         return time.time()
 
+def get_now():
+    """
+    Return the current timestamp as a string to be sent over the network.
+    """
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S %f")
+
 
 class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'foreman'
     CALLBACK_NEEDS_WHITELIST = True
-
-    TIME_FORMAT = "%Y-%m-%d %H:%M:%S %f"
 
     def __init__(self):
         super(CallbackModule, self).__init__()
@@ -186,7 +190,7 @@ class CallbackModule(CallbackBase):
                 "facts": {
                     "ansible_facts": self.facts[host],
                     "_type": "ansible",
-                    "_timestamp": datetime.now().strftime(self.TIME_FORMAT),
+                    "_timestamp": get_now(),
                 },
             }
 
@@ -216,7 +220,7 @@ class CallbackModule(CallbackBase):
             status["skipped"] = total['skipped']
             log = list(build_log(self.items[host]))
             metrics["time"] = {"total": int(get_time() - self.start_time)}
-            now = datetime.now().strftime(self.TIME_FORMAT)
+            now = get_now()
             report = {
                 "config_report": {
                     "host": host,

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -107,30 +107,30 @@ class CallbackModule(CallbackBase):
         if HAS_REQUESTS:
             requests_version = requests.__version__.split('.')
             if int(requests_version[0]) < 2 or int(requests_version[1]) < 14:
-                self._disable_plugin('The `requests` python module is too old.')
+                self._disable_plugin(u'The `requests` python module is too old.')
         else:
-            self._disable_plugin('The `requests` python module is not installed.')
+            self._disable_plugin(u'The `requests` python module is not installed.')
 
         if self.FOREMAN_URL.startswith('https://'):
             if not os.path.exists(self.FOREMAN_SSL_CERT[0]):
-                self._disable_plugin('FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])
+                self._disable_plugin(u'FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])
 
             if not os.path.exists(self.FOREMAN_SSL_CERT[1]):
-                self._disable_plugin('FOREMAN_SSL_KEY %s not found.' % self.FOREMAN_SSL_CERT[1])
+                self._disable_plugin(u'FOREMAN_SSL_KEY %s not found.' % self.FOREMAN_SSL_CERT[1])
 
     def _disable_plugin(self, msg):
         self.disabled = True
         if msg:
-            self._display.warning(msg + ' Disabling the Foreman callback plugin.')
+            self._display.warning(msg + u' Disabling the Foreman callback plugin.')
         else:
-            self._display.warning('Disabling the Foreman callback plugin.')
+            self._display.warning(u'Disabling the Foreman callback plugin.')
 
     def _ssl_verify(self):
         if self.FOREMAN_SSL_VERIFY.lower() in ["1", "true", "on"]:
             verify = True
         elif self.FOREMAN_SSL_VERIFY.lower() in ["0", "false", "off"]:
             requests.packages.urllib3.disable_warnings()
-            self._display.warning("SSL verification of %s disabled" %
+            self._display.warning(u"SSL verification of %s disabled" %
                                   self.FOREMAN_URL)
             verify = False
         else:  # Set to a CA bundle:
@@ -160,7 +160,7 @@ class CallbackModule(CallbackBase):
                                   verify=self.ssl_verify)
                 r.raise_for_status()
             except requests.exceptions.RequestException as err:
-                self._display.warning('Sending facts to Foreman at {url} failed for {host}: {err}'.format(
+                self._display.warning(u'Sending facts to Foreman at {url} failed for {host}: {err}'.format(
                     host=host, err=to_text(err), url=self.FOREMAN_URL))
 
     def _build_log(self, data):
@@ -219,7 +219,7 @@ class CallbackModule(CallbackBase):
                                   verify=self.ssl_verify)
                 r.raise_for_status()
             except requests.exceptions.RequestException as err:
-                self._display.warning('Sending report to Foreman at {url} failed for {host}: {err}'.format(
+                self._display.warning(u'Sending report to Foreman at {url} failed for {host}: {err}'.format(
                     host=host, err=to_text(err), url=self.FOREMAN_URL))
             self.items[host] = []
 


### PR DESCRIPTION
##### SUMMARY
Foreman facts callback does not work well when more facts are added from roles

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
foreman

##### ADDITIONAL INFORMATION
We upload facts for any "ok" event, given Foreman behavior, that removes all existing facts in Foreman of Ansible source. While setup phase upload all ansible_* modules, if next play introduces new fact, it deletes all facts from step one and adds just newly added facts. Also sending update for each play is not performance heavy, it's better to build the final set in memory and then send at once.

```paste below
there's no visible change in fact
```
