### PR TITLE
FreeBSD/FreeNAS addition to the list of supported platforms; 'reset' ACL functionality added

### DIFF
--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -28,6 +28,7 @@ options:
     description:
     - Define whether the ACL should be present or not.
     - The C(query) state gets the current ACL without changing it, for use in C(register) operations.
+    - The C(absent) state with specified C(path) and without C(entry) or C(etype) deletes all ACLs of a specified C(path)
     choices: [ absent, present, query ]
     default: query
   follow:
@@ -53,7 +54,8 @@ options:
     version_added: '1.5'
   permissions:
     description:
-    - The permissions to apply/remove can be any combination of C(r), C(w) and C(x) (read, write and execute respectively)
+    - On Linux or FreeBSD, the basic permissions to apply/remove can be any combination of C(r), C(w) and C(x) (read, write and execute respectively)
+    - if C(use_nfsv4_acls) is set to C(true), for the possible values of C(permissions) on FreeBSD please refer to C(setfacl(1)) part C(NFSv4 ACL ENTRIES).
     version_added: '1.5'
   entry:
     description:
@@ -66,6 +68,7 @@ options:
   recursive:
     description:
     - Recursively sets the specified ACL.
+    - FreeBSD: starting from FreeBSD 12
     - Incompatible with C(state=query).
     type: bool
     default: no
@@ -75,15 +78,30 @@ options:
     - Select if and when to recalculate the effective right masks of the files.
     - See C(setfacl) documentation for more info.
     - Incompatible with C(state=query).
+    - Linux-only
     choices: [ default, mask, no_mask ]
     default: default
     version_added: '2.7'
+  reset:
+    description:
+    - removes all extended ACL entries
+    - the base ACL entries of the owner, group and others are retained.
+    type: bool
+    default: 'no'
+    version_added: '2.8'
+  use_nfsv4_acls:
+    description:
+    - use NFSv4 ACL notation
+    - necessary to set ACLs on FreeBSD ZFS file systems
+
 author:
 - Brian Coca (@bcoca)
 - Jérémie Astori (@astorije)
+- Mike Grozak (@rhaido)
 notes:
 - The C(acl) module requires that ACLs are enabled on the target filesystem and that the C(setfacl) and C(getfacl) binaries are installed.
-- As of Ansible 2.0, this module only supports Linux distributions.
+- This module only supports Linux and FreeBSD distributions.
+- Certain functionality is Linux-specific and not available anywhere else - please read descriptions carefully.
 - As of Ansible 2.3, the I(name) option has been changed to I(path) as default, but I(name) still works as well.
 '''
 
@@ -122,6 +140,20 @@ EXAMPLES = r'''
   acl:
     path: /etc/foo.conf
   register: acl_info
+
+- name: reset all ACLs of a directory
+  acl:
+    path: /mnt/tank/data/foo.dir
+    state: absent
+
+- name: reset all ACLs prior to applying new ones (FreeNAS example)
+  acl:
+    path: /mnt/tank/data/foo2.dir
+    etype: user
+    entity: foo
+    permissions: full_set:file_inherit/dir_inherit
+    use_nfsv4_acls: true
+    state: present
 '''
 
 RETURN = r'''
@@ -171,7 +203,10 @@ def split_entry(entry):
 def build_entry(etype, entity, permissions=None, use_nfsv4_acls=False):
     '''Builds and returns an entry string. Does not include the permissions bit if they are not provided.'''
     if use_nfsv4_acls:
-        return ':'.join([etype, entity, permissions, 'allow'])
+        if get_platform().lower() == 'freebsd' and etype in ('owner@','group@','everyone@'):
+            return ':'.join([etype, permissions, 'allow'])
+        else:
+            return ':'.join([etype, entity, permissions, 'allow'])
 
     if permissions:
         return etype + ':' + entity + ':' + permissions
@@ -179,28 +214,36 @@ def build_entry(etype, entity, permissions=None, use_nfsv4_acls=False):
     return etype + ':' + entity
 
 
-def build_command(module, mode, path, follow, default, recursive, recalculate_mask, entry=''):
+def build_command(module, mode, path, follow, default, recursive, recalculate_mask, reset, entry=''):
     '''Builds and returns a getfacl/setfacl command.'''
+    if mode in ('set','rm'):
+        cmd = [module.get_bin_path('setfacl'),True)]
+
+        if recursive:
+            '''starting from FreeBSD 12 setfacl supports recursive option (-R)'''
+            if get_platform().lower() == 'linux':
+                cmd.append('--recursive')
+            if get_platform().lower() == 'freebsd':
+                cmd.append('-R')
+
     if mode == 'set':
-        cmd = [module.get_bin_path('setfacl', True)]
+        '''Discard all ACL if reset option is set.'''
+        if reset:
+            cmd.append('-b')
         cmd.append('-m "%s"' % entry)
+
     elif mode == 'rm':
-        cmd = [module.get_bin_path('setfacl', True)]
-        cmd.append('-x "%s"' % entry)
+        if reset:
+            '''If we already reset everything, no need to be precise'''
+            cmd.append('-b')
+        else:
+            cmd.append('-x "%s"' % entry)
     else:  # mode == 'get'
         cmd = [module.get_bin_path('getfacl', True)]
         # prevents absolute path warnings and removes headers
         if get_platform().lower() == 'linux':
             cmd.append('--omit-header')
             cmd.append('--absolute-names')
