### PR TITLE
Pluribus Networks vrouter ospf6 module with UT

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
@@ -116,8 +116,7 @@ def check_cli(module, cli):
 
     if nic_str:
         # Check for nic
-        show = cli + ' vrouter-ospf6-show vrouter-name %s ' % vrouter_name
-        show += ' format nic no-show-headers'
+        show = cli + ' vrouter-ospf6-show vrouter-name %s format nic no-show-headers' % vrouter_name
         out = module.run_command(show, use_unsafe_shell=True)[1]
 
         NIC_EXISTS = True if nic_str in out else False
@@ -146,7 +145,7 @@ def main():
             ["state", "present", ["pn_vrouter_name", "pn_nic",
                                   "pn_ospf6_area"]],
             ["state", "absent", ["pn_vrouter_name", "pn_nic"]]
-            ),
+        ),
     )
 
     # Accessing the arguments
@@ -163,14 +162,15 @@ def main():
 
     VROUTER_EXISTS, NIC_EXISTS = check_cli(module, cli)
 
+    if VROUTER_EXISTS is False:
+        module.fail_json(
+            failed=True,
+            msg='vRouter %s does not exist' % vrouter_name
+        )
+
     cli += ' %s vrouter-name %s ' % (command, vrouter_name)
 
     if command == 'vrouter-ospf6-add':
-        if VROUTER_EXISTS is False:
-            module.fail_json(
-                failed=True,
-                msg='vRouter %s does not exist' % vrouter_name
-            )
         if NIC_EXISTS is True:
             module.exit_json(
                 skipped=True,
@@ -182,11 +182,6 @@ def main():
             cli += ' ospf6-area %s ' % ospf6_area
 
     if command == 'vrouter-ospf6-remove':
-        if VROUTER_EXISTS is False:
-            module.fail_json(
-                failed=True,
-                msg='vRouter %s does not exist' % vrouter_name
-            )
         if NIC_EXISTS is False:
             module.exit_json(
                 skipped=True,

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_vrouter_ospf6
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to add/remove vrouter-ospf6
+description:
+  - This module can be used to add interface ip to OSPF6 protocol
+    or remove interface ip from OSPF6 protocol on vRouter.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: false
+    type: str
+  state:
+    description:
+      - State the action to perform. Use C(present) to add vrouter-ospf6 and
+        C(absent) to remove interface from vrouter-ospf6.
+    required: true
+    type: str
+    choices: ['present', 'absent']
+  pn_ospf6_area:
+    description:
+      - area id for this interface in IPv4 address format.
+    required: false
+    type: str
+  pn_nic:
+    description:
+      - OSPF6 control for this interface.
+    required: false
+    type: str
+  pn_vrouter_name:
+    description:
+      - name of service config.
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Add vrouter interface nic to ospf6
+  pn_vrouter_ospf6:
+    pn_cliswitch: "sw01"
+    state: "present"
+    pn_vrouter_name: "foo-vrouter"
+    pn_nic: "eth0.4092"
+    pn_ospf6_area: "0.0.0.0"
+
+- name: Remove vrouter interface nic to ospf6
+  pn_vrouter_ospf6:
+    pn_cliswitch: "sw01"
+    state: "absent"
+    pn_vrouter_name: "foo-vrouter"
+    pn_nic: "eth0.4092"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the vrouter-ospf6 command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the vrouter-ospf6 command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks if vRouter exists on the target node.
+    This method also checks for idempotency using the vrouter-interface-show
+    command.
+    If the given vRouter exists, return VROUTER_EXISTS as True else False.
+
+    If nic_str exists on the given vRouter, return NIC_EXISTS as True else
+    False. This is required for vrouter-ospf6-remove.
+
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    :return Booleans: VROUTER_EXISTS, NIC_EXISTS
+    """
+    vrouter_name = module.params['pn_vrouter_name']
+    nic_str = module.params['pn_nic']
+
+    # Check for vRouter
+    check_vrouter = cli + ' vrouter-show format name no-show-headers '
+    out = module.run_command(check_vrouter, use_unsafe_shell=True)[1]
+    out = out.split()
+
+    VROUTER_EXISTS = True if vrouter_name in out else False
+
+    if nic_str:
+        # Check for nic
+        show = cli + ' vrouter-ospf6-show vrouter-name %s ' % vrouter_name
+        show += ' format nic no-show-headers'
+        out = module.run_command(show, use_unsafe_shell=True)[1]
+
+        NIC_EXISTS = True if nic_str in out else False
+
+    return VROUTER_EXISTS, NIC_EXISTS
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        present='vrouter-ospf6-add',
+        absent='vrouter-ospf6-remove'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_ospf6_area=dict(required=False, type='str'),
+            pn_nic=dict(required=False, type='str'),
+            pn_vrouter_name=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ["state", "present", ["pn_vrouter_name", "pn_nic",
+                                  "pn_ospf6_area"]],
+            ["state", "absent", ["pn_vrouter_name", "pn_nic"]]
+            ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    ospf6_area = module.params['pn_ospf6_area']
+    nic = module.params['pn_nic']
+    vrouter_name = module.params['pn_vrouter_name']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    VROUTER_EXISTS, NIC_EXISTS = check_cli(module, cli)
+
+    cli += ' %s vrouter-name %s ' % (command, vrouter_name)
+
+    if command == 'vrouter-ospf6-add':
+        if VROUTER_EXISTS is False:
+            module.fail_json(
+                failed=True,
+                msg='vRouter %s does not exist' % vrouter_name
+            )
+        if NIC_EXISTS is True:
+            module.exit_json(
+                skipped=True,
+                msg='OSPF6 with nic %s already exist' % nic
+            )
+        if nic:
+            cli += ' nic %s' % nic
+        if ospf6_area:
+            cli += ' ospf6-area %s ' % ospf6_area
+
+    if command == 'vrouter-ospf6-remove':
+        if VROUTER_EXISTS is False:
+            module.fail_json(
+                failed=True,
+                msg='vRouter %s does not exist' % vrouter_name
+            )
+        if NIC_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='OSPF6 with nic %s does not exist' % nic
+            )
+        if nic:
+            cli += ' nic %s' % nic
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/netvisor/test_pn_vrouter_ospf6.py
+++ b/test/units/modules/network/netvisor/test_pn_vrouter_ospf6.py
@@ -1,0 +1,62 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_vrouter_ospf6
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestVrouterOSPF6Module(TestNvosModule):
+
+    module = pn_vrouter_ospf6
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_vrouter_ospf6.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_vrouter_ospf6.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+        self.mock_run_check_cli.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'vrouter-ospf6-add':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'vrouter-ospf6-remove':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = True, False
+        if state == 'absent':
+            self.run_check_cli.return_value = True, True
+
+    def test_vrouter_ospf6_add(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
+                         'pn_nic': 'eth0.4092', 'pn_ospf6_area': '0.0.0.0', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-ospf6-add vrouter-name foo-vrouter  nic eth0.4092 ospf6-area 0.0.0.0 '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_vrouter_ospf6_remove(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
+                         'pn_nic': 'eth0.4092', 'state': 'absent'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-ospf6-remove vrouter-name foo-vrouter  nic eth0.4092'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of vrouter ospf6 for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_vrouter_ospf6.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```