### PR TITLE
Allow creating keyed group parents

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -335,7 +335,6 @@ class Constructable(object):
     def _add_host_to_keyed_groups(self, keys, variables, host, strict=False):
         ''' helper to create groups for plugins based on variable values and add the corresponding hosts to it'''
         if keys and isinstance(keys, list):
-            groups = []
             for keyed in keys:
                 if keyed and isinstance(keyed, dict):
 
@@ -350,25 +349,33 @@ class Constructable(object):
                         prefix = keyed.get('prefix', '')
                         sep = keyed.get('separator', '_')
 
+                        new_raw_group_names = []
                         if isinstance(key, string_types):
-                            groups.append('%s%s%s' % (prefix, sep, key))
+                            new_raw_group_names.append('%s%s%s' % (prefix, sep, key))
                         elif isinstance(key, list):
                             for name in key:
-                                groups.append('%s%s%s' % (prefix, sep, name))
+                                new_raw_group_names.append('%s%s%s' % (prefix, sep, name))
                         elif isinstance(key, Mapping):
                             for (gname, gval) in key.items():
                                 name = '%s%s%s' % (gname, sep, gval)
-                                groups.append('%s%s%s' % (prefix, sep, name))
+                                new_raw_group_names.append('%s%s%s' % (prefix, sep, name))
                         else:
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
+
+                        parent_name = keyed.get('parent_group', None)
+                        if parent_name:
+                            self.inventory.add_group(parent_name)
+
+                        for group_name in new_raw_group_names:
+                            gname = to_safe_group_name(group_name)
+                            self.inventory.add_group(gname)
+                            self.inventory.add_child(gname, host)
+
+                            if parent_name:
+                                self.inventory.add_child(parent_name, gname)
+
                     else:
                         if strict:
                             raise AnsibleParserError("No key or key resulted empty, invalid entry")
                 else:
                     raise AnsibleParserError("Invalid keyed group entry, it must be a dictionary: %s " % keyed)
-
-            # now actually add any groups
-            for group_name in groups:
-                gname = to_safe_group_name(group_name)
-                self.inventory.add_group(gname)
-                self.inventory.add_child(gname, host)


### PR DESCRIPTION
##### SUMMARY
A solution for https://github.com/ansible/ansible/issues/52035

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/constructed.py

##### ADDITIONAL INFORMATION
Snippet from inventory contents:

```yaml
keyed_groups:
  - prefix: ""
    separator: ""
    key: placement.availability_zone
    parent_group: zones
```

Snippet from the output this produces:

```
    "zones": {
        "children": [
            "us_east_1a", 
            "us_east_1b", 
            "us_east_1c", 
            "us_east_1d", 
            "us_east_1e", 
            "us_east_1f", 
            "us_east_2a", 
            "us_east_2b", 
            "us_east_2c", 
            "us_west_1a", 
            "us_west_1b"
        ]
    }
```
