### PR TITLE
elb_application_lb :Fix required_together statement - access_logs_s3_prefix is not requir…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -541,7 +541,7 @@ def main():
                                   ('state', 'present', ['subnets', 'security_groups'])
                               ],
                               required_together=[
-                                  ['access_logs_enabled', 'access_logs_s3_bucket', 'access_logs_s3_prefix']
+                                  ['access_logs_enabled', 'access_logs_s3_bucket']
                               ]
                               )
 


### PR DESCRIPTION
…ed as per the documentation

##### SUMMARY
Fixes #52016 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb

##### ADDITIONAL INFORMATION
After a syntax correction in https://github.com/ansible/ansible/commit/01c0446cb54acca76a21a86a698b5937ffb879f2#diff-a1bcebad578f0e6bfd841049d327a587 the module behavior stopped matching the documentation.
