### PR TITLE
Pluribus Networks vflow table profile module with UT

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_vflow_table_profile.py
+++ b/lib/ansible/modules/network/netvisor/pn_vflow_table_profile.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_vflow_table_profile
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to modify vflow-table-profile
+description:
+  - This module can be used to modify a vFlow table profile.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: false
+    type: str
+  state:
+    description:
+      - State the action to perform. Use C(update) to modify
+        the vflow-table-profile.
+    required: true
+    type: str
+    choices: ['update']
+  pn_profile:
+    description:
+      - type of vFlow profile.
+    required: false
+    type: str
+    choices: ['application', 'ipv6', 'qos']
+  pn_hw_tbl:
+    description:
+      - hardware table used by vFlow.
+    required: false
+    type: str
+    choices: ['switch-main', 'switch-hash', 'npu-main', 'npu-hash']
+  pn_enable:
+    description:
+      - enable or disable vflow profile table.
+    required: false
+    type: bool
+"""
+
+EXAMPLES = """
+- name: Modify vflow table profile
+  pn_vflow_table_profile:
+    pn_cliswitch: 'sw01'
+    state: 'update'
+    pn_profile: 'ipv6'
+    pn_hw_tbl: 'switch-main'
+    pn_enable: true
+
+- name: Modify vflow table profile
+  pn_vflow_table_profile:
+    state: 'update'
+    pn_profile: 'qos'
+    pn_hw_tbl: 'switch-main'
+    pn_enable: false
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the vflow-table-profile command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the vflow-table-profile command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli, booleanArgs
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        update='vflow-table-profile-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_profile=dict(required=False, type='str',
+                            choices=['application', 'ipv6', 'qos']),
+            pn_hw_tbl=dict(required=False, type='str',
+                           choices=['switch-main', 'switch-hash',
+                                    'npu-main', 'npu-hash']),
+            pn_enable=dict(required=False, type='bool'),
+        ),
+        required_if=(
+            ['state', 'update', ['pn_profile', 'pn_hw_tbl']],
+        ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    profile = module.params['pn_profile']
+    hw_tbl = module.params['pn_hw_tbl']
+    enable = module.params['pn_enable']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    if command == 'vflow-table-profile-modify':
+        cli += ' %s ' % command
+        if profile:
+            cli += ' profile ' + profile
+        if hw_tbl:
+            cli += ' hw-tbl ' + hw_tbl
+
+        cli += booleanArgs(enable, 'enable', 'disable')
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/netvisor/test_pn_vflow_table_profile.py
+++ b/test/units/modules/network/netvisor/test_pn_vflow_table_profile.py
@@ -1,0 +1,49 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_vflow_table_profile
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestVflowTableProfileModule(TestNvosModule):
+
+    module = pn_vflow_table_profile
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_vflow_table_profile.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['update'] == 'vflow-table-profile-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+
+    def test_vflow_table_profile_modify_t1(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_profile': 'ipv6',
+                         'pn_hw_tbl': 'switch-main', 'pn_enable': True, 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vflow-table-profile-modify  profile ipv6 hw-tbl switch-main enable '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_vflow_table_profile_modify_t2(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_profile': 'qos',
+                         'pn_hw_tbl': 'switch-main', 'pn_enable': False, 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vflow-table-profile-modify  profile qos hw-tbl switch-main disable '
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of pn vflow table profile for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_vflow_table_profile.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```