### PR TITLE
crypttab: Trim trailing newlines

### DIFF
--- a/lib/ansible/modules/system/crypttab.py
+++ b/lib/ansible/modules/system/crypttab.py
@@ -212,6 +212,7 @@ class Line(object):
         self.opts = Options(opts)
 
         if line is not None:
+            self.line = self.line.rstrip('\n')
             if self._line_valid(line):
                 self.name, backing_device, password, opts = self._split_line(line)
 


### PR DESCRIPTION
##### SUMMARY
Having a comment or an empty line in /etc/crypttab results in an
additional empty line being added, because the newline that is part of
the line being read is getting re-injected in addition to the newline
used to concatenate the lines.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
crypttab