### PR TITLE
Simplify docker_*_facts return names

### DIFF
--- a/changelogs/fragments/docker-facts.yaml
+++ b/changelogs/fragments/docker-facts.yaml
@@ -1,6 +1,7 @@
 minor_changes:
-- "docker_container, docker_network, docker_volume - return facts as regular variable additionally to
-   facts. This is now the preferred way to obtain results."
+- "docker_container, docker_network, docker_volume - return facts as regular variables ``container``,
+   ``network`` respectively ``volume`` additionally to facts. This is now the preferred way to
+   obtain results. The facts will be removed in Ansible 2.12."
 - "docker_service - return facts as regular variable ``service_facts``; this is a dictionary mapping
    service names to container dictionaries. The facts are still returned, but it is recommended to
-   use ``register`` and ``service_facts`` in the future."
+   use ``register`` and ``service_facts`` in the future. The facts will be removed in Ansible 2.12."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -276,11 +276,11 @@ Noteworthy module changes
   This allows for more flexibility and better module support.
 
 * The ``docker_container`` module has deprecated the returned fact ``docker_container``. The same value is
-  available as the returned variable ``docker_container``. The returned fact will be removed in Ansible 2.12.
+  available as the returned variable ``container``. The returned fact will be removed in Ansible 2.12.
 * The ``docker_network`` module has deprecated the returned fact ``docker_container``. The same value is
-  available as the returned variable ``docker_network``. The returned fact will be removed in Ansible 2.12.
+  available as the returned variable ``network``. The returned fact will be removed in Ansible 2.12.
 * The ``docker_volume`` module has deprecated the returned fact ``docker_container``. The same value is
-  available as the returned variable ``docker_volume``. The returned fact will be removed in Ansible 2.12.
+  available as the returned variable ``volume``. The returned fact will be removed in Ansible 2.12.
 
 * The ``docker_service`` module was renamed to :ref:`docker_compose <docker_compose_module>`.
 * The renamed ``docker_compose`` module used to return one fact per service, named same as the service. A dictionary

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -873,12 +873,13 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-docker_container:
+container:
     description:
-      - Before 2.3 this was 'ansible_docker_container' but was renamed due to conflicts with the connection plugin.
       - Facts representing the current state of the container. Matches the docker inspection output.
       - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
-        are also accessible directly. Note that the returned fact will be removed in Ansible 2.12.
+        are also accessible directly as C(docker_container). Note that the returned fact will be removed in Ansible 2.12.
+      - Before 2.3 this was C(ansible_docker_container) but was renamed in 2.3 to C(docker_container) due to
+        conflicts with the connection plugin.
       - Empty if C(state) is I(absent)
       - If detached is I(False), will include Output attribute containing any output from container run.
     returned: always
@@ -2253,7 +2254,7 @@ class ContainerManager(DockerBaseClass):
 
         if self.facts:
             self.results['ansible_facts'] = {'docker_container': self.facts}
-            self.results['docker_container'] = self.facts
+            self.results['container'] = self.facts
 
     def present(self, state):
         container = self._get_container(self.parameters.name)

--- a/lib/ansible/modules/cloud/docker/docker_container_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_container_facts.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 
 - name: Print information about container
   debug:
