### PR TITLE
VMware: Don't ignore folder value even if we have unique VM found

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -903,7 +903,7 @@ class PyVmomi(object):
                     if vm_obj and user_folder in actual_vm_folder_path:
                         vm_obj = vm
                         break
-            else:
+            elif vms:
                 # We have a unique match
                 actual_vm_folder_path = self.get_vm_path(content=self.content, vm_name=vms[0])
                 if vm_obj and user_folder in actual_vm_folder_path:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -51,7 +51,18 @@ options:
    folder:
      description:
      - Absolute path to find an existing guest.
-     - This is required parameter, if C(name) is supplied and multiple virtual machines with same name are found.
+     - This is a required parameter, if C(name) is supplied and multiple virtual machines with same name are found.
+     - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
+     - 'Examples:'
+     - '   folder: /ha-datacenter/vm'
+     - '   folder: ha-datacenter/vm'
+     - '   folder: /datacenter1/vm'
+     - '   folder: datacenter1/vm'
+     - '   folder: /datacenter1/vm/folder1'
+     - '   folder: datacenter1/vm/folder1'
+     - '   folder: /folder1/datacenter1/vm'
+     - '   folder: folder1/datacenter1/vm'
+     - '   folder: /folder1/datacenter1/vm/folder2'
    datacenter:
      description:
      - Datacenter name where the virtual machine is located in.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
@@ -54,8 +54,6 @@ options:
      - '   folder: /folder1/datacenter1/vm'
      - '   folder: folder1/datacenter1/vm'
      - '   folder: /folder1/datacenter1/vm/folder2'
-     - '   folder: vm/folder2'
-     - '   folder: folder2'
    datacenter:
      description:
      - The datacenter name to which virtual machine belongs to.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -47,7 +47,7 @@ options:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
      - This is required if name is supplied.
-     - The folder should include the datacenter. ESX's datacenter is ha-datacenter
+     - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
      - 'Examples:'
      - '   folder: /ha-datacenter/vm'
      - '   folder: ha-datacenter/vm'
@@ -58,8 +58,6 @@ options:
      - '   folder: /folder1/datacenter1/vm'
      - '   folder: folder1/datacenter1/vm'
      - '   folder: /folder1/datacenter1/vm/folder2'
-     - '   folder: vm/folder2'
-     - '   folder: folder2'
    datacenter:
      description:
      - Destination datacenter for the deploy operation

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -44,8 +44,8 @@ options:
     - This is required if name is not supplied.
   folder:
     description:
-    - Destination folder, absolute or relative path to find an existing guest or create the new guest.
-    - The folder should include the datacenter. ESX's datacenter is ha-datacenter
+    - Destination folder, absolute path to find an existing guest.
+    - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
     - 'Examples:'
     - '   folder: /ha-datacenter/vm'
     - '   folder: ha-datacenter/vm'
@@ -56,12 +56,9 @@ options:
     - '   folder: /folder1/datacenter1/vm'
     - '   folder: folder1/datacenter1/vm'
     - '   folder: /folder1/datacenter1/vm/folder2'
-    - '   folder: vm/folder2'
-    - '   folder: folder2'
-    default: /vm
   scheduled_at:
     description:
-    - Date and time in string format at which specificed task needs to be performed.
+    - Date and time in string format at which specified task needs to be performed.
     - "The required format for date and time - 'dd/mm/yyyy hh:mm'."
     - Scheduling task requires vCenter server. A standalone ESXi server does not support this option.
   force:
@@ -139,7 +136,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        folder=dict(type='str', default='/vm'),
+        folder=dict(type='str'),
         force=dict(type='bool', default=False),
         scheduled_at=dict(type='str'),
         state_change_timeout=dict(type='int', default=0),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -57,7 +57,7 @@ options:
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
-     - This is required parameter, if C(name) is supplied.
+     - This is a required parameter, if C(name) is supplied.
      - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
      - 'Examples:'
      - '   folder: /ha-datacenter/vm'
@@ -69,8 +69,6 @@ options:
      - '   folder: /folder1/datacenter1/vm'
      - '   folder: folder1/datacenter1/vm'
      - '   folder: /folder1/datacenter1/vm/folder2'
-     - '   folder: vm/folder2'
-     - '   folder: folder2'
    datacenter:
      description:
      - Destination datacenter for the deploy operation.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_upgrade.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_upgrade.py
@@ -43,8 +43,8 @@ options:
    folder:
         description:
             - Destination folder, absolute or relative path to find an existing guest.
-            - This is required, if C(name) is supplied.
-            - The folder should include the datacenter. ESX's datacenter is ha-datacenter
+            - This is a required parameter, if C(name) is supplied.
+            - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
             - 'Examples:'
             - '   folder: /ha-datacenter/vm'
             - '   folder: ha-datacenter/vm'
@@ -55,7 +55,6 @@ options:
             - '   folder: /folder1/datacenter1/vm'
             - '   folder: folder1/datacenter1/vm'
             - '   folder: /folder1/datacenter1/vm/folder2'
-            - '   folder: vm/folder2'
    datacenter:
         description:
             - Destination datacenter where the virtual machine exists.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_vnc.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_vnc.py
@@ -56,7 +56,18 @@ options:
   folder:
     description:
       - Destination folder, absolute or relative path to find an existing guest.
-      - The folder should include the datacenter. ESX's datacenter is ha-datacenter
+      - This is a required parameter, only if multiple VMs are found with same name.
+      - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
+      - 'Examples:'
+      - '   folder: /ha-datacenter/vm'
+      - '   folder: ha-datacenter/vm'
+      - '   folder: /datacenter1/vm'
+      - '   folder: datacenter1/vm'
+      - '   folder: /datacenter1/vm/folder1'
+      - '   folder: datacenter1/vm/folder1'
+      - '   folder: /folder1/datacenter1/vm'
+      - '   folder: folder1/datacenter1/vm'
+      - '   folder: /folder1/datacenter1/vm/folder2'
     required: false
   vnc_ip:
     description:

--- a/test/integration/targets/vmware_guest/tasks/check_mode.yml
+++ b/test/integration/targets/vmware_guest/tasks/check_mode.yml
@@ -33,6 +33,7 @@
 - name: get a guest
   set_fact:
     guest1: "{{ vmlist.json[0] }}"
+    folder: "{{ vmlist.json[0] | dirname }}"
 
 - name: Perform all operation in check mode
   vmware_guest:
@@ -43,6 +44,7 @@
     name: "{{ guest1|basename }}"
     datacenter: "{{ (guest1|basename).split('_')[0] }}"
     state: "{{ item }}"
+    folder: "{{ folder }}"
   with_items:
     - absent
     - present
@@ -72,6 +74,7 @@
     name: non_existent_vm
     datacenter: "{{ (guest1|basename).split('_')[0] }}"
     state: "{{ item }}"
+    folder: "{{ folder }}"
   with_items:
     - present
     - poweredoff


### PR DESCRIPTION
##### SUMMARY
Sometimes there are multiple VMs with same name but different locations
are found using API, use additional information about folder from user to
uniquely locate the VM.

Fixes: #51591

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py