### PR TITLE
Install the NuGet package provider if needed

### DIFF
--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -61,7 +61,6 @@ lib/ansible/modules/windows/win_pagefile.ps1 PSUseSupportsShouldProcess
 lib/ansible/modules/windows/win_power_plan.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_product_facts.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_psexec.ps1 PSUseDeclaredVarsMoreThanAssignments
-lib/ansible/modules/windows/win_psmodule.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_rabbitmq_plugin.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_rabbitmq_plugin.ps1 PSAvoidUsingInvokeExpression
 lib/ansible/modules/windows/win_region.ps1 PSAvoidUsingEmptyCatchBlock


### PR DESCRIPTION
##### SUMMARY
Under adding a repository the NuGet package provider in the version 2.8.5.201 or newer is required. When it's not available the win_psrepository fails.

Fixes partially #50332 - for Ansible 2.7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule

##### ADDITIONAL INFORMATION
It's a backport of the #50759 - the win_psrepository module is a descendant of the win_psmodule.

Additionally, the pull requests remove some code smells.