### PR TITLE
[Backport 2.7] spot instance request stay opened when module exit with timeout

### DIFF
--- a/changelogs/fragments/51535-ec2-fix-spot-request-end-date.yaml
+++ b/changelogs/fragments/51535-ec2-fix-spot-request-end-date.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2 - Correctly sets the end date of the Spot Instance request. Sets `ValidUntil` value in proper way so it will be auto-canceled through `spot_wait_timeout` interval.

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -539,6 +539,7 @@ EXAMPLES = '''
 '''
 
 import time
+import datetime
 import traceback
 from ast import literal_eval
 from distutils.version import LooseVersion
@@ -1190,6 +1191,15 @@ def create_instances(module, ec2, vpc, override_count=None):
                     count=count_remaining,
                     type=spot_type,
                 ))
+
+                # Set spot ValidUntil
+                # ValidUntil -> (timestamp). The end date of the request, in
+                # UTC format (for example, YYYY -MM -DD T*HH* :MM :SS Z).
+                utc_valid_until = (
+                    datetime.datetime.utcnow()
+                    + datetime.timedelta(seconds=spot_wait_timeout))
+                params['valid_until'] = utc_valid_until.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
                 res = ec2.request_spot_instances(spot_price, **params)
 
                 # Now we have to do the intermediate waiting


### PR DESCRIPTION
##### SUMMARY

Fixes: #51534

* set valid_until equal to current time + spot_wait_timeout
* add setting ValidUntil to  value
* add changelog fragment
* fix shebang issue

(cherry picked from commit d40f0313e2b1c6cf91ada4cb35e19a24ef404675)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/51535-ec2-fix-spot-request-end-date.yaml
lib/ansible/modules/cloud/amazon/ec2.py
