### PR TITLE
New module: xfs_quota

### DIFF
--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -315,7 +315,6 @@ def main():
 
     module.exit_json(**result)
 
-    return True
 
 
 def quota_report(module, mountpoint, name, quota_type, used_type):

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -1,0 +1,362 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Emmanouil Kampitakis <info@kampitakis.de>
+# Copyright: (c) 2018, William Leemans <willie@elaba.net>
+
+# Contributors:
+# (c) 2018, Emmanouil Kampitakis <info@kampitakis.de>
+# (c) 2018, Nicolas Magliaro <nicolasmagliaro@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: xfs_quota
+short_description: Set Quotas on XFS filesystems
+description:
+  - Configure Quotas on XFS filesystems. /etc/projects and /etc/projid needs to be configured before calling this module when setting project quotas.
+version_added: "2.3"
+author: "William Leemans (@bushvin) <willie@elaba.net>"
+options:
+  type:
+    description:
+      - The xfs quota type.
+    required: true
+    choices:
+      - user
+      - group
+      - project
+  name:
+    description:
+      - the name of the user, group or project to apply the quota to, if other than default
+  mountpoint:
+    description:
+      - the mountpoint on which to apply the quotas
+    required: true
+  bhard:
+    description:
+      - hard blocks quota limit
+  bsoft:
+    description:
+      - soft blocks quota limit
+  ihard:
+    description:
+      - hard inodes quota limit
+  isoft:
+    description:
+      - soft inodes quota limit
+  rtbhard:
+    description:
+      - hard realtime blocks quota limit
+  rtbsoft:
+    description:
+      - soft realtime blocks quota limit
+  state:
+    description:
+      - Whether to apply the limits or remove them.
+      - When removing limit, they are set to 0, and not quite removed.
+    default: present
+    choices:
+      - present
+      - absent
+
+notes:
+   - Not tested on any debian based system
+requirements:
+   - xfsprogs
+'''
+
+EXAMPLES = r'''
+- name: Set default project soft and hard limit on /opt of 1g
+  xfs_quota:
+    type: project
+    mountpoint: /opt
+    bsoft: 1g
+    bhard: 1g
+    state: present
+
+- name: Remove the default limits on /opt
+  xfs_quota:
+    type: project
+    mountpoint: /opt
+    state: absent
+
+- name: Set default soft user inode limits on /home of 1024 inodes and hard of 2048
+  xfs_quota:
+    type: user
+    mountpoint: /home
+    isoft: 1024
+    ihard: 2048
+
+'''
+
+import os
+import sys
+import json
+import pwd
+import grp
+
+from ansible.module_utils.basic import *
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            type=dict(required=True, choices=['user', 'group', 'project']),
+            name=dict(required=False, default=None),
+            mountpoint=dict(aliases=['path'], required=True),
+            bhard=dict(required=False, default=None),
+            bsoft=dict(required=False, default=None),
+            ihard=dict(required=False, default=None),
+            isoft=dict(required=False, default=None),
+            rtbhard=dict(required=False, default=None),
+            rtbsoft=dict(required=False, default=None),
+            state=dict(required=False, default='present', choices=['present', 'absent'])
+        ),
+        supports_check_mode=True
+    )
+
+    quota_type = module.params['type']
+    name = module.params['name']
+    mountpoint = module.params['mountpoint']
+    bhard = module.params['bhard']
+    bsoft = module.params['bsoft']
+    ihard = module.params['ihard']
+    isoft = module.params['isoft']
+    rtbhard = module.params['rtbhard']
+    rtbsoft = module.params['rtbsoft']
+    state = module.params['state']
+
+    if bhard is not None:
+        bhard = human_to_bytes(bhard)
+
+    if bsoft is not None:
+        bsoft = human_to_bytes(bsoft)
+
+    if rtbhard is not None:
+        rtbhard = human_to_bytes(rtbhard)
+
+    if rtbsoft is not None:
+        rtbsoft = human_to_bytes(rtbsoft)
+
+    changed = False
+
+    if os.getuid() != 0:
+        module.fail_json(msg='You need to be root to run this module')
+
+    if not os.path.ismount(mountpoint):
+        module.fail_json(msg='%s is not a mountpoint' % mountpoint)
+
+    mp = get_fs_by_mountpoint(mountpoint)
+    if mp is None:
+        module.fail_json(msg='%s is not a mountpoint or not located on an xfs filesystem.' % mountpoint)
+
+    if quota_type == 'user':
+        type_arg = '-u'
+        quota_default = 'root'
+        if name is None:
+            name = quota_default
+
+        if 'uquota' not in mp['mntopts'] \
+                and 'usrquota' not in mp['mntopts'] \
+                and 'quota' not in mp['mntopts'] \
+                and 'uqnoenforce' not in mp['mntopts'] \
+                and 'qnoenforce' not in mp['mntopts']:
+            module.fail_json(
+                msg='%s is not mounted with the uquota/usrquota/quota/uqnoenforce/qnoenforce option.'
+                    % mountpoint
+            )
+        try:
+            pwd.getpwnam(name)
+        except:
+            module.fail_json(msg='User %s doesn\'t exist.' % name)
+
+    if quota_type == 'group':
+        type_arg = '-g'
+        quota_default = 'root'
+        if name is None:
+            name = quota_default
+
+        if 'gquota' not in mp['mntopts'] and 'grpquota' not in mp['mntopts'] and 'gqnoenforce' not in mp['mntopts']:
+            module.fail_json(
+                msg='%s is not mounted with the gquota/grpquota/gqnoenforce option. (current options: %s)'
+                    % (mountpoint, mp['mntopts'])
+            )
+        try:
+            grp.getgrnam(name)
+        except:
+            module.fail_json(msg='User %s doesn\'t exist.' % name)
+
+    elif quota_type == 'project':
+        type_arg = '-p'
+        quota_default = '#0'
+        if name is None:
+            name = quota_default
+
+        if 'pquota' not in mp['mntopts'] and 'prjquota' not in mp['mntopts'] and 'pqnoenforce' not in mp['mntopts']:
+            module.fail_json(msg='%s is not mounted with the pquota/prjquota/pqnoenforce option.' % mountpoint)
+
+        if name != quota_default and not os.path.isfile('/etc/projects'):
+            module.fail_json(msg='/etc/projects doesn\'t exist.')
+
+        if name != quota_default and not os.path.isfile('/etc/projid'):
+            module.fail_json(msg='/etc/projid doesn\'t exist.')
+
+        if name != quota_default and name is not None and get_project_id(name) is None:
+            module.fail_json(msg='%s hasn\'t been defined in /etc/projid.' % name)
+
+        prj_set = True
+        if name != quota_default:
+            cmd = 'project %s' % name
+            r = exec_quota(module, cmd, mountpoint)
+            if r['rc'] != 0:
+                module.fail_json(msg='Could not get project state.', cmd=cmd, retval=r)
+            else:
+                for line in r['stdout']:
+                    if '%s - project identifier is not set' in line:
+                        prj_set = False
+                        break
+
+        if not prj_set and not module.check_mode:
+            cmd = 'project -s'
+            r = exec_quota(module, cmd, mountpoint)
+            if r['rc'] != 0:
+                module.fail_json(msg='Could not get quota realtime block report.', cmd=cmd, retval=r)
+            else:
+                changed = True
+        elif not prj_set and module.check_mode:
+            changed = True
+
+    changed = False
+
+    # Set limits
+    if state == 'absent':
+        bhard = 0
+        bsoft = 0
+        ihard = 0
+        isoft = 0
+        rtbhard = 0
+        rtbsoft = 0
+
+    if bsoft is not None or bhard is not None:
+        current_bsoft, current_bhard = quota_report(module, mountpoint, name, quota_type, 'b')
+
+    if isoft is not None or ihard is not None:
+        current_isoft, current_ihard = quota_report(module, mountpoint, name, quota_type, 'i')
+
+    if rtbsoft is not None or rtbhard is not None:
+        current_rtbsoft, current_rtbhard = quota_report(module, mountpoint, name, quota_type, 'rtb')
+
+    limit = []
+    if bsoft is not None and int(bsoft/1024) != current_bsoft:
+        limit.append('bsoft=%s' % bsoft)
+
+    if bhard is not None and int(bhard/1024) != current_bhard:
+        limit.append('bhard=%s' % bhard)
+
+    if isoft is not None and isoft != current_isoft:
+        limit.append('isoft=%s' % isoft)
+
+    if ihard is not None and ihard != current_ihard:
+        limit.append('ihard=%s' % ihard)
+
+    if rtbsoft is not None and int(rtbsoft/1024) != current_rtbsoft:
+        limit.append('rtbsoft=%s' % rtbsoft)
+
+    if rtbhard is not None and int(rtbhard/1024) != current_rtbhard:
+        limit.append('rtbhard=%s' % rtbhard)
+
+    if len(limit) > 0 and not module.check_mode:
+        if name == quota_default:
+            cmd = 'limit %s -d %s' % (type_arg, ' '.join(limit))
+        else:
+            cmd = 'limit %s %s %s' % (type_arg, ' '.join(limit), name)
+
+        r = exec_quota(module, cmd, mountpoint)
+        if r['rc'] != 0:
+            module.fail_json(msg='Could not set limits.', cmd=cmd, retval=r)
+        else:
+            changed = True
+    elif len(limit) > 0 and module.check_mode:
+        changed = True
+
+    module.exit_json(changed=changed)
+
+
+def quota_report(module, mountpoint, name, quota_type, used_type):
+    soft = None
+    hard = None
+
+    if quota_type == 'project':
+        type_arg = '-p'
+    elif quota_type == 'user':
+        type_arg = '-u'
+    elif quota_type == 'group':
+        type_arg = '-g'
+
+    if used_type == 'b':
+        used_arg = '-b'
+        used_name = 'blocks'
+    elif used_type == 'i':
+        used_arg = '-i'
+        used_name = 'inodes'
+    elif used_type == 'rtb':
+        used_arg = '-r'
+        used_name = 'realtime blocks'
+
+    r = exec_quota(module, 'report %s %s' % (type_arg, used_arg), mountpoint)
+
+    if r['rc'] != 0:
+        module.fail_json(msg='Could not get quota report for %s (%s).' % (used_name, r['stderr']))
+    else:
+        for line in r['stdout']:
+            line = line.strip().split()
+            if len(line) and line[0] == name:
+                soft = int(line[2])
+                hard = int(line[3])
+                break
+
+    return soft, hard
+
+
+def exec_quota(module, cmd, mountpoint):
+    cmd = ['xfs_quota', '-x', '-c'] + [cmd, mountpoint]
+    (rc, stdout, stderr) = module.run_command(cmd, use_unsafe_shell=True)
+    return {'rc': rc, 'stdout': stdout.split('\n'), 'stderr': stderr.split('\n')}
+
+
+def get_fs_by_mountpoint(mountpoint):
+    mpr = None
+    with open('/proc/mounts', 'r') as s:
+        for line in s.readlines():
+            mp = line.strip().split()
+            if len(mp) == 6 and mp[1] == mountpoint and mp[2] == 'xfs':
+                mpr = dict(zip(['spec', 'file', 'vfstype', 'mntopts', 'freq', 'passno'], mp))
+                mpr['mntopts'] = mpr['mntopts'].split(',')
+                break
+    return mpr
+
+
+def get_project_id(name):
+    prjid = None
+    with open('/etc/projid', 'r') as s:
+        for line in s.readlines():
+            line = line.strip().partition(':')
+            if line[0] == name:
+                prjid = line[2]
+                break
+
+    return prjid
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -216,7 +216,7 @@ def main():
             module.fail_json(msg='%s is not mounted with the pquota/prjquota/pqnoenforce option.' % mountpoint, **result)
 
         if name != quota_default and not os.path.isfile('/etc/projects'):
-            module.fail_json(msg='/etc/projects doesn\'t exist.', **result)
+            module.fail_json(msg="Path '/etc/projects' does not exist.", **result)
 
         if name != quota_default and not os.path.isfile('/etc/projid'):
             module.fail_json(msg='/etc/projid doesn\'t exist.', **result)

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -251,8 +251,6 @@ def main():
         elif not prj_set and module.check_mode:
             result['changed'] = True
 
-    result['changed'] = False
-
     # Set limits
     if state == 'absent':
         bhard = 0

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -123,15 +123,15 @@ from ansible.module_utils.basic import human_to_bytes
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            bhard=dict(type='str', required=False, default=None),
-            bsoft=dict(type='str', required=False, default=None),
-            ihard=dict(type='int', required=False, default=None),
-            isoft=dict(type='int', required=False, default=None),
+            bhard=dict(type='str'),
+            bsoft=dict(type='str'),
+            ihard=dict(type='int'),
+            isoft=dict(type='int'),
             mountpoint=dict(type='str', required=True),
-            name=dict(type='str', required=False, default=None),
-            rtbhard=dict(type='str', required=False, default=None),
-            rtbsoft=dict(type='str', required=False, default=None),
-            state=dict(type='str', required=False, default='present', choices=['present', 'absent']),
+            name=dict(type='str'),
+            rtbhard=dict(type='str'),
+            rtbsoft=dict(type='str'),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
             type=dict(type='str', required=True, choices=['user', 'group', 'project'])
         ),
         supports_check_mode=True

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: xfs_quota
 short_description: Manage quotas on XFS filesystems

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -176,14 +176,10 @@ def main():
         if name is None:
             name = quota_default
 
-        if 'uquota' not in mp['mntopts'] \
-                and 'usrquota' not in mp['mntopts'] \
-                and 'quota' not in mp['mntopts'] \
-                and 'uqnoenforce' not in mp['mntopts'] \
-                and 'qnoenforce' not in mp['mntopts']:
+        if 'uquota' not in mp['mntopts'] and 'usrquota' not in mp['mntopts'] and 'quota' not in mp['mntopts'] and 'uqnoenforce' not in mp['mntopts'] and \
+                'qnoenforce' not in mp['mntopts']:
             module.fail_json(
-                msg="Path '%s' is not mounted with the uquota/usrquota/quota/uqnoenforce/qnoenforce option."
-                    % mountpoint, **result
+                msg="Path '%s' is not mounted with the uquota/usrquota/quota/uqnoenforce/qnoenforce option." % mountpoint, **result
             )
         try:
             pwd.getpwnam(name)
@@ -198,8 +194,7 @@ def main():
 
         if 'gquota' not in mp['mntopts'] and 'grpquota' not in mp['mntopts'] and 'gqnoenforce' not in mp['mntopts']:
             module.fail_json(
-                msg="Path '%s' is not mounted with the gquota/grpquota/gqnoenforce option. (current options: %s)"
-                    % (mountpoint, mp['mntopts']), **result
+                msg="Path '%s' is not mounted with the gquota/grpquota/gqnoenforce option. (current options: %s)" % (mountpoint, mp['mntopts']), **result
             )
         try:
             grp.getgrnam(name)
@@ -280,27 +275,27 @@ def main():
     limit = []
     if bsoft is not None and int(bsoft) != current_bsoft:
         limit.append('bsoft=%s' % bsoft)
-        result['xfs_quota']['bsoft'] = int(bsoft)
+        result['bsoft'] = int(bsoft)
 
     if bhard is not None and int(bhard) != current_bhard:
         limit.append('bhard=%s' % bhard)
-        result['xfs_quota']['bhard'] = int(bhard)
+        result['bhard'] = int(bhard)
 
     if isoft is not None and isoft != current_isoft:
         limit.append('isoft=%s' % isoft)
-        result['xfs_quota']['isoft'] = isoft
+        result['isoft'] = isoft
 
     if ihard is not None and ihard != current_ihard:
         limit.append('ihard=%s' % ihard)
-        result['xfs_quota']['ihard'] = ihard
+        result['ihard'] = ihard
 
     if rtbsoft is not None and int(rtbsoft) != current_rtbsoft:
         limit.append('rtbsoft=%s' % rtbsoft)
-        result['xfs_quota']['rtbsoft'] = int(rtbsoft)
+        result['rtbsoft'] = int(rtbsoft)
 
     if rtbhard is not None and int(rtbhard) != current_rtbhard:
         limit.append('rtbhard=%s' % rtbhard)
-        result['xfs_quota']['rtbhard'] = int(rtbhard)
+        result['rtbhard'] = int(rtbhard)
 
     if len(limit) > 0 and not module.check_mode:
         if name == quota_default:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -123,16 +123,16 @@ from ansible.module_utils.basic import human_to_bytes
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            type=dict(required=True, choices=['user', 'group', 'project']),
-            name=dict(required=False, default=None),
-            mountpoint=dict(required=True),
             bhard=dict(required=False, default=None),
             bsoft=dict(required=False, default=None),
             ihard=dict(required=False, default=None),
             isoft=dict(required=False, default=None),
+            mountpoint=dict(required=True),
+            name=dict(required=False, default=None),
             rtbhard=dict(required=False, default=None),
             rtbsoft=dict(required=False, default=None),
-            state=dict(required=False, default='present', choices=['present', 'absent'])
+            state=dict(required=False, default='present', choices=['present', 'absent']),
+            type=dict(required=True, choices=['user', 'group', 'project'])
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -222,7 +222,7 @@ def main():
             module.fail_json(msg="Path '/etc/projid' does not exist.", **result)
 
         if name != quota_default and name is not None and get_project_id(name) is None:
-            module.fail_json(msg='%s hasn\'t been defined in /etc/projid.' % name, **result)
+            module.fail_json(msg="Entry '%s' has not been defined in /etc/projid." % name, **result)
 
         prj_set = True
         if name != quota_default:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
 ---
 module: xfs_quota
 short_description: Set Quotas on XFS filesystems
-descrition:
+description:
   - Configure Quotas on XFS filesystems. /etc/projects and /etc/projid needs to be configured before calling this module when setting project quotas.
 version_added: "2.8"
 author: "William Leemans (@bushvin) <willie@elaba.net>"

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {
-    'metadata_version': '1.0',
+    'metadata_version': '1.1',
     'status': ['preview'],
     'supported_by': 'community'
 }
@@ -24,7 +24,7 @@ module: xfs_quota
 short_description: Set Quotas on XFS filesystems
 description:
   - Configure Quotas on XFS filesystems. /etc/projects and /etc/projid needs to be configured before calling this module when setting project quotas.
-version_added: "2.3"
+version_added: "2.8"
 author: "William Leemans (@bushvin) <willie@elaba.net>"
 options:
   type:
@@ -113,7 +113,7 @@ def main():
         argument_spec=dict(
             type=dict(required=True, choices=['user', 'group', 'project']),
             name=dict(required=False, default=None),
-            mountpoint=dict(aliases=['path'], required=True),
+            mountpoint=dict(required=True),
             bhard=dict(required=False, default=None),
             bsoft=dict(required=False, default=None),
             ihard=dict(required=False, default=None),
@@ -290,6 +290,8 @@ def main():
         changed = True
 
     module.exit_json(changed=changed)
+
+    return True
 
 
 def quota_report(module, mountpoint, name, quota_type, used_type):

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -28,7 +28,7 @@ author:
 options:
   type:
     description:
-      - The xfs quota type.
+      - The XFS quota type.
     type: str
     required: true
     choices:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -168,7 +168,7 @@ def main():
 
     mp = get_fs_by_mountpoint(mountpoint)
     if mp is None:
-        module.fail_json(msg="Path '%s' is not a mount point or not located on an xfs file system.' % mountpoint, **result)
+        module.fail_json(msg="Path '%s' is not a mount point or not located on an xfs file system." % mountpoint, **result)
 
     if quota_type == 'user':
         type_arg = '-u'

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -265,12 +265,12 @@ def main():
     current_rtbsoft, current_rtbhard = quota_report(module, mountpoint, name, quota_type, 'rtb')
 
     result['xfs_quota'] = dict(
-        bsoft = current_bsoft,
-        bhard = current_bhard,
-        isoft = current_isoft,
-        ihard = current_ihard,
-        rtbsoft = current_rtbsoft,
-        rtbhard = current_rtbhard
+        bsoft=current_bsoft,
+        bhard=current_bhard,
+        isoft=current_isoft,
+        ihard=current_ihard,
+        rtbsoft=current_rtbsoft,
+        rtbhard=current_rtbhard
     )
 
     limit = []

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -311,7 +311,7 @@ def main():
         rc, stdout, stderr = exec_quota(module, cmd, mountpoint)
         if rc != 0:
             result['cmd'] = cmd
-            result['rc'] = rc 
+            result['rc'] = rc
             result['stdout'] = stdout
             result['stderr'] = stderr
             module.fail_json(msg='Could not set limits.', **result)
@@ -322,7 +322,6 @@ def main():
         result['changed'] = True
 
     module.exit_json(**result)
-
 
 
 def quota_report(module, mountpoint, name, quota_type, used_type):
@@ -350,12 +349,12 @@ def quota_report(module, mountpoint, name, quota_type, used_type):
 
     if rc != 0:
         result = dict(
-                changed=False,
-                rc=rc,
-                stdout=stdout,
-                stderr=stderr,
-                )
-        module.fail_json(msg='Could not get quota report for %s.' % used_name,**result)
+            changed=False,
+            rc=rc,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        module.fail_json(msg='Could not get quota report for %s.' % used_name, **result)
 
     for line in stdout.split('\n'):
         line = line.strip().split()
@@ -375,7 +374,6 @@ def exec_quota(module, cmd, mountpoint):
         module.fail_json(msg='You need to be root or have CAP_SYS_ADMIN capability to perform this operation')
 
     return rc, stdout, stderr
-
 
 
 def get_fs_by_mountpoint(mountpoint):

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -117,7 +117,6 @@ import os
 import pwd
 
 from ansible.module_utils.basic import AnsibleModule, human_to_bytes
-from ansible.module_utils.basic import human_to_bytes
 
 
 def main():

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -123,16 +123,16 @@ from ansible.module_utils.basic import human_to_bytes
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            bhard=dict(required=False, default=None),
-            bsoft=dict(required=False, default=None),
-            ihard=dict(required=False, default=None),
-            isoft=dict(required=False, default=None),
-            mountpoint=dict(required=True),
-            name=dict(required=False, default=None),
-            rtbhard=dict(required=False, default=None),
-            rtbsoft=dict(required=False, default=None),
-            state=dict(required=False, default='present', choices=['present', 'absent']),
-            type=dict(required=True, choices=['user', 'group', 'project'])
+            bhard=dict(type='str', required=False, default=None),
+            bsoft=dict(type='str', required=False, default=None),
+            ihard=dict(type='int', required=False, default=None),
+            isoft=dict(type='int', required=False, default=None),
+            mountpoint=dict(type='str', required=True),
+            name=dict(type='str', required=False, default=None),
+            rtbhard=dict(type='str', required=False, default=None),
+            rtbsoft=dict(type='str', required=False, default=None),
+            state=dict(type='str', required=False, default='present', choices=['present', 'absent']),
+            type=dict(type='str', required=True, choices=['user', 'group', 'project'])
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -80,8 +80,6 @@ options:
       - present
       - absent
 
-notes:
-   - Not tested on any debian based system
 requirements:
    - xfsprogs
 '''

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -42,9 +42,11 @@ options:
   bhard:
     description:
       - Hard blocks quota limit.
+      - This argument supports human readable sizes.
   bsoft:
     description:
       - Soft blocks quota limit.
+      - This argument supports human readable sizes.
   ihard:
     description:
       - Hard inodes quota limit.
@@ -54,9 +56,11 @@ options:
   rtbhard:
     description:
       - Hard realtime blocks quota limit.
+      - This argument supports human readable sizes.
   rtbsoft:
     description:
       - Soft realtime blocks quota limit.
+      - This argument supports human readable sizes.
   state:
     description:
       - Whether to apply the limits or remove them.

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -113,7 +113,6 @@ EXAMPLES = r'''
 RETURN = ''' # '''
 
 import grp
-import json
 import os
 import pwd
 import sys

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -110,11 +110,11 @@ EXAMPLES = r'''
 
 RETURN = ''' # '''
 
-import os
-import sys
-import json
-import pwd
 import grp
+import json
+import os
+import pwd
+import sys
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import human_to_bytes

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -164,7 +164,7 @@ def main():
     )
 
     if not os.path.ismount(mountpoint):
-        module.fail_json(msg='%s is not a mountpoint' % mountpoint, **result)
+        module.fail_json(msg="Path '%s' is not a mount point" % mountpoint, **result)
 
     mp = get_fs_by_mountpoint(mountpoint)
     if mp is None:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -105,8 +105,8 @@ import json
 import pwd
 import grp
 
-from ansible.module_utils.basic import *
-
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import human_to_bytes
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -115,7 +115,6 @@ RETURN = ''' # '''
 import grp
 import os
 import pwd
-import sys
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import human_to_bytes

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -198,7 +198,7 @@ def main():
 
         if 'gquota' not in mp['mntopts'] and 'grpquota' not in mp['mntopts'] and 'gqnoenforce' not in mp['mntopts']:
             module.fail_json(
-                msg='%s is not mounted with the gquota/grpquota/gqnoenforce option. (current options: %s)'
+                msg="Path '%s' is not mounted with the gquota/grpquota/gqnoenforce option. (current options: %s)"
                     % (mountpoint, mp['mntopts']), **result
             )
         try:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -182,7 +182,7 @@ def main():
                 and 'uqnoenforce' not in mp['mntopts'] \
                 and 'qnoenforce' not in mp['mntopts']:
             module.fail_json(
-                msg='%s is not mounted with the uquota/usrquota/quota/uqnoenforce/qnoenforce option.'
+                msg="Path '%s' is not mounted with the uquota/usrquota/quota/uqnoenforce/qnoenforce option."
                     % mountpoint, **result
             )
         try:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -278,13 +278,13 @@ def main():
     )
 
     limit = []
-    if bsoft is not None and int(bsoft / 1024) != current_bsoft:
+    if bsoft is not None and int(bsoft) != current_bsoft:
         limit.append('bsoft=%s' % bsoft)
