### PR TITLE
Add support of facts gathering WWNs on AIX OS

### DIFF
--- a/changelogs/fragments/fibre_channel_wwn_fact_aix.yaml
+++ b/changelogs/fragments/fibre_channel_wwn_fact_aix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - gather Fibre Channel WWNs fact on AIX (extends https://github.com/ansible/ansible/pull/37043)

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -67,7 +67,7 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
                     # if device is available (not in defined state), get its WWN
                     if 'Available' in line:
                         data = line.split(' ')
-                        cmd="/usr/sbin/lscfg -vl %s | grep 'Network Address'" % data[0]
+                        cmd = "/usr/sbin/lscfg -vl %s | grep 'Network Address'" % data[0]
                         rc, lscfg_out, err = module.run_command(cmd, use_unsafe_shell=True)
                         # example output
                         # lscfg -vpl fcs3 | grep "Network Address"

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -65,12 +65,12 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
             cmd = cmd + " -Cc adapter -l fcs*"
             rc, lsdev_out, err = module.run_command(cmd)
             if lsdev_out:
+                lscfg_cmd = module.get_bin_path('lscfg')
                 for line in lsdev_out.splitlines():
                     # if device is available (not in defined state), get its WWN
                     if 'Available' in line:
                         data = line.split(' ')
-                        cmd = module.get_bin_path('lscfg')
-                        cmd = cmd + " -vl %s | grep 'Network Address'" % data[0]
+                        cmd = lscfg_cmd + " -vl %s | grep 'Network Address'" % data[0]
                         rc, lscfg_out, err = module.run_command(cmd, use_unsafe_shell=True)
                         # example output
                         # lscfg -vpl fcs3 | grep "Network Address"

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -76,7 +76,7 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
                         # lscfg -vpl fcs3 | grep "Network Address"
                         #        Network Address.............10000090FA551509
                         for line in lscfg_out.splitlines():
-                            if line.find('Network Address') != -1:
+                            if 'Network Address' in line:
                                 data = line.split('.')
                                 fc_facts['fibre_channel_wwn'].append(data[-1].rstrip())
         return fc_facts

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -70,12 +70,13 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
                     # if device is available (not in defined state), get its WWN
                     if 'Available' in line:
                         data = line.split(' ')
-                        cmd = lscfg_cmd + " -vl %s | grep 'Network Address'" % data[0]
-                        rc, lscfg_out, err = module.run_command(cmd, use_unsafe_shell=True)
+                        cmd = lscfg_cmd + " -vl %s" % data[0]
+                        rc, lscfg_out, err = module.run_command(cmd)
                         # example output
                         # lscfg -vpl fcs3 | grep "Network Address"
                         #        Network Address.............10000090FA551509
-                        if lscfg_out:
-                            data = lscfg_out.split('.')
-                            fc_facts['fibre_channel_wwn'].append(data[-1].rstrip())
+                        for line in lscfg_out.splitlines():
+                            if line.find('Network Address') != -1:
+                                data = line.split('.')
+                                fc_facts['fibre_channel_wwn'].append(data[-1].rstrip())
         return fc_facts

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -61,13 +61,16 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
                     fc_facts['fibre_channel_wwn'].append(data[-1].rstrip())
         elif sys.platform.startswith('aix'):
             # get list of available fibre-channel devices (fcs)
-            rc, lsdev_out, err = module.run_command("/usr/sbin/lsdev -Cc adapter -l fcs*")
+            cmd = module.get_bin_path('lsdev')
+            cmd = cmd + " -Cc adapter -l fcs*"
+            rc, lsdev_out, err = module.run_command(cmd)
             if lsdev_out:
                 for line in lsdev_out.splitlines():
                     # if device is available (not in defined state), get its WWN
                     if 'Available' in line:
                         data = line.split(' ')
-                        cmd = "/usr/sbin/lscfg -vl %s | grep 'Network Address'" % data[0]
+                        cmd = module.get_bin_path('lscfg')
+                        cmd = cmd + " -vl %s | grep 'Network Address'" % data[0]
                         rc, lscfg_out, err = module.run_command(cmd, use_unsafe_shell=True)
                         # example output
                         # lscfg -vpl fcs3 | grep "Network Address"

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -67,13 +67,12 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
                     # if device is available (not in defined state), get its WWN
                     if 'Available' in line:
                         data = line.split(' ')
-                        fcsdev = data[0]
-                        # get device configuration
-                        rc, lscfg_out, err = module.run_command("/usr/sbin/lscfg -vpl %s | grep 'Network Address'" % (fcsdev))
+                        cmd="/usr/sbin/lscfg -vl %s | grep 'Network Address'" % data[0]
+                        rc, lscfg_out, err = module.run_command(cmd, use_unsafe_shell=True)
                         # example output
                         # lscfg -vpl fcs3 | grep "Network Address"
                         #        Network Address.............10000090FA551509
                         if lscfg_out:
                             data = lscfg_out.split('.')
-                            fc_facts['fibre_channel_wwn'].append(data[-1])
+                            fc_facts['fibre_channel_wwn'].append(data[-1].rstrip())
         return fc_facts

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -61,7 +61,7 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
                     fc_facts['fibre_channel_wwn'].append(data[-1].rstrip())
         elif sys.platform.startswith('aix'):
             # get list of available fibre-channel devices (fcs)
-            rc, lsdev_out, err = self.module.run_command("/usr/sbin/lsdev -Cc adapter -l fcs*")
+            rc, lsdev_out, err = module.run_command("/usr/sbin/lsdev -Cc adapter -l fcs*")
             if lsdev_out:
                 for line in lsdev_out.splitlines():
                     # if device is available (not in defined state), get its WWN
@@ -69,7 +69,7 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
                         data = line.split(' ')
                         fcsdev = data[0]
                         # get device configuration
-                        rc, lscfg_out, err = self.module.run_command("/usr/sbin/lscfg -vpl %s | grep 'Network Address'" % (fcsdev))
+                        rc, lscfg_out, err = module.run_command("/usr/sbin/lscfg -vpl %s | grep 'Network Address'" % (fcsdev))
                         # example output
                         # lscfg -vpl fcs3 | grep "Network Address"
                         #        Network Address.............10000090FA551509


### PR DESCRIPTION
##### SUMMARY
Add support of facts gathering WWNs on AIX OS

Extends #37043 / c65909d "Add network fact to obtain FC WWN initiator ports" for AIX support

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
facts module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```
aix$ lsdev -Cc adapter -l fcs*
fcs0 Defined   00-00 8Gb PCI Express Dual Port FC Adapter
fcs1 Defined   00-01 8Gb PCI Express Dual Port FC Adapter
fcs2 Available 04-00 8Gb PCI Express Dual Port FC Adapter
fcs3 Available 04-01 8Gb PCI Express Dual Port FC Adapter

aix$ lscfg -vl fcs3 | grep "Network Address"
        Network Address.............10000090FA551509
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
$ ansible -v vios8 -m setup -a "filter=ansible_fibre*"
Using /home/mator/ans/ansible.cfg as config file
vios8 | SUCCESS => {
    "ansible_facts": {
        "ansible_fibre_channel_wwn": []
    }, 
    "changed": false
}
```
after:
```
$ ansible vios8 -m setup -a "filter=ansible_fibre*"
vios8 | SUCCESS => {
    "ansible_facts": {
        "ansible_fibre_channel_wwn": [
            "10000090FA551508", 
            "10000090FA551509"
        ]
    }, 
    "changed": false
}
```

