### PR TITLE
Fix idempotence in rabbitmq_plugin

### DIFF
--- a/changelogs/fragments/52166-fix_rabbitmq_plugin_idempotence.yml
+++ b/changelogs/fragments/52166-fix_rabbitmq_plugin_idempotence.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix rabbitmq_plugin idempotence due to information message in new version of rabbitmq
+    (https://github.com/ansible/ansible/pull/52166)

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_plugin.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_plugin.py
@@ -154,6 +154,8 @@ def main():
     if state == 'enabled':
         if not new_only:
             for plugin in enabled_plugins:
+                if " " in plugin:
+                    continue
                 if plugin not in names:
                     rabbitmq_plugins.disable(plugin)
                     disabled.append(plugin)


### PR DESCRIPTION
##### SUMMARY
With rabbitmq 3.7 (and maybe be earlier versions), the idempotence doesn't work any-more with `rabbitmq_plugin`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_plugin.py

##### ADDITIONAL INFORMATION
`rabbitmq_plugin.py` parse the output of `rabbitmq-plugins list -E -m` to detect plugins to add / delete.
But, at least in rabbitmq 3.7, the output is clutter with a message who break the idempotence.

rabbitmq 3.7
```
rabbitmq-plugins list -E -m
Listing plugins with pattern ".*" ...
rabbitmq_management
```  
rabbitmq 3.3.5
```
rabbitmq-plugins list -E -m
rabbitmq_management
```
In rabbitmq 3.7 there is an `-q` who silence this message but doesn't exist in 3.3.5.  
Since there is no space in plugins name, I think that checking that there is no space in the plugin name is the best solution for backward compatibility.

Before this fix
```
$ sudo python /home/molecule/.ansible/tmp/ansible-tmp-1550068067.35-138470711103733/rabbitmq_plugin.py execute

{"disabled": ["Listing plugins with pattern \".*\" ..."], "invocation": {"module_args": {"prefix": null, "names": "rabbitmq_management", "state": "enabled", "new_only": false}}, "changed": true, "enabled": []}
```
After this fix
```
$ sudo python /home/molecule/.ansible/tmp/ansible-tmp-1550068067.35-138470711103733/rabbitmq_plugin.py execute

{"disabled": [], "invocation": {"module_args": {"prefix": null, "names": "rabbitmq_management", "state": "enabled", "new_only": false}}, "changed": false, "enabled": []}
```

@chrishoffman : any comments about this ?

Regards