-        result['xfs_quota']['bsoft'] = int(bsoft / 1024)
+        result['xfs_quota']['bsoft'] = int(bsoft)
 
-    if bhard is not None and int(bhard / 1024) != current_bhard:
+    if bhard is not None and int(bhard) != current_bhard:
         limit.append('bhard=%s' % bhard)
-        result['xfs_quota']['bhard'] = int(bhard / 1024)
+        result['xfs_quota']['bhard'] = int(bhard)
 
     if isoft is not None and isoft != current_isoft:
         limit.append('isoft=%s' % isoft)
@@ -294,13 +294,13 @@ def main():
         limit.append('ihard=%s' % ihard)
         result['xfs_quota']['ihard'] = ihard
 
-    if rtbsoft is not None and int(rtbsoft / 1024) != current_rtbsoft:
+    if rtbsoft is not None and int(rtbsoft) != current_rtbsoft:
         limit.append('rtbsoft=%s' % rtbsoft)
-        result['xfs_quota']['rtbsoft'] = int(rtbsoft / 1024)
+        result['xfs_quota']['rtbsoft'] = int(rtbsoft)
 
-    if rtbhard is not None and int(rtbhard / 1024) != current_rtbhard:
+    if rtbhard is not None and int(rtbhard) != current_rtbhard:
         limit.append('rtbhard=%s' % rtbhard)
-        result['xfs_quota']['rtbhard'] = int(rtbhard / 1024)
+        result['xfs_quota']['rtbhard'] = int(rtbhard)
 
     if len(limit) > 0 and not module.check_mode:
         if name == quota_default:
@@ -338,12 +338,15 @@ def quota_report(module, mountpoint, name, quota_type, used_type):
     if used_type == 'b':
         used_arg = '-b'
         used_name = 'blocks'
+        factor = 1024
     elif used_type == 'i':
         used_arg = '-i'
         used_name = 'inodes'
+        factor = 1
     elif used_type == 'rtb':
         used_arg = '-r'
         used_name = 'realtime blocks'
+        factor = 1024
 
     rc, stdout, stderr = exec_quota(module, 'report %s %s' % (type_arg, used_arg), mountpoint)
 
@@ -359,8 +362,8 @@ def quota_report(module, mountpoint, name, quota_type, used_type):
     for line in stdout.split('\n'):
         line = line.strip().split()
         if len(line) > 3 and line[0] == name:
-            soft = int(line[2])
-            hard = int(line[3])
+            soft = int(line[2]) * factor
+            hard = int(line[3]) * factor
             break
 
     return soft, hard

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -188,7 +188,7 @@ def main():
         try:
             pwd.getpwnam(name)
         except KeyError as e:
-            module.fail_json(msg='User %s doesn\'t exist.' % name, **result)
+            module.fail_json(msg="User '%s' does not exist." % name, **result)
 
     if quota_type == 'group':
         type_arg = '-g'

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -110,7 +110,38 @@ EXAMPLES = r'''
 
 '''
 
-RETURN = ''' # '''
+RETURN = r'''
+bhard:
+    description: the current bhard setting in bytes
+    returned: always
+    type: int
+    sample: 1024
+bsoft:
+    description: the current bsoft setting in bytes
+    returned: always
+    type: int
+    sample: 1024
+ihard:
+    description: the current ihard setting in bytes
+    returned: always
+    type: int
+    sample: 100
+isoft:
+    description: the current isoft setting in bytes
+    returned: always
+    type: int
+    sample: 100
+rtbhard:
+    description: the current rtbhard setting in bytes
+    returned: always
+    type: int
+    sample: 1024
+rtbsoft:
+    description: the current rtbsoft setting in bytes
+    returned: always
+    type: int
+    sample: 1024
+'''
 
 import grp
 import os

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -168,7 +168,7 @@ def main():
 
     mp = get_fs_by_mountpoint(mountpoint)
     if mp is None:
-        module.fail_json(msg='%s is not a mountpoint or not located on an xfs filesystem.' % mountpoint, **result)
+        module.fail_json(msg="Path '%s' is not a mount point or not located on an xfs file system.' % mountpoint, **result)
 
     if quota_type == 'user':
         type_arg = '-u'

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -133,7 +133,7 @@ def main():
             state=dict(type='str', default='present', choices=['absent', 'present']),
             type=dict(type='str', required=True, choices=['group', 'project', 'user'])
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     quota_type = module.params['type']

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -249,8 +249,9 @@ def main():
                 result['stdout'] = stdout
                 result['stderr'] = stderr
                 module.fail_json(msg='Could not get quota realtime block report.', **result)
-            else:
-                result['changed'] = True
+
+            result['changed'] = True
+
         elif not prj_set and module.check_mode:
             result['changed'] = True
 
@@ -314,8 +315,8 @@ def main():
             result['stdout'] = stdout
             result['stderr'] = stderr
             module.fail_json(msg='Could not set limits.', **result)
-        else:
-            result['changed'] = True
+
+        result['changed'] = True
 
     elif len(limit) > 0 and module.check_mode:
         result['changed'] = True
@@ -355,13 +356,13 @@ def quota_report(module, mountpoint, name, quota_type, used_type):
                 stderr=stderr,
                 )
         module.fail_json(msg='Could not get quota report for %s.' % used_name,**result)
-    else:
-        for line in stdout.split('\n'):
-            line = line.strip().split()
-            if len(line) > 3 and line[0] == name:
-                soft = int(line[2])
-                hard = int(line[3])
-                break
+
+    for line in stdout.split('\n'):
+        line = line.strip().split()
+        if len(line) > 3 and line[0] == name:
+            soft = int(line[2])
+            hard = int(line[3])
+            break
 
     return soft, hard
 

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -228,7 +228,7 @@ def main():
         if name != quota_default:
             cmd = 'project %s' % name
             rc, stdout, stderr = exec_quota(module, cmd, mountpoint)
-            if rrc != 0:
+            if rc != 0:
                 result['cmd'] = cmd
                 result['rc'] = rc
                 result['stdout'] = stdout

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -204,7 +204,7 @@ def main():
         try:
             grp.getgrnam(name)
         except KeyError as e:
-            module.fail_json(msg='User %s doesn\'t exist.' % name, **result)
+            module.fail_json(msg="User '%s' does not exist." % name, **result)
 
     elif quota_type == 'project':
         type_arg = '-p'

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -18,7 +18,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: xfs_quota
-short_description: Set Quotas on XFS filesystems
+short_description: Manage quotas on XFS filesystems
 description:
   - Configure Quotas on XFS filesystems. /etc/projects and /etc/projid needs to be configured before calling this module when setting project quotas.
 version_added: "2.8"

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -41,7 +41,7 @@ options:
     type: str
   mountpoint:
     description:
-      - the mountpoint on which to apply the quotas
+      - The mount point on which to apply the quotas.
     type: str
     required: true
   bhard:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -160,7 +160,9 @@ def main():
     if rtbsoft is not None:
         rtbsoft = human_to_bytes(rtbsoft)
 
-    changed = False
+    result = dict(
+        changed = False
+    )
 
     if os.getuid() != 0:
         module.fail_json(msg='You need to be root to run this module')
@@ -244,11 +246,11 @@ def main():
             if r['rc'] != 0:
                 module.fail_json(msg='Could not get quota realtime block report.', cmd=cmd, retval=r)
             else:
-                changed = True
+                result['changed'] = True
         elif not prj_set and module.check_mode:
-            changed = True
+            result['changed'] = True
 
-    changed = False
+    result['changed'] = False
 
     # Set limits
     if state == 'absent':
@@ -297,11 +299,11 @@ def main():
         if r['rc'] != 0:
             module.fail_json(msg='Could not set limits.', cmd=cmd, retval=r)
         else:
-            changed = True
+            result['changed'] = True
     elif len(limit) > 0 and module.check_mode:
-        changed = True
+        result['changed'] = True
 
-    module.exit_json(changed=changed)
+    module.exit_json(**result)
 
     return True
 

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -4,9 +4,6 @@
 # Copyright: (c) 2018, Emmanouil Kampitakis <info@kampitakis.de>
 # Copyright: (c) 2018, William Leemans <willie@elaba.net>
 
-# Contributors:
-# (c) 2018, Emmanouil Kampitakis <info@kampitakis.de>
-# (c) 2018, Nicolas Magliaro <nicolasmagliaro@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -260,33 +260,43 @@ def main():
         rtbhard = 0
         rtbsoft = 0
 
-    if bsoft is not None or bhard is not None:
-        current_bsoft, current_bhard = quota_report(module, mountpoint, name, quota_type, 'b')
+    current_bsoft, current_bhard = quota_report(module, mountpoint, name, quota_type, 'b')
+    current_isoft, current_ihard = quota_report(module, mountpoint, name, quota_type, 'i')
+    current_rtbsoft, current_rtbhard = quota_report(module, mountpoint, name, quota_type, 'rtb')
 
-    if isoft is not None or ihard is not None:
-        current_isoft, current_ihard = quota_report(module, mountpoint, name, quota_type, 'i')
-
-    if rtbsoft is not None or rtbhard is not None:
-        current_rtbsoft, current_rtbhard = quota_report(module, mountpoint, name, quota_type, 'rtb')
+    result['xfs_quota'] = dict(
+        bsoft = current_bsoft,
+        bhard = current_bhard,
+        isoft = current_isoft,
+        ihard = current_ihard,
+        rtbsoft = current_rtbsoft,
+        rtbhard = current_rtbhard
+    )
 
     limit = []
     if bsoft is not None and int(bsoft / 1024) != current_bsoft:
         limit.append('bsoft=%s' % bsoft)
+        result['xfs_quota']['bsoft'] = int(bsoft / 1024)
 
     if bhard is not None and int(bhard / 1024) != current_bhard:
         limit.append('bhard=%s' % bhard)
+        result['xfs_quota']['bhard'] = int(bhard / 1024)
 
     if isoft is not None and isoft != current_isoft:
         limit.append('isoft=%s' % isoft)
+        result['xfs_quota']['isoft'] = isoft
 
     if ihard is not None and ihard != current_ihard:
         limit.append('ihard=%s' % ihard)
+        result['xfs_quota']['ihard'] = ihard
 
     if rtbsoft is not None and int(rtbsoft / 1024) != current_rtbsoft:
         limit.append('rtbsoft=%s' % rtbsoft)
+        result['xfs_quota']['rtbsoft'] = int(rtbsoft / 1024)
 
     if rtbhard is not None and int(rtbhard / 1024) != current_rtbhard:
         limit.append('rtbhard=%s' % rtbhard)
+        result['xfs_quota']['rtbhard'] = int(rtbhard / 1024)
 
     if len(limit) > 0 and not module.check_mode:
         if name == quota_default:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -160,7 +160,7 @@ def main():
         rtbsoft = human_to_bytes(rtbsoft)
 
     result = dict(
-        changed=False
+        changed=False,
     )
 
     if not os.path.ismount(mountpoint):

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -335,7 +335,7 @@ def quota_report(module, mountpoint, name, quota_type, used_type):
     r = exec_quota(module, 'report %s %s' % (type_arg, used_arg), mountpoint)
 
     if r['rc'] != 0:
-        module.fail_json(msg='Could not get quota report for %s (%s).' % (used_name, r['stderr']), **result)
+        module.fail_json(msg='Could not get quota report for %s (%s).' % (used_name, r['stderr']))
     else:
         for line in r['stdout']:
             line = line.strip().split()

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -22,7 +22,8 @@ short_description: Set Quotas on XFS filesystems
 description:
   - Configure Quotas on XFS filesystems. /etc/projects and /etc/projid needs to be configured before calling this module when setting project quotas.
 version_added: "2.8"
