### PR TITLE
win_rds: wait for reboot to be complete

### DIFF
--- a/test/integration/targets/win_rds/tasks/main.yml
+++ b/test/integration/targets/win_rds/tasks/main.yml
@@ -19,8 +19,23 @@
 
   - name: reboot server if needed
     win_reboot:
-      post_reboot_delay: 10
     when: rds_install.reboot_required
+
+  # After a reboot Windows is still configuring the feature, this is a hack to wait until that is finished
+  - name: wait for component servicing to be finished
+    win_shell: |
+      $start = Get-Date
+      $path = "HKLM:\SYSTEM\CurrentControlSet\Control\Winlogon\Notifications\Components\TrustedInstaller"
+      $tries = 0
+      while ((Get-ItemProperty -Path $path -Name Events).Events.Contains("CreateSession")) {
+          $tries += 1
+          Start-Sleep -Seconds 5
+          if (((Get-Date) - $start).TotalSeconds -gt 180) {
+              break
+          }
+      }
+      $tries
+    changed_when: False
 
   - name: run win_rds_cap integration tests
     include_tasks: win_rds_cap.yml


### PR DESCRIPTION
##### SUMMARY
After rebooting a host when installing the RDS features WinRM comes back online before RDS is fully configured. This causes some issues with the tests. Instead of waiting an arbitrary amount of seconds we will wait until `TrustedInstaller` is finished with the configuration before continuing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_rds*