### PR TITLE
Fixes Trackback when calling `ansible-doc -a` #52034

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -80,7 +80,7 @@ class DocCLI(CLI):
 
         # process all plugins of type
         if options.all_plugins:
-            args = self.get_all_plugins_of_type(options['type'])
+            args = self.get_all_plugins_of_type(options.type)
             if options.module_path:
                 display.warning('Ignoring "--module-path/-M" option as "--all/-a" only displays builtins')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Option is not a dictionary, its an instance. So referenced instance veritable.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc