### PR TITLE
win_dsc - return warning from DSC invocation

### DIFF
--- a/changelogs/fragments/win_dsc-warning.yaml
+++ b/changelogs/fragments/win_dsc-warning.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_dsc - Display the warnings produced by the DSC engine for better troubleshooting - https://github.com/ansible/ansible/issues/51543

--- a/lib/ansible/modules/windows/win_dsc.ps1
+++ b/lib/ansible/modules/windows/win_dsc.ps1
@@ -236,7 +236,11 @@ try
 {
     #Defined variables in strictmode
     $TestError, $TestError = $null
-    $TestResult = Invoke-DscResource @Config -Method Test -ModuleName $Module -ErrorVariable TestError -ErrorAction SilentlyContinue
+    $TestResult = Invoke-DscResource @Config -Method Test -ModuleName $Module -ErrorVariable TestError -ErrorAction SilentlyContinue -WarningVariable TestWarn
+    foreach ($warning in $TestWarn) {
+        Add-Warning -obj $result -message $warning.Message
+    }
+
     if ($TestError)
     {
        throw ($TestError[0].Exception.Message)
@@ -245,7 +249,10 @@ try
     {
         if ($check_mode -eq $False)
         {
-            $SetResult = Invoke-DscResource -Method Set @Config -ModuleName $Module -ErrorVariable SetError -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+            $SetResult = Invoke-DscResource -Method Set @Config -ModuleName $Module -ErrorVariable SetError -ErrorAction SilentlyContinue -WarningVariable SetWarn
+            foreach ($warning in $SetWarn) {
+                Add-Warning -obj $result -message $warning.Message
+            }
             if ($SetError -and ($SetResult -eq $null))
             {
                 #If SetError was filled, throw to exit out of the try/catch loop

--- a/test/integration/targets/win_dsc/tasks/tests.yml
+++ b/test/integration/targets/win_dsc/tasks/tests.yml
@@ -307,6 +307,9 @@
     that:
     - test_dsc_custom is changed
     - test_dsc_custom_output.content|b64decode|strip_newline == test_dsc_custom_expected|strip_newline
+    - test_dsc_custom.warnings | length == 2
+    - "'[[xTestResource]DirectResourceAccess] test warning' in test_dsc_custom.warnings[0]"
+    - "'[[xTestResource]DirectResourceAccess] set warning' in test_dsc_custom.warnings[1]"
 
 - name: run custom DSC resource with version
   win_dsc:

--- a/test/integration/targets/win_dsc/templates/ANSIBLE_xTestResource.psm1
+++ b/test/integration/targets/win_dsc/templates/ANSIBLE_xTestResource.psm1
@@ -119,6 +119,7 @@ CimInstanceArrayParam:
     }
     New-Item -Path $Path -ItemType File > $null
     Set-Content -Path $Path -Value $file_contents > $null
+    Write-Warning -Message "set warning"
 }
 
 Function Test-TargetResource
@@ -167,6 +168,7 @@ Function Test-TargetResource
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $CimInstanceArrayParam
     )
+    Write-Warning -Message "test warning"
     return $false
 }
 


### PR DESCRIPTION
##### SUMMARY
This PR has the `win_dsc` module capture warnings produced by the DSC invocation and returns them back to Ansible. This is displayed to the user as a normal warning in Ansible and can help with debugging problems or even being told that something is not 100% correct.

I'm not sure whether this is eligible for a backport, @abadger will have to weigh in on this.

Fixes https://github.com/ansible/ansible/issues/51543

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_dsc