### PR TITLE
Backport/2.7/51898

### DIFF
--- a/changelogs/fragments/51898-remove-non-standard-redfish-manager-attrs-commands.yaml
+++ b/changelogs/fragments/51898-remove-non-standard-redfish-manager-attrs-commands.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- "remove non-standard {Get/Set}ManagerAttributes commands (https://github.com/ansible/ansible/issues/47590)"
+- "deprecate {Get/Set}ManagerAttributes commands (https://github.com/ansible/ansible/issues/47590)"

--- a/changelogs/fragments/51898-remove-non-standard-redfish-manager-attrs-commands.yaml
+++ b/changelogs/fragments/51898-remove-non-standard-redfish-manager-attrs-commands.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "remove non-standard {Get/Set}ManagerAttributes commands (https://github.com/ansible/ansible/issues/47590)"

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -515,6 +515,27 @@ class RedfishUtils(object):
             result['entries'].append(firmware)
         return result
 
+    def get_manager_attributes(self):
+        result = {}
+        manager_attributes = {}
+        key = "Attributes"
+
+        response = self.get_request(self.root_uri + self.manager_uri + "/" + key)
+        if response['ret'] is False:
+            if '404' in response.get('msg'):
+                response['msg'] = 'The GetManagerAttributes command is not supported on this Redfish service'
+            return response
+        result['ret'] = True
+        data = response['data']
+
+        if key not in data:
+            return {'ret': False, 'msg': "Key %s not found" % key}
+
+        for attribute in data[key].items():
+            manager_attributes[attribute[0]] = attribute[1]
+        result["entries"] = manager_attributes
+        return result
+
     def get_bios_attributes(self):
         result = {}
         bios_attributes = {}
@@ -650,6 +671,24 @@ class RedfishUtils(object):
         if response['ret'] is False:
             return response
         return {'ret': True}
+
+    def set_manager_attributes(self, attr):
+        attributes = "Attributes"
+
+        # Example: manager_attr = {\"name\":\"value\"}
+        # Check if value is a number. If so, convert to int.
+        if attr['mgr_attr_value'].isdigit():
+            manager_attr = "{\"%s\": %i}" % (attr['mgr_attr_name'], int(attr['mgr_attr_value']))
+        else:
+            manager_attr = "{\"%s\": \"%s\"}" % (attr['mgr_attr_name'], attr['mgr_attr_value'])
+
+        payload = {"Attributes": json.loads(manager_attr)}
+        response = self.patch_request(self.root_uri + self.manager_uri + "/" + attributes, payload, HEADERS)
+        if response['ret'] is False:
+            if '404' in response.get('msg'):
+                response['msg'] = 'The SetManagerAttributes command is not supported on this Redfish service'
+            return response
+        return {'ret': True, 'changed': True, 'msg': "Modified Manager attribute"}
 
     def set_bios_attributes(self, attr):
         result = {}

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -515,25 +515,6 @@ class RedfishUtils(object):
             result['entries'].append(firmware)
         return result
 
-    def get_manager_attributes(self):
-        result = {}
-        manager_attributes = {}
-        key = "Attributes"
-
-        response = self.get_request(self.root_uri + self.manager_uri + "/" + key)
-        if response['ret'] is False:
-            return response
-        result['ret'] = True
-        data = response['data']
-
-        if key not in data:
-            return {'ret': False, 'msg': "Key %s not found" % key}
-
-        for attribute in data[key].items():
-            manager_attributes[attribute[0]] = attribute[1]
-        result["entries"] = manager_attributes
-        return result
-
     def get_bios_attributes(self):
         result = {}
         bios_attributes = {}
@@ -666,22 +647,6 @@ class RedfishUtils(object):
             payload = {"Boot": {"BootSourceOverrideTarget": bootdevice}}
 
         response = self.patch_request(self.root_uri + self.systems_uri, payload, HEADERS)
-        if response['ret'] is False:
-            return response
-        return {'ret': True}
-
-    def set_manager_attributes(self, attr):
-        attributes = "Attributes"
-
-        # Example: manager_attr = {\"name\":\"value\"}
-        # Check if value is a number. If so, convert to int.
-        if attr['mgr_attr_value'].isdigit():
-            manager_attr = "{\"%s\": %i}" % (attr['mgr_attr_name'], int(attr['mgr_attr_value']))
-        else:
-            manager_attr = "{\"%s\": \"%s\"}" % (attr['mgr_attr_name'], attr['mgr_attr_value'])
-
-        payload = {"Attributes": json.loads(manager_attr)}
-        response = self.patch_request(self.root_uri + self.manager_uri + "/" + attributes, payload, HEADERS)
         if response['ret'] is False:
             return response
         return {'ret': True}

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -52,6 +52,16 @@ options:
     description:
       - value of BIOS attribute to update
     default: 'null'
