### PR TITLE
win become - fix token elevation issues - 2.6

### DIFF
--- a/changelogs/fragments/win-become-elevation.yaml
+++ b/changelogs/fragments/win-become-elevation.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win become - Fix some scenarios where become failed to create an elevated process


### PR DESCRIPTION
This is an implementation of https://github.com/ansible/ansible/pull/48082/commits/8bffcf8e50e6493c332bfcaec9e1abe61b92a416
that was done in the PR https://github.com/ansible/ansible/pull/48082 to devel.
The changes have been manually brought across to the the stable-2.7 branch as it
cannot be cleanly cherry picked due to the substantial differences in become
between these versions.

Currently we impersonate the `SYSTEM` token in order to elevate our become
process with the highest privileges it has available but there are some edge
cases where the first `SYSTEM` token we come across doesn't have the
`SeTcbPrivilege` which is required for the above. This PR adds a further check
in the search for a `SYSTEM` token to make sure it has the `SeTcbPrivilege`
before continuing.

(cherry picked from commit cc5088c9e197996f95d2b7cc04cd767157d76ded)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/52056

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win become