### PR TITLE
Filesystem should return at least the uuid

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -147,7 +147,7 @@ class Filesystem(object):
     def get_uuid(self, dev):
         """ Fetch the UUID """
         blkid = self.module.get_bin_path('blkid', required=True)
-        cmd = "{} {} -s UUID -o value".format(blkid, dev)
+        cmd = "{0} {1} -s UUID -o value".format(blkid, dev)
         _, out, _ = self.module.run_command(cmd, check_rc=True)
         match = re.search(r"(\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)", out)
         if match:
@@ -406,7 +406,7 @@ def main():
     if same_fs and not resizefs and not force:
         # Fetch the fs UUID
         uuid = filesystem.get_uuid(dev)
-        module.exit_json(changed=False,  uuid=uuid)
+        module.exit_json(changed=False, uuid=uuid)
     elif same_fs and resizefs:
         uuid = filesystem.get_uuid(dev)
         if not filesystem.GROW:


### PR DESCRIPTION
##### SUMMARY

When creating filesystems on a unix system, better use the UUID instead of the device name when mounting devices.


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module filesystem

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Simply added the `uuid` key to the return dict populated with the corresponding partition's UUID. When not available for some reason, return a empty string
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before 
ok: [some-machine] => {"changed": false}

After
ok: [some-machine] => {"changed": false, "uuid": "b50ed141-6e77-4982-ba4e-8369c05524fd"}
```
