### PR TITLE
debug: prevent failing when printing var=rc

### DIFF
--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -75,4 +75,6 @@ class ActionModule(ActionBase):
             result['skipped_reason'] = "Verbosity threshold not met."
             result['skipped'] = True
 
+        result['failed'] = False
+
         return result


### PR DESCRIPTION
##### SUMMARY
If `failed` is not set in a task result, `TaskExecutor` determines failing state according to a value of `result['rc']` (if present). We need to set `failed` in `debug` explicitly, so when `var=rc` is passed into `debug`, `TaskExecutor` does not use that value to determine whether the task failed or not.

<!--- Describe the change below, including rationale and design decisions -->
Fixes #52073
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/action/debug.py