### PR TITLE
win_service - use custom binary for tests

### DIFF
--- a/test/integration/targets/win_service/defaults/main.yml
+++ b/test/integration/targets/win_service/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
-# parameters set here for creating new service in tests
+test_win_service_binary_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/win_service/SleepService.exe
+test_win_service_dir: C:\ansible testing\[win_service]
+test_win_service_path: '{{ test_win_service_dir }}\SleepService.exe'
 test_win_service_name: TestService [*abc]
 test_win_service_display_name: Test Service
 test_win_service_description: Test Service description
-test_win_service_path: C:\Windows\System32\snmptrap.exe
-
-# used for the pause tests, need to use an actual service
-test_win_service_pause_name: TapiSrv

--- a/test/integration/targets/win_service/files/Program.cs
+++ b/test/integration/targets/win_service/files/Program.cs
@@ -1,0 +1,16 @@
+using System.ServiceProcess;
+
+namespace SleepService
+{
+    internal static class Program
+    {
+        private static void Main(string[] args)
+        {
+            ServiceBase.Run(new ServiceBase[1]
+            {
+                (ServiceBase) new SleepService(args)
+            });
+        }
+    }
+}
+

--- a/test/integration/targets/win_service/files/SleepService.cs
+++ b/test/integration/targets/win_service/files/SleepService.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Management;
+using System.ServiceProcess;
+
+namespace SleepService
+{
+    public class SleepService : ServiceBase
+    {
+        private IContainer components = null;
+        private string[] serviceArgs;
+        private string displayName;
+
+        public SleepService(string[] args)
+        {
+            CanPauseAndContinue = true;
+            CanShutdown = true;
+            CanStop = true;
+            AutoLog = false;
+            serviceArgs = args;
+            InitializeComponent();
+
+            string eventSource = "Ansible Test";
+            if (!EventLog.SourceExists(eventSource))
+                EventLog.CreateEventSource(eventSource, "Application");
+            EventLog.Source = eventSource;
+            EventLog.Log = "Application";
+        }
+
+        private string GetServiceName()
+        {
+            using (ManagementObjectCollection.ManagementObjectEnumerator enumerator = new ManagementObjectSearcher(string.Format("SELECT * FROM Win32_Service WHERE ProcessId = {0}", (object)Process.GetCurrentProcess().Id)).Get().GetEnumerator())
+            {
+                if (enumerator.MoveNext())
+                    return enumerator.Current["Name"].ToString();
+            }
+            return ServiceName;
+        }
+
+        protected override void OnContinue()
+        {
+            EventLog.WriteEntry(string.Format("{0} OnContinue", displayName));
+        }
+
+        protected override void OnCustomCommand(int command)
+        {
+            EventLog.WriteEntry(string.Format("{0} OnCustomCommand {1}", displayName, command.ToString()));
+        }
+
+        protected override void OnPause()
+        {
+            EventLog.WriteEntry(string.Format("{0} OnPause", displayName));
+        }
+
+        protected override void OnStart(string[] args)
+        {
+            displayName = this.GetServiceName();
+            EventLog.WriteEntry(string.Format("{0} OnStart Args:\n{1}", displayName, string.Join("\n", serviceArgs)));
+        }
+
+        protected override void OnShutdown()
+        {
+            EventLog.WriteEntry(string.Format("{0} OnShutdown", displayName));
+        }
+
+        protected override void OnStop()
+        {
+            EventLog.WriteEntry(string.Format("{0} OnStop", displayName));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && components != null)
+                components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            components = new Container();
+            ServiceName = nameof(SleepService);
+        }
+    }
+}
+

--- a/test/integration/targets/win_service/tasks/main.yml
+++ b/test/integration/targets/win_service/tasks/main.yml
@@ -16,39 +16,38 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: create test directory
+  win_file:
+    path: '{{ test_win_service_dir }}'
+    state: directory
+
+# This binary has been pre-compiled with the code in the files directory of this role
+- name: download service executable
+  win_get_url:
+    url: '{{ test_win_service_binary_url }}'
+    dest: '{{ test_win_service_path }}'
+
 - name: remove the dummy test services if it is left over from previous tests
   win_service:
-    name: '{{item}}'
+    name: '{{ item }}'
     force_dependent_services: True
     state: absent
   with_items:
-  - '{{test_win_service_name}}'
+  - '{{ test_win_service_name }}'
   - TestServiceParent2
   - TestServiceDependency
-
-- name: get details of the {{test_win_service_pause_name}} service
-  win_service:
-    name: '{{test_win_service_pause_name}}'
-  register: pause_service_details
 
 - block:
   - include_tasks: tests.yml
 
   always:
-  - name: ensure the {{test_win_service_pause_name}} is set to stopped if it was stopped
+  - name: remove test services
     win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: stopped
-      force_dependent_services: True
-    when: pause_service_details.state == 'stopped'
-
-  - name: make sure all services are removed in the end
-    win_service:
-      name: '{{item}}'
+      name: '{{ item }}'
       force_dependent_services: True
       state: absent
     with_items:
-    - '{{test_win_service_name}}'
+    - '{{ test_win_service_name }}'
     - TestServiceParent2
     - TestServiceDependency
 
@@ -56,4 +55,9 @@
     win_environment:
       name: TEST_SERVICE_PATH
       level: machine
