### PR TITLE
flatpak_remote: Handle empty output in remote_exists

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -169,6 +169,8 @@ def remote_exists(module, binary, name, method):
     output = _flatpak_command(module, False, command)
     for line in output.splitlines():
         listed_remote = line.split()
+        if len(listed_remote) == 0:
+            continue
         if listed_remote[0] == to_native(name):
             return True
     return False


### PR DESCRIPTION
##### SUMMARY

`flatpak remote-list -d` can return an empty output, it should be handled gracefully

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak_remote

##### ADDITIONAL INFORMATION
* Fedora 29
* `flatpak` version 1.2.0
* python3
* ansible 2.7.5
