### PR TITLE
The section filter does not exist on IOS 12.2(53r)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -357,7 +357,7 @@ def parse_password_type(data):
 
 
 def map_config_to_obj(module):
-    data = get_config(module, flags=['| section username'])
+    data = get_config(module, flags=['| include username'])
 
     match = re.findall(r'(?:^(?:u|\s{2}u))sername (\S+)', data, re.M)
     if not match:


### PR DESCRIPTION
##### SUMMARY
On IOS 12.2(53r) _and probably others_ `| section <keyword>` doesn't exist leading to the below failure

`fatal: [XXXXXXXXXXXXXXXXXX]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_QIulr4/ansible_module_ios_user.py\", line 409, in <module>\n    main()\n  File \"/tmp/ansible_QIulr4/ansible_module_ios_user.py\", line 382, in main\n    have = map_config_to_obj(module)\n  File \"/tmp/ansible_QIulr4/ansible_module_ios_user.py\", line 242, in map_config_to_obj\n    data = get_config(module, flags=['| section username'])\n  File \"/tmp/ansible_QIulr4/ansible_modlib.zip/ansible/module_utils/network/ios/ios.py\", line 117, in get_config\n  File \"/tmp/ansible_QIulr4/ansible_modlib.zip/ansible/module_utils/connection.py\", line 149, in __rpc__\nansible.module_utils.connection.ConnectionError: show running-config | section username\r\n                                           ^\r\n% Invalid input detected at '^' marker.\r\n\r\nXXXXXXXXXXXXXXXXXXXX#\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}`

A simple change to `| include username` fixes this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ios_user

##### ADDITIONAL INFORMATION
This is a simple compatibility change to allow the `ios_user` module to work on `IOS 12.2(53r)`

The below is an example from `12.2(53r)`

```
XXXXXXXXXXXXXXXXXX#show running-config | section username
                                         ^
% Invalid input detected at '^' marker.

XXXXXXXXXXXXXXXXXX#show running-config | include username
username xxxxxxxxx secret 5 nnnnnnnnnnnnnnnnnnnnnnnnnnn
username xxxxxxxxx secret 5 nnnnnnnnnnnnnnnnnnnnnnnnnnn
```

The below is an example from a device supporting `| section <keyword>`

```
XXXXXXXXXXXXXXXXXX#show running-config | section username
username xxxxxxxxx secret 4 nnnnnnnnnnnnnnnnnnnnnnnnnnnn
username xxxxxxxxx privilege 15 secret 4 nnnnnnnnnnnnnnnnnnnnnnnnnnnn
username xxxxxxxxx secret 5 nnnnnnnnnnnnnnnnnnnnnnnnnnnn


XXXXXXXXXXXXXXXXXX#show running-config | include username
username xxxxxxxxx secret 4 nnnnnnnnnnnnnnnnnnnnnnnnnnnn
username xxxxxxxxx privilege 15 secret 4 nnnnnnnnnnnnnnnnnnnnnnnnnnnn
username xxxxxxxxx secret 5 nnnnnnnnnnnnnnnnnnnnnnnnnnnn
```