### PR TITLE
Promote include_tasks/role and import_tasks/role to stableinterface

### DIFF
--- a/changelogs/fragments/include-import-promotion.yaml
+++ b/changelogs/fragments/include-import-promotion.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- include/import - Promote ``include_tasks``, ``import_tasks``, ``include_role``,
+  and ``import_role`` to ``stableinterface``

--- a/lib/ansible/modules/utilities/logic/import_role.py
+++ b/lib/ansible/modules/utilities/logic/import_role.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['preview'],
+    'status': ['stableinterface'],
     'supported_by': 'core'
 }
 

--- a/lib/ansible/modules/utilities/logic/import_tasks.py
+++ b/lib/ansible/modules/utilities/logic/import_tasks.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['preview'],
+    'status': ['stableinterface'],
     'supported_by': 'core'
 }
 

--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['preview'],
+    'status': ['stableinterface'],
     'supported_by': 'core'
 }
 

--- a/lib/ansible/modules/utilities/logic/include_tasks.py
+++ b/lib/ansible/modules/utilities/logic/include_tasks.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['preview'],
+    'status': ['stableinterface'],
     'supported_by': 'core'
 }
 


### PR DESCRIPTION
##### SUMMARY
Promote include_tasks/role and import_tasks/role to stableinterface for the 2.8 release.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/utilities/logic/include_tasks.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```