### PR TITLE
Add support of facts gathering WWNs on Solaris 10 and Solaris 11 OS

### DIFF
--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -43,4 +43,19 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
             for fcfile in glob.glob('/sys/class/fc_host/*/port_name'):
                 for line in get_file_lines(fcfile):
                     fc_facts['fibre_channel_wwn'].append(line.rstrip()[2:])
+        elif sys.platform.startswith('sunos'):
+            """
+            on solaris 10 or solaris 11 should use `fcinfo hba-port`
+            on solaris 9, `prtconf -pv`
+            """
+            cmd = "/usr/sbin/fcinfo hba-port | grep 'Port WWN'"
+            rc, fcinfo_out, err = module.run_command(cmd, use_unsafe_shell=True)
+            """
+            # fcinfo hba-port  | grep "Port WWN"
+            HBA Port WWN: 10000090fa1658de
+            """
+            if fcinfo_out:
+                for line in fcinfo_out.splitlines():
+                    data = line.split(' ')
+                    fc_facts['fibre_channel_wwn'].append(data[-1].rstrip())
         return fc_facts

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -48,7 +48,8 @@ class FcWwnInitiatorFactCollector(BaseFactCollector):
             on solaris 10 or solaris 11 should use `fcinfo hba-port`
             on solaris 9, `prtconf -pv`
             """
-            cmd = "/usr/sbin/fcinfo hba-port | grep 'Port WWN'"
+            cmd = module.get_bin_path('fcinfo')
+            cmd = cmd + " hba-port | grep 'Port WWN'"
             rc, fcinfo_out, err = module.run_command(cmd, use_unsafe_shell=True)
             """
             # fcinfo hba-port  | grep "Port WWN"


### PR DESCRIPTION
##### SUMMARY
Extends PR #37043 / git commit c65909d "Add network fact to obtain FC WWN initiator ports" for Solaris OS support.




##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
facts / network

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```
solaris$ fcinfo hba-port | grep 'Port WWN'
HBA Port WWN: 10000090fa1658de
HBA Port WWN: 10000090fa1658df
HBA Port WWN: 10000090fa165b5c
HBA Port WWN: 10000090fa165b5d
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
before
```
$ ansible deimos -m setup -a "filter=ansible_fibre*"
deimos | SUCCESS => {
    "ansible_facts": {
        "ansible_fibre_channel_wwn": []
    }, 
    "changed": false
}
```
after
```
$ ansible deimos -m setup -a "filter=ansible_fibre*"
deimos | SUCCESS => {
    "ansible_facts": {
        "ansible_fibre_channel_wwn": [
            "10000090fa1658de", 
            "10000090fa1658df", 
            "10000090fa165b5c", 
            "10000090fa165b5d"
        ]
    }, 
    "changed": false
}
```