### PR TITLE
remove non-standard GetManagerAttributes, SetManagerAttributes

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -531,25 +531,6 @@ class RedfishUtils(object):
             result['entries'].append(firmware)
         return result
 
-    def get_manager_attributes(self):
-        result = {}
-        manager_attributes = {}
-        key = "Attributes"
-
-        response = self.get_request(self.root_uri + self.manager_uri + "/" + key)
-        if response['ret'] is False:
-            return response
-        result['ret'] = True
-        data = response['data']
-
-        if key not in data:
-            return {'ret': False, 'msg': "Key %s not found" % key}
-
-        for attribute in data[key].items():
-            manager_attributes[attribute[0]] = attribute[1]
-        result["entries"] = manager_attributes
-        return result
-
     def get_bios_attributes(self):
         result = {}
         bios_attributes = {}
@@ -685,44 +666,6 @@ class RedfishUtils(object):
         if response['ret'] is False:
             return response
         return {'ret': True}
-
-    def set_manager_attributes(self, attr):
-        result = {}
-        # Here I'm making the assumption that the key 'Attributes' is part of the URI.
-        # It may not, but in the hardware I tested with, getting to the final URI where
-        # the Manager Attributes are, appear to be part of a specific OEM extension.
-        key = "Attributes"
-
-        # Search for key entry and extract URI from it
-        response = self.get_request(self.root_uri + self.manager_uri + "/" + key)
-        if response['ret'] is False:
-            return response
-        result['ret'] = True
-        data = response['data']
-
-        if key not in data:
-            return {'ret': False, 'msg': "Key %s not found" % key}
-
-        # Check if attribute exists
-        if attr['mgr_attr_name'] not in data[key]:
-            return {'ret': False, 'msg': "Manager attribute %s not found" % attr['mgr_attr_name']}
-
-        # Example: manager_attr = {\"name\":\"value\"}
-        # Check if value is a number. If so, convert to int.
-        if attr['mgr_attr_value'].isdigit():
-            manager_attr = "{\"%s\": %i}" % (attr['mgr_attr_name'], int(attr['mgr_attr_value']))
-        else:
-            manager_attr = "{\"%s\": \"%s\"}" % (attr['mgr_attr_name'], attr['mgr_attr_value'])
-
-        # Find out if value is already set to what we want. If yes, return
-        if data[key][attr['mgr_attr_name']] == attr['mgr_attr_value']:
-            return {'ret': True, 'changed': False, 'msg': "Manager attribute already set"}
-
-        payload = {"Attributes": json.loads(manager_attr)}
-        response = self.patch_request(self.root_uri + self.manager_uri + "/" + key, payload, HEADERS)
-        if response['ret'] is False:
-            return response
-        return {'ret': True, 'changed': True, 'msg': "Modified Manager attribute %s" % attr['mgr_attr_name']}
 
     def set_bios_attributes(self, attr):
         result = {}

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -55,18 +55,6 @@ options:
       - value of BIOS attribute to update
     default: 'null'
     version_added: "2.8"
-  manager_attribute_name:
-    required: false
-    description:
-      - name of Manager attribute to update
-    default: 'null'
-    version_added: "2.8"
-  manager_attribute_value:
-    required: false
-    description:
-      - value of Manager attribute to update
-    default: 'null'
-    version_added: "2.8"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -109,36 +97,6 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-
-  - name: Enable NTP in the OOB Controller
-    redfish_config:
-      category: Manager
-      command: SetManagerAttributes
-      manager_attribute_name: NTPConfigGroup.1.NTPEnable
-      manager_attribute_value: Enabled
-      baseuri: "{{ baseuri }}"
-      username: "{{ username}}"
-      password: "{{ password }}"
-
-  - name: Set NTP server 1 to {{ ntpserver1 }} in the OOB Controller
-    redfish_config:
-      category: Manager
-      command: SetManagerAttributes
-      manager_attribute_name: NTPConfigGroup.1.NTP1
-      manager_attribute_value: "{{ ntpserver1 }}"
-      baseuri: "{{ baseuri }}"
-      username: "{{ username}}"
-      password: "{{ password }}"
-
-  - name: Set Timezone to {{ timezone }} in the OOB Controller
-    redfish_config:
-      category: Manager
-      command: SetManagerAttributes
-      manager_attribute_name: Time.1.Timezone
-      manager_attribute_value: "{{ timezone }}"
-      baseuri: "{{ baseuri }}"
-      username: "{{ username}}"
-      password: "{{ password }}"
 '''
 
 RETURN = '''
