### PR TITLE
Add laps_password lookup for retrieving a Windows LAPS Password

### DIFF
--- a/lib/ansible/plugins/lookup/laps_password.py
+++ b/lib/ansible/plugins/lookup/laps_password.py
@@ -189,7 +189,6 @@ from ansible.plugins.lookup import LookupBase
 LDAP_IMP_ERR = None
 try:
     import ldap
-    import ldap.sasl
     import ldapurl
     HAS_LDAP = True
 except ImportError:

--- a/lib/ansible/plugins/lookup/laps_password.py
+++ b/lib/ansible/plugins/lookup/laps_password.py
@@ -246,14 +246,25 @@ def get_laps_password(conn, cn, search_base):
 
 class LookupModule(LookupBase):
 
-    def run(self, terms, variables=None, kdc=None, port=None, scheme='ldap', start_tls=False, validate_certs='demand',
-            cacert_file=None, search_base=None, username=None, password=None, auth='gssapi', allow_plaintext=False,
-            **kwargs):
-
+    def run(self, terms, variables=None, **kwargs):
         if not HAS_LDAP:
             msg = missing_required_lib("python-ldap", url="https://pypi.org/project/python-ldap/")
             msg += ". Import Error: %s" % LDAP_IMP_ERR
             raise AnsibleError(msg)
+
+        # Load the variables and direct args into the lookup options
+        self.set_options(var_options=variables, direct=kwargs)
+        kdc = self.get_option('kdc')
+        port = self.get_option('port')
+        scheme = self.get_option('scheme')
+        start_tls = self.get_option('start_tls')
+        validate_certs = self.get_option('validate_certs')
+        cacert_file = self.get_option('cacert_file')
+        search_base = self.get_option('search_base')
+        username = self.get_option('username')
+        password = self.get_option('password')
+        auth = self.get_option('auth')
+        allow_plaintext = self.get_option('allow_plaintext')
 
         # Validate and set input values
         # https://www.openldap.org/lists/openldap-software/200202/msg00456.html

