### PR TITLE
Fixed typo of 'adress' to 'address'

### DIFF
--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -220,7 +220,7 @@ class LinuxNetwork(Network):
                             default_ipv4['broadcast'] = broadcast
                             default_ipv4['netmask'] = netmask
                             default_ipv4['network'] = network
-                            # NOTE: macadress is ref from outside scope
+                            # NOTE: macaddress is ref from outside scope
                             default_ipv4['macaddress'] = macaddress
                             default_ipv4['mtu'] = interfaces[device]['mtu']
                             default_ipv4['type'] = interfaces[device].get("type", "unknown")

--- a/lib/ansible/modules/cloud/ovh/ovh_ip_failover.py
+++ b/lib/ansible/modules/cloud/ovh/ovh_ip_failover.py
@@ -80,7 +80,7 @@ options:
 '''
 
 EXAMPLES = '''
-# Route an IP adress 1.1.1.1 to the service ns666.ovh.net
+# Route an IP address 1.1.1.1 to the service ns666.ovh.net
 - ovh_ip_failover:
     name: 1.1.1.1
     service: ns666.ovh.net

--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -236,7 +236,7 @@ EXAMPLES = '''
 
 ---
 # Typical output of a vsphere_facts run on a guest
-# If vmware tools is not installed, ipadresses with return None
+# If vmware tools is not installed, ipaddresses with return None
 
 - hw_eth0:
   - addresstype: "assigned"

--- a/lib/ansible/modules/network/fortios/fortios_address.py
+++ b/lib/ansible/modules/network/fortios/fortios_address.py
@@ -97,7 +97,7 @@ EXAMPLES = """
 
 RETURN = """
 firewall_address_config:
-  description: full firewall adresses config string.
+  description: full firewall addresses config string.
   returned: always
   type: str
 change_string:

--- a/lib/ansible/modules/network/fortios/fortios_antivirus_heuristic.py
+++ b/lib/ansible/modules/network/fortios/fortios_antivirus_heuristic.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_antivirus_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_antivirus_profile.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_antivirus_quarantine.py
+++ b/lib/ansible/modules/network/fortios/fortios_antivirus_quarantine.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_antivirus_settings.py
+++ b/lib/ansible/modules/network/fortios/fortios_antivirus_settings.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_application_custom.py
+++ b/lib/ansible/modules/network/fortios/fortios_application_custom.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_application_group.py
+++ b/lib/ansible/modules/network/fortios/fortios_application_group.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_application_list.py
+++ b/lib/ansible/modules/network/fortios/fortios_application_list.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_application_name.py
+++ b/lib/ansible/modules/network/fortios/fortios_application_name.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_application_rule_settings.py
+++ b/lib/ansible/modules/network/fortios/fortios_application_rule_settings.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_authentication_rule.py
+++ b/lib/ansible/modules/network/fortios/fortios_authentication_rule.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_authentication_scheme.py
+++ b/lib/ansible/modules/network/fortios/fortios_authentication_scheme.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_authentication_setting.py
+++ b/lib/ansible/modules/network/fortios/fortios_authentication_setting.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_dlp_filepattern.py
+++ b/lib/ansible/modules/network/fortios/fortios_dlp_filepattern.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py
+++ b/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py
@@ -46,7 +46,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_dlp_fp_sensitivity.py
+++ b/lib/ansible/modules/network/fortios/fortios_dlp_fp_sensitivity.py
@@ -46,7 +46,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_dlp_sensor.py
+++ b/lib/ansible/modules/network/fortios/fortios_dlp_sensor.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_dlp_settings.py
+++ b/lib/ansible/modules/network/fortios/fortios_dlp_settings.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_dnsfilter_domain_filter.py
+++ b/lib/ansible/modules/network/fortios/fortios_dnsfilter_domain_filter.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_dnsfilter_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_dnsfilter_profile.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_endpoint_control_client.py
+++ b/lib/ansible/modules/network/fortios/fortios_endpoint_control_client.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_endpoint_control_forticlient_ems.py
+++ b/lib/ansible/modules/network/fortios/fortios_endpoint_control_forticlient_ems.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_endpoint_control_forticlient_registration_sync.py
+++ b/lib/ansible/modules/network/fortios/fortios_endpoint_control_forticlient_registration_sync.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_endpoint_control_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_endpoint_control_profile.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_endpoint_control_settings.py
+++ b/lib/ansible/modules/network/fortios/fortios_endpoint_control_settings.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_extender_controller_extender.py
+++ b/lib/ansible/modules/network/fortios/fortios_extender_controller_extender.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_DoS_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_DoS_policy.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_DoS_policy6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_DoS_policy6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_address.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_address.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_address6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_address6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_address6_template.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_address6_template.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_addrgrp.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_addrgrp.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_addrgrp6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_addrgrp6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_auth_portal.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_auth_portal.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_central_snat_map.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_central_snat_map.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_dnstranslation.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_dnstranslation.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_identity_based_route.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_identity_based_route.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_interface_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_interface_policy.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_interface_policy6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_interface_policy6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_internet_service.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_internet_service.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_internet_service_custom.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_internet_service_custom.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_internet_service_group.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_internet_service_group.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_ip_translation.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ip_translation.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_ipmacbinding_setting.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ipmacbinding_setting.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_ipmacbinding_table.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ipmacbinding_table.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_ippool.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ippool.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_ippool6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ippool6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_ipv6_eh_filter.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ipv6_eh_filter.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_ldb_monitor.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ldb_monitor.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_local_in_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_local_in_policy.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_local_in_policy6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_local_in_policy6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_multicast_address.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_multicast_address.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_multicast_address6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_multicast_address6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_multicast_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_multicast_policy.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_multicast_policy6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_multicast_policy6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_policy.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_policy46.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_policy46.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_policy6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_policy6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_policy64.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_policy64.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_profile_group.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_profile_group.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_profile_protocol_options.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_profile_protocol_options.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_proxy_address.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_proxy_address.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_proxy_addrgrp.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_proxy_addrgrp.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_proxy_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_proxy_policy.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vip.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vip.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vip46.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vip46.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vip6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vip6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vip64.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vip64.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp46.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp46.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp6.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp64.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_vipgrp64.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_ips_sensor.py
+++ b/lib/ansible/modules/network/fortios/fortios_ips_sensor.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_system_central_management.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_central_management.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_system_sdn_connector.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_sdn_connector.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter.py
@@ -33,7 +33,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_content.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_content.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_content_header.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_content_header.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_fortiguard.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_fortiguard.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_ftgd_local_cat.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_ftgd_local_cat.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_ftgd_local_rating.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_ftgd_local_rating.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_ips_urlfilter_cache_setting.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_ips_urlfilter_cache_setting.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_ips_urlfilter_setting.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_ips_urlfilter_setting.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_ips_urlfilter_setting6.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_ips_urlfilter_setting6.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_override.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_override.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_profile.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_search_engine.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_search_engine.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter_urlfilter.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter_urlfilter.py
@@ -45,7 +45,7 @@ requirements:
 options:
     host:
        description:
-            - FortiOS or FortiGate ip adress.
+            - FortiOS or FortiGate ip address.
        required: true
     username:
         description:

--- a/lib/ansible/modules/web_infrastructure/sophos_utm/utm_dns_host.py
+++ b/lib/ansible/modules/web_infrastructure/sophos_utm/utm_dns_host.py
@@ -104,7 +104,7 @@ result:
             description: The ipv4 address of the object
             type: str
         address6:
-            description: The ipv6 adress of the object
+            description: The ipv6 address of the object
             type: str
         comment:
             description: The comment string

--- a/test/integration/targets/cnos_backup/cnos_backup_sample_hosts
+++ b/test/integration/targets/cnos_backup/cnos_backup_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_backup_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_backup_sample]

--- a/test/integration/targets/cnos_banner/cnos_banner_sample_hosts
+++ b/test/integration/targets/cnos_banner/cnos_banner_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_banner_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_banner_sample]

--- a/test/integration/targets/cnos_bgp/cnos_bgp_sample_hosts
+++ b/test/integration/targets/cnos_bgp/cnos_bgp_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_bgp_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_bgp_sample]

--- a/test/integration/targets/cnos_command/cnos_command_sample_hosts
+++ b/test/integration/targets/cnos_command/cnos_command_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_command_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_command]

--- a/test/integration/targets/cnos_conditional_command/cnos_conditional_command_sample_hosts
+++ b/test/integration/targets/cnos_conditional_command/cnos_conditional_command_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_conditional_command_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_conditional_command_sample]

--- a/test/integration/targets/cnos_conditional_template/cnos_conditional_template_sample_hosts
+++ b/test/integration/targets/cnos_conditional_template/cnos_conditional_template_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_conditional_template_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_conditional_template_sample]

--- a/test/integration/targets/cnos_config/cnos_config_sample_hosts
+++ b/test/integration/targets/cnos_config/cnos_config_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_command_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_config]

--- a/test/integration/targets/cnos_facts/cnos_facts_sample_hosts
+++ b/test/integration/targets/cnos_facts/cnos_facts_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_facts_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_facts]

--- a/test/integration/targets/cnos_image/cnos_image_sample_hosts
+++ b/test/integration/targets/cnos_image/cnos_image_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_image_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_image_sample]

--- a/test/integration/targets/cnos_interface/cnos_interface_sample_hosts
+++ b/test/integration/targets/cnos_interface/cnos_interface_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_interface_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_interface_sample]

--- a/test/integration/targets/cnos_l2_interface/cnos_l2_interface_sample_hosts
+++ b/test/integration/targets/cnos_l2_interface/cnos_l2_interface_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_l2_interface_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_l2_interface_sample]

--- a/test/integration/targets/cnos_l3_interface/cnos_l3_interface_sample_hosts
+++ b/test/integration/targets/cnos_l3_interface/cnos_l3_interface_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_l3_interface_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_l3_interface_sample]

--- a/test/integration/targets/cnos_linkagg/cnos_linkagg_sample_hosts
+++ b/test/integration/targets/cnos_linkagg/cnos_linkagg_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_portchannel_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_linkagg_sample]

--- a/test/integration/targets/cnos_rollback/cnos_rollback_sample_hosts
+++ b/test/integration/targets/cnos_rollback/cnos_rollback_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_rollback_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_rollback_sample]

--- a/test/integration/targets/cnos_showrun/cnos_showrun_sample_hosts
+++ b/test/integration/targets/cnos_showrun/cnos_showrun_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_facts_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_showrun_sample]

--- a/test/integration/targets/cnos_template/cnos_template_sample_hosts
+++ b/test/integration/targets/cnos_template/cnos_template_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_template_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_template_sample]

--- a/test/integration/targets/cnos_vlag/cnos_vlag_sample_hosts
+++ b/test/integration/targets/cnos_vlag/cnos_vlag_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_vlag_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos_vlag_sample]

--- a/test/integration/targets/cnos_vlan/cnos_vlan_sample_hosts
+++ b/test/integration/targets/cnos_vlan/cnos_vlan_sample_hosts
@@ -3,11 +3,11 @@
 #    - Comments begin with the '#' character
 #    - Blank lines are ignored
 #    - Groups of hosts are delimited by [header] elements
-#    - You can enter hostnames or ip addresses
+#    - You can enter hostnames or ip Addresses
 #    - A hostname/ip can be a member of multiple groups
 #
 # In the /etc/ansible/hosts file u have to enter [cnos_vlan_sample] tag
-# Following you should specify IP Adresses details 
+# Following you should specify IP Addresses details 
 # Please change <username> and <password> with appropriate value for your switch.
 
 [cnos]


### PR DESCRIPTION
Signed-off-by: Amol Kahat <akahat@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed type: 'adress' -> 'address'
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
