### PR TITLE
Removes superfluous commands nxos_vlan

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -212,10 +212,6 @@ def map_obj_to_commands(updates, module):
 
         if state == 'absent':
             if obj_in_have:
-                if obj_in_have['mapped_vni'] != 'None':
-                    commands.append('vlan {0}'.format(vlan_id))
-                    commands.append('no vn-segment')
-                    commands.append('exit')
                 commands.append('no vlan {0}'.format(vlan_id))
 
         elif state == 'present':


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/51745
At the end the vlan itself is always deleted for state being absent, vni removal is unnecessary.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/network/nxos/nxos_vlan.py