### PR TITLE
Issue with NetworkConfig parsing device configs with inconsistent indentation levels.

### DIFF
--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -214,8 +214,7 @@ class NetworkConfig(object):
         ancestors = list()
         config = list()
 
-        curlevel = 0
-        prevlevel = 0
+        indents = [0]
 
         for linenum, line in enumerate(to_native(lines, errors='surrogate_or_strict').split('\n')):
             text = entry_reg.sub('', line).strip()
@@ -228,20 +227,21 @@ class NetworkConfig(object):
             # handle top level commands
             if toplevel.match(line):
                 ancestors = [cfg]
-                prevlevel = curlevel
-                curlevel = 0
+                indents = [0]
 
             # handle sub level commands
             else:
                 match = childline.match(line)
                 line_indent = match.start(1)
 
-                prevlevel = curlevel
-                curlevel = int(line_indent / self._indent)
+                if line_indent < indents[-1]:
+                    while indents[-1] > line_indent:
+                        indents.pop()
 
-                if (curlevel - 1) > prevlevel:
-                    curlevel = prevlevel + 1
+                if line_indent > indents[-1]:
+                    indents.append(line_indent)
 
+                curlevel = len(indents) - 1
                 parent_level = curlevel - 1
 
                 cfg._parents = ancestors[:curlevel]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This attempts to fix an issue with incorrect parsing of network configs where the indentation spacing varies for the same config hierarchy level.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/common/config.py 
NetworkConfig parse()
--




##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I discovered an issue when using the parse function of the NetworkConfig class when my network device used different spacing for indention that reflected the same level in the config hierarchy.

An example of this (taken from a Cisco ASA):
```
interface Port-channel2
 description Outside
 lacp max-bundle 4
!
context admin
  description admin-context
  allocate-interface GigabitEthernet1
  config-url disk0:/admin.cfg
  join-failover-group 1
!
```

When parsing the `context` block above with `indent=1` , the resulting config hierarchy is as follows:
```
obj.raw: context admin
obj.parents: []
obj.raw:   description admin-context
obj.parents: ['context admin']
obj.raw:   allocate-interface GigabitEthernet1
obj.parents: ['context admin', 'description admin-context']
obj.raw:   config-url disk0:/admin.cfg
obj.parents: ['context admin', 'description admin-context']
obj.raw:   join-failover-group 1
obj.parents: ['context admin', 'description admin-context']
```

This happens because logic that determines the config hierarchy level is based on the `indent` attribute. When the config itself is inconsistent in what it uses for indentation, this proves to be an issue.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Using a more contrived example to illustrate the issue and potential fix. The lines below are named based on the number of spaces being used for indentation.

```
indent 0
  indent 2
    indent 4
      indent 6
        indent 8
       indent 7
     indent 5
   indent 3
  indent 2
 indent 1
   indent 3
     indent 5
  indent 2
indent 0
```

This shows how the config is parsed using `indent=1`:
printed with `"{0:30s}  {1}".format(obj.raw, obj.line)`
```
indent 0                        indent 0
  indent 2                      indent 0 indent 2
    indent 4                    indent 0 indent 2 indent 4
      indent 6                  indent 0 indent 2 indent 4 indent 6
        indent 8                indent 0 indent 2 indent 4 indent 6 indent 8
       indent 7                 indent 0 indent 2 indent 4 indent 6 indent 8 indent 7
     indent 5                   indent 0 indent 2 indent 4 indent 6 indent 8 indent 5
   indent 3                     indent 0 indent 2 indent 4 indent 3
  indent 2                      indent 0 indent 2 indent 2
 indent 1                       indent 0 indent 1
   indent 3                     indent 0 indent 1 indent 3
     indent 5                   indent 0 indent 1 indent 3 indent 5
  indent 2                      indent 0 indent 1 indent 2
indent 0                        indent 0
```

and using `indent=2`:
```
indent 0                        indent 0
  indent 2                      indent 0 indent 2
    indent 4                    indent 0 indent 2 indent 4
      indent 6                  indent 0 indent 2 indent 4 indent 6
        indent 8                indent 0 indent 2 indent 4 indent 6 indent 8
       indent 7                 indent 0 indent 2 indent 4 indent 7
     indent 5                   indent 0 indent 2 indent 5
   indent 3                     indent 0 indent 3
  indent 2                      indent 0 indent 2
 indent 1                       indent 1
   indent 3                     indent 1 indent 3
     indent 5                   indent 1 indent 3 indent 5
  indent 2                      indent 1 indent 2
indent 0                        indent 0
```

The changes in this PR modify the `parse` function so that it doesn't rely on the `self.indent` value to calculate the config hierarchy level for a particular line. It instead keeps track of each indentation level in a list that is popped only when it encounters a line that has a lesser number of spaces for indentation.

The result is:
```
indent 0                        indent 0
  indent 2                      indent 0 indent 2
    indent 4                    indent 0 indent 2 indent 4
      indent 6                  indent 0 indent 2 indent 4 indent 6
        indent 8                indent 0 indent 2 indent 4 indent 6 indent 8
       indent 7                 indent 0 indent 2 indent 4 indent 6 indent 7
     indent 5                   indent 0 indent 2 indent 4 indent 5
   indent 3                     indent 0 indent 2 indent 3
  indent 2                      indent 0 indent 2
 indent 1                       indent 0 indent 1
   indent 3                     indent 0 indent 1 indent 3
     indent 5                   indent 0 indent 1 indent 3 indent 5
  indent 2                      indent 0 indent 1 indent 2
indent 0                        indent 0
```

