### PR TITLE
dataloader: check exact value of dir

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -290,12 +290,12 @@ class DataLoader:
             for path in paths:
                 upath = unfrackpath(path, follow=False)
                 b_upath = to_bytes(upath, errors='surrogate_or_strict')
-                b_mydir = os.path.dirname(b_upath)
+                b_pb_base_dir = os.path.dirname(b_upath)
 
                 # if path is in role and 'tasks' not there already, add it into the search
-                if (is_role or self._is_role(path)) and b_mydir.endswith(b'tasks'):
-                    search.append(os.path.join(os.path.dirname(b_mydir), b_dirname, b_source))
-                    search.append(os.path.join(b_mydir, b_source))
+                if (is_role or self._is_role(path)) and b_pb_base_dir.endswith(b'/tasks'):
+                    search.append(os.path.join(os.path.dirname(b_pb_base_dir), b_dirname, b_source))
+                    search.append(os.path.join(b_pb_base_dir, b_source))
                 else:
                     # don't add dirname if user already is using it in source
                     if b_source.split(b'/')[0] != dirname:

--- a/test/integration/targets/template/custom_tasks/tasks/main.yml
+++ b/test/integration/targets/template/custom_tasks/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- template:
+    src: test
+    dest: "{{ output_dir }}/templated_test"
+  register: custom_template_result
+
+- debug:
+    msg: "{{ custom_template_result }}"
+
+- assert:
+    that:
+      - custom_template_result.changed

--- a/test/integration/targets/template/custom_tasks/templates/test
+++ b/test/integration/targets/template/custom_tasks/templates/test
@@ -1,0 +1,1 @@
+Sample Text

--- a/test/integration/targets/template/custom_template.yml
+++ b/test/integration/targets/template/custom_template.yml
@@ -1,0 +1,4 @@
+- hosts: testhost
+  gather_facts: yes
+  roles:
+    - { role: custom_tasks }

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -9,3 +9,6 @@ ansible testhost -i testhost, -m debug -a 'msg={{ hostvars["localhost"] }}' -e "
 
 # Test for https://github.com/ansible/ansible/issues/27262
 ansible-playbook ansible_managed.yml -c  ansible_managed.cfg -i ../../inventory -e @../../integration_config.yml -v "$@"
+
+# Test for #42585
+ANSIBLE_ROLES_PATH=../ ansible-playbook custom_template.yml -i ../../inventory -e @../../integration_config.yml -v "$@"


### PR DESCRIPTION
##### SUMMARY
Include path in role with directory which has 'tasks' as end.
For example, roles/sometasks/templates is now considered while searching path.

Fixes: #42585

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/dataloader.py
