### PR TITLE
Fix: Yum module does not use proxy when username is not set #51548

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -703,7 +703,6 @@ class YumModule(YumDnf):
         # setting system proxy environment and saving old, if exists
         my = self.yum_base()
         namepass = ""
-        proxy_url = ""
         scheme = ["http", "https"]
         old_proxy_env = [os.getenv("http_proxy"), os.getenv("https_proxy")]
         try:
@@ -726,10 +725,7 @@ class YumModule(YumDnf):
                         )
                 else:
                     for item in scheme:
-                        os.environ[item + "_proxy"] = re.sub(
-                            r"(http://)",
-                            r"\g<1>", proxy_url
-                        )
+                        os.environ[item + "_proxy"] = my.conf.proxy
             yield
         except yum.Errors.YumBaseError:
             raise

--- a/test/integration/targets/yum/tasks/proxy.yml
+++ b/test/integration/targets/yum/tasks/proxy.yml
@@ -17,6 +17,9 @@
         line: "proxy=http://127.0.0.1:8888"
         state: present
 
+    - name: clear proxy logs
+      shell: ': > /var/log/tinyproxy/tinyproxy.log'
+
     - name: install ninvaders with unauthenticated proxy
       yum:
         name: 'https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
@@ -28,6 +31,9 @@
           - "yum_proxy_result.changed"
           - "'msg' in yum_proxy_result"
           - "'rc' in yum_proxy_result"
+
+    - name: check that it install via unauthenticated proxy
+      command: grep -q Request /var/log/tinyproxy/tinyproxy.log
 
     - name: uninstall ninvaders with unauthenticated proxy
       yum:
@@ -67,6 +73,9 @@
         line: "proxy=http://1testuser:1testpassword@127.0.0.1:8888"
         state: present
 
+    - name: clear proxy logs
+      shell: ': > /var/log/tinyproxy/tinyproxy.log'
+
     - name: install ninvaders with authenticated proxy
       yum:
         name: 'https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
@@ -78,6 +87,9 @@
           - "yum_proxy_result.changed"
           - "'msg' in yum_proxy_result"
           - "'rc' in yum_proxy_result"
+
+    - name: check that it install via authenticated proxy
+      command: grep -q Request /var/log/tinyproxy/tinyproxy.log
 
     - name: uninstall ninvaders with authenticated proxy
       yum:
@@ -108,6 +120,9 @@
         line: "proxy_password=1testpassword"
         state: present
 
+    - name: clear proxy logs
+      shell: ': > /var/log/tinyproxy/tinyproxy.log'
+
     - name: install ninvaders with proxy, proxy_username, and proxy_password config in yum.conf
       yum:
         name: 'https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
@@ -119,6 +134,9 @@
           - "yum_proxy_result.changed"
           - "'msg' in yum_proxy_result"
           - "'rc' in yum_proxy_result"
+
+    - name: check that it install via proxy with proxy_username, proxy_password config in yum.conf
+      command: grep -q Request /var/log/tinyproxy/tinyproxy.log
 
   always:
     #cleanup

--- a/test/integration/targets/yum/tasks/proxy.yml
+++ b/test/integration/targets/yum/tasks/proxy.yml
@@ -19,6 +19,9 @@
 
     - name: clear proxy logs
       shell: ': > /var/log/tinyproxy/tinyproxy.log'
+      changed_when: false
+      args:
+        executable: /usr/bin/bash
 
     - name: install ninvaders with unauthenticated proxy
       yum:
@@ -75,6 +78,9 @@
 
     - name: clear proxy logs
       shell: ': > /var/log/tinyproxy/tinyproxy.log'
+      changed_when: false
+      args:
+        executable: /usr/bin/bash
 
     - name: install ninvaders with authenticated proxy
       yum:
@@ -122,6 +128,9 @@
 
     - name: clear proxy logs
       shell: ': > /var/log/tinyproxy/tinyproxy.log'
+      changed_when: false
+      args:
+        executable: /usr/bin/bash
 
     - name: install ninvaders with proxy, proxy_username, and proxy_password config in yum.conf
       yum:


### PR DESCRIPTION
##### SUMMARY

#51548 is unresolved. fix it.

`proxy_url` is initialized by `proxy_url = ""`.

https://github.com/ansible/ansible/blob/2721ed260e57fddd0af373c9401d01763614465d/lib/ansible/modules/packaging/os/yum.py#L706

Therefore `proxy_url` is `""` in the following code. (when username is not set)

https://github.com/ansible/ansible/blob/2721ed260e57fddd0af373c9401d01763614465d/lib/ansible/modules/packaging/os/yum.py#L727-L732

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- yum
- tests
