### PR TITLE
win_updates - mark as unstable again

### DIFF
--- a/test/integration/targets/win_updates/aliases
+++ b/test/integration/targets/win_updates/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group2
+unstable


### PR DESCRIPTION
##### SUMMARY
The win_updates tests are still slightly unstable on older hosts so marking this as unstable again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates