### PR TITLE
Adds 'y', 'n', 'on', 'off' to Values to be Converted to Booleans

### DIFF
--- a/lib/ansible/plugins/action/set_fact.py
+++ b/lib/ansible/plugins/action/set_fact.py
@@ -51,7 +51,8 @@ class ActionModule(ActionBase):
                                      "letters, numbers and underscores." % k)
                     return result
 
-                if not C.DEFAULT_JINJA2_NATIVE and isinstance(v, string_types) and v.lower() in ('true', 'false', 'yes', 'no'):
+                v_is_boolean = isinstance(v, string_types) and v.lower() in ('true', 'false', 'yes', 'no', 'y', 'n', 'on', 'off')
+                if v_is_boolean and not C.DEFAULT_JINJA2_NATIVE:
                     v = boolean(v, strict=False)
                 facts[k] = v
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #51618

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
set_fact

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Short playbook which will succeed if `DEFAULT_JINJA2_NATIVE` is set to `False` after applying the patch:

```yaml
- hosts: localhost
  gather_facts: no

  tasks:
    - set_fact:
        string_y: "y"
        string_n: "n"
        string_yes: "yes"
        string_no: "no"
        string_on: "on"
        string_off: "off"
        string_true: "true"
        string_false: "false"
    
    - assert:
        that:
          - string_y ==  "y"
          - string_n ==  "n"
          - string_yes ==  "yes"
          - string_no ==  "no"
          - string_on ==  "on"
          - string_off ==  "off"
          - string_true ==  "true"
          - string_false ==  "false"
      when: lookup('config', 'DEFAULT_JINJA2_NATIVE') == true

    - assert:
        that:
          - string_y ==  true
          - string_n ==  false
          - string_yes ==  true
          - string_no ==  false
          - string_on ==  true
          - string_off ==  false
          - string_true ==  true
          - string_false ==  false
      when: lookup('config', 'DEFAULT_JINJA2_NATIVE') == false
```
