### PR TITLE
SmartOS imgadm: Adding import and delete ability for docker images

### DIFF
--- a/lib/ansible/modules/cloud/smartos/imgadm.py
+++ b/lib/ansible/modules/cloud/smartos/imgadm.py
@@ -54,12 +54,12 @@ options:
         description:
           - Image UUID. Can either be a full UUID or C(*) for all images.
     name:
-        version_added: "2.8"
+        version_added: "2.9"
         required: false
         description:
           - Image name. Cannot be used with UUID.
     docker:
-        version_added: "2.8"
+        version_added: "2.9"
         required: false
         description:
         - Docker images need this flag enabled.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/50399

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/smartos/imgadm.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Adding a `docker` boolean to specify when a Docker image should be referenced. 

Adding a `name` string to be able to import Docker images by name (which is the only supported method). This can also be used later to refer to other SmartOS-specific images by name instead of UUID.

<!--- Paste verbatim command output below, e.g. before and after your change -->

The following playbook tasks now work:

```yaml
- name: Import minio Docker Image
  imgadm:
    name: minio/minio:latest
    docker: True
    state: present

- name: Remove minio
  imgadm:
    name: minio/minio:latest
    docker: True
    state: absent

```

Note: `state: latest` does not work for Docker images since `imgadm` does not support it. If this is attempted, the task will fail with: `Cannot update Docker images. No support by imgadm yet.`
