### PR TITLE
Update os_image requirements

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -80,7 +80,7 @@ options:
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
-requirements: ["openstacksdk"]
+requirements: ["openstacksdk", "shade"]
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -80,7 +80,8 @@ options:
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
-requirements: ["openstacksdk", "shade"]
+requirements: ["openstacksdk"]
+requirements: ["shade (if ansible < 2.6.0)"]
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
shade is required for this module

 FAILED! => {"changed": false, "msg": "shade is required for this module"}

+label: docsite_pr

##### SUMMARY
shade is required for this module

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
os_image

##### ADDITIONAL INFORMATION
$ ansible --version
ansible 2.5.1
python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
