### PR TITLE
New module postgresql_set - Change a PostgreSQL server configuration parameter

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -323,7 +323,7 @@ def main():
     print('VERSION ', ver)
     if PG_REQ_VER > float(ver):
         module.warn("PostgreSQL is %s version but %s "
-                    "or later is required %s" % (ver, PG_REQ_VER))
+                    "or later is required" % (ver, PG_REQ_VER))
         kw = dict(
             changed=False,
             name=name,

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 # Copyright: (c) 2018, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -13,8 +13,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: postgresql_set
 short_description: Change a PostgreSQL server configuration parameter
@@ -34,91 +33,91 @@ version_added: "2.8"
 options:
   name:
     description:
-      - Name of PostgreSQL server parameter.
-    required: true
+    - Name of PostgreSQL server parameter.
     type: str
+    required: true
   value:
     description:
-      - Parameter value to set. To remove parameter string from postgresql.auto.conf and
-        reload the server configuration you must pass I(value=default).
-    required: true
+    - Parameter value to set. To remove parameter string from postgresql.auto.conf and
+      reload the server configuration you must pass I(value=default).
     type: str
+    required: true
   reset:
     description:
-      - Restore parameter to initial state (boot_val). Mutually exclusive with I(value).
-    default: false
+    - Restore parameter to initial state (boot_val). Mutually exclusive with I(value).
     type: bool
+    default: false
   session_role:
     description:
-      - Switch to session_role after connecting. The specified session_role must
-        be a role that the current login_user is a member of.
-      - Permissions checking for SQL commands is carried out as though
-        the session_role were the one that had logged in originally.
+    - Switch to session_role after connecting. The specified session_role must
+      be a role that the current login_user is a member of.
+    - Permissions checking for SQL commands is carried out as though
+      the session_role were the one that had logged in originally.
   db:
     description:
-      - Name of database to connect.
+    - Name of database to connect.
     type: str
   port:
     description:
-      - Database port to connect.
-    default: 5432
+    - Database port to connect.
     type: int
+    default: 5432
   login_user:
     description:
-      - User (role) used to authenticate with PostgreSQL.
-    default: postgres
+    - User (role) used to authenticate with PostgreSQL.
     type: str
+    default: postgres
   login_password:
     description:
-      - Password used to authenticate with PostgreSQL.
+    - Password used to authenticate with PostgreSQL.
     type: str
   login_host:
     description:
-      - Host running PostgreSQL.
+    - Host running PostgreSQL.
     type: str
   login_unix_socket:
     description:
-      - Path to a Unix domain socket for local connections.
+    - Path to a Unix domain socket for local connections.
     type: str
   ssl_mode:
     description:
-      - Determines whether or with what priority a secure SSL TCP/IP connection
-        will be negotiated with the server.
-      - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-        more information on the modes.
-      - Default of C(prefer) matches libpq default.
-    default: prefer
-    choices: ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+    - Determines whether or with what priority a secure SSL TCP/IP connection
+      will be negotiated with the server.
+    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
+      more information on the modes.
+    - Default of C(prefer) matches libpq default.
     type: str
+    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
+    default: prefer
   ssl_rootcert:
     description:
-      - Specifies the name of a file containing SSL certificate authority (CA)
-        certificate(s).
-      - If the file exists, the server's certificate will be
-        verified to be signed by one of these authorities.
+    - Specifies the name of a file containing SSL certificate authority (CA)
+      certificate(s).
+    - If the file exists, the server's certificate will be
+      verified to be signed by one of these authorities.
     type: str
 notes:
-   - Check_mode is not supported because ALTER SYSTEM can't be run inside a transaction block
-     U(https://www.postgresql.org/docs/current/sql-altersystem.html).
-   - Supported version of PostgreSQL is 9.4 and later.
-   - For some parameters restart of PostgreSQL server is required.
-     See official documentation U(https://www.postgresql.org/).
-   - The default authentication assumes that you are either logging in as or
-     sudo'ing to the postgres account on the host.
-   - This module uses psycopg2, a Python PostgreSQL database adapter. You must
-     ensure that psycopg2 is installed on the host before using this module. If
-     the remote host is the PostgreSQL server (which is the default case), then
-     PostgreSQL must also be installed on the remote host. For Ubuntu-based
-     systems, install the postgresql, libpq-dev, and python-psycopg2 packages
-     on the remote host before using this module.
+- Check_mode is not supported because ALTER SYSTEM can't be run inside a transaction block
+  U(https://www.postgresql.org/docs/current/sql-altersystem.html).
+- Supported version of PostgreSQL is 9.4 and later.
+- For some parameters restart of PostgreSQL server is required.
+  See official documentation U(https://www.postgresql.org/).
+- The default authentication assumes that you are either logging in as or
+  sudo'ing to the postgres account on the host.
+- This module uses psycopg2, a Python PostgreSQL database adapter. You must
+  ensure that psycopg2 is installed on the host before using this module. If
+  the remote host is the PostgreSQL server (which is the default case), then
+  PostgreSQL must also be installed on the remote host. For Ubuntu-based
+  systems, install the postgresql, libpq-dev, and python-psycopg2 packages
+  on the remote host before using this module.
 requirements: [ psycopg2 ]
 author:
-   - Andrew Klychkov (@Andersson007)
+- Andrew Klychkov (@Andersson007)
 '''
 
-EXAMPLES = '''
-# Restore wal_keep_segments parameter to initial state
-- postgresql_set:
+EXAMPLES = r'''
+- name: Restore wal_keep_segments parameter to initial state
+  postgresql_set:
     name: wal_keep_segments
     reset: yes
 
@@ -136,59 +135,55 @@ EXAMPLES = '''
 # In this situation you see the same parameter in prev_val and cur_value, but 'changed=True'
 # (Of course, if you passed the value that was different from the current server setting).
 
-# Set log_min_duration_statement parameter to 1 second
-- postgresql_set:
+- name: Set log_min_duration_statement parameter to 1 second
+  postgresql_set:
     name: log_min_duration_statement
     value: 1s
 
-# Set wal_log_hints parameter to default value (remove parameter from postgresql.auto.conf)
-- postgresql_set:
+- name: Set wal_log_hints parameter to default value (remove parameter from postgresql.auto.conf)
+  postgresql_set:
     name: wal_log_hints
     value: default
 '''
 
-RETURN = '''
+RETURN = r'''
 name:
-    description: Name of PostgreSQL server parameter.
-    returned: always
-    type: str
-    sample: 'shared_buffers'
+  description: Name of PostgreSQL server parameter.
+  returned: always
+  type: str
+  sample: 'shared_buffers'
 restart_required:
-    description: Information about parameter current state.
-    returned: always
-    type: bool
-    sample: true
+  description: Information about parameter current state.
+  returned: always
+  type: bool
+  sample: true
 prev_val:
-    description: Information about previous state of the parameter.
-    returned: always
-    type: str
-    sample: '4MB'
+  description: Information about previous state of the parameter.
+  returned: always
+  type: str
+  sample: '4MB'
 cur_val:
-    description: Information about current state of the parameter.
-    returned: always
-    type: str
-    sample: '64MB'
+  description: Information about current state of the parameter.
+  returned: always
+  type: str
+  sample: '64MB'
 '''
 
 PG_REQ_VER = 9.4
 
-
-import traceback
+from copy import deepcopy
 
 try:
     import psycopg2
-    import psycopg2.extras
+    HAS_PSYCOPG2 = True
 except ImportError:
-    postgresqldb_found = False
-else:
-    postgresqldb_found = True
+    HAS_PSYCOPG2 = False
 
-import ansible.module_utils.postgres as pgutils
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import SQLParseError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.postgres import postgres_common_argument_spec
 from ansible.module_utils.six import iteritems
-from copy import deepcopy
+from ansible.module_utils._text import to_native
 
 
 # To allow to set value like 1mb instead of 1MB, etc:
@@ -209,10 +204,9 @@ def param_get(cursor, module, name):
         cursor.execute("SHOW %s" % name)
         val = cursor.fetchone()
     except SQLParseError as e:
-        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+        module.fail_json(msg=to_native(e))
     except psycopg2.ProgrammingError as e:
-        module.fail_json(msg="Unable to get %s value due to : %s" % (name, to_native(e)),
-                         exception=traceback.format_exc())
+        module.fail_json(msg="Unable to get %s value due to : %s" % (name, to_native(e)))
 
     return (val, info)
 
@@ -226,10 +220,9 @@ def param_set(cursor, module, name, value):
         cursor.execute(query)
         cursor.execute("SELECT pg_reload_conf()")
     except SQLParseError as e:
-        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+        module.fail_json(msg=to_native(e))
     except psycopg2.ProgrammingError as e:
-        module.fail_json(msg="Unable to get %s value due to : %s" % (name, to_native(e)),
-                         exception=traceback.format_exc())
+        module.fail_json(msg="Unable to get %s value due to : %s" % (name, to_native(e)))
     return True
 
 # ===========================================
@@ -238,23 +231,22 @@ def param_set(cursor, module, name, value):
 
 
 def main():
-    argument_spec = pgutils.postgres_common_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = postgres_common_argument_spec()
+    argument_spec.update(
         name=dict(type='str', required=True),
         db=dict(type='str'),
-        ssl_mode=dict(type='str', default='prefer', choices=[
-            'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
+        ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(type='str'),
         value=dict(type='str'),
         reset=dict(type='bool'),
         session_role=dict(type='str'),
-    ))
+    )
     # This module doesn't support check mode
     # because ALTER SYSTEM SET command can't be used
     # in transaction mode https://www.postgresql.org/docs/current/sql-altersystem.html.
     module = AnsibleModule(
         argument_spec=argument_spec,
-        supports_check_mode=False
+        supports_check_mode=False,
     )
 
     name = module.params["name"]
@@ -270,14 +262,12 @@ def main():
                 value = value.upper()
 
     if value and reset:
-        module.fail_json(msg="%s: value and reset params are mutually "
-                             "exclusive" % name)
+        module.fail_json(msg="%s: value and reset params are mutually exclusive" % name)
 
     if not value and not reset:
-        module.fail_json(msg="%s: at least one of value or "
-                             "reset param must be specified" % name)
+        module.fail_json(msg="%s: at least one of value or reset param must be specified" % name)
 
-    if not postgresqldb_found:
+    if not HAS_PSYCOPG2:
         module.fail_json(msg="the python psycopg2 module is required")
 
     # To use defaults values, keyword arguments must be absent, so
@@ -296,7 +286,7 @@ def main():
               if k in params_map and v != '' and v is not None)
 
     # If a login_unix_socket is specified, incorporate it here.
-    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
+    is_localhost = "host" not in kw or kw["host"] is None or kw["host"] == "localhost"
     if is_localhost and module.params["login_unix_socket"] != "":
         kw["host"] = module.params["login_unix_socket"]
 
@@ -310,21 +300,17 @@ def main():
         cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
     except TypeError as e:
         if 'sslrootcert' in e.args[0]:
-            module.fail_json(
-                msg='Postgresql server must be at least version 8.4 to support sslrootcert')
-        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
-                         exception=traceback.format_exc())
+            module.fail_json(msg='Postgresql server must be at least version 8.4 to support sslrootcert')
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e))
     except Exception as e:
-        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
-                         exception=traceback.format_exc())
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e))
 
     # Check server version (needs 9.4 or later):
     cursor.execute('SELECT version()')
     ver = cursor.fetchone()[0].split()[1]
     ver = '.'.join(ver.split('.')[:2])
     if PG_REQ_VER > float(ver):
