### PR TITLE
pkgutil: add update all, check-mode, squashing and examples

### DIFF
--- a/lib/ansible/modules/packaging/os/pkgutil.py
+++ b/lib/ansible/modules/packaging/os/pkgutil.py
@@ -19,47 +19,46 @@ DOCUMENTATION = r'''
 module: pkgutil
 short_description: Manage CSW-Packages on Solaris
 description:
-    - Manages CSW packages (SVR4 format) on Solaris 10 and 11.
-    - These were the native packages on Solaris <= 10 and are available
-      as a legacy feature in Solaris 11.
-    - Pkgutil is an advanced packaging system, which resolves dependency on installation.
-      It is designed for CSW packages.
-version_added: "1.3"
+- Manages CSW packages (SVR4 format) on Solaris 10 and 11.
+- These were the native packages on Solaris <= 10 and are available as a legacy feature in Solaris 11.
+- Pkgutil is an advanced packaging system, which resolves dependency on installation.
+  It is designed for CSW packages.
+version_added: '1.3'
 author:
-    - Alexander Winkler (@dermute)
-    - David Ponessa (@scathatheworm)
+- Alexander Winkler (@dermute)
+- David Ponessa (@scathatheworm)
 options:
   name:
     description:
-      - The name of the package.
-      - When using C(state=latest), this can be C('*'), which updates all installed packages managed by pkgutil.
+    - The name of the package.
+    - When using C(state=latest), this can be C('*'), which updates all installed packages managed by pkgutil.
     type: list
     required: true
     aliases: [ pkg ]
   site:
     description:
-      - The repository path to install the package from.
-      - Its global definition is done in C(/etc/opt/csw/pkgutil.conf).
+    - The repository path to install the package from.
+    - Its global definition is done in C(/etc/opt/csw/pkgutil.conf).
   state:
     description:
-      - Whether to install (C(present)), or remove (C(absent)) packages.
-      - The upgrade (C(latest)) operation will update/install the packages to the latest version available.
+    - Whether to install (C(present)), or remove (C(absent)) packages.
+    - The upgrade (C(latest)) operation will update/install the packages to the latest version available.
     type: str
     choices: [ absent, latest, present ]
     default: present
   update_catalog:
     description:
-      - If you want to refresh your catalog from the mirror, set this to (C(yes)).
+    - If you want to refresh your catalog from the mirror, set this to (C(yes)).
     type: bool
     default: no
-    version_added: "2.1"
+    version_added: '2.1'
   force:
     description:
-      - Allows the update process to downgrade packages to what is present in the repostory set this to (C(yes)).
-      - It is useful as a rollback to stable from testing, and similar operations.
+    - Allows the update process to downgrade packages to what is present in the repostory set this to (C(yes)).
+    - It is useful as a rollback to stable from testing, and similar operations.
     type: bool
     default: no
-    version_added: "2.5"
+    version_added: '2.8'
 '''
 
 EXAMPLES = r'''
@@ -97,6 +96,8 @@ EXAMPLES = r'''
     state: latest
     force: yes
 '''
+
+RETURN = r''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/lib/ansible/modules/packaging/os/pkgutil.py
+++ b/lib/ansible/modules/packaging/os/pkgutil.py
@@ -112,7 +112,7 @@ def packages_not_installed(module, name):
         if rc != 0:
             pkgs += [ pkg ]
     return pkgs
-    
+
 def packages_installed(module, name):
     # check if each package is installed
     # and return list of the ones present
@@ -125,7 +125,7 @@ def packages_installed(module, name):
         if rc == 0 and 'CSW' in pkg:
             pkgs += [ pkg ]
     return pkgs
-    
+
 def packages_not_latest(module, name, site, update_catalog):
     # check status of each package
     # and return list of the ones with an upgrade available
@@ -271,7 +271,6 @@ def main():
             # If the package list comes up empty, everything is already up to date
             else:
                 module.exit_json(changed=False)
-        
 
     elif state in ['absent', 'removed']:
         # Build list of packages requested for removal that are actually present

--- a/lib/ansible/modules/packaging/os/pkgutil.py
+++ b/lib/ansible/modules/packaging/os/pkgutil.py
@@ -115,8 +115,10 @@ def packages_installed(module, names):
     ''' Check if each package is installed and return list of the ones present '''
     pkgs = []
     for pkg in names:
+        if pkg.startswith('CSW'):
+            continue
         rc, out, err = run_command(module, ['pkginfo', '-q', pkg])
-        if rc == 0 and 'CSW' in pkg:
+        if rc == 0:
             pkgs.append(pkg)
     return pkgs
 
@@ -136,9 +138,8 @@ def packages_not_latest(module, names, site, update_catalog):
     # Find packages in the catalog which are not up to date
     packages = []
     for line in out.split('\n')[1:-1]:
-        if 'catalog' not in line:
-            if 'SAME' not in line:
-                packages.append(line.split(' ')[0])
+        if 'catalog' not in line and 'SAME' not in line:
+            packages.append(line.split(' ')[0])
 
     # Remove duplicates
     return list(set(packages))
@@ -217,7 +218,7 @@ def main():
     if state in ['installed', 'present']:
         # Fail with an explicit error when trying to "install" '*'
         if name == ['*']:
-            module.fail_json(msg="Can not use state: present with name: *")
+            module.fail_json(msg="Can not use 'state: present' with name: '*'")
 
         # Build list of packages that are actually not installed from the ones requested
         pkgs = packages_not_installed(module, name)

--- a/lib/ansible/modules/packaging/os/pkgutil.py
+++ b/lib/ansible/modules/packaging/os/pkgutil.py
@@ -27,7 +27,9 @@ description:
     - Pkgutil is an advanced packaging system, which resolves dependency on installation.
       It is designed for CSW packages.
 version_added: "1.3"
-author: "Alexander Winkler (@dermute)"
+author:
+    - "Alexander Winkler (@dermute)"
+    - "David Ponessa (github.com/scathatheworm)"
 options:
   name:
     description:
@@ -60,7 +62,7 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
-    version_added: "2.4"
+    version_added: "2.5"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/packaging/os/pkgutil.py
+++ b/lib/ansible/modules/packaging/os/pkgutil.py
@@ -44,7 +44,7 @@ options:
     - Whether to install (C(present)), or remove (C(absent)) packages.
     - The upgrade (C(latest)) operation will update/install the packages to the latest version available.
     type: str
-    choices: [ absent, latest, present ]
+    choices: [ absent, installed, latest, present, removed ]
     default: present
   update_catalog:
     description:

--- a/lib/ansible/modules/packaging/os/pkgutil.py
+++ b/lib/ansible/modules/packaging/os/pkgutil.py
@@ -116,7 +116,7 @@ def packages_installed(module, names):
     ''' Check if each package is installed and return list of the ones present '''
     pkgs = []
     for pkg in names:
-        if pkg.startswith('CSW'):
+        if not pkg.startswith('CSW'):
             continue
         rc, out, err = run_command(module, ['pkginfo', '-q', pkg])
         if rc == 0:

--- a/test/integration/targets/pkgutil/aliases
+++ b/test/integration/targets/pkgutil/aliases
@@ -1,0 +1,2 @@
+destructive
+unsupported

--- a/test/integration/targets/pkgutil/tasks/main.yml
+++ b/test/integration/targets/pkgutil/tasks/main.yml
@@ -1,0 +1,116 @@
+# Test code for the pkgutil module
+
+# Copyright: (c) 2019, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+# CLEAN ENVIRONMENT
+- name: Remove CSWtop
+  pkgutil:
+    name: CSWtop
+    state: absent
+  register: originally_installed
+
+
+# ADD PACKAGE
+- name: Add package (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  check_mode: yes
+  register: cm_add_package
+
+- name: Verify cm_add_package
+  assert:
+    that:
+    - cm_add_package is changed
+
+- name: Add package (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  register: nm_add_package
+
+- name: Verify nm_add_package
+  assert:
+    that:
+    - nm_add_package is changed
+
+- name: Add package again (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  check_mode: yes
+  register: cm_add_package_again
+
+- name: Verify cm_add_package_again
+  assert:
+    that:
+    - cm_add_package_again is not changed
+
+- name: Add package again (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  register: nm_add_package_again
+
+- name: Verify nm_add_package_again
+  assert:
+    that:
+    - nm_add_package_again is not changed
+
+
+# REMOVE PACKAGE
+- name: Remove package (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  check_mode: yes
+  register: cm_remove_package
+
+- name: Verify cm_remove_package
+  assert:
+    that:
+    - cm_remove_package is changed
+
+- name: Remove package (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  register: nm_remove_package
+
+- name: Verify nm_remove_package
+  assert:
+    that:
+    - nm_remove_package is changed
+
+- name: Remove package again (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  check_mode: yes
+  register: cm_remove_package_again
+
+- name: Verify cm_remove_package_again
+  assert:
+    that:
+    - cm_remove_package_again is not changed
+
+- name: Remove package again (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  register: nm_remove_package_again
+
+- name: Verify nm_remove_package_again
+  assert:
+    that:
+    - nm_remove_package_again is not changed
+
+
+# RESTORE ENVIRONMENT
+- name: Reinstall CSWtop
+  pkgutil:
+    name: CSWtop
+    state: present
+  when: originally_installed is changed

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -761,7 +761,6 @@ lib/ansible/modules/packaging/os/pacman.py E326
 lib/ansible/modules/packaging/os/pkg5.py E326
 lib/ansible/modules/packaging/os/pkgin.py E322
 lib/ansible/modules/packaging/os/pkgng.py E322
-lib/ansible/modules/packaging/os/pkgutil.py E326
 lib/ansible/modules/packaging/os/portage.py E322
 lib/ansible/modules/packaging/os/portage.py E325
 lib/ansible/modules/packaging/os/portinstall.py E322

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -761,6 +761,7 @@ lib/ansible/modules/packaging/os/pacman.py E326
 lib/ansible/modules/packaging/os/pkg5.py E326
 lib/ansible/modules/packaging/os/pkgin.py E322
 lib/ansible/modules/packaging/os/pkgng.py E322
+lib/ansible/modules/packaging/os/pkgutil.py E326
 lib/ansible/modules/packaging/os/portage.py E322
 lib/ansible/modules/packaging/os/portage.py E325
 lib/ansible/modules/packaging/os/portinstall.py E322


### PR DESCRIPTION
##### SUMMARY
Original PR #27866 from @scathatheworm

When working with Solaris pkgutil CSW packages, I came across this module being very basic in functionality, in particular, that I could not use it to update all CSW packages.

When going into details into the code I also found it did not incorporate a possibility of doing dry-run from the underlying utility, or supported to specify multiple packages for operations.

This module probably sees very little use, but it seemed like nice functionality to add and make it behave a little more like other package modules.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
pkgutil module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
- Added ability to upgrade all packages:
```yaml
- pkgutil:
    name: '*'
    state: latest
```
- Added ability to modify state of a list of packages:
```yaml
- pkgutil:
    name:
    - CSWtop
    - CSWwget
    - CSWlsof
    state: present
```
- Added ability to have underlying tool perform a dry-run when using check mode, pkgutil -n

- Added ability to configure force option to force packages to state determined by repository (downgrade for example)
```yaml
- pkgutil:
    name: CSWtop
    state: latest
    force: yes
```
- Added more examples and documentation to show the new functionality