### PR TITLE
use re.split to allow spaces

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1365,7 +1365,7 @@ class AnsibleModule(object):
         new_mode = stat.S_IMODE(path_stat.st_mode)
 
         # Now parse all symbolic modes
-        for mode in re.split('[,\s]+', symbolic_mode):
+        for mode in re.split('[, ]+', symbolic_mode):
             # Per single mode. This always contains a '+', '-' or '='
             # Split it on that
             permlist = MODE_OPERATOR_RE.split(mode)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1365,7 +1365,7 @@ class AnsibleModule(object):
         new_mode = stat.S_IMODE(path_stat.st_mode)
 
         # Now parse all symbolic modes
-        for mode in symbolic_mode.split(','):
+        for mode in re.split('[,\s]+', symbolic_mode):
             # Per single mode. This always contains a '+', '-' or '='
             # Split it on that
             permlist = MODE_OPERATOR_RE.split(mode)


### PR DESCRIPTION
##### SUMMARY
Fixes  #51788, use re.split for a more relaxed splitting of symbolic file modes

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
basic.py

##### ADDITIONAL INFORMATION