--- a/lib/ansible/plugins/lookup/laps_password.py
+++ b/lib/ansible/plugins/lookup/laps_password.py
@@ -1,0 +1,340 @@
+# (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+lookup: laps_password
+author: Jordan Borean (@jborean93)
+version_added: "2.8"
+short_description: Retrieves the LAPS password for a server.
+description:
+- This lookup returns the LAPS password set for a server from the Active Directory database.
+options:
+  _terms:
+    description:
+    - The host name to retrieve the LAPS password for.
+    - This is the C(Common Name (CN)) of the host.
+    required: True
+    type: str
+  allow_plaintext:
+    description:
+    - When set to C(yes), will allow traffic to be sent unencrypted.
+    - It is highly recommended to not touch this to avoid any credentials being exposed over the network.
+    - Use C(scheme=ldaps), C(auth=gssapi), or C(start_tls=yes) to ensure the traffic is encrypted.
+    default: no
+    type: bool
+  auth:
+    description:
+    - The type of authentication to use when connecting to the Active Directory server
+    - When using C(simple), the I(username) and I(password) options must be set. If not using C(scheme=ldaps) or
+      C(start_tls=True) then these credentials are exposed in plaintext in the network traffic.
+    - It is recommended ot use C(gssapi) as it will encrypt the traffic automatically.
+    - When using C(gssapi), run C(kinit) before running Ansible to get a valid Kerberos ticket, otherwise set
+      I(username) and I(password) for this lookup to do this for you. This requires the Python C(gssapi) library to be
+      installed.
+    choices:
+    - simple
+    - gssapi
+    default: gssapi
+    type: str
+  cacert_file:
+    description:
+    - The path to a CA certificate PEM file to use for certificate validation.
+    - Certificate validation is used when C(scheme=ldaps) or C(start_tls=yes).
+    - This may fail on hosts with an older OpenLDAP install like MacOS, this will have to be updated before
+      reinstalling python-ldap to get working again.
+    type: str
+  kdc:
+    description:
+    - The active directory host to query.
+    - This could be the hostname or an explicit LDAP URI.
+    - If the URI is set, I(port) and I(scheme) are ignored.
+    required: True
+    type: str
+  password:
+    description:
+    - The password for C(username).
+    - Required when C(username) is set.
+    type: str
+  port:
+    description:
+    - The LDAP port to communicate over.
+    - If I(kdc) is already an LDAP URI then this is ignored.
+    type: int
+  scheme:
+    description:
+    - The LDAP scheme to use.
+    - When using C(ldap), it is recommended to set C(auth=gssapi), or C(start_tls=yes), otherwise traffic will be in
+      plaintext.
+    - The Active Directory host must be configured for C(ldaps) with a certificate before it can be used.
+    - If I(kdc) is already an LDAP URI then this is ignored.
+    choices:
+    - ldap
+    - ldaps
+    default: ldap
+  search_base:
+    description:
+    - Changes the search base used when searching for the host in Active Directory.
+    - Will default to search in the C(defaultNamingContext) of the Active Directory server.
+    - If multiple matches are found then a more explicit search_base is required so only 1 host is found.
+    - If searching a larger Active Directory database, it is recommended to narrow the search_base for performance
+      reasons.
+    type: str
+  start_tls:
+    description:
+    - When C(scheme=ldap), will use the StartTLS extension to encrypt traffic sent over the wire.
+    - This requires the Active Directory to be set up with a certificate that supports StartTLS.
+    - This is ignored when C(scheme=ldaps) as the traffic is already encrypted.
+    type: bool
+    default: no
+  username:
+    description:
+    - Required when using C(auth=simple).
+    - The username to authenticate with.
+    - Recommended to use the username in the UPN format, e.g. C(username@DOMAIN.COM).
+    - When using C(auth=gssapi), this is optional as an already checked out Kerberos ticket retrieved with C(kinit) is
+      used when no username is specified.
+    - If set when C(auth=gssapi), then the Python C(gssapi) library needs to be installed which will then retrieve the
+      Kerberos ticket like C(kinit) would.
+    type: str
+  validate_certs:
+    description:
+    - When using C(scheme=ldaps) or C(start_tls=yes), this controls the certificate validation behaviour.
+    - C(demand) will fail if no certificate or an invalid certificate is provided.
+    - C(try) will fail for invalid certificates but will continue if no certificate is provided.
+    - C(allow) will request and check a certificate but will continue even if it is invalid.
+    - C(never) will not request a certificate from the server so no validation occurs.
+    default: demand
+    choices:
+    - never
+    - allow
+    - try
+    - demand
+    type: str
+requirements:
+- python-ldap
+- gssapi (for explicit Kerberos credentials)
+notes:
+- If a host was found but had no LAPS password attribute C(ms-Mcs-AdmPwd), the lookup will fail.
+- Due to the sensitive nature of the data travelling across the network, it is highly recommended to run with either
+  C(auth=gssapi), C(scheme=ldaps), or C(start_tls=yes).
+- Failing to run with one of the above settings will result in the account credentials as well as the LAPS password to
+  be sent in plaintext.
+- Some scenarios may not work when running on a host with an older OpenLDAP install like MacOS. It is recommended to
+  install the latest OpenLDAP version and build python-ldap against this, see
+  U(https://keathmilligan.net/python-ldap-and-macos/) for more information.
+"""
+
+EXAMPLES = """
+- name: Get the LAPS password using Kerberos auth, relies on kinit already being called
+  set_fact:
+    ansible_password: "{{ lookup('laps_password', 'SERVER', kdc='dc01.ansible.com') }}"
+
+- name: Use Kerberos auth and explicit credentials
+  set_fact:
+    ansible_password: "{{ lookup('laps_password', 'WINDOWS-PC',
+                                 kdc='dc01.ansible.com',
+                                 username='username@ANSIBLE.COM',
+                                 password='SuperSecret123') }}"
+
+- name: Use Simple auth over LDAPS
+  set_fact:
+    ansible_password: "{{ lookup('laps_password', 'server',
+                                 kdc='dc01.ansible.com',
+                                 auth='simple',
+                                 scheme='ldaps',
+                                 username='username@ANSIBLE.COM',
+                                 password='SuperSecret123') }}"
+
+
+- name: Use Simple auth of LDAP with StartTLS
+  set_fact:
+    ansible_password: "{{ lookup('laps_password', 'app01',
+                                 kdc='dc01.ansible.com',
+                                 auth='simple',
+                                 start_tls=True,
+                                 username='username@ANSIBLE.COM',
+                                 password='SuperSecret123') }}"
+
+- name: Narrow down the search base
+  set_fact:
+    ansible_password: "{{ lookup('laps_password', 'sql10',
+                                 kdc='dc01.ansible.com',
+                                 search_base='OU=Databases,DC=ansible,DC=com') }}"
+
+- name: Set certificate file to use when validating the TLS certificate
+  set_fact:
+    ansible_password: "{{ lookup('laps_password', 'windows-pc',
+                                 kdc='dc01.ansible.com',
+                                 start_tls=True,
+                                 cacert_file='/usr/local/share/certs/ad.pem') }}"
+"""
+
+RETURN = """
+_raw:
+  description:
+  - The LAPS password(s) for the host(s) requested.
+  type: str
+"""
+
+import traceback
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.basic import missing_required_lib
+from ansible.plugins.lookup import LookupBase
+
+LDAP_IMP_ERR = None
+try:
+    import ldap
+    import ldap.sasl
+    import ldapurl
+    HAS_LDAP = True
+except ImportError:
+    LDAP_IMP_ERR = traceback.format_exc()
+    HAS_LDAP = False
+
+GSSAPI_IMP_ERR = None
+try:
+    import gssapi
+    from gssapi.raw import acquire_cred_with_password
+    HAS_GSSAPI = True
+except ImportError:
+    GSSAPI_IMP_ERR = traceback.format_exc()
+    HAS_GSSAPI = False
+
+
+def kinit(username, password):
+    if not HAS_GSSAPI:
+        msg = missing_required_lib("gssapi", reason="for explicit credentials with auth=gssapi",
+                                   url="https://pypi.org/project/gssapi/")
+        msg += ". Import Error: %s" % GSSAPI_IMP_ERR
+        raise AnsibleError(msg)
+
+    kerb_mech = gssapi.OID.from_int_seq('1.2.840.113554.1.2.2')  # Kerberos v5 OID
+    name = gssapi.Name(base=username, name_type=gssapi.NameType.kerberos_principal)
+    acquire_cred_with_password(name, to_bytes(password), usage='initiate', mechs=[kerb_mech])
+
+
+def get_laps_password(conn, cn, search_base):
+    search_filter = u"(&(objectClass=computer)(CN=%s))" % to_text(cn)
+
+    ldap_results = conn.search_s(to_text(search_base), ldap.SCOPE_SUBTREE, search_filter,
+                                 attrlist=[u"distinguishedName", u"ms-Mcs-AdmPwd"])
+
+    # Filter out non server hosts, search_s seems to return 3 extra entries
+    # that are not computer classes, they do not have a distinguished name
+    # set in the returned results
+    valid_results = [attr for dn, attr in ldap_results if dn]
+
+    if len(valid_results) == 0:
+        raise AnsibleError("Failed to find the server '%s' in the base '%s'" % (cn, search_base))
+    elif len(valid_results) > 1:
+        found_servers = [to_native(attr['distinguishedName'][0]) for attr in valid_results]
+        raise AnsibleError("Found too many results for the server '%s' in the base '%s'. Specify a more explicit "
+                           "search base for the server required. Found servers '%s'"
+                           % (cn, search_base, "', '".join(found_servers)))
+
+    password = valid_results[0].get('ms-Mcs-AdmPwd', None)
+    if not password:
+        distinguished_name = to_native(valid_results[0]['distinguishedName'][0])
+        raise AnsibleError("The server '%s' did not have the LAPS attribute 'ms-Mcs-AdmPwd'" % distinguished_name)
+
+    return to_native(password[0])
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, kdc=None, port=None, scheme='ldap', start_tls=False, validate_certs='demand',
+            cacert_file=None, search_base=None, username=None, password=None, auth='gssapi', allow_plaintext=False,
+            **kwargs):
+
+        if not HAS_LDAP:
+            msg = missing_required_lib("python-ldap", url="https://pypi.org/project/python-ldap/")
+            msg += ". Import Error: %s" % LDAP_IMP_ERR
+            raise AnsibleError(msg)
+
+        # Validate and set input values
+        # https://www.openldap.org/lists/openldap-software/200202/msg00456.html
+        validate_certs_map = {
+            'never': ldap.OPT_X_TLS_NEVER,
+            'allow': ldap.OPT_X_TLS_ALLOW,
+            'try': ldap.OPT_X_TLS_TRY,
+            'demand': ldap.OPT_X_TLS_DEMAND,  # Same as OPT_X_TLS_HARD
+        }
+        validate_certs_value = validate_certs_map.get(validate_certs, None)
+        if validate_certs_value is None:
+            valid_keys = list(validate_certs_map.keys())
+            valid_keys.sort()
+            raise AnsibleError("Invalid validate_certs value '%s': valid values are '%s'"
+                               % (validate_certs, "', '".join(valid_keys)))
+
+        if auth not in ['gssapi', 'simple']:
+            raise AnsibleError("Invalid auth value '%s': expecting either 'gssapi', or 'simple'" % auth)
+        elif auth == 'gssapi' and not ldap.SASL_AVAIL:
+            raise AnsibleError("Cannot use auth=gssapi when SASL is not configured with the local LDAP install")
+        elif auth == 'simple' and not (username and password):
+            raise AnsibleError("The username and password values are required when auth=simple")
+
+        if username and not password:
+            raise AnsibleError("The password must be set if username is also set")
+
+        if ldapurl.isLDAPUrl(kdc):
+            ldap_url = ldapurl.LDAPUrl(ldapUrl=kdc)
+        else:
+            port = port if port else 389 if scheme == 'ldap' else 636
+            ldap_url = ldapurl.LDAPUrl(hostport="%s:%d" % (kdc, port), urlscheme=scheme)
+
+        # We have encryption if using LDAPS, or StartTLS is used, or we auth with SASL/GSSAPI
+        encrypted = ldap_url.urlscheme == 'ldaps' or start_tls or auth == 'gssapi'
+        if not encrypted and not allow_plaintext:
+            raise AnsibleError("Current configuration will result in plaintext traffic exposing credentials. Set "
+                               "auth=gssapi, scheme=ldaps, start_tls=True, or allow_plaintext=True to continue")
+
+        conn = ldap.initialize(ldap_url.initializeUrl(), bytes_mode=False)
+        conn.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+        conn.set_option(ldap.OPT_REFERRALS, 0)  # Allow us to search from the base
+
+        if ldap_url.urlscheme == 'ldaps' or start_tls:
+            if not ldap.TLS_AVAIL:
+                raise AnsibleError("Cannot use TLS as the local LDAP installed has not been configured to support it")
+
+            conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, validate_certs_value)
+            if cacert_file:
+                try:
+                    # While this is a path, python-ldap expects a str/unicode and not bytes
+                    conn.set_option(ldap.OPT_X_TLS_CACERTFILE, to_text(cacert_file))
+                except ValueError:
+                    # https://keathmilligan.net/python-ldap-and-macos/
+                    raise AnsibleError("Failed to set path to cacert file, this is a known issue with older OpenLDAP "
+                                       "libraries on the host. Update OpenLDAP and reinstall python-ldap to continue")
+
+            # Need to setup a new TLS Context for the above settings to take affect
+            conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+
+        # Make sure we run StartTLS before doing the bind to protect the credentials
+        if start_tls:
+            conn.start_tls_s()
+
+        if auth == 'simple':
+            conn.bind_s(to_text(username), to_text(password))
+        else:
+            if username:
+                kinit(username, password)
+            conn.sasl_gssapi_bind_s()
+
+        try:
+            if not search_base:
+                root_dse = conn.read_rootdse_s()
+                search_base = root_dse['defaultNamingContext'][0]
+
+            ret = []
+            # TODO: change method to search for all servers in 1 request instead of multiple requests
+            for server in terms:
+                ret.append(get_laps_password(conn, server, search_base))
+        finally:
+            conn.unbind_s()
+
+        return ret

--- a/lib/ansible/plugins/lookup/laps_password.py
+++ b/lib/ansible/plugins/lookup/laps_password.py
@@ -132,7 +132,7 @@ EXAMPLES = """
   set_fact:
     ansible_password: "{{ lookup('laps_password', 'SERVER', kdc='dc01.ansible.com') }}"
 
