### PR TITLE
Add two more failure conditions to unarchive

### DIFF
--- a/changelogs/fragments/unarchive-fix-bad-user-and-group.yaml
+++ b/changelogs/fragments/unarchive-fix-bad-user-and-group.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - add two more error conditions to unarchive to present more accurate error message (https://github.com/ansible/ansible/issues/51848)

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -172,6 +172,8 @@ MOD_TIME_DIFF_RE = re.compile(r': Mod time differs$')
 EMPTY_FILE_RE = re.compile(r': : Warning: Cannot stat: No such file or directory$')
 MISSING_FILE_RE = re.compile(r': Warning: Cannot stat: No such file or directory$')
 ZIP_FILE_MODE_RE = re.compile(r'([r-][w-][SsTtx-]){3}')
+INVALID_OWNER_RE = re.compile(r': Invalid owner')
+INVALID_GROUP_RE = re.compile(r': Invalid group')
 
 
 def crc32(path):
@@ -729,6 +731,10 @@ class TgzArchive(object):
             if MOD_TIME_DIFF_RE.search(line):
                 out += line + '\n'
             if MISSING_FILE_RE.search(line):
+                out += line + '\n'
+            if INVALID_OWNER_RE.search(line):
+                out += line + '\n'
+            if INVALID_GROUP_RE.search(line):
                 out += line + '\n'
         if out:
             unarchived = False


### PR DESCRIPTION
##### SUMMARY
Under the condition where the unarchive failed due to a non-existent user or group, the "is_unarchived" function still returned "unarchived" as true. This caused an error later on when the module is checking for files it expects to be there, but aren't. 

Fixes #51848 
Fixes #45971 (duplicates)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ADDITIONAL INFORMATION
Previous output incorrectly said problem was a missing file:
```
fatal: [localhost]: FAILED! => {"changed": false, "dest": "/", "gid": 0, "group": "root", "handler": "TgzArchive", "mode": "0755", "msg": "Unexpected error when accessing exploded file: [Errno 2] No such file or directory: '/var/lib/tomcat8/webapps/cas/META-INF'", "owner": "root", "size": 4096, "src": "/root/.ansible/tmp/ansible-tmp-1549494633.45-18088113372762/source", "state": "directory", "uid": 0}
```

Now output explains that the group is invalid:
```
fatal: [68.183.128.104]: FAILED! => {"changed": false, "dest": "./", "extract_results": {"cmd": ["/usr/bin/gtar", "--extract", "-C", "./", "--group=tomcat", "-f", "/home/ansible/.ansible/tmp/ansible-tmp-1549578513.130642-149977025868099/source"], "err": "/usr/bin/gtar: tomcat: Invalid group\n/usr/bin/gtar: Error is not recoverable: exiting now\n", "out": "", "rc": 2}, "gid": 1002, "group": "ansible", "handler": "TarArchive", "mode": "0700", "msg": "failed to unpack /home/ansible/.ansible/tmp/ansible-tmp-1549578513.130642-149977025868099/source to ./", "owner": "ansible", "secontext": "unconfined_u:object_r:user_home_dir_t:s0", "size": 242, "src": "/home/ansible/.ansible/tmp/ansible-tmp-1549578513.130642-149977025868099/source", "state": "directory", "uid": 1002}
```