### PR TITLE
portinstall module: make_args parameter #32385, added compile options…

### DIFF
--- a/lib/ansible/modules/packaging/os/portmake.py
+++ b/lib/ansible/modules/packaging/os/portmake.py
@@ -211,7 +211,6 @@ class PortMake(object):
                 # rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" % (package_without_digits))
         return occurrences
 
-    
     def remove_package(self, package):
         """
         removes a single package using system's pkg and cleans up all corresponding options in make.conf

--- a/lib/ansible/modules/packaging/os/portmake.py
+++ b/lib/ansible/modules/packaging/os/portmake.py
@@ -211,9 +211,10 @@ class PortMake(object):
                 # rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" % (package_without_digits))
         return occurrences
 
+    
     def remove_package(self, package):
         """
-        removes a single package using system's pkg
+        removes a single package using system's pkg and cleans up all corresponding options in make.conf
         """
         rc, out, err = self.module.run_command("%s %s" % (
             self.pkg_delete_path, shlex_quote(package)), use_unsafe_shell=True)
@@ -270,8 +271,9 @@ class PortMake(object):
                     continue
                 else:
                     # some options differ
-                    # remove package to be built with proper options
-                    self.remove_package(package)
+                    # remove package leave options in makle.conf
+                    rc, out, err = self.module.run_command("%s %s" % (
+                        self.pkg_delete_path, shlex_quote(package)), use_unsafe_shell=True)
 
             # install package as it is not here yet or has just been uninstalled
             matches = self.matching_packages(package)

--- a/lib/ansible/modules/packaging/os/portmake.py
+++ b/lib/ansible/modules/packaging/os/portmake.py
@@ -1,0 +1,447 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, Daniel Winter
+# Based on the portinstall module by https://github.com/berenddeboer <berend@pobox.com>
+#
+# make_args parameter added by Daniel Winter https://github.com/planet-winter <daniel@planets.world>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: portmake
+short_description: Installing packages from FreeBSD's Ports system with make configure options
+description:
+    - Manage packages for FreeBSD using the Ports system.
+    - Set or unset  make configure options per Port
+    - Saves the ports configure options to /etc/make.conf making them persistent for eg a portsupgrade
+    - Allows overriding DISABLE_VULNERABILITIES to install Ports regardless of vulnerabilities known to make ansible run succeed.
+version_added: "2.4"
+options:
+    name:
+        description:
+            - name of package to install/remove
+        required: true
+    state:
+        description:
+            - state of the package
+        choices: [ 'present', 'absent' ]
+        required: false
+        default: present
+    options_set:
+        description:
+            - specific compile options to set (as set with make configure)
+        required: false
+    options_unset:
+        description:
+            - specific compile options to unset (as set with make configure)
+        required: false
+    disable_vulnerabilities:
+        description:
+            - override DISABLE_VULNERABILITIES to install Ports regardless of vulnerabilities. Ensure ansible run installs required ports regardless.
+
+author: "Daniel Winter <daniel@planets.world>"
+'''
+
+EXAMPLES = '''
+# Install package security/cyrus-sasl2-saslauthd
+- portinstall_make_args:
+    name: security/cyrus-sasl2-saslauthd
+    state: present
+
+# Install several packages with options each
+- portinstall_make_args:
+    name: "{{ item.name }}"
+    state: "present"
+    options_set: "{{ item.options_set }}"
+    options_unset: "{{ item.options_unset }}"
+    with_items:
+      - { name: "sysutils/screen", options_set: "XTERM_256", options_unset: "SYSTEM_SCREENRC" }
+      - { name: "lang/php56-extensions", options_set: "PGSQL", options_unset: "" }
+
+'''
+
+import os
+import re
+import sys
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves import shlex_quote
+from subprocess import Popen, PIPE
+import time
+from tempfile import mkstemp
+from os import fdopen, remove
+import shutil
+
+
+class PortMake(object):
+
+    def __init__(self, module):
+        self.module = module
+        self.pkgng = None
+        
+        # if pkg_info not found assume pkgng 
+        if self.module.get_bin_path('pkg_info', False):
+            self.pkg_info_path = self.module.get_bin_path('pkg_info', False)
+            self.pkgng = False
+        else:
+            pkg_info_path = self.module.get_bin_path('pkg', True)
+            self.pkg_info_path = pkg_info_path + " info"
+            self.pkgng = True
+
+        # If pkg_delete not found, we assume pkgng
+        if self.module.get_bin_path('pkg_delete', False):
+            self.pkg_delete_path = self.module.get_bin_path('pkg_delete', False)
+            self.pkgng = False
+        else:
+            pkg_delete_path = self.module.get_bin_path('pkg', True)
+            self.pkg_delete_path = pkg_delete_path + " delete -y"
+            self.pkgng = True
+            
+        if self.module.get_bin_path('ports_glob', False):
+            self.ports_glob_path = module.get_bin_path('ports_glob', False)
+        else:
+            rc, out, err = self.module.run_command("pkg install -y portupgrade")
+            #self.install_packages("ports-mgmt/portupgrade", "","", "")
+            self.ports_glob_path = module.get_bin_path('ports_glob', True)
+
+            
+    def package_installed(self, package):
+        """
+        query the pkg system wether a package is installed
+        """
+
+        found = False
+        
+        if not self.pkgng:
+            rc, out, err = self.module.run_command("%s -e `ports_glob %s`"  % (self.pkg_info_path, shlex_quote(package)), use_unsafe_shell=True)
+        else:
+            rc, out, err = self.module.run_command("%s --exists %s" % (self.pkg_info_path, package))
+        if rc == 0:
+            found = True
+
+        if not found:
+            # databases/mysql55-client installs as mysql-client, so try solving
+            # that the ugly way. Pity FreeBSD doesn't have a fool proof way of checking
+            # some package is installed
+            package_without_digits = re.sub('[0-9]', '', package)
+            if package != package_without_digits:
+                rc, out, err = self.module.run_command("%s %s" % (self.pkg_info_path, package_without_digits))
+            if rc == 0:
+                found = True
+
+        return found
+
+
+    def get_package_options(self, package):
+        """
+        get a string of options package has been compiled with
+        """
+
+        rc, out, err = self.module.run_command("%s %s" % (self.pkg_info_path, package))
+
+        re_opt = re.compile(r"\s+(\w+)\s+:\s+on", re.IGNORECASE)
+        options_list = re_opt.findall(out)
+
+        options = " ".join(options_list)    
+
+        return options
+
+
+
+    def package_options_match(self, package, options_set, options_unset, options_add):
+        """
+        for found package check if all the set options match the ones of the installed package info
+        """
+
+        rc, out, err = self.module.run_command("%s %s" % (self.pkg_info_path, package))
+
+        options = options_add + options_set
+        for opt_set in options.split():
+            re_opt_set = re.compile(r"\s+?%s\s+?:\s+?on" % (opt_set))
+            if not re_opt_set.findall(out):
+                return False
+
+        for opt_unset in options_unset.split():
+            re_opt_unset = re.compile(r"\s+?%s\s+?:\s?off" % (opt_unset))
+            if not re_opt_unset.findall(out):
+                return False
+
+        return True
+
+
+
+    def matching_packages(self, package):
+        """
+        counts the number of packages found
+        """
+        #rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" %(package.split('/')[-1]))
+        
+        rc, out, err = self.module.run_command("%s %s" % (self.ports_glob_path, package))
+
+        occurrences = out.count('\n')
+        if occurrences == 0:
+            package_without_digits = re.sub('[0-9]', '', package)
+            if package != package_without_digits:
+                rc, out, err = self.module.run_command("%s %s" % (self.ports_glob_path, package_without_digits))
+                occurrences = out.count('\n')
+                #rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" % (package_without_digits))
+        return occurrences
+
+
+
+    def remove_package(self, package):
+        """
+        removes a single package using system's pkg
+        """
+        rc, out, err = self.module.run_command("%s %s" % (self.pkg_delete_path, shlex_quote(package)), use_unsafe_shell=True)
+                    
+        if self.package_installed(package):
+            name_without_digits = re.sub('[0-9]', '', package)
+            rc, out, err = self.module.run_command("%s %s" % (self.pkg_delete_path, shlex_quote(name_without_digits)), use_unsafe_shell=True)
+        if self.package_installed(package):
+            self.module.fail_json(msg="failed to remove %s: %s" % (package, out))
+        else:
+            mf = MakeFile(self.module)
+            mf.remove_port_options(package)
+
+            
+    def remove_packages(self, packages):
+        """
+        removes a list of packages
+        """
+        remove_c = 0
+
+        # Using a for loop in case of error, we can report the package that failed
+        for package in packages:
+            # Query the package first, to see if we even need to remove
+            if not self.package_installed(package):
+                continue
+
+            self.remove_package(package)
+            remove_c += 1
+
+        return remove_c
+
+
+    def get_options_name(self, package):
+        rc, out, err = self.module.run_command("make -C /usr/ports/%s -V OPTIONS_NAME" % (package))
+        if rc == 0:
+            options_name = out.rstrip()
+            return options_name
+        else:
+            self.module.fail_json(msg="failed to figure out configure options name for %s: %s" % (package, out))
+
+
+    def install_packages(self, packages, options_set_list, options_unset_list, options_add_list, disable_vulnerabilities=False):
+        """
+        installs a list of packages using portinstall with make options given
+        """
+        install_c = 0
+
+        for (package, options_set, options_unset, options_add) in zip(packages, options_set_list, options_unset_list, options_add_list):
+            if self.package_installed(package):
+                # package is installed. check options
+                if self.package_options_match(package, options_set, options_unset, options_add):
+                    # all ok no need to do anything for this package
+                    continue
+                else:
+                    # some options differ
+                    if options_add:
+                        # if we added options differing remember the oldpackage options
+                        old_options_set = self.get_package_options(package)
+                    self.remove_package(package)
+
+            # install package as it is not here yet or has just been uninstalled
+            matches = self.matching_packages(package)
+            if matches == 1:            
+                # unset seems to have higher prio than set
+                # empty unset variables to override any set ones in /var/db/ports/*/*/options
+                # could not get portinstall to pass settings to make via --make-args, using ENV 
+
+                options_name = self.get_options_name(package)
+
+                mf = MakeFile(self.module)
+                if options_set != [] or options_add != []:
+                    mf.set_port_option(options_name, options_set + " " + options_add)
+                if options_unset != []:
+                    mf.unset_port_option(options_name, options_unset)
+
+                compile_options = ""
+                if disable_vulnerabilities:
+                    compile_options = compile_options + "-DDISABLE_VULNERABILITIES"
+                
+                rc, out, err = self.module.run_command("make -C /usr/ports/%s clean" % (package))
+               
+                rc, out, err = self.module.run_command("make -C /usr/ports/%s install %s BATCH=yes" % (package, compile_options))
+
+                rc, out, err = self.module.run_command("make -C /usr/ports/%s clean" % (package))
+                
+                if self.package_installed(package):
+                    install_c += 1
+                else:
+                    self.module.fail_json(msg="failed to install %s: %s" % (package, out))
+
+            elif matches == 0:
+                self.module.fail_json(msg="no matches for package %s" % (package))
+
+            else:
+                self.module.fail_json(msg="%s matches found for package name %s" % (matches, package))
+
+        if install_c > 0:
+            self.module.exit_json(changed=True, msg="present %s package(s)" % (install_c))
+
+        self.module.exit_json(changed=False, msg="package(s) already present")
+
+
+
+class MakeFile():
+    
+    def __init__(self, module):
+        self.module = module
+        self.make_conf = "/etc/make.conf"
+        self.anchor = "## ansible ports module managed: DO NOT EDIT below! ##"
+        # temporary file in the current directory for os.rename to be atomic
+        fd, self.tempfile = mkstemp(dir=os.path.dirname(self.make_conf))
+        self.make_config = []
+
+        
+    def _read_make_conf(self):
+        if os.path.isfile(self.make_conf):
+            shutil.copy(self.make_conf, self.tempfile)
+
+        self.make_config = []
+        with open(self.tempfile, 'r') as tempfile:  
+            for line in tempfile:
+                self.make_config.append(line)
+
+                
+    def _write_make_conf(self):
+        with open(self.tempfile, 'w') as tempfile:
+            for line in self.make_config:
+                tempfile.write(line)
+        # atomic operation
+        os.rename(self.tempfile, self.make_conf)
+
+    
+    def _port_option_is_set(self, option, value):
+        option_value_pattern = "%s\+=%s" % (option, value)
+        for line in self.make_config:
+            if bool(re.match(option_value_pattern, line)):
+                return True
+        return False
+    
+        
+    def set_port_option(self, option, values):
+        self._port_option(option, values, kind="SET")
+
+        
+    def unset_port_option(self, option, values):
+        self._port_option(option, values, kind="UNSET")
+
+        
+    def _port_option(self, option, values, kind=None):
+        self._read_make_conf()
+        option_set = "%s_%s" % (option, kind)
+        for value in values.split():
+            if not self._port_option_is_set(option_set, value):
+                self.make_config.append("%s+=%s\n" % (option_set, value))
+        self._write_make_conf()
+        
+        
+    def remove_port_options(self, package):
+        self._read_make_conf()
+
+        pm = PortMake(self.module)
+        try:
+            options_name = pm.get_options_name(package)
+            options_pattern = "%s.+SET\+=.*" % (options_name)
+            for line in self.make_config:
+                if bool(re.match(options_pattern, line)):
+                    self.make_config.remove(line)
+        except:
+            # we might be trying to remove a package which is not in
+            #  the ports tree anymore, thus failing here
+            pass
+        
+        self._write_make_conf()
+
+
+        
+def main():
+    module = AnsibleModule(
+        argument_spec    = dict(
+            state        = dict(default="present", choices=["present","absent"]),
+            name         = dict(type='str', aliases=["pkg"], required=True),
+            options_set  = dict(type='list', required=False),
+            options_unset= dict(type='list', required=False),
+            options_add  = dict(type='list', required=False),
+            disable_vulnerabilities = dict(type='bool', required=False)
+           )
+        )
+
+    params = module.params
+
+    pkg_list = params["name"].split(",")
+
+    # add empty parameters for each package if none are given
+    if params["options_set"]:
+        options_set_list = params["options_set"]
+    else:
+        options_set_list = []
+        for pkg in pkg_list:
+            options_set_list.append("")
+
+    if params["options_unset"]:
+        options_unset_list = params["options_unset"]
+    else:
+        options_unset_list = []
+        for pkg in pkg_list:
+            options_unset_list.append("")
+
+    if params["options_add"]:
+        options_add_list = params["options_add"]
+    else:
+        options_add_list = []
+        for pkg in pkg_list:
+            options_add_list.append("")
+
+    if ( len(pkg_list) != len(options_set_list) or
+         len(pkg_list) != len(options_unset_list) or
+         len(pkg_list) != len(options_add_list) ):
+        module.fail_json( msg="""
+            %s packages given. This does not match the
+            %s options_set, %s options_unset, or %s options
+            add lists specified."""
+            % ( len(pkg_list), len(options_set_list), len(options_unset_list), len(options_add_list) )
+        )
+
+    if params["disable_vulnerabilities"]:
+        disable_vulnerabilities = params["disable_vulnerabilities"]
+    else:
+        disable_vulnerabilities = False
+        
+
+    pm = PortMake(module)
+                
+    if params["state"] == "present":
+        pm.install_packages(pkg_list, options_set_list, options_unset_list, options_add_list, \
+                            disable_vulnerabilities=disable_vulnerabilities)
+
+    elif params["state"] == "absent":
+        remove_count = pm.remove_packages(pkg_list)
+        if remove_count > 0:    
+            module.exit_json(changed=True, msg="removed %s package(s)" % remove_count)
+        module.exit_json(changed=False, msg="package(s) already absent")
+                                        
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/packaging/os/portmake.py
+++ b/lib/ansible/modules/packaging/os/portmake.py
@@ -72,6 +72,8 @@ EXAMPLES = '''
 
 '''
 
+RETURN = ""
+
 import os
 import re
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/packaging/os/portmake.py
+++ b/lib/ansible/modules/packaging/os/portmake.py
@@ -89,7 +89,7 @@ class PortMake(object):
     def __init__(self, module):
         self.module = module
         self.pkgng = None
-        
+
         # if pkg_info not found assume pkgng 
         if self.module.get_bin_path('pkg_info', False):
             self.pkg_info_path = self.module.get_bin_path('pkg_info', False)
@@ -107,7 +107,7 @@ class PortMake(object):
             pkg_delete_path = self.module.get_bin_path('pkg', True)
             self.pkg_delete_path = pkg_delete_path + " delete -y"
             self.pkgng = True
-            
+
         if self.module.get_bin_path('ports_glob', False):
             self.ports_glob_path = module.get_bin_path('ports_glob', False)
         else:
@@ -115,14 +115,14 @@ class PortMake(object):
             #self.install_packages("ports-mgmt/portupgrade", "","", "")
             self.ports_glob_path = module.get_bin_path('ports_glob', True)
 
-            
+
     def package_installed(self, package):
         """
         query the pkg system wether a package is installed
         """
 
         found = False
-        
+
         if not self.pkgng:
             rc, out, err = self.module.run_command("%s -e `ports_glob %s`"  % (self.pkg_info_path, shlex_quote(package)), use_unsafe_shell=True)
         else:
@@ -186,7 +186,7 @@ class PortMake(object):
         counts the number of packages found
         """
         #rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" %(package.split('/')[-1]))
-        
+
         rc, out, err = self.module.run_command("%s %s" % (self.ports_glob_path, package))
 
         occurrences = out.count('\n')
@@ -205,7 +205,7 @@ class PortMake(object):
         removes a single package using system's pkg
         """
         rc, out, err = self.module.run_command("%s %s" % (self.pkg_delete_path, shlex_quote(package)), use_unsafe_shell=True)
-                    
+        
         if self.package_installed(package):
             name_without_digits = re.sub('[0-9]', '', package)
             rc, out, err = self.module.run_command("%s %s" % (self.pkg_delete_path, shlex_quote(name_without_digits)), use_unsafe_shell=True)
@@ -215,7 +215,7 @@ class PortMake(object):
             mf = MakeFile(self.module)
             mf.remove_port_options(package)
 
-            
+    
     def remove_packages(self, packages):
         """
         removes a list of packages
@@ -282,7 +282,7 @@ class PortMake(object):
                 rc, out, err = self.module.run_command("make -C /usr/ports/%s clean" % (package))
                 rc, out, err = self.module.run_command("make -C /usr/ports/%s install %s BATCH=yes" % (package, compile_options))
                 rc, out, err = self.module.run_command("make -C /usr/ports/%s clean" % (package))
-                
+
                 if self.package_installed(package):
                     install_c += 1
                 else:
