### PR TITLE
fix azure_rm_deployment test

### DIFF
--- a/test/integration/targets/azure_rm_deployment/tasks/main.yml
+++ b/test/integration/targets/azure_rm_deployment/tasks/main.yml
@@ -6,7 +6,7 @@
   azure_rm_deployment:
     resource_group: "{{ resource_group }}"
     location: "eastus"
-    template_link: 'https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-vm-simple-linux/azuredeploy.json'
+    template_link: 'https://raw.githubusercontent.com/Azure/azure-quickstart-templates/d01a5c06f4f1bc03a049ca17bbbd6e06d62657b3/101-vm-simple-linux/azuredeploy.json'
     deployment_name: "{{ dns_label }}"
     parameters:
       adminUsername:


### PR DESCRIPTION
##### SUMMARY
* recent changes to args for hosted template file broke the test; changed test to use a specific known-working commit instead of `master`.
* long-term may want to consider hosting the template in httptester or just embedding a local copy

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_deployment tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