-author: "William Leemans (@bushvin) <willie@elaba.net>"
+author:
+- William Leemans (@bushvin)
 options:
   type:
     description:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -20,7 +20,8 @@ DOCUMENTATION = '''
 module: xfs_quota
 short_description: Manage quotas on XFS filesystems
 description:
-  - Configure Quotas on XFS filesystems. /etc/projects and /etc/projid needs to be configured before calling this module when setting project quotas.
+  - Configure quotas on XFS filesystems.
+  - Before using this module /etc/projects and /etc/projid need to be configured.
 version_added: "2.8"
 author:
 - William Leemans (@bushvin)

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
 ---
 module: xfs_quota
 short_description: Set Quotas on XFS filesystems
-description:
+descrition:
   - Configure Quotas on XFS filesystems. /etc/projects and /etc/projid needs to be configured before calling this module when setting project quotas.
 version_added: "2.8"
 author: "William Leemans (@bushvin) <willie@elaba.net>"
@@ -34,29 +34,29 @@ options:
       - project
   name:
     description:
-      - the name of the user, group or project to apply the quota to, if other than default
+      - The name of the user, group or project to apply the quota to, if other than default.
   mountpoint:
     description:
       - the mountpoint on which to apply the quotas
     required: true
   bhard:
     description:
-      - hard blocks quota limit
+      - Hard blocks quota limit.
   bsoft:
     description:
-      - soft blocks quota limit
+      - Soft blocks quota limit.
   ihard:
     description:
-      - hard inodes quota limit
+      - Hard inodes quota limit.
   isoft:
     description:
-      - soft inodes quota limit
+      - Soft inodes quota limit.
   rtbhard:
     description:
-      - hard realtime blocks quota limit
+      - Hard realtime blocks quota limit.
   rtbsoft:
     description:
-      - soft realtime blocks quota limit
+      - Soft realtime blocks quota limit.
   state:
     description:
       - Whether to apply the limits or remove them.

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -213,7 +213,7 @@ def main():
             name = quota_default
 
         if 'pquota' not in mp['mntopts'] and 'prjquota' not in mp['mntopts'] and 'pqnoenforce' not in mp['mntopts']:
-            module.fail_json(msg='%s is not mounted with the pquota/prjquota/pqnoenforce option.' % mountpoint, **result)
+            module.fail_json(msg="Path '%s' is not mounted with the pquota/prjquota/pqnoenforce option.' % mountpoint, **result)
 
         if name != quota_default and not os.path.isfile('/etc/projects'):
             module.fail_json(msg="Path '/etc/projects' does not exist.", **result)

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -342,7 +342,7 @@ def quota_report(module, mountpoint, name, quota_type, used_type):
     else:
         for line in r['stdout']:
             line = line.strip().split()
-            if len(line) and line[0] == name:
+            if len(line) > 3 and line[0] == name:
                 soft = int(line[2])
                 hard = int(line[3])
                 break

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -116,7 +116,7 @@ import grp
 import os
 import pwd
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, human_to_bytes
 from ansible.module_utils.basic import human_to_bytes
 
 

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -177,7 +177,7 @@ def main():
             )
         try:
             pwd.getpwnam(name)
-        except:
+        except KeyError as e:
             module.fail_json(msg='User %s doesn\'t exist.' % name)
 
     if quota_type == 'group':
@@ -193,7 +193,7 @@ def main():
             )
         try:
             grp.getgrnam(name)
-        except:
+        except KeyError as e:
             module.fail_json(msg='User %s doesn\'t exist.' % name)
 
     elif quota_type == 'project':
@@ -257,10 +257,10 @@ def main():
         current_rtbsoft, current_rtbhard = quota_report(module, mountpoint, name, quota_type, 'rtb')
 
     limit = []
-    if bsoft is not None and int(bsoft/1024) != current_bsoft:
+    if bsoft is not None and int(bsoft / 1024) != current_bsoft:
         limit.append('bsoft=%s' % bsoft)
 
-    if bhard is not None and int(bhard/1024) != current_bhard:
+    if bhard is not None and int(bhard / 1024) != current_bhard:
         limit.append('bhard=%s' % bhard)
 
     if isoft is not None and isoft != current_isoft:
@@ -269,10 +269,10 @@ def main():
     if ihard is not None and ihard != current_ihard:
         limit.append('ihard=%s' % ihard)
 
-    if rtbsoft is not None and int(rtbsoft/1024) != current_rtbsoft:
+    if rtbsoft is not None and int(rtbsoft / 1024) != current_rtbsoft:
         limit.append('rtbsoft=%s' % rtbsoft)
 
-    if rtbhard is not None and int(rtbhard/1024) != current_rtbhard:
+    if rtbhard is not None and int(rtbhard / 1024) != current_rtbhard:
         limit.append('rtbhard=%s' % rtbhard)
 
     if len(limit) > 0 and not module.check_mode:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -219,7 +219,7 @@ def main():
             module.fail_json(msg="Path '/etc/projects' does not exist.", **result)
 
         if name != quota_default and not os.path.isfile('/etc/projid'):
-            module.fail_json(msg='/etc/projid doesn\'t exist.', **result)
+            module.fail_json(msg="Path '/etc/projid' does not exist.", **result)
 
         if name != quota_default and name is not None and get_project_id(name) is None:
             module.fail_json(msg='%s hasn\'t been defined in /etc/projid.' % name, **result)

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -27,6 +27,7 @@ options:
   type:
     description:
       - The xfs quota type.
+    type: str
     required: true
     choices:
       - user
@@ -35,36 +36,45 @@ options:
   name:
     description:
       - The name of the user, group or project to apply the quota to, if other than default.
+    type: str
   mountpoint:
     description:
       - the mountpoint on which to apply the quotas
+    type: str
     required: true
   bhard:
     description:
       - Hard blocks quota limit.
       - This argument supports human readable sizes.
+    type: str
   bsoft:
     description:
       - Soft blocks quota limit.
       - This argument supports human readable sizes.
+    type: str
   ihard:
     description:
       - Hard inodes quota limit.
+    type: int
   isoft:
     description:
       - Soft inodes quota limit.
+    type: int
   rtbhard:
     description:
       - Hard realtime blocks quota limit.
       - This argument supports human readable sizes.
+    type: str
   rtbsoft:
     description:
       - Soft realtime blocks quota limit.
       - This argument supports human readable sizes.
+    type: str
   state:
     description:
       - Whether to apply the limits or remove them.
       - When removing limit, they are set to 0, and not quite removed.
+    type: str
     default: present
     choices:
       - present

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -131,7 +131,7 @@ def main():
             rtbhard=dict(type='str'),
             rtbsoft=dict(type='str'),
             state=dict(type='str', default='present', choices=['absent', 'present']),
-            type=dict(type='str', required=True, choices=['user', 'group', 'project'])
+            type=dict(type='str', required=True, choices=['group', 'project', 'user'])
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -190,7 +190,7 @@ def main():
         except KeyError as e:
             module.fail_json(msg="User '%s' does not exist." % name, **result)
 
-    if quota_type == 'group':
+    elif quota_type == 'group':
         type_arg = '-g'
         quota_default = 'root'
         if name is None:

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -213,7 +213,7 @@ def main():
             name = quota_default
 
         if 'pquota' not in mp['mntopts'] and 'prjquota' not in mp['mntopts'] and 'pqnoenforce' not in mp['mntopts']:
-            module.fail_json(msg="Path '%s' is not mounted with the pquota/prjquota/pqnoenforce option.' % mountpoint, **result)
+            module.fail_json(msg="Path '%s' is not mounted with the pquota/prjquota/pqnoenforce option." % mountpoint, **result)
 
         if name != quota_default and not os.path.isfile('/etc/projects'):
             module.fail_json(msg="Path '/etc/projects' does not exist.", **result)
@@ -236,7 +236,7 @@ def main():
                 module.fail_json(msg='Could not get project state.', **result)
             else:
                 for line in stdout.split('\n'):
-                    if '%s - project identifier is not set' in line:
+                    if "Project Id '%s' - is not set." in line:
                         prj_set = False
                         break
 

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -99,6 +99,8 @@ EXAMPLES = r'''
 
 '''
 
+RETURN = ''' # '''
+
 import os
 import sys
 import json
@@ -107,6 +109,7 @@ import grp
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import human_to_bytes
+
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/system/xfs_quota.py
+++ b/lib/ansible/modules/system/xfs_quota.py
@@ -130,7 +130,7 @@ def main():
             name=dict(type='str'),
             rtbhard=dict(type='str'),
             rtbsoft=dict(type='str'),
-            state=dict(type='str', default='present', choices=['present', 'absent']),
+            state=dict(type='str', default='present', choices=['absent', 'present']),
             type=dict(type='str', required=True, choices=['user', 'group', 'project'])
         ),
         supports_check_mode=True

--- a/test/integration/targets/xfs_quota/aliases
+++ b/test/integration/targets/xfs_quota/aliases
@@ -1,0 +1,1 @@
+needs/root

--- a/test/integration/targets/xfs_quota/aliases
+++ b/test/integration/targets/xfs_quota/aliases
@@ -1,2 +1,3 @@
 needs/privileged
 needs/root
+shippable/posix/group1

--- a/test/integration/targets/xfs_quota/aliases
+++ b/test/integration/targets/xfs_quota/aliases
@@ -1,3 +1,4 @@
 needs/privileged
 needs/root
 shippable/posix/group1
+skip/osx

--- a/test/integration/targets/xfs_quota/aliases
+++ b/test/integration/targets/xfs_quota/aliases
@@ -1,1 +1,2 @@
+needs/privileged
 needs/root

--- a/test/integration/targets/xfs_quota/aliases
+++ b/test/integration/targets/xfs_quota/aliases
@@ -2,3 +2,4 @@ needs/privileged
 needs/root
 shippable/posix/group1
 skip/osx
+skip/freebsd

--- a/test/integration/targets/xfs_quota/defaults/main.yml
+++ b/test/integration/targets/xfs_quota/defaults/main.yml
@@ -40,4 +40,3 @@ pquota_project_isoft: 300
 pquota_project_ihard: 400
 pquota_project_rtbsoft: 3m
 pquota_project_rthard: 4m
-

--- a/test/integration/targets/xfs_quota/defaults/main.yml
+++ b/test/integration/targets/xfs_quota/defaults/main.yml
@@ -1,0 +1,43 @@
+---
+uquota_default_bsoft: 1m
+uquota_default_bhard: 2m
+uquota_default_isoft: 100
+uquota_default_ihard: 200
+uquota_default_rtbsoft: 1m
+uquota_default_rthard: 2m
+
+uquota_user_bsoft: 2m
+uquota_user_bhard: 3m
+uquota_user_isoft: 300
+uquota_user_ihard: 400
+uquota_user_rtbsoft: 3m
+uquota_user_rthard: 4m
+
+gquota_default_bsoft: 1m
+gquota_default_bhard: 2m
+gquota_default_isoft: 100
+gquota_default_ihard: 200
+gquota_default_rtbsoft: 1m
+gquota_default_rthard: 2m
+
+gquota_group_bsoft: 2m
+gquota_group_bhard: 3m
+gquota_group_isoft: 300
+gquota_group_ihard: 400
+gquota_group_rtbsoft: 3m
+gquota_group_rthard: 4m
+
+pquota_default_bsoft: 1m
+pquota_default_bhard: 2m
+pquota_default_isoft: 100
+pquota_default_ihard: 200
+pquota_default_rtbsoft: 1m
+pquota_default_rthard: 2m
+
+pquota_project_bsoft: 2m
+pquota_project_bhard: 3m
+pquota_project_isoft: 300
+pquota_project_ihard: 400
+pquota_project_rtbsoft: 3m
+pquota_project_rthard: 4m
+

--- a/test/integration/targets/xfs_quota/defaults/main.yml
+++ b/test/integration/targets/xfs_quota/defaults/main.yml
@@ -4,39 +4,39 @@ uquota_default_bhard: 2m
 uquota_default_isoft: 100
 uquota_default_ihard: 200
 uquota_default_rtbsoft: 1m
-uquota_default_rthard: 2m
+uquota_default_rtbhard: 2m
 
 uquota_user_bsoft: 2m
 uquota_user_bhard: 3m
 uquota_user_isoft: 300
 uquota_user_ihard: 400
 uquota_user_rtbsoft: 3m
-uquota_user_rthard: 4m
+uquota_user_rtbhard: 4m
 
 gquota_default_bsoft: 1m
 gquota_default_bhard: 2m
 gquota_default_isoft: 100
 gquota_default_ihard: 200
 gquota_default_rtbsoft: 1m
-gquota_default_rthard: 2m
+gquota_default_rtbhard: 2m
 
 gquota_group_bsoft: 2m
 gquota_group_bhard: 3m
 gquota_group_isoft: 300
 gquota_group_ihard: 400
 gquota_group_rtbsoft: 3m
-gquota_group_rthard: 4m
+gquota_group_rtbhard: 4m
 
 pquota_default_bsoft: 1m
 pquota_default_bhard: 2m
 pquota_default_isoft: 100
 pquota_default_ihard: 200
 pquota_default_rtbsoft: 1m
-pquota_default_rthard: 2m
+pquota_default_rtbhard: 2m
 
 pquota_project_bsoft: 2m
 pquota_project_bhard: 3m
 pquota_project_isoft: 300
 pquota_project_ihard: 400
 pquota_project_rtbsoft: 3m
-pquota_project_rthard: 4m
+pquota_project_rtbhard: 4m

--- a/test/integration/targets/xfs_quota/tasks/gquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/gquota.yml
@@ -1,4 +1,4 @@
-
+---
 - name: 'Create disk image'
   command: >
     dd if=/dev/zero of={{ ansible_user_dir }}/ansible_testing/img-gquota bs=1M count=20
@@ -18,9 +18,6 @@
         opts: gquota
         state: mounted
       become: True
-
-#    - include_tasks: gquota-default.yml
-#    - include_tasks: gquota-group.yml
 
     - name: 'Apply default group limits'
       xfs_quota:
@@ -94,9 +91,6 @@
           - test_gquota_group_bsoft_after.xfs_quota.rtbsoft == gquota_group_rtbsoft|human_to_bytes
           - test_gquota_group_bsoft_after.xfs_quota.rtbhard == gquota_group_rthard|human_to_bytes
 
