### PR TITLE
Pluribus Networks prefix list network module with Unit test cases

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
+++ b/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
@@ -31,7 +31,7 @@ options:
         prefix-list-network and C(absent) to delete prefix-list-network.
     required: true
     type: str
-    choice: ['present', 'absent']
+    choices: ['present', 'absent']
   pn_netmask:
     description:
       - netmask of the network associated the prefix list.

--- a/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
+++ b/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
@@ -106,8 +106,8 @@ def check_cli(module, cli):
 
     if not out:
         module.fail_json(
-             failed=True,
-             msg='Prefix list with name %s does not exists' % name
+            failed=True,
+            msg='Prefix list with name %s does not exists' % name
         )
 
     cli = show
@@ -172,8 +172,8 @@ def main():
     if command == 'prefix-list-network-add':
         if NETWORK_EXISTS is True:
             module.exit_json(
-                 skipped=True,
-                 msg='Prefix list with network %s already exists' % network
+                skipped=True,
+                msg='Prefix list with network %s already exists' % network
             )
 
     if name:

--- a/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
+++ b/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_prefix_list_network
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to add/remove prefix-list-network
+description:
+  - This module is used to add network associated with prefix list
+    and remove networks associated with prefix list.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: false
+    type: str
+  state:
+    description:
+      - State the action to perform. Use C(present) to create
+        prefix-list-network and C(absent) to delete prefix-list-network.
+    required: true
+    type: str
+    choice: ['present', 'absent']
+  pn_netmask:
+    description:
+      - netmask of the network associated the prefix list.
+    required: false
+    type: str
+  pn_name:
+    description:
+      - Prefix List Name.
+    required: false
+    type: str
+  pn_network:
+    description:
+      - network associated with the prefix list.
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: prefix list network add
+  pn_prefix_list_network:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    pn_network: "172.16.3.1"
+    pn_netmask: "24"
+    state: "present"
+
+- name: prefix list network remove
+  pn_prefix_list_network:
+    pn_cliswitch: "sw01"
+    state: "absent"
+    pn_name: "foo"
+    pn_network: "172.16.3.1"
+    pn_netmask: "24"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the prefix-list-network command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the prefix-list-network command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using prefix-list-network-show command.
+    If network exists, return as True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    """
+    name = module.params['pn_name']
+    network = module.params['pn_network']
+    show = cli
+
+    cli += ' prefix-list-show name %s format name no-show-headers' % name
+    rc, out, err = module.run_command(cli, use_unsafe_shell=True)
+
+    if not out:
+        module.fail_json(
+             failed=True,
+             msg='Prefix list with name %s does not exists' % name
+        )
+
+    cli = show
+    cli += ' prefix-list-network-show name %s format network no-show-headers' % name
+    out = module.run_command(cli, use_unsafe_shell=True)[1]
+
+    if out:
+        out = out.split()[1]
+        return True if network in out.split('/')[0] else False
+
+    return False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        present='prefix-list-network-add',
+        absent='prefix-list-network-remove'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_netmask=dict(required=False, type='str'),
+            pn_name=dict(required=False, type='str'),
+            pn_network=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ["state", "present", ["pn_name", "pn_network", "pn_netmask"]],
+            ["state", "absent", ["pn_name", "pn_network", "pn_netmask"]],
+        ),
+        required_together=(
+            ["pn_network", "pn_netmask"],
+        ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    netmask = module.params['pn_netmask']
+    name = module.params['pn_name']
+    network = module.params['pn_network']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    NETWORK_EXISTS = check_cli(module, cli)
+    cli += ' %s ' % command
+
+    if command == 'prefix-list-network-remove':
+        if NETWORK_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='Prefix list with network %s does not exist' % network
+            )
+
+    if command == 'prefix-list-network-add':
+        if NETWORK_EXISTS is True:
+            module.exit_json(
+                 skipped=True,
+                 msg='Prefix list with network %s already exists' % network
+            )
+
+    if name:
+        cli += ' name ' + name
+    if network:
+        cli += ' network ' + network
+    if netmask:
+        cli += ' netmask ' + netmask
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/netvisor/test_pn_prefix_list_network.py
+++ b/test/units/modules/network/netvisor/test_pn_prefix_list_network.py
@@ -1,0 +1,62 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_prefix_list_network
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestPrefixListNetworkModule(TestNvosModule):
+
+    module = pn_prefix_list_network
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_prefix_list_network.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_prefix_list_network.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+        self.mock_run_check_cli.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'prefix-list-network-add':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'prefix-list-network-remove':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = False
+        if state == 'absent':
+            self.run_check_cli.return_value = True
+
+    def test_prefix_list_network_add(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_network': '172.16.3.1', 'pn_netmask': '24', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 prefix-list-network-add  name foo network 172.16.3.1 netmask 24'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_prefix_list_network_remove(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_network': '172.16.3.1', 'pn_netmask': '24', 'state': 'absent'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 prefix-list-network-remove  name foo network 172.16.3.1 netmask 24'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of prefix list network for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_prefix_list_network.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```