### PR TITLE
scaleway_compute: add "terminate" option to use with "absent" state

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -74,6 +74,7 @@ options:
       - Terminate and trash a server with its volumes instead of deleting it
     default: false
     type: bool
+    version_added: "2.8"
 
   tags:
     description:

--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -344,8 +344,10 @@ def restart_server(compute_api, server):
 def stop_server(compute_api, server):
     return perform_action(compute_api=compute_api, server=server, action="poweroff")
 
+
 def terminate_server(compute_api, server):
     return perform_action(compute_api=compute_api, server=server, action="terminate")
+
 
 def start_server(compute_api, server):
     return perform_action(compute_api=compute_api, server=server, action="poweron")
@@ -460,8 +462,7 @@ def absent_strategy_terminate(compute_api, wished_server):
         response = terminate_server(compute_api=compute_api, server=target_server)
 
         if not response.ok:
-            err_msg = 'Error while terminating a server [{0}: {1}]'.format(response.status_code,
-                                                                                           response.json)
+            err_msg = 'Error while terminating a server [{0}: {1}]'.format(response.status_code, response.json)
             compute_api.module.fail_json(msg=err_msg)
 
         wait_to_complete_state_transition(compute_api=compute_api, server=target_server)

--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -457,7 +457,8 @@ def absent_strategy_terminate(compute_api, wished_server):
     if compute_api.module.check_mode:
         return changed, {"status": "Server %s would be made absent." % target_server["id"]}
 
-    # Even running server can be terminated
+    # Only running server can be terminated
+    # FIXME: stop with terminate will not destroy non-running server (API limitation)
     while fetch_state(compute_api=compute_api, server=target_server) != "stopped":
         wait_to_complete_state_transition(compute_api=compute_api, server=target_server)
         response = terminate_server(compute_api=compute_api, server=target_server)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using "absent" state destroys the server but keeps its volumes unattached.
To completely destroy the server with volumes the Scaleway API has
undocumented yet but provided "terminate" action instead of "poweroff".
This option is only applicable to running servers, and there is no
equivalent API command to completely destroy stopped servers.

This patch adds "terminate: yes/no" module option. If new state is
"absent" and "terminate" is set to yes, it will use "terminate" action
to stop and destroy server.

If server is already stopped, this will not destroy it and return error.
It is not an expected behaviour, but this way the Scaleway API works.
It can be worked around by using same module twice with terminate and
without it to destroy server and keeping volumes at worst. But better
would be if Scaleway allows this action for stopped servers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51874

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scaleway_compute
