### PR TITLE
Fix performance issue with large task retries.

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -18,6 +18,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleConnectionFailure, AnsibleActionFail, AnsibleActionSkip
 from ansible.executor.task_result import TaskResult
 from ansible.module_utils.six import iteritems, string_types, binary_type
+from ansible.module_utils.six.moves import xrange
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.connection import write_to_file_descriptor
 from ansible.playbook.conditional import Conditional
@@ -638,7 +639,7 @@ class TaskExecutor:
 
         display.debug("starting attempt loop")
         result = None
-        for attempt in range(1, retries + 1):
+        for attempt in xrange(1, retries + 1):
             display.debug("running the handler")
             try:
                 result = self._handler.run(task_vars=variables)


### PR DESCRIPTION
##### SUMMARY

Fix performance issue with large task retries.

Tasks with high retry values on Python 2 will have a long delay before the task starts while the retries are expanded by `range` into a list. Switching to `xrange` from `ansible.module_utils.six.moves` fixes this while maintaining Python 3 compatibility.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

task_executor.py
