### PR TITLE
Include Windows as a platform in playbooks_conditionals

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -397,7 +397,7 @@ Possible values (sample, not complete list)::
     Suse
     Windows
 
-.. See `OS_FAMILY_MAP` and python platform module.
+.. Ansible checks `OS_FAMILY_MAP`; if there's no match, it returns the value of `platform.system()`.
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -395,8 +395,9 @@ Possible values (sample, not complete list)::
     Slackware
     Solaris
     Suse
+    Windows
 
-.. See `OS_FAMILY_MAP`
+.. See `OS_FAMILY_MAP` and python platform module.
 
 .. seealso::
 


### PR DESCRIPTION
##### SUMMARY
Minor change to playbooks_conditionals page to include Windows as a valid platform. Also references the python platform module for the underlying source of information.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
playbooks_conditionals

##### ADDITIONAL INFORMATION

+label: docsite_pr
