### PR TITLE
Allow creating keyed groups without prefix or separator

### DIFF
--- a/changelogs/fragments/51612-keyed_groups_without_prefix.yaml
+++ b/changelogs/fragments/51612-keyed_groups_without_prefix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Do not include prefix or separator in inventory plugin constructured group names if prefix is specified to be null.

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -350,7 +350,10 @@ class Constructable(object):
                         prefix = keyed.get('prefix', '')
                         sep = keyed.get('separator', '_')
 
-                        if isinstance(key, string_types):
+                        if prefix is None:
+                            # Allow user to specify un-keyed group via null
+                            groups.append(key)
+                        elif isinstance(key, string_types):
                             groups.append('%s%s%s' % (prefix, sep, key))
                         elif isinstance(key, list):
                             for name in key:

--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -123,6 +123,9 @@ keyed_groups:
 # places each host in a group named 'azure_loc_(location name)', depending on the VM's location
 - prefix: azure_loc
   key: location
+# place hosts in groups named 'running', 'stopped', 'deallocated', etc., depending on the VM's powerstate
+- prefix: null
+  key: powerstate
 # places host in a group named 'some_tag_X' using the value of the 'sometag' tag on a VM as X, and defaulting to the
 # value 'none' (eg, the group 'some_tag_none') if the 'sometag' tag is not defined for a VM.
 - prefix: some_tag


### PR DESCRIPTION
##### SUMMARY
The current `Constructable` inventory plugin base class does not maintain feature parity with the deprecated inventory scripts. This patch allows a deliberate use of plugin keyed groups such that they use the same group names as the old scripts.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/inventory/__init__.py`
lib/ansible/plugins/inventory/azure_rm.py

Applies to other specific inventory plugins as well.

##### ADDITIONAL INFORMATION
The old script can be invoked via:

```
AZURE_SUBSCRIPTION_ID=<foo> AZURE_CLIENT_ID=<bar> AZURE_SECRET=<foo> AZURE_TENANT=<bar> ansible-inventory -i contrib/inventory/azure_rm.py --list --export
```

This returns content that contains groups that includes:

 - eastus
 - azure
 - linux
 - (many others)

I attempt the same thing with the inventory plugin:

```
AZURE_SUBSCRIPTION_ID=<foo> AZURE_CLIENT_ID=<bar> AZURE_SECRET=<foo> AZURE_TENANT=<bar> ansible-inventory -i azure_rm.yml --list --export
```

Where the inventory file looks like:

```yaml
plugin: azure_rm
auth_source: env
keyed_groups:
- prefix: null
  key: location
- prefix: ""
  key: powerstate
- prefix:
  key: name
```

You can see the docs for where I got some of these ideas from. Here, I am attempting everything thing I can possibly think of in order to restore the old groups - and none of them work. Examples of groups that this produces:

 - None_eastus
 - None_<infrastructure_specific_group>
 - _running

(Note: this means that `None` is in `string_types`)

If I wanted the prefix of "None", I could have put in the literal string "None". Even using the empty string still leaves the separator in.

I need to upgrade people from the scripts to the plugins, and ideally keep referential integrity within the AWX database to the old groups. There's no way to do this without a code change, so that's why I'm proposing this patch. I'd like to consider it for backporting, if it's accepted.

With this patch, `prefix: null` will produce a group named `eastus`.

Ping @jladdjr @kdelee @bcoca 
