### PR TITLE
fixed wrong limit on 'Fetch all deployments' sample

### DIFF
--- a/lib/ansible/plugins/lookup/k8s.py
+++ b/lib/ansible/plugins/lookup/k8s.py
@@ -135,7 +135,7 @@ EXAMPLES = """
 
 - name: Fetch all deployments
   set_fact:
-    deployments: "{{ lookup('k8s', kind='Deployment', namespace='testing') }}"
+    deployments: "{{ lookup('k8s', kind='Deployment') }}"
 
 - name: Fetch all deployments in a namespace
   set_fact:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/51675

Update the example for 'Fetch all deployments'
From: ```"{{ lookup('k8s', kind='Deployment', namespace='testing') }}"```
To: ```"{{ lookup('k8s', kind='Deployment') }}"```

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
k8s

##### ADDITIONAL INFORMATION
