### PR TITLE
Update nxos_facts.py

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -172,6 +172,7 @@ vlan_list:
 """
 import re
 
+from ansible.module_utils.network.common.utils import to_list
 from ansible.module_utils.network.nxos.nxos import run_commands, get_config
 from ansible.module_utils.network.nxos.nxos import get_capabilities, get_interface_type
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
@@ -451,7 +452,11 @@ class Interfaces(FactsBase):
 
     def populate_structured_interfaces(self, data):
         interfaces = dict()
-        for item in data['TABLE_interface']['ROW_interface']:
+        data = data['TABLE_interface']['ROW_interface']
+
+            if isinstance(data, dict):
+                data = to_list(data)
+
             name = item['interface']
 
             intf = dict()
@@ -477,7 +482,7 @@ class Interfaces(FactsBase):
             data = data['TABLE_intf']
             if data:
                 if isinstance(data, dict):
-                    data = [data]
+                    data = to_list(data)
                 for item in data:
                     name = item['ROW_intf']['intf-name']
                     intf = self.facts['interfaces'][name]
@@ -497,7 +502,7 @@ class Interfaces(FactsBase):
         data = data['TABLE_nbor']['ROW_nbor']
 
         if isinstance(data, dict):
-            data = [data]
+            data = to_list(data)
 
         for item in data:
             local_intf = normalize_interface(item['l_port_id'])
@@ -514,7 +519,7 @@ class Interfaces(FactsBase):
         data = data['TABLE_cdp_neighbor_detail_info']['ROW_cdp_neighbor_detail_info']
 
         if isinstance(data, dict):
-            data = [data]
+            data = to_list(data)
 
         for item in data:
             local_intf = item['intf_id']
@@ -820,7 +825,7 @@ class Legacy(FactsBase):
     def parse_structured_module(self, data):
         data = data['TABLE_modinfo']['ROW_modinfo']
         if isinstance(data, dict):
-            data = [data]
+            data = to_list(data)
         objects = list(self.transform_iterable(data, self.MODULE_MAP))
         return objects
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
when there is a single interface, data['TABLE_interface']['ROW_interface'] is a dict, not an array (case handled like populate_structured_neighbors_lldp)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_facts.py

##### ADDITIONAL INFORMATION



BEFORE fix
```paste below
PLAY [nxos] ****************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************
ok: [xxxxxxxxx]

TASK [nxos_facts : nxos_facts | get nxos facts] ****************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: string indices must be integers
fatal: [xxxxxxxxxx]: FAILED! => {
    "changed": false, 
    "rc": 1
}

MSG:

MODULE FAILURE
See stdout/stderr for the exact error


MODULE_STDERR:

Traceback (most recent call last):
  File "/home/xxx/.ansible/tmp/ansible-local-1379dtiyx8/ansible-tmp-1549291810.13-164228265130085/AnsiballZ_nxos_facts.py", line 113, in <module>
    _ansiballz_main()
  File "/home/xxx/.ansible/tmp/ansible-local-1379dtiyx8/ansible-tmp-1549291810.13-164228265130085/AnsiballZ_nxos_facts.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/xxx/.ansible/tmp/ansible-local-1379dtiyx8/ansible-tmp-1549291810.13-164228265130085/AnsiballZ_nxos_facts.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_nxos_facts_payload_Txdrav/__main__.py", line 1003, in <module>
  File "/tmp/ansible_nxos_facts_payload_Txdrav/__main__.py", line 986, in main
  File "/tmp/ansible_nxos_facts_payload_Txdrav/__main__.py", line 387, in populate
  File "/tmp/ansible_nxos_facts_payload_Txdrav/__main__.py", line 422, in populate_structured_interfaces
TypeError: string indices must be integers



msg:
MODULE FAILURE
See stdout/stderr for the exact error

PLAY RECAP *****************************************************************************************************
xxxxxxx              : ok=1    changed=0    unreachable=0    failed=1   
```
AFTER fix

```
PLAY [nxos] ****************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************
ok: [xxxxxxxxxx]

TASK [nxos_facts : nxos_facts | get nxos facts] ****************************************************************
ok: [xxxxxxxxx]

PLAY RECAP *****************************************************************************************************
xxxxxxxxx                 : ok=2    changed=0    unreachable=0    failed=0   




```
