### PR TITLE
Change some file listings to try and figure out which rpm macro is un…

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -14,7 +14,7 @@ License:   GPLv3+
 Group:     Development/Libraries
 Source:    https://releases.ansible.com/ansible/%{name}-%{upstream_version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-%{!?__python2: %global __python2 /usr/bin/python2.6}
+%{!?__python2: %global __python2 /usr/bin/python2.7}
 %{!?python_sitelib: %global python_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
 BuildArch: noarch
@@ -124,7 +124,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root)
-%{python_sitelib}/ansible*
+%{python_sitelib}/ansible/
+%{python_sitelib}/ansible-*.egg-info
 %{_bindir}/ansible*
 %dir %{_datadir}/ansible
 %config(noreplace) %{_sysconfdir}/ansible


### PR DESCRIPTION
…defined

One of the file path macros that we use in the rpm file list isn't being
defined on Fedora 29 in Jenkins which is causing it to fail to build
there.  Change the potential problems so that we can tell which file
entry is causing the failures on its next rebuild

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
packaging/rpm/ansible.spec

##### ADDITIONAL INFORMATION
Need to get some information out of the Jenkins build log to see whether it's %{_bindir} or %{python_sitelib} which is undefined when building for Fedora 29 on Jenkins.