### PR TITLE
add warnings for the stdin usage examples

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -159,6 +159,10 @@ To encrypt a string read from stdin and name it 'db_password':
 
     echo -n 'letmein' | ansible-vault encrypt_string --vault-id dev@password --stdin-name 'db_password'
 
+.. warning::
+
+   This method leaves the string in your shell history. Do not use it outside of testing.
+
 Result::
 
     Reading plaintext input from stdin. (ctrl-d to end input)
@@ -182,6 +186,10 @@ Output::
     Reading plaintext input from stdin. (ctrl-d to end input)
 
 User enters 'hunter2' and hits ctrl-d.
+
+.. warning::
+
+   Do not press Enter after supplying the string. That will add a newline to the encrypted value.
 
 Result::
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
* Add a warning about leaving secrets in the shell history.
* Add a warning about accidental newlines in the encrypted string.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vault

##### ADDITIONAL INFORMATION
The excess newline resulted in a lengthy debugging, going in all the wrong directions.