@@ -302,7 +302,7 @@ class PortMake(object):
 
 
 class MakeFile():
-    
+
     def __init__(self, module):
         self.module = module
         self.make_conf = "/etc/make.conf"
@@ -311,7 +311,7 @@ class MakeFile():
         fd, self.tempfile = mkstemp(dir=os.path.dirname(self.make_conf))
         self.make_config = []
 
-        
+
     def _read_make_conf(self):
         if os.path.isfile(self.make_conf):
             shutil.copy(self.make_conf, self.tempfile)
@@ -321,7 +321,7 @@ class MakeFile():
             for line in tempfile:
                 self.make_config.append(line)
 
-                
+
     def _write_make_conf(self):
         with open(self.tempfile, 'w') as tempfile:
             for line in self.make_config:
@@ -329,23 +329,23 @@ class MakeFile():
         # atomic operation
         os.rename(self.tempfile, self.make_conf)
 
-    
+
     def _port_option_is_set(self, option, value):
         option_value_pattern = "%s\+=%s" % (option, value)
         for line in self.make_config:
             if bool(re.match(option_value_pattern, line)):
                 return True
         return False
-    
-        
+
+
     def set_port_option(self, option, values):
         self._port_option(option, values, kind="SET")
 
-        
+
     def unset_port_option(self, option, values):
         self._port_option(option, values, kind="UNSET")
 
-        
+
     def _port_option(self, option, values, kind=None):
         self._read_make_conf()
         option_set = "%s_%s" % (option, kind)
@@ -353,8 +353,8 @@ class MakeFile():
             if not self._port_option_is_set(option_set, value):
                 self.make_config.append("%s+=%s\n" % (option_set, value))
         self._write_make_conf()
-        
-        
+
+
     def remove_port_options(self, package):
         self._read_make_conf()
 
@@ -373,7 +373,7 @@ class MakeFile():
         self._write_make_conf()
 
 
