### PR TITLE
template: Warn about error_on_undefined_vars

### DIFF
--- a/changelogs/fragments/25563-template-warn_about_error_on_undefined.yaml
+++ b/changelogs/fragments/25563-template-warn_about_error_on_undefined.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- While templating user is warned about 'error_on_undefined_errors' set to False in order
+  to avoid unexpected behaviours (https://github.com/ansible/ansible/issues/25563)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -399,6 +399,11 @@ class Templar:
         if fail_on_undefined is None:
             fail_on_undefined = self._fail_on_undefined_errors
 
+        if not fail_on_undefined:
+            display.warning(msg="Raising an error on undefined variables is set to False."
+                                " This may result in unexpected behaviors while templating."
+                                " Please see documentation for 'error_on_undefined_vars'.")
+
         try:
             if convert_bare:
                 variable = self._convert_bare_variable(variable)
@@ -652,6 +657,11 @@ class Templar:
 
         if fail_on_undefined is None:
             fail_on_undefined = self._fail_on_undefined_errors
+
+        if not fail_on_undefined:
+            display.warning(msg="Raising an error on undefined variables is set to False."
+                                " This may result in unexpected behaviors while templating."
+                                " Please see documentation for 'error_on_undefined_vars'.")
 
         try:
             # allows template header overrides to change jinja2 options.


### PR DESCRIPTION
##### SUMMARY
Added a warning message to user stating that 'error_on_undefined_vars' is set to
False, which may result in unexpected behavior in templating.

Fixes: #25563

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/25563-template-warn_about_error_on_undefined.yaml
lib/ansible/template/__init__.py