### PR TITLE
make editor selection aware of VISUAL env variable

### DIFF
--- a/changelogs/fragments/vault-editor-env-fix.yml
+++ b/changelogs/fragments/vault-editor-env-fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vault - edit command reads editor from VISUAL env variable before EDITOR, finally defaulting to `vi' (https://github.com/ansible/ansible/pull/51991)

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1094,7 +1094,9 @@ class VaultEditor:
             os.chown(dest, prev.st_uid, prev.st_gid)
 
     def _editor_shell_command(self, filename):
-        env_editor = os.environ.get('EDITOR', 'vi')
+        env_editor = os.environ.get('VISUAL')
+        if not env_editor:
+            env_editor = os.environ.get('EDITOR', 'vi')
         editor = shlex.split(env_editor)
         editor.append(filename)
 


### PR DESCRIPTION
Vault editor should prefer editor set in VISUAL env variable and only then fallback to EDITOR.

##### SUMMARY
When ansible-vault command opens editor it first looks for editor set in EDITOR env variable and falls back to vi if EDITOR is not set.
This fixes it so that it first looks for editor in set in VISUAL env variable, then in EDITOR and finally falls back to vi.

For background info:
https://unix.stackexchange.com/questions/4859/visual-vs-editor-what-s-the-difference

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
parsing

##### ADDITIONAL INFORMATION
Following should open ansible vault file in emacs after the change.
```
VISUAL=emacs ansible-vault edit </path/to/vault/file>
```
