### PR TITLE
Restore behavior for detecting only localhost, and no limit match. Fixes #52152

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -477,9 +477,6 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # create the inventory, and filter it based on the subset specified (if any)
         inventory = InventoryManager(loader=loader, sources=options['inventory'])
-        subset = options.get('subset', False)
-        if subset:
-            inventory.subset(subset)
 
         # create the variable manager, which will be shared throughout
         # the code, ensuring a consistent view of global variables
@@ -497,8 +494,10 @@ class CLI(with_metaclass(ABCMeta, object)):
                 display.warning("provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'")
             no_hosts = True
 
+        inventory.subset(subset)
+
         hosts = inventory.list_hosts(pattern)
-        if len(hosts) == 0 and no_hosts is False:
+        if not hosts and no_hosts is False:
             raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
 
         return hosts

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -99,6 +99,14 @@ class PlaybookCLI(CLI):
         # create base objects
         loader, inventory, variable_manager = self._play_prereqs()
 
+        # (which is not returned in list_hosts()) is taken into account for
+        # warning if inventory is empty.  But it can't be taken into account for
+        # checking if limit doesn't match any hosts.  Instead we don't worry about
+        # limit if only implicit localhost was in inventory to start with.
+        #
+        # Fix this when we rewrite inventory by making localhost a real host (and thus show up in list_hosts())
+        CLI.get_host_list(inventory, context.CLIARGS['subset'])
+
         # flush fact cache if requested
         if context.CLIARGS['flush_cache']:
             self._flush_cache(inventory, variable_manager)

--- a/test/integration/targets/inventory/aliases
+++ b/test/integration/targets/inventory/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/inventory/playbook.yml
+++ b/test/integration/targets/inventory/playbook.yml
@@ -1,0 +1,4 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - ping:

--- a/test/integration/targets/inventory/runme.sh
+++ b/test/integration/targets/inventory/runme.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x
+
+# https://github.com/ansible/ansible/issues/52152
+# Ensure that non-matching limit causes failure with rc 1
+ansible-playbook -i ../../inventory --limit foo playbook.yml
+if [ "$?" != "1" ]; then
+    echo "Non-matching limit should cause failure"
+    exit 1
+fi


### PR DESCRIPTION
##### SUMMARY
Restore behavior for detecting only localhost, and no limit match. Fixes #52152

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```