-    var: result.docker_container
+    var: result.container
   when: result.exists
 '''
 
@@ -67,7 +67,7 @@ exists:
     type: bool
     returned: always
     sample: true
-docker_container:
+container:
     description:
       - Facts representing the current state of the container. Matches the docker inspection output.
       - Will be C(None) if container does not exist.
@@ -126,7 +126,7 @@ def main():
     client.module.exit_json(
         changed=False,
         exists=(True if container else False),
-        docker_container=container,
+        container=container,
     )
 
 

--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -143,40 +143,40 @@ can_talk_to_docker:
     returned: both on success and on error
     type: bool
 
-docker_host_facts:
+host_facts:
     description:
       - Facts representing the basic state of the docker host. Matches the C(docker system info) output.
     returned: always
     type: dict
-docker_volumes_list:
+volumes:
     description:
       - List of dict objects containing the basic information about each volume.
         Keys matches the C(docker volume ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(volumes) is C(yes)
     type: list
-docker_networks_list:
+networks:
     description:
       - List of dict objects containing the basic information about each network.
         Keys matches the C(docker network ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(networks) is C(yes)
     type: list
-docker_containers_list:
+containers:
     description:
       - List of dict objects containing the basic information about each container.
         Keys matches the C(docker container ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(containers) is C(yes)
     type: list
-docker_images_list:
+images:
     description:
       - List of dict objects containing the basic information about each image.
         Keys matches the C(docker image ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(images) is C(yes)
     type: list
-docker_disk_usage:
+disk_usage:
     description:
       - Information on summary disk usage by images, containers and volumes on docker host
         unless I(verbose_output=yes). See description for I(verbose_output).
@@ -209,14 +209,14 @@ class DockerHostManager(DockerBaseClass):
 
         listed_objects = ['volumes', 'networks', 'containers', 'images']
 
-        self.results['docker_host_facts'] = self.get_docker_host_facts()
+        self.results['host_facts'] = self.get_docker_host_facts()
 
         if self.client.module.params['disk_usage']:
-            self.results['docker_disk_usage'] = self.get_docker_disk_usage_facts()
+            self.results['disk_usage'] = self.get_docker_disk_usage_facts()
 
         for docker_object in listed_objects:
             if self.client.module.params[docker_object]:
-                returned_name = "docker_" + docker_object + "_list"
+                returned_name = docker_object
                 filter_name = docker_object + "_filters"
                 filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name))
                 self.results[returned_name] = self.get_docker_items_list(docker_object, filters)
@@ -314,7 +314,6 @@ def main():
 
     results = dict(
         changed=False,
-        docker_host_facts=[]
     )
 
     DockerHostManager(client, results)

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -241,11 +241,11 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-docker_network:
+network:
     description:
     - Network inspection results for the affected network.
     - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
-      are also accessible directly. Note that the returned fact will be removed in Ansible 2.12.
+      are also accessible directly as C(docker_network). Note that the returned fact will be removed in Ansible 2.12.
     returned: success
     type: dict
     sample: {}
@@ -575,7 +575,7 @@ class DockerNetworkManager(object):
 
         network_facts = self.get_existing_network()
         self.results['ansible_facts'] = {u'docker_network': network_facts}
-        self.results['docker_network'] = network_facts
+        self.results['network'] = network_facts
 
     def absent(self):
         self.diff_tracker.add('exists', parameter=False, active=self.existing_network is not None)

--- a/lib/ansible/modules/cloud/docker/docker_network_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_network_facts.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 
 - name: Print information about network
   debug:
-    var: result.docker_network
+    var: result.network
   when: result.exists
 '''
 
@@ -67,7 +67,7 @@ exists:
     type: bool
     returned: always
     sample: true
-docker_network:
+network:
     description:
       - Facts representing the current state of the network. Matches the docker inspection output.
       - Will be C(None) if network does not exist.
@@ -122,7 +122,7 @@ def main():
     client.module.exit_json(
         changed=False,
         exists=(True if network else False),
-        docker_network=network,
+        network=network,
     )
 
 

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -76,7 +76,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-nodes_facts:
+nodes:
     description:
       - Facts representing the current state of the nodes. Matches the C(docker node inspect) output.
       - Can contain multiple entries if more than one node provided in I(name), or I(name) is not provided.
@@ -136,11 +136,11 @@ def main():
 
     client.fail_task_if_not_swarm_manager()
 
-    node = get_node_facts(client)
+    nodes = get_node_facts(client)
 
     client.module.exit_json(
         changed=False,
-        nodes_facts=node,
+        nodes=nodes,
     )
 
 

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -83,13 +83,13 @@ requirements:
 '''
 
 RETURN = '''
-docker_stack_spec_diff:
+stack_spec_diff:
     description: |
         dictionary containing the differences between the 'Spec' field
         of the stack services before and after applying the new stack
         definition.
     sample: >