+      state: absent
+
+  - name: remove test directory
+    win_file:
+      path: '{{ test_win_service_dir }}'
       state: absent

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -427,7 +427,7 @@
     - win_service_local_system_desktop is changed
     - win_service_local_system_desktop.username == 'LocalSystem'
     - win_service_local_system_desktop.desktop_interact == True
-    
+
 - name: set service username to Local System with desktop interaction again
   win_service:
     name: "{{test_win_service_name}}"
@@ -800,116 +800,116 @@
     - win_service_removed.state is not defined
     - win_service_removed.username is not defined
 
-# only run these tests if TapiSrv is already stopped, don't want to impact an existing server
-- block:
-  - name: start the pausable service
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: started
-    register: stat_pausable_service
+- name: create new pausable dummy test service
+  win_service:
+    name: "{{test_win_service_name}}"
+    path: "{{test_win_service_path}}"
+    display_name: "{{test_win_service_display_name}}"
+    description: "{{test_win_service_description}}"
+    state: started
+  register: stat_pausable_service
 
-  - name: assert get details on a pausable service
-    assert:
-      that:
-      - stat_pausable_service.can_pause_and_continue == True
+- name: assert get details on a pausable service
+  assert:
+    that:
+    - stat_pausable_service.can_pause_and_continue == True
 
-  - name: pause a service check
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: paused
-    register: win_service_paused_check
-    check_mode: yes
+- name: pause a service check
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: paused
+  register: win_service_paused_check
+  check_mode: yes
 
-  - name: assert pause a service check
-    assert:
-      that:
-      - win_service_paused_check is changed
-      - win_service_paused_check.state == 'running'
+- name: assert pause a service check
+  assert:
+    that:
+    - win_service_paused_check is changed
+    - win_service_paused_check.state == 'running'
 
-  - name: pause a service
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: paused
-    register: win_service_paused
+- name: pause a service
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: paused
+  register: win_service_paused
 
-  - name: assert pause a service
-    assert:
-      that:
-      - win_service_paused is changed
-      - win_service_paused.state == 'paused'
+- name: assert pause a service
+  assert:
+    that:
+    - win_service_paused is changed
+    - win_service_paused.state == 'paused'
 
-  - name: pause a service again
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: paused
-    register: win_service_paused_again
+- name: pause a service again
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: paused
+  register: win_service_paused_again
 
-  - name: assert pause a service again
-    assert:
-      that:
-      - win_service_paused_again is not changed
+- name: assert pause a service again
+  assert:
+    that:
+    - win_service_paused_again is not changed
 
-  - name: start a paused service check
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: started
-    register: start_paused_service_check
-    check_mode: yes
+- name: start a paused service check
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: started
+  register: start_paused_service_check
+  check_mode: yes
 
-  - name: assert start a paused service check
-    assert:
-      that:
-      - start_paused_service_check is changed
-      - start_paused_service_check.state == 'paused'
+- name: assert start a paused service check
+  assert:
+    that:
+    - start_paused_service_check is changed
+    - start_paused_service_check.state == 'paused'
 
-  - name: start a paused service
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: started
-    register: start_paused_service
+- name: start a paused service
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: started
+  register: start_paused_service
 
-  - name: assert start a paused service
-    assert:
-      that:
-      - start_paused_service is changed
-      - start_paused_service.state == 'running'
+- name: assert start a paused service
+  assert:
+    that:
+    - start_paused_service is changed
+    - start_paused_service.state == 'running'
 
-  - name: pause service for next test
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: paused
+- name: pause service for next test
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: paused
 
-  - name: stop a paused service check
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: stopped
-      force_dependent_services: True
-    register: stop_paused_service_check
-    check_mode: yes
+- name: stop a paused service check
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: stopped
+    force_dependent_services: True
+  register: stop_paused_service_check
+  check_mode: yes
 
-  - name: assert stop a paused service check
-    assert:
-      that:
-      - stop_paused_service_check is changed
-      - stop_paused_service_check.state == 'paused'
+- name: assert stop a paused service check
+  assert:
+    that:
+    - stop_paused_service_check is changed
+    - stop_paused_service_check.state == 'paused'
 
-  - name: stop a paused service
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: stopped
-      force_dependent_services: True
-    register: stop_paused_service
+- name: stop a paused service
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: stopped
+    force_dependent_services: True
+  register: stop_paused_service
 
-  - name: assert stop a paused service
-    assert:
-      that:
-      - stop_paused_service is changed
-      - stop_paused_service.state == 'stopped'
+- name: assert stop a paused service
+  assert:
+    that:
+    - stop_paused_service is changed
+    - stop_paused_service.state == 'stopped'
 
-  - name: fail to pause a stopped service check
-    win_service:
-      name: '{{test_win_service_pause_name}}'
-      state: paused
-    register: fail_pause_stopped_service
-    failed_when: "fail_pause_stopped_service.msg != 'failed to pause service ' + test_win_service_pause_name + ': The service does not support pausing'"
-  when: pause_service_details.state == 'stopped'
+- name: fail to pause a stopped service check
+  win_service:
+    name: '{{test_win_service_name}}'
+    state: paused
+  register: fail_pause_stopped_service
+  failed_when: "fail_pause_stopped_service.msg != 'failed to pause service ' + test_win_service_name + ': The service does not support pausing'"


### PR DESCRIPTION
##### SUMMARY
To avoid the issue of finding a safe service to manipulate within the tests this PR runs the win_service integration on a dummy service binary. This allows us to run the pause tests on all hosts and makes the tests compatible with Server 2019.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_service