-        module.warn("PostgreSQL is %s version but %s "
-                    "or later is required" % (ver, PG_REQ_VER))
+        module.warn("PostgreSQL is %s version but %s or later is required" % (ver, PG_REQ_VER))
         kw = dict(
             changed=False,
             restart_required=False,
@@ -340,8 +326,7 @@ def main():
         try:
             cursor.execute('SET ROLE %s' % session_role)
         except Exception as e:
-            module.fail_json(msg="Could not switch role: %s" % to_native(e),
-                             exception=traceback.format_exc())
+            module.fail_json(msg="Could not switch role: %s" % to_native(e))
 
     # Set default returned values:
     restart_required = False
@@ -361,8 +346,7 @@ def main():
 
     # Do job
     if context == "internal":
-        module.fail_json(msg="%s: cannot be changed (internal context). "
-                             "See documentation" % name)
+        module.fail_json(msg="%s: cannot be changed (internal context). See documentation" % name)
 
     if context == "postmaster":
         restart_required = True

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -447,7 +447,7 @@ def main():
             kw['value_pretty'] = value
             kw['changed'] = True
 
-        # Anyway returns current value in the check_mode:
+        # Anyway returns current raw value in the check_mode:
         kw['value'] = dict(
             value=raw_val,
             unit=unit,

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -326,7 +326,7 @@ def main():
     argument_spec.update(
         name=dict(type='str', required=True),
         db=dict(type='str', aliases=['login_db']),
-        port=dict(type=int, default=5432, aliases=['login_port']),
+        port=dict(type='int', default=5432, aliases=['login_port']),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(type='str'),
         value=dict(type='str'),

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -326,7 +326,7 @@ def main():
     argument_spec.update(
         name=dict(type='str', required=True),
         db=dict(type='str', aliases=['login_db']),
-        port=dict(type=int, aliases=['login_port']),
+        port=dict(type=int, default=5432, aliases=['login_port']),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(type='str'),
         value=dict(type='str'),

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -1,0 +1,398 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+DOCUMENTATION = '''
+---
+module: postgresql_set
+short_description: Change a PostgreSQL server configuration parameter
+description:
+   - Allows to change a PostgreSQL server configuration parameter.
+   - The module uses ALTER SYSTEM command U(https://www.postgresql.org/docs/current/sql-altersystem.html)
+     and apply changes by reload server configuration.
+   - ALTER SYSTEM is used for changing server configuration parameters across the entire database cluster.
+   - It can be more convenient than the traditional method of manually editing the postgresql.conf file.
+   - ALTER SYSTEM writes the given parameter setting to the $PGDATA/postgresql.auto.conf file,
+     which is read in addition to postgresql.conf U(https://www.postgresql.org/docs/current/sql-altersystem.html).
+   - The module allows to reset parameter to boot_val (cluster initial value) or remove parameter
+     string from postgresql.auto.conf and reload.
+   - After change you can see in ansible output the previous and
+     the new parameter value and other information using returned values and M(debug) module.
+version_added: "2.8"
+options:
+  name:
+    description:
+      - Name of PostgreSQL server parameter.
+    required: true
+    type: str
+  value:
+    description:
+      - Parameter value to set. To remove parameter string from postgresql.auto.conf and
+        reload the server configuration you must pass I(value=default).
+    required: true
+    type: str
+  reset:
+    description:
+      - Restore parameter to initial state (boot_val). Mutually exclusive with I(value).
+    default: false
+    type: bool
+  session_role:
+    description:
+      - Switch to session_role after connecting. The specified session_role must
+        be a role that the current login_user is a member of.
+      - Permissions checking for SQL commands is carried out as though
+        the session_role were the one that had logged in originally.
+  db:
+    description:
+      - Name of database to connect.
+    type: str
+  port:
+    description:
+      - Database port to connect.
+    default: 5432
+    type: int
+  login_user:
+    description:
+      - User (role) used to authenticate with PostgreSQL.
+    default: postgres
+    type: str
+  login_password:
+    description:
+      - Password used to authenticate with PostgreSQL.
+    type: str
+  login_host:
+    description:
+      - Host running PostgreSQL.
+    type: str
+  login_unix_socket:
+    description:
+      - Path to a Unix domain socket for local connections.
+    type: str
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection
+        will be negotiated with the server.
+      - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
+        more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    default: prefer
+    choices: ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+    type: str
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA)
+        certificate(s).
+      - If the file exists, the server's certificate will be
+        verified to be signed by one of these authorities.
+    type: str
+notes:
+   - Check_mode is not supported because ALTER SYSTEM can't be run inside a transaction block
+     U(https://www.postgresql.org/docs/current/sql-altersystem.html).
+   - Supported version of PostgreSQL is 9.4 and later.
+   - For some parameters restart of PostgreSQL server is required.
+     See official documentation U(https://www.postgresql.org/).
+   - The default authentication assumes that you are either logging in as or
+     sudo'ing to the postgres account on the host.
+   - This module uses psycopg2, a Python PostgreSQL database adapter. You must
+     ensure that psycopg2 is installed on the host before using this module. If
+     the remote host is the PostgreSQL server (which is the default case), then
+     PostgreSQL must also be installed on the remote host. For Ubuntu-based
+     systems, install the postgresql, libpq-dev, and python-psycopg2 packages
+     on the remote host before using this module.
+requirements: [ psycopg2 ]
+author:
+   - Andrew Klychkov (@Andersson007)
+'''
+
+EXAMPLES = '''
+# Restore wal_keep_segments parameter to initial state
+- postgresql_set:
+    name: wal_keep_segments
+    reset: yes
+
+# Set work_mem parameter to 32MB and show what's been changed and restart is required or not
+# (output example: "msg": "work_mem 4MB >> 64MB restart_req: False")
+- postgresql_set:
+    name: work_mem
+    value: 32mb
+    register: set_value
+
+- debug:
+    msg: "{{ set_value.name }} {{ set_value.prev_val }} >> {{ set_value.cur_value }} restart_req: {{ set_value.restart_required }}"
+  when: set_value.changed
+# Ensure that the restart of PostgreSQL serever must be required for some parameters.
+# In this situation you see the same parameter in prev_val and cur_value, but 'changed=True'
+# (Of course, if you passed the value that was different from the current server setting).
+
+# Set log_min_duration_statement parameter to 1 second
+- postgresql_set:
+    name: log_min_duration_statement
+    value: 1s
+
+# Set wal_log_hints parameter to default value (remove parameter from postgresql.auto.conf)
+- postgresql_set:
+    name: wal_log_hints
+    value: default
+'''
+
+RETURN = '''
+name:
+    description: Name of PostgreSQL server parameter.
+    returned: always
+    type: str
+    sample: 'shared_buffers'
+restart_required:
+    description: Information about parameter current state.
+    returned: always
+    type: bool
+    sample: true
+prev_val:
+    description: Information about previous state of the parameter.
+    returned: always
+    type: str
+    sample: '4MB'
+cur_val:
+    description: Information about current state of the parameter.
+    returned: always
+    type: str
+    sample: '64MB'
+'''
+
+PG_REQ_VER = 9.4
+
+
+import traceback
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    postgresqldb_found = False
+else:
+    postgresqldb_found = True
+
+import ansible.module_utils.postgres as pgutils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.database import SQLParseError, pg_quote_identifier
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems
+
+
+# To allow to set value like 1mb instead of 1MB, etc:
+POSSIBLE_SIZE_UNITS = ("mb", "gb", "tb")
+
+
+# ===========================================
+# PostgreSQL module specific support methods.
+#
+
+
+def param_get(cursor, module, name):
+    query = ("SELECT name, setting, unit, context, boot_val "
+             "FROM pg_settings WHERE name = '%s'" % name)
+    try:
+        cursor.execute(query)
+        info = cursor.fetchall()
+        cursor.execute("SHOW %s" % name)
+        val = cursor.fetchone()
+    except SQLParseError as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+    except psycopg2.ProgrammingError as e:
+        module.fail_json(msg="Unable to get %s value due to : %s" % (name, to_native(e)),
+                         exception=traceback.format_exc())
+
+    return (val, info)
+
+
+def param_set(cursor, module, name, value):
+    try:
+        if value in ('DEFAULT', 'default'):
+            query = "ALTER SYSTEM SET %s = DEFAULT" % name
+        else:
+            query = "ALTER SYSTEM SET %s = '%s'" % (name, value)
+        cursor.execute(query)
+        cursor.execute("SELECT pg_reload_conf()")
+    except SQLParseError as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+    except psycopg2.ProgrammingError as e:
+        module.fail_json(msg="Unable to get %s value due to : %s" % (name, to_native(e)),
+                         exception=traceback.format_exc())
+    return True
+
+# ===========================================
+# Module execution.
+#
+
+
+def main():
+    argument_spec = pgutils.postgres_common_argument_spec()
+    argument_spec.update(dict(
+        name=dict(type='str', required=True),
+        db=dict(type='str'),
+        ssl_mode=dict(type='str', default='prefer', choices=[
+            'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
+        ssl_rootcert=dict(type='str'),
+        value=dict(type='str'),
+        reset=dict(type='bool'),
+        session_role=dict(type='str'),
+    ))
+    # This module doesn't support check mode
+    # because ALTER SYSTEM SET command can't be used
+    # in transactions https://www.postgresql.org/docs/current/sql-altersystem.html.
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False
+    )
+
+    name = module.params["name"]
+    value = module.params["value"]
+    reset = module.params["reset"]
+    sslrootcert = module.params["ssl_rootcert"]
+    session_role = module.params["session_role"]
+
+    # Allow to pass values like 1mb instead of 1MB, etc:
+    if value:
+        for unit in POSSIBLE_SIZE_UNITS:
+            if unit in value:
+                value = value.upper()
+
+    if value and reset:
+        module.fail_json(msg="%s: value and reset params are mutually "
+                             "exclusive" % name)
+
+    if not value and not reset:
+        module.fail_json(msg="%s: at least one of value or "
+                             "reset param must be specified" % name)
+
+    if not postgresqldb_found:
+        module.fail_json(msg="the python psycopg2 module is required")
+
+    # To use defaults values, keyword arguments must be absent, so
+    # check which values are empty and don't include in the **kw
+    # dictionary
+    params_map = {
+        "login_host": "host",
+        "login_user": "user",
+        "login_password": "password",
+        "port": "port",
+        "db": "database",
+        "ssl_mode": "sslmode",
+        "ssl_rootcert": "sslrootcert"
+    }
+    kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
+              if k in params_map and v != "" and v)
+
+    # If a login_unix_socket is specified, incorporate it here.
+    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
+    if is_localhost and module.params["login_unix_socket"] != "":
+        kw["host"] = module.params["login_unix_socket"]
+
+    if psycopg2.__version__ < '2.4.3' and sslrootcert:
+        module.fail_json(msg='psycopg2 must be at least 2.4.3 '
+                             'in order to user the ssl_rootcert parameter')
+
+    try:
+        db_connection = psycopg2.connect(**kw)
+        db_connection.set_session(autocommit=True)
+        cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    except TypeError as e:
+        if 'sslrootcert' in e.args[0]:
+            module.fail_json(
+                msg='Postgresql server must be at least version 8.4 to support sslrootcert')
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
+                         exception=traceback.format_exc())
+    except Exception as e:
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e),
+                         exception=traceback.format_exc())
+
+    # Check server version (needs 9.4 or later):
+    cursor.execute('SELECT version()')
+    ver = cursor.fetchone()[0].split()[1]
+    print('VERSION ', ver)
+    if PG_REQ_VER > float(ver):
+        module.warn("PostgreSQL is %s version but %s "
+                    "or later is required %s" % (ver, PG_REQ_VER))
+        kw = dict(
+            changed=False,
+            name=name,
+            restart_required=False,
+            cur_val="",
+            prev_val="",
+        )
+        module.exit_json(**kw)
+
+    # Switch role, if specified:
+    if session_role:
+        try:
+            cursor.execute('SET ROLE %s' % pg_quote_identifier(session_role, 'role'))
+        except Exception as e:
+            module.fail_json(msg="Could not switch role: %s" % to_native(e),
+                             exception=traceback.format_exc())
+
+    # Set default returned values:
+    restart_required = False
+    changed = False
+    kw['name'] = name
+    kw['restart_required'] = restart_required
+    kw['result'] = 'nothing to change'
+
+    # Get info about param state:
+    res = param_get(cursor, module, name)
+    current_value = res[0][0]
+    raw_val = res[1][0][1]
+    unit = res[1][0][2]
+    if unit is None:
+        unit = ''
+    boot_val = res[1][0][4]
+    context = res[1][0][3]
+
+    kw['prev_val'], kw['cur_val'] = current_value, current_value
+
+    # Do job
+    if context == "internal":
+        module.fail_json(msg="%s: cannot be changed (internal context). "
+                             "See documentation" % name)
+
+    if context == "postmaster":
+        restart_required = True
+
+    # Set param:
+    if value is not None and value != current_value:
+        changed = param_set(cursor, module, name, value)
+        kw['prev_val'] = current_value
+        kw['cur_val'] = value
+    # Reset param:
+    elif reset:
+        if raw_val == boot_val:
+            # nothing to change, exit:
+            module.exit_json(**kw)
+        changed = param_set(cursor, module, name, boot_val)
+
+        kw['prev_val'] = current_value
+        kw['cur_val'] = boot_val
+
+    if changed:
+        if not restart_required:
+            new_value = param_get(cursor, module, name)[0][0]
+            kw['prev_val'] = current_value
+            kw['cur_val'] = new_value
+
+    kw['changed'] = changed
+    kw['restart_required'] = restart_required
+    module.exit_json(**kw)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -243,13 +243,19 @@ def param_get(cursor, module, name):
         val[0] = 'off'
 
     if unit == 'kB':
-        raw_val = int(raw_val) * 1024
-        boot_val = int(boot_val) * 1024
+        if int(raw_val) > 0:
+            raw_val = int(raw_val) * 1024
+        if int(boot_val) > 0:
+            boot_val = int(boot_val) * 1024
+
         unit = 'b'
 
     elif unit == 'MB':
-        raw_val = int(raw_val) * 1024 * 1024
-        boot_val = int(boot_val) * 1024 * 1024
+        if int(raw_val) > 0:
+            raw_val = int(raw_val) * 1024 * 1024
+        if int(boot_val) > 0:
+            boot_val = int(boot_val) * 1024 * 1024
+
         unit = 'b'
 
     return (val[0], raw_val, unit, boot_val, context)

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -327,11 +327,11 @@ def main():
                     "or later is required" % (ver, PG_REQ_VER))
         kw = dict(
             changed=False,
-            name=name,
             restart_required=False,
             cur_val="",
             prev_val="",
         )