-        "docker_stack_specs_diff":
+        "stack_spec_diff":
         {'test_stack_test_service': {u'TaskTemplate': {u'ContainerSpec': {delete: [u'Env']}}}}
     returned: on change
     type: dict
@@ -277,9 +277,9 @@ def main():
         else:
             module.exit_json(
                 changed=True,
-                docker_stack_spec_diff=json_diff(before_stack_services,
-                                                 after_stack_services,
-                                                 dump=True))
+                stack_spec_diff=json_diff(before_stack_services,
+                                          after_stack_services,
+                                          dump=True))
 
     else:
         if docker_stack_services(module, name):

--- a/lib/ansible/modules/cloud/docker/docker_swarm_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_facts.py
@@ -120,7 +120,7 @@ EXAMPLES = '''
   register: result
 
 - debug:
-    var: result.docker_swarm_facts
+    var: result.swarm_facts
 '''
 
 RETURN = '''
@@ -144,27 +144,27 @@ docker_swarm_manager:
     returned: both on success and on error
     type: bool
 
-docker_swarm_facts:
+swarm_facts:
     description:
       - Facts representing the basic state of the docker Swarm cluster.
       - Contains tokens to connect to the Swarm
     returned: always
     type: dict
-docker_nodes_list:
+nodes:
     description:
       - List of dict objects containing the basic information about each volume.
         Keys matches the C(docker node ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(nodes) is C(yes)
     type: list
-docker_services_list:
+services:
     description:
       - List of dict objects containing the basic information about each volume.
         Keys matches the C(docker service ls) output unless I(verbose_output=yes).
         See description for I(verbose_output).
     returned: When I(services) is C(yes)
     type: list
-docker_tasks_list:
+tasks:
     description:
       - List of dict objects containing the basic information about each volume.
         Keys matches the C(docker service ps) output unless I(verbose_output=yes).
@@ -200,11 +200,11 @@ class DockerSwarmManager(DockerBaseClass):
 
         self.client.fail_task_if_not_swarm_manager()
 
-        self.results['docker_swarm_facts'] = self.get_docker_swarm_facts()
+        self.results['swarm_facts'] = self.get_docker_swarm_facts()
 
         for docker_object in listed_objects:
             if self.client.module.params[docker_object]:
-                returned_name = "docker_" + docker_object + "_list"
+                returned_name = docker_object
                 filter_name = docker_object + "_filters"
                 filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name))
                 self.results[returned_name] = self.get_docker_items_list(docker_object, filters)
@@ -334,7 +334,6 @@ def main():
 
     results = dict(
         changed=False,
-        docker_swarm_facts=[],
     )
 
     DockerSwarmManager(client, results)

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -115,11 +115,11 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-docker_volume:
+volume:
     description:
     - Volume inspection results for the affected volume.
     - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
-      are also accessible directly. Note that the returned fact will be removed in Ansible 2.12.
+      are also accessible directly as C(docker_volume). Note that the returned fact will be removed in Ansible 2.12.
     returned: success
     type: dict
     sample: {}
@@ -291,7 +291,7 @@ class DockerVolumeManager(object):
 
         volume_facts = self.get_existing_volume()
         self.results['ansible_facts'] = {u'docker_volume': volume_facts}
-        self.results['docker_volume'] = volume_facts
+        self.results['volume'] = volume_facts
 
     def absent(self):
         self.diff_tracker.add('exists', parameter=False, active=self.existing_volume is not None)

--- a/lib/ansible/modules/cloud/docker/docker_volume_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume_facts.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
 
 - name: Print information about volume
   debug:
-    var: result.docker_volume
+    var: result.volume
   when: result.exists
 '''
 
@@ -63,7 +63,7 @@ exists:
     type: bool
     returned: always
     sample: true
-docker_volume:
+volume:
     description:
       - Volume inspection results for the affected volume.
       - Will be C(None) if volume does not exist.
@@ -115,7 +115,7 @@ def main():
     client.module.exit_json(
         changed=False,
         exists=(True if volume else False),
-        docker_volume=volume,
+        volume=volume,
     )
 
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -543,15 +543,15 @@
     #      of hello-world. We don't know why this happens, but it happens
     #      often enough to be annoying. That's why we disable this for now,
     #      and simply test that 'Output' is contained in the result.
