### PR TITLE
Update yaml.py example to include A colon for single host in a group

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -45,7 +45,7 @@ all: # keys must be unique, i.e. only one 'hosts' per group
             children:
                 group_x:
                     hosts:
-                        test5
+                        test5:
             vars:
                 g2_var2: value3
             hosts:

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -45,7 +45,14 @@ all: # keys must be unique, i.e. only one 'hosts' per group
             children:
                 group_x:
                     hosts:
-                        test5:
+                        test5   # Note that one machine will work without a colon
+                #group_x:
+                #    hosts:
+                #        test5  # But this won't
+                #        test7  #
+                group_y:
+                    hosts:
+                        test6:  # So always use a colon
             vars:
                 g2_var2: value3
             hosts:


### PR DESCRIPTION
##### SUMMARY
took me some time to find that out, you can have a single host under a group without the A colon, but if you add another host also w/o A colon, they will be parsed as a single line.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- yaml.py

##### ADDITIONAL INFORMATION

this will work
```yaml
all:
  vars:
    ansible_user: ansible

  children:
    ios:
      vars:
        ansible_network_os: ios

      hosts:
        sw1
```
but not this, the host list will be treated as `"sw1 sw2"`
```yaml
all:
  vars:
    ansible_user: ansible

  children:
    ios:
      vars:
        ansible_network_os: ios

      hosts:
        sw1
        sw2
```
