### PR TITLE
rhaido: added FreeBSD/FreeNAS support; tested against FreeNAS 11 ZFS …

### DIFF
--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -17,7 +17,7 @@ module: acl
 version_added: '1.4'
 short_description: Set and retrieve file ACL information.
 description:
-- Set and retrieve file ACL information.
+  - Set and retrieve file ACL information.
 options:
   path:
     description:
@@ -70,7 +70,7 @@ options:
   recursive:
     description:
     - Recursively sets the specified ACL.
-    - FreeBSD: starting from FreeBSD 12
+    - Available on FreeBSD starting from FreeBSD 1
     - Incompatible with C(state=query).
     type: bool
     default: no

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -29,6 +29,7 @@ options:
     description:
     - Define whether the ACL should be present or not.
     - The C(query) state gets the current ACL without changing it, for use in C(register) operations.
+    - The C(absent) state with specified C(path) and without C(entry) or C(etype) deletes all ACLs of a specified C(path)
     choices: [ absent, present, query ]
     default: query
   follow:
@@ -54,7 +55,8 @@ options:
     version_added: '1.5'
   permissions:
     description:
-    - The permissions to apply/remove can be any combination of C(r), C(w) and C(x) (read, write and execute respectively)
+    - On Linux or FreeBSD, the basic permissions to apply/remove can be any combination of C(r), C(w) and C(x) (read, write and execute respectively)
+    - if C(use_nfsv4_acls) is set to C(true), for the possible values of C(permissions) on FreeBSD please refer to C(setfacl(1)) part C(NFSv4 ACL ENTRIES).
     version_added: '1.5'
   entry:
     description:
@@ -67,30 +69,43 @@ options:
   recursive:
     description:
     - Recursively sets the specified ACL.
+    - FreeBSD: starting from FreeBSD 12
     - Incompatible with C(state=query).
     type: bool
     default: no
     version_added: '2.0'
-  use_nfsv4_acls:
-    description:
-    - Use NFSv4 ACLs instead of POSIX ACLs.
-    type: bool
-    default: no
-    version_added: '2.2'
   recalculate_mask:
     description:
     - Select if and when to recalculate the effective right masks of the files.
     - See C(setfacl) documentation for more info.
     - Incompatible with C(state=query).
+    - Linux-only
     choices: [ default, mask, no_mask ]
     default: default
     version_added: '2.7'
+  reset:
+    description:
+    - removes all extended ACL entries
+    - the base ACL entries of the owner, group and others are retained.
+    type: bool
+    default: 'no'
+    version_added: '2.8'
+  use_nfsv4_acls:
+    description:
+    - Use NFSv4 ACLs instead of POSIX ACLs.
+    - necessary to set ACLs on FreeBSD ZFS file systems
+    type: bool
+    default: no
+    version_added: '2.2'
+
 author:
 - Brian Coca (@bcoca)
 - Jérémie Astori (@astorije)
+- Mike Grozak (@rhaido)
 notes:
 - The C(acl) module requires that ACLs are enabled on the target filesystem and that the C(setfacl) and C(getfacl) binaries are installed.
-- As of Ansible 2.0, this module only supports Linux distributions.
+- This module only supports Linux and FreeBSD distributions.
+- Certain functionality is Linux-specific and not available anywhere else - please read descriptions carefully.
 - As of Ansible 2.3, the I(name) option has been changed to I(path) as default, but I(name) still works as well.
 '''
 
@@ -129,6 +144,21 @@ EXAMPLES = r'''
   acl:
     path: /etc/foo.conf
   register: acl_info
+
+- name: strip all ACLs from a directory
+  acl:
+    path: /mnt/tank/data/foo.dir
+    state: absent
+
+- name: NFS4 ACLs/FreeNAS/FreeBSD - reset all ACLs before applying new ones
+  acl:
+    path: /mnt/tank/data/foo2.dir
+    etype: user
+    entity: foo
+    permissions: "full_set:file_inherit/dir_inherit"
+    use_nfsv4_acls: true
+    reset: yes
+    state: present
 '''
 
 RETURN = r'''
@@ -178,7 +208,10 @@ def split_entry(entry):
 def build_entry(etype, entity, permissions=None, use_nfsv4_acls=False):
     '''Builds and returns an entry string. Does not include the permissions bit if they are not provided.'''
     if use_nfsv4_acls:
-        return ':'.join([etype, entity, permissions, 'allow'])
+        if get_platform().lower() == 'freebsd' and etype in ('owner@','group@','everyone@'):
+            return ':'.join([etype, permissions, 'allow'])
+        else:
+            return ':'.join([etype, entity, permissions, 'allow'])
 
     if permissions:
         return etype + ':' + entity + ':' + permissions
@@ -186,28 +219,36 @@ def build_entry(etype, entity, permissions=None, use_nfsv4_acls=False):
     return etype + ':' + entity
 
 
-def build_command(module, mode, path, follow, default, recursive, recalculate_mask, entry=''):
+def build_command(module, mode, path, follow, default, recursive, recalculate_mask, reset, entry=''):
     '''Builds and returns a getfacl/setfacl command.'''
