### PR TITLE
Make serial runs use the play order

### DIFF
--- a/changelogs/fragments/52083-support_order_in_serial_runs.yaml
+++ b/changelogs/fragments/52083-support_order_in_serial_runs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - playbook_executor - use play ordering when running serial.

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -255,7 +255,7 @@ class PlaybookExecutor:
         '''
 
         # make sure we have a unique list of hosts
-        all_hosts = self._inventory.get_hosts(play.hosts)
+        all_hosts = self._inventory.get_hosts(play.hosts, order=play.order)
         all_hosts_len = len(all_hosts)
 
         # the serial value can be listed as a scalar or a list of


### PR DESCRIPTION
##### SUMMARY
Fixes #49846
This passes the order from the play to get_hosts() so that order works even when running in serial.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
playbook_executor

##### ADDITIONAL INFORMATION
To test, create a serial playbook and order: reverse_inventory