### PR TITLE
Send openstack inventory logs to stderr

### DIFF
--- a/changelogs/fragments/51827-openstack_logs_to_stderr.yml
+++ b/changelogs/fragments/51827-openstack_logs_to_stderr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openstack inventory plugin - send logs from sdk to stderr so they do not combine with output

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -108,6 +108,7 @@ fail_on_errors: yes
 '''
 
 import collections
+import sys
 
 from ansible.errors import AnsibleParserError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
@@ -172,8 +173,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             else:
                 config_files = None
 
+            # Redict logging to stderr so it does not mix with output
+            # particular ansible-inventory JSON output
             # TODO(mordred) Integrate openstack's logging with ansible's logging
-            sdk.enable_logging()
+            sdk.enable_logging(stream=sys.stderr)
 
             cloud_inventory = sdk_inventory.OpenStackInventory(
                 config_files=config_files,


### PR DESCRIPTION
##### SUMMARY
Resolves https://github.com/ansible/ansible/issues/50100

This redirects logs from the openstack sdk to stderr. This is a blocker for integrating openstack inventories into our systems.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/openstack.py

##### ADDITIONAL INFORMATION
This was a TODO item for... @mordred ??

You can improve on this latter, but I need to get error messages _out_ of stdout. You can put them anywhere else you like later. As long as it's not stdout.

See method docs:

https://github.com/openstack/openstacksdk/blob/9675c1fb0b065017a0fadf75f52d8193cce7dd24/openstack/_log.py#L68-L71

Ping @ryanpetrello in relation to https://github.com/ansible/awx/pull/3107