### PR TITLE
[stable-2.7] ios retry config if section filter fails (#49485)

### DIFF
--- a/changelogs/fragments/49485-ios-retry-section.yaml
+++ b/changelogs/fragments/49485-ios-retry-section.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- If an ios module uses a section filter on a device which does not support it, retry the command without the filter.


### PR DESCRIPTION
##### SUMMARY
* Attempt to work around devices that don't understand | section

* Fix case of no flags
(cherry picked from commit 6caed0c)

Co-authored-by: Nathaniel Case <this.is@nathanielca.se>

Closes 51845 and 51095

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios