### PR TITLE
Fix to allow Po interface descriptions

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_interface.py
@@ -158,7 +158,7 @@ class OnyxInterfaceModule(BaseOnyxModule):
         IF_TYPE_ETH: ('absent',),
         IF_TYPE_VLAN: (),
         IF_TYPE_LOOPBACK: ('up', 'down'),
-        IF_TYPE_PO: (),
+        IF_TYPE_PO: ('absent'),
     }
 
     IF_MODIFIABLE_ATTRS = ('speed', 'description', 'mtu')

--- a/lib/ansible/modules/network/onyx/onyx_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_interface.py
@@ -135,25 +135,30 @@ class OnyxInterfaceModule(BaseOnyxModule):
     IF_ETH_REGEX = re.compile(r"^Eth(\d+\/\d+|\d+\/\d+\/\d+)$")
     IF_VLAN_REGEX = re.compile(r"^Vlan (\d+)$")
     IF_LOOPBACK_REGEX = re.compile(r"^Loopback (\d+)$")
+    IF_PO_REGEX = re.compile(r"^Po(\d+)$")
 
     IF_TYPE_ETH = "ethernet"
     IF_TYPE_LOOPBACK = "loopback"
     IF_TYPE_VLAN = "vlan"
+    IF_TYPE_PO = "port-channel"
 
     IF_TYPE_MAP = {
         IF_TYPE_ETH: IF_ETH_REGEX,
         IF_TYPE_VLAN: IF_VLAN_REGEX,
         IF_TYPE_LOOPBACK: IF_LOOPBACK_REGEX,
+        IF_TYPE_PO: IF_PO_REGEX
     }
     UNSUPPORTED_ATTRS = {
         IF_TYPE_ETH: (),
         IF_TYPE_VLAN: ('speed', 'rx_rate', 'tx_rate'),
         IF_TYPE_LOOPBACK: ('speed', 'mtu', 'rx_rate', 'tx_rate'),
+        IF_TYPE_PO: ('speed', 'rx_rate', 'tx_rate'),
     }
     UNSUPPORTED_STATES = {
         IF_TYPE_ETH: ('absent',),
         IF_TYPE_VLAN: (),
         IF_TYPE_LOOPBACK: ('up', 'down'),
+        IF_TYPE_PO: (),
     }
 
     IF_MODIFIABLE_ATTRS = ('speed', 'description', 'mtu')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add port-channel support for onyx_interface.py by defining IF_PO_REGEX, IF_TYPE_PO and modifying IF_TYPE_MAP, UNSUPPORTED_ATTRS and UNSUPPORTED_STATES.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes 51725

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
onyx_interface

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See https://github.com/ansible/ansible/issues/51725 to reproduce. After this change I get the following working:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ cat test2.yaml 
- hosts: switches
  gather_facts: no
  tasks:
  - onyx_interface:
      name: 'Po1'
      description: 'test'

$ ansible-playbook test2.yaml -l mellswitch01

PLAY [switches] *******************************************************************************************************************

TASK [onyx_interface] *************************************************************************************************************
changed: [mellswitch01]

PLAY RECAP ************************************************************************************************************************
mellswitch01           : ok=1    changed=1    unreachable=0    failed=0    skipped=0   


```
