### PR TITLE
Retrieve SOA record using DNS zone instead of building it from record name

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -83,10 +83,8 @@ options:
   managed_zone:
     description:
     - Identifies the managed zone addressed by this request.
-    - Can be the managed zone name or id.
-    - 'This field represents a link to a ManagedZone resource in GCP. It can be specified
-      in two ways. First, you can place in the name of the resource here as a string
-      Alternatively, you can add `register: name-of-resource` to a gcp_dns_managed_zone
+    - 'This field represents a link to a ManagedZone resource in GCP.
+      You can add `register: name-of-resource` to a gcp_dns_managed_zone
       task and then set this managed_zone field to "{{ name-of-resource }}"'
     required: true
 extends_documentation_fragment: gcp
@@ -358,13 +356,11 @@ class SOAForwardable(object):
 
 
 def prefetch_soa_resource(module):
-    name = module.params['name'].split('.')[1:]
-
     resource = SOAForwardable(
         {
             'type': 'SOA',
             'managed_zone': module.params['managed_zone'],
-            'name': '.'.join(name),
+            'name': replace_resource_dict(module.params['managed_zone'], 'dnsName'),
             'project': module.params['project'],
             'scopes': module.params['scopes'],
             'service_account_file': module.params['service_account_file'],


### PR DESCRIPTION
##### SUMMARY
When a DNS record is updated using the gcp_dns_resource_record_set module, the SOA entry of the zone must be updated as well.

To retrieve the SOA record in the zone, the module makes a request to Google Cloud API asking for entries of type SOA and with a name built from the name of the record currently updated.

For example, is the user tries to update the record "www.example.com.", the module looks for a record of type SOA and with the name "example.com.".
```
name = module.params['name'].split('.')[1:]
```

However, a zone may contain subdomains that don't have their own SOA record. For example, in the same Google DNS managed zone, the user may want to update "sub.www.example.com." without having a SOA record for the subdomain "www.example.com.". The good SOA record to update is still "example.com.".

Currently, in this case, the module fails to retrieve the SOA record, and fails to operate.

With this fix, the SOA is retrieved from the dnsName attribute of the "managed_zone" parameter. This may not be accurate if there is actually a SOA record for the subdomain, but it always work.

This fix requires the "managed_zone" parameter to be a dictionary (a result from the module gcp_dns_managed_zone). The documentation mentions that it is possible to use a name or an id for the "managed_zone" parameter but it does not work so this fix won't break this feature.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_dns_resource_record_set
