### PR TITLE
add vm_group feature in vm creation

### DIFF
--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -26,7 +26,7 @@ along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'metadata_version': '1.2'}
+                    'metadata_version': '1.1'}
 
 DOCUMENTATION = '''
 ---
@@ -165,7 +165,8 @@ options:
       - vmgroup_name':' the vm group name vms to be added in. It must exist beforehand.
       - role':' vm role in the vm group. It must exist beforehand.
       - vmgroup_id':' alterntative way to specify a vm group than I(vmgroup_name).
-      - vmgroup_uid':' if mulitiple vm groupd have same name, you can select one by group owner uid.
+      - vmgroup_uid':' if mulitiple vm groups have same name, you can select one by group owner uid.
+    version_added: "2.8"
   disk_saveas:
     description:
       - Creates an image from a VM disk.

--- a/test/legacy/roles/one_vm/tasks/main.yml
+++ b/test/legacy/roles/one_vm/tasks/main.yml
@@ -43,12 +43,15 @@
   failed_when: not vm_missing is failed
 
 - block:
-    - name: Deploy a VM with networks, memory and cpu
+    - name: Deploy a VM with networks, vm group, memory and cpu
       one_vm:
         template_id: '{{ one_template_id }}'
         networks: '{{ one_networks_good }}'
         memory: '{{ one_memory }}'
         cpu: '{{ one_cpu }}'
+        vm_group:
+          vmgroup_name: '{{ one_vmgroup_name }}'
+          role: '{{ one_vmgroup_role }}'
       register: deployed_vm
 
     - name: Verify deploying of the VM
@@ -63,6 +66,8 @@
           - deployed_vm.instances[0].cpu == "{{ one_cpu }}"
           - deployed_vm.instances[0].state == "ACTIVE"
           - deployed_vm.instances[0].lcm_state == "RUNNING"
+          - deployed_vm.instances[0].vmgroup.vmgroup_name== "{{ one_vmgroup_name }}"
+          - deployed_vm.instances[0].vmgroup.role == "{{ one_vmgroup_role }}"
 
     - name: Delete a VM in check-mode
       one_vm:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding vm_grooup feature.  User can add new vms into a vm_group when creating.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
opennebula
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
examples:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# Deploy an new instance with a vm group
- one_vm:
    template_id: 53
    vm_group:
      vmgroup_name: my_group
      role: my_app
  register: vm
```
