### PR TITLE
Custom jinja Undefined class for handling nested undefined attributes

### DIFF
--- a/changelogs/fragments/jinja2_nested_undefined.yaml
+++ b/changelogs/fragments/jinja2_nested_undefined.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jinja2 - accesses to attributes on an undefined value now return further undefined values rather than throwing an exception

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -37,6 +37,24 @@ using an import, a task can notify any of the named tasks within the imported fi
 
 To achieve the results of notifying a single name but running mulitple handlers, utilize ``include_tasks``, or ``listen`` :ref:`handlers`.
 
+Jinja Undefined values
+----------------------
+
+Beginning in version 2.8, attempting to access an attribute of an Undefined value in Jinja will return another Undefined value, rather than throwing an error immediately. This means that you can now simply use
+a default with a value in a nested data structure when you don't know if the intermediate values are defined.
+
+In Ansible 2.8::
+
+    {{ foo.bar.baz | default('DEFAULT') }}
+
+In Ansible 2.7 and older::
+
+    {{ ((foo | default({})).bar | default({})).baz | default('DEFAULT') }}
+    
+    or
+    
+    {{ foo.bar.baz if (foo is defined and foo.bar is defined and foo.bar.baz is defined) else 'DEFAULT' }}
+
 Command Line
 ============
 

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -642,5 +642,30 @@
   register: encoding_1252_diff_result
   loop: '{{ template_encoding_1252_encodings }}'
 
+- name: Check that nested undefined values return Undefined
+  vars:
+    dict_var:
+      bar: {}
+    list_var:
+      - foo: {}
+  assert:
+    that:
+      - dict_var is defined
+      - dict_var.bar is defined
+      - dict_var.bar.baz is not defined
+      - dict_var.bar.baz | default('DEFAULT') == 'DEFAULT'
+      - dict_var.bar.baz.abc is not defined
+      - dict_var.bar.baz.abc | default('DEFAULT') == 'DEFAULT'
+      - dict_var.baz is not defined
+      - dict_var.baz.abc is not defined
+      - dict_var.baz.abc | default('DEFAULT') == 'DEFAULT'
+      - list_var.0 is defined
+      - list_var.1 is not defined
+      - list_var.0.foo is defined
+      - list_var.0.foo.bar is not defined
+      - list_var.0.foo.bar | default('DEFAULT') == 'DEFAULT'
+      - list_var.1.foo is not defined
+      - list_var.1.foo | default('DEFAULT') == 'DEFAULT'
+
 # aliases file requires root for template tests so this should be safe
 - include: backup_test.yml


### PR DESCRIPTION
##### SUMMARY
This commit creates a custom Jinja2 Undefined class that returns Undefined for any further accesses, rather than raising an exception. This allows doing something like `foo.bar.baz | default('whatever')` rather than `((foo | default({})).bar | default({})).baz | default('whatever')` when you don't know if all levels of the structure are defined.

This was created as an alternative to #50706

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
templates

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
