### PR TITLE
win_rds move to test group 3

### DIFF
--- a/test/integration/targets/win_rds_cap/aliases
+++ b/test/integration/targets/win_rds_cap/aliases
@@ -1,1 +1,2 @@
-shippable/windows/group4
+shippable/windows/group3
+destructive

--- a/test/integration/targets/win_rds_rap/aliases
+++ b/test/integration/targets/win_rds_rap/aliases
@@ -1,1 +1,2 @@
-shippable/windows/group4
+shippable/windows/group3
+destructive

--- a/test/integration/targets/win_rds_settings/aliases
+++ b/test/integration/targets/win_rds_settings/aliases
@@ -1,1 +1,2 @@
-shippable/windows/group4
+shippable/windows/group3
+destructive


### PR DESCRIPTION
##### SUMMARY
The RDS groups take a long time to finish, this moves them to another group that has more time to spare. Also marks them as destructive as they are destructive tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test