### PR TITLE
Fix copy module to reset filesystem acls

### DIFF
--- a/changelogs/fragments/44412-copy-fix-unwanted-acls.yaml
+++ b/changelogs/fragments/44412-copy-fix-unwanted-acls.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix unwanted ACLs when using copy module (https://github.com/ansible/ansible/issues/44412)

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -682,6 +682,10 @@ def main():
                     # of existing attributes. Get rid of them:
 
                     if src_has_acls:
+                        # FIXME If dest has any default ACLs, there are not applied to src now because
+                        # they were overridden by copystat. Should/can we do anything about this?
+                        # 'system.posix_acl_default' in os.listxattr(os.path.dirname(b_dest))
+
                         try:
                             clear_facls(dest)
                         except ValueError as e:
@@ -698,19 +702,6 @@ def main():
                                 pass
                             else:
                                 raise
-
-                        # The default ACLs are not applied because we copied metadata that tells
-                        # what the ACLs are (default ACLs were overridden via copystat).
-                        # However, if the file did not start with any ACLs,
-                        # it will end up with the default ACLs.
-                        try:
-                            dest_dir_has_default_acls = 'system.posix_acl_default' in os.listxattr(os.path.dirname(b_dest))
-                        except OSError as e:
-                            dest_dir_has_default_acls = True
-
-                        if dest_dir_has_default_acls:
-                            # FIXME take care of default ACLs? how?
-                            pass
 
             except (IOError, OSError):
                 module.fail_json(msg="failed to copy: %s to %s" % (src, dest), traceback=traceback.format_exc())

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -656,7 +656,7 @@ def main():
                             raise
                 module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])
 
-                if PY3 and hasattr(os, 'listxattr') and platform.system == 'Linux' and not remote_src:
+                if PY3 and hasattr(os, 'listxattr') and platform.system() == 'Linux' and not remote_src:
                     # atomic_move used above to copy src into dest might, in some cases,
                     # use shutil.copy2 which in turn uses shutil.copystat.
                     # Since Python 3.3, shutil.copystat copies file extended attributes:

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -654,6 +654,15 @@ def main():
                             module.warn("Unable to copy stats {0}".format(to_native(b_src)))
                         else:
                             raise
+
+                # might be needed below
+                if PY3 and hasattr(os, 'listxattr'):
+                    try:
+                        src_has_acls = 'system.posix_acl_access' in os.listxattr(src)
+                    except Exception as e:
+                        # assume unwanted ACLs by default
+                        src_has_acls = True
+
                 module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])
 
                 if PY3 and hasattr(os, 'listxattr') and platform.system() == 'Linux' and not remote_src:
@@ -671,11 +680,6 @@ def main():
                     # If not remote_src, then the file was copied from the controller. In that
                     # case, any filesystem ACLs are artifacts of the copy rather than preservation
                     # of existing attributes. Get rid of them:
-
-                    try:
-                        src_has_acls = 'system.posix_acl_access' in os.listxattr(src)
-                    except OSError as e:
-                        src_has_acls = True
 
                     if src_has_acls:
                         try:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -407,6 +407,20 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 self._connection._shell.tmpdir = None
 
     def _transfer_file(self, local_path, remote_path):
+        """
+        Copy a file from the controller to a remote path
+
+        :arg local_path: Path on controller to transfer
+        :arg remote_path: Path on the remote system to transfer into
+
+        .. warning::
+            * When you use this function you likely want to use use fixup_perms2() on the
+              remote_path to make sure that the remote file is readable when the user becomes
+              a non-privileged user.
+            * If you use fixup_perms2() on the file and copy or move the file into place, you will
+              need to then remove filesystem acls on the file once it has been copied into place by
+              the module.  See how the copy module implements this for help.
+        """
         self._connection.put_file(local_path, remote_path)
         return remote_path
 

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -305,6 +305,10 @@ class ActionModule(ActionBase):
             self._remove_tempfile_if_content_defined(content, content_tempfile)
             self._loader.cleanup_tmp_file(source_full)
 
+            # FIXME: I don't think this is needed when PIPELINING=0 because the source is created
+            # world readable.  Access to the directory itself is controlled via fixup_perms2() as
+            # part of executing the module. Check that umask with scp/sftp/piped doesn't cause
+            # a problem before acting on this idea. (This idea would save a round-trip)
             # fix file permissions when the copy is done as a different user
             if remote_path:
                 self._fixup_perms2((self._connection._shell.tmpdir, remote_path))

--- a/test/integration/targets/copy/tasks/acls.yml
+++ b/test/integration/targets/copy/tasks/acls.yml
@@ -1,0 +1,33 @@
+- block:
+  - block:
+    - name: Testing ACLs
+      copy:
+        content: "TEST"
+        mode: 0644
+        dest: "~/test.txt"
+
+    - shell: getfacl ~/test.txt
+      register: acls
+
+    become: yes
+    become_user: "{{ remote_unprivileged_user }}"
+
+  - name: Check that there are no ACLs leftovers
+    assert:
+      that:
+        - "'user:{{ remote_unprivileged_user }}:r-x\t#effective:r--' not in acls.stdout_lines"
+
+  - name: Check that permissions match with what was set in the mode param
+    assert:
+      that:
+        - "'user::rw-' in acls.stdout_lines"
+        - "'group::r--' in acls.stdout_lines"
+        - "'other::r--' in acls.stdout_lines"
+
+  always:
+    - name: Clean up
+      file:
+        path: "~/test.txt"
+        state: absent
+      become: yes
+      become_user: "{{ remote_unprivileged_user }}"

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -59,7 +59,7 @@
       remote_user: '{{ remote_unprivileged_user }}'
 
     - import_tasks: acls.yml
-      when: ansible_system == 'Linux' or ansible_system == 'FreeBSD'
+      when: ansible_system == 'Linux'
 
   always:
     - name: Cleaning

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -58,6 +58,9 @@
     - import_tasks: tests.yml
       remote_user: '{{ remote_unprivileged_user }}'
 
+    - import_tasks: acls.yml
+      when: ansible_system == 'Linux' or ansible_system == 'FreeBSD'
+
   always:
     - name: Cleaning
       file:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Alternative to https://github.com/ansible/ansible/pull/50419 and https://github.com/ansible/ansible/pull/51296

The controller's fixup_perms2 uses filesystem acls to make the temporary
file for copy readable by an unprivileged become user. On Python3, the
acls are then copied to the destination filename so we have to remove
them from there.

We can't remove them prior to the copy because we may not have
permission to read the file if the acls are not present. We can't
remove them in atomic_move() because the move function shouldn't know
anything about controller features. We may want to generalize this into
a helper function, though.

Fixes #44412

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
copy
assemble
template

##### ADDITIONAL INFORMATION
The below action plugins use `_transfer_file` and `fixup_perms2()` too. However, the files that are transferred to the remote system are only kept in ansible temp dir and removed after they are used. Therefore it is not necessary to remove ACLs in those cases.
```
lib/ansible/plugins/action/patch.py
lib/ansible/plugins/action/script.py
lib/ansible/plugins/action/unarchive.py
lib/ansible/plugins/action/uri.py
```