### PR TITLE
apt_repository: Fix crash caused by cache.update() raising an IOError on timeout.

### DIFF
--- a/changelogs/fragments/51995-apt_repository-catch-IOError.yaml
+++ b/changelogs/fragments/51995-apt_repository-catch-IOError.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt_repository - Fix crash caused by ``cache.update()`` raising an ``IOError`` due to a timeout in ``apt update`` (https://github.com/ansible/ansible/issues/51995)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The call to `cache.update()` might raise an `IOError`, so we need to catch `IOError` as well as `OSError`.

I have also added code to clean up the mess when this error happens. Unfortunately there does not seem to be any way to run `apt update` in a "dry-run" mode, so the only way to test whether a repository url is valid is by adding it to `/etc/apt/sources.list.d`, attempting an `apt update`, and then removing it again afterwards if it fails.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51995

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/packaging/os/apt_repository.py

##### ADDITIONAL INFORMATION
The cause of the bug is that when `cache.update()` fails due to a timeout, it raise a `FetchFailedException`. But `FetchFailedException` inherits from `IOError`, not `OSError`, so it doesn't get caught.
