### PR TITLE
[backport-2.7] meraki_admin - Add documentation about absent priority (#51766)

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -45,7 +45,8 @@ options:
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
     state:
         description:
-        - Create or modify an organization
+        - Create or modify, or delete an organization
+        - If C(state) is C(absent), name takes priority over email if both are specified.
         choices: [ absent, present, query ]
         required: true
     org_name:


### PR DESCRIPTION
##### SUMMARY
* Add documentation about absent priority

* Remove 7 at the end of file

(cherry picked from commit f9f7b29a5a5543e8d1c25e8cc1f2d3040d8536b7)
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meraki_admin
