### PR TITLE
meraki_admin - Add documentation about absent priority

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+7#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2018, Kevin Breit (@kbreit) <kevin.breit@kevinbreit.net>
@@ -45,7 +45,8 @@ options:
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
     state:
         description:
-        - Create or modify an organization
+        - Create or modify, or delete an organization
+        - If C(state) is C(absent), name takes priority over email if both are specified.
         choices: [ absent, present, query ]
         required: true
     org_name:

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -1,4 +1,4 @@
-7#!/usr/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2018, Kevin Breit (@kbreit) <kevin.breit@kevinbreit.net>


### PR DESCRIPTION
##### SUMMARY
Documentation needed to be improved when `state: absent` is called. If email and name are both specified, name takes priority.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meraki_admin