-        
+
 def main():
     module = AnsibleModule(
         argument_spec    = dict(

--- a/lib/ansible/modules/packaging/os/portmake.py
+++ b/lib/ansible/modules/packaging/os/portmake.py
@@ -49,7 +49,7 @@ options:
         description:
             - override DISABLE_VULNERABILITIES to install Ports regardless of vulnerabilities. Ensure ansible run installs required ports regardless.
         required: false
-        choices: [ 'true', 'false' ]
+        type: bool
         default: false
 author: "Daniel Winter (@planet-winter)"
 '''
@@ -111,7 +111,7 @@ class PortMake(object):
         else:
             rc, out, err = self.module.run_command(
                 "pkg install -y portupgrade")
-            #self.install_packages("ports-mgmt/portupgrade", "","", "")
+            # self.install_packages("ports-mgmt/portupgrade", "","", "")
             self.ports_glob_path = module.get_bin_path('ports_glob', True)
 
     def package_installed(self, package):
@@ -183,7 +183,7 @@ class PortMake(object):
         """
         counts the number of packages found
         """
-        #rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" %(package.split('/')[-1]))
+        # rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" %(package.split('/')[-1]))
 
         rc, out, err = self.module.run_command(
             "%s %s" % (self.ports_glob_path, package))
@@ -195,7 +195,7 @@ class PortMake(object):
                 rc, out, err = self.module.run_command("%s %s" % (
                     self.ports_glob_path, package_without_digits))
                 occurrences = out.count('\n')
-                #rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" % (package_without_digits))
+                # rc, out, err = self.module.run_command("make -C /usr/ports/ quicksearch name=%s" % (package_without_digits))
         return occurrences
 
     def remove_package(self, package):
@@ -354,7 +354,7 @@ class MakeFile():
 
     def remove_port_options(self, package, options_name=None):
         self._read_make_conf()
-        if options_name != None:
+        if options_name is not None:
             options_pattern = "%s" % (options_name)
             lines_remove = []
             for line in self.make_config:

--- a/lib/ansible/modules/packaging/os/portmake.py
+++ b/lib/ansible/modules/packaging/os/portmake.py
@@ -72,7 +72,18 @@ EXAMPLES = '''
 
 '''
 
-RETURN = ""
+RETURN = '''
+stdout:
+    description: output from make process
+    returned: success, when needed
+    type: str
+    sample: ""
+stderr:
+    description: error output from make process
+    returned: success, when needed
+    type: str
+    sample: ""
+'''
 
 import os
 import re

--- a/test/integration/targets/portmake/aliases
+++ b/test/integration/targets/portmake/aliases
@@ -1,0 +1,2 @@
+destructive
+shippable/posix/group1

--- a/test/integration/targets/portmake/aliases
+++ b/test/integration/targets/portmake/aliases
@@ -1,2 +1,3 @@
 destructive
 shippable/posix/group1
+skip/freebsd11.1

--- a/test/integration/targets/portmake/tasks/main.yml
+++ b/test/integration/targets/portmake/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: include tests if OS is a FreeBSD
-  include_tasks: portmake.yml
+  include_tasks: reduced_tests.yml
   when: ansible_distribution == 'FreeBSD'

--- a/test/integration/targets/portmake/tasks/main.yml
+++ b/test/integration/targets/portmake/tasks/main.yml
@@ -1,0 +1,4 @@
+
+- name: include tests if OS is a FreeBSD
+  include_tasks: portmake.yml
+  when: ansible_distribution == 'FreeBSD'

--- a/test/integration/targets/portmake/tasks/main.yml
+++ b/test/integration/targets/portmake/tasks/main.yml
@@ -1,4 +1,3 @@
-
 - name: include tests if OS is a FreeBSD
   include_tasks: portmake.yml
   when: ansible_distribution == 'FreeBSD'

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,11 +1,16 @@
 ####
 # setup portstree
 
-- name: silent install of subversion without module dependency
-  shell: pkg install -y subversion >/dev/null 2>&1
+- name: silent install of subversion with pkgng
+  pkgng:
+    name: subversion
+    state: present
 
-- name: silently checkout a tested revision of the ports tree to make the tests more stable
-  shell: svn checkout -r 493256 https://svn.FreeBSD.org/ports/head /usr/ports >/dev/null 2>&1
+- name: checkout a tested revision of the ports tree to make the tests less dependent on externals
+  subversion:
+    repo: https://svn.FreeBSD.org/ports/head
+    dest: /usr/ports
+    revision: 493256
 
 ###
 # check ports setup
@@ -27,54 +32,55 @@
     msg: "could not find directory /usr/ports/security/sudo"
   when: dir_security_sudo.stat.exists == False
 
+
 ####
 # test manual compilation and installation of packages
 
-- name: pkg remove screen
-  shell: pkg remove screen
-  args:
-    deletes: /usr/local/bin/screen  
+- name: remove screen package. do not fail if it was not installed
+  pkgng:
+    name: screen
+    state: absent
   ignore_errors: true
   
-- name: pkg remove sudo
-  shell: pkg remove sudo
-  args:
-    deletes: /usr/local/bin/sudo
+- name: remove sudo package. do not fail if it was not installed
+  pkgng:
+    name: sudo
+    state: absent
   ignore_errors: true
 
-- name: test make install screen
-  shell: make install clean
+- name: test make install screen to see wether port builds with vanilla method
+  shell: make install clean >/dev/null
   args:
     chdir: /usr/ports/sysutils/screen
     creates: /usr/local/bin/screen  
 
-- name: test make install sudo
-  shell: make install clean
+- name: test make install sudo to see wether port builds with vanilla method
+  shell: make install clean >/dev/null
   args:
     chdir: /usr/ports/security/sudo
     creates: /usr/local/bin/sudo
    
-- name: pkg delete screen
-  shell: pkg delete screen
-  args:
-    deletes: /usr/local/bin/screen  
+- name: remove screen package
+  pkgng:
+    name: screen
+    state: absent   
 
-- name: pkg delete sudo
-  shell: pkg delete sudo
-  args:
-    deletes: /usr/local/bin/sudo
+- name: remove sudo package
+  pkgng:
+    name: sudo
+    state: absent
 
 
 ####
 # test portmake absent
 
 #
-# using disable_vulnerabilities: true to allow build with current vulnerabilities after porsnap
-# testing its function seperately below
+# using disable_vulnerabilities: true to allow build with possible existent vulnerabilities
+# testing disable_vulnerabilities function seperately below
 # 
 
 - name: check absence of package screen
-  shell: pkg info screen
+  command: pkg info screen
   register: pkg_info_out
   failed_when: pkg_info_out.rc == 0
 
@@ -99,8 +105,11 @@
   ignore_errors: true
 
 - name: delete possibly installed pkg
-  shell: pkg delete screen
+  pkgng:
+    name: screen
+    state: absent
   ignore_errors: true
+
 
 # test portmake present
 
@@ -111,7 +120,7 @@
     disable_vulnerabilities: true
     
 - name: check for presence of package screen
-  shell: pkg info screen
+  command: pkg info screen
   register: pkg_info_out
   failed_when: pkg_info_out.rc != 0
 
@@ -122,7 +131,7 @@
     disable_vulnerabilities: true
     
 - name: check for presence of package screen - still installed?
-  shell: pkg info screen
+  command: pkg info screen
   register: pkg_info_out
   failed_when: pkg_info_out.rc != 0
  
@@ -185,12 +194,12 @@
     state: "present"
 
 - name: check for presence of package
-  shell: pkg info screen
+  command: pkg info screen
   register: pkg_info_out
   failed_when: pkg_info_out.rc != 0
 
 - name: check for presence of package
-  shell: pkg info sudo
+  command: pkg info sudo
   register: pkg_info_out
   failed_when: pkg_info_out.rc != 0
 
@@ -202,23 +211,23 @@
     state: "absent"
 
 - name: check for absence of package
-  shell: pkg info screen
+  command: pkg info screen
   register: pkg_info_out
   failed_when: pkg_info_out.rc == 0
 
 - name: check for absence of package
-  shell: pkg info sudo
+  command: pkg info sudo
   register: pkg_info_out
   failed_when: pkg_info_out.rc == 0
-  
+
+
 ####
 # tests portmake absent removing pkg and make.conf lines
 
-- name: remove an possibly existing make.conf file to test creation
-  shell: rm -f /etc/make.conf
-  args:
-    deletes: /etc/make.conf
-  ignore_errors: true
+- name: remove an possibly existing make.conf file to test creation thereof
+  file:
+    path: /etc/make.conf
+    state: absent
 
 - name: install a port with options - screen
   portmake:
@@ -237,13 +246,20 @@
     disable_vulnerabilities: true
     
 - name: check all options in make.conf are removed for screen
-  shell: "grep 'sysutils_screen_' /etc/make.conf"
+  command: "grep 'sysutils_screen_' /etc/make.conf"
   register: grep_makeconf_out
   failed_when: grep_makeconf_out.rc == 0
 
 - name: remove and write a test line to make.conf file to test it is not overwritten
-  shell: rm -f /etc/make.conf; echo "TEST_VARIABLE=nonsense" > /etc/make.conf
-  ignore_errors: true
+  file:
+    path: /etc/make.conf
+    state: absent
+
+- name: write a test line to make.conf file to test it is not overwritten
+  lineinfile:
+    path: /etc/make.conf
+    line: 'TEST_VARIABLE=nonsense'
+    create: yes
 
 - name: install a port with options - screen
   portmake:
@@ -254,11 +270,11 @@
     disable_vulnerabilities: true
 
 - name: check test line in make.conf still exists
-  shell: "grep 'TEST_VARIABLE=nonsense' /etc/make.conf"
+  command: "grep 'TEST_VARIABLE=nonsense' /etc/make.conf"
   register: grep_makeconf_out
   failed_when: grep_makeconf_out.rc != 0
 
 - name: check port options in make.conf are here as well
-  shell: "grep 'sysutils_screen_' /etc/make.conf"
+  command: "grep 'sysutils_screen_' /etc/make.conf"
   register: grep_makeconf_out
   failed_when: grep_makeconf_out.rc != 0

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -5,7 +5,7 @@
   shell: pkg install -y subversion >/dev/null 2>&1
 
 - name: silently checkout a tested revision of the ports tree to make the tests more stable
-  svn checkout -r 493256 https://svn.FreeBSD.org/ports/head /usr/ports >/dev/null 2>&1
+  shell: svn checkout -r 493256 https://svn.FreeBSD.org/ports/head /usr/ports >/dev/null 2>&1
 
 ###
 # check ports setup

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,36 +1,30 @@
-####
-# setup portstree
-
-- name: silent install of subversion and ca root certs with pkgng
-  pkgng:
-    name: subversion,ca_root_nss
-    state: present
-
-- name: checkout a tested revision of the ports tree to make the tests less dependent on externals
-  subversion:
-    repo: https://svn.FreeBSD.org/ports/head
-    dest: /usr/ports
-    revision: 493256
-
 ###
 # check ports setup
 - name: check for existence of screen directory
   stat:
     path: /usr/ports/sysutils/screen
   register: dir_sysutils_screen
-  
-- fail:
-    msg: "could not find directory /usr/ports/sysutils/screen"
-  when: dir_sysutils_screen.stat.exists == False
 
 - name: check for existence of sudo directory
   stat:
     path: /usr/ports/sysutils/screen
   register: dir_security_sudo
+
+
+# setup portstree if needed
+- name: silent install of subversion and ca root certs with pkgng
+  pkgng:
+    name: subversion,ca_root_nss
+    state: present
+  when: dir_sysutils_screen.stat.exists == False or dir_security_sudo.stat.exists == False
   
-- fail:
-    msg: "could not find directory /usr/ports/security/sudo"
-  when: dir_security_sudo.stat.exists == False
+- name: checkout a tested revision of the ports tree to make the tests less dependent on externals
+  subversion:
+    repo: https://svn.FreeBSD.org/ports/head
+    dest: /usr/ports
+    revision: 493256
+    force: yes
+  when: dir_sysutils_screen.stat.exists == False or dir_security_sudo.stat.exists == False
 
 
 ####

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,8 +1,8 @@
 ####
 # setup ports
 
-- name: portsnap interactive fetch forced in nnon login shell session and extract or update
-  shell: portsnap --interactive auto
+- name: portsnap interactive fetch forced in non login shell session and extract or update silently
+  shell: portsnap --interactive auto >/dev/null 2>&1
 
 ###
 # check ports setup

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,0 +1,241 @@
+####
+# setup ports
+
+- name: portsnap fetch extract
+  shell: portsnap fetch extract
+  args:
+    creates: /usr/ports/Makefile
+
+###
+# check ports setup
+- name: check for existence of screen directory
+  stat:
+    path: /usr/ports/sysutils/screen
+  register: dir_sysutils_screen
+  
+- fail:
+    msg: "could not find directory /usr/ports/sysutils/screen"
+  when: dir_sysutils_screen.stat.exists == True
+
+- name: check for existence of sudo directory
+  stat:
+    path: /usr/ports/sysutils/screen
+  register: dir_security_sudo
+  
+- fail:
+    msg: "could not find directory /usr/ports/security/sudo"
+  when: dir_security_sudo.stat.exists == True
+
+
+####
+# test manual compilation and installation of packages
+
+- name: test make install screen
+  shell: make install clean
+  args:
+    chdir: /usr/ports/sysutils/screen
+    creates: /usr/local/bin/screen  
+
+- name: test make install sudo
+  shell: make install clean
+  args:
+    chdir: /usr/ports/security/sudo
+    creates: /usr/local/bin/sudo
+   
+- name: pkg remove screen
+  shell: pkg remove screen
+  args:
+    deletes: /usr/local/bin/screen  
+
+- name: pkg remove sudo
+  shell: pkg remove sudo
+  args:
+    deletes: /usr/local/bin/sudo
+
+
+####
+# test portmake absent
+
+#
+# using disable_vulnerabilities: true to allow build with current vulnerabilities after porsnap
+# testing its function seperately below
+# 
+
+- name: check absence of package screen
+  shell: pkg info screen
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc == 0
+
+- name: test removal of package screen  not installed
+  portmake:
+    name: "sysutils/screen"
+    state: "absent"
+    
+- name: test removal of package screen not installed with unneded options
+  portmake:
+    name: "sysutils/screen"
+    state: "absent"
+    options_set: "XTERM_256"
+
+####
+# test portmake present
+ 
+- name: test installation of package screen
+  portmake:
+    name: "sysutils/screen"
+    state: "present"
+    disable_vulnerabilities: true
+    
+- name: check for presence of package screen
+  shell: pkg info screen
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc != 0
+
+- name: test installation of package screen if already installed
+  portmake:
+    name: sysutils/screen
+    state: "present"
+    disable_vulnerabilities: true
+    
+- name: check for presence of package screen - still installed?
+  shell: pkg info screen
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc != 0
+ 
+- name: test installation of package screen if already installed - with new params
+  portmake:
+    name: sysutils/screen
+    state: "present"
+    options_set: "XTERM_256"
+    disable_vulnerabilities: true
+    
+- name: check for added compile paramter of package screen
+  shell: "pkg info screen | grep XTERM_256"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("on") == -1
+
+- name: test installation of same package with an aditional option - previous option saved in /etc/make.conf
+  portmake:
+    name: sysutils/screen
+    state: "present"
+    options_set: "SHOWENC"
+    disable_vulnerabilities: true
+    
+- name: check old compile paramter of package
+  shell: "pkg info screen | grep 'XTERM_256'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("on") == -1
+
+- name: check new compile paramter of package
+  shell: "pkg info screen | grep 'SHOWENC'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("on") == -1
+
+- name: test installation of same package with an additional unset options
+  portmake:
+    name: sysutils/screen
+    state: "present"
+    options_unset: "SHOWENC NETHACK"
+
+- name: check old compile parameter of package
+  shell: "pkg info screen | grep 'XTERM_256'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("on") == -1
+
+- name: check previously set compile option is absent
+  shell: "pkg info screen | grep 'SHOWENC'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("off") == -1
+
+- name: check compile option is absent
+  shell: "pkg info screen | grep 'NETHACK'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("off") == -1
+
+  
+# test installation of several ports
+
+- name: test installation of two pkgs
+  portmake:
+    name: sysutils/screen, security/sudo
+    state: "present"
+
+- name: check for presence of package
+  shell: pkg info screen
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc != 0
+
+- name: check for presence of package
+  shell: pkg info sudo
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc != 0
+
+# clean up - remove several packages
+
+- name: test removal of two pkgs
+  portmake:
+    name: sysutils/screen, security/sudo
+    state: "absent"
+
+- name: check for absence of package
+  shell: pkg info screen
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc == 0
+
+- name: check for absence of package
+  shell: pkg info sudo
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc == 0
+
+  
+####
+# tests portmake absent removing pkg and make.conf lines
+
+- name: remove an possibly existing make.conf file to test creation
+  shell: rm -f /etc/make.conf
+  args:
+    deletes: /etc/make.conf
+  ignore_errors: true
+
+- name: install a port with options - screen
+  portmake:
+    name: sysutils/screen
+    options_set: "XTERM_256"
+    options_unset: "SHOWENC NETHACK"
+    state: "present"
+
+- name: uninstall a port with options - screen
+  portmake:
+    name: sysutils/screen
+    options_set: "XTERM_256"
+    options_unset: "SHOWENC NETHACK"
+    state: "present"
+
+- name: check all options in make.conf are removed for screen
+  shell: "grep 'sysutils_screen_' /etc/make.conf"
+  register: grep_makeconf_out
+  failed_when: grep_makeconf_out.rc == 0
+
+- name: remove and write a test line to make.conf file to test it is not overwritten
+  shell: rm -f /etc/make.conf; echo "TEST_VARIABLE=nonsense" > /etc/make.conf
+  ignore_errors: true
+
+- name: install a port with options - screen
+  portmake:
+    name: sysutils/screen
+    options_set: "XTERM_256"
+    options_unset: "SHOWENC NETHACK"
+    state: "present"
+
+- name: check test line in make.conf still exists
+  shell: "grep 'TEST_VARIABLE=nonsense' /etc/make.conf"
+  register: grep_makeconf_out
+  failed_when: grep_makeconf_out.rc != 0
+
+- name: check port options in make.conf are here as well
+  shell: "grep 'sysutils_screen_' /etc/make.conf"
+  register: grep_makeconf_out
+  failed_when: grep_makeconf_out.rc != 0
+
+
+

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -13,7 +13,7 @@
   
 - fail:
     msg: "could not find directory /usr/ports/sysutils/screen"
-  when: dir_sysutils_screen.stat.exists == True
+  when: dir_sysutils_screen.stat.exists == False
 
 - name: check for existence of sudo directory
   stat:
@@ -22,10 +22,22 @@
   
 - fail:
     msg: "could not find directory /usr/ports/security/sudo"
-  when: dir_security_sudo.stat.exists == True
+  when: dir_security_sudo.stat.exists == False
 
 ####
 # test manual compilation and installation of packages
+
+- name: pkg remove screen
+  shell: pkg remove screen
+  args:
+    deletes: /usr/local/bin/screen  
+  ignore_errors: true
+  
+- name: pkg remove sudo
+  shell: pkg remove sudo
+  args:
+    deletes: /usr/local/bin/sudo
+  ignore_errors: true
 
 - name: test make install screen
   shell: make install clean
@@ -39,13 +51,13 @@
     chdir: /usr/ports/security/sudo
     creates: /usr/local/bin/sudo
    
-- name: pkg remove screen
-  shell: pkg remove screen
+- name: pkg delete screen
+  shell: pkg delete screen
   args:
     deletes: /usr/local/bin/screen  
 
-- name: pkg remove sudo
-  shell: pkg remove sudo
+- name: pkg delete sudo
+  shell: pkg delete sudo
   args:
     deletes: /usr/local/bin/sudo
 
@@ -75,8 +87,20 @@
     options_set: "XTERM_256"
 
 ####
+# test portmake present without disable_vulnerabilities not continuosly testable
+
+- name: test installation of package screen without disable_vulnerabilities - may fail
+  portmake:
+    name: "sysutils/screen"
+    state: "present"
+  ignore_errors: true
+
+- name: delete possibly installed pkg
+  shell: pkg delete screen
+  ignore_errors: true
+
 # test portmake present
- 
+
 - name: test installation of package screen
   portmake:
     name: "sysutils/screen"
@@ -199,14 +223,16 @@
     options_set: "XTERM_256"
     options_unset: "SHOWENC NETHACK"
     state: "present"
-
+    disable_vulnerabilities: true
+    
 - name: uninstall a port with options - screen
   portmake:
     name: sysutils/screen
     options_set: "XTERM_256"
     options_unset: "SHOWENC NETHACK"
     state: "present"
-
+    disable_vulnerabilities: true
+    
 - name: check all options in make.conf are removed for screen
   shell: "grep 'sysutils_screen_' /etc/make.conf"
   register: grep_makeconf_out
@@ -222,6 +248,7 @@
     options_set: "XTERM_256"
     options_unset: "SHOWENC NETHACK"
     state: "present"
+    disable_vulnerabilities: true
 
 - name: check test line in make.conf still exists
   shell: "grep 'TEST_VARIABLE=nonsense' /etc/make.conf"

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,8 +1,11 @@
 ####
-# setup ports
+# setup portstree
 
-- name: portsnap interactive fetch forced in non login shell session and extract or update silently
-  shell: portsnap --interactive auto >/dev/null 2>&1
+- name: silent install of subversion without module dependency
+  shell: pkg install -y subversion >/dev/null 2>&1
+
+- name: silently checkout a tested revision of the ports tree to make the tests more stable
+  svn checkout -r 493256 https://svn.FreeBSD.org/ports/head /usr/ports >/dev/null 2>&1
 
 ###
 # check ports setup

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,10 +1,8 @@
 ####
 # setup ports
 
-- name: portsnap noninteractive fetch (cron) and  extract
-  shell: portsnap cron  extract
-  args:
-    creates: /usr/ports/Makefile
+- name: portsnap interactive fetch forced in nnon login shell session and extract or update
+  shell: portsnap --interactive auto
 
 ###
 # check ports setup

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,9 +1,9 @@
 ####
 # setup portstree
 
-- name: silent install of subversion with pkgng
+- name: silent install of subversion and ca root certs with pkgng
   pkgng:
-    name: subversion
+    name: subversion,ca_root_nss
     state: present
 
 - name: checkout a tested revision of the ports tree to make the tests less dependent on externals
@@ -49,13 +49,13 @@
   ignore_errors: true
 
 - name: test make install screen to see wether port builds with vanilla method
-  shell: make install clean >/dev/null
+  shell: make install clean BATCH=YES >/dev/null
   args:
     chdir: /usr/ports/sysutils/screen
     creates: /usr/local/bin/screen  
 
 - name: test make install sudo to see wether port builds with vanilla method
-  shell: make install clean >/dev/null
+  shell: make install clean BATCH=YES >/dev/null
   args:
     chdir: /usr/ports/security/sudo
     creates: /usr/local/bin/sudo
@@ -75,7 +75,7 @@
 # test portmake absent
 
 #
-# using disable_vulnerabilities: true to allow build with possible existent vulnerabilities
+# using disable_vulnerabilities: true ffto allow build with possible existent vulnerabilities
 # testing disable_vulnerabilities function seperately below
 # 
 

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -1,8 +1,8 @@
 ####
 # setup ports
 
-- name: portsnap fetch extract
-  shell: portsnap fetch extract
+- name: portsnap noninteractive fetch (cron) and  extract
+  shell: portsnap cron  extract
   args:
     creates: /usr/ports/Makefile
 
@@ -25,7 +25,6 @@
 - fail:
     msg: "could not find directory /usr/ports/security/sudo"
   when: dir_security_sudo.stat.exists == True
-
 
 ####
 # test manual compilation and installation of packages
@@ -186,7 +185,6 @@
   shell: pkg info sudo
   register: pkg_info_out
   failed_when: pkg_info_out.rc == 0
-
   
 ####
 # tests portmake absent removing pkg and make.conf lines
@@ -236,6 +234,3 @@
   shell: "grep 'sysutils_screen_' /etc/make.conf"
   register: grep_makeconf_out
   failed_when: grep_makeconf_out.rc != 0
-
-
-

--- a/test/integration/targets/portmake/tasks/portmake.yml
+++ b/test/integration/targets/portmake/tasks/portmake.yml
@@ -27,49 +27,12 @@
   when: dir_sysutils_screen.stat.exists == False or dir_security_sudo.stat.exists == False
 
 
-####
-# test manual compilation and installation of packages
-
-- name: remove screen package. do not fail if it was not installed
-  pkgng:
-    name: screen
-    state: absent
-  ignore_errors: true
-  
-- name: remove sudo package. do not fail if it was not installed
-  pkgng:
-    name: sudo
-    state: absent
-  ignore_errors: true
-
-- name: test make install screen to see wether port builds with vanilla method
-  shell: make install clean BATCH=YES >/dev/null
-  args:
-    chdir: /usr/ports/sysutils/screen
-    creates: /usr/local/bin/screen  
-
-- name: test make install sudo to see wether port builds with vanilla method
-  shell: make install clean BATCH=YES >/dev/null
-  args:
-    chdir: /usr/ports/security/sudo
-    creates: /usr/local/bin/sudo
-   
-- name: remove screen package
-  pkgng:
-    name: screen
-    state: absent   
-
-- name: remove sudo package
-  pkgng:
-    name: sudo
-    state: absent
-
 
 ####
 # test portmake absent
 
 #
-# using disable_vulnerabilities: true ffto allow build with possible existent vulnerabilities
+# using disable_vulnerabilities: true to allow build with possible existent vulnerabilities
 # testing disable_vulnerabilities function seperately below
 # 
 
@@ -88,21 +51,6 @@
     name: "sysutils/screen"
     state: "absent"
     options_set: "XTERM_256"
-
-####
-# test portmake present without disable_vulnerabilities not continuosly testable
-
-- name: test installation of package screen without disable_vulnerabilities - may fail
-  portmake:
-    name: "sysutils/screen"
-    state: "present"
-  ignore_errors: true
-
-- name: delete possibly installed pkg
-  pkgng:
-    name: screen
-    state: absent
-  ignore_errors: true
 
 
 # test portmake present

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -1,17 +1,4 @@
 ###
-# check ports setup
-
-- name: check for existence of screen directory
-  stat:
-    path: /usr/ports/sysutils/screen
-  register: dir_sysutils_screen
-
-- name: check for existence of sudo directory
-  stat:
-    path: /usr/ports/sysutils/screen
-  register: dir_security_sudo
-
-
 # setup portstree if needed
 - name: silent install of subversion and ca root certs with pkgng
   pkgng:
@@ -25,9 +12,6 @@
     dest: /usr/ports
     revision: 493256
     force: yes
-  when: dir_sysutils_screen.stat.exists == False or dir_security_sudo.stat.exists == False
-
-
 
 ###
 # test portmake absent
@@ -63,7 +47,6 @@
     options_set: "XTERM_256"
     options_unset: "NETHACK"
     state: "present"
-    disable_vulnerabilities: true
 
 - name: check for added compile paramter of package screen
   shell: "pkg info screen | grep XTERM_256"

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -35,10 +35,16 @@
 ###
 # test portmake present
 
-- name: remove an possibly existing make.conf file to test creation thereof
+- name: remove an possibly existing make.conf.
   file:
     path: /etc/make.conf
     state: absent
+
+- name: set default python version for build to work...
+  lineinfile:
+    path: /etc/make.conf
+    line: 'DEFAULT_VERSIONS += python=3.6'
+    create: yes
 
 - name: install a port with options - screen
   portmake:

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -14,9 +14,9 @@
   when: dir_www_p5_HTTP_Tiny.stat.exists == False
 
 - name: checkout ports tree if not yet done
-  command: svnlite co https://svn.FreeBSD.org/ports/head
+  command: svnlite co https://svn.FreeBSD.org/ports/head ports
   args:
-    chdir: /usr/ports
+    chdir: /usr
   when: dir_www_p5_HTTP_Tiny.stat.exists == False
 
 

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -4,7 +4,6 @@
   pkgng:
     name: subversion,ca_root_nss
     state: present
-  when: dir_sysutils_screen.stat.exists == False or dir_security_sudo.stat.exists == False
   
 - name: checkout a tested revision of the ports tree to make the tests less dependent on externals
   subversion:

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -16,20 +16,20 @@
 # test portmake absent
 
 - name: check absence of package screen
-  command: pkg info screen
+  command: pkg info tmux
   register: pkg_info_out
   failed_when: pkg_info_out.rc == 0
 
-- name: test removal of package screen  not installed
+- name: test removal of package tmux  not installed
   portmake:
-    name: "sysutils/screen"
+    name: "sysutils/tmux"
     state: "absent"
     
-- name: test removal of package screen not installed with unneded options
+- name: test removal of package tmux not installed with unneded options
   portmake:
-    name: "sysutils/screen"
+    name: "sysutils/tmux"
     state: "absent"
-    options_set: "XTERM_256"
+    options_set: "BACKSPACE"
 
 
 ###
@@ -46,20 +46,20 @@
     line: 'DEFAULT_VERSIONS += python=3.6'
     create: yes
 
-- name: install a port with options - screen
+- name: install a port with options - tmux
   portmake:
-    name: sysutils/screen
-    options_set: "XTERM_256"
-    options_unset: "NETHACK"
+    name: sysutils/tmux
+    options_set: "BACKSPACE"
+    options_unset: "EXAMPLES"
     state: "present"
 
-- name: check for added compile paramter of package screen
-  shell: "pkg info screen | grep XTERM_256"
+- name: check for added compile paramter of package tmux
+  shell: "pkg info tmux | grep BACKSPACE"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("on") == -1
 
-- name: check compile option NETHACK is absent
-  shell: "pkg info screen | grep 'NETHACK'"
+- name: check compile option EXAMPLES is absent
+  shell: "pkg info tmux | grep 'EXAMPLES'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("off") == -1
 
@@ -71,23 +71,23 @@
 
 - name: test installation of same package with an aditional option  and previous option saved in /etc/make.conf
   portmake:
-    name: sysutils/screen
+    name: sysutils/tmux
     state: "present"
-    options_set: "SHOWENC"
+    options_set: "LIBEVENT_STATIC"
     disable_vulnerabilities: true
     
 - name: check old compile paramter of package
-  shell: "pkg info screen | grep 'XTERM_256'"
+  shell: "pkg info tmux | grep 'BACKSPACE'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("on") == -1
 
-- name: check compile option NETHACK is absent
-  shell: "pkg info screen | grep 'NETHACK'"
+- name: check compile option EXAMPLES is absent
+  shell: "pkg info tmux | grep 'EXAMPLES'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("off") == -1
 
 - name: check new compile paramter of package
-  shell: "pkg info screen | grep 'SHOWENC'"
+  shell: "pkg info tmux | grep 'LIBEVENT_STATIC'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("on") == -1
 
@@ -99,15 +99,15 @@
 ###
 # tests portmake absent removing pkg and make.conf lines
 
-- name: uninstall screen with unecessary options
+- name: uninstall tmux with unecessary options
   portmake:
-    name: sysutils/screen
-    options_set: "XTERM_256"
-    options_unset: "SHOWENC NETHACK"
+    name: sysutils/tmux
+    options_set: "BACKSPACE"
+    options_unset: "EXAMPLES DOCS"
     state: "absent"
     disable_vulnerabilities: true
     
-- name: check all options in make.conf are removed for screen
-  command: "grep 'sysutils_screen_' /etc/make.conf"
+- name: check all options in make.conf are removed for tmux
+  command: "grep 'sysutils_tmux_' /etc/make.conf"
   register: grep_makeconf_out
   failed_when: grep_makeconf_out.rc == 0

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -1,38 +1,46 @@
+---
 ###
-# setup portstree if needed
-- name: silent install of subversion and ca root certs with pkgng
+# setup
+
+- name: check for existence of port directory
+  stat:
+    path: /usr/ports/www/p5-HTTP-Tiny
+  register: dir_www_p5_HTTP_Tiny
+
+- name: silent install of ca root certs with pkgng
   pkgng:
-    name: subversion,ca_root_nss
+    name: ca_root_nss
     state: present
-  
-- name: checkout a tested revision of the ports tree to make the tests less dependent on externals
-  subversion:
-    repo: https://svn.FreeBSD.org/ports/head
-    dest: /usr/ports
-    revision: 493256
-    force: yes
+  when: dir_www_p5_HTTP_Tiny.stat.exists == False
+
+- name: checkout ports tree if not yet done
+  command: svnlite co https://svn.FreeBSD.org/ports/head
+  args:
+    chdir: /usr/ports
+  when: dir_www_p5_HTTP_Tiny.stat.exists == False
+
 
 ###
 # test portmake absent
 
-- name: test removal of package tmux  not installed
+- name: test removal of package p5-HTTP-Tiny not installed
   portmake:
-    name: "sysutils/tmux"
+    name: "www/p5-HTTP-Tiny"
     state: "absent"
 
-- name: check absence of package tmux
-  command: pkg info tmux
+- name: check absence of package p5-HTTP-Tiny
+  command: pkg info p5-HTTP-Tiny
   register: pkg_info_out
   failed_when: pkg_info_out.rc == 0
 
-- name: test removal of package tmux not installed with unneded options
+- name: test removal of package p5-HTTP-Tiny not installed with unneded options
   portmake:
-    name: "sysutils/tmux"
+    name: "www/p5-HTTP-Tiny"
     state: "absent"
-    options_set: "BACKSPACE"
+    options_set: "COOKIE"
 
-- name: check absence of package tmux
-  command: pkg info tmux
+- name: check absence of package p5-HTTP-Tiny
+  command: pkg info p5-HTTP-Tiny
   register: pkg_info_out
   failed_when: pkg_info_out.rc == 0
 
@@ -45,26 +53,20 @@
     path: /etc/make.conf
     state: absent
 
-- name: set default python version for build to work...
-  lineinfile:
-    path: /etc/make.conf
-    line: 'DEFAULT_VERSIONS += python=3.6'
-    create: yes
-
-- name: install a port with options - tmux
+- name: install a port with options - p5-HTTP-Tiny
   portmake:
-    name: sysutils/tmux
-    options_set: "BACKSPACE"
-    options_unset: "EXAMPLES"
+    name: www/p5-HTTP-Tiny
+    options_set: "COOKIE"
+    options_unset: "HTTPS"
     state: "present"
 
-- name: check for added compile paramter of package tmux
-  shell: "pkg info tmux | grep BACKSPACE"
+- name: check for added compile paramter of package p5-HTTP-Tiny
+  shell: "pkg info p5-HTTP-Tiny | grep COOKIE"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("on") == -1
 
-- name: check compile option EXAMPLES is absent
-  shell: "pkg info tmux | grep 'EXAMPLES'"
+- name: check compile option HTTPS is absent
+  shell: "pkg info p5-HTTP-Tiny | grep 'HTTPS'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("off") == -1
 
@@ -76,23 +78,23 @@
 
 - name: test installation of same package with an aditional option  and previous option saved in /etc/make.conf
   portmake:
-    name: sysutils/tmux
+    name: www/p5-HTTP-Tiny
     state: "present"
-    options_set: "LIBEVENT_STATIC"
+    options_set: "IO_SOCKET_IP"
     disable_vulnerabilities: true
     
 - name: check old compile paramter of package
-  shell: "pkg info tmux | grep 'BACKSPACE'"
+  shell: "pkg info p5-HTTP-Tiny | grep 'COOKIE'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("on") == -1
 
-- name: check compile option EXAMPLES is absent
-  shell: "pkg info tmux | grep 'EXAMPLES'"
+- name: check compile option HTTPS is absent
+  shell: "pkg info p5-HTTP-Tiny | grep 'HTTPS'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("off") == -1
 
 - name: check new compile paramter of package
-  shell: "pkg info tmux | grep 'LIBEVENT_STATIC'"
+  shell: "pkg info p5-HTTP-Tiny | grep 'IO_SOCKET_IP'"
   register: pkg_info_out
   failed_when: pkg_info_out.stdout.find("on") == -1
 
@@ -104,15 +106,15 @@
 ###
 # tests portmake absent removing pkg and make.conf lines
 
-- name: uninstall tmux with unecessary options
+- name: uninstall p5-HTTP-Tiny with unecessary options
   portmake:
-    name: sysutils/tmux
-    options_set: "BACKSPACE"
-    options_unset: "EXAMPLES DOCS"
+    name: www/p5-HTTP-Tiny
+    options_set: "COOKIE"
+    options_unset: "HTTPS IO_SOCKET_IP"
     state: "absent"
     disable_vulnerabilities: true
     
-- name: check all options in make.conf are removed for tmux
-  command: "grep 'sysutils_tmux_' /etc/make.conf"
+- name: check all options in make.conf are removed for p5-HTTP-Tiny
+  command: "grep 'sysutils_p5-HTTP-Tiny_' /etc/make.conf"
   register: grep_makeconf_out
   failed_when: grep_makeconf_out.rc == 0

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -1,0 +1,125 @@
+###
+# check ports setup
+
+- name: check for existence of screen directory
+  stat:
+    path: /usr/ports/sysutils/screen
+  register: dir_sysutils_screen
+
+- name: check for existence of sudo directory
+  stat:
+    path: /usr/ports/sysutils/screen
+  register: dir_security_sudo
+
+
+# setup portstree if needed
+- name: silent install of subversion and ca root certs with pkgng
+  pkgng:
+    name: subversion,ca_root_nss
+    state: present
+  when: dir_sysutils_screen.stat.exists == False or dir_security_sudo.stat.exists == False
+  
+- name: checkout a tested revision of the ports tree to make the tests less dependent on externals
+  subversion:
+    repo: https://svn.FreeBSD.org/ports/head
+    dest: /usr/ports
+    revision: 493256
+    force: yes
+  when: dir_sysutils_screen.stat.exists == False or dir_security_sudo.stat.exists == False
+
+
+
+###
+# test portmake absent
+
+- name: check absence of package screen
+  command: pkg info screen
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc == 0
+
+- name: test removal of package screen  not installed
+  portmake:
+    name: "sysutils/screen"
+    state: "absent"
+    
+- name: test removal of package screen not installed with unneded options
+  portmake:
+    name: "sysutils/screen"
+    state: "absent"
+    options_set: "XTERM_256"
+
+
+###
+# test portmake present
+
+- name: remove an possibly existing make.conf file to test creation thereof
+  file:
+    path: /etc/make.conf
+    state: absent
+
+- name: install a port with options - screen
+  portmake:
+    name: sysutils/screen
+    options_set: "XTERM_256"
+    options_unset: "NETHACK"
+    state: "present"
+    disable_vulnerabilities: true
+
+- name: check for added compile paramter of package screen
+  shell: "pkg info screen | grep XTERM_256"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("on") == -1
+
+- name: check compile option NETHACK is absent
+  shell: "pkg info screen | grep 'NETHACK'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("off") == -1
+
+- name: write a test line to make.conf file to test it is not overwritten
+  lineinfile:
+    path: /etc/make.conf
+    line: 'TEST_VARIABLE=nonsense'
+    create: yes
+
+- name: test installation of same package with an aditional option  and previous option saved in /etc/make.conf
+  portmake:
+    name: sysutils/screen
+    state: "present"
+    options_set: "SHOWENC"
+    disable_vulnerabilities: true
+    
+- name: check old compile paramter of package
+  shell: "pkg info screen | grep 'XTERM_256'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("on") == -1
+
+- name: check compile option NETHACK is absent
+  shell: "pkg info screen | grep 'NETHACK'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("off") == -1
+
+- name: check new compile paramter of package
+  shell: "pkg info screen | grep 'SHOWENC'"
+  register: pkg_info_out
+  failed_when: pkg_info_out.stdout.find("on") == -1
+
+- name: check test line in make.conf is still here
+  command: "grep 'TEST_VARIABLE=nonsense' /etc/make.conf"
+  register: grep_makeconf_out
+  failed_when: grep_makeconf_out.rc != 0
+
+###
+# tests portmake absent removing pkg and make.conf lines
+
+- name: uninstall screen with unecessary options
+  portmake:
+    name: sysutils/screen
+    options_set: "XTERM_256"
+    options_unset: "SHOWENC NETHACK"
+    state: "absent"
+    disable_vulnerabilities: true
+    
+- name: check all options in make.conf are removed for screen
+  command: "grep 'sysutils_screen_' /etc/make.conf"
+  register: grep_makeconf_out
+  failed_when: grep_makeconf_out.rc == 0

--- a/test/integration/targets/portmake/tasks/reduced_tests.yml
+++ b/test/integration/targets/portmake/tasks/reduced_tests.yml
@@ -15,27 +15,32 @@
 ###
 # test portmake absent
 
-- name: check absence of package screen
-  command: pkg info tmux
-  register: pkg_info_out
-  failed_when: pkg_info_out.rc == 0
-
 - name: test removal of package tmux  not installed
   portmake:
     name: "sysutils/tmux"
     state: "absent"
-    
+
+- name: check absence of package tmux
+  command: pkg info tmux
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc == 0
+
 - name: test removal of package tmux not installed with unneded options
   portmake:
     name: "sysutils/tmux"
     state: "absent"
     options_set: "BACKSPACE"
 
+- name: check absence of package tmux
+  command: pkg info tmux
+  register: pkg_info_out
+  failed_when: pkg_info_out.rc == 0
+
 
 ###
 # test portmake present
 
-- name: remove an possibly existing make.conf.
+- name: remove a possibly existing make.conf.
   file:
     path: /etc/make.conf
     state: absent


### PR DESCRIPTION
portmake

##### SUMMARY
a module to build FreeBSD Ports using make
 - set and unset compile options for the given port as named in make config
 - persists the options set or unset in /etc/make.conf. This enables an eg. a manual portupgrade to use the same options and compile the updated ports with them.
 - option to install a port regardless of port security issues for ansible run not to fail

"Fixes #32385"

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
portmake

##### ADDITIONAL INFORMATION

this module adds more functionality than the existing similar portinstall module.

In many cases an installation of a service is not possible in FreeBSD without compiling a certain port option into the package. This rendered the portinstall module unusable for our use cases.


