### PR TITLE
Re-add support for setting shell from play context

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -83,7 +83,8 @@ class ConnectionBase(AnsiblePlugin):
 
         # we always must have shell
         if not self._shell:
-            self._shell = get_shell_plugin(shell_type=getattr(self, '_shell_type', None), executable=self._play_context.executable)
+            shell_type = play_context.shell if play_context.shell else getattr(self, '_shell_type', None)
+            self._shell = get_shell_plugin(shell_type=shell_type, executable=self._play_context.executable)
 
         self.become = None
 

--- a/test/integration/targets/shell/action_plugins/test_shell.py
+++ b/test/integration/targets/shell/action_plugins/test_shell.py
@@ -1,0 +1,20 @@
+# This file is part of Ansible
+
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+        result['shell'] = self._connection._shell.SHELL_FAMILY
+        return result
+

--- a/test/integration/targets/shell/action_plugins/test_shell.py
+++ b/test/integration/targets/shell/action_plugins/test_shell.py
@@ -17,4 +17,3 @@ class ActionModule(ActionBase):
         del tmp  # tmp no longer has any effect
         result['shell'] = self._connection._shell.SHELL_FAMILY
         return result
-

--- a/test/integration/targets/shell/aliases
+++ b/test/integration/targets/shell/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group1

--- a/test/integration/targets/shell/connection_plugins/test_connection_default.py
+++ b/test/integration/targets/shell/connection_plugins/test_connection_default.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+connection: test_connection_default
+short_description: test connection plugin used in tests
+description:
+- This is a test connection plugin used for shell testing
+author: ansible (@core)
+version_added: historical
+options:
+'''
+
+from ansible.plugins.connection import ConnectionBase
+
+
+class Connection(ConnectionBase):
+    ''' test connnection '''
+
+    transport = 'test_connection_default'
+
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)
+
+    def transport(self):
+        pass
+
+    def _connect(self):
+        pass
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        pass
+
+    def put_file(self, in_path, out_path):
+        pass
+
+    def fetch_file(self, in_path, out_path):
+        pass
+
+    def close(self):
+        pass

--- a/test/integration/targets/shell/connection_plugins/test_connection_override.py
+++ b/test/integration/targets/shell/connection_plugins/test_connection_override.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+connection: test_connection_override
+short_description: test connection plugin used in tests
+description:
+- This is a test connection plugin used for shell testing
+author: ansible (@core)
+version_added: historical
+options:
+'''
+
+from ansible.plugins.connection import ConnectionBase
+
+
+class Connection(ConnectionBase):
+    ''' test connection '''
+
+    transport = 'test_connection_override'
+
+    def __init__(self, *args, **kwargs):
+        self._shell_type = 'powershell'  # Set a shell type that is not sh
+        super(Connection, self).__init__(*args, **kwargs)
+
+    def transport(self):
+        pass
+
+    def _connect(self):
+        pass
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        pass
+
+    def put_file(self, in_path, out_path):
+        pass
+
+    def fetch_file(self, in_path, out_path):
+        pass
+
+    def close(self):
+        pass

--- a/test/integration/targets/shell/tasks/main.yml
+++ b/test/integration/targets/shell/tasks/main.yml
@@ -1,9 +1,37 @@
 ---
-- name: test that you can override shell by using ansible_shell_type
+- name: get shell when shell_type is not defined
   test_shell:
-  register: shell_type
-  failed_when: shell_type.shell != item
+  register: shell_type_default
+  failed_when: shell_type_default.shell != 'sh'
   vars:
+    ansible_connection: test_connection_default
+
+- name: get shell when shell_type is not defined but is overridden
+  test_shell:
+  register: shell_type_default_override
+  failed_when: shell_type_default_override.shell != item
+  vars:
+    ansible_connection: test_connection_default
+    ansible_shell_type: '{{ item }}'
+  with_items:
+  - csh
+  - fish
+  - powershell
+  - sh
+
+- name: get shell when shell_type is defined
+  test_shell:
+  register: shell_type_defined
+  failed_when: shell_type_defined.shell != 'powershell'
+  vars:
+    ansible_connection: test_connection_override
+
+- name: get shell when shell_type is defined but is overridden
+  test_shell:
+  register: shell_type_defined_override
+  failed_when: shell_type_defined_override.shell != item
+  vars:
+    ansible_connection: test_connection_default
     ansible_shell_type: '{{ item }}'
   with_items:
   - csh

--- a/test/integration/targets/shell/tasks/main.yml
+++ b/test/integration/targets/shell/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: test that you can override shell by using ansible_shell_type
+  test_shell:
+  register: shell_type
+  failed_when: shell_type.shell != item
+  vars:
+    ansible_shell_type: '{{ item }}'
+  with_items:
+  - csh
+  - fish
+  - powershell
+  - sh


### PR DESCRIPTION
##### SUMMARY
With the changes in become plugins https://github.com/ansible/ansible/pull/50991, the connection plugins no longer set the shell plugin based on the play context. This means we cannot set the shell on variables like `ansible_shell_type`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
connection