### PR TITLE
Update GetBiosBootOrder to use standard spec resources

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -577,52 +577,73 @@ class RedfishUtils(object):
         result["entries"] = bios_attributes
         return result
 
-    def get_bios_boot_order(self):
+    def get_boot_order(self):
         result = {}
-        boot_device_list = []
-        boot_device_details = []
-        key = "Bios"
-        bootsources = "BootSources"
-        # Get these entries, but does not fail if not found
-        properties = ['Index', 'Id', 'Name', 'Enabled']
+        # Get these entries from BootOption, if present
+        properties = ['DisplayName', 'BootOptionReference']
 
-        # Search for 'key' entry and extract URI from it
+        # Retrieve System resource
         response = self.get_request(self.root_uri + self.systems_uri)
         if response['ret'] is False:
             return response
         result['ret'] = True
         data = response['data']
 
-        if key not in data:
-            return {'ret': False, 'msg': "Key %s not found" % key}
+        # Confirm needed Boot properties are present
+        if 'Boot' not in data or 'BootOrder' not in data['Boot']:
+            return {'ret': False, 'msg': "Key BootOrder not found"}
 
-        bios_uri = data[key]["@odata.id"]
+        if 'Boot' not in data or 'BootOptions' not in data['Boot']:
+            return {'ret': False, 'msg': "Key BootOptions not found"}
 
-        # Get boot mode first as it will determine what attribute to read
-        response = self.get_request(self.root_uri + bios_uri)
+        if '@odata.id' not in data['Boot']['BootOptions']:
+            return {'ret': False, 'msg': "@odata.id not found in BootOptions"}
+
+        boot_options_uri = data['Boot']['BootOptions']["@odata.id"]
+        boot_order = data['Boot']['BootOrder']
+
+        # Get BootOptions resource
+        response = self.get_request(self.root_uri + boot_options_uri)
         if response['ret'] is False:
             return response
         data = response['data']
-        boot_mode = data[u'Attributes']["BootMode"]
-        if boot_mode == "Uefi":
-            boot_seq = "UefiBootSeq"
-        else:
-            boot_seq = "BootSeq"
 
-        response = self.get_request(self.root_uri + self.systems_uri + "/" + bootsources)
-        if response['ret'] is False:
-            return response
-        result['ret'] = True
-        data = response['data']
+        # Retrieve Members array
+        if 'Members' not in data:
+            return {'ret': False,
+                    'msg': "Members not found in BootOptionsCollection"}
+        members = data['Members']
 
