### PR TITLE
Added description to single net interface

### DIFF
--- a/changelogs/fragments/51602-ec2_instance_single_iface_description.yaml
+++ b/changelogs/fragments/51602-ec2_instance_single_iface_description.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_instance - Correctly adds description when adding a single ENI to the instance

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -926,6 +926,8 @@ def build_network_spec(params, ec2=None):
                 ec2=ec2
             )
             spec['Groups'] = [g['GroupId'] for g in groups]
+        if network.get('description') is not None:
+            spec['Description'] = network['description']
         # TODO more special snowflake network things
 
         return [spec]


### PR DESCRIPTION
##### SUMMARY
When adding a single network interface, the description doesn't get added to the created ENI ( further info in #51396 ). 
Fixes #51396

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance.py

##### ADDITIONAL INFORMATION
N/A
