### PR TITLE
DOC: Update "yum group list" command

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -215,7 +215,7 @@ notes:
     of packages in a single transaction and yum requires groups to be specified
     in different ways when used in that way.  Package groups are specified as
     "@development-tools" and environment groups are "@^gnome-desktop-environment".
-    Use the "yum group list" command to see which category of group the group
+    Use the "yum group list hidden ids" command to see which category of group the group
     you want to install falls into.'
   - 'The yum module does not support clearing yum cache in an idempotent way, so it
     was decided not to implement it, the only method is to use shell and call the yum


### PR DESCRIPTION
##### SUMMARY
The command "yum group list" outputs like
```
Available Environment Groups:
   Minimal Install
   Infrastructure Server
...
```

However, we can't install "Infrastructure Server" because it contains a space. Error message:
`"It appears that a space separated string of packages was passed in as an argument. To operate on several packages, pass a comma separated string of packages or a list of packages."`

Using "yum group list hidden ids" shows the correct names:
```
[root@cdo7erpp1 ~]# yum group list hidden ids
Loaded plugins: langpacks, ulninfo
Available Environment Groups:
   Minimal Install (minimal)
   Infrastructure Server (infrastructure-server-environment)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
yum

##### ADDITIONAL INFORMATION
Package IDs may be hard to find because the groups names don't match the IDs.
