### PR TITLE
Fixes issue where uppercase named A_Record delete was getting skipped

### DIFF
--- a/changelogs/fragments/nios_a_record_delete_failure_with_uppercase_name.yaml
+++ b/changelogs/fragments/nios_a_record_delete_failure_with_uppercase_name.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fixes bug where nios_a_record wasn't getting deleted if an uppercase named a_record was being passed. (https://github.com/ansible/ansible/pull/51539)
+

--- a/changelogs/fragments/nios_a_record_delete_failure_with_uppercase_name.yaml
+++ b/changelogs/fragments/nios_a_record_delete_failure_with_uppercase_name.yaml
@@ -1,3 +1,2 @@
 bugfixes:
   - Fixes bug where nios_a_record wasn't getting deleted if an uppercase named a_record was being passed. (https://github.com/ansible/ansible/pull/51539)
-

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -356,6 +356,11 @@ class WapiModule(WapiBase):
                     test_obj_filter = dict([('name', name)])
                 else:
                     test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
+            elif (ib_obj_type == NIOS_A_RECORD):
+                # resolves issue where a_record with uppercase name was returning null and was failing
+                test_obj_filter = obj_filter
+                test_obj_filter['name'] = test_obj_filter['name'].lower()
+            # check if test_obj_filter is empty copy passed obj_filter
             else:
                 test_obj_filter = dict([('name', name)])
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=ib_spec.keys())


### PR DESCRIPTION
* fixes 51193

Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>
(cherry picked from commit 15cef845cab0520af421ee6a903bc173535910fc)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backporting fix of the PR #51193, where A_record delete was getting skipped if the user was passing an uppercase name.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios_a_record
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
cherry-pick from: 15cef845cab0520af421ee6a903bc173535910fc
```