+  mgr_attr_name:
+    required: false
+    description:
+      - name of Manager attribute to update
+    default: 'null'
+  mgr_attr_value:
+    required: false
+    description:
+      - value of Manager attribute to update
+    default: 'null'
 
 author: "Jose Delarosa (github: jose-delarosa)"
 '''
@@ -94,6 +104,36 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       user: "{{ user }}"
       password: "{{ password }}"
+
+  - name: Enable NTP in the OOB Controller
+    redfish_config:
+      category: Manager
+      command: SetManagerAttributes
+      mgr_attr_name: NTPConfigGroup.1.NTPEnable
+      mgr_attr_value: Enabled
+      baseuri: "{{ baseuri }}"
+      user: "{{ user}}"
+      password: "{{ password }}"
+
+  - name: Set NTP server 1 to {{ ntpserver1 }} in the OOB Controller
+    redfish_config:
+      category: Manager
+      command: SetManagerAttributes
+      mgr_attr_name: NTPConfigGroup.1.NTP1
+      mgr_attr_value: "{{ ntpserver1 }}"
+      baseuri: "{{ baseuri }}"
+      user: "{{ user}}"
+      password: "{{ password }}"
+
+  - name: Set Timezone to {{ timezone }} in the OOB Controller
+    redfish_config:
+      category: Manager
+      command: SetManagerAttributes
+      mgr_attr_name: Time.1.Timezone
+      mgr_attr_value: "{{ timezone }}"
+      baseuri: "{{ baseuri }}"
+      user: "{{ user}}"
+      password: "{{ password }}"
 '''
 
 RETURN = '''
@@ -111,7 +151,8 @@ from ansible.module_utils._text import to_native
 
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
-    "Systems": ["SetBiosDefaultSettings", "SetBiosAttributes"]
+    "Systems": ["SetBiosDefaultSettings", "SetBiosAttributes"],
+    "Manager": ["SetManagerAttributes"],
 }
 
 
@@ -124,6 +165,8 @@ def main():
             baseuri=dict(required=True),
             user=dict(required=True),
             password=dict(required=True, no_log=True),
+            mgr_attr_name=dict(default='null'),
+            mgr_attr_value=dict(default='null'),
             bios_attr_name=dict(default='null'),
             bios_attr_value=dict(default='null'),
         ),
@@ -137,6 +180,9 @@ def main():
     creds = {'user': module.params['user'],
              'pswd': module.params['password']}
 
+    # Manager attributes to update
+    mgr_attributes = {'mgr_attr_name': module.params['mgr_attr_name'],
+                      'mgr_attr_value': module.params['mgr_attr_value']}
     # BIOS attributes to update
     bios_attributes = {'bios_attr_name': module.params['bios_attr_name'],
                        'bios_attr_value': module.params['bios_attr_value']}
@@ -168,6 +214,20 @@ def main():
                 result = rf_utils.set_bios_default_settings()
             elif command == "SetBiosAttributes":
                 result = rf_utils.set_bios_attributes(bios_attributes)
+
+    elif category == "Manager":
+        # execute only if we find a Manager service resource
+        result = rf_utils._find_managers_resource(rf_uri)
+        if result['ret'] is False:
+            module.fail_json(msg=to_native(result['msg']))
+
+        for command in command_list:
+            if command == "SetManagerAttributes":
+                module.deprecate(msg='The SetManagerAttributes command in '
+                                     'module redfish_config is deprecated. '
+                                     'Use an OEM Redfish module instead.',
+                                 version='2.8')
+                result = rf_utils.set_manager_attributes(mgr_attributes)
 
     # Return data back or fail with proper message
     if result['ret'] is True:

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -52,16 +52,6 @@ options:
     description:
       - value of BIOS attribute to update
     default: 'null'
-  mgr_attr_name:
-    required: false
-    description:
-      - name of Manager attribute to update
-    default: 'null'
-  mgr_attr_value:
-    required: false
-    description:
-      - value of Manager attribute to update
-    default: 'null'
 
 author: "Jose Delarosa (github: jose-delarosa)"
 '''
@@ -104,36 +94,6 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       user: "{{ user }}"
       password: "{{ password }}"
-
-  - name: Enable NTP in the OOB Controller
-    redfish_config:
-      category: Manager
-      command: SetManagerAttributes
-      mgr_attr_name: NTPConfigGroup.1.NTPEnable
-      mgr_attr_value: Enabled
-      baseuri: "{{ baseuri }}"
-      user: "{{ user}}"
-      password: "{{ password }}"
-
-  - name: Set NTP server 1 to {{ ntpserver1 }} in the OOB Controller
-    redfish_config:
-      category: Manager
-      command: SetManagerAttributes
-      mgr_attr_name: NTPConfigGroup.1.NTP1
-      mgr_attr_value: "{{ ntpserver1 }}"
-      baseuri: "{{ baseuri }}"
-      user: "{{ user}}"
-      password: "{{ password }}"
-
-  - name: Set Timezone to {{ timezone }} in the OOB Controller
-    redfish_config:
-      category: Manager
-      command: SetManagerAttributes
-      mgr_attr_name: Time.1.Timezone
-      mgr_attr_value: "{{ timezone }}"
-      baseuri: "{{ baseuri }}"
-      user: "{{ user}}"
-      password: "{{ password }}"
 '''
 
 RETURN = '''
