### PR TITLE
Fix yaml indentation for from_yaml_all filter example 

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -69,9 +69,9 @@ for example::
   tasks:
     - shell: cat /some/path/to/multidoc-file.yaml
       register: result
-   - debug:
-       msg: '{{ item }}'
-    loop: '{{ result.stdout | from_yaml_all | list }}'
+    - debug:
+        msg: '{{ item }}'
+      loop: '{{ result.stdout | from_yaml_all | list }}'
 
 
 .. _forcing_variables_to_be_defined:


### PR DESCRIPTION
##### SUMMARY
Fix the yaml indentation for `from_yaml_all` filter example  in documentation:

https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#filters-for-formatting-data

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
documentation

##### ADDITIONAL INFORMATION