-
-
-
   always:
     - name: 'Unmount filesystem'
       mount:
@@ -109,5 +103,3 @@
       file:
         path: '{{ ansible_user_dir }}/ansible_testing/img-gquota'
         state: absent
-
-

--- a/test/integration/targets/xfs_quota/tasks/gquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/gquota.yml
@@ -27,10 +27,21 @@
         ihard: '{{ gquota_default_ihard }}'
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
         rtbsoft: '{{ gquota_default_rtbsoft }}'
-        rtbhard: '{{ gquota_default_rthard }}'
+        rtbhard: '{{ gquota_default_rtbhard }}'
         type: group
       become: True
-      register: test_gquota_default_bsoft_before
+      register: test_gquota_default_before
+
+    - name: Assert default group limits results
+      assert:
+        that:
+          - test_gquota_default_before.changed
+          - test_gquota_default_before.xfs_quota.bsoft == gquota_default_bsoft|human_to_bytes
+          - test_gquota_default_before.xfs_quota.bhard == gquota_default_bhard|human_to_bytes
+          - test_gquota_default_before.xfs_quota.isoft == gquota_default_isoft
+          - test_gquota_default_before.xfs_quota.ihard == gquota_default_ihard
+          - test_gquota_default_before.xfs_quota.rtbsoft == gquota_default_rtbsoft|human_to_bytes
+          - test_gquota_default_before.xfs_quota.rtbhard == gquota_default_rtbhard|human_to_bytes
 
     - name: 'Apply group limits'
       xfs_quota:
@@ -41,10 +52,21 @@
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
         name: xfsquotauser
         rtbsoft: '{{ gquota_group_rtbsoft }}'
-        rtbhard: '{{ gquota_group_rthard }}'
+        rtbhard: '{{ gquota_group_rtbhard }}'
         type: group
       become: True
-      register: test_gquota_group_bsoft_before
+      register: test_gquota_group_before
+
+    - name: Assert group limits results for xfsquotauser
+      assert:
+        that:
+          - test_gquota_group_before.changed
+          - test_gquota_group_before.xfs_quota.bsoft == gquota_group_bsoft|human_to_bytes
+          - test_gquota_group_before.xfs_quota.bhard == gquota_group_bhard|human_to_bytes
+          - test_gquota_group_before.xfs_quota.isoft == gquota_group_isoft
+          - test_gquota_group_before.xfs_quota.ihard == gquota_group_ihard
+          - test_gquota_group_before.xfs_quota.rtbsoft == gquota_group_rtbsoft|human_to_bytes
+          - test_gquota_group_before.xfs_quota.rtbhard == gquota_group_rtbhard|human_to_bytes
 
     - name: 'Re-apply default group limits'
       xfs_quota:
@@ -54,10 +76,15 @@
         ihard: '{{ gquota_default_ihard }}'
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
         rtbsoft: '{{ gquota_default_rtbsoft }}'
-        rtbhard: '{{ gquota_default_rthard }}'
+        rtbhard: '{{ gquota_default_rtbhard }}'
         type: group
       become: True
-      register: test_gquota_default_bsoft_after
+      register: test_gquota_default_after
+
+    - name: Assert default group limits results after re-apply
+      assert:
+        that:
+          - not test_gquota_default_after.changed
 
     - name: 'Re-apply group limits'
       xfs_quota:
@@ -68,28 +95,54 @@
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
         name: xfsquotauser
         rtbsoft: '{{ gquota_group_rtbsoft }}'
-        rtbhard: '{{ gquota_group_rthard }}'
+        rtbhard: '{{ gquota_group_rtbhard }}'
         type: group
       become: True
-      register: test_gquota_group_bsoft_after
+      register: test_gquota_group_after
 
-    - name: 'Evaluate group quotas'
+    - name: Assert group limits results for xfsquotauser after re-apply
       assert:
         that:
-          - not test_gquota_default_bsoft_after.changed
-          - test_gquota_default_bsoft_after.xfs_quota.bsoft == gquota_default_bsoft|human_to_bytes
-          - test_gquota_default_bsoft_after.xfs_quota.bhard == gquota_default_bhard|human_to_bytes
-          - test_gquota_default_bsoft_after.xfs_quota.isoft == gquota_default_isoft|human_to_bytes
-          - test_gquota_default_bsoft_after.xfs_quota.ihard == gquota_default_ihard|human_to_bytes
-          - test_gquota_default_bsoft_after.xfs_quota.rtbsoft == gquota_default_rtbsoft|human_to_bytes
-          - test_gquota_default_bsoft_after.xfs_quota.rtbhard == gquota_default_rthard|human_to_bytes
-          - not test_gquota_group_bsoft_after.changed
-          - test_gquota_group_bsoft_after.xfs_quota.bsoft == gquota_group_bsoft|human_to_bytes
-          - test_gquota_group_bsoft_after.xfs_quota.bhard == gquota_group_bhard|human_to_bytes
-          - test_gquota_group_bsoft_after.xfs_quota.isoft == gquota_group_isoft|human_to_bytes
-          - test_gquota_group_bsoft_after.xfs_quota.ihard == gquota_group_ihard|human_to_bytes
-          - test_gquota_group_bsoft_after.xfs_quota.rtbsoft == gquota_group_rtbsoft|human_to_bytes
-          - test_gquota_group_bsoft_after.xfs_quota.rtbhard == gquota_group_rthard|human_to_bytes
+          - not test_gquota_group_after.changed
+
+    - name: 'Reset default group limits'
+      xfs_quota:
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        state: absent
+        type: group
+      become: True
+      register: test_reset_gquota_default
+
+    - name: Assert reset of default group limits results
+      assert:
+        that:
+          - test_reset_gquota_default.changed
+          - test_reset_gquota_default.xfs_quota.bsoft == 0
+          - test_reset_gquota_default.xfs_quota.bhard == 0
+          - test_reset_gquota_default.xfs_quota.isoft == 0
+          - test_reset_gquota_default.xfs_quota.ihard == 0
+          - test_reset_gquota_default.xfs_quota.rtbsoft == 0
+          - test_reset_gquota_default.xfs_quota.rtbhard == 0
+
+    - name: 'Reset group limits for xfsquotauser'
+      xfs_quota:
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        name: xfsquotauser
+        state: absent
+        type: group
+      become: True
+      register: test_reset_gquota_group
+
+    - name: Assert reset of default group limits results
+      assert:
+        that:
+          - test_reset_gquota_group.changed
+          - test_reset_gquota_group.xfs_quota.bsoft == 0
+          - test_reset_gquota_group.xfs_quota.bhard == 0
+          - test_reset_gquota_group.xfs_quota.isoft == 0
+          - test_reset_gquota_group.xfs_quota.ihard == 0
+          - test_reset_gquota_group.xfs_quota.rtbsoft == 0
+          - test_reset_gquota_group.xfs_quota.rtbhard == 0
 
   always:
     - name: 'Unmount filesystem'

--- a/test/integration/targets/xfs_quota/tasks/gquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/gquota.yml
@@ -36,12 +36,12 @@
       assert:
         that:
           - test_gquota_default_before.changed
-          - test_gquota_default_before.xfs_quota.bsoft == gquota_default_bsoft|human_to_bytes
-          - test_gquota_default_before.xfs_quota.bhard == gquota_default_bhard|human_to_bytes
-          - test_gquota_default_before.xfs_quota.isoft == gquota_default_isoft
-          - test_gquota_default_before.xfs_quota.ihard == gquota_default_ihard
-          - test_gquota_default_before.xfs_quota.rtbsoft == gquota_default_rtbsoft|human_to_bytes
-          - test_gquota_default_before.xfs_quota.rtbhard == gquota_default_rtbhard|human_to_bytes
+          - test_gquota_default_before.bsoft == gquota_default_bsoft|human_to_bytes
+          - test_gquota_default_before.bhard == gquota_default_bhard|human_to_bytes
+          - test_gquota_default_before.isoft == gquota_default_isoft
+          - test_gquota_default_before.ihard == gquota_default_ihard
+          - test_gquota_default_before.rtbsoft == gquota_default_rtbsoft|human_to_bytes
+          - test_gquota_default_before.rtbhard == gquota_default_rtbhard|human_to_bytes
 
     - name: 'Apply group limits'
       xfs_quota:
@@ -61,12 +61,12 @@
       assert:
         that:
           - test_gquota_group_before.changed
-          - test_gquota_group_before.xfs_quota.bsoft == gquota_group_bsoft|human_to_bytes
-          - test_gquota_group_before.xfs_quota.bhard == gquota_group_bhard|human_to_bytes
-          - test_gquota_group_before.xfs_quota.isoft == gquota_group_isoft
-          - test_gquota_group_before.xfs_quota.ihard == gquota_group_ihard
-          - test_gquota_group_before.xfs_quota.rtbsoft == gquota_group_rtbsoft|human_to_bytes
-          - test_gquota_group_before.xfs_quota.rtbhard == gquota_group_rtbhard|human_to_bytes
+          - test_gquota_group_before.bsoft == gquota_group_bsoft|human_to_bytes
+          - test_gquota_group_before.bhard == gquota_group_bhard|human_to_bytes
+          - test_gquota_group_before.isoft == gquota_group_isoft
+          - test_gquota_group_before.ihard == gquota_group_ihard
+          - test_gquota_group_before.rtbsoft == gquota_group_rtbsoft|human_to_bytes
+          - test_gquota_group_before.rtbhard == gquota_group_rtbhard|human_to_bytes
 
     - name: 'Re-apply default group limits'
       xfs_quota:
@@ -117,12 +117,12 @@
       assert:
         that:
           - test_reset_gquota_default.changed
-          - test_reset_gquota_default.xfs_quota.bsoft == 0
-          - test_reset_gquota_default.xfs_quota.bhard == 0
-          - test_reset_gquota_default.xfs_quota.isoft == 0
-          - test_reset_gquota_default.xfs_quota.ihard == 0
-          - test_reset_gquota_default.xfs_quota.rtbsoft == 0
-          - test_reset_gquota_default.xfs_quota.rtbhard == 0
+          - test_reset_gquota_default.bsoft == 0
+          - test_reset_gquota_default.bhard == 0
+          - test_reset_gquota_default.isoft == 0
+          - test_reset_gquota_default.ihard == 0
+          - test_reset_gquota_default.rtbsoft == 0
+          - test_reset_gquota_default.rtbhard == 0
 
     - name: 'Reset group limits for xfsquotauser'
       xfs_quota:
@@ -137,12 +137,12 @@
       assert:
         that:
           - test_reset_gquota_group.changed
-          - test_reset_gquota_group.xfs_quota.bsoft == 0
-          - test_reset_gquota_group.xfs_quota.bhard == 0
-          - test_reset_gquota_group.xfs_quota.isoft == 0
-          - test_reset_gquota_group.xfs_quota.ihard == 0
-          - test_reset_gquota_group.xfs_quota.rtbsoft == 0
-          - test_reset_gquota_group.xfs_quota.rtbhard == 0
+          - test_reset_gquota_group.bsoft == 0
+          - test_reset_gquota_group.bhard == 0
+          - test_reset_gquota_group.isoft == 0
+          - test_reset_gquota_group.ihard == 0
+          - test_reset_gquota_group.rtbsoft == 0
+          - test_reset_gquota_group.rtbhard == 0
 
   always:
     - name: 'Unmount filesystem'

