### PR TITLE
Added OS families

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -474,7 +474,7 @@ class Distribution(object):
                      'Darwin': ['MacOSX'],
                      'FreeBSD': ['FreeBSD', 'TrueOS'],
                      'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix'],
-                     'DragonFly': ['DragonFly'],
+                     'DragonFly': ['DragonflyBSD', 'Gentoo/DragonflyBSD']
                      'OpenBSD': ['OpenBSD'],
                      'NetBSD': ['NetBSD']}
 

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -473,7 +473,10 @@ class Distribution(object):
                      'HP-UX': ['HPUX'],
                      'Darwin': ['MacOSX'],
                      'FreeBSD': ['FreeBSD', 'TrueOS'],
-                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix']}
+                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix'],
+                     'DragonFly': ['DragonFly'],
+                     'OpenBSD': ['OpenBSD'],
+                     'NetBSD': ['NetBSD']}
 
     OS_FAMILY = {}
     for family, names in OS_FAMILY_MAP.items():

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -474,7 +474,7 @@ class Distribution(object):
                      'Darwin': ['MacOSX'],
                      'FreeBSD': ['FreeBSD', 'TrueOS'],
                      'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix'],
-                     'DragonFly': ['DragonflyBSD', 'Gentoo/DragonflyBSD']
+                     'DragonFly': ['DragonflyBSD', 'Gentoo/DragonflyBSD'],
                      'OpenBSD': ['OpenBSD'],
                      'NetBSD': ['NetBSD']}
 


### PR DESCRIPTION
OS families added for Dragonfly, OpenBSD and NetBSD

##### SUMMARY
Added OS families Map for Dragonfly, OpenBSD and NetBSD. Fixes #43739 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
