### PR TITLE
Allow setting resource.RLIMIT_NOFILE in modules

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -13,18 +13,6 @@ ALLOW_WORLD_READABLE_TMPFILES:
   type: boolean
   yaml: {key: defaults.allow_world_readable_tmpfiles}
   version_added: "2.1"
-ANSIBALLZ_RLIMIT_NOFILE:
-  name: Adjust maximum file descriptor limit during Python module execution
-  description:
-  - Attempts to set RLIMIT_NOFILE to the specified value in the AnsiballZ wrapper (can speed up subprocess usage on
-    Python 2.x. See https://bugs.python.org/issue11284). Default value of 0 does not attempt to adjust existing system-defined limits.
-  default: 0
-  env:
-  - {name: ANSIBLE_ANSIBALLZ_RLIMIT_NOFILE}
-  ini:
-  - {key: ansiballz_rlimit_nofile, section: defaults}
-  vars:
-  - {name: ansible_ansiballz_rlimit_nofile}
 ANSIBLE_CONNECTION_PATH:
   name: Path of ansible-connection script
   default: null
@@ -1634,6 +1622,19 @@ PLUGIN_FILTERS_CFG:
   - key: plugin_filters_cfg
     section: defaults
   type: path
+PYTHON_MODULE_RLIMIT_NOFILE:
+  name: Adjust maximum file descriptor limit during Python module execution
+  description:
+  - Attempts to set RLIMIT_NOFILE to the specified value in the AnsiballZ wrapper (can speed up subprocess usage on
+    Python 2.x. See https://bugs.python.org/issue11284). Default value of 0 does not attempt to adjust existing system-defined limits.
+  default: 0
+  env:
+  - {name: ANSIBLE_PYTHON_MODULE_RLIMIT_NOFILE}
+  ini:
+  - {key: python_module_rlimit_nofile, section: defaults}
+  vars:
+  - {name: ansible_python_module_rlimit_nofile}
+  version_added: '2.8'
 RETRY_FILES_ENABLED:
   name: Retry files
   default: True

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1623,10 +1623,11 @@ PLUGIN_FILTERS_CFG:
     section: defaults
   type: path
 PYTHON_MODULE_RLIMIT_NOFILE:
-  name: Adjust maximum file descriptor limit during Python module execution
+  name: Adjust maximum file descriptor soft limit during Python module execution
   description:
-  - Attempts to set RLIMIT_NOFILE to the specified value in the AnsiballZ wrapper (can speed up subprocess usage on
-    Python 2.x. See https://bugs.python.org/issue11284). Default value of 0 does not attempt to adjust existing system-defined limits.
+  - Attempts to set RLIMIT_NOFILE soft limit to the specified value when executing Python modules (can speed up subprocess usage on
+    Python 2.x. See https://bugs.python.org/issue11284). The value will be limited by the existing hard limit. Default
+    value of 0 does not attempt to adjust existing system-defined limits.
   default: 0
   env:
   - {name: ANSIBLE_PYTHON_MODULE_RLIMIT_NOFILE}

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -13,6 +13,18 @@ ALLOW_WORLD_READABLE_TMPFILES:
   type: boolean
   yaml: {key: defaults.allow_world_readable_tmpfiles}
   version_added: "2.1"
+ANSIBALLZ_RLIMIT_NOFILE:
+  name: Adjust maximum file descriptor limit during Python module execution
+  description:
+  - Attempts to set RLIMIT_NOFILE to the specified value in the AnsiballZ wrapper (can speed up subprocess usage on
+    Python 2.x. See https://bugs.python.org/issue11284). Default value of 0 does not attempt to adjust existing system-defined limits.
+  default: 0
+  env:
+  - {name: ANSIBLE_ANSIBALLZ_RLIMIT_NOFILE}
+  ini:
+  - {key: ansiballz_rlimit_nofile, section: defaults}
+  vars:
+  - {name: ansible_ansiballz_rlimit_nofile}
 ANSIBLE_CONNECTION_PATH:
   name: Path of ansible-connection script
   default: null

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -356,7 +356,7 @@ ANSIBALLZ_RLIMIT_TEMPLATE = '''
 
     existing_soft, existing_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
 
-    # adjust both limits subject to existing hard limit
+    # adjust soft limit subject to existing hard limit
     requested_limit = min(existing_hard, %(rlimit_nofile)d)
     try:
         resource.setrlimit(resource.RLIMIT_NOFILE, (requested_limit, existing_hard))
@@ -781,7 +781,10 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         interpreter = u"'{0}'".format(u"', '".join(interpreter_parts))
 
         # FUTURE: the module cache entry should be invalidated if we got this value from a host-dependent source
-        rlimit_nofile = int(C.config.get_config_value('PYTHON_MODULE_RLIMIT_NOFILE', variables=task_vars))
+        rlimit_nofile = C.config.get_config_value('PYTHON_MODULE_RLIMIT_NOFILE', variables=task_vars)
+
+        if not isinstance(rlimit_nofile, int):
+            rlimit_nofile = int(templar.template(rlimit_nofile))
 
         if rlimit_nofile:
             rlimit = ANSIBALLZ_RLIMIT_TEMPLATE % dict(

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -94,6 +94,7 @@ _ANSIBALLZ_WRAPPER = True # For test-module script to tell this is a ANSIBALLZ_W
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 def _ansiballz_main():
+%(rlimit)s
     import os
     import os.path
     import sys
@@ -348,6 +349,12 @@ ANSIBALLZ_COVERAGE_TEMPLATE = '''
         atexit.register(atexit_coverage)
 
         cov.start()
+'''
+
+ANSIBALLZ_RLIMIT_TEMPLATE = '''
+    import resource
+
+    resource.setrlimit(resource.RLIMIT_NOFILE, (%(rlimit_nofile)d, %(rlimit_nofile)d))
 '''
 
 
@@ -764,6 +771,15 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         interpreter_parts = interpreter.split(u' ')
         interpreter = u"'{0}'".format(u"', '".join(interpreter_parts))
 
+        rlimit_nofile = int(os.environ.get('_ANSIBLE_RLIMIT_NOFILE', '0'))
+
+        if rlimit_nofile:
+            rlimit = ANSIBALLZ_RLIMIT_TEMPLATE % dict(
+                rlimit_nofile=rlimit_nofile,
+            )
+        else:
+            rlimit = ''
+
         coverage_config = os.environ.get('_ANSIBLE_COVERAGE_CONFIG')
 
         if coverage_config:
@@ -791,6 +807,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
             minute=now.minute,
             second=now.second,
             coverage=coverage,
+            rlimit=rlimit,
         )))
         b_module_data = output.getvalue()
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -359,11 +359,11 @@ ANSIBALLZ_RLIMIT_TEMPLATE = '''
     # adjust both limits subject to existing hard limit
     requested_limit = min(existing_hard, %(rlimit_nofile)d)
     try:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (requested_limit, requested_limit))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (requested_limit, existing_hard))
     except ValueError:
         # some platforms (eg macOS) lie about their hard limit; try staying within the existing soft limit instead
         requested_limit = min(existing_soft, %(rlimit_nofile)d)
-        resource.setrlimit(resource.RLIMIT_NOFILE, (requested_limit, requested_limit))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (requested_limit, existing_hard))
 '''
 
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -353,9 +353,9 @@ ANSIBALLZ_COVERAGE_TEMPLATE = '''
 
 ANSIBALLZ_RLIMIT_TEMPLATE = '''
     import resource
-    
+
     existing_soft, existing_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    
+
     # adjust both limits subject to existing hard limit
     requested_limit = min(existing_hard, %(rlimit_nofile)d)
     try:
@@ -781,7 +781,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         interpreter = u"'{0}'".format(u"', '".join(interpreter_parts))
 
         # FUTURE: the module cache entry should be invalidated if we got this value from a host-dependent source
-        rlimit_nofile = int(C.config.get_config_value('ANSIBALLZ_RLIMIT_NOFILE', variables=task_vars))
+        rlimit_nofile = int(C.config.get_config_value('PYTHON_MODULE_RLIMIT_NOFILE', variables=task_vars))
 
         if rlimit_nofile:
             rlimit = ANSIBALLZ_RLIMIT_TEMPLATE % dict(

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -357,13 +357,14 @@ ANSIBALLZ_RLIMIT_TEMPLATE = '''
     existing_soft, existing_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
 
     # adjust soft limit subject to existing hard limit
-    requested_limit = min(existing_hard, %(rlimit_nofile)d)
-    try:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (requested_limit, existing_hard))
-    except ValueError:
-        # some platforms (eg macOS) lie about their hard limit; try staying within the existing soft limit instead
-        requested_limit = min(existing_soft, %(rlimit_nofile)d)
-        resource.setrlimit(resource.RLIMIT_NOFILE, (requested_limit, existing_hard))
+    requested_soft = min(existing_hard, %(rlimit_nofile)d)
+
+    if requested_soft != existing_soft:
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (requested_soft, existing_hard))
+        except ValueError:
+            # some platforms (eg macOS) lie about their hard limit
+            pass
 '''
 
 

--- a/test/integration/targets/ansiballz_python/aliases
+++ b/test/integration/targets/ansiballz_python/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group1

--- a/test/integration/targets/ansiballz_python/library/check_rlimit_and_maxfd.py
+++ b/test/integration/targets/ansiballz_python/library/check_rlimit_and_maxfd.py
@@ -18,12 +18,13 @@ def main():
     )
 
     rlimit_nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
+
     try:
         maxfd = subprocess.MAXFD
     except AttributeError:
         maxfd = -1
 
-    module.exit_json(rlimit_nofile=rlimit_nofile, maxfd=maxfd)
+    module.exit_json(rlimit_nofile=rlimit_nofile, maxfd=maxfd, infinity=resource.RLIM_INFINITY)
 
 
 if __name__ == '__main__':

--- a/test/integration/targets/ansiballz_python/library/check_rlimit_and_maxfd.py
+++ b/test/integration/targets/ansiballz_python/library/check_rlimit_and_maxfd.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+#
+# Copyright 2018 Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import resource
+import subprocess
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict()
+    )
+
+    rlimit_nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
+    try:
+        maxfd = subprocess.MAXFD
+    except AttributeError:
+        maxfd = -1
+
+    module.exit_json(rlimit_nofile=rlimit_nofile, maxfd=maxfd)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansiballz_python/tasks/main.yml
+++ b/test/integration/targets/ansiballz_python/tasks/main.yml
@@ -1,0 +1,9 @@
+- check_rlimit_and_maxfd:
+  vars:
+    ansible_ansiballz_rlimit_nofile: 123
+  register: rlimit_return
+
+- assert:
+    that:
+    - rlimit_return.rlimit_nofile[0] <= 123
+    - rlimit_return.maxfd <= 123

--- a/test/integration/targets/ansiballz_python/tasks/main.yml
+++ b/test/integration/targets/ansiballz_python/tasks/main.yml
@@ -1,4 +1,5 @@
-- check_rlimit_and_maxfd:
+- name: set a very low file descriptor limit
+  check_rlimit_and_maxfd:
   vars:
     ansible_python_module_rlimit_nofile: 123
   register: rlimit_return
@@ -7,3 +8,16 @@
     that:
     - rlimit_return.rlimit_nofile[0] <= 123
     - rlimit_return.maxfd <= 123
+
+- debug: msg='{{ rlimit_return.rlimit_nofile[1] + 1000 }}'
+
+- name: attempt to set a value higher than existing hard limit
+  check_rlimit_and_maxfd:
+  vars:
+    ansible_python_module_rlimit_nofile: '{{ rlimit_return.rlimit_nofile[1] + 1000 }}'
+  register: rlimit_limited_return
+
+- assert:
+    that:
+    # ensure that both limits are equal to the previously found hard limit
+    - rlimit_limited_return.rlimit_nofile[0] == rlimit_limited_return.rlimit_nofile[1] == rlimit_return.rlimit_nofile[1]

--- a/test/integration/targets/ansiballz_python/tasks/main.yml
+++ b/test/integration/targets/ansiballz_python/tasks/main.yml
@@ -1,23 +1,56 @@
-- name: set a very low file descriptor limit
+- name: get the ansible-test imposed file descriptor limit
+  check_rlimit_and_maxfd:
+  register: rlimit_limited_return
+
+- name: get existing file descriptor limit
+  check_rlimit_and_maxfd:
+  register: rlimit_original_return
+  vars:
+    ansible_python_module_rlimit_nofile: 0  # ignore limit set by ansible-test
+
+- name: attempt to set a value lower than existing soft limit
   check_rlimit_and_maxfd:
   vars:
-    ansible_python_module_rlimit_nofile: 123
-  register: rlimit_return
+    ansible_python_module_rlimit_nofile: '{{ rlimit_original_return.rlimit_nofile[0] - 1 }}'
+  register: rlimit_below_soft_return
 
-- assert:
-    that:
-    - rlimit_return.rlimit_nofile[0] <= 123
-    - rlimit_return.maxfd <= 123
+- name: attempt to set a value higher than existing soft limit
+  check_rlimit_and_maxfd:
+  vars:
+    ansible_python_module_rlimit_nofile: '{{ rlimit_original_return.rlimit_nofile[0] + 1 }}'
+  register: rlimit_above_soft_return
 
-- debug: msg='{{ rlimit_return.rlimit_nofile[1] + 1000 }}'
+- name: attempt to set a value lower than existing hard limit
+  check_rlimit_and_maxfd:
+  vars:
+    ansible_python_module_rlimit_nofile: '{{ rlimit_original_return.rlimit_nofile[1] - 1 }}'
+  register: rlimit_below_hard_return
 
 - name: attempt to set a value higher than existing hard limit
   check_rlimit_and_maxfd:
   vars:
-    ansible_python_module_rlimit_nofile: '{{ rlimit_return.rlimit_nofile[1] + 1000 }}'
-  register: rlimit_limited_return
+    ansible_python_module_rlimit_nofile: '{{ rlimit_original_return.rlimit_nofile[1] + 1 }}'
+  register: rlimit_above_hard_return
 
 - assert:
     that:
-    # ensure that both limits are equal to the previously found hard limit
-    - rlimit_limited_return.rlimit_nofile[0] == rlimit_limited_return.rlimit_nofile[1] == rlimit_return.rlimit_nofile[1]
+      # make sure ansible-test was able to set the limit unless it exceeds the hard limit or the value is lower on macOS
+      - rlimit_limited_return.rlimit_nofile[0] == 1024 or rlimit_original_return.rlimit_nofile[1] < 1024 or (rlimit_limited_return.rlimit_nofile[0] < 1024 and ansible_distribution == 'MacOSX')
+      # make sure that maxfd matches the soft limit on Python 2.x (-1 on Python 3.x)
+      - rlimit_limited_return.maxfd == rlimit_limited_return.rlimit_nofile[0] or rlimit_limited_return.maxfd == -1
+
+      # we should always be able to set the limit lower than the existing soft limit
+      - rlimit_below_soft_return.rlimit_nofile[0] == rlimit_original_return.rlimit_nofile[0] - 1
+      # the hard limit should not have changed
+      - rlimit_below_soft_return.rlimit_nofile[1] == rlimit_original_return.rlimit_nofile[1]
+      # lowering the limit should also lower the max file descriptors reported by Python 2.x (-1 on Python 3.x)
+      - rlimit_below_soft_return.maxfd == rlimit_original_return.rlimit_nofile[0] - 1 or rlimit_below_soft_return.maxfd == -1
+
+      # we should be able to set the limit higher than the existing soft limit if it does not exceed the hard limit (except on macOS)
+      - rlimit_above_soft_return.rlimit_nofile[0] == rlimit_original_return.rlimit_nofile[0] + 1 or rlimit_original_return.rlimit_nofile[0] == rlimit_original_return.rlimit_nofile[1] or ansible_distribution == 'MacOSX'
+
+      # we should be able to set the limit lower than the existing hard limit (except on macOS)
+      - rlimit_below_hard_return.rlimit_nofile[0] == rlimit_original_return.rlimit_nofile[1] - 1 or ansible_distribution == 'MacOSX'
+
+      # setting the limit higher than the existing hard limit should use the hard limit (except on macOS)
+      - rlimit_above_hard_return.rlimit_nofile[0] == rlimit_original_return.rlimit_nofile[1] or ansible_distribution == 'MacOSX'

--- a/test/integration/targets/ansiballz_python/tasks/main.yml
+++ b/test/integration/targets/ansiballz_python/tasks/main.yml
@@ -1,6 +1,6 @@
 - check_rlimit_and_maxfd:
   vars:
-    ansible_ansiballz_rlimit_nofile: 123
+    ansible_python_module_rlimit_nofile: 123
   register: rlimit_return
 
 - assert:

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 ansible --version
 ansible --help
 
-ansible testhost -i ../../inventory -m command -a "ulimit -n" "$@"
+ansible testhost -i ../../inventory -m shell -a "ulimit -n" "$@"
 
 ansible testhost -i ../../inventory -m ping  "$@"
 ansible testhost -i ../../inventory -m setup "$@"

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -5,6 +5,8 @@ set -eux -o pipefail
 ansible --version
 ansible --help
 
+ansible testhost -i ../../inventory -m command -a "ulimit -n" "$@"
+
 ansible testhost -i ../../inventory -m ping  "$@"
 ansible testhost -i ../../inventory -m setup "$@"
 

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -5,8 +5,6 @@ set -eux -o pipefail
 ansible --version
 ansible --help
 
-ansible testhost -i ../../inventory -m shell -a "ulimit -n" "$@"
-
 ansible testhost -i ../../inventory -m ping  "$@"
 ansible testhost -i ../../inventory -m setup "$@"
 

--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -40,7 +40,7 @@ def ansible_environment(args, color=True, ansible_config=None):
         raise ApplicationError('Configuration not found: %s' % ansible_config)
 
     ansible = dict(
-        _ANSIBLE_RLIMIT_NOFILE='1024',
+        ANSIBLE_ANSIBALLZ_RLIMIT_NOFILE='1024',
         ANSIBLE_FORCE_COLOR='%s' % 'true' if args.color and color else 'false',
         ANSIBLE_DEPRECATION_WARNINGS='false',
         ANSIBLE_HOST_KEY_CHECKING='false',

--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -40,7 +40,7 @@ def ansible_environment(args, color=True, ansible_config=None):
         raise ApplicationError('Configuration not found: %s' % ansible_config)
 
     ansible = dict(
-        ANSIBLE_ANSIBALLZ_RLIMIT_NOFILE='1024',
+        ANSIBLE_PYTHON_MODULE_RLIMIT_NOFILE='1024',
         ANSIBLE_FORCE_COLOR='%s' % 'true' if args.color and color else 'false',
         ANSIBLE_DEPRECATION_WARNINGS='false',
         ANSIBLE_HOST_KEY_CHECKING='false',

--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -40,6 +40,7 @@ def ansible_environment(args, color=True, ansible_config=None):
         raise ApplicationError('Configuration not found: %s' % ansible_config)
 
     ansible = dict(
+        _ANSIBLE_RLIMIT_NOFILE='1024',
         ANSIBLE_FORCE_COLOR='%s' % 'true' if args.color and color else 'false',
         ANSIBLE_DEPRECATION_WARNINGS='false',
         ANSIBLE_HOST_KEY_CHECKING='false',

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -111,6 +111,7 @@ class TestActionBase(unittest.TestCase):
         mock_module_loader.find_plugin.side_effect = mock_find_plugin
         mock_shared_obj_loader = MagicMock()
         mock_shared_obj_loader.module_loader = mock_module_loader
+        mock_templar = MagicMock()
 
         # we're using a real play context here
         play_context = PlayContext()
@@ -121,7 +122,7 @@ class TestActionBase(unittest.TestCase):
             connection=mock_connection,
             play_context=play_context,
             loader=fake_loader,
-            templar=None,
+            templar=mock_templar,
             shared_loader_obj=mock_shared_obj_loader,
         )
 


### PR DESCRIPTION
##### SUMMARY

Proof of concept for setting the `NOFILE` resource limit in modules using the AnsiballZ wrapper.

This is useful for lowering the `NOFILE` limit when using Python 2.x. Doing so improves the performance of `subprocess.Popen` with `close_fds=True`, which is the default setting for `run_command`:

https://github.com/ansible/ansible/blob/ad549e375a35fddf2675ff2b122e6f3119fb27e1/lib/ansible/module_utils/basic.py#L2648

Modules which make frequent calls to `run_command` will see improved performance as a result. The improvement can be significant for systems with a high `NOFILE` limit, thus a work-around is already in place in `ansible-test`:

https://github.com/ansible/ansible/blob/ad549e375a35fddf2675ff2b122e6f3119fb27e1/test/runner/injector/injector.py#L100

However, this issue is not limited to CI, so including this feature has two benefits:

1. Regular users can benefit from the performance improvement.
2. The `ansible_python_interpreter` injection in `ansible-test` could be removed.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

module_common.py

##### ADDITIONAL INFORMATION

Setting the limit must be done before `subprocess` is imported to allow for the new limit to be used in the current process. See the source for:

- [Python 2.6 /Lib/subprocess.py:424](https://github.com/python/cpython/blob/6c003210943fc91e5911bcbabe1fe4b0030cf38b/Lib/subprocess.py#L424)
- [Python 2.7 /Lib/subprocess.py:101](https://github.com/python/cpython/blob/8fe830d374da0855e0712160620dd61aa6519d14/Lib/subprocess.py#L101)

The source of the performance loss can be seen here:

- [Python 2.6 /Lib/subprocess.py:1012-1014](https://github.com/python/cpython/blob/6c003210943fc91e5911bcbabe1fe4b0030cf38b/Lib/subprocess.py#L1012-L1014)
- [Python 2.7 /Lib/subprocess.py:871-882](https://github.com/python/cpython/blob/8fe830d374da0855e0712160620dd61aa6519d14/Lib/subprocess.py#L871-L882)

The performance loss is not an issue on Python 3.x, but setting the limit can still be useful.

Attempting to set the soft limit or hard limit higher than the current hard limit will fail, as is [documented](https://docs.python.org/2/library/resource.html#resource.setrlimit). Unfortunately the hard limit cannot be trusted on some platforms, such as macOS. The hard limit may be reported as unlimited even though there is a limit.

For example, here is a 24K hard limit for a non-root user which is not reported:

```
>>> import resource
>>> resource.RLIM_INFINITY
9223372036854775807
>>> resource.getrlimit(resource.RLIMIT_NOFILE)
(7168, 9223372036854775807)
>>> resource.setrlimit(resource.RLIMIT_NOFILE, (24576, resource.RLIM_INFINITY))
>>> resource.getrlimit(resource.RLIMIT_NOFILE)
(24576, 9223372036854775807)
>>> resource.setrlimit(resource.RLIMIT_NOFILE, (24577, resource.RLIM_INFINITY))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: current limit exceeds maximum limit
```

The same test performed as root failed at 48K instead.