@@ -151,8 +111,7 @@ from ansible.module_utils._text import to_native
 
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
-    "Systems": ["SetBiosDefaultSettings", "SetBiosAttributes"],
-    "Manager": ["SetManagerAttributes"],
+    "Systems": ["SetBiosDefaultSettings", "SetBiosAttributes"]
 }
 
 
@@ -165,8 +124,6 @@ def main():
             baseuri=dict(required=True),
             user=dict(required=True),
             password=dict(required=True, no_log=True),
-            mgr_attr_name=dict(default='null'),
-            mgr_attr_value=dict(default='null'),
             bios_attr_name=dict(default='null'),
             bios_attr_value=dict(default='null'),
         ),
@@ -180,9 +137,6 @@ def main():
     creds = {'user': module.params['user'],
              'pswd': module.params['password']}
 
-    # Manager attributes to update
-    mgr_attributes = {'mgr_attr_name': module.params['mgr_attr_name'],
-                      'mgr_attr_value': module.params['mgr_attr_value']}
     # BIOS attributes to update
     bios_attributes = {'bios_attr_name': module.params['bios_attr_name'],
                        'bios_attr_value': module.params['bios_attr_value']}
@@ -214,16 +168,6 @@ def main():
                 result = rf_utils.set_bios_default_settings()
             elif command == "SetBiosAttributes":
                 result = rf_utils.set_bios_attributes(bios_attributes)
-
-    elif category == "Manager":
-        # execute only if we find a Manager service resource
-        result = rf_utils._find_managers_resource(rf_uri)
-        if result['ret'] is False:
-            module.fail_json(msg=to_native(result['msg']))
-
-        for command in command_list:
-            if command == "SetManagerAttributes":
-                result = rf_utils.set_manager_attributes(mgr_attributes)
 
     # Return data back or fail with proper message
     if result['ret'] is True:

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -126,7 +126,7 @@ CATEGORY_COMMANDS_ALL = {
     "Chassis": ["GetFanInventory"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory"],
-    "Manager": ["GetLogs"],
+    "Manager": ["GetManagerAttributes", "GetLogs"],
 }
 
 CATEGORY_COMMANDS_DEFAULT = {
@@ -134,7 +134,7 @@ CATEGORY_COMMANDS_DEFAULT = {
     "Chassis": "GetFanInventory",
     "Accounts": "ListUsers",
     "Update": "GetFirmwareInventory",
-    "Manager": "GetLogs"
+    "Manager": "GetManagerAttributes"
 }
 
 
@@ -254,7 +254,13 @@ def main():
                 module.fail_json(msg=resource['msg'])
 
             for command in command_list:
-                if command == "GetLogs":
+                if command == "GetManagerAttributes":
+                    module.deprecate(msg='The GetManagerAttributes command in '
+                                         'module redfish_facts is deprecated. '
+                                         'Use an OEM Redfish module instead.',
+                                     version='2.8')
+                    result["manager_attributes"] = rf_utils.get_manager_attributes()
+                elif command == "GetLogs":
                     result["log"] = rf_utils.get_logs()
 
     # Return data back

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -134,7 +134,7 @@ CATEGORY_COMMANDS_DEFAULT = {
     "Chassis": "GetFanInventory",
     "Accounts": "ListUsers",
     "Update": "GetFirmwareInventory",
-    "Manager": "GetManagerNicInventory"
+    "Manager": "GetLogs"
 }
 
 

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -126,7 +126,7 @@ CATEGORY_COMMANDS_ALL = {
     "Chassis": ["GetFanInventory"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory"],
-    "Manager": ["GetManagerAttributes", "GetLogs"],
+    "Manager": ["GetLogs"],
 }
 
 CATEGORY_COMMANDS_DEFAULT = {
@@ -134,7 +134,7 @@ CATEGORY_COMMANDS_DEFAULT = {
     "Chassis": "GetFanInventory",
     "Accounts": "ListUsers",
     "Update": "GetFirmwareInventory",
-    "Manager": "GetManagerAttributes"
+    "Manager": "GetManagerNicInventory"
 }
 
 
@@ -254,9 +254,7 @@ def main():
                 module.fail_json(msg=resource['msg'])
 
             for command in command_list:
-                if command == "GetManagerAttributes":
-                    result["manager_attributes"] = rf_utils.get_manager_attributes()
-                elif command == "GetLogs":
+                if command == "GetLogs":
                     result["log"] = rf_utils.get_logs()
 
     # Return data back


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The commands `GetManagerAttributes` and `SetManagerAttributes` reply on an `Attributes` property in the `Manager` resource. But this is not a standard property in the Redfish spec; it is a vendor-specific Oem property. Accordingly, these 2 non-standard commands are being removed with this PR. These commands can be added by a vendor in an appropriate Oem extension module if needed.

Fixes #47590

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_facts.py
redfish_config.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related_utils issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
See issue #47590 for the original behavior. After this PR, the subject commands (`GetManagerAttributes` and `SetManagerAttributes`) will no longer be available in the standard modules.
