### PR TITLE
rhsm_repository: Properly handle no repos

### DIFF
--- a/changelogs/fragments/rhsm_repository-handle-no-repos.yml
+++ b/changelogs/fragments/rhsm_repository-handle-no-repos.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rhsm_repository - handle systems without any repos

--- a/lib/ansible/modules/packaging/os/rhsm_repository.py
+++ b/lib/ansible/modules/packaging/os/rhsm_repository.py
@@ -160,7 +160,7 @@ def get_repository_list(module, list_parameter):
                 "enabled": True if repo_enabled == '1' else False
             }
 
-        repo_result.append(repo)
+            repo_result.append(repo)
 
     return repo_result
 


### PR DESCRIPTION
When no repos are defined, the `repo` variable is undefined. Therefore
append it only to the result if a repo was found. Otherwise Ansible will
fail with an UnboundLocalError.

##### SUMMARY
When no repos are defined, the `repo` variable is undefined. Therefore
append it only to the result if a repo was found. Otherwise Ansible will
fail with an UnboundLocalError.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rhsm_repository

##### ADDITIONAL INFORMATION
Use this playbook against a RHEL 76 system that is not subscribed:
```paste below
---
- hosts: all
  tasks:
    - name: enable recommended repos
      rhsm_repository:
        name:
          - rhel-7-server-optional-rpms
          - rhel-7-server-extras-rpms

```