-    - "'Output' in detach_no_cleanup.docker_container"
-    # - "'Hello from Docker!' in detach_no_cleanup.docker_container.Output"
+    - "'Output' in detach_no_cleanup.container"
+    # - "'Hello from Docker!' in detach_no_cleanup.container.Output"
     - detach_no_cleanup_cleanup is changed
-    - "'Output' in detach_cleanup.docker_container"
-    # - "'Hello from Docker!' in detach_cleanup.docker_container.Output"
+    - "'Output' in detach_cleanup.container"
+    # - "'Hello from Docker!' in detach_cleanup.container.Output"
     - detach_cleanup_cleanup is not changed
 - assert:
     that:
-    - "'Cannot retrieve result as auto_remove is enabled' == detach_auto_remove.docker_container.Output"
+    - "'Cannot retrieve result as auto_remove is enabled' == detach_auto_remove.container.Output"
     - detach_auto_remove_cleanup is not changed
   when: docker_py_version is version('2.1.0', '>=')
 
@@ -2378,7 +2378,7 @@
     - memory_swap_1 is changed
     # Sometimes (in particular during integration tests, maybe when not running
     # on a proper VM), memory_swap cannot be set and will be -1 afterwards.
-    - memory_swap_2 is not changed or memory_swap_2.docker_container.HostConfig.MemorySwap == -1
+    - memory_swap_2 is not changed or memory_swap_2.container.HostConfig.MemorySwap == -1
     - memory_swap_3 is changed
 
 - debug: var=memory_swap_1
@@ -2780,7 +2780,7 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    pid_mode: "container:{{ pid_mode_helper.docker_container.Id }}"
+    pid_mode: "container:{{ pid_mode_helper.container.Id }}"
   register: pid_mode_1
   ignore_errors: yes
   # docker-py < 2.0 does not support "arbitrary" pid_mode values
@@ -3103,9 +3103,9 @@
     - recreate_2 is changed
     - recreate_3 is changed
     - recreate_4 is changed
-    - recreate_1.docker_container.Id != recreate_2.docker_container.Id
-    - recreate_2.docker_container.Id == recreate_3.docker_container.Id
-    - recreate_3.docker_container.Id != recreate_4.docker_container.Id
+    - recreate_1.container.Id != recreate_2.container.Id
+    - recreate_2.container.Id == recreate_3.container.Id
+    - recreate_3.container.Id != recreate_4.container.Id
 
 ####################################################################
 ## restart #########################################################
@@ -3144,7 +3144,7 @@
     that:
     - restart_1 is changed
     - restart_2 is changed
-    - restart_1.docker_container.Id == restart_2.docker_container.Id
+    - restart_1.container.Id == restart_2.container.Id
 
 ####################################################################
 ## restart_policy ##################################################

--- a/test/integration/targets/docker_container_facts/tasks/main.yml
+++ b/test/integration/targets/docker_container_facts/tasks/main.yml
@@ -18,8 +18,8 @@
   - assert:
       that:
       - "not result.exists"
-      - "'docker_container' in result"
-      - "result.docker_container is none"
+      - "'container' in result"
+      - "result.container is none"
 
   - name: Make sure container exists
     docker_container:
@@ -54,9 +54,9 @@
   - assert:
       that:
       - result.exists
-      - "'docker_container' in result"
-      - "result.docker_container"
-      - "result.docker_container == docker_inspect_result[0]"
+      - "'container' in result"
+      - "result.container"
+      - "result.container == docker_inspect_result[0]"
 
   when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
 

--- a/test/integration/targets/docker_host_facts/tasks/test_host_facts.yml
+++ b/test/integration/targets/docker_host_facts/tasks/test_host_facts.yml
@@ -15,12 +15,12 @@
   - name: assert reading docker host facts when docker is running
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage is not defined'
 
 # Container and volume are created so that all lists are non-empty:
 # * container and volume lists are non-emtpy because of the created objects;
