### PR TITLE
fix docker default remote_user

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -22,10 +22,9 @@ DOCUMENTATION = """
       remote_user:
         description:
             - The user to execute as inside the container
-        default: The set user as per docker's configuration
         vars:
             - name: ansible_user
-            - name: ansible_docker4_user
+            - name: ansible_docker_user
       docker_extra_args:
         description:
             - Extra arguments to pass to the docker command line


### PR DESCRIPTION
##### SUMMARY
Fix bogus default value in config- exposed by become plugins (#50911) actually using this value in more cases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker.py

##### ADDITIONAL INFORMATION
