### PR TITLE
Make aws_ses_identity module work when region is provided via enviroment or config

### DIFF
--- a/changelogs/fragments/51531-aws_ses_identity-fix-implicit-region.yaml
+++ b/changelogs/fragments/51531-aws_ses_identity-fix-implicit-region.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - aws_ses_identity module works when region is provided using config or environment variables rather than the region parameter (https://github.com/ansible/ansible/issues/51531)

--- a/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
@@ -215,7 +215,7 @@ notification_attributes:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, get_aws_connection_info
 
 import time
 
@@ -526,7 +526,7 @@ def main():
     state = module.params.get("state")
 
     if state == 'present':
-        region = module.params.get('region')
+        region = get_aws_connection_info(module, boto3=True)[0]
         account_id = get_account_id(module)
         validate_params_for_identity_present(module)
         create_or_update_identity(connection, module, region, account_id)

--- a/test/integration/targets/aws_ses_identity/tasks/main.yaml
+++ b/test/integration/targets/aws_ses_identity/tasks/main.yaml
@@ -111,6 +111,35 @@
         state: absent
         <<: *aws_connection_info
 # ============================================================
+# Test for https://github.com/ansible/ansible/issues/51531
+# because aws region is explicitly used rather than just to
+# obtain a connection, make sure this still works when
+# region comes from an environment rather than a parameter.
+- name: test register identity without explicit region
+  block:
+    - name: register email identity without explicit region
+      aws_ses_identity:
+        identity: "{{ email_identity }}"
+        state: present
+        <<: *aws_connection_info
+        region: "{{ omit }}"
+      register: result
+      environment:
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+    - name: assert changed is True
+      assert:
+        that:
+          - result.changed == True
+    - import_tasks: assert_defaults.yaml
+      vars:
+        identity: "{{ email_identity }}"
+  always:
+    - name: cleanup email identity
+      aws_ses_identity:
+        identity: "{{ email_identity }}"
+        state: absent
+        <<: *aws_connection_info
+# ============================================================
 - name: test register email identity check mode
   block:
     - name: register email identity check mode


### PR DESCRIPTION
##### SUMMARY
fixes #51531 which highlighted that aws_ses_identity will fail if the aws region is specfied using any mechanism other than explicitly passing the region parameter.

This error was introduced in #38422 because region was obtained from the module parameters rather than from `get_aws_connection_info`.

This fix restores the correct behaviour of loading the region using the `get_aws_connection_info` method so region is now consistent with the rest of the AWS modules.

I've checked the other aws_ses_* modulees and they're not affected by this bug.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ses_identity
