### PR TITLE
Correct integration tests for the win_disk_facts module

### DIFF
--- a/test/integration/targets/win_disk_facts/aliases
+++ b/test/integration/targets/win_disk_facts/aliases
@@ -1,1 +1,3 @@
 shippable/windows/group2
+skip/windows/2008    # The Storage PowerShell module was introduced in W2K12
+skip/windows/2008-R2 # The Storage PowerShell module was introduced in W2K12

--- a/test/integration/targets/win_disk_facts/tasks/main.yml
+++ b/test/integration/targets/win_disk_facts/tasks/main.yml
@@ -1,12 +1,12 @@
 # NOTE: The win_disk_facts module only works on Win2012R2+
 
 - name: check whether storage module is available (windows 2008 r2 or later)
-  raw: PowerShell -Command Import-Module Storage
+  win_shell: '(Get-Module -Name Storage -ListAvailable | Measure-Object).Count -eq 1'
   register: win_feature_has_storage_module
-  ignore_errors: true
+  changed_when: false
 
 - name: Only run tests when Windows is capable
-  when: ( win_feature_has_storage_module is successful) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 3)
+  when: win_feature_has_storage_module.stdout | trim | bool == True
   block:
 
   - name: Test in normal mode

--- a/test/integration/targets/win_disk_facts/tasks/tests.yml
+++ b/test/integration/targets/win_disk_facts/tasks/tests.yml
@@ -6,12 +6,12 @@
   assert:
     that:
     - disks_found.changed == false
-    - disks_found.ansible_facts.disks[0].size is defined
-    - disks_found.ansible_facts.disks[0].number is defined
-    - disks_found.ansible_facts.disks[0].operational_status is defined
-    - disks_found.ansible_facts.disks[0].read_only is defined
-    - disks_found.ansible_facts.disks[0].clustered is defined
-    - disks_found.ansible_facts.disks[0].location is defined
-    - disks_found.ansible_facts.disks[0].guid is defined
-    - disks_found.ansible_facts.disks[0].path is defined
-    - disks_found.ansible_facts.disks[0].bootable is defined
+    - disks_found.ansible_facts.ansible_disks[0].number is defined
+    - disks_found.ansible_facts.ansible_disks[0].guid is defined
+    - disks_found.ansible_facts.ansible_disks[0].location is defined
+    - disks_found.ansible_facts.ansible_disks[0].path is defined
+    - disks_found.ansible_facts.ansible_disks[0].read_only is defined
+    - disks_found.ansible_facts.ansible_disks[0].clustered is defined
+    - disks_found.ansible_facts.ansible_disks[0].bootable is defined
+    - disks_found.ansible_facts.ansible_disks[0].physical_disk.size is defined
+    - disks_found.ansible_facts.ansible_disks[0].physical_disk.operational_status is defined


### PR DESCRIPTION
##### SUMMARY
The pull request corrects integration tests for the module win_disk_facts.

It's a backport of #51044.

Fixes #51031 for Ansible 2.7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_disk_facts