### PR TITLE
provider_segmentation_id is int

### DIFF
--- a/changelogs/fragments/51600-provider_segmentation_id-is-int.yaml
+++ b/changelogs/fragments/51600-provider_segmentation_id-is-int.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - os_network - According to the OpenStack Networking API the attribute
+    provider:segmentation_id of a network has to be an integer.
+    (https://github.com/ansible/ansible/issues/51655)

--- a/lib/ansible/modules/cloud/openstack/os_network.py
+++ b/lib/ansible/modules/cloud/openstack/os_network.py
@@ -153,7 +153,7 @@ def main():
         external=dict(default=False, type='bool'),
         provider_physical_network=dict(required=False),
         provider_network_type=dict(required=False),
-        provider_segmentation_id=dict(required=False),
+        provider_segmentation_id=dict(required=False, type='int'),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

According to the [OpenStack Networking API](https://developer.openstack.org/api-ref/network/v2/index.html?expanded=create-network-detail#create-network) 
the attribute provider:segmentation_id of a network has to be
an integer.
Even if neutron accepts provider:segmentation_id to be a
string, other implementations may not.

Fixes #51655

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
os_network

##### ADDITIONAL INFORMATION
Verified against packstack rocky with ovn.
