### PR TITLE
New module for fortios dlp fp doc source

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
@@ -37,6 +37,9 @@ options:
 extends_documentation_fragment:
     - aws
     - ec2
+requirements:
+  - botocore
+  - boto3
 '''
 
 EXAMPLES = '''
@@ -80,127 +83,174 @@ vpc_id:
 '''
 
 try:
-    import boto.ec2
-    import boto.vpc
-    from boto.exception import EC2ResponseError
-    HAS_BOTO = True
+    import botocore
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import AnsibleAWSError, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import (
+    AWSRetry,
+    boto3_conn,
+    ec2_argument_spec,
+    get_aws_connection_info,
+    camel_dict_to_snake_dict,
+    boto3_tag_list_to_ansible_dict,
+    ansible_dict_to_boto3_filter_list,
+    ansible_dict_to_boto3_tag_list,
+    compare_aws_tags
+)
 from ansible.module_utils.six import string_types
 
 
-class AnsibleIGWException(Exception):
-    pass
+class AnsibleEc2Igw(object):
 
+    def __init__(self, module, results):
+        self._module = module
+        self._results = results
+        self._connection = self._module.client('ec2')
+        self._check_mode = self._module.check_mode
 
-def get_igw_info(igw):
-    return {'gateway_id': igw.id,
-            'tags': igw.tags,
-            'vpc_id': igw.vpc_id
-            }
+    def process(self):
+        vpc_id = self._module.params.get('vpc_id')
+        state = self._module.params.get('state', 'present')
+        tags = self._module.params.get('tags')
 
+        if state == 'present':
+            self.ensure_igw_present(vpc_id, tags)
+        elif state == 'absent':
+            self.ensure_igw_absent(vpc_id)
 
-def get_resource_tags(vpc_conn, resource_id):
-    return dict((t.name, t.value) for t in
-                vpc_conn.get_all_tags(filters={'resource-id': resource_id}))
+    def get_matching_igw(self, vpc_id):
+        filters = ansible_dict_to_boto3_filter_list({'attachment.vpc-id': vpc_id})
+        igws = []
+        try:
+            response = self._connection.describe_internet_gateways(Filters=filters)
+            igws = response.get('InternetGateways', [])
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self._module.fail_json_aws(e)
 
+        igw = None
+        if len(igws) > 1:
+            self._module.fail_json(
+                msg='EC2 returned more than one Internet Gateway for VPC {0}, aborting'.format(vpc_id))
+        elif igws:
+            igw = camel_dict_to_snake_dict(igws[0])
 
-def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
-    try:
-        cur_tags = get_resource_tags(vpc_conn, resource_id)
-        if cur_tags == tags:
-            return {'changed': False, 'tags': cur_tags}
+        return igw
 
-        if check_mode:
-            latest_check_mode_tags = cur_tags
+    def check_input_tags(self, tags):
+        nonstring_tags = [k for k, v in tags.items() if not isinstance(v, string_types)]
+        if nonstring_tags:
+            self._module.fail_json(msg='One or more tags contain non-string values: {0}'.format(nonstring_tags))
 
-        to_delete = dict((k, cur_tags[k]) for k in cur_tags if k not in tags)
-        if to_delete and not add_only:
-            if check_mode:
-                # just overwriting latest_check_mode_tags instead of deleting keys
-                latest_check_mode_tags = dict((k, cur_tags[k]) for k in cur_tags if k not in to_delete)
-            else:
-                vpc_conn.delete_tags(resource_id, to_delete)
+    def ensure_tags(self, igw_id, tags, add_only):
+        final_tags = []
 
-        to_add = dict((k, tags[k]) for k in tags if k not in cur_tags or cur_tags[k] != tags[k])
-        if to_add:
-            if check_mode:
-                latest_check_mode_tags.update(to_add)
-            else:
-                vpc_conn.create_tags(resource_id, to_add)
+        filters = ansible_dict_to_boto3_filter_list({'resource-id': igw_id, 'resource-type': 'internet-gateway'})
+        cur_tags = None
+        try:
+            cur_tags = self._connection.describe_tags(Filters=filters)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self._module.fail_json_aws(e, msg="Couldn't describe tags")
 
-        if check_mode:
-            return {'changed': True, 'tags': latest_check_mode_tags}
-        latest_tags = get_resource_tags(vpc_conn, resource_id)
-        return {'changed': True, 'tags': latest_tags}
-    except EC2ResponseError as e:
-        raise AnsibleIGWException(
-            'Unable to update tags for {0}, error: {1}'.format(resource_id, e))
+        purge_tags = bool(not add_only)
+        to_update, to_delete = compare_aws_tags(boto3_tag_list_to_ansible_dict(cur_tags.get('Tags')), tags, purge_tags)
+        final_tags = boto3_tag_list_to_ansible_dict(cur_tags.get('Tags'))
 
+        if to_update:
+            try:
+                if self._check_mode:
+                    # update tags
+                    final_tags.update(to_update)
+                else:
+                    AWSRetry.exponential_backoff()(self._connection.create_tags)(
+                        Resources=[igw_id],
+                        Tags=ansible_dict_to_boto3_tag_list(to_update)
+                    )
 
-def get_matching_igw(vpc_conn, vpc_id):
-    igws = vpc_conn.get_all_internet_gateways(filters={'attachment.vpc-id': vpc_id})
-    if len(igws) > 1:
-        raise AnsibleIGWException(
-            'EC2 returned more than one Internet Gateway for VPC {0}, aborting'
-            .format(vpc_id))
-    return igws[0] if igws else None
+                self._results['changed'] = True
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self._module.fail_json_aws(e, msg="Couldn't create tags")
 
+        if to_delete:
+            try:
+                if self._check_mode:
+                    # update tags
+                    for key in to_delete:
+                        del final_tags[key]
+                else:
+                    tags_list = []
+                    for key in to_delete:
+                        tags_list.append({'Key': key})
 
-def ensure_igw_absent(vpc_conn, vpc_id, check_mode):
-    igw = get_matching_igw(vpc_conn, vpc_id)
-    if igw is None:
-        return {'changed': False}
+                    AWSRetry.exponential_backoff()(self._connection.delete_tags)(Resources=[igw_id], Tags=tags_list)
 
-    if check_mode:
-        return {'changed': True}
+                self._results['changed'] = True
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self._module.fail_json_aws(e, msg="Couldn't delete tags")
 
-    try:
-        vpc_conn.detach_internet_gateway(igw.id, vpc_id)
-        vpc_conn.delete_internet_gateway(igw.id)
-    except EC2ResponseError as e:
-        raise AnsibleIGWException(
-            'Unable to delete Internet Gateway, error: {0}'.format(e))
+        if not self._check_mode and (to_update or to_delete):
+            try:
+                response = self._connection.describe_tags(Filters=filters)
+                final_tags = boto3_tag_list_to_ansible_dict(response.get('Tags'))
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self._module.fail_json_aws(e, msg="Couldn't describe tags")
 
-    return {'changed': True}
+        return final_tags
 
+    @staticmethod
+    def get_igw_info(igw):
+        return {
+            'gateway_id': igw['internet_gateway_id'],
+            'tags': igw['tags'],
+            'vpc_id': igw['vpc_id']
+        }
 
-def ensure_igw_present(vpc_conn, vpc_id, tags, check_mode):
-    igw = get_matching_igw(vpc_conn, vpc_id)
-    changed = False
-    if igw is None:
-        if check_mode:
-            return {'changed': True, 'gateway_id': None}
+    def ensure_igw_absent(self, vpc_id):
+        igw = self.get_matching_igw(vpc_id)
+        if igw is None:
+            return self._results
+
+        if self._check_mode:
+            self._results['changed'] = True
+            return self._results
 
         try:
-            igw = vpc_conn.create_internet_gateway()
-            vpc_conn.attach_internet_gateway(igw.id, vpc_id)
-            changed = True
-        except EC2ResponseError as e:
-            raise AnsibleIGWException(
-                'Unable to create Internet Gateway, error: {0}'.format(e))
+            self._results['changed'] = True
+            self._connection.detach_internet_gateway(InternetGatewayId=igw['internet_gateway_id'], VpcId=vpc_id)
+            self._connection.delete_internet_gateway(InternetGatewayId=igw['internet_gateway_id'])
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self._module.fail_json_aws(e, msg="Unable to delete Internet Gateway")
 
-    igw.vpc_id = vpc_id
+        return self._results
 
-    if tags != igw.tags:
-        if check_mode:
-            check_mode_tags = ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
-            igw_info = get_igw_info(igw)
-            igw_info.get('tags', {}).update(check_mode_tags.get('tags', {}))
-            return {'changed': True, 'gateway': igw_info}
-        ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
-        igw.tags = tags
-        changed = True
+    def ensure_igw_present(self, vpc_id, tags):
+        self.check_input_tags(tags)
 
-    igw_info = get_igw_info(igw)
+        igw = self.get_matching_igw(vpc_id)
 
-    return {
-        'changed': changed,
-        'gateway': igw_info
-    }
+        if igw is None:
+            if self._check_mode:
+                self._results['changed'] = True
+                self._results['gateway_id'] = None
+                return self._results
+
+            try:
+                response = self._connection.create_internet_gateway()
+                igw = camel_dict_to_snake_dict(response['InternetGateway'])
+                self._connection.attach_internet_gateway(InternetGatewayId=igw['internet_gateway_id'], VpcId=vpc_id)
+                self._results['changed'] = True
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self._module.fail_json_aws(e, msg='Unable to create Internet Gateway')
+
+        igw['vpc_id'] = vpc_id
+
+        igw['tags'] = self.ensure_tags(igw_id=igw['internet_gateway_id'], tags=tags, add_only=False)
+
+        igw_info = self.get_igw_info(igw)
+        self._results.update(igw_info)
+
+        return self._results
 
 
 def main():
@@ -213,41 +263,17 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
+    results = dict(
+        changed=False
+    )
+    igw_manager = AnsibleEc2Igw(module=module, results=results)
+    igw_manager.process()
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto is required for this module')
-
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
-
-    if region:
-        try:
-            connection = connect_to_aws(boto.vpc, region, **aws_connect_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
-            module.fail_json(msg=str(e))
-    else:
-        module.fail_json(msg="region must be specified")
-
-    vpc_id = module.params.get('vpc_id')
-    state = module.params.get('state', 'present')
-    tags = module.params.get('tags')
-
-    nonstring_tags = [k for k, v in tags.items() if not isinstance(v, string_types)]
-    if nonstring_tags:
-        module.fail_json(msg='One or more tags contain non-string values: {0}'.format(nonstring_tags))
-
-    try:
-        if state == 'present':
-            result = ensure_igw_present(connection, vpc_id, tags, check_mode=module.check_mode)
-        elif state == 'absent':
-            result = ensure_igw_absent(connection, vpc_id, check_mode=module.check_mode)
-    except AnsibleIGWException as e:
-        module.fail_json(msg=str(e))
-
-    module.exit_json(changed=result['changed'], **result.get('gateway', {}))
+    module.exit_json(**results)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py
+++ b/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py
@@ -1,0 +1,395 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2018 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# the lib use python logging can get it if the following is set in your
+# Ansible config.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_dlp_fp_doc_source
+short_description: Create a DLP fingerprint database by allowing the FortiGate to access a file server containing files from which to create fingerprints in
+   Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by
+      allowing the user to configure dlp feature and fp_doc_source category.
+      Examples includes all options and need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip adress.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: false
+    dlp_fp_doc_source:
+        description:
+            - Create a DLP fingerprint database by allowing the FortiGate to access a file server containing files from which to create fingerprints.
+        default: null
+        suboptions:
+            state:
+                description:
+                    - Indicates whether to create or remove the object
+                choices:
+                    - present
+                    - absent
+            date:
+                description:
+                    - Day of the month on which to scan the server (1 - 31).
+            file-path:
+                description:
+                    - Path on the server to the fingerprint files (max 119 characters).
+            file-pattern:
+                description:
+                    - Files matching this pattern on the server are fingerprinted. Optionally use the * and ? wildcards.
+            keep-modified:
+                description:
+                    - Enable so that when a file is changed on the server the FortiGate keeps the old fingerprint and adds a new fingerprint to the database.
+                choices:
+                    - enable
+                    - disable
+            name:
+                description:
+                    - Name of the DLP fingerprint database.
+                required: true
+            password:
+                description:
+                    - Password required to log into the file server.
+            period:
+                description:
+                    - Frequency for which the FortiGate checks the server for new or changed files.
+                choices:
+                    - none
+                    - daily
+                    - weekly
+                    - monthly
+            remove-deleted:
+                description:
+                    - Enable to keep the fingerprint database up to date when a file is deleted from the server.
+                choices:
+                    - enable
+                    - disable
+            scan-on-creation:
+                description:
+                    - Enable to keep the fingerprint database up to date when a file is added or changed on the server.
+                choices:
+                    - enable
+                    - disable
+            scan-subdirectories:
+                description:
+                    - Enable/disable scanning subdirectories to find files to create fingerprints from.
+                choices:
+                    - enable
+                    - disable
+            sensitivity:
+                description:
+                    - Select a sensitivity or threat level for matches with this fingerprint database. Add sensitivities using fp-sensitivity. Source dlp
+                      .fp-sensitivity.name.
+            server:
+                description:
+                    - IPv4 or IPv6 address of the server.
+            server-type:
+                description:
+                    - Protocol used to communicate with the file server. Currently only Samba (SMB) servers are supported.
+                choices:
+                    - samba
+            tod-hour:
+                description:
+                    - Hour of the day on which to scan the server (0 - 23, default = 1).
+            tod-min:
+                description:
+                    - Minute of the hour on which to scan the server (0 - 59).
+            username:
+                description:
+                    - User name required to log into the file server.
+            vdom:
+                description:
+                    - Select the VDOM that can communicate with the file server.
+                choices:
+                    - mgmt
+                    - current
+            weekday:
+                description:
+                    - Day of the week on which to scan the server.
+                choices:
+                    - sunday
+                    - monday
+                    - tuesday
+                    - wednesday
+                    - thursday
+                    - friday
+                    - saturday
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Create a DLP fingerprint database by allowing the FortiGate to access a file server containing files from which to create fingerprints.
+    fortios_dlp_fp_doc_source:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      dlp_fp_doc_source:
+        state: "present"
+        date: "3"
+        file-path: "<your_own_value>"
+        file-pattern: "<your_own_value>"
+        keep-modified: "enable"
+        name: "default_name_7"
+        password: "<your_own_value>"
+        period: "none"
+        remove-deleted: "enable"
+        scan-on-creation: "enable"
+        scan-subdirectories: "enable"
+        sensitivity: "<your_own_value> (source dlp.fp-sensitivity.name)"
+        server: "192.168.100.40"
+        server-type: "samba"
+        tod-hour: "16"
+        tod-min: "17"
+        username: "<your_own_value>"
+        vdom: "mgmt"
+        weekday: "sunday"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+fos = None
+
+
+def login(data):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_dlp_fp_doc_source_data(json):
+    option_list = ['date', 'file-path', 'file-pattern',
+                   'keep-modified', 'name', 'password',
+                   'period', 'remove-deleted', 'scan-on-creation',
+                   'scan-subdirectories', 'sensitivity', 'server',
+                   'server-type', 'tod-hour', 'tod-min',
+                   'username', 'vdom', 'weekday']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def dlp_fp_doc_source(data, fos):
+    vdom = data['vdom']
+    dlp_fp_doc_source_data = data['dlp_fp_doc_source']
+    filtered_data = filter_dlp_fp_doc_source_data(dlp_fp_doc_source_data)
+    if dlp_fp_doc_source_data['state'] == "present":
+        return fos.set('dlp',
+                       'fp-doc-source',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif dlp_fp_doc_source_data['state'] == "absent":
+        return fos.delete('dlp',
+                          'fp-doc-source',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def fortios_dlp(data, fos):
+    login(data)
+
+    methodlist = ['dlp_fp_doc_source']
+    for method in methodlist:
+        if data[method]:
+            resp = eval(method)(data, fos)
+            break
+
+    fos.logout()
+    return not resp['status'] == "success", resp['status'] == "success", resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": "False"},
+        "dlp_fp_doc_source": {
+            "required": False, "type": "dict",
+            "options": {
+                "state": {"required": True, "type": "str",
+                          "choices": ["present", "absent"]},
+                "date": {"required": False, "type": "int"},
+                "file-path": {"required": False, "type": "str"},
+                "file-pattern": {"required": False, "type": "str"},
+                "keep-modified": {"required": False, "type": "str",
+                                  "choices": ["enable", "disable"]},
+                "name": {"required": True, "type": "str"},
+                "password": {"required": False, "type": "str"},
+                "period": {"required": False, "type": "str",
+                           "choices": ["none", "daily", "weekly",
+                                       "monthly"]},
+                "remove-deleted": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "scan-on-creation": {"required": False, "type": "str",
+                                     "choices": ["enable", "disable"]},
+                "scan-subdirectories": {"required": False, "type": "str",
+                                        "choices": ["enable", "disable"]},
+                "sensitivity": {"required": False, "type": "str"},
+                "server": {"required": False, "type": "str"},
+                "server-type": {"required": False, "type": "str",
+                                "choices": ["samba"]},
+                "tod-hour": {"required": False, "type": "int"},
+                "tod-min": {"required": False, "type": "int"},
+                "username": {"required": False, "type": "str"},
+                "vdom": {"required": False, "type": "str",
+                         "choices": ["mgmt", "current"]},
+                "weekday": {"required": False, "type": "str",
+                            "choices": ["sunday", "monday", "tuesday",
+                                        "wednesday", "thursday", "friday",
+                                        "saturday"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    global fos
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_dlp(module.params, fos)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
**##### SUMMARY

Fortinet is adding Ansible support for FortiOS and FortiGate products. This module follows the same structure, guidelines and ideas given in previous approved module for a parallel feature of FortiGate (webfiltering): https://github.com/ansible/ansible/pull/37196 
In this case we are providing a different functionality: "DLP FingerPrint doc source"

Please note that this will be part of other modules to come for FortiGate, including different functionalities: system, wireless-controller, firewall, webfilter, ips, web-proxy, wanopt, application, dlp spamfilter, log, vpn, certificate, user, dnsfilter, antivirus, report, waf, authentication, switch controller, endpoint-control and router. We plan to follow the same style, structure and usage as in the previous module in order to make it easier to comply with Ansible guidelines.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

fortios_dlp_fp_doc_source
##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (new_module ddbbe5dfa5) last updated 2018/09/24 14:54:57 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/magonzalez/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/magonzalez/ansible/lib/ansible
  executable location = /home/magonzalez/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```**