+        kw['name'] = name
         db_connection.close()
         module.exit_json(**kw)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -20,14 +20,14 @@ short_description: Change a PostgreSQL server configuration parameter
 description:
    - Allows to change a PostgreSQL server configuration parameter.
    - The module uses ALTER SYSTEM command U(https://www.postgresql.org/docs/current/sql-altersystem.html)
-     and apply changes by reload server configuration.
+     and applys changes by reload server configuration.
    - ALTER SYSTEM is used for changing server configuration parameters across the entire database cluster.
-   - It can be more convenient than the traditional method of manually editing the postgresql.conf file.
+   - It can be more convenient and safe than the traditional method of manually editing the postgresql.conf file.
    - ALTER SYSTEM writes the given parameter setting to the $PGDATA/postgresql.auto.conf file,
      which is read in addition to postgresql.conf U(https://www.postgresql.org/docs/current/sql-altersystem.html).
    - The module allows to reset parameter to boot_val (cluster initial value) by I(reset=yes) or remove parameter
      string from postgresql.auto.conf and reload I(value=default).
-   - After change you can see in ansible output the previous and
+   - After change you can see in the ansible output the previous and
      the new parameter value and other information using returned values and M(debug) module.
 version_added: "2.8"
 options:
@@ -59,11 +59,15 @@ options:
     description:
     - Name of database to connect.
     type: str
+    aliases:
+    - login_db
   port:
     description:
     - Database port to connect.
     type: int
     default: 5432
+    aliases:
+    - login_port
   login_user:
     description:
     - User (role) used to authenticate with PostgreSQL.
@@ -321,7 +325,8 @@ def main():
     argument_spec = postgres_common_argument_spec()
     argument_spec.update(
         name=dict(type='str', required=True),
-        db=dict(type='str'),
+        db=dict(type='str', aliases=['login_db']),
+        port=dict(type=int, aliases=['login_port']),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(type='str'),
         value=dict(type='str'),

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -290,7 +290,7 @@ def pretty_to_bytes(pretty_val):
 
 def param_set(cursor, module, name, value, context):
     try:
-        if value.lower() in 'default':
+        if str(value).lower() == 'default':
             query = "ALTER SYSTEM SET %s = DEFAULT" % name
         else:
             query = "ALTER SYSTEM SET %s = '%s'" % (name, value)

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -185,7 +185,7 @@ else:
 
 import ansible.module_utils.postgres as pgutils
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.database import SQLParseError, pg_quote_identifier
+from ansible.module_utils.database import SQLParseError
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 
@@ -320,6 +320,7 @@ def main():
     # Check server version (needs 9.4 or later):
     cursor.execute('SELECT version()')
     ver = cursor.fetchone()[0].split()[1]
+    ver = '.'.join(ver.split('.')[:1])
     print('VERSION ', ver)
     if PG_REQ_VER > float(ver):
         module.warn("PostgreSQL is %s version but %s "
@@ -336,7 +337,7 @@ def main():
     # Switch role, if specified:
     if session_role:
         try:
-            cursor.execute('SET ROLE %s' % pg_quote_identifier(session_role, 'role'))
+            cursor.execute('SET ROLE %s' % session_role)
         except Exception as e:
             module.fail_json(msg="Could not switch role: %s" % to_native(e),
                              exception=traceback.format_exc())

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -764,7 +764,7 @@
 
 # Test postgresql_set
 - include: postgresql_set.yml
-  when: postgres_version_resp.stdout is version('9.4', '<=')
+  when: postgres_version_resp.stdout is version('9.4', '>=')
 
 # Verify different session_role scenarios
 - include: session_role.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -762,6 +762,10 @@
     that:
       - "result.stdout_lines[-1] == '(0 rows)'"
 
+# Test postgresql_set
+- include: postgresql_set.yml
+  when: postgres_version_resp.stdout is version('9.4', '<=')
+
 # Verify different session_role scenarios
 - include: session_role.yml
 

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -211,7 +211,7 @@
       - set_aut.restart_required == false
       - set_aut.value.value == 'off'
 
-# Test check_mode, step 3. It is different from the prev test - it runs withou check_mode: yes
+# Test check_mode, step 3. It is different from the prev test - it runs without check_mode: yes
 # Before the check_mode tests autovacuum was off
 - name: postgresql - check that autovacuum wasn't actually changed after change in check_mode
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -10,6 +10,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
     name: work_mem
     reset: yes
   ignore_errors: yes
@@ -18,6 +20,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
     name: work_mem
     value: 12MB
   register: set_wm
@@ -43,6 +47,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
     name: work_mem
     reset: yes
   register: reset_wm
@@ -67,6 +73,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
     name: work_mem
     reset: yes
   register: reset_wm2
@@ -91,6 +99,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
     name: work_mem
     value: 14MB
   ignore_errors: yes
@@ -99,6 +109,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
     name: work_mem
     value: default
   register: def_wm
@@ -123,6 +135,8 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
     name: shared_buffers
     value: 111MB
   register: set_shb

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -31,11 +31,11 @@
     that:
       - set_wm.name == 'work_mem'
       - set_wm.changed == true
-      - set_wm.cur_val == '12MB'
-      - set_wm.cur_val != set_wm.prev_val
+      - set_wm.value_pretty == '12MB'
+      - set_wm.value_pretty != set_wm.prev_val_pretty
       - set_wm.restart_required == false
-      - set_wm.setting.value == 12582912
-      - set_wm.setting.unit == 'b'
+      - set_wm.value.value == 12582912
+      - set_wm.value.unit == 'b'
   when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != "FreeBSD"
 
 - assert:
@@ -60,9 +60,9 @@
     that:
       - reset_wm.name == 'work_mem'
       - reset_wm.changed == true
-      - reset_wm.cur_val != reset_wm.prev_val
+      - reset_wm.value_pretty != reset_wm.prev_val_pretty
       - reset_wm.restart_required == false
-      - reset_wm.setting.value != '12582912' 
+      - reset_wm.value.value != '12582912' 
   when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != "FreeBSD"
 
 - assert:
@@ -87,7 +87,7 @@
     that:
       - reset_wm2.name == 'work_mem'
       - reset_wm2.changed == false
-      - reset_wm2.cur_val == reset_wm2.prev_val
+      - reset_wm2.value_pretty == reset_wm2.prev_val_pretty
       - reset_wm2.restart_required == false
   when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
 
@@ -123,9 +123,9 @@
     that:
       - def_wm.name == 'work_mem'
       - def_wm.changed == true
-      - def_wm.cur_val != def_wm.prev_val
+      - def_wm.value_pretty != def_wm.prev_val_pretty
       - def_wm.restart_required == false
-      - def_wm.setting.value != '14680064' 
+      - def_wm.value.value != '14680064' 
   when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != 'FreeBSD'
 
 - assert:
@@ -152,7 +152,7 @@
       - set_shb.changed == true
       - set_shb.restart_required == true
 
-# We don't check setting.utin because it is none
+# We don't check value.utin because it is none
 - name: postgresql_set - set autovacuum (enabled by default, restart is not required)
   become_user: "{{ pg_user }}"
   become: yes
@@ -169,4 +169,4 @@
       - set_aut.name == 'autovacuum'
       - set_aut.changed == true
       - set_aut.restart_required == false
-      - set_aut.setting.value == 'off'
+      - set_aut.value.value == 'off'

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -1,6 +1,18 @@
 # Test code for the postgresql_set module
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Notice: assertions are different for Ubuntu 16.04 because they don't work
+# correctly for these tests. However I checked it manually on 16.04
+# and it works as expected.
+
+- name: postgresql_set - preparation to the nex step
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    name: work_mem
+    reset: yes
+  ignore_errors: yes
 
 - name: postgresql_set - set work_mem (restart is not required)
   become_user: "{{ pg_user }}"
@@ -8,16 +20,24 @@
   postgresql_set:
     name: work_mem
     value: 12MB
-  register: result
+  register: set_wm
   ignore_errors: yes
 
 - assert:
     that:
-      - result.name == 'work_mem'
-      - result.changed
-      - result.cur_val == '12MB'
-      - result.cur_val != result.prev_val
-      - result.restart_required == false
+      - set_wm.name == 'work_mem'
+      - set_wm.changed == true
+      - set_wm.cur_val == '12MB'
+      - set_wm.cur_val != set_wm.prev_val
+      - set_wm.restart_required == false
+  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
+
+- assert:
+    that:
+      - set_wm.name == 'work_mem'
+      - set_wm.changed == true
+      - set_wm.restart_required == false
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '16'
 
 - name: postgresql_set - reset work_mem (restart is not required)
   become_user: "{{ pg_user }}"
@@ -25,15 +45,23 @@
   postgresql_set:
     name: work_mem
     reset: yes
-  register: result
+  register: reset_wm
   ignore_errors: yes
 
 - assert:
     that:
-      - result.name == 'work_mem'
-      - result.changed
-      - result.cur_val != result.prev_val
-      - result.restart_required == false
+      - reset_wm.name == 'work_mem'
+      - reset_wm.changed == true
+      - reset_wm.cur_val != reset_wm.prev_val
+      - reset_wm.restart_required == false
+  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
+
+- assert:
+    that:
+      - set_wm.name == 'work_mem'
+      - set_wm.changed == true
+      - set_wm.restart_required == false
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '16'
 
 - name: postgresql_set - reset work_mem again to check that nothing changed (restart is not required)
   become_user: "{{ pg_user }}"
@@ -41,15 +69,23 @@
   postgresql_set:
     name: work_mem
     reset: yes
-  register: result
+  register: reset_wm2
   ignore_errors: yes
 
 - assert:
     that:
-      - result.name == 'work_mem'
-      - result.changed == false
-      - result.cur_val == result.prev_val
-      - result.restart_required == false
+      - reset_wm2.name == 'work_mem'
+      - reset_wm2.changed == false
+      - reset_wm2.cur_val == reset_wm2.prev_val
+      - reset_wm2.restart_required == false
+  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
+
+- assert:
+    that:
+      - reset_wm2.name == 'work_mem'
+      - reset_wm2.changed == false
+      - reset_wm2.restart_required == false
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '16'
 
 - name: postgresql_set - preparation to the next step
   become_user: "{{ pg_user }}"
@@ -65,15 +101,23 @@
   postgresql_set:
     name: work_mem
     value: default
-  register: result
+  register: def_wm
   ignore_errors: yes
 
 - assert:
     that:
-      - result.name == 'work_mem'
-      - result.changed
-      - result.cur_val != result.prev_val
-      - result.restart_required == false
+      - def_wm.name == 'work_mem'
+      - def_wm.changed == true
+      - def_wm.cur_val != def_wm.prev_val
+      - def_wm.restart_required == false
+  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
+
+- assert:
+    that:
+      - def_wm.name == 'work_mem'
+      - def_wm.changed == true
+      - def_wm.restart_required == false
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '16'
 
 - name: postgresql_set - set shared_buffers (restart is required)
   become_user: "{{ pg_user }}"
@@ -81,11 +125,11 @@
   postgresql_set:
     name: shared_buffers
     value: 111MB
-  register: result
+  register: set_shb
   ignore_errors: yes
 
 - assert:
     that:
-      - result.name == 'shared_buffers'
-      - result.changed
-      - result.restart_required == true
+      - set_shb.name == 'shared_buffers'
+      - set_shb.changed == true
+      - set_shb.restart_required == true

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -34,6 +34,8 @@
       - set_wm.cur_val == '12MB'
       - set_wm.cur_val != set_wm.prev_val
       - set_wm.restart_required == false
+      - set_wm.setting.value == 12582912
+      - set_wm.setting.unit == 'b'
   when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != "FreeBSD"
 
 - assert:
@@ -60,13 +62,14 @@
       - reset_wm.changed == true
       - reset_wm.cur_val != reset_wm.prev_val
       - reset_wm.restart_required == false
+      - reset_wm.setting.value != '12582912' 
   when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != "FreeBSD"
 
 - assert:
     that:
-      - set_wm.name == 'work_mem'
-      - set_wm.changed == true
-      - set_wm.restart_required == false
+      - reset_wm.name == 'work_mem'
+      - reset_wm.changed == true
+      - reset_wm.restart_required == false
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '16'
 
 - name: postgresql_set - reset work_mem again to check that nothing changed (restart is not required)
@@ -122,6 +125,7 @@
       - def_wm.changed == true
       - def_wm.cur_val != def_wm.prev_val
       - def_wm.restart_required == false
+      - def_wm.setting.value != '14680064' 
   when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != 'FreeBSD'
 
 - assert:
@@ -147,3 +151,22 @@
       - set_shb.name == 'shared_buffers'
       - set_shb.changed == true
       - set_shb.restart_required == true
+
+# We don't check setting.utin because it is none
+- name: postgresql_set - set autovacuum (enabled by default, restart is not required)
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
+    name: autovacuum
+    value: off
+  register: set_aut
+  ignore_errors: yes
+
+- assert:
+    that:
+      - set_aut.name == 'autovacuum'
+      - set_aut.changed == true
+      - set_aut.restart_required == false
+      - set_aut.setting.value == 'off'

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -1,0 +1,92 @@
+# Test code for the postgresql_set module
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: postgresql_set - set work_mem (restart is not required)
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    name: work_mem
+    value: 12MB
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result.name == 'work_mem'
+      - result.changed
+      - result.cur_val == '12MB'
+      - result.cur_val != result.prev_val
+      - result.restart_required == false
+
+- name: postgresql_set - reset work_mem (restart is not required)
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    name: work_mem
+    reset: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result.name == 'work_mem'
+      - result.changed
+      - result.cur_val != result.prev_val
+      - result.restart_required == false
+
+- name: postgresql_set - reset work_mem again to check that nothing changed (restart is not required)
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    name: work_mem
+    reset: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result.name == 'work_mem'
+      - result.changed == false
+      - result.cur_val == result.prev_val
+      - result.restart_required == false
+
+- name: postgresql_set - preparation to the next step
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    name: work_mem
+    value: 12MB
+  register: result
+  ignore_errors: yes
+
+- name: postgresql_set - set work_mem to initial state (restart is not required)
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    name: work_mem
+    value: default
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result.name == 'work_mem'
+      - result.changed
+      - result.cur_val != result.prev_val
+      - result.restart_required == false
+
+- name: postgresql_set - set shared_buffers (restart is required)
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    name: shared_buffers
+    value: 111MB
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result.name == 'shared_buffers'
+      - result.changed
+      - result.restart_required == true

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -2,9 +2,9 @@
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# Notice: assertions are different for Ubuntu 16.04 because they don't work
-# correctly for these tests. However I checked it manually on 16.04
-# and it works as expected.
+# Notice: assertions are different for Ubuntu 16.04 and FreeBSD because they don't work
+# correctly for these tests. There are some stranges exactly in Shippable CI.
+# However I checked it manually for all points and it worked as expected.
 
 - name: postgresql_set - preparation to the next step
   become_user: "{{ pg_user }}"
@@ -34,7 +34,7 @@
       - set_wm.cur_val == '12MB'
       - set_wm.cur_val != set_wm.prev_val
       - set_wm.restart_required == false
-  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
+  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != "FreeBSD"
 
 - assert:
     that:
@@ -60,7 +60,7 @@
       - reset_wm.changed == true
       - reset_wm.cur_val != reset_wm.prev_val
       - reset_wm.restart_required == false
-  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
+  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != "FreeBSD"
 
 - assert:
     that:
@@ -122,14 +122,14 @@
       - def_wm.changed == true
       - def_wm.cur_val != def_wm.prev_val
       - def_wm.restart_required == false
-  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16'
+  when: ansible_distribution != "Ubuntu" and ansible_distribution_major_version != '16' and ansible_distribution != 'FreeBSD'
 
 - assert:
     that:
       - def_wm.name == 'work_mem'
       - def_wm.changed == true
       - def_wm.restart_required == false
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '16'
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '16' and ansible_distribution != 'FreeBSD'
 
 - name: postgresql_set - set shared_buffers (restart is required)
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -6,7 +6,7 @@
 # correctly for these tests. However I checked it manually on 16.04
 # and it works as expected.
 
-- name: postgresql_set - preparation to the nex step
+- name: postgresql_set - preparation to the next step
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_set:

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -56,8 +56,7 @@
   become: yes
   postgresql_set:
     name: work_mem
-    value: 12MB
-  register: result
+    value: 14MB
   ignore_errors: yes
 
 - name: postgresql_set - set work_mem to initial state (restart is not required)

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -170,3 +170,63 @@
       - set_aut.changed == true
       - set_aut.restart_required == false
       - set_aut.value.value == 'off'
+
+# Test check_mode, step 1. At the previous test we set autovacuum = 'off'
+- name: postgresql - try to change autovacuum again in check_mode
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
+    name: autovacuum
+    value: on
+  register: set_aut
+  ignore_errors: yes
+  check_mode: yes
+
+- assert:
+    that:
+      - set_aut.name == 'autovacuum'
+      - set_aut.changed == true
+      - set_aut.restart_required == false
+      - set_aut.value.value == 'off'
+
+# Test check_mode, step 2
+- name: postgresql - check that autovacuum wasn't actually changed after change in check_mode
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
+    name: autovacuum
+    value: off
+  register: set_aut
+  ignore_errors: yes
+  check_mode: yes
+
+- assert:
+    that:
+      - set_aut.name == 'autovacuum'
+      - set_aut.changed == false
+      - set_aut.restart_required == false
+      - set_aut.value.value == 'off'
+
+# Test check_mode, step 3. It is different from the prev test - it runs withou check_mode: yes
+# Before the check_mode tests autovacuum was off
+- name: postgresql - check that autovacuum wasn't actually changed after change in check_mode
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    db: postgres
+    login_user: "{{ pg_user }}"
+    name: autovacuum
+    value: off
+  register: set_aut
+  ignore_errors: yes
+
+- assert:
+    that:
+      - set_aut.name == 'autovacuum'
+      - set_aut.changed == false
+      - set_aut.restart_required == false
+      - set_aut.value.value == 'off'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
postgresql_set: Change a PostgreSQL server configuration parameter

   - Allows to change a PostgreSQL server configuration parameter.
   - The module uses ALTER SYSTEM command U(https://www.postgresql.org/docs/current/sql-altersystem.html)
     and apply changes by reload server configuration.
   - ALTER SYSTEM is used for changing server configuration parameters across the entire database cluster.
   - It can be more convenient than the traditional method of manually editing the postgresql.conf file.
   - ALTER SYSTEM writes the given parameter setting to the $PGDATA/postgresql.auto.conf file,
     which is read in addition to postgresql.conf U(https://www.postgresql.org/docs/current/sql-altersystem.html).
   - The module allows to reset parameter to boot_val (cluster initial value) by I(reset=yes) or remove parameter
     string from postgresql.auto.conf and reload I(value=default).
   - After change you can see in ansible output the previous and
     the new parameter value and other information using returned values and M(debug) module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_set
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Check_mode is not supported because ALTER SYSTEM can't be run inside a transaction block
  U(https://www.postgresql.org/docs/current/sql-altersystem.html).
- Supported version of PostgreSQL is 9.4 and later.
- Pay attention, change setting with 'postmaster' context can return changed is true
  when actually nothing changes because the same value may be presented in
  several different form, for example, 1024MB, 1GB, etc. However in pg_settings
  system view it can be defined like 131072 number of 8kB pages.
  The final check of the parameter value cannot compare it because the server was
  not restarted and the value in pg_settings is not updated yet.
- For some parameters restart of PostgreSQL server is required.
  See official documentation U(https://www.postgresql.org/).
<!--- Paste verbatim command output below, e.g. before and after your change -->

If restart is required for the changed parameter, user will see
```
[WARNING]: Restart of PostgreSQL is required for setting shared_buffers
```

##### EXAMPLES
```
# Restore wal_keep_segments parameter to initial state
- postgresql_set:
    name: wal_keep_segments
    reset: yes

# Set work_mem parameter to 32MB and show what's been changed and restart is required or not
# (output example: "msg": "work_mem 4MB >> 64MB restart_req: False")
- postgresql_set:
    name: work_mem
    value: 32mb
    register: set_value

- debug:
    msg: "{{ set_value.name }} {{ set_value.prev_val }} >> {{ set_value.cur_value }} restart_req: {{ set_value.restart_required }}"
  when: set_value.changed
# Ensure that the restart of PostgreSQL serever must be required for some parameters.
# In this situation you see the same parameter in prev_val and cur_value, but 'changed=True'
# (Of course, if you passed the value that was different from the current server setting).

# Set log_min_duration_statement parameter to 1 second
- postgresql_set:
    name: log_min_duration_statement
    value: 1s

# Set wal_log_hints parameter to default value (remove parameter from postgresql.auto.conf)
- postgresql_set:
    name: wal_log_hints
    value: default
```
##### RETURN
```
name:
  description: Name of PostgreSQL server parameter.
  returned: always
  type: str
  sample: 'shared_buffers'
restart_required:
  description: Information about parameter current state.
  returned: always
  type: bool
  sample: true
prev_val_pretty:
  description: Information about previous state of the parameter.
  returned: always
  type: str
  sample: '4MB'
value_pretty:
  description: Information about current state of the parameter.
  returned: always
  type: str
  sample: '64MB'
value:
  description:
  - Dictionary that contains the current parameter value (at the time of playbook finish).
  - Pay attention that for real change some parameters restart of PostgreSQL server is required.
  - Returns the current value in the check mode.
  returned: always
  type: dict
  sample: { "value": 67108864, "unit": "b" }
context:
  description:
  - PostgreSQL setting context.
  returned: always
  type: str
  sample: user
```