### PR TITLE
docker_swarm_service: Extend env and add env_files support

### DIFF
--- a/changelogs/fragments/51762-docker_swarm_service-extend-env-and-add-env-file.yml
+++ b/changelogs/fragments/51762-docker_swarm_service-extend-env-and-add-env-file.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "docker_swarm_service - ``env`` parameter not supports setting values as a dict."
+  - "docker_swarm_service - Added support for ``env_files`` parameter."

--- a/changelogs/fragments/51762-docker_swarm_service-extend-env-and-add-env-file.yml
+++ b/changelogs/fragments/51762-docker_swarm_service-extend-env-and-add-env-file.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - "docker_swarm_service - ``env`` parameter not supports setting values as a dict."
+  - "docker_swarm_service - ``env`` parameter now supports setting values as a dict."
   - "docker_swarm_service - Added support for ``env_files`` parameter."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -605,6 +605,8 @@ def get_docker_environment(env, env_files):
             parsed_env_file = parse_env_file(env_file)
             for name, value in parsed_env_file.items():
                 env_dict[name] = str(value)
+    if env and isinstance(env, string_types):
+        env = env.split(',')
     if env and isinstance(env, dict):
         for name, value in env.items():
             if not isinstance(value, string_types):

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -129,7 +129,7 @@ options:
       - List or dictionary of the service environment variables.
       - If passed a list each items need to be in the format of C(KEY=VALUE).
       - If passed a dictionary values which might be parsed as numbers,
-        booleans or other types by the YAML parser must be quoted (e.g. I("true"))
+        booleans or other types by the YAML parser must be quoted (e.g. C("true"))
         in order to avoid data loss.
       - Corresponds to the C(--env) option of C(docker service create).
   env_files:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -605,9 +605,9 @@ def get_docker_environment(env, env_files):
             parsed_env_file = parse_env_file(env_file)
             for name, value in parsed_env_file.items():
                 env_dict[name] = str(value)
-    if env and isinstance(env, string_types):
+    if env is not None and isinstance(env, string_types):
         env = env.split(',')
-    if env and isinstance(env, dict):
+    if env is not None and isinstance(env, dict):
         for name, value in env.items():
             if not isinstance(value, string_types):
                 raise ValueError(
@@ -615,7 +615,7 @@ def get_docker_environment(env, env_files):
                     'Ambiguous env options must be wrapped in quotes to avoid YAML parsing. Key: %s' % name
                 )
             env_dict[name] = str(value)
-    elif env and isinstance(env, list):
+    elif env is not None and isinstance(env, list):
         for item in env:
             try:
                 name, value = item.split('=', 1)
@@ -626,9 +626,13 @@ def get_docker_environment(env, env_files):
         raise ValueError(
             'Invalid type for env %s (%s). Only list or dict allowed.' % (env, type(env))
         )
-
     env_list = format_environment(env_dict)
-    return sorted(env_list) or None
+    if not env_list:
+        if env is not None or env_files is not None:
+            return []
+        else:
+            return None
+    return sorted(env_list)
 
 
 class DockerService(DockerBaseClass):

--- a/test/integration/targets/docker_swarm_service/files/env-file-1
+++ b/test/integration/targets/docker_swarm_service/files/env-file-1
@@ -1,0 +1,2 @@
+TEST3=val3
+TEST4=val4

--- a/test/integration/targets/docker_swarm_service/files/env-file-2
+++ b/test/integration/targets/docker_swarm_service/files/env-file-2
@@ -1,0 +1,2 @@
+TEST3=val5
+TEST5=val5

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -718,13 +718,29 @@
       - "TEST2=val3"
   register: env_3
 