--- a/test/integration/targets/xfs_quota/tasks/gquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/gquota.yml
@@ -1,0 +1,113 @@
+
+- name: 'Create disk image'
+  command: >
+    dd if=/dev/zero of={{ ansible_user_dir }}/ansible_testing/img-gquota bs=1M count=20
+
+- name: 'Create XFS filesystem'
+  filesystem:
+    dev: '{{ ansible_user_dir }}/ansible_testing/img-gquota'
+    fstype: xfs
+
+- block:
+    - name: 'Mount filesystem'
+      mount:
+        fstab: '{{ ansible_user_dir }}/ansible_testing/fstab'
+        src: '{{ ansible_user_dir }}/ansible_testing/img-gquota'
+        path: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        fstype: xfs
+        opts: gquota
+        state: mounted
+      become: True
+
+#    - include_tasks: gquota-default.yml
+#    - include_tasks: gquota-group.yml
+
+    - name: 'Apply default group limits'
+      xfs_quota:
+        bsoft: '{{ gquota_default_bsoft }}'
+        bhard: '{{ gquota_default_bhard }}'
+        isoft: '{{ gquota_default_isoft }}'
+        ihard: '{{ gquota_default_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        rtbsoft: '{{ gquota_default_rtbsoft }}'
+        rtbhard: '{{ gquota_default_rthard }}'
+        type: group
+      become: True
+      register: test_gquota_default_bsoft_before
+
+    - name: 'Apply group limits'
+      xfs_quota:
+        bsoft: '{{ gquota_group_bsoft }}'
+        bhard: '{{ gquota_group_bhard }}'
+        isoft: '{{ gquota_group_isoft }}'
+        ihard: '{{ gquota_group_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        name: xfsquotauser
+        rtbsoft: '{{ gquota_group_rtbsoft }}'
+        rtbhard: '{{ gquota_group_rthard }}'
+        type: group
+      become: True
+      register: test_gquota_group_bsoft_before
+
+    - name: 'Re-apply default group limits'
+      xfs_quota:
+        bsoft: '{{ gquota_default_bsoft }}'
+        bhard: '{{ gquota_default_bhard }}'
+        isoft: '{{ gquota_default_isoft }}'
+        ihard: '{{ gquota_default_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        rtbsoft: '{{ gquota_default_rtbsoft }}'
+        rtbhard: '{{ gquota_default_rthard }}'
+        type: group
+      become: True
+      register: test_gquota_default_bsoft_after
+
+    - name: 'Re-apply group limits'
+      xfs_quota:
+        bsoft: '{{ gquota_group_bsoft }}'
+        bhard: '{{ gquota_group_bhard }}'
+        isoft: '{{ gquota_group_isoft }}'
+        ihard: '{{ gquota_group_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        name: xfsquotauser
+        rtbsoft: '{{ gquota_group_rtbsoft }}'
+        rtbhard: '{{ gquota_group_rthard }}'
+        type: group
+      become: True
+      register: test_gquota_group_bsoft_after
+
+    - name: 'Evaluate group quotas'
+      assert:
+        that:
+          - not test_gquota_default_bsoft_after.changed
+          - test_gquota_default_bsoft_after.xfs_quota.bsoft == gquota_default_bsoft|human_to_bytes
+          - test_gquota_default_bsoft_after.xfs_quota.bhard == gquota_default_bhard|human_to_bytes
+          - test_gquota_default_bsoft_after.xfs_quota.isoft == gquota_default_isoft|human_to_bytes
+          - test_gquota_default_bsoft_after.xfs_quota.ihard == gquota_default_ihard|human_to_bytes
+          - test_gquota_default_bsoft_after.xfs_quota.rtbsoft == gquota_default_rtbsoft|human_to_bytes
+          - test_gquota_default_bsoft_after.xfs_quota.rtbhard == gquota_default_rthard|human_to_bytes
+          - not test_gquota_group_bsoft_after.changed
+          - test_gquota_group_bsoft_after.xfs_quota.bsoft == gquota_group_bsoft|human_to_bytes
+          - test_gquota_group_bsoft_after.xfs_quota.bhard == gquota_group_bhard|human_to_bytes
+          - test_gquota_group_bsoft_after.xfs_quota.isoft == gquota_group_isoft|human_to_bytes
+          - test_gquota_group_bsoft_after.xfs_quota.ihard == gquota_group_ihard|human_to_bytes
+          - test_gquota_group_bsoft_after.xfs_quota.rtbsoft == gquota_group_rtbsoft|human_to_bytes
+          - test_gquota_group_bsoft_after.xfs_quota.rtbhard == gquota_group_rthard|human_to_bytes
+
+
+
+
+  always:
+    - name: 'Unmount filesystem'
+      mount:
+        fstab: '{{ ansible_user_dir }}/ansible_testing/fstab'
+        path: '{{ ansible_user_dir }}/ansible_testing/gquota'
+        state: unmounted
+      become: True
+
+    - name: Remove disk image
+      file:
+        path: '{{ ansible_user_dir }}/ansible_testing/img-gquota'
+        state: absent
+
+

--- a/test/integration/targets/xfs_quota/tasks/main.yml
+++ b/test/integration/targets/xfs_quota/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- block: 
+    - name: Create test user
+      user:
+        name: xfsquotauser
+        state: present
+      become: yes
+
+    - include_tasks: uquota.yml
+    - include_tasks: gquota.yml
+    - include_tasks: pquota.yml
+
+  always:
+    - name: cleanup test user
+      user:
+        name: xfsquotauser
+        state: absent
+      become: yes
+
+

--- a/test/integration/targets/xfs_quota/tasks/main.yml
+++ b/test/integration/targets/xfs_quota/tasks/main.yml
@@ -16,5 +16,3 @@
         name: xfsquotauser
         state: absent
       become: yes
-
-

--- a/test/integration/targets/xfs_quota/tasks/pquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/pquota.yml
@@ -1,0 +1,152 @@
+
+- name: 'Create disk image'
+  command: >
+    dd if=/dev/zero of={{ ansible_user_dir }}/ansible_testing/img-pquota bs=1M count=20
+
+- name: 'Create XFS filesystem'
+  filesystem:
+    dev: '{{ ansible_user_dir }}/ansible_testing/img-pquota'
+    fstype: xfs
+
+- name: Create xfs related files
+  file:
+    path:  '/etc/{{ item }}'
+    state: touch
+  become: True
+  loop:
+    - 'projid'
+    - 'projects'
+
+- name: 'Add test xfs quota project id'
+  lineinfile:
+    path: /etc/projid
+    line: 'xft_quotaval:99999'
+    state: present
+  become: True
+
+- name: 'Add test xfs quota project path'
+  lineinfile:
+    path: /etc/projects
+    line: '99999:{{ ansible_user_dir }}/ansible_testing/pquota/test'
+    state: present
+  become: True
+
+- block:
+    - name: 'Mount filesystem'
+      mount:
+        fstab: '{{ ansible_user_dir }}/ansible_testing/fstab'
+        src: '{{ ansible_user_dir }}/ansible_testing/img-pquota'
+        path: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        fstype: xfs
+        opts: pquota
+        state: mounted
+      become: True
+
+    - name: 'Create test directory'
+      file:
+        path: '{{ ansible_user_dir }}/ansible_testing/pquota/test'
+        state: directory
+      become: True
+
+
+    - name: 'Apply default project limits'
+      xfs_quota:
+        bsoft: '{{ pquota_default_bsoft }}'
+        bhard: '{{ pquota_default_bhard }}'
+        isoft: '{{ pquota_default_isoft }}'
+        ihard: '{{ pquota_default_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        rtbsoft: '{{ pquota_default_rtbsoft }}'
+        rtbhard: '{{ pquota_default_rthard }}'
+        type: project 
+      become: True
+      register: test_pquota_default_bsoft_before
+
+    - name: 'Apply project limits'
+      xfs_quota:
+        bsoft: '{{ pquota_project_bsoft }}'
+        bhard: '{{ pquota_project_bhard }}'
+        isoft: '{{ pquota_project_isoft }}'
+        ihard: '{{ pquota_project_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        name: xft_quotaval
+        rtbsoft: '{{ pquota_project_rtbsoft }}'
+        rtbhard: '{{ pquota_project_rthard }}'
+        type: project 
+      become: True
+      register: test_pquota_project_bsoft_before
+
+    - name: 'Re-apply default project limits'
+      xfs_quota:
+        bsoft: '{{ pquota_default_bsoft }}'
+        bhard: '{{ pquota_default_bhard }}'
+        isoft: '{{ pquota_default_isoft }}'
+        ihard: '{{ pquota_default_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        rtbsoft: '{{ pquota_default_rtbsoft }}'
+        rtbhard: '{{ pquota_default_rthard }}'
+        type: project
+      become: True
+      register: test_pquota_default_bsoft_after
+
+    - name: 'Re-apply project limits'
+      xfs_quota:
+        bsoft: '{{ pquota_project_bsoft }}'
+        bhard: '{{ pquota_project_bhard }}'
+        isoft: '{{ pquota_project_isoft }}'
+        ihard: '{{ pquota_project_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        name: xft_quotaval
+        rtbsoft: '{{ pquota_project_rtbsoft }}'
+        rtbhard: '{{ pquota_project_rthard }}'
+        type: project
+      become: True
+      register: test_pquota_project_bsoft_after
+
+    - name: 'Evaluate Project quotas'
+      assert:
+        that:
+          - not test_pquota_default_bsoft_after.changed
+          - test_pquota_default_bsoft_after.xfs_quota.bsoft == pquota_default_bsoft|human_to_bytes
+          - test_pquota_default_bsoft_after.xfs_quota.bhard == pquota_default_bhard|human_to_bytes
+          - test_pquota_default_bsoft_after.xfs_quota.isoft == pquota_default_isoft|human_to_bytes
+          - test_pquota_default_bsoft_after.xfs_quota.ihard == pquota_default_ihard|human_to_bytes
+          - test_pquota_default_bsoft_after.xfs_quota.rtbsoft == pquota_default_rtbsoft|human_to_bytes
+          - test_pquota_default_bsoft_after.xfs_quota.rtbhard == pquota_default_rthard|human_to_bytes
+          - not test_pquota_project_bsoft_after.changed
+          - test_pquota_project_bsoft_after.xfs_quota.bsoft == pquota_project_bsoft|human_to_bytes
+          - test_pquota_project_bsoft_after.xfs_quota.bhard == pquota_project_bhard|human_to_bytes
+          - test_pquota_project_bsoft_after.xfs_quota.isoft == pquota_project_isoft|human_to_bytes
+          - test_pquota_project_bsoft_after.xfs_quota.ihard == pquota_project_ihard|human_to_bytes
+          - test_pquota_project_bsoft_after.xfs_quota.rtbsoft == pquota_project_rtbsoft|human_to_bytes
+          - test_pquota_project_bsoft_after.xfs_quota.rtbhard == pquota_project_rthard|human_to_bytes
+
+
+  always:
+    - name: 'Unmount filesystem'
+      mount:
+        fstab: '{{ ansible_user_dir }}/ansible_testing/fstab'
+        path: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        state: unmounted
+      become: True
+
+    - name: Remove disk image
+      file:
+        path: '{{ ansible_user_dir }}/ansible_testing/img-pquota'
+        state: absent
+
+    - name: Remove xfs quota project id
+      lineinfile:
+        path: /etc/projid
+        regexp: '^xft_quotaval:99999$'
+        state: absent
+      become: True
+
+    - name: Remove xfs quota project path
+      lineinfile:
+        path: /etc/projects
+        regexp: '^99999:.*$'
+        state: absent
+      become: True
+
+

--- a/test/integration/targets/xfs_quota/tasks/pquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/pquota.yml
@@ -66,12 +66,12 @@
       assert:
         that:
           - test_pquota_default_before.changed
-          - test_pquota_default_before.xfs_quota.bsoft == pquota_default_bsoft|human_to_bytes
-          - test_pquota_default_before.xfs_quota.bhard == pquota_default_bhard|human_to_bytes
-          - test_pquota_default_before.xfs_quota.isoft == pquota_default_isoft
-          - test_pquota_default_before.xfs_quota.ihard == pquota_default_ihard
-          - test_pquota_default_before.xfs_quota.rtbsoft == pquota_default_rtbsoft|human_to_bytes
-          - test_pquota_default_before.xfs_quota.rtbhard == pquota_default_rtbhard|human_to_bytes
+          - test_pquota_default_before.bsoft == pquota_default_bsoft|human_to_bytes
+          - test_pquota_default_before.bhard == pquota_default_bhard|human_to_bytes
+          - test_pquota_default_before.isoft == pquota_default_isoft
+          - test_pquota_default_before.ihard == pquota_default_ihard
+          - test_pquota_default_before.rtbsoft == pquota_default_rtbsoft|human_to_bytes
+          - test_pquota_default_before.rtbhard == pquota_default_rtbhard|human_to_bytes
 
     - name: 'Apply project limits'
       xfs_quota:
@@ -91,12 +91,12 @@
       assert:
         that:
           - test_pquota_project_before.changed
-          - test_pquota_project_before.xfs_quota.bsoft == pquota_project_bsoft|human_to_bytes
-          - test_pquota_project_before.xfs_quota.bhard == pquota_project_bhard|human_to_bytes
-          - test_pquota_project_before.xfs_quota.isoft == pquota_project_isoft
-          - test_pquota_project_before.xfs_quota.ihard == pquota_project_ihard
-          - test_pquota_project_before.xfs_quota.rtbsoft == pquota_project_rtbsoft|human_to_bytes
-          - test_pquota_project_before.xfs_quota.rtbhard == pquota_project_rtbhard|human_to_bytes
+          - test_pquota_project_before.bsoft == pquota_project_bsoft|human_to_bytes
+          - test_pquota_project_before.bhard == pquota_project_bhard|human_to_bytes
+          - test_pquota_project_before.isoft == pquota_project_isoft
+          - test_pquota_project_before.ihard == pquota_project_ihard
+          - test_pquota_project_before.rtbsoft == pquota_project_rtbsoft|human_to_bytes
+          - test_pquota_project_before.rtbhard == pquota_project_rtbhard|human_to_bytes
 
     - name: 'Re-apply default project limits'
       xfs_quota:
@@ -147,12 +147,12 @@
       assert:
         that:
           - test_reset_pquota_default.changed
