### PR TITLE
[2.7] ufw: check values for direction depending on situation

### DIFF
--- a/changelogs/fragments/50402-ufw-check-direction.yml
+++ b/changelogs/fragments/50402-ufw-check-direction.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ufw: make sure that only valid values for ``direction`` are passed on."

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -309,9 +309,13 @@ def main():
             execute(cmd + [[command], [value]])
 
         elif command == 'default':
+            if params['direction'] not in ['outgoing', 'incoming', 'routed']:
+                module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed".')
             execute(cmd + [[command], [value], [params['direction']]])
 
         elif command == 'rule':
+            if params['direction'] not in ['in', 'out', None]:
+                module.fail_json(msg='For rules, direction must be one of "in" and "out".')
             # Rules are constructed according to the long format
             #
             # ufw [--dry-run] [route] [delete] [insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \


### PR DESCRIPTION
##### SUMMARY
Backport of #50402 to stable-2.7: makes sure only acceptable values for `direction` are passed on to `ufw`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
