### PR TITLE
[2.7] [k8s] Always check envvars when auth parameter is not provided (#51495)

### DIFF
--- a/changelogs/fragments/51495-k8s-load-envvars.yaml
+++ b/changelogs/fragments/51495-k8s-load-envvars.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- All K8S_AUTH_* environment variables are now properly loaded by the k8s lookup plugin

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -140,11 +140,11 @@ class K8sAnsibleMixin(object):
         auth = copy.deepcopy(auth_params)
 
         # If authorization variables aren't defined, look for them in environment variables
-        for key, value in iteritems(auth_params):
-            if key in auth_args and value is None:
-                env_value = os.getenv('K8S_AUTH_{0}'.format(key.upper()), None)
+        for arg in auth_args:
+            if auth_params.get(arg) is None:
+                env_value = os.getenv('K8S_AUTH_{0}'.format(arg.upper()), None)
                 if env_value is not None:
-                    auth[key] = env_value
+                    auth[arg] = env_value
 
         def auth_set(*names):
             return all([auth.get(name) for name in names])


### PR DESCRIPTION
(cherry picked from commit 0be66113d4b073131557e3eae6e25762d06c19f2)

##### SUMMARY
This will make it so that all code using the `get_api_client`
method will make use of the environment variables, instead of
silently ignoring them if default values haven't been set. This
affects at least the k8s lookup plugin.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s