-- name: Use Kerberos auth and explicit credentials
+- name: Use Kerberos auth with explicit credentials
   set_fact:
     ansible_password: "{{ lookup('laps_password', 'WINDOWS-PC',
                                  kdc='dc01.ansible.com',
@@ -149,7 +149,7 @@ EXAMPLES = """
                                  password='SuperSecret123') }}"
 
 
-- name: Use Simple auth of LDAP with StartTLS
+- name: Use Simple auth with LDAP and StartTLS
   set_fact:
     ansible_password: "{{ lookup('laps_password', 'app01',
                                  kdc='dc01.ansible.com',
@@ -158,7 +158,7 @@ EXAMPLES = """
                                  username='username@ANSIBLE.COM',
                                  password='SuperSecret123') }}"
 
-- name: Narrow down the search base
+- name: Narrow down the search base to a an OU
   set_fact:
     ansible_password: "{{ lookup('laps_password', 'sql10',
                                  kdc='dc01.ansible.com',

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -42,3 +42,6 @@ linode_api4 ; python_version > '2.6' # APIv4
 # requirement for the gitlab module
 python-gitlab
 httmock
+
+# requirement for laps_password lookup plugin
+python-ldap

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -42,6 +42,3 @@ linode_api4 ; python_version > '2.6' # APIv4
 # requirement for the gitlab module
 python-gitlab
 httmock
