### PR TITLE
Allow users to use unsafe keyed group names

### DIFF
--- a/changelogs/fragments/51958-allow-unsafe-names-in-keyed-group-entry.yaml
+++ b/changelogs/fragments/51958-allow-unsafe-names-in-keyed-group-entry.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- add keyed_groups option to use unsafe group names on a per-entry basis

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -399,6 +399,7 @@ class Constructable(object):
                     if key:
                         prefix = keyed.get('prefix', '')
                         sep = keyed.get('separator', '_')
+                        unsafe = keyed.get('unsafe', False)
                         raw_parent_name = keyed.get('parent_group', None)
 
                         new_raw_group_names = []
@@ -415,12 +416,18 @@ class Constructable(object):
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
 
                         for bare_name in new_raw_group_names:
-                            gname = to_safe_group_name('%s%s%s' % (prefix, sep, bare_name))
+                            if unsafe:
+                                gname = '%s%s%s' % (prefix, sep, bare_name)
+                            else:
+                                gname = to_safe_group_name('%s%s%s' % (prefix, sep, bare_name))
                             self.inventory.add_group(gname)
                             self.inventory.add_child(gname, host)
 
                             if raw_parent_name:
-                                parent_name = to_safe_group_name(raw_parent_name)
+                                if unsafe:
+                                    parent_name = raw_parent_name
+                                else:
+                                    parent_name = to_safe_group_name(raw_parent_name)
                                 self.inventory.add_group(parent_name)
                                 self.inventory.add_child(parent_name, gname)
 

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -63,6 +63,13 @@ EXAMPLES = r'''
           separator: ""
           key: ec2_region
 
+        # this creates a group per ec2 region and preserves the original syntax like "us-west-1"
+        # only works if setting TRANSFORM_INVALID_GROUP_CHARS is false
+        - prefix: ""
+          separator: ""
+          key: ec2_region
+          unsafe: true
+
         # this creates a common parent group for all ec2 availability zones
         - key: ec2_placement
           parent_group: all_ec2_zones

--- a/test/units/plugins/inventory/test_constructed.py
+++ b/test/units/plugins/inventory/test_constructed.py
@@ -78,6 +78,26 @@ def test_keyed_group_separator(inventory_module):
         assert group.hosts == [host]
 
 
+def test_keyed_group_unsafe_names(inventory_module):
+    inventory_module.inventory.add_host('foohost')
+    inventory_module.inventory.set_variable('foohost', 'region', 'japan-south-3')
+    host = inventory_module.inventory.get_host('foohost')
+    keyed_groups = [
+        {
+            'prefix': 'region',
+            'separator': '-',
+            'key': 'region',
+            'unsafe': True
+        }
+    ]
+    inventory_module._add_host_to_keyed_groups(
+        keyed_groups, host.vars, host.name, strict=False
+    )
+    assert 'region-japan-south-3' in inventory_module.inventory.groups
+    group = inventory_module.inventory.groups['region-japan-south-3']
+    assert group.hosts == [host]
+
+
 def test_keyed_parent_groups(inventory_module):
     inventory_module.inventory.add_host('web1')
     inventory_module.inventory.add_host('web2')


### PR DESCRIPTION
##### SUMMARY
Proposed patch to address https://github.com/ansible/ansible/issues/51844

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/azure_rm.py
lib/ansible/plugins/inventory/aws_ec2.py

Those are the ones of interest to me. We can change the docs in those places if desired, but keyed groups are a general functionality, and where the documentation for those lies is more murky.

##### ADDITIONAL INFORMATION
For manual testing, I built off the example given by @wenottingham in the issue

```paste below
plugin: aws_ec2
regions:
  - us-west-1
groups:
  ec2: true
keyed_groups:
  - prefix: ""
    separator: ""
    key: placement.region
  - prefix: "unsafe_region_"
    separator: ""
    key: placement.region
    unsafe: true
```

As expected with this patch, I obtain the group name `unsafe_region_us-west-1`.

I really don't care one way or the other about preserving the "safe" functionality in which this example produces the group name `us_west_1`, but I assume there is a reason it was done this way so I assume the sanitization logic has to be kept, and probably kept as the default. So that's what this seeks to do.