### PR TITLE
Ansible.Basic: make module options case insensitive with dep warning

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -94,6 +94,10 @@ add ``$ErrorActionPreference = "Continue"`` to the top of the module. This chang
 of the EAP that was accidentally removed in a previous release and ensure that modules are more resiliant to errors
 that may occur in execution.
 
+PowerShell module options and option choices are currently case insensitive to what is defined in the module
+specification. This behaviour is deprecated and a warning displayed to the user if a case insensitive match was found.
+A future release of Ansible will make these checks case sensitive.
+
 
 Modules removed
 ---------------


### PR DESCRIPTION
##### SUMMARY
Historically module options for PowerShell modules are case insensitive. This PR makes sure the new AnsibleModule continues that behaviour but adds a warning saying this will be changed in a future Ansible version.

Fixes https://github.com/ansible/ansible/issues/51528

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/csharp/Ansible.Basic.cs