### PR TITLE
Fixing state=present for jenkins_plugin module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -478,7 +478,7 @@ class JenkinsPlugin(object):
                             self._write_file(plugin_file, data)
 
                         changed = True
-            else:
+            elif self.params['version'] == 'latest':
                 # Check for update from the updates JSON file
                 plugin_data = self._download_updates()
 


### PR DESCRIPTION
##### SUMMARY
This PR should fix the problem when a Jenkins plugin is re-installed when `state: present` ever time even if already installed. This should fix #43728.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`jenkins_plugin`

##### ADDITIONAL INFORMATION
This PR requires somebody to verify the functionality.