### PR TITLE
Pluribus Networks prefix list module with UT

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_prefix_list.py
+++ b/lib/ansible/modules/network/netvisor/pn_prefix_list.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_prefix_list
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to create/delete prefix-list
+description:
+  - This module can be used to create or delete prefix list.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: false
+    type: str
+  state:
+    description:
+      - State the action to perform. Use C(present) to create prefix-list and
+        C(absent) to delete prefix-list.
+    required: true
+    type: str
+    choices: ['present', 'absent']
+  pn_name:
+    description:
+      - Prefix List Name.
+    required: false
+    type: str
+  pn_scope:
+    description:
+      - scope of prefix-list.
+    required: false
+    type: str
+    choices: ['local', 'fabric']
+"""
+
+EXAMPLES = """
+- name: Create prefix list
+  pn_prefix_list:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    pn_scope: "local"
+    state: "present"
+
+- name: Delete prefix list
+  pn_prefix_list:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    state: "absent"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the prefix-list command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the prefix-list command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the prefix-list-show command.
+    If a name exists, return True if name exists else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    """
+    name = module.params['pn_name']
+
+    cli += ' prefix-list-show format name no-show-headers'
+    out = module.run_command(cli, use_unsafe_shell=True)[1]
+
+    out = out.split()
+
+    return True if name in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        present='prefix-list-create',
+        absent='prefix-list-delete'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_name=dict(required=False, type='str'),
+            pn_scope=dict(required=False, type='str',
+                          choices=['local', 'fabric']),
+        ),
+        required_if=(
+            ["state", "present", ["pn_name", "pn_scope"]],
+            ["state", "absent", ["pn_name"]],
+        ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    name = module.params['pn_name']
+    scope = module.params['pn_scope']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    NAME_EXISTS = check_cli(module, cli)
+
+    cli += ' %s name %s ' % (command, name)
+
+    if command == 'prefix-list-delete':
+        if NAME_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='prefix-list with name %s does not exist' % name
+            )
+    else:
+        if command == 'prefix-list-create':
+            if NAME_EXISTS is True:
+                module.exit_json(
+                    skipped=True,
+                    msg='prefix list with name %s already exists' % name
+                )
+        cli += ' scope %s ' % scope
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/netvisor/test_pn_prefix_list.py
+++ b/test/units/modules/network/netvisor/test_pn_prefix_list.py
@@ -1,0 +1,62 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_prefix_list
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestPrefixListModule(TestNvosModule):
+
+    module = pn_prefix_list
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_prefix_list.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_prefix_list.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+        self.mock_run_check_cli.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'prefix-list-create':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'prefix-list-delete':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = False
+        if state == 'absent':
+            self.run_check_cli.return_value = True
+
+    def test_prefix_list_create(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_scope': 'local', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 prefix-list-create name foo  scope local '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_prefix_list_delete(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'state': 'absent'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 prefix-list-delete name foo '
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of prefix list module for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_prefix_list.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```