### PR TITLE
Add TLSA to the list of allowed record types

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -71,6 +71,7 @@ options:
     - SOA
     - SPF
     - SRV
+    - TLSA
     - TXT
   ttl:
     description:
@@ -170,7 +171,7 @@ def main():
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent'], type='str'),
             name=dict(required=True, type='str'),
-            type=dict(required=True, type='str', choices=['A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS', 'PTR', 'SOA', 'SPF', 'SRV', 'TXT']),
+            type=dict(required=True, type='str', choices=['A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS', 'PTR', 'SOA', 'SPF', 'SRV', 'TLSA', 'TXT']),
             ttl=dict(type='int'),
             target=dict(type='list', elements='str'),
             managed_zone=dict(required=True),


### PR DESCRIPTION
##### SUMMARY
Currently TLSA is not in the list of allowed record types. There is no reason for this.

This pull request adds TLSA to the list of allowed record types.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_dns_resource_record_set

##### ADDITIONAL INFORMATION
The list of DNS types is missing some other types that may need to be allowed (such as DNSKEY or DS).
