### PR TITLE
acme_challenge_cert_helper: fix bad module.fail_json() call

### DIFF
--- a/changelogs/fragments/51795-acme_challenge_cert_helper-module-fail.yaml
+++ b/changelogs/fragments/51795-acme_challenge_cert_helper-module-fail.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_challenge_cert_helper - the module no longer crashes when the required ``cryptography`` library cannot be found."

--- a/lib/ansible/modules/crypto/acme/acme_challenge_cert_helper.py
+++ b/lib/ansible/modules/crypto/acme/acme_challenge_cert_helper.py
@@ -179,7 +179,7 @@ def main():
         ),
     )
     if not HAS_CRYPTOGRAPHY:
-        module.fail(msg='cryptography >= 1.3 is required for this module.')
+        module.fail_json(msg='cryptography >= 1.3 is required for this module.')
 
     try:
         # Get parameters


### PR DESCRIPTION
##### SUMMARY
A tiny bugfix for `acme_challenge_cert_helper`: if `cryptography` was not found, it tried to call `module.fail()` instead of `module.fail_json()`.

Found and fixed by @jborean93 in #51787, which will not be backported, hence this PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_challenge_cert_helper
