### PR TITLE
[2.7] ufw: prevent bug in 'ufw --dry-run reset' to delete firewall rules

### DIFF
--- a/changelogs/fragments/ufw-reset-check-mode.yaml
+++ b/changelogs/fragments/ufw-reset-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ufw - when using ``state: reset`` in check mode, ``ufw --dry-run reset`` was executed, which causes a loss of firewall rules. The ``ufw`` module was adjusted to no longer run ``ufw --dry-run reset`` to prevent this from happening."

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -301,6 +301,8 @@ def main():
         cmd = [[ufw_bin], [module.check_mode, '--dry-run']]
 
         if command == 'state':
+            if value == 'reset' and module.check_mode:
+                continue
             states = {'enabled': 'enable', 'disabled': 'disable',
                       'reloaded': 'reload', 'reset': 'reset'}
             execute(cmd + [['-f'], [states[value]]])


### PR DESCRIPTION
##### SUMMARY
This bug was indirectly fixed in the `ufw` module in #49948, which is a new feature PR. This PR makes sure that in check mode, `ufw --dry-run reset` is no longer called.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