@@ -156,8 +114,7 @@ from ansible.module_utils._text import to_native
 
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
-    "Systems": ["SetBiosDefaultSettings", "SetBiosAttributes"],
-    "Manager": ["SetManagerAttributes"],
+    "Systems": ["SetBiosDefaultSettings", "SetBiosAttributes"]
 }
 
 
@@ -170,8 +127,6 @@ def main():
             baseuri=dict(required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),
-            manager_attribute_name=dict(default='null'),
-            manager_attribute_value=dict(default='null'),
             bios_attribute_name=dict(default='null'),
             bios_attribute_value=dict(default='null'),
         ),
@@ -185,9 +140,6 @@ def main():
     creds = {'user': module.params['username'],
              'pswd': module.params['password']}
 
-    # Manager attributes to update
-    mgr_attributes = {'mgr_attr_name': module.params['manager_attribute_name'],
-                      'mgr_attr_value': module.params['manager_attribute_value']}
     # BIOS attributes to update
     bios_attributes = {'bios_attr_name': module.params['bios_attribute_name'],
                        'bios_attr_value': module.params['bios_attribute_value']}
@@ -219,16 +171,6 @@ def main():
                 result = rf_utils.set_bios_default_settings()
             elif command == "SetBiosAttributes":
                 result = rf_utils.set_bios_attributes(bios_attributes)
-
-    elif category == "Manager":
-        # execute only if we find a Manager service resource
-        result = rf_utils._find_managers_resource(rf_uri)
-        if result['ret'] is False:
-            module.fail_json(msg=to_native(result['msg']))
-
-        for command in command_list:
-            if command == "SetManagerAttributes":
-                result = rf_utils.set_manager_attributes(mgr_attributes)
 
     # Return data back or fail with proper message
     if result['ret'] is True:

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -135,7 +135,7 @@ CATEGORY_COMMANDS_ALL = {
     "Chassis": ["GetFanInventory"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory"],
-    "Manager": ["GetManagerAttributes", "GetManagerNicInventory", "GetLogs"],
+    "Manager": ["GetManagerNicInventory", "GetLogs"],
 }
 
 CATEGORY_COMMANDS_DEFAULT = {
@@ -143,7 +143,7 @@ CATEGORY_COMMANDS_DEFAULT = {
     "Chassis": "GetFanInventory",
     "Accounts": "ListUsers",
     "Update": "GetFirmwareInventory",
-    "Manager": "GetManagerAttributes"
+    "Manager": "GetManagerNicInventory"
 }
 
 
@@ -263,9 +263,7 @@ def main():
                 module.fail_json(msg=resource['msg'])
 
             for command in command_list:
-                if command == "GetManagerAttributes":
-                    result["manager_attributes"] = rf_utils.get_manager_attributes()
-                elif command == "GetManagerNicInventory":
+                if command == "GetManagerNicInventory":
                     result["manager_nics"] = rf_utils.get_nic_inventory(resource_type=category)
                 elif command == "GetLogs":
                     result["log"] = rf_utils.get_logs()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The commands `GetManagerAttributes` and `SetManagerAttributes` reply on an `Attributes` property in the `Manager` resource. But this is not a standard property in the Redfish spec; it is a vendor-specific Oem property. Accordingly, these 2 non-standard commands are being removed with this PR. These commands can be added by a vendor in an appropriate Oem extension module if needed.

Fixes #47590

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_facts.py
redfish_config.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related_utils issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
See issue #47590 for the original behavior. After this PR, the subject commands (`GetManagerAttributes` and `SetManagerAttributes`) will no longer be available in the standard modules.
