### PR TITLE
test win_setup - make py3 compatible

### DIFF
--- a/test/integration/targets/win_setup/tasks/main.yml
+++ b/test/integration/targets/win_setup/tasks/main.yml
@@ -92,7 +92,7 @@
     - setup_result.ansible_facts.gather_subset is defined
     - setup_result.ansible_facts.gather_subset[0] == '!all'
     - setup_result.ansible_facts.gather_subset[1] == '!min'
-    - setup_result.ansible_facts.keys() | union(['gather_subset','module_setup']) | length == 2
+    - setup_result.ansible_facts.keys() | list | union(['gather_subset','module_setup']) | length == 2
 
 - name: test gather_subset "!all,!min,interfaces" with list
   setup:
@@ -117,7 +117,7 @@
     - setup_result.ansible_facts.ansible_interfaces[0].interface_name
     - setup_result.ansible_facts.ansible_interfaces[0].connection_name
     - setup_result.ansible_facts.ansible_interfaces[0].interface_index
-    - setup_result.ansible_facts.keys() | union(['ansible_interfaces','gather_subset','module_setup']) | length == 3
+    - setup_result.ansible_facts.keys() | list | union(['ansible_interfaces','gather_subset','module_setup']) | length == 3
 
 - name: test gather_subset "!all,!min,bogus" with list
   setup:
@@ -136,6 +136,6 @@
     - setup_result.ansible_facts.gather_subset is defined
     - setup_result.ansible_facts.gather_subset[0] == '!all'
     - setup_result.ansible_facts.gather_subset[1] == '!min'
-    - setup_result.ansible_facts.keys() | union(['gather_subset','module_setup']) | length == 2
+    - setup_result.ansible_facts.keys() | list | union(['gather_subset','module_setup']) | length == 2
     - setup_result.warnings | length == 1
     - setup_result.warnings[0] | regex_search('bogus')


### PR DESCRIPTION
##### SUMMARY
The current tests in `test/integration/targets/win_setup` are not compatible with Pythoon 3. It fails with the error

```
TASK [win_setup : verify that only status keys are returned] ********************************************                                                                                                          task path: /Users/jborean/.ansible/test/tmp/win_setup-gv3x2uf_-ÅÑŚÌβŁÈ/test/integration/targets/win_setup/tasks/main.yml:86
fatal: [2016]: FAILED! => {                                                                                                                                                                                        
    "msg": "The conditional check 'setup_result.ansible_facts.keys() | union(['gather_subset','module_setup']) | length == 2' failed. The error was: Unexpected templating type error occurred on ({% if setup_resu
lt.ansible_facts.keys() | union(['gather_subset','module_setup']) | length == 2 %} True {% else %} False {% endif %}): unsupported operand type(s) for +: 'dict_keys' and 'list'"                                  
}      
```

This PR fixes that issue so it will run on both Python 2 and 3.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/win_setup