### PR TITLE
Fix safe_eval on Python 3.8.

### DIFF
--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -90,6 +90,14 @@ def safe_eval(expr, locals=None, include_exceptions=False):
             )
         )
 
+    # And in Python 3.6 too, although not encountered until Python 3.8, see https://bugs.python.org/issue32892
+    if sys.version_info[:2] >= (3, 6):
+        SAFE_NODES.update(
+            set(
+                (ast.Constant,)
+            )
+        )
+
     filter_list = []
     for filter_ in filter_loader.all():
         filter_list.extend(filter_.filters().keys())


### PR DESCRIPTION
##### SUMMARY

Fix safe_eval on Python 3.8.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

safe_eval