-        boot_device_list = data[u'Attributes'][boot_seq]
-        for b in boot_device_list:
-            boot_device = {}
-            for property in properties:
-                if property in b:
-                    boot_device[property] = b[property]
-            boot_device_details.append(boot_device)
-        result["entries"] = boot_device_details
+        # Build dict of BootOptions keyed by BootOptionReference
+        boot_options_dict = {}
+        for member in members:
+            if '@odata.id' not in member:
+                return {'ret': False,
+                        'msg': "@odata.id not found in BootOptions"}
+            boot_option_uri = member['@odata.id']
+            response = self.get_request(self.root_uri + boot_option_uri)
+            if response['ret'] is False:
+                return response
+            data = response['data']
+            if 'BootOptionReference' not in data:
+                return {'ret': False,
+                        'msg': "BootOptionReference not found in BootOption"}
+            boot_option_ref = data['BootOptionReference']
+
+            # fetch the props to display for this boot device
+            boot_props = {}
+            for prop in properties:
+                if prop in data:
+                    boot_props[prop] = data[prop]
+
+            boot_options_dict[boot_option_ref] = boot_props
+
+        # Build boot device list
+        boot_device_list = []
+        for ref in boot_order:
+            boot_device_list.append(boot_options_dict.get(ref))
+
+        result["entries"] = boot_device_list
         return result
 
     def set_bios_default_settings(self):

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -131,7 +131,7 @@ from ansible.module_utils.redfish_utils import RedfishUtils
 CATEGORY_COMMANDS_ALL = {
     "Systems": ["GetSystemInventory", "GetPsuInventory", "GetCpuInventory",
                 "GetNicInventory", "GetStorageControllerInventory",
-                "GetDiskInventory", "GetBiosAttributes", "GetBiosBootOrder"],
+                "GetDiskInventory", "GetBiosAttributes", "GetBootOrder"],
     "Chassis": ["GetFanInventory"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory"],
@@ -223,8 +223,8 @@ def main():
                     result["disk"] = rf_utils.get_disk_inventory()
                 elif command == "GetBiosAttributes":
                     result["bios_attribute"] = rf_utils.get_bios_attributes()
-                elif command == "GetBiosBootOrder":
-                    result["bios_boot_order"] = rf_utils.get_bios_boot_order()
+                elif command == "GetBootOrder":
+                    result["boot_order"] = rf_utils.get_boot_order()
 
         elif category == "Chassis":
             # execute only if we find Chassis resource


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Per the issue #47571, the existing GetBiosBootOrder command was retrieving non-standard
BIOS properties to populate the output inventory (facts) file. I updated the code to use the standard `BootOrder` and `BootOptions` properties from the `ComputerSystem` resource.

Also as discussed in that issue, the command was renamed from `GetBiosBootOrder` to `GetBootOrder` since the boot order info is no longer being retrieved from the BIOS resource.

Fixes #47571 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
**Before**

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook command:
```
$ ansible-playbook -i myinventory.yml playbooks/bios/get_bios_boot_order.yml 

PLAY [Get boot order] **********************************************************

TASK [Define output file] ******************************************************
included: /Users/bdodd/Development/DMTF/Ansible/playbooks/bios/create_output_file.yml for mockup-devel

TASK [Define timestamp] ********************************************************
ok: [mockup-devel]

TASK [Define file to place results] ********************************************
ok: [mockup-devel]

TASK [Create dropoff directory for host] ***************************************
ok: [mockup-devel]

TASK [Get device boot order] ***************************************************
ok: [mockup-devel]

TASK [Copy results to output file] *********************************************
changed: [mockup-devel]

PLAY RECAP *********************************************************************
mockup-devel               : ok=6    changed=1    unreachable=0    failed=0    skipped=0   
```

Output JSON result:
```
{
    "ansible_facts": {
        "redfish_facts": {
            "bios_boot_order": {
                "msg": "HTTP Error: 404",
                "ret": false
            }
        }
    },
    "changed": false,
    "failed": false
}
```

**After**

Command:
```
$ ansible-playbook -i myinventory.yml playbooks/bios/get_bios_boot_order.yml 

PLAY [Get boot order] **********************************************************

TASK [Define output file] ******************************************************
included: /Users/bdodd/Development/DMTF/Ansible/playbooks/bios/create_output_file.yml for mockup-devel

TASK [Define timestamp] ********************************************************
ok: [mockup-devel]

TASK [Define file to place results] ********************************************
ok: [mockup-devel]

TASK [Create dropoff directory for host] ***************************************
ok: [mockup-devel]

TASK [Get device boot order] ***************************************************
ok: [mockup-devel]

TASK [Copy results to output file] *********************************************
changed: [mockup-devel]

PLAY RECAP *********************************************************************
mockup-devel               : ok=6    changed=1    unreachable=0    failed=0    skipped=0   
```

Output JSON result:
```
{
    "ansible_facts": {
        "redfish_facts": {
            "bios_boot_order": {
                "entries": [
                    {
                        "BootOptionReference": "Boot0001",
                        "DisplayName": "Generic USB Boot"
                    },
                    {
                        "BootOptionReference": "Boot0000",
                        "DisplayName": "Windows Boot Manager"
                    },
                    {
                        "BootOptionReference": "Boot0002",
                        "DisplayName": "iSCSI IPv4 Boot LUN 0"
                    },
                    {
                        "BootOptionReference": "Boot0004",
                        "DisplayName": "NIC 1 PXE Boot - IPv6"
                    },
                    {
                        "BootOptionReference": "Boot0003",
                        "DisplayName": "NIC 1 PXE Boot - IPv4"
                    }
                ],
                "ret": true
            }
        }
    },
    "changed": false,
    "failed": false
}
```