-          - test_reset_pquota_default.xfs_quota.bsoft == 0
-          - test_reset_pquota_default.xfs_quota.bhard == 0
-          - test_reset_pquota_default.xfs_quota.isoft == 0
-          - test_reset_pquota_default.xfs_quota.ihard == 0
-          - test_reset_pquota_default.xfs_quota.rtbsoft == 0
-          - test_reset_pquota_default.xfs_quota.rtbhard == 0
+          - test_reset_pquota_default.bsoft == 0
+          - test_reset_pquota_default.bhard == 0
+          - test_reset_pquota_default.isoft == 0
+          - test_reset_pquota_default.ihard == 0
+          - test_reset_pquota_default.rtbsoft == 0
+          - test_reset_pquota_default.rtbhard == 0
 
     - name: 'Reset project limits for xft_quotaval'
       xfs_quota:
@@ -167,12 +167,12 @@
       assert:
         that:
           - test_reset_pquota_project.changed
-          - test_reset_pquota_project.xfs_quota.bsoft == 0
-          - test_reset_pquota_project.xfs_quota.bhard == 0
-          - test_reset_pquota_project.xfs_quota.isoft == 0
-          - test_reset_pquota_project.xfs_quota.ihard == 0
-          - test_reset_pquota_project.xfs_quota.rtbsoft == 0
-          - test_reset_pquota_project.xfs_quota.rtbhard == 0
+          - test_reset_pquota_project.bsoft == 0
+          - test_reset_pquota_project.bhard == 0
+          - test_reset_pquota_project.isoft == 0
+          - test_reset_pquota_project.ihard == 0
+          - test_reset_pquota_project.rtbsoft == 0
+          - test_reset_pquota_project.rtbhard == 0
 
   always:
     - name: 'Unmount filesystem'

--- a/test/integration/targets/xfs_quota/tasks/pquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/pquota.yml
@@ -1,4 +1,4 @@
-
+---
 - name: 'Create disk image'
   command: >
     dd if=/dev/zero of={{ ansible_user_dir }}/ansible_testing/img-pquota bs=1M count=20
@@ -121,7 +121,6 @@
           - test_pquota_project_bsoft_after.xfs_quota.rtbsoft == pquota_project_rtbsoft|human_to_bytes
           - test_pquota_project_bsoft_after.xfs_quota.rtbhard == pquota_project_rthard|human_to_bytes
 
-
   always:
     - name: 'Unmount filesystem'
       mount:
@@ -148,5 +147,3 @@
         regexp: '^99999:.*$'
         state: absent
       become: True
-
-

--- a/test/integration/targets/xfs_quota/tasks/pquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/pquota.yml
@@ -57,10 +57,21 @@
         ihard: '{{ pquota_default_ihard }}'
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
         rtbsoft: '{{ pquota_default_rtbsoft }}'
-        rtbhard: '{{ pquota_default_rthard }}'
+        rtbhard: '{{ pquota_default_rtbhard }}'
         type: project 
       become: True
-      register: test_pquota_default_bsoft_before
+      register: test_pquota_default_before
+
+    - name: Assert default project limits results
+      assert:
+        that:
+          - test_pquota_default_before.changed
+          - test_pquota_default_before.xfs_quota.bsoft == pquota_default_bsoft|human_to_bytes
+          - test_pquota_default_before.xfs_quota.bhard == pquota_default_bhard|human_to_bytes
+          - test_pquota_default_before.xfs_quota.isoft == pquota_default_isoft
+          - test_pquota_default_before.xfs_quota.ihard == pquota_default_ihard
+          - test_pquota_default_before.xfs_quota.rtbsoft == pquota_default_rtbsoft|human_to_bytes
+          - test_pquota_default_before.xfs_quota.rtbhard == pquota_default_rtbhard|human_to_bytes
 
     - name: 'Apply project limits'
       xfs_quota:
@@ -71,10 +82,21 @@
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
         name: xft_quotaval
         rtbsoft: '{{ pquota_project_rtbsoft }}'
-        rtbhard: '{{ pquota_project_rthard }}'
+        rtbhard: '{{ pquota_project_rtbhard }}'
         type: project 
       become: True
-      register: test_pquota_project_bsoft_before
+      register: test_pquota_project_before
+
+    - name: Assert project limits results for xft_quotaval
+      assert:
+        that:
+          - test_pquota_project_before.changed
+          - test_pquota_project_before.xfs_quota.bsoft == pquota_project_bsoft|human_to_bytes
+          - test_pquota_project_before.xfs_quota.bhard == pquota_project_bhard|human_to_bytes
+          - test_pquota_project_before.xfs_quota.isoft == pquota_project_isoft
+          - test_pquota_project_before.xfs_quota.ihard == pquota_project_ihard
+          - test_pquota_project_before.xfs_quota.rtbsoft == pquota_project_rtbsoft|human_to_bytes
+          - test_pquota_project_before.xfs_quota.rtbhard == pquota_project_rtbhard|human_to_bytes
 
     - name: 'Re-apply default project limits'
       xfs_quota:
@@ -84,10 +106,15 @@
         ihard: '{{ pquota_default_ihard }}'
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
         rtbsoft: '{{ pquota_default_rtbsoft }}'
-        rtbhard: '{{ pquota_default_rthard }}'
+        rtbhard: '{{ pquota_default_rtbhard }}'
         type: project
       become: True
-      register: test_pquota_default_bsoft_after
+      register: test_pquota_default_after
+
+    - name: Assert default project limits results after re-apply
+      assert:
+        that:
+          - not test_pquota_default_after.changed
 
     - name: 'Re-apply project limits'
       xfs_quota:
@@ -98,28 +125,54 @@
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
         name: xft_quotaval
         rtbsoft: '{{ pquota_project_rtbsoft }}'
-        rtbhard: '{{ pquota_project_rthard }}'
+        rtbhard: '{{ pquota_project_rtbhard }}'
         type: project
       become: True
-      register: test_pquota_project_bsoft_after
+      register: test_pquota_project_after
 
-    - name: 'Evaluate Project quotas'
+    - name: Assert project limits results for xft_quotaval after re-apply
       assert:
         that:
-          - not test_pquota_default_bsoft_after.changed
-          - test_pquota_default_bsoft_after.xfs_quota.bsoft == pquota_default_bsoft|human_to_bytes
-          - test_pquota_default_bsoft_after.xfs_quota.bhard == pquota_default_bhard|human_to_bytes
-          - test_pquota_default_bsoft_after.xfs_quota.isoft == pquota_default_isoft|human_to_bytes
-          - test_pquota_default_bsoft_after.xfs_quota.ihard == pquota_default_ihard|human_to_bytes
-          - test_pquota_default_bsoft_after.xfs_quota.rtbsoft == pquota_default_rtbsoft|human_to_bytes
-          - test_pquota_default_bsoft_after.xfs_quota.rtbhard == pquota_default_rthard|human_to_bytes
-          - not test_pquota_project_bsoft_after.changed
-          - test_pquota_project_bsoft_after.xfs_quota.bsoft == pquota_project_bsoft|human_to_bytes
-          - test_pquota_project_bsoft_after.xfs_quota.bhard == pquota_project_bhard|human_to_bytes
-          - test_pquota_project_bsoft_after.xfs_quota.isoft == pquota_project_isoft|human_to_bytes
-          - test_pquota_project_bsoft_after.xfs_quota.ihard == pquota_project_ihard|human_to_bytes
-          - test_pquota_project_bsoft_after.xfs_quota.rtbsoft == pquota_project_rtbsoft|human_to_bytes
-          - test_pquota_project_bsoft_after.xfs_quota.rtbhard == pquota_project_rthard|human_to_bytes
+          - not test_pquota_project_after.changed
+
+    - name: 'Reset default project limits'
+      xfs_quota:
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        state: absent
+        type: project
+      become: True
+      register: test_reset_pquota_default
+
+    - name: Assert reset of default projecy limits results
+      assert:
+        that:
+          - test_reset_pquota_default.changed
+          - test_reset_pquota_default.xfs_quota.bsoft == 0
+          - test_reset_pquota_default.xfs_quota.bhard == 0
+          - test_reset_pquota_default.xfs_quota.isoft == 0
+          - test_reset_pquota_default.xfs_quota.ihard == 0
+          - test_reset_pquota_default.xfs_quota.rtbsoft == 0
+          - test_reset_pquota_default.xfs_quota.rtbhard == 0
+
+    - name: 'Reset project limits for xft_quotaval'
+      xfs_quota:
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/pquota'
+        name: xft_quotaval
+        state: absent
+        type: project
+      become: True
+      register: test_reset_pquota_project
+
+    - name: Assert reset of project limits results for xft_quotaval
+      assert:
+        that:
+          - test_reset_pquota_project.changed
+          - test_reset_pquota_project.xfs_quota.bsoft == 0
+          - test_reset_pquota_project.xfs_quota.bhard == 0
+          - test_reset_pquota_project.xfs_quota.isoft == 0
+          - test_reset_pquota_project.xfs_quota.ihard == 0
+          - test_reset_pquota_project.xfs_quota.rtbsoft == 0
+          - test_reset_pquota_project.xfs_quota.rtbhard == 0
 
   always:
     - name: 'Unmount filesystem'

--- a/test/integration/targets/xfs_quota/tasks/uquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/uquota.yml
@@ -36,12 +36,12 @@
       assert:
         that:
           - test_uquota_default_before.changed
-          - test_uquota_default_before.xfs_quota.bsoft == uquota_default_bsoft|human_to_bytes
-          - test_uquota_default_before.xfs_quota.bhard == uquota_default_bhard|human_to_bytes
-          - test_uquota_default_before.xfs_quota.isoft == uquota_default_isoft
-          - test_uquota_default_before.xfs_quota.ihard == uquota_default_ihard
-          - test_uquota_default_before.xfs_quota.rtbsoft == uquota_default_rtbsoft|human_to_bytes
-          - test_uquota_default_before.xfs_quota.rtbhard == uquota_default_rtbhard|human_to_bytes
+          - test_uquota_default_before.bsoft == uquota_default_bsoft|human_to_bytes
+          - test_uquota_default_before.bhard == uquota_default_bhard|human_to_bytes
+          - test_uquota_default_before.isoft == uquota_default_isoft
+          - test_uquota_default_before.ihard == uquota_default_ihard
+          - test_uquota_default_before.rtbsoft == uquota_default_rtbsoft|human_to_bytes
+          - test_uquota_default_before.rtbhard == uquota_default_rtbhard|human_to_bytes
 
     - name: 'Apply user limits'
       xfs_quota:
@@ -61,12 +61,12 @@
       assert:
         that:
           - test_uquota_user_before.changed
-          - test_uquota_user_before.xfs_quota.bsoft == uquota_user_bsoft|human_to_bytes
-          - test_uquota_user_before.xfs_quota.bhard == uquota_user_bhard|human_to_bytes
-          - test_uquota_user_before.xfs_quota.isoft == uquota_user_isoft
-          - test_uquota_user_before.xfs_quota.ihard == uquota_user_ihard
-          - test_uquota_user_before.xfs_quota.rtbsoft == uquota_user_rtbsoft|human_to_bytes
-          - test_uquota_user_before.xfs_quota.rtbhard == uquota_user_rtbhard|human_to_bytes
+          - test_uquota_user_before.bsoft == uquota_user_bsoft|human_to_bytes
+          - test_uquota_user_before.bhard == uquota_user_bhard|human_to_bytes
+          - test_uquota_user_before.isoft == uquota_user_isoft
+          - test_uquota_user_before.ihard == uquota_user_ihard
+          - test_uquota_user_before.rtbsoft == uquota_user_rtbsoft|human_to_bytes
+          - test_uquota_user_before.rtbhard == uquota_user_rtbhard|human_to_bytes
 
     - name: 'Re-apply default user limits'
       xfs_quota:
@@ -117,12 +117,12 @@
       assert:
         that:
           - test_reset_uquota_default.changed
-          - test_reset_uquota_default.xfs_quota.bsoft == 0
-          - test_reset_uquota_default.xfs_quota.bhard == 0
-          - test_reset_uquota_default.xfs_quota.isoft == 0
-          - test_reset_uquota_default.xfs_quota.ihard == 0
-          - test_reset_uquota_default.xfs_quota.rtbsoft == 0
-          - test_reset_uquota_default.xfs_quota.rtbhard == 0
+          - test_reset_uquota_default.bsoft == 0
+          - test_reset_uquota_default.bhard == 0
+          - test_reset_uquota_default.isoft == 0
+          - test_reset_uquota_default.ihard == 0
+          - test_reset_uquota_default.rtbsoft == 0
+          - test_reset_uquota_default.rtbhard == 0
 
     - name: 'Reset user limits for xfsquotauser'
       xfs_quota:
@@ -137,12 +137,12 @@
       assert:
         that:
           - test_reset_uquota_user.changed
-          - test_reset_uquota_user.xfs_quota.bsoft == 0
-          - test_reset_uquota_user.xfs_quota.bhard == 0
-          - test_reset_uquota_user.xfs_quota.isoft == 0
-          - test_reset_uquota_user.xfs_quota.ihard == 0
-          - test_reset_uquota_user.xfs_quota.rtbsoft == 0
-          - test_reset_uquota_user.xfs_quota.rtbhard == 0
+          - test_reset_uquota_user.bsoft == 0
+          - test_reset_uquota_user.bhard == 0
+          - test_reset_uquota_user.isoft == 0
+          - test_reset_uquota_user.ihard == 0
+          - test_reset_uquota_user.rtbsoft == 0
+          - test_reset_uquota_user.rtbhard == 0
 
   always:
     - name: 'Unmount filesystem'

