### PR TITLE
Backport/2.7/51028

### DIFF
--- a/changelogs/fragments/51028-get-standard-redfish-properties-for-firmware-entries.yaml
+++ b/changelogs/fragments/51028-get-standard-redfish-properties-for-firmware-entries.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_utils - get standard properties for firmware entries (https://github.com/ansible/ansible/issues/49832)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -490,26 +490,29 @@ class RedfishUtils(object):
 
     def get_firmware_inventory(self):
         result = {}
-        firmware = {}
         response = self.get_request(self.root_uri + self.firmware_uri)
         if response['ret'] is False:
             return response
         result['ret'] = True
         data = response['data']
 
+        result['entries'] = []
         for device in data[u'Members']:
-            d = device[u'@odata.id']
-            d = d.replace(self.firmware_uri, "")    # leave just device name
-            if "Installed" in d:
-                uri = self.root_uri + self.firmware_uri + d
-                # Get details for each device that is relevant
-                response = self.get_request(uri)
-                if response['ret'] is False:
-                    return response
-                result['ret'] = True
-                data = response['data']
-                firmware[data[u'Name']] = data[u'Version']
-        result["entries"] = firmware
+            uri = self.root_uri + device[u'@odata.id']
+            # Get details for each device
+            response = self.get_request(uri)
+            if response['ret'] is False:
+                return response
+            result['ret'] = True
+            data = response['data']
+            firmware = {}
+            # Get these standard properties if present
+            for key in ['Name', 'Id', 'Status', 'Version', 'Updateable',
+                        'SoftwareId', 'LowestSupportedVersion', 'Manufacturer',
+                        'ReleaseDate']:
+                if key in data:
+                    firmware[key] = data.get(key)
+            result['entries'].append(firmware)
         return result
 
     def get_manager_attributes(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated code to fetch schema-defined standard properties for each SoftwareInventory entry. Also removed the filter that was only looking at the entries with "Installed" in the @odata.id.

Fixes #49832 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before change:**
```paste below
$ ansible-playbook -i myinventory.yml playbooks/inventory/get_firmware_inventory.yml 

PLAY [Device Firmware Inventory] ***********************************************

TASK [Set output file] *********************************************************
included: /Users/bdodd/Development/DMTF/Ansible/playbooks/inventory/create_output_file.yml for mockup-rackmount

TASK [Define timestamp] ********************************************************
ok: [mockup-rackmount]

TASK [Define file to place results] ********************************************
ok: [mockup-rackmount]

TASK [Create dropoff directory for host] ***************************************
ok: [mockup-rackmount]

TASK [Get Firmware Inventory] **************************************************
ok: [mockup-rackmount]

TASK [Copy results to output file] *********************************************
changed: [mockup-rackmount]

PLAY RECAP *********************************************************************
mockup-rackmount           : ok=6    changed=1    unreachable=0    failed=0    skipped=0   
```

Returned inventory JSON file (note that `entries` is empty):
```
{
    "ansible_facts": {
        "redfish_facts": {
            "firmware": {
                "entries": {},
                "ret": true
            }
        }
    },
    "changed": false,
    "failed": false
}
```

**After change:**
```
$ ansible-playbook -i myinventory.yml playbooks/inventory/get_firmware_inventory.yml 

PLAY [Device Firmware Inventory] ***********************************************

TASK [Set output file] *********************************************************
included: /Users/bdodd/Development/DMTF/Ansible/playbooks/inventory/create_output_file.yml for mockup-rackmount

TASK [Define timestamp] ********************************************************
ok: [mockup-rackmount]

TASK [Define file to place results] ********************************************
ok: [mockup-rackmount]

TASK [Create dropoff directory for host] ***************************************
ok: [mockup-rackmount]

TASK [Get Firmware Inventory] **************************************************
ok: [mockup-rackmount]

TASK [Copy results to output file] *********************************************
changed: [mockup-rackmount]

PLAY RECAP *********************************************************************
mockup-rackmount           : ok=6    changed=1    unreachable=0    failed=0    skipped=0   
```

Returned inventory JSON file (note that `entries` is now populated):
```
{
    "ansible_facts": {
        "redfish_facts": {
            "firmware": {
                "entries": [
                    {
                        "Id": "BMC",
                        "LowestSupportedVersion": "1.30.367a12-rev1",
                        "Manufacturer": "Contoso",
                        "Name": "Contoso BMC Firmware",
                        "ReleaseDate": "2017-08-22T12:00:00",
                        "SoftwareId": "1624A9DF-5E13-47FC-874A-DF3AFF143089",
                        "Status": {
                            "Health": "OK",
                            "State": "Enabled"
                        },
                        "Updateable": true,
                        "Version": "1.45.455b66-rev4"
                    },
                    {
                        "Id": "BIOS",
                        "LowestSupportedVersion": "P79 v1.10",
                        "Manufacturer": "Contoso",
                        "Name": "Contoso BIOS Firmware",
                        "ReleaseDate": "2017-12-06T12:00:00",
                        "SoftwareId": "FEE82A67-6CE2-4625-9F44-237AD2402C28",
                        "Status": {
                            "Health": "OK",
                            "State": "Enabled"
                        },
                        "Updateable": true,
                        "Version": "P79 v1.45"
                    }
                ],
                "ret": true
            }
        }
    },
    "changed": false,
    "failed": false
}
```