-
-    if recursive:
-        cmd.append('--recursive')
-
-    if recalculate_mask == 'mask' and mode in ['set', 'rm']:
-        cmd.append('--mask')
-    elif recalculate_mask == 'no_mask' and mode in ['set', 'rm']:
-        cmd.append('--no-mask')
 
     if not follow:
         if get_platform().lower() == 'linux':
@@ -210,6 +253,13 @@ def build_command(module, mode, path, follow, default, recursive, recalculate_ma
 
     if default:
         cmd.insert(1, '-d')
+
+    '''Linux-specific functionality'''
+    if get_platform().lower() == 'linux':
+        if recalculate_mask == 'mask' and mode in ['set', 'rm']:
+            cmd.append('--mask')
+        elif recalculate_mask == 'no_mask' and mode in ['set', 'rm']:
+            cmd.append('--no-mask')
 
     cmd.append(path)
     return cmd
@@ -277,6 +327,7 @@ def main():
                 choices=['default', 'mask', 'no_mask'],
                 type='str'
             ),
+            reset=dict(required=False, type='bool', default=False),
             use_nfsv4_acls=dict(required=False, type='bool', default=False)
         ),
         supports_check_mode=True,
@@ -295,6 +346,7 @@ def main():
     default = module.params.get('default')
     recursive = module.params.get('recursive')
     recalculate_mask = module.params.get('recalculate_mask')
+    reset = module.params.get('reset')
     use_nfsv4_acls = module.params.get('use_nfsv4_acls')
 
     if not os.path.exists(path):
@@ -306,6 +358,9 @@ def main():
 
         if recalculate_mask in ['mask', 'no_mask']:
             module.fail_json(msg="'recalculate_mask' MUST NOT be set to 'mask' or 'no_mask' when 'state=query'.")
+
+        if reset:
+            module.fail_json(msg="'reset' MUST NOT be set when 'state=query'.")
 
     if not entry:
         if state == 'absent' and permissions:
@@ -324,8 +379,11 @@ def main():
         if state == 'present' and not entry.count(":") in [2, 3]:
             module.fail_json(msg="'entry' MUST have 3 or 4 sections divided by ':' when 'state=present'.")
 
-        if state == 'absent' and not entry.count(":") in [1, 2]:
-            module.fail_json(msg="'entry' MUST have 2 or 3 sections divided by ':' when 'state=absent'.")
+        if state == 'absent':
+            if not entry.count(":") in [1, 2]:
+                module.fail_json(msg="'entry' MUST have 2 or 3 sections divided by ':' when 'state=absent'.")
+            if reset:
+                module.fail_json(msg="'entry' can not be used together with 'state=absent' and 'reset=yes'")
 
         if state == 'query':
             module.fail_json(msg="'entry' MUST NOT be set when 'state=query'.")
@@ -334,10 +392,6 @@ def main():
         if default_flag is not None:
             default = default_flag
 
-    if get_platform().lower() == 'freebsd':
-        if recursive:
-            module.fail_json(msg="recursive is not supported on that platform.")
-
     changed = False
     msg = ""
 
@@ -345,7 +399,7 @@ def main():
         entry = build_entry(etype, entity, permissions, use_nfsv4_acls)
         command = build_command(
             module, 'set', path, follow,
-            default, recursive, recalculate_mask, entry
+            default, recursive, recalculate_mask, reset, entry
         )
         changed = acl_changed(module, command)
 
@@ -354,11 +408,19 @@ def main():
         msg = "%s is present" % entry
 
     elif state == 'absent':
-        entry = build_entry(etype, entity, use_nfsv4_acls)
-        command = build_command(
-            module, 'rm', path, follow,
-            default, recursive, recalculate_mask, entry
-        )
+        if not entry and not etype:
+            reset = True
+            command = build_command(
+                module, 'rm', path, follow,
+                default, recursive, recalculate_mask, reset, entry
+            )
+        else:
+            entry = build_entry(etype, entity, use_nfsv4_acls)
+            command = build_command(
+                module, 'rm', path, follow,
+                default, recursive, recalculate_mask, entry
+            )
+
         changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
@@ -370,7 +432,7 @@ def main():
 
     acl = run_acl(
         module,
-        build_command(module, 'get', path, follow, default, recursive, recalculate_mask)
+        build_command(module, 'get', path, follow, default, recursive, recalculate_mask, reset)
     )
 
     module.exit_json(changed=changed, msg=msg, acl=acl)


### PR DESCRIPTION
##### SUMMARY
This pull request adds:
- support of FreeBSD/FreeNAS ACLs including NFSv4 ZFS ACLs (production usage of this feature, verified)
- support of recursive ACLs (starting from FreeBSD 12)
- added new parameter/cross-platform feature: 'reset' ACLs. It can be used in the following scenarios:
    1. Just remove all ACLs - tested for both Linux and FreeBSD/FreeNAS ZFS ACLs
    1. Reset ACLs before applying a new one - i.e. in case you want to start from scratch in any case.
- documentation was updated (also with missing 'use_nfsv4_acls' parameter description) and examples were added

All additions/features were tested on Linux (Debian 9 Stretch) and on FreeNAS/FreeBSD 11.1

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acl