--- a/test/integration/targets/xfs_quota/tasks/uquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/uquota.yml
@@ -1,0 +1,109 @@
+
+- name: 'Create disk image'
+  command: >
+    dd if=/dev/zero of={{ ansible_user_dir }}/ansible_testing/img-uquota bs=1M count=20
+
+- name: 'Create XFS filesystem'
+  filesystem:
+    dev: '{{ ansible_user_dir }}/ansible_testing/img-uquota'
+    fstype: xfs
+
+- block:
+    - name: 'Mount filesystem'
+      mount:
+        fstab: '{{ ansible_user_dir }}/ansible_testing/fstab'
+        src: '{{ ansible_user_dir }}/ansible_testing/img-uquota'
+        path: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        fstype: xfs
+        opts: uquota
+        state: mounted
+      become: True
+
+
+    - name: 'Apply default user limits'
+      xfs_quota:
+        bsoft: '{{ uquota_default_bsoft }}'
+        bhard: '{{ uquota_default_bhard }}'
+        isoft: '{{ uquota_default_isoft }}'
+        ihard: '{{ uquota_default_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        rtbsoft: '{{ uquota_default_rtbsoft }}'
+        rtbhard: '{{ uquota_default_rthard }}'
+        type: user
+      become: True
+      register: test_uquota_default_bsoft_before
+
+    - name: 'Apply user limits'
+      xfs_quota:
+        bsoft: '{{ uquota_user_bsoft }}'
+        bhard: '{{ uquota_user_bhard }}'
+        isoft: '{{ uquota_user_isoft }}'
+        ihard: '{{ uquota_user_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        name: xfsquotauser
+        rtbsoft: '{{ uquota_user_rtbsoft }}'
+        rtbhard: '{{ uquota_user_rthard }}'
+        type: user
+      become: True
+      register: test_uquota_user_bsoft_before
+
+    - name: 'Re-apply default user limits'
+      xfs_quota:
+        bsoft: '{{ uquota_default_bsoft }}'
+        bhard: '{{ uquota_default_bhard }}'
+        isoft: '{{ uquota_default_isoft }}'
+        ihard: '{{ uquota_default_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        rtbsoft: '{{ uquota_default_rtbsoft }}'
+        rtbhard: '{{ uquota_default_rthard }}'
+        type: user
+      become: True
+      register: test_uquota_default_bsoft_after
+
+    - name: 'Re-apply user limits'
+      xfs_quota:
+        bsoft: '{{ uquota_user_bsoft }}'
+        bhard: '{{ uquota_user_bhard }}'
+        isoft: '{{ uquota_user_isoft }}'
+        ihard: '{{ uquota_user_ihard }}'
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        name: xfsquotauser
+        rtbsoft: '{{ uquota_user_rtbsoft }}'
+        rtbhard: '{{ uquota_user_rthard }}'
+        type: user
+      become: True
+      register: test_uquota_user_bsoft_after
+
+    - name: 'Evaluate user quotas'
+      assert:
+        that:
+          - not test_uquota_default_bsoft_after.changed
+          - test_uquota_default_bsoft_after.xfs_quota.bsoft == uquota_default_bsoft|human_to_bytes
+          - test_uquota_default_bsoft_after.xfs_quota.bhard == uquota_default_bhard|human_to_bytes
+          - test_uquota_default_bsoft_after.xfs_quota.isoft == uquota_default_isoft|human_to_bytes
+          - test_uquota_default_bsoft_after.xfs_quota.ihard == uquota_default_ihard|human_to_bytes
+          - test_uquota_default_bsoft_after.xfs_quota.rtbsoft == uquota_default_rtbsoft|human_to_bytes
+          - test_uquota_default_bsoft_after.xfs_quota.rtbhard == uquota_default_rthard|human_to_bytes
+          - not test_uquota_user_bsoft_after.changed
+          - test_uquota_user_bsoft_after.xfs_quota.bsoft == uquota_user_bsoft|human_to_bytes
+          - test_uquota_user_bsoft_after.xfs_quota.bhard == uquota_user_bhard|human_to_bytes
+          - test_uquota_user_bsoft_after.xfs_quota.isoft == uquota_user_isoft|human_to_bytes
+          - test_uquota_user_bsoft_after.xfs_quota.ihard == uquota_user_ihard|human_to_bytes
+          - test_uquota_user_bsoft_after.xfs_quota.rtbsoft == uquota_user_rtbsoft|human_to_bytes
+          - test_uquota_user_bsoft_after.xfs_quota.rtbhard == uquota_user_rthard|human_to_bytes
+
+
+  always:
+    - name: 'Unmount filesystem'
+      mount:
+        fstab: '{{ ansible_user_dir }}/ansible_testing/fstab'
+        path: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        state: unmounted
+      become: True
+
+    - name: Remove disk image
+      file:
+        path: '{{ ansible_user_dir }}/ansible_testing/img-uquota'
+        state: absent
+
+

--- a/test/integration/targets/xfs_quota/tasks/uquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/uquota.yml
@@ -1,4 +1,4 @@
-
+---
 - name: 'Create disk image'
   command: >
     dd if=/dev/zero of={{ ansible_user_dir }}/ansible_testing/img-uquota bs=1M count=20
@@ -18,7 +18,6 @@
         opts: uquota
         state: mounted
       become: True
-
 
     - name: 'Apply default user limits'
       xfs_quota:
@@ -92,7 +91,6 @@
           - test_uquota_user_bsoft_after.xfs_quota.rtbsoft == uquota_user_rtbsoft|human_to_bytes
           - test_uquota_user_bsoft_after.xfs_quota.rtbhard == uquota_user_rthard|human_to_bytes
 
-
   always:
     - name: 'Unmount filesystem'
       mount:
@@ -105,5 +103,3 @@
       file:
         path: '{{ ansible_user_dir }}/ansible_testing/img-uquota'
         state: absent
-
-

--- a/test/integration/targets/xfs_quota/tasks/uquota.yml
+++ b/test/integration/targets/xfs_quota/tasks/uquota.yml
@@ -27,10 +27,21 @@
         ihard: '{{ uquota_default_ihard }}'
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
         rtbsoft: '{{ uquota_default_rtbsoft }}'
-        rtbhard: '{{ uquota_default_rthard }}'
+        rtbhard: '{{ uquota_default_rtbhard }}'
         type: user
       become: True
-      register: test_uquota_default_bsoft_before
+      register: test_uquota_default_before
+
+    - name: Assert default user limits results
+      assert:
+        that:
+          - test_uquota_default_before.changed
+          - test_uquota_default_before.xfs_quota.bsoft == uquota_default_bsoft|human_to_bytes
+          - test_uquota_default_before.xfs_quota.bhard == uquota_default_bhard|human_to_bytes
+          - test_uquota_default_before.xfs_quota.isoft == uquota_default_isoft
+          - test_uquota_default_before.xfs_quota.ihard == uquota_default_ihard
+          - test_uquota_default_before.xfs_quota.rtbsoft == uquota_default_rtbsoft|human_to_bytes
+          - test_uquota_default_before.xfs_quota.rtbhard == uquota_default_rtbhard|human_to_bytes
 
     - name: 'Apply user limits'
       xfs_quota:
@@ -41,10 +52,21 @@
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
         name: xfsquotauser
         rtbsoft: '{{ uquota_user_rtbsoft }}'
-        rtbhard: '{{ uquota_user_rthard }}'
+        rtbhard: '{{ uquota_user_rtbhard }}'
         type: user
       become: True
-      register: test_uquota_user_bsoft_before
+      register: test_uquota_user_before
+
+    - name: Assert user limits results
+      assert:
+        that:
+          - test_uquota_user_before.changed
+          - test_uquota_user_before.xfs_quota.bsoft == uquota_user_bsoft|human_to_bytes
+          - test_uquota_user_before.xfs_quota.bhard == uquota_user_bhard|human_to_bytes
+          - test_uquota_user_before.xfs_quota.isoft == uquota_user_isoft
+          - test_uquota_user_before.xfs_quota.ihard == uquota_user_ihard
+          - test_uquota_user_before.xfs_quota.rtbsoft == uquota_user_rtbsoft|human_to_bytes
+          - test_uquota_user_before.xfs_quota.rtbhard == uquota_user_rtbhard|human_to_bytes
 
     - name: 'Re-apply default user limits'
       xfs_quota:
@@ -54,10 +76,15 @@
         ihard: '{{ uquota_default_ihard }}'
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
         rtbsoft: '{{ uquota_default_rtbsoft }}'
-        rtbhard: '{{ uquota_default_rthard }}'
+        rtbhard: '{{ uquota_default_rtbhard }}'
         type: user
       become: True
-      register: test_uquota_default_bsoft_after
+      register: test_uquota_default_after
+
+    - name: Assert default user limits results after re-apply
+      assert:
+        that:
+          - not test_uquota_default_after.changed
 
     - name: 'Re-apply user limits'
       xfs_quota:
@@ -68,28 +95,54 @@
         mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
         name: xfsquotauser
         rtbsoft: '{{ uquota_user_rtbsoft }}'
-        rtbhard: '{{ uquota_user_rthard }}'
+        rtbhard: '{{ uquota_user_rtbhard }}'
         type: user
       become: True
-      register: test_uquota_user_bsoft_after
+      register: test_uquota_user_after
 
-    - name: 'Evaluate user quotas'
+    - name: Assert user limits results for xfsquotauser after re-apply
       assert:
         that:
-          - not test_uquota_default_bsoft_after.changed
-          - test_uquota_default_bsoft_after.xfs_quota.bsoft == uquota_default_bsoft|human_to_bytes
-          - test_uquota_default_bsoft_after.xfs_quota.bhard == uquota_default_bhard|human_to_bytes
-          - test_uquota_default_bsoft_after.xfs_quota.isoft == uquota_default_isoft|human_to_bytes
-          - test_uquota_default_bsoft_after.xfs_quota.ihard == uquota_default_ihard|human_to_bytes
-          - test_uquota_default_bsoft_after.xfs_quota.rtbsoft == uquota_default_rtbsoft|human_to_bytes
-          - test_uquota_default_bsoft_after.xfs_quota.rtbhard == uquota_default_rthard|human_to_bytes
-          - not test_uquota_user_bsoft_after.changed
-          - test_uquota_user_bsoft_after.xfs_quota.bsoft == uquota_user_bsoft|human_to_bytes
-          - test_uquota_user_bsoft_after.xfs_quota.bhard == uquota_user_bhard|human_to_bytes
-          - test_uquota_user_bsoft_after.xfs_quota.isoft == uquota_user_isoft|human_to_bytes
-          - test_uquota_user_bsoft_after.xfs_quota.ihard == uquota_user_ihard|human_to_bytes
-          - test_uquota_user_bsoft_after.xfs_quota.rtbsoft == uquota_user_rtbsoft|human_to_bytes
-          - test_uquota_user_bsoft_after.xfs_quota.rtbhard == uquota_user_rthard|human_to_bytes
+          - not test_uquota_user_after.changed
+
+    - name: 'Reset default user limits'
+      xfs_quota:
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        state: absent
+        type: user
+      become: True
+      register: test_reset_uquota_default
+
+    - name: Assert reset of default user limits results
+      assert:
+        that:
+          - test_reset_uquota_default.changed
+          - test_reset_uquota_default.xfs_quota.bsoft == 0
+          - test_reset_uquota_default.xfs_quota.bhard == 0
+          - test_reset_uquota_default.xfs_quota.isoft == 0
+          - test_reset_uquota_default.xfs_quota.ihard == 0
+          - test_reset_uquota_default.xfs_quota.rtbsoft == 0
+          - test_reset_uquota_default.xfs_quota.rtbhard == 0
+
+    - name: 'Reset user limits for xfsquotauser'
+      xfs_quota:
+        mountpoint: '{{ ansible_user_dir }}/ansible_testing/uquota'
+        name: xfsquotauser
+        state: absent
+        type: user
+      become: True
+      register: test_reset_uquota_user
+
+    - name: Assert reset of default user limits results
+      assert:
+        that:
+          - test_reset_uquota_user.changed
+          - test_reset_uquota_user.xfs_quota.bsoft == 0
+          - test_reset_uquota_user.xfs_quota.bhard == 0
+          - test_reset_uquota_user.xfs_quota.isoft == 0
+          - test_reset_uquota_user.xfs_quota.ihard == 0
+          - test_reset_uquota_user.xfs_quota.rtbsoft == 0
+          - test_reset_uquota_user.xfs_quota.rtbhard == 0
 
   always:
     - name: 'Unmount filesystem'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a new module to manage XFS quota's

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
xfs_quota

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There was no 'easy' way to manage XFS quota's, so I wrote one.
This module allows to manage block and inode quotas for 'projects' and 'users' on XFS filesystems

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
