### PR TITLE
fix string_format sanity check

### DIFF
--- a/test/sanity/pylint/plugins/string_format.py
+++ b/test/sanity/pylint/plugins/string_format.py
@@ -13,7 +13,10 @@ from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils
 from pylint.checkers.utils import check_messages
-from pylint.checkers.strings import parse_format_method_string
+try:
+    from pylint.checkers.utils import parse_format_method_string
+except ImportError:
+    from pylint.checkers.strings import parse_format_method_string
 
 _PY3K = sys.version_info[:2] >= (3, 0)
 


### PR DESCRIPTION
##### SUMMARY
* newer version of Pylint moved the impl; use conditional import to find for new/old

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
string_format sanity check

##### ADDITIONAL INFORMATION

