### PR TITLE
docsite: correct path, list requirements for testing module docs, etc.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_documentation.rst
+++ b/docs/docsite/rst/dev_guide/testing_documentation.rst
@@ -10,17 +10,43 @@ Before you submit a module for inclusion in the main Ansible repo, you must test
 
 To check the HTML output of your module documentation:
 
-#. Save your completed module file into the correct directory: ``lib/ansible/modules/$CATEGORY/my_code.py``.
-#. Move to the docsite directory: ``cd /path/to/ansible/docs/docsite/``.
-#. Run the command to build the docs for your module: ``MODULES=my_code make webdocs``.
-#. View the HTML page at ``file:///path/to/ansible/docs/docsite/_build/html/my_code_module.html``.
+#. Ensure working development environment.
+#. Ensure your module is in the correct directory.
+#. Build HTML pages: ``make webdocs``
+#. View the HTML page at ``file:///${ansibledevdir}/docs/docsite/_build/html/modules/${mymodule}_module.html``.
 
-To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=my_code,my_other_code make webdocs``.
+.. code-block:: bash
+
+   # If you don't already, ensure you are using your local checkout, e.g. in ~/ansible.repo
+   ansibledevdir=~/ansible.repo
+   git clone git@github.com:ansible/ansible.git ${ansibledevdir}
+   cd ${ansibledevdir}
+   # install required Python packages (drop '--user' in venv/virtualenv)
+   pip install --user -r requirements.txt
+   pip install --user -r docs/docsite/requirements.txt
+
+   mymodule=digital_ocean_droplet  # put YOUR module name here
+   CATEGORY=cloud/digital_ocean    # put YOUR category here
+   # develop $mymodule in ${ansibledevdir}/lib/ansible/modules/$CATEGORY/${mymodule}.py
+
+   # For running ansible-test end development versions of ansible, ansible-playbook etc.
+   # You may use your module with them too.
+   source ${ansibledevdir}/hacking/env-setup
+
+   # edit your module's DOCUMENTATION, EXAMPLES, RETURN values, then build HTML.
+   cd ${ansibledevdir}
+   MODULES=${mymodule} make webdocs
+
+   # Open $docURI in your browser
+   docURI=file:///${ansibledevdir}/docs/docsite/_build/html/modules/${mymodule}_module.html
+   echo $docURI
+
+To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=$mymodule,$mymodule2 make webdocs``.
 
 To ensure that your documentation matches your ``argument_spec``, run the ``validate-modules`` test.
 
 .. code-block:: bash
 
-   # If you don't already, ensure you are using your local checkout
-   source hacking/env-setup
-   ./test/sanity/validate-modules/validate-modules --arg-spec --warnings  lib/ansible/modules/$CATEGORY/my_code.py
+   cd ${ansibledevdir}
+   pip install --user -r test/runner/requirements/sanity.txt
+   ./test/sanity/validate-modules/validate-modules --arg-spec --warnings lib/ansible/modules/$CATEGORY/${mymodule}.py

--- a/docs/docsite/rst/dev_guide/testing_documentation.rst
+++ b/docs/docsite/rst/dev_guide/testing_documentation.rst
@@ -10,43 +10,27 @@ Before you submit a module for inclusion in the main Ansible repo, you must test
 
 To check the HTML output of your module documentation:
 
-#. Ensure working development environment.
-#. Ensure your module is in the correct directory.
-#. Build HTML pages: ``make webdocs``
-#. View the HTML page at ``file:///${ansibledevdir}/docs/docsite/_build/html/modules/${mymodule}_module.html``.
+#. Ensure working :ref:`development environment <environment_setup>`.
+#. Install required Python packages (drop '--user' in venv/virtualenv):
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   # If you don't already, ensure you are using your local checkout, e.g. in ~/ansible.repo
-   ansibledevdir=~/ansible.repo
-   git clone git@github.com:ansible/ansible.git ${ansibledevdir}
-   cd ${ansibledevdir}
-   # install required Python packages (drop '--user' in venv/virtualenv)
-   pip install --user -r requirements.txt
-   pip install --user -r docs/docsite/requirements.txt
+      pip install --user -r requirements.txt
+      pip install --user -r docs/docsite/requirements.txt
 
-   mymodule=digital_ocean_droplet  # put YOUR module name here
-   CATEGORY=cloud/digital_ocean    # put YOUR category here
-   # develop $mymodule in ${ansibledevdir}/lib/ansible/modules/$CATEGORY/${mymodule}.py
+#. Ensure your module is in the correct directory: ``lib/ansible/modules/$CATEGORY/mymodule.py``.
+#. Build HTML from your module documentation: ``MODULES=mymodule make webdocs``.
+#. To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=$mymodule,$mymodule2 make webdocs``.
+#. View the HTML page at ``file:///path/to/docs/docsite/_build/html/modules/mymodule_module.html``.
 
-   # For running ansible-test end development versions of ansible, ansible-playbook etc.
-   # You may use your module with them too.
-   source ${ansibledevdir}/hacking/env-setup
+To ensure that your module documentation matches your ``argument_spec``:
 
-   # edit your module's DOCUMENTATION, EXAMPLES, RETURN values, then build HTML.
-   cd ${ansibledevdir}
-   MODULES=${mymodule} make webdocs
+#. Install required Python packages (drop '--user' in venv/virtualenv):
 
-   # Open $docURI in your browser
-   docURI=file:///${ansibledevdir}/docs/docsite/_build/html/modules/${mymodule}_module.html
-   echo $docURI
+   .. code-block:: bash
 
-To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=$mymodule,$mymodule2 make webdocs``.
+      pip install --user -r test/runner/requirements/sanity.txt
 
-To ensure that your documentation matches your ``argument_spec``, run the ``validate-modules`` test.
+#. run the ``validate-modules`` test::
 
-.. code-block:: bash
-
-   cd ${ansibledevdir}
-   pip install --user -r test/runner/requirements/sanity.txt
-   ./test/sanity/validate-modules/validate-modules --arg-spec --warnings lib/ansible/modules/$CATEGORY/${mymodule}.py
+   ./test/sanity/validate-modules/validate-modules --arg-spec --warnings lib/ansible/modules/$CATEGORY/mymodule.py

--- a/docs/docsite/rst/dev_guide/testing_documentation.rst
+++ b/docs/docsite/rst/dev_guide/testing_documentation.rst
@@ -20,7 +20,7 @@ To check the HTML output of your module documentation:
 
 #. Ensure your module is in the correct directory: ``lib/ansible/modules/$CATEGORY/mymodule.py``.
 #. Build HTML from your module documentation: ``MODULES=mymodule make webdocs``.
-#. To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=$mymodule,$mymodule2 make webdocs``.
+#. To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=mymodule,mymodule2 make webdocs``.
 #. View the HTML page at ``file:///path/to/docs/docsite/_build/html/modules/mymodule_module.html``.
 
 To ensure that your module documentation matches your ``argument_spec``:


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
Devguide update: correct, update, list requirements for testing module docs.
<!--- Describe the change below, including rationale and design decisions -->
* module HTML docs are in '_build/html/module' subdir
* remove unneeded 'cd docs/docsite'
* add Bash example
* add requirements

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dev_guide/testing_documentation.rst