### PR TITLE
adding quiet option to assert (ansible#27124)

### DIFF
--- a/changelogs/fragments/52032-add_quiet_option_to_assert.yml
+++ b/changelogs/fragments/52032-add_quiet_option_to_assert.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - assert - added ``quiet`` option to the ``assert`` module to avoid verbose
+    output (https://github.com/ansible/ansible/issues/27124).
+

--- a/changelogs/fragments/52032-add_quiet_option_to_assert.yml
+++ b/changelogs/fragments/52032-add_quiet_option_to_assert.yml
@@ -1,4 +1,3 @@
 minor_changes:
   - assert - added ``quiet`` option to the ``assert`` module to avoid verbose
     output (https://github.com/ansible/ansible/issues/27124).
-

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -38,6 +38,10 @@ options:
     version_added: "2.7"
     description:
       - "The customized message used for a successful assertion"
+  quiet:
+    version_added: "2.8"
+    description:
+      - "Set this to true to avoid verbose output"
 notes:
      - This module is also supported for Windows targets.
 author:
@@ -66,5 +70,6 @@ EXAMPLES = '''
     that:
       - "my_param <= 100"
       - "my_param >= 0"
+    quiet: True
     msg: "'my_param' must be between 0 and 100"
 '''

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -41,7 +41,9 @@ options:
   quiet:
     version_added: "2.8"
     description:
-      - "Set this to true to avoid verbose output"
+      - "Set this to C(true) to avoid verbose output"
+    type: bool
+    default: false
 notes:
      - This module is also supported for Windows targets.
 author:
@@ -77,5 +79,5 @@ EXAMPLES = '''
     that:
       - "my_param <= 100"
       - "my_param >= 0"
-    quiet: True
+    quiet: true
 '''

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -24,24 +24,24 @@ version_added: "1.5"
 options:
   that:
     description:
-      - "A string expression of the same form that can be passed to the 'when' statement"
-      - "Alternatively, a list of string expressions"
+      - "A string expression of the same form that can be passed to the 'when' statement."
+      - "Alternatively, a list of string expressions."
     required: true
   fail_msg:
     version_added: "2.7"
     description:
-      - "The customized message used for a failing assertion"
-      - "This argument was called 'msg' before version 2.7, now it's renamed to 'fail_msg' with alias 'msg'"
+      - "The customized message used for a failing assertion."
+      - "This argument was called 'msg' before version 2.7, now it's renamed to 'fail_msg' with alias 'msg'."
     aliases:
       - msg
   success_msg:
     version_added: "2.7"
     description:
-      - "The customized message used for a successful assertion"
+      - "The customized message used for a successful assertion."
   quiet:
     version_added: "2.8"
     description:
-      - "Set this to C(true) to avoid verbose output"
+      - "Set this to C(true) to avoid verbose output."
     type: bool
     default: false
 notes:

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -70,6 +70,12 @@ EXAMPLES = '''
     that:
       - "my_param <= 100"
       - "my_param >= 0"
-    quiet: True
     msg: "'my_param' must be between 0 and 100"
+
+- name: use quiet to avoid verbose output
+  assert:
+    that:
+      - "my_param <= 100"
+      - "my_param >= 0"
+    quiet: True
 '''

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -71,7 +71,7 @@ class ActionModule(ActionBase):
         cond = Conditional(loader=self._loader)
         if not quiet:
             result['_ansible_verbose_always'] = True
-        result['_ansible_verbose_always'] = True
+
         for that in thats:
             cond.when = [that]
             test_result = cond.evaluate_conditional(templar=self._templar, all_vars=task_vars)

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -21,13 +21,15 @@ from ansible.errors import AnsibleError
 from ansible.playbook.conditional import Conditional
 from ansible.plugins.action import ActionBase
 from ansible.module_utils.six import string_types
+from ansible.module_utils.parsing.convert_bool import boolean
+
 
 
 class ActionModule(ActionBase):
     ''' Fail with custom message '''
 
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('fail_msg', 'msg', 'success_msg', 'that'))
+    _VALID_ARGS = frozenset(('fail_msg', 'msg', 'quiet', 'success_msg', 'that'))
 
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:
@@ -54,6 +56,8 @@ class ActionModule(ActionBase):
         elif not isinstance(success_msg, string_types):
             raise AnsibleError('Incorrect type for success_msg, expected string and got %s' % type(success_msg))
 
+        quiet = boolean(self._task.args.get('quiet', False), strict=False)
+
         # make sure the 'that' items are a list
         thats = self._task.args['that']
         if not isinstance(thats, list):
@@ -65,6 +69,8 @@ class ActionModule(ActionBase):
         # by this point, and is not used again, so we don't care about mangling
         # that value now
         cond = Conditional(loader=self._loader)
+        if not quiet:
+            result['_ansible_verbose_always'] = True
         result['_ansible_verbose_always'] = True
         for that in thats:
             cond.when = [that]

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -24,7 +24,6 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import boolean
 
 
-
 class ActionModule(ActionBase):
     ''' Fail with custom message '''
 

--- a/test/integration/targets/assert/aliases
+++ b/test/integration/targets/assert/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/assert/assert_quiet.out.quiet.stderr
+++ b/test/integration/targets/assert/assert_quiet.out.quiet.stderr
@@ -1,0 +1,2 @@
++ ansible-playbook -i localhost, -c local quiet.yml
+++ set +x

--- a/test/integration/targets/assert/assert_quiet.out.quiet.stdout
+++ b/test/integration/targets/assert/assert_quiet.out.quiet.stdout
@@ -12,5 +12,5 @@ ok: [localhost] => (item=item_A) => {
 }
 
 PLAY RECAP *********************************************************************
-localhost                  : ok=2    changed=0    unreachable=0    failed=0   
+localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   
 

--- a/test/integration/targets/assert/assert_quiet.out.quiet.stdout
+++ b/test/integration/targets/assert/assert_quiet.out.quiet.stdout
@@ -1,0 +1,19 @@
+
+PLAY [localhost] ***************************************************************
+
+TASK [Gathering Facts] *********************************************************
+ok: [localhost]
+
+TASK [assert] ******************************************************************
+ok: [localhost] => (item=item_A)
+
+TASK [assert] ******************************************************************
+ok: [localhost] => (item=item_A) => {
+    "changed": false, 
+    "item": "item_A", 
+    "msg": "All assertions passed"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=0    unreachable=0    failed=0   
+

--- a/test/integration/targets/assert/assert_quiet.out.quiet.stdout
+++ b/test/integration/targets/assert/assert_quiet.out.quiet.stdout
@@ -6,11 +6,11 @@ ok: [localhost] => (item=item_A)
 
 TASK [assert] ******************************************************************
 ok: [localhost] => (item=item_A) => {
-    "changed": false, 
-    "item": "item_A", 
+    "changed": false,
+    "item": "item_A",
     "msg": "All assertions passed"
 }
 
 PLAY RECAP *********************************************************************
-localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   
+localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0
 

--- a/test/integration/targets/assert/assert_quiet.out.quiet.stdout
+++ b/test/integration/targets/assert/assert_quiet.out.quiet.stdout
@@ -12,5 +12,5 @@ ok: [localhost] => (item=item_A) => {
 }
 
 PLAY RECAP *********************************************************************
-localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0
+localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 

--- a/test/integration/targets/assert/assert_quiet.out.quiet.stdout
+++ b/test/integration/targets/assert/assert_quiet.out.quiet.stdout
@@ -1,9 +1,6 @@
 
 PLAY [localhost] ***************************************************************
 
-TASK [Gathering Facts] *********************************************************
-ok: [localhost]
-
 TASK [assert] ******************************************************************
 ok: [localhost] => (item=item_A)
 
@@ -15,5 +12,5 @@ ok: [localhost] => (item=item_A) => {
 }
 
 PLAY RECAP *********************************************************************
-localhost                  : ok=3    changed=0    unreachable=0    failed=0   
+localhost                  : ok=2    changed=0    unreachable=0    failed=0   
 

--- a/test/integration/targets/assert/inventory
+++ b/test/integration/targets/assert/inventory
@@ -1,0 +1,3 @@
+[all]
+localhost
+

--- a/test/integration/targets/assert/quiet.yml
+++ b/test/integration/targets/assert/quiet.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  vars:
+    item_A: yes
+  tasks:
+  - assert:
+      that: "{{ item }} is defined"
+      quiet: True
+    with_items:
+      - item_A
+  - assert:
+      that: "{{ item }} is defined"
+      quiet: False
+    with_items:
+      - item_A
+

--- a/test/integration/targets/assert/quiet.yml
+++ b/test/integration/targets/assert/quiet.yml
@@ -13,4 +13,3 @@
       quiet: False
     with_items:
       - item_A
-

--- a/test/integration/targets/assert/quiet.yml
+++ b/test/integration/targets/assert/quiet.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  gather_facts: False
   vars:
     item_A: yes
   tasks:

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -18,7 +18,7 @@ run_test() {
 
    # The shenanigans with redirection and 'tee' are to capture STDOUT and
    # STDERR separately while still displaying both to the console
-   { ansible-playbook -i 'localhost,' -c local ${testname}.yml \
+   { ansible-playbook -i 'localhost,' -c local "${testname}.yml" \
       > >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
       2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
    diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -21,6 +21,9 @@ run_test() {
    { ansible-playbook -i 'localhost,' -c local "${testname}.yml" \
       > >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
       2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
+   # clean up Python 2 vs 3 differences
+   sed -i 's/[[:blank:]]*$//' "${OUTFILE}.${testname}.stdout"
+   sed -i 's/[[:blank:]]*$//' "${OUTFILE}.${testname}.stderr"
    diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
    diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
 }

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# This test compares "known good" output with various settings against output
+# with the current code. It's brittle by nature, but this is probably the
+# "best" approach possible.
+#
+# Notes:
+# * options passed to this script (such as -v) are ignored, as they would change
+#   the output and break the test
+# * the number of asterisks after a "banner" differs is forced to 79 by
+#   redirecting stdin from /dev/null
+
+set -eux
+
+run_test() {
+   # testname is playbook name
+   local testname=$1
+
+   # The shenanigans with redirection and 'tee' are to capture STDOUT and
+   # STDERR separately while still displaying both to the console
+   { ansible-playbook -i 'localhost,' -c local ${testname}.yml \
+      > >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
+      2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
+   diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
+   diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
+}
+
+diff_failure() {
+   if [[ $INIT = 0 ]]; then
+      echo "FAILURE...diff mismatch!"
+      exit 1
+   fi
+}
+
+cleanup() {
+   if [[ $INIT = 0 ]]; then
+      rm -f "${OUTFILE}."*
+   fi
+}
+
+BASEFILE=assert_quiet.out
+
+ORIGFILE="${BASEFILE}"
+OUTFILE="${BASEFILE}.new"
+
+trap 'cleanup' EXIT
+
+# The --init flag will (re)generate the "good" output files used by the tests
+INIT=0
+if [[ ${1:-} == "--init" ]]; then
+   shift
+   OUTFILE=$ORIGFILE
+   INIT=1
+fi
+
+# Force the 'default' callback plugin
+export ANSIBLE_STDOUT_CALLBACK=default
+# Disable color in output for consistency
+export ANSIBLE_FORCE_COLOR=0
+export ANSIBLE_NOCOLOR=1
+# Disable retry files
+export ANSIBLE_RETRY_FILES_ENABLED=0
+
+run_test quiet

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -23,7 +23,7 @@ run_test() {
       2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
    # clean up Python 2 vs 3 differences
    sed -i'' 's/ *$//' "${OUTFILE}.${testname}.stdout"
-   sed -i'' 's/ *$//' "${OUTFILE}.${testname}.stdout"
+   sed -i'' 's/ *$//' "${OUTFILE}.${testname}.stderr"
    diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
    diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
 }

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -19,8 +19,11 @@ run_test() {
    # The shenanigans with redirection and 'tee' are to capture STDOUT and
    # STDERR separately while still displaying both to the console
    { ansible-playbook -i 'localhost,' -c local "${testname}.yml" \
-      > >(set +x; sed 's/ *$//' | tee "${OUTFILE}.${testname}.stdout"); } \
-      2> >(set +x; sed 's/ *$//' | tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
+      > >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
+      2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
+
+   perl -pi -e 's/ *$//s' "${OUTFILE}.${testname}.stdout"
+   perl -pi -e 's/ *$//s' "${OUTFILE}.${testname}.stderr"
 
    diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
    diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -19,11 +19,9 @@ run_test() {
    # The shenanigans with redirection and 'tee' are to capture STDOUT and
    # STDERR separately while still displaying both to the console
    { ansible-playbook -i 'localhost,' -c local "${testname}.yml" \
-      > >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
-      2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
-   # clean up Python 2 vs 3 differences
-   sed -i'' 's/ *$//' "${OUTFILE}.${testname}.stdout"
-   sed -i'' 's/ *$//' "${OUTFILE}.${testname}.stderr"
+      > >(set +x; sed 's/ *$//' | tee "${OUTFILE}.${testname}.stdout"); } \
+      2> >(set +x; sed 's/ *$//' | tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
+
    diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
    diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
 }

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -22,8 +22,8 @@ run_test() {
       > >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
       2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
    # clean up Python 2 vs 3 differences
-   sed -i 's/ *$//' "${OUTFILE}.${testname}.stdout"
-   sed -i 's/ *$//' "${OUTFILE}.${testname}.stdout"
+   sed -i'' 's/ *$//' "${OUTFILE}.${testname}.stdout"
+   sed -i'' 's/ *$//' "${OUTFILE}.${testname}.stdout"
    diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
    diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
 }

--- a/test/integration/targets/assert/runme.sh
+++ b/test/integration/targets/assert/runme.sh
@@ -22,8 +22,8 @@ run_test() {
       > >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
       2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2) 0</dev/null
    # clean up Python 2 vs 3 differences
-   sed -i 's/[[:blank:]]*$//' "${OUTFILE}.${testname}.stdout"
-   sed -i 's/[[:blank:]]*$//' "${OUTFILE}.${testname}.stderr"
+   sed -i 's/ *$//' "${OUTFILE}.${testname}.stdout"
+   sed -i 's/ *$//' "${OUTFILE}.${testname}.stdout"
    diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
    diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds quiet boolean option to assert.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
HINT: Fixes #27124

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
assert
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
assert always produces verbose output, and sometimes this isn't desired (e.g., with with_items).  This change allows one to add quiet: True to assert to eliminate the verbose output.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:
$ cat test2.yml 
---
- hosts: localhost
  tasks:
  - assert:
      that: "{{ item }} is defined"
#      quiet: True
    with_items:
      - item_A
      - item_B

$ ansible-playbook -i "localhost," -c local test2.yml -e'item_A=aaa'

PLAY [localhost] ********************************************************************************

TASK [Gathering Facts] **************************************************************************
ok: [localhost]

TASK [assert] ***********************************************************************************
ok: [localhost] => (item=item_A) => {
    "changed": false, 
    "item": "item_A", 
    "msg": "All assertions passed"
}
failed: [localhost] (item=item_B) => {
    "assertion": "item_B is defined", 
    "changed": false, 
    "evaluated_to": false, 
    "item": "item_B", 
    "msg": "Assertion failed"
}

PLAY RECAP **************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   

After (i.e., with quiet: True):
$ cat test2.yml 
---
- hosts: localhost
  tasks:
  - assert:
      that: "{{ item }} is defined"
      quiet: True
    with_items:
      - item_A
      - item_B

$ ansible-playbook -i "localhost," -c local test2.yml -e'item_A=aaa'

PLAY [localhost] ********************************************************************************

TASK [Gathering Facts] **************************************************************************
ok: [localhost]

TASK [assert] ***********************************************************************************
ok: [localhost] => (item=item_A)
failed: [localhost] (item=item_B) => {"assertion": "item_B is defined", "changed": false, "evaluated_to": false, "item": "item_B", "msg": "Assertion failed"}

PLAY RECAP **************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   

```
