### PR TITLE
add diff_mode_enabled to documentation

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -84,6 +84,12 @@ options:
       description:
         - Start the playbook at the task matching this name.
       version_added: 2.7
+    diff_mode_enabled:
+      description:
+        - Enable diff mode for the job template.
+      version_added: 2.7
+      type: bool
+      default: 'no'
     fact_caching_enabled:
       description:
         - Enable use of fact caching for the job template.

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -906,7 +906,6 @@ lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py E326
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py E324
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py E323
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py E322
-lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py E325
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_team.py E322
 lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py E317
 lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py E326


### PR DESCRIPTION
option 'diff_mode_enabled' is not mentioned in documentation

+label: docsite_pr

##### SUMMARY
add already implemented option 'diff_mode_enabled' to documentation

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
tower_job_template
