### PR TITLE
Fixes traceback when calling `ansible-doc -a` (#52034)

### DIFF
--- a/changelogs/fragments/52034-fix-traceback-on_ansible-doc_-all.yaml
+++ b/changelogs/fragments/52034-fix-traceback-on_ansible-doc_-all.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-doc - Fix traceback on providing arguemnt --all to ansible-doc command

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -117,7 +117,7 @@ class DocCLI(CLI):
 
         # process all plugins of type
         if self.options.all_plugins:
-            self.args = self.get_all_plugins_of_type(plugin_type, loader)
+            self.args = self.get_all_plugins_of_type(plugin_type)
 
         # dump plugin metadata as JSON
         if self.options.json_dump:

--- a/test/units/cli/test_doc.py
+++ b/test/units/cli/test_doc.py
@@ -1,0 +1,12 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.cli.doc import DocCLI
+
+
+def test_parsing_all_option():
+    doc_cli = DocCLI(['/n/ansible-doc', '-a'])
+    doc_cli.parse()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set loader as an optional argument to fix the traceback. 
Fixed & Verified on stable-2.7 release branch. 

To fix similar issue on devel branch -  
https://github.com/aniketkhisti/ansible/commit/129e630b302fee200f09b85f5aee5f9dda277c9f
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible-doc` 