@@ -55,13 +55,13 @@
   - name: assert reading docker host facts when docker is running and list containers
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage is not defined'
-         - 'output.docker_containers_list[0].Image is string'
-         - 'output.docker_containers_list[0].ImageID is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.networks is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage is not defined'
+         - 'output.containers[0].Image is string'
+         - 'output.containers[0].ImageID is not defined'
 
   - name: Get info on Docker host and list containers with verbose output
     docker_host_facts:
@@ -72,13 +72,13 @@
   - name: assert reading docker host facts when docker is running and list containers with verbose output
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage is not defined'
-         - 'output.docker_containers_list[0].Image is string'
-         - 'output.docker_containers_list[0].ImageID is string'
+         - 'output.host_facts.Name is string'
+         - 'output.networks is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage is not defined'
+         - 'output.containers[0].Image is string'
+         - 'output.containers[0].ImageID is string'
 
   - name: Get info on Docker host and list images
     docker_host_facts:
@@ -88,13 +88,13 @@
   - name: assert reading docker host facts when docker is running and list images
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list[0].Id is string'
-         - 'output.docker_images_list[0].ParentId is not defined'
-         - 'output.docker_disk_usage is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images[0].Id is string'
+         - 'output.images[0].ParentId is not defined'
+         - 'output.disk_usage is not defined'
 
   - name: Get info on Docker host and list images with verbose output
     docker_host_facts:
@@ -105,13 +105,13 @@
   - name: assert reading docker host facts when docker is running and list images with verbose output
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list[0].Id is string'
-         - 'output.docker_images_list[0].ParentId is string'
-         - 'output.docker_disk_usage is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images[0].Id is string'
+         - 'output.images[0].ParentId is string'
+         - 'output.disk_usage is not defined'
 
   - name: Get info on Docker host and list networks
     docker_host_facts:
@@ -121,13 +121,13 @@
   - name: assert reading docker host facts when docker is running and list networks
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list[0].Id is string'
-         - 'output.docker_networks_list[0].Created is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks[0].Id is string'
+         - 'output.networks[0].Created is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage is not defined'
 
   - name: Get info on Docker host and list networks with verbose output
     docker_host_facts:
@@ -138,13 +138,13 @@
   - name: assert reading docker host facts when docker is running and list networks with verbose output
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list[0].Id is string'
-         - 'output.docker_networks_list[0].Created is string'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks[0].Id is string'
+         - 'output.networks[0].Created is string'
+         - 'output.volumes is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage is not defined'
 
   - name: Get info on Docker host and list volumes
     docker_host_facts:
@@ -154,13 +154,13 @@
   - name: assert reading docker host facts when docker is running and list volumes
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list[0].Name is string'
-         - 'output.docker_volumes_list[0].Mountpoint is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks is not defined'
+         - 'output.volumes[0].Name is string'
+         - 'output.volumes[0].Mountpoint is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage is not defined'
 
   - name: Get info on Docker host and list volumes with verbose output
     docker_host_facts:
@@ -171,13 +171,13 @@
   - name: assert reading docker host facts when docker is running and list volumes with verbose output
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list[0].Name is string'
-         - 'output.docker_volumes_list[0].Mountpoint is string'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks is not defined'
+         - 'output.volumes[0].Name is string'
+         - 'output.volumes[0].Mountpoint is string'
+         - 'output.images is not defined'
+         - 'output.disk_usage is not defined'
 
   - name: Get info on Docker host and get disk usage
     docker_host_facts:
@@ -187,13 +187,13 @@
   - name: assert reading docker host facts when docker is running and get disk usage
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage.LayersSize is number'
-         - 'output.docker_disk_usage.BuilderSize is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage.LayersSize is number'
+         - 'output.disk_usage.BuilderSize is not defined'
 
   - name: Get info on Docker host and get disk usage with verbose output
     docker_host_facts:
@@ -204,13 +204,13 @@
   - name: assert reading docker host facts when docker is running and get disk usage with verbose output
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list is not defined'
-         - 'output.docker_networks_list is not defined'
-         - 'output.docker_volumes_list is not defined'
-         - 'output.docker_images_list is not defined'
-         - 'output.docker_disk_usage.LayersSize is number'
-         - 'output.docker_disk_usage.BuilderSize is number'
+         - 'output.host_facts.Name is string'
+         - 'output.containers is not defined'
+         - 'output.networks is not defined'
+         - 'output.volumes is not defined'
+         - 'output.images is not defined'
+         - 'output.disk_usage.LayersSize is number'
+         - 'output.disk_usage.BuilderSize is number'
 
   - name: Get info on Docker host, disk usage and get all lists together
     docker_host_facts:
@@ -224,17 +224,17 @@
   - name: assert reading docker host facts when docker is running, disk usage and get lists together
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list[0].Image is string'
-         - 'output.docker_containers_list[0].ImageID is not defined'
-         - 'output.docker_networks_list[0].Id is string'
-         - 'output.docker_networks_list[0].Created is not defined'
-         - 'output.docker_volumes_list[0].Name is string'
-         - 'output.docker_volumes_list[0].Mountpoint is not defined'
-         - 'output.docker_images_list[0].Id is string'
-         - 'output.docker_images_list[0].ParentId is not defined'
-         - 'output.docker_disk_usage.LayersSize is number'
-         - 'output.docker_disk_usage.BuilderSize is not defined'
+         - 'output.host_facts.Name is string'
+         - 'output.containers[0].Image is string'
+         - 'output.containers[0].ImageID is not defined'
+         - 'output.networks[0].Id is string'
+         - 'output.networks[0].Created is not defined'
+         - 'output.volumes[0].Name is string'
+         - 'output.volumes[0].Mountpoint is not defined'
+         - 'output.images[0].Id is string'
+         - 'output.images[0].ParentId is not defined'
+         - 'output.disk_usage.LayersSize is number'
+         - 'output.disk_usage.BuilderSize is not defined'
 
   - name: Get info on Docker host, disk usage and get all lists together with verbose output
     docker_host_facts:
@@ -249,17 +249,17 @@
   - name: assert reading docker host facts when docker is running and get disk usage with verbose output
     assert:
       that:
-         - 'output.docker_host_facts.Name is string'
-         - 'output.docker_containers_list[0].Image is string'
-         - 'output.docker_containers_list[0].ImageID is string'
-         - 'output.docker_networks_list[0].Id is string'
-         - 'output.docker_networks_list[0].Created is string'
-         - 'output.docker_volumes_list[0].Name is string'
-         - 'output.docker_volumes_list[0].Mountpoint is string'
-         - 'output.docker_images_list[0].Id is string'
-         - 'output.docker_images_list[0].ParentId is string'
-         - 'output.docker_disk_usage.LayersSize is number'
-         - 'output.docker_disk_usage.BuilderSize is number'
+         - 'output.host_facts.Name is string'
+         - 'output.containers[0].Image is string'
+         - 'output.containers[0].ImageID is string'
+         - 'output.networks[0].Id is string'
+         - 'output.networks[0].Created is string'
+         - 'output.volumes[0].Name is string'
+         - 'output.volumes[0].Mountpoint is string'
+         - 'output.images[0].Id is string'
+         - 'output.images[0].ParentId is string'
+         - 'output.disk_usage.LayersSize is number'
+         - 'output.disk_usage.BuilderSize is number'
 
   always:
   - name: Delete container

--- a/test/integration/targets/docker_network_facts/tasks/main.yml
+++ b/test/integration/targets/docker_network_facts/tasks/main.yml
@@ -18,8 +18,8 @@
   - assert:
       that:
       - "not result.exists"
-      - "'docker_network' in result"
-      - "result.docker_network is none"
+      - "'network' in result"
+      - "result.network is none"
 
   - name: Make sure network exists
     docker_network:
@@ -50,9 +50,9 @@
   - assert:
       that:
       - result.exists
