### PR TITLE
Properly parse boolean env values as boolean

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -148,6 +148,8 @@ class K8sAnsibleMixin(object):
             if auth_params.get(arg) is None:
                 env_value = os.getenv('K8S_AUTH_{0}'.format(arg.upper()), None)
                 if env_value is not None:
+                    if AUTH_ARG_SPEC[arg].get('type') == 'bool':
+                        env_value = env_value.lower() not in ['0', 'false', 'no']
                     auth[arg] = env_value
 
         def auth_set(*names):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`K8S_AUTH_*` environment values are currently always strings, which prevents the use of `K8S_AUTH_VERIFY_SSL` unless you set it to an empty string. Now if set a boolean value to `[no, false, 0]` (or the uppercased/capitalized equivalents), it will be properly parsed into `[True, False]`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s