-
-# requirement for laps_password lookup plugin
-python-ldap

--- a/test/units/plugins/lookup/test_laps_password.py
+++ b/test/units/plugins/lookup/test_laps_password.py
@@ -1,0 +1,435 @@
+# -*- coding: utf-8 -*-
+# (c) 2019, Jordan Borean <jborean@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import platform
+import pytest
+import sys
+
+from units.compat.mock import patch, MagicMock
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import laps_password
+
+ldap = pytest.importorskip("ldap")
+
+
+@pytest.fixture("function")
+def reset_imports():
+    # ensure the changes to these globals aren't persisted after each test
+    orig_has_gssapi = laps_password.HAS_GSSAPI
+    orig_gssapi_imp_err = laps_password.GSSAPI_IMP_ERR
+    orig_has_ldap = laps_password.HAS_LDAP
+    orig_ldap_imp_err = laps_password.LDAP_IMP_ERR
+    yield None
+    laps_password.HAS_GSSAPI = orig_has_gssapi
+    laps_password.GSSAPI_IMP_ERR = orig_gssapi_imp_err
+    laps_password.HAS_LDAP = orig_has_ldap
+    laps_password.LDAP_IMP_ERR = orig_ldap_imp_err
+
+
+def test_missing_ldap(reset_imports):
+    laps_password.HAS_LDAP = False
+    laps_password.LDAP_IMP_ERR = "no import for you!"
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"])
+
+    assert str(err.value) == "Failed to import the required Python library (python-ldap) on %s's Python %s. See " \
+                             "https://pypi.org/project/python-ldap/ for more info. Please read module documentation " \
+                             "and install in the appropriate location. " \
+                             "Import Error: no import for you!" % (platform.node(), sys.executable)
+
+
+def test_invalid_cert_mapping():
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"], validate_certs="incorrect")
+
+    assert str(err.value) == "Invalid validate_certs value 'incorrect': valid values are 'allow', 'demand', " \
+                             "'never', 'try'"
+
+
+def test_invalid_auth():
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"], auth="fail")
+
+    assert str(err.value) == "Invalid auth value 'fail': expecting either 'gssapi', or 'simple'"
+
+
+def test_gssapi_without_sasl(monkeypatch):
+    monkeypatch.setattr("ldap.SASL_AVAIL", 0)
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"])
+
+    assert str(err.value) == "Cannot use auth=gssapi when SASL is not configured with the local LDAP install"
+
+
+def test_simple_auth_without_credentials():
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"], auth="simple")
+
+    assert str(err.value) == "The username and password values are required when auth=simple"
+
+
+def test_password_not_set_with_username():
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"], username="test")
+
+    assert str(err.value) == "The password must be set if username is also set"
+
+
+def test_not_encrypted_without_override():
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"], kdc="dc01", auth="simple", username="test", password="test")
+
+    assert str(err.value) == "Current configuration will result in plaintext traffic exposing credentials. Set " \
+                             "auth=gssapi, scheme=ldaps, start_tls=True, or allow_plaintext=True to continue"
+
+
+def test_ldaps_without_tls(monkeypatch):
+    monkeypatch.setattr("ldap.TLS_AVAIL", 0)
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"], kdc="dc01", scheme="ldaps")
+
+    assert str(err.value) == "Cannot use TLS as the local LDAP installed has not been configured to support it"
+
+
+def test_start_tls_without_tls(monkeypatch):
+    monkeypatch.setattr("ldap.TLS_AVAIL", 0)
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run(["host"], kdc="dc01", start_tls=True)
+
+    assert str(err.value) == "Cannot use TLS as the local LDAP installed has not been configured to support it"
+
+
+def test_normal_run(monkeypatch):
+    def get_laps_password(conn, cn, search_base):
+        return "CN=%s,%s" % (cn, search_base)
+
+    mock_ldap = MagicMock()
+    mock_ldap.return_value.read_rootdse_s.return_value = {"defaultNamingContext": ["DC=domain,DC=com"]}
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    mock_get_laps_password = MagicMock(side_effect=get_laps_password)
+    monkeypatch.setattr(laps_password, "get_laps_password", mock_get_laps_password)
+
+    actual = laps_password.LookupModule().run(["host1", "host2"], kdc="dc01")
+    assert actual == ["CN=host1,DC=domain,DC=com", "CN=host2,DC=domain,DC=com"]
+
+    # Verify the call count to get_laps_password
+    assert mock_get_laps_password.call_count == 2
+
+    # Verify the initialize() method call
+    assert mock_ldap.call_count == 1
+    assert mock_ldap.call_args[0] == ("ldap://dc01:389",)
+    assert mock_ldap.call_args[1] == {"bytes_mode": False}
+
+    # Verify the number of calls made to the mocked LDAP object
+    assert mock_ldap.mock_calls[1][0] == "().set_option"
+    assert mock_ldap.mock_calls[1][1] == (ldap.OPT_PROTOCOL_VERSION, 3)
+
+    assert mock_ldap.mock_calls[2][0] == "().set_option"
+    assert mock_ldap.mock_calls[2][1] == (ldap.OPT_REFERRALS, 0)
+
+    assert mock_ldap.mock_calls[3][0] == '().sasl_gssapi_bind_s'
+    assert mock_ldap.mock_calls[3][1] == ()
+
+    assert mock_ldap.mock_calls[4][0] == "().read_rootdse_s"
+    assert mock_ldap.mock_calls[4][1] == ()
+
+    assert mock_ldap.mock_calls[5][0] == "().unbind_s"
+    assert mock_ldap.mock_calls[5][1] == ()
+
+
+def test_run_with_simple_auth_and_search_base(monkeypatch):
+    def get_laps_password(conn, cn, search_base):
+        return "CN=%s,%s" % (cn, search_base)
+
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    mock_get_laps_password = MagicMock(side_effect=get_laps_password)
+    monkeypatch.setattr(laps_password, "get_laps_password", mock_get_laps_password)
+
+    actual = laps_password.LookupModule().run(["host1", "host2"], kdc="dc01", auth="simple", username="user",
+                                              password="pass", allow_plaintext=True,
+                                              search_base="OU=Workstations,DC=domain,DC=com")
+    assert actual == ["CN=host1,OU=Workstations,DC=domain,DC=com", "CN=host2,OU=Workstations,DC=domain,DC=com"]
+
+    # Verify the call count to get_laps_password
+    assert mock_get_laps_password.call_count == 2
+
+    # Verify the initialize() method call
+    assert mock_ldap.call_count == 1
+    assert mock_ldap.call_args[0] == ("ldap://dc01:389",)
+    assert mock_ldap.call_args[1] == {"bytes_mode": False}
+
+    # Verify the number of calls made to the mocked LDAP object
+    assert mock_ldap.mock_calls[1][0] == "().set_option"
+    assert mock_ldap.mock_calls[1][1] == (ldap.OPT_PROTOCOL_VERSION, 3)
+
+    assert mock_ldap.mock_calls[2][0] == "().set_option"
+    assert mock_ldap.mock_calls[2][1] == (ldap.OPT_REFERRALS, 0)
+
+    assert mock_ldap.mock_calls[3][0] == '().bind_s'
+    assert mock_ldap.mock_calls[3][1] == (u"user", u"pass")
+
+    assert mock_ldap.mock_calls[4][0] == "().unbind_s"
+    assert mock_ldap.mock_calls[4][1] == ()
+
+
+@pytest.mark.parametrize("kwargs, expected", [
+    [{"kdc": "dc01"}, "ldap://dc01:389"],
+    [{"kdc": "dc02", "port": 1234}, "ldap://dc02:1234"],
+    [{"kdc": "dc03", "scheme": "ldaps"}, "ldaps://dc03:636"],
+    # Verifies that an explicit URI ignores port and scheme
+    [{"kdc": "ldap://dc04", "port": 1234, "scheme": "ldaps"}, "ldap://dc04"],
+])
+def test_uri_options(monkeypatch, kwargs, expected):
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    laps_password.LookupModule().run([], **kwargs)
+
+    assert mock_ldap.call_count == 1
+    assert mock_ldap.call_args[0] == (expected,)
+    assert mock_ldap.call_args[1] == {"bytes_mode": False}
+
+
+@pytest.mark.parametrize("validate, expected", [
+    ["never", ldap.OPT_X_TLS_NEVER],
+    ["allow", ldap.OPT_X_TLS_ALLOW],
+    ["try", ldap.OPT_X_TLS_TRY],
+    ["demand", ldap.OPT_X_TLS_DEMAND],
+])
+def test_certificate_validation(monkeypatch, validate, expected):
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    laps_password.LookupModule().run([], kdc="dc01", start_tls=True, validate_certs=validate)
+
+    assert mock_ldap.mock_calls[3][0] == "().set_option"
+    assert mock_ldap.mock_calls[3][1] == (ldap.OPT_X_TLS_REQUIRE_CERT, expected)
+
+    assert mock_ldap.mock_calls[4][0] == "().set_option"
+    assert mock_ldap.mock_calls[4][1] == (ldap.OPT_X_TLS_NEWCTX, 0)
+
+    assert mock_ldap.mock_calls[5][0] == "().start_tls_s"
+    assert mock_ldap.mock_calls[5][1] == ()
+
+    assert mock_ldap.mock_calls[6][0] == "().sasl_gssapi_bind_s"
+    assert mock_ldap.mock_calls[6][1] == ()
+
+
+def test_certificate_validate_with_custom_cacert(monkeypatch):
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    laps_password.LookupModule().run([], kdc="dc01", scheme="ldaps", cacert_file="cacert.pem")
+
+    assert mock_ldap.mock_calls[3][0] == "().set_option"
+    assert mock_ldap.mock_calls[3][1] == (ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
+
+    assert mock_ldap.mock_calls[4][0] == "().set_option"
+    assert mock_ldap.mock_calls[4][1] == (ldap.OPT_X_TLS_CACERTFILE, u"cacert.pem")
+
+    assert mock_ldap.mock_calls[5][0] == "().set_option"
+    assert mock_ldap.mock_calls[5][1] == (ldap.OPT_X_TLS_NEWCTX, 0)
+
+    assert mock_ldap.mock_calls[6][0] == "().sasl_gssapi_bind_s"
+    assert mock_ldap.mock_calls[6][1] == ()
+
+
+def test_certificate_validate_with_custom_cacert_fail(monkeypatch):
+    def set_option(key, value):
+        if key == ldap.OPT_X_TLS_CACERTFILE:
+            raise ValueError("set_option() failed")
+
+    mock_ldap = MagicMock()
+    mock_ldap.return_value.set_option.side_effect = set_option
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run([], kdc="dc01", scheme="ldaps", cacert_file="cacert.pem")
+
+    assert str(err.value) == "Failed to set path to cacert file, this is a known issue with older OpenLDAP " \
+                             "libraries on the host. Update OpenLDAP and reinstall python-ldap to continue"
+
+
+def test_simple_auth_with_ldaps(monkeypatch):
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    laps_password.LookupModule().run([], kdc="dc01", scheme="ldaps", auth="simple", username="user", password="pass")
+
+    assert mock_ldap.mock_calls[3][0] == "().set_option"
+    assert mock_ldap.mock_calls[3][1] == (ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
+
+    assert mock_ldap.mock_calls[4][0] == "().set_option"
+    assert mock_ldap.mock_calls[4][1] == (ldap.OPT_X_TLS_NEWCTX, 0)
+
+    assert mock_ldap.mock_calls[5][0] == '().bind_s'
+    assert mock_ldap.mock_calls[5][1] == (u"user", u"pass")
+
+    assert mock_ldap.mock_calls[6][0] == "().read_rootdse_s"
+    assert mock_ldap.mock_calls[6][1] == ()
+
+
+def test_simple_auth_with_start_tls(monkeypatch):
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    laps_password.LookupModule().run([], kdc="dc01", start_tls=True, auth="simple", username="user", password="pass")
+
+    assert mock_ldap.mock_calls[3][0] == "().set_option"
+    assert mock_ldap.mock_calls[3][1] == (ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
+
+    assert mock_ldap.mock_calls[4][0] == "().set_option"
+    assert mock_ldap.mock_calls[4][1] == (ldap.OPT_X_TLS_NEWCTX, 0)
+
+    assert mock_ldap.mock_calls[5][0] == "().start_tls_s"
+    assert mock_ldap.mock_calls[5][1] == ()
+
+    assert mock_ldap.mock_calls[6][0] == '().bind_s'
+    assert mock_ldap.mock_calls[6][1] == (u"user", u"pass")
+
+    assert mock_ldap.mock_calls[7][0] == "().read_rootdse_s"
+    assert mock_ldap.mock_calls[7][1] == ()
+
+
+def test_gssapi_with_explicit_credentials(monkeypatch):
+    mock_kinit = MagicMock()
+    monkeypatch.setattr(laps_password, "kinit", mock_kinit)
+
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    laps_password.LookupModule().run([], kdc="dc01", username="user", password="pass")
+
+    # Assert we called kinit at least once
+    assert mock_kinit.call_count == 1
+    assert mock_kinit.call_args[0] == ("user", "pass")
+
+    # Verify the number of calls made to the mocked LDAP object
+    assert mock_ldap.mock_calls[1][0] == "().set_option"
+    assert mock_ldap.mock_calls[1][1] == (ldap.OPT_PROTOCOL_VERSION, 3)
+
+    assert mock_ldap.mock_calls[2][0] == "().set_option"
+    assert mock_ldap.mock_calls[2][1] == (ldap.OPT_REFERRALS, 0)
+
+    assert mock_ldap.mock_calls[3][0] == '().sasl_gssapi_bind_s'
+    assert mock_ldap.mock_calls[3][1] == ()
+
+    assert mock_ldap.mock_calls[4][0] == "().read_rootdse_s"
+    assert mock_ldap.mock_calls[4][1] == ()
+
+
+def test_gssapi_with_explicit_credentials_no_gssapi(monkeypatch):
+    laps_password.HAS_GSSAPI = False
+    laps_password.GSSAPI_IMP_ERR = "no import for you!"
+
+    mock_ldap = MagicMock()
+    monkeypatch.setattr("ldap.initialize", mock_ldap)
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.LookupModule().run([], kdc="dc01", username="user", password="pass")
+
+    assert str(err.value) == "Failed to import the required Python library (gssapi) on %s's Python %s. This is " \
+                             "required for explicit credentials with auth=gssapi. See " \
+                             "https://pypi.org/project/gssapi/ for more info. Please read module documentation " \
+                             "and install in the appropriate location. " \
+                             "Import Error: no import for you!" % (platform.node(), sys.executable)
+
+
+def test_get_password_valid():
+    mock_conn = MagicMock()
+    mock_conn.search_s.return_value = [
+        ("CN=server,DC=domain,DC=local",
+         {"ms-Mcs-AdmPwd": ["pass"], "distinguishedName": ["CN=server,DC=domain,DC=local"]}),
+        # Replicates the 3 extra entries AD returns that aren't server objects
+        (None, ["ldap://ForestDnsZones.domain.com/DC=ForestDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://DomainDnsZones.domain.com/DC=DomainDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://domain.com/CN=Configuration,DC=domain,DC=com"]),
+    ]
+
+    actual = laps_password.get_laps_password(mock_conn, "server", "DC=domain,DC=local")
+    assert actual == "pass"
+
+    assert len(mock_conn.method_calls) == 1
+    assert mock_conn.method_calls[0][0] == "search_s"
+    assert mock_conn.method_calls[0][1] == ("DC=domain,DC=local", ldap.SCOPE_SUBTREE,
+                                            "(&(objectClass=computer)(CN=server))")
+    assert mock_conn.method_calls[0][2] == {"attrlist": ["distinguishedName", "ms-Mcs-AdmPwd"]}
+
+
+def test_get_password_laps_not_configured():
+    mock_conn = MagicMock()
+    mock_conn.search_s.return_value = [
+        ("CN=server,DC=domain,DC=local", {"distinguishedName": ["CN=server,DC=domain,DC=local"]}),
+        (None, ["ldap://ForestDnsZones.domain.com/DC=ForestDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://DomainDnsZones.domain.com/DC=DomainDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://domain.com/CN=Configuration,DC=domain,DC=com"]),
+    ]
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.get_laps_password(mock_conn, "server2", "DC=test,DC=local")
+    assert str(err.value) == \
+        "The server 'CN=server,DC=domain,DC=local' did not have the LAPS attribute 'ms-Mcs-AdmPwd'"
+
+    assert len(mock_conn.method_calls) == 1
+    assert mock_conn.method_calls[0][0] == "search_s"
+    assert mock_conn.method_calls[0][1] == ("DC=test,DC=local", ldap.SCOPE_SUBTREE,
+                                            "(&(objectClass=computer)(CN=server2))")
+    assert mock_conn.method_calls[0][2] == {"attrlist": ["distinguishedName", "ms-Mcs-AdmPwd"]}
+
+
+def test_get_password_no_results():
+    mock_conn = MagicMock()
+    mock_conn.search_s.return_value = [
+        (None, ["ldap://ForestDnsZones.domain.com/DC=ForestDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://DomainDnsZones.domain.com/DC=DomainDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://domain.com/CN=Configuration,DC=domain,DC=com"]),
+    ]
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.get_laps_password(mock_conn, "server", "DC=domain,DC=local")
+    assert str(err.value) == "Failed to find the server 'server' in the base 'DC=domain,DC=local'"
+
+    assert len(mock_conn.method_calls) == 1
+    assert mock_conn.method_calls[0][0] == "search_s"
+    assert mock_conn.method_calls[0][1] == ("DC=domain,DC=local", ldap.SCOPE_SUBTREE,
+                                            "(&(objectClass=computer)(CN=server))")
+    assert mock_conn.method_calls[0][2] == {"attrlist": ["distinguishedName", "ms-Mcs-AdmPwd"]}
+
+
+def test_get_password_multiple_results():
+    mock_conn = MagicMock()
+    mock_conn.search_s.return_value = [
+        ("CN=server,OU=Workstations,DC=domain,DC=local",
+         {"ms-Mcs-AdmPwd": ["pass"], "distinguishedName": ["CN=server,OU=Workstations,DC=domain,DC=local"]}),
+        ("CN=server,OU=Servers,DC=domain,DC=local",
+         {"ms-Mcs-AdmPwd": ["pass"], "distinguishedName": ["CN=server,OU=Servers,DC=domain,DC=local"]}),
+        (None, ["ldap://ForestDnsZones.domain.com/DC=ForestDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://DomainDnsZones.domain.com/DC=DomainDnsZones,DC=domain,DC=com"]),
+        (None, ["ldap://domain.com/CN=Configuration,DC=domain,DC=com"]),
+    ]
+
+    with pytest.raises(AnsibleError) as err:
+        laps_password.get_laps_password(mock_conn, "server", "DC=domain,DC=local")
+    assert str(err.value) == \
+        "Found too many results for the server 'server' in the base 'DC=domain,DC=local'. Specify a more explicit " \
+        "search base for the server required. Found servers 'CN=server,OU=Workstations,DC=domain,DC=local', " \
+        "'CN=server,OU=Servers,DC=domain,DC=local'"
+
+    assert len(mock_conn.method_calls) == 1
+    assert mock_conn.method_calls[0][0] == "search_s"
+    assert mock_conn.method_calls[0][1] == ("DC=domain,DC=local", ldap.SCOPE_SUBTREE,
+                                            "(&(objectClass=computer)(CN=server))")
+    assert mock_conn.method_calls[0][2] == {"attrlist": ["distinguishedName", "ms-Mcs-AdmPwd"]}


### PR DESCRIPTION
##### SUMMARY
Adds a lookup that can be used to retrieve a server's LAPS configured password from Active Directory. Unfortunately I am unable to create integration tests due to the difficulties of setting up a domain environment in CI but I will create a separate repo that can test this lookup.

Documentaton for how to run these tests in an actual environment can be found at https://github.com/jborean93/ansible-lookup-laps_password.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
laps_password lookup