-      - "'docker_network' in result"
-      - "result.docker_network"
-      - "result.docker_network == docker_inspect_result[0]"
+      - "'network' in result"
+      - "result.network"
+      - "result.network == docker_inspect_result[0]"
 
   when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.21', '>=')
 

--- a/test/integration/targets/docker_node_facts/tasks/test_node_facts.yml
+++ b/test/integration/targets/docker_node_facts/tasks/test_node_facts.yml
@@ -36,8 +36,8 @@
   - name: assert reading docker swarm node facts
     assert:
       that:
-         - 'output.nodes_facts | length > 0'
-         - 'output.nodes_facts[0].ID is string'
+         - 'output.nodes | length > 0'
+         - 'output.nodes[0].ID is string'
 
   - name: Try to get docker_node_facts using the self parameter
     docker_node_facts:
@@ -47,12 +47,12 @@
   - name: assert reading swarm facts with list of nodes option
     assert:
       that:
-         - 'output.nodes_facts | length == 1'
-         - 'output.nodes_facts[0].ID is string'
+         - 'output.nodes | length == 1'
+         - 'output.nodes[0].ID is string'
 
   - name: Get local docker node name
     set_fact:
-      localnodename:  "{{ output.nodes_facts[0].Description.Hostname }}"
+      localnodename:  "{{ output.nodes[0].Description.Hostname }}"
 
 
   - name: Try to get docker_node_facts using the local node name as parameter
@@ -63,8 +63,8 @@
   - name: assert reading reading swarm facts and using node filter (random node name)
     assert:
       that:
-         - 'output.nodes_facts | length == 1'
-         - 'output.nodes_facts[0].ID is string'
+         - 'output.nodes | length == 1'
+         - 'output.nodes[0].ID is string'
 
   - name: Create random name
     set_fact:
@@ -78,7 +78,7 @@
   - name: assert reading reading swarm facts and using node filter (random node name)
     assert:
       that:
-         - 'output.nodes_facts | length == 0'
+         - 'output.nodes | length == 0'
 
   always:
   - name: Cleanup

--- a/test/integration/targets/docker_prune/tasks/main.yml
+++ b/test/integration/targets/docker_prune/tasks/main.yml
@@ -35,14 +35,14 @@
   - assert:
       that:
       # containers
-      - container.docker_container.Id in result.containers
+      - container.container.Id in result.containers
       - "'containers_space_reclaimed' in result"
       # images
       - "'images_space_reclaimed' in result"
       # networks
-      - network.docker_network.Name in result.networks
+      - network.network.Name in result.networks
       # volumes
-      - volume.docker_volume.Name in result.volumes
+      - volume.volume.Name in result.volumes
       - "'volumes_space_reclaimed' in result"
       # builder_cache
       - "'builder_cache_space_reclaimed' in result"

--- a/test/integration/targets/docker_stack/tasks/test_stack.yml
+++ b/test/integration/targets/docker_stack/tasks/test_stack.yml
@@ -80,7 +80,7 @@
   #  assert:
   #    that:
   #    - output is changed
-  #    - output.docker_stack_spec_diff == stack_update_expected_diff
+  #    - output.stack_spec_diff == stack_update_expected_diff
 
   - name: Delete stack
     register: output

--- a/test/integration/targets/docker_swarm_facts/tasks/test_swarm_facts.yml
+++ b/test/integration/targets/docker_swarm_facts/tasks/test_swarm_facts.yml
@@ -39,9 +39,9 @@
   - name: assert creding docker swarm facts
     assert:
       that:
-         - 'output.docker_swarm_facts.JoinTokens.Manager'
-         - 'output.docker_swarm_facts.JoinTokens.Worker'
-         - 'output.docker_swarm_facts.ID'
+         - 'output.swarm_facts.JoinTokens.Manager'
+         - 'output.swarm_facts.JoinTokens.Worker'
+         - 'output.swarm_facts.ID'
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
@@ -54,17 +54,17 @@
   - name: assert reding swarm facts with list of nodes option
     assert:
       that:
-         - 'output.docker_swarm_facts.JoinTokens.Manager'
-         - 'output.docker_swarm_facts.JoinTokens.Worker'
-         - 'output.docker_swarm_facts.ID'
-         - 'output.docker_nodes_list[0].ID is string'
+         - 'output.swarm_facts.JoinTokens.Manager'
+         - 'output.swarm_facts.JoinTokens.Worker'
+         - 'output.swarm_facts.ID'
+         - 'output.nodes[0].ID is string'
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
 
   - name: Get local docker node name
     set_fact:
-      localnodename:  "{{ output.docker_nodes_list[0].Hostname }}"
+      localnodename:  "{{ output.nodes[0].Hostname }}"
 
 
   - name: Try to get docker_swarm_facts and verbose list of nodes when docker is running in swarm mode and as manager
@@ -76,11 +76,11 @@
   - name: assert reading swarm facts with list of nodes and versbose output options
     assert:
       that:
-         - 'output.docker_swarm_facts.JoinTokens.Manager'
-         - 'output.docker_swarm_facts.JoinTokens.Worker'
-         - 'output.docker_swarm_facts.ID'
-         - 'output.docker_nodes_list[0].ID is string'
-         - 'output.docker_nodes_list[0].CreatedAt'
+         - 'output.swarm_facts.JoinTokens.Manager'
+         - 'output.swarm_facts.JoinTokens.Worker'
+         - 'output.swarm_facts.ID'
+         - 'output.nodes[0].ID is string'
+         - 'output.nodes[0].CreatedAt'
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
@@ -95,10 +95,10 @@
   - name: assert reading reading swarm facts and using node filter (random node name)
     assert:
       that:
-         - 'output.docker_swarm_facts.JoinTokens.Manager'
-         - 'output.docker_swarm_facts.JoinTokens.Worker'
-         - 'output.docker_swarm_facts.ID'
-         - 'output.docker_nodes_list | length == 1'
+         - 'output.swarm_facts.JoinTokens.Manager'
+         - 'output.swarm_facts.JoinTokens.Worker'
+         - 'output.swarm_facts.ID'
+         - 'output.nodes | length == 1'
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
@@ -117,10 +117,10 @@
   - name: assert reading reading swarm facts and using node filter (random node name)
     assert:
       that:
-         - 'output.docker_swarm_facts.JoinTokens.Manager'
-         - 'output.docker_swarm_facts.JoinTokens.Worker'
-         - 'output.docker_swarm_facts.ID'
-         - 'output.docker_nodes_list | length == 0'
+         - 'output.swarm_facts.JoinTokens.Manager'
+         - 'output.swarm_facts.JoinTokens.Worker'
+         - 'output.swarm_facts.ID'
+         - 'output.nodes | length == 0'
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'

--- a/test/integration/targets/docker_volume_facts/tasks/main.yml
+++ b/test/integration/targets/docker_volume_facts/tasks/main.yml
@@ -17,8 +17,8 @@
   - assert:
       that:
       - "not result.exists"
-      - "'docker_volume' in result"
-      - "result.docker_volume is none"
+      - "'volume' in result"
+      - "result.volume is none"
 
   - name: Make sure volume exists
     docker_volume:
@@ -47,9 +47,9 @@
   - assert:
       that:
       - result.exists
-      - "'docker_volume' in result"
-      - "result.docker_volume"
-      - "result.docker_volume == docker_volume_inspect_result[0]"
+      - "'volume' in result"
+      - "result.volume"
+      - "result.volume == docker_volume_inspect_result[0]"
 
   # Requirements for docker_volume
   when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.24', '>=')


### PR DESCRIPTION
##### SUMMARY
As discussed [here](https://github.com/ansible/ansible/pull/50622#discussion_r254968430), the return values of `docker_*_facts` could be much shorter. In fact, for the only docker _facts module available in 2.7 (docker_image_facts), that already was the case.

I didn't adjust docker_node_facts, since there's already a major overhaul PR around #51701 which would clash.

All modified modules are only added for Ansible 2.8, thus no changelog fragment is necessary.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
docker_container_facts
docker_host_facts
docker_network_facts
docker_node_facts
docker_swarm_facts
docker_volume_facts
