### PR TITLE
Install the NuGet package provider if needed

### DIFF
--- a/changelogs/fragments/52130-win_psmodule-update_nuget.yaml
+++ b/changelogs/fragments/52130-win_psmodule-update_nuget.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_psmodule - the NuGet package provider will be updated, if needed, to avoid issue under adding a repository

--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -39,8 +39,8 @@ Function Install-NugetProvider {
   param(
     [bool]$CheckMode
     )
-  $PackageProvider = Get-PackageProvider -ListAvailable|?{($_.name -eq 'Nuget') -and ($_.version -ge "2.8.5.201")}
-  if (!($PackageProvider)){
+  $PackageProvider = Get-PackageProvider -ListAvailable| Where-Object {($_.name -eq 'Nuget') -and ($_.version -ge "2.8.5.201")}
+  if (-not ($PackageProvider)){
       try{
         Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -ErrorAction Stop -WhatIf:$CheckMode | out-null
         $result.changed = $true
@@ -64,10 +64,11 @@ Function Install-Repository {
     $Repo = (Get-PSRepository).SourceLocation
 
     # If repository isn't already present, try to register it as trusted.
-    if ($Repo -notcontains $Url){ 
+    if ($Repo -notcontains $Url){
       try {
-           if (!($CheckMode)) {
-               Register-PSRepository -Name $Name -SourceLocation $Url -InstallationPolicy Trusted -ErrorAction Stop       
+           if (-not ($CheckMode)) {
+              Install-NugetProvider
+              Register-PSRepository -Name $Name -SourceLocation $Url -InstallationPolicy Trusted -ErrorAction Stop
            }
           $result.changed = $true
           $result.repository_changed = $true
@@ -90,9 +91,10 @@ Function Remove-Repository{
 
     # Try to remove the repository
     if ($Repo -contains $Name){
-        try {         
+        try {
             if (!($CheckMode)) {
-                Unregister-PSRepository -Name $Name -ErrorAction Stop
+              Install-NugetProvider
+              Unregister-PSRepository -Name $Name -ErrorAction Stop
             }
             $result.changed = $true
             $result.repository_changed = $true
@@ -112,13 +114,13 @@ Function Install-PsModule {
       [bool]$AllowClobber,
       [bool]$CheckMode
     )
-    if (Get-Module -Listavailable|?{$_.name -eq $Name}){
+    if (Get-Module -Listavailable| Where-Object {$_.name -eq $Name}){
         $result.output = "Module $($Name) already present"
     }
-    else {      
+    else {
       try{
         # Install NuGet Provider if needed
-        Install-NugetProvider -CheckMode $CheckMode;
+        Install-NugetProvider -CheckMode $CheckMode
 
         $ht = @{
             Name      = $Name;
@@ -129,16 +131,16 @@ Function Install-PsModule {
 
         # If specified, use repository name to select module source
         if ($Repository) {
-            $ht["Repository"] = "$Repository";
+            $ht["Repository"] = "$Repository"
         }
 
         # Check Powershell Version (-AllowClobber was introduced in PowerShellGet 1.6.0)
-        if ("AllowClobber" -in ((Get-Command PowerShellGet\Install-Module | Select -ExpandProperty Parameters).Keys)) {
-          $ht['AllowClobber'] = $AllowClobber;
+        if ("AllowClobber" -in ((Get-Command PowerShellGet\Install-Module | Select-Object -ExpandProperty Parameters).Keys)) {
+          $ht['AllowClobber'] = $AllowClobber
         }
-        
-        Install-Module @ht | out-null;
-        
+
+        Install-Module @ht | out-null
+
         $result.output = "Module $($Name) installed"
         $result.changed = $true
       }
@@ -156,7 +158,7 @@ Function Remove-PsModule {
       [bool]$CheckMode
     )
     # If module is present, unistalls it.
-    if (Get-Module -Listavailable|?{$_.name -eq $Name}){
+    if (Get-Module -Listavailable| Where-Object {$_.name -eq $Name}){
       try{
         Uninstall-Module -Name $Name -Confirm:$false -Force -ErrorAction Stop -WhatIf:$CheckMode | out-null
         $result.output = "Module $($Name) removed"
@@ -182,16 +184,16 @@ if ($PsVersion.Major -lt 5){
 
 if ($state -eq "present") {
     if (($repo) -and ($url)) {
-        Install-Repository -Name $repo -Url $url -CheckMode $check_mode 
+        Install-Repository -Name $repo -Url $url -CheckMode $check_mode
     }
     else {
         $ErrorMessage = "Repository Name and Url are mandatory if you want to add a new repository"
     }
 
-    Install-PsModule -Name $Name -Repository $repo -CheckMode $check_mode -AllowClobber $allow_clobber;
+    Install-PsModule -Name $Name -Repository $repo -CheckMode $check_mode -AllowClobber $allow_clobber
 }
-else {  
-    if ($repo) {   
+else {
+    if ($repo) {
         Remove-Repository -Name $repo -CheckMode $check_mode
     }
     Remove-PsModule -Name $Name -CheckMode $check_mode

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -56,7 +56,6 @@ lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingWMICmdlet
 lib/ansible/modules/windows/win_pagefile.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_pagefile.ps1 PSUseSupportsShouldProcess
-lib/ansible/modules/windows/win_psmodule.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_rabbitmq_plugin.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_rabbitmq_plugin.ps1 PSAvoidUsingInvokeExpression
 lib/ansible/modules/windows/win_region.ps1 PSAvoidUsingEmptyCatchBlock


### PR DESCRIPTION
##### SUMMARY
Under adding a repository the NuGet package provider in the version 2.8.5.201 or newer is required. When it's not available the win_psrepository fails.

Fixes partially #50332 - for Ansible 2.6.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule

##### ADDITIONAL INFORMATION
It's a backport of the #50759 - the win_psrepository module is a descendant of the win_psmodule.

Additionally, the pull requests remove some code smells.
