### PR TITLE
added support for breakout ports

### DIFF
--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -108,7 +108,7 @@ options:
     description:
     - The type of interface for the static EPG deployement.
     type: str
-    choices: [ fex, port_channel, switch_port, vpc ]
+    choices: [ breakout, fex, port_channel, switch_port, vpc ]
     default: switch_port
     version_added: '2.6'
   state:
@@ -280,6 +280,7 @@ from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 INTERFACE_TYPE_MAPPING = dict(
+    breakout='uni/infra/funcprof/brkoutportgrp-{0}',
     fex='uni/infra/funcprof/accportgrp-{0}',
     port_channel='uni/infra/funcprof/accbundle-{0}',
     switch_port='uni/infra/funcprof/accportgrp-{0}',
@@ -300,7 +301,7 @@ def main():
         from_card=dict(type='str', aliases=['from_card_range']),
         to_card=dict(type='str', aliases=['to_card_range']),
         policy_group=dict(type='str', aliases=['policy_group_name']),
-        interface_type=dict(type='str', default='switch_port', choices=['fex', 'port_channel', 'switch_port', 'vpc']),
+        interface_type=dict(type='str', default='switch_port', choices=['breakout', 'fex', 'port_channel', 'switch_port', 'vpc']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
 


### PR DESCRIPTION
##### SUMMARY
With the interface_types fex, port_channel, switch_port and vpc we can't create a binding to a policy group which is of type breakout (e.g. "tDn": "uni/infra/funcprof/brkoutportgrp-10g-4x")

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aci_access_port_to_interface_policy_leaf_profile 

##### ADDITIONAL INFORMATION
If we want to split a 40G or 100G port into 4x10G or 4x25G we need to support this type of policy group. 