+    if mode in ('set','rm'):
+        cmd = [module.get_bin_path('setfacl',True)]
+
+        if recursive:
+            '''starting from FreeBSD 12 setfacl supports recursive option (-R)'''
+            if get_platform().lower() == 'linux':
+                cmd.append('--recursive')
+            if get_platform().lower() == 'freebsd':
+                cmd.append('-R')
+
     if mode == 'set':
-        cmd = [module.get_bin_path('setfacl', True)]
+        '''Discard all ACL if reset option is set.'''
+        if reset:
+            cmd.append('-b')
         cmd.append('-m "%s"' % entry)
+
     elif mode == 'rm':
-        cmd = [module.get_bin_path('setfacl', True)]
-        cmd.append('-x "%s"' % entry)
+        if reset:
+            '''If we already reset everything, no need to be precise'''
+            cmd.append('-b')
+        else:
+            cmd.append('-x "%s"' % entry)
     else:  # mode == 'get'
         cmd = [module.get_bin_path('getfacl', True)]
         # prevents absolute path warnings and removes headers
         if get_platform().lower() == 'linux':
             cmd.append('--omit-header')
             cmd.append('--absolute-names')
-
-    if recursive:
-        cmd.append('--recursive')
-
-    if recalculate_mask == 'mask' and mode in ['set', 'rm']:
-        cmd.append('--mask')
-    elif recalculate_mask == 'no_mask' and mode in ['set', 'rm']:
-        cmd.append('--no-mask')
 
     if not follow:
         if get_platform().lower() == 'linux':
@@ -217,6 +258,13 @@ def build_command(module, mode, path, follow, default, recursive, recalculate_ma
 
     if default:
         cmd.insert(1, '-d')
+
+    '''Linux-specific functionality'''
+    if get_platform().lower() == 'linux':
+        if recalculate_mask == 'mask' and mode in ['set', 'rm']:
+            cmd.append('--mask')
+        elif recalculate_mask == 'no_mask' and mode in ['set', 'rm']:
+            cmd.append('--no-mask')
 
     cmd.append(path)
     return cmd
@@ -265,13 +313,13 @@ def main():
             entity=dict(type='str', default=''),
             etype=dict(
                 type='str',
-                choices=['group', 'mask', 'other', 'user'],
+                choices=['other', 'user', 'group', 'mask', 'owner@', 'group@', 'everyone@'],
             ),
             permissions=dict(type='str'),
             state=dict(
                 type='str',
                 default='query',
-                choices=['absent', 'present', 'query'],
+                choices=['query', 'present', 'absent'],
             ),
             follow=dict(type='bool', default=True),
             default=dict(type='bool', default=False),
@@ -281,6 +329,7 @@ def main():
                 default='default',
                 choices=['default', 'mask', 'no_mask'],
             ),
+            reset=dict(type='bool', default=False),
             use_nfsv4_acls=dict(type='bool', default=False)
         ),
         supports_check_mode=True,
@@ -299,6 +348,7 @@ def main():
     default = module.params.get('default')
     recursive = module.params.get('recursive')
     recalculate_mask = module.params.get('recalculate_mask')
+    reset = module.params.get('reset')
     use_nfsv4_acls = module.params.get('use_nfsv4_acls')
 
     if not os.path.exists(path):
@@ -311,14 +361,17 @@ def main():
         if recalculate_mask in ['mask', 'no_mask']:
             module.fail_json(msg="'recalculate_mask' MUST NOT be set to 'mask' or 'no_mask' when 'state=query'.")
 
+        if reset:
+            module.fail_json(msg="'reset' MUST NOT be set when 'state=query'.")
+
     if not entry:
-        if state == 'absent' and permissions:
-            module.fail_json(msg="'permissions' MUST NOT be set when 'state=absent'.")
+        if state == 'absent':
+            if permissions:
+                module.fail_json(msg="'permissions' MUST NOT be set when 'state=absent'.")
+            if reset and etype:
+                module.fail_json(msg="'reset' can not be used together with explicit removal of ACLs")
 
-        if state == 'absent' and not entity:
-            module.fail_json(msg="'entity' MUST be set when 'state=absent'.")
-
-        if state in ['present', 'absent'] and not etype:
+        if state == 'present' and not etype:
             module.fail_json(msg="'etype' MUST be set when 'state=%s'." % state)
 
     if entry:
@@ -328,8 +381,11 @@ def main():
         if state == 'present' and not entry.count(":") in [2, 3]:
             module.fail_json(msg="'entry' MUST have 3 or 4 sections divided by ':' when 'state=present'.")
 
-        if state == 'absent' and not entry.count(":") in [1, 2]:
-            module.fail_json(msg="'entry' MUST have 2 or 3 sections divided by ':' when 'state=absent'.")
+        if state == 'absent':
+            if not entry.count(":") in [1, 2]:
+                module.fail_json(msg="'entry' MUST have 2 or 3 sections divided by ':' when 'state=absent'.")
+            if reset:
+                module.fail_json(msg="'entry' can not be used together with 'state=absent' and 'reset=yes'")
 
         if state == 'query':
             module.fail_json(msg="'entry' MUST NOT be set when 'state=query'.")
