### PR TITLE
Updating update_url for jenkins_plugin

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -65,7 +65,7 @@ options:
       - URL of the Update Centre.
       - Used as the base URL to download the plugins and the
         I(update-center.json) JSON file.
-    default: https://updates.jenkins-ci.org
+    default: https://updates.jenkins.io
   url:
     description:
       - URL of the Jenkins server.
@@ -721,7 +721,7 @@ def main():
             default='present'),
         timeout=dict(default=30, type="int"),
         updates_expiration=dict(default=86400, type="int"),
-        updates_url=dict(default='https://updates.jenkins-ci.org'),
+        updates_url=dict(default='https://updates.jenkins.io'),
         url=dict(default='http://localhost:8080'),
         url_password=dict(no_log=True),
         version=dict(),


### PR DESCRIPTION
##### SUMMARY
This PR is changing the `update_url` default value as reported in the #52084.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`jenkins_plugin`

##### ADDITIONAL INFORMATION
```shell
### Current URL
$ curl -LI https://updates.jenkins-ci.org/latest/git.hpi
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

### New URL
$ curl -LI https://updates.jenkins.io/latest/git.hpi
HTTP/1.1 302 Found
Date: Tue, 12 Feb 2019 15:47:51 GMT
Server: Apache/2.4.29 (Ubuntu)
Location: https://updates.jenkins.io/download/plugins/git/3.9.3/git.hpi
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 302 Found
Date: Tue, 12 Feb 2019 15:47:51 GMT
Server: Apache/2.4.29 (Ubuntu)
Location: http://mirrors.jenkins-ci.org/plugins/git/3.9.3/git.hpi
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 302 Found
Date: Tue, 12 Feb 2019 15:47:51 GMT
Server: Apache/2.4.29 (Ubuntu)
X-MirrorBrain-Mirror: ftp-nyc.osuosl.org
X-MirrorBrain-Realm: other
Link: <http://mirrors.jenkins-ci.org/plugins/git/3.9.3/git.hpi.meta4>; rel=describedby; type="application/metalink4+xml"
Link: <http://ftp-nyc.osuosl.org/pub/jenkins/plugins/git/3.9.3/git.hpi>; rel=duplicate; pri=1; geo=us
Link: <http://ftp-chi.osuosl.org/pub/jenkins/plugins/git/3.9.3/git.hpi>; rel=duplicate; pri=2; geo=us
Location: http://ftp-nyc.osuosl.org/pub/jenkins/plugins/git/3.9.3/git.hpi
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 200 OK
Date: Tue, 12 Feb 2019 15:47:51 GMT
Server: Apache
Last-Modified: Wed, 30 Jan 2019 15:09:49 GMT
ETag: "1f0b8d-580ae4d0ff9e0"
Accept-Ranges: bytes
Content-Length: 2034573
Content-Type: application/vnd.hp-hpid
```