### PR TITLE
extra_args_precommand parameter added to zypper_repository module

### DIFF
--- a/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -125,3 +125,25 @@
     priority: 100
     auto_import_keys: true
     state: "present"
+
+- name: add docker repo with params
+  zypper_repository:
+    name: docker
+    repo: http://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/
+    state: present
+    extra_args_precommand: --root {{ output_dir | expanduser }}/testdir/
+
+- name: add docker repo with params again for checking idempotence
+  zypper_repository:
+    name: docker
+    repo: http://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/
+    state: present
+    extra_args_precommand: --root {{ output_dir | expanduser }}/testdir/
+
+- name: check listrepo from custom root
+  command: zypper --root {{ output_dir | expanduser }}/testdir/ lr docker
+  register: zypper_result
+
+- assert:
+    that:
+      - '"docker" in zypper_result.stdout'


### PR DESCRIPTION
Signed-off-by: Gustavo Martinez Bernal <gustavo.martinez.bernal@intel.com>

##### SUMMARY
<!--- -->
Adding extra_args_precommand parameter to zypper_repository module to enable user to specify pre command arguments like install repositories in custom path. Example: zypper --root /path/to/install ar <some_url_repo> some_repo


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!---  -->
New parameter in zypper_repository

##### ADDITIONAL INFORMATION
<!---  -->
extra_args_precommand parameter added to zypper_repository module

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
