### PR TITLE
callbacks/slack: Explicitly set Content-Type header

### DIFF
--- a/changelogs/fragments/51824-slack-req-content-type.yaml
+++ b/changelogs/fragments/51824-slack-req-content-type.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+    - >-
+      slack: Explicitly set Content-Type header to "application/json" for
+      improved compatibility with non-Slack chat systems

--- a/lib/ansible/plugins/callback/slack.py
+++ b/lib/ansible/plugins/callback/slack.py
@@ -114,6 +114,10 @@ class CallbackModule(CallbackBase):
                                   'variable.')
 
     def send_msg(self, attachments):
+        headers = {
+            'Content-type': 'application/json',
+        }
+
         payload = {
             'channel': self.channel,
             'username': self.username,
@@ -127,7 +131,8 @@ class CallbackModule(CallbackBase):
         self._display.debug(data)
         self._display.debug(self.webhook_url)
         try:
-            response = open_url(self.webhook_url, data=data, validate_certs=self.validate_certs)
+            response = open_url(self.webhook_url, data=data, validate_certs=self.validate_certs,
+                                headers=headers)
             return response.read()
         except Exception as e:
             self._display.warning(u'Could not submit message to Slack: %s' %


### PR DESCRIPTION
##### SUMMARY
There are other chat systems with hook implementations more or less
compatible with Slack, such as Rocket.Chat. The latter requires the
Content-Type header to be set to "application/json" (the body is JSON).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
slack