@@ -338,10 +394,6 @@ def main():
         if default_flag is not None:
             default = default_flag
 
-    if get_platform().lower() == 'freebsd':
-        if recursive:
-            module.fail_json(msg="recursive is not supported on that platform.")
-
     changed = False
     msg = ""
 
@@ -349,7 +401,7 @@ def main():
         entry = build_entry(etype, entity, permissions, use_nfsv4_acls)
         command = build_command(
             module, 'set', path, follow,
-            default, recursive, recalculate_mask, entry
+            default, recursive, recalculate_mask, reset, entry
         )
         changed = acl_changed(module, command)
 
@@ -358,11 +410,19 @@ def main():
         msg = "%s is present" % entry
 
     elif state == 'absent':
-        entry = build_entry(etype, entity, use_nfsv4_acls)
-        command = build_command(
-            module, 'rm', path, follow,
-            default, recursive, recalculate_mask, entry
-        )
+        if not entry and not etype:
+            reset = True
+            command = build_command(
+                module, 'rm', path, follow,
+                default, recursive, recalculate_mask, reset
+            )
+        else:
+            entry = build_entry(etype, entity, use_nfsv4_acls)
+            command = build_command(
+                module, 'rm', path, follow,
+                default, recursive, recalculate_mask, reset, entry
+            )
+
         changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
@@ -374,7 +434,7 @@ def main():
 
     acl = run_acl(
         module,
-        build_command(module, 'get', path, follow, default, recursive, recalculate_mask)
+        build_command(module, 'get', path, follow, default, recursive, recalculate_mask, reset)
     )
 
     module.exit_json(changed=changed, msg=msg, acl=acl)

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -51,7 +51,8 @@ options:
   etype:
     description:
     - The entity type of the ACL to apply, see C(setfacl) documentation for more info.
-    choices: [ group, mask, other, user ]
+    - owner@, group@, everyone@ - NFSv4 definitions of POSIX counterparts (valid for FreeBSD/FreeNAS ZFS ACLs)
+    choices: [ user, group, other, mask, owner@, group@, everyone@ ]
     version_added: '1.5'
   permissions:
     description:
@@ -89,7 +90,6 @@ options:
     - the base ACL entries of the owner, group and others are retained.
     type: bool
     default: 'no'
-    version_added: '2.8'
   use_nfsv4_acls:
     description:
     - Use NFSv4 ACLs instead of POSIX ACLs.
@@ -208,7 +208,7 @@ def split_entry(entry):
 def build_entry(etype, entity, permissions=None, use_nfsv4_acls=False):
     '''Builds and returns an entry string. Does not include the permissions bit if they are not provided.'''
     if use_nfsv4_acls:
-        if get_platform().lower() == 'freebsd' and etype in ('owner@','group@','everyone@'):
+        if get_platform().lower() == 'freebsd' and etype in ('owner@', 'group@', 'everyone@'):
             return ':'.join([etype, permissions, 'allow'])
         else:
             return ':'.join([etype, entity, permissions, 'allow'])
@@ -221,8 +221,8 @@ def build_entry(etype, entity, permissions=None, use_nfsv4_acls=False):
 
 def build_command(module, mode, path, follow, default, recursive, recalculate_mask, reset, entry=''):
     '''Builds and returns a getfacl/setfacl command.'''
-    if mode in ('set','rm'):
-        cmd = [module.get_bin_path('setfacl',True)]
+    if mode in ('set', 'rm'):
+        cmd = [module.get_bin_path('setfacl', True)]
 
         if recursive:
             '''starting from FreeBSD 12 setfacl supports recursive option (-R)'''
@@ -313,7 +313,7 @@ def main():
             entity=dict(type='str', default=''),
             etype=dict(
                 type='str',
-                choices=['other', 'user', 'group', 'mask', 'owner@', 'group@', 'everyone@'],
+                choices=['user', 'group', 'other', 'mask', 'owner@', 'group@', 'everyone@'],
             ),
             permissions=dict(type='str'),
             state=dict(

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -90,6 +90,7 @@ options:
     - the base ACL entries of the owner, group and others are retained.
     type: bool
     default: 'no'
+    version_added: '2.8'
   use_nfsv4_acls:
     description:
     - Use NFSv4 ACLs instead of POSIX ACLs.


### PR DESCRIPTION
##### SUMMARY
This pull request adds:

- support of FreeBSD/FreeNAS ACLs including NFSv4 ZFS ACLs (production usage of this feature, verified)
- support of recursive ACLs (starting from FreeBSD 12)
- added new parameter/cross-platform feature: 'reset' ACLs. It can be used in the following scenarios:
    a. srip all ACLs - tested for both Linux and FreeBSD/FreeNAS ZFS ACLs
    b. reset ACLs before applying new ones - i.e. in case you want to start from scratch in any case.
- documentation was updated and examples were added

All additions/features were tested on Linux (Debian 9 Stretch) and on FreeNAS/FreeBSD 11.1

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acl