+- name: env (empty)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    env: []
+  register: env_4
+
+- name: env (empty idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    env: []
+  register: env_5
+
 - name: env (fail unwrapped values)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
     env:
       TEST1: true
-  register: env_4
+  register: env_6
   ignore_errors: yes
 
 - name: env (fail invalid formatted string)
@@ -734,25 +750,8 @@
     env:
       - "TEST1=val3"
       - "TEST2"
-  register: env_5
-  ignore_errors: yes
-
-- name: env (empty)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
-    env: []
-  register: env_6
-
-- name: env (empty idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
-    env: []
   register: env_7
-
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -765,10 +764,10 @@
       - env_1 is changed
       - env_2 is not changed
       - env_3 is changed
-      - env_4 is failed
-      - env_5 is failed
-      - env_6 is changed
-      - env_7 is not changed
+      - env_4 is changed
+      - env_5 is not changed
+      - env_6 is failed
+      - env_7 is failed
 
 ####################################################################
 ## env_files #######################################################
@@ -817,6 +816,20 @@
       - "{{ role_path }}/files/env-file-1"
   register: env_file_5
 
+- name: env_files (empty)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env_files: []
+  register: env_file_6
+
+- name: env_files (empty idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env_files: []
+  register: env_file_7
+
 - name: cleanup
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -830,6 +843,8 @@
     - env_file_3 is changed
     - env_file_4 is changed
     - env_file_5 is not changed
+    - env_file_6 is changed
+    - env_file_7 is not changed
 
 ###################################################################
 ## force_update ###################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -704,8 +704,8 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     env:
-      - "TEST1=val1"
-      - "TEST2=val2"
+      TEST1: val1
+      TEST2: val2
   register: env_2
 
 - name: env (changes)
@@ -718,13 +718,32 @@
       - "TEST2=val3"
   register: env_3
 
+- name: env (fail unwrapped values)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env:
+      TEST1: true
+  register: env_4
+  ignore_errors: yes
+
+- name: env (fail invalid formatted string)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env:
+      - "TEST1=val3"
+      - "TEST2"
+  register: env_5
+  ignore_errors: yes
+
 - name: env (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
-  register: env_4
+  register: env_6
 
 - name: env (empty idempotency)
   docker_swarm_service:
@@ -732,7 +751,8 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
-  register: env_5
+  register: env_7
+
 
 - name: cleanup
   docker_swarm_service:
@@ -745,8 +765,71 @@
       - env_1 is changed
       - env_2 is not changed
       - env_3 is changed
-      - env_4 is changed
-      - env_5 is not changed
+      - env_4 is failed
+      - env_5 is failed
+      - env_6 is changed
+      - env_7 is not changed
+
+####################################################################
+## env_files #######################################################
+####################################################################
+
+- name: env_files
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env_files:
+      - "{{ role_path }}/files/env-file-1"
+  register: env_file_1
+
+- name: env_files (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env_files:
+      - "{{ role_path }}/files/env-file-1"
+  register: env_file_2
+
+- name: env_files (more items)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env_files:
+      - "{{ role_path }}/files/env-file-1"
+      - "{{ role_path }}/files/env-file-2"
+  register: env_file_3
+
+- name: env_files (order)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env_files:
+      - "{{ role_path }}/files/env-file-2"
+      - "{{ role_path }}/files/env-file-1"
+  register: env_file_4
+
+- name: env_files (multiple idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    env_files:
+      - "{{ role_path }}/files/env-file-2"
+      - "{{ role_path }}/files/env-file-1"
+  register: env_file_5
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+    - env_file_1 is changed
+    - env_file_2 is not changed
+    - env_file_3 is changed
+    - env_file_4 is changed
+    - env_file_5 is not changed
 
 ###################################################################
 ## force_update ###################################################

--- a/test/units/modules/cloud/docker/test_docker_swarm_service.py
+++ b/test/units/modules/cloud/docker/test_docker_swarm_service.py
@@ -67,7 +67,7 @@ def test_get_docker_environment(mocker, docker_swarm_service):
     mocker.patch.object(
         docker_swarm_service,
         'format_environment',
-        side_effect=lambda d: ['{}={}'.format(key, value) for key, value in d.items()],
+        side_effect=lambda d: ['{0}={1}'.format(key, value) for key, value in d.items()],
     )
     # Test with env list and dict
     result = docker_swarm_service.get_docker_environment(

--- a/test/units/modules/cloud/docker/test_docker_swarm_service.py
+++ b/test/units/modules/cloud/docker/test_docker_swarm_service.py
@@ -2,7 +2,6 @@ import pytest
 
 
 class APIErrorMock(Exception):
-
     def __init__(self, message, response=None, explanation=None):
         self.message = message
         self.response = response
@@ -26,6 +25,7 @@ def docker_module_mock(mocker):
 @pytest.fixture(autouse=True)
 def docker_swarm_service():
     from ansible.modules.cloud.docker import docker_swarm_service
+
     return docker_swarm_service
 
 
@@ -46,14 +46,37 @@ def test_retry_on_out_of_sequence_error(mocker, docker_swarm_service):
 
 def test_no_retry_on_general_api_error(mocker, docker_swarm_service):
     run_mock = mocker.MagicMock(
-        side_effect=APIErrorMock(
-            message='',
-            response=None,
-            explanation='some error',
-        )
+        side_effect=APIErrorMock(message='', response=None, explanation='some error')
     )
     manager = docker_swarm_service.DockerServiceManager(client=None)
     manager.run = run_mock
     with pytest.raises(APIErrorMock):
         manager.run_safe()
     assert run_mock.call_count == 1
+
+
+def test_get_docker_environment(mocker, docker_swarm_service):
+    env_file_result = {'TEST1': 'A', 'TEST2': 'B', 'TEST3': 'C'}
+    env_dict = {'TEST3': 'CC', 'TEST4': 'D'}
+
+    env_list = ['TEST3=CC', 'TEST4=D']
+    expected_result = sorted(['TEST1=A', 'TEST2=B', 'TEST3=CC', 'TEST4=D'])
+    mocker.patch.object(
+        docker_swarm_service, 'parse_env_file', return_value=env_file_result
+    )
+    mocker.patch.object(
+        docker_swarm_service,
+        'format_environment',
+        side_effect=lambda d: ['{}={}'.format(key, value) for key, value in d.items()],
+    )
+    # Test with env list and dict
+    result = docker_swarm_service.get_docker_environment(
+        env_dict, env_files=['dummypath']
+    )
+    assert result == expected_result
+    # Test with env list and file
+    result = docker_swarm_service.get_docker_environment(
+        env_list,
+        env_files=['dummypath']
+    )
+    assert result == expected_result

--- a/test/units/modules/cloud/docker/test_docker_swarm_service.py
+++ b/test/units/modules/cloud/docker/test_docker_swarm_service.py
@@ -86,3 +86,15 @@ def test_get_docker_environment(mocker, docker_swarm_service):
         env_string, env_files=['dummypath']
     )
     assert result == expected_result
+
+    assert result == expected_result
+    # Test with empty env
+    result = docker_swarm_service.get_docker_environment(
+        [], env_files=None
+    )
+    assert result == []
+    # Test with empty env_files
+    result = docker_swarm_service.get_docker_environment(
+        None, env_files=[]
+    )
+    assert result == []

--- a/test/units/modules/cloud/docker/test_docker_swarm_service.py
+++ b/test/units/modules/cloud/docker/test_docker_swarm_service.py
@@ -58,6 +58,7 @@ def test_no_retry_on_general_api_error(mocker, docker_swarm_service):
 def test_get_docker_environment(mocker, docker_swarm_service):
     env_file_result = {'TEST1': 'A', 'TEST2': 'B', 'TEST3': 'C'}
     env_dict = {'TEST3': 'CC', 'TEST4': 'D'}
+    env_string = "TEST3=CC,TEST4=D"
 
     env_list = ['TEST3=CC', 'TEST4=D']
     expected_result = sorted(['TEST1=A', 'TEST2=B', 'TEST3=CC', 'TEST4=D'])
@@ -69,7 +70,7 @@ def test_get_docker_environment(mocker, docker_swarm_service):
         'format_environment',
         side_effect=lambda d: ['{0}={1}'.format(key, value) for key, value in d.items()],
     )
-    # Test with env list and dict
+    # Test with env dict and file
     result = docker_swarm_service.get_docker_environment(
         env_dict, env_files=['dummypath']
     )
@@ -78,5 +79,10 @@ def test_get_docker_environment(mocker, docker_swarm_service):
     result = docker_swarm_service.get_docker_environment(
         env_list,
         env_files=['dummypath']
+    )
+    assert result == expected_result
+    # Test with env string and file
+    result = docker_swarm_service.get_docker_environment(
+        env_string, env_files=['dummypath']
     )
     assert result == expected_result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR adds the possibility the specify `env` as a dict.
```yaml
env:
  KEY1: VALUE1
  KEY2: VALUE2
```

It also adds a new option called `env_files` which accepts a list of paths to env-files.
```yaml
env_files:
  - path/to/file.env
  - some/other/file.env
```

The order in this list matters where the last file will override variables already defined in previous files. It is useful for sharing env-files for different environments where a common file with defaults can be overridden by an environment specific file.

I chose to not map the behaviour of `env_files` to the docker-compose equivalent called `env_file` which accepts both a list and a string. Then we could not rely on the argument spec `path` type validation but would be required to implement our own validation that the specified files exist.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
