### PR TITLE
fix string_format sanity check (#51780)

### DIFF
--- a/test/sanity/pylint/plugins/string_format.py
+++ b/test/sanity/pylint/plugins/string_format.py
@@ -13,7 +13,10 @@ from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils
 from pylint.checkers.utils import check_messages
-from pylint.checkers.strings import parse_format_method_string
+try:
+    from pylint.checkers.utils import parse_format_method_string
+except ImportError:
+    from pylint.checkers.strings import parse_format_method_string
 
 _PY3K = sys.version_info[:2] >= (3, 0)
 


### PR DESCRIPTION
##### SUMMARY
* newer version of Pylint moved the impl; use conditional import to find for new/old

(cherry picked from commit 6654c7aeea70a12fb848073ca3b0c377cf79e3d1)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
