### PR TITLE
use default values if environment variables are undefined

### DIFF
--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -127,8 +127,8 @@ class LookupModule(LookupBase):
                 params = self.parse_params(term)
                 try:
                     url = os.environ['ANSIBLE_CONSUL_URL']
-                    validate_certs = os.environ['ANSIBLE_CONSUL_VALIDATE_CERTS'] or True
-                    client_cert = os.environ['ANSIBLE_CONSUL_CLIENT_CERT'] or None
+                    validate_certs = os.environ.get('ANSIBLE_CONSUL_VALIDATE_CERTS', True)
+                    client_cert = os.environ.get('ANSIBLE_CONSUL_CLIENT_CERT', None)
                     u = urlparse(url)
                     consul_api = consul.Consul(host=u.hostname, port=u.port, scheme=u.scheme, verify=validate_certs,
                                                cert=client_cert)


### PR DESCRIPTION
use the default values if ANSIBLE_CONSUL_URL is set, but ANSIBLE_CONSUL_VALIDATE_CERTS and ANSIBLE_CONSUL_CLIENT_CERT are undefined

##### SUMMARY
fix for issue #51960 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
consul_kv lookup plugin

##### ADDITIONAL INFORMATION

