### PR TITLE
Correct path of unit tests directory

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -23,9 +23,9 @@ please open a bug or ask for help on Ansible IRC.
 What Are Unit Tests?
 ====================
 
-Ansible includes a set of unit tests in the :file:`test/unit` directory. These tests primarily cover the
+Ansible includes a set of unit tests in the :file:`test/units` directory. These tests primarily cover the
 internals but can also can cover Ansible modules.  The structure of the unit tests matches
-the structure of the code base, so the tests that reside in the :file:`test/unit/modules/` directory
+the structure of the code base, so the tests that reside in the :file:`test/units/modules/` directory
 are organized by module groups.
 
 Integration tests can be used for most modules, but there are situations where


### PR DESCRIPTION
<!--- Your description here -->

+label: docsite_pr

##### SUMMARY
The module unit tests guide states that unit tests are found in test/unit, the actual path is test/units, plural. 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
An ack grep indicates these are the only two instances

```
:~/src/ansible $ ag test/unit[^s]
docs/docsite/rst/dev_guide/testing_units_modules.rst
26:Ansible includes a set of unit tests in the :file:`test/unit` directory. These tests primarily cover the
28:the structure of the code base, so the tests that reside in the :file:`test/unit/modules/` directory
```
