### PR TITLE
docker_swarm_facts and docker_host_facts: return more information on failure

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -21,10 +21,11 @@ short_description: Retrieves facts about docker host and lists of objects of the
 description:
   - Retrieves facts about a docker host.
   - Essentially returns the output of C(docker system info).
-  - Returns lists of objects names for the services - images, networks, volumes, containers.
-  - Returns disk usage information.
-  - The output differs depending on API version available on docker host.
-  - Must be executed on a host running a Docker, otherwise the module will fail.
+  - The module also allows to list object names for containers, images, networks and volumes.
+    It also allows to query information on disk usage.
+  - The output differs depending on API version of the docker daemon.
+  - If the docker daemon cannot be contacted or does not meet the API version requirements,
+    the module will fail.
 
 version_added: "2.8"
 
@@ -136,6 +137,12 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+can_talk_to_docker:
+    description:
+      - Will be C(true) if the module can talk to the docker daemon.
+    returned: both on success and on error
+    type: bool
+
 docker_host_facts:
     description:
       - Facts representing the basic state of the docker host. Matches the C(docker system info) output.
@@ -299,7 +306,11 @@ def main():
         supports_check_mode=True,
         min_docker_version='1.10.0',
         min_docker_api_version='1.21',
+        fail_results=dict(
+            can_talk_to_docker=False,
+        ),
     )
+    client.fail_results['can_talk_to_docker'] = True
 
     results = dict(
         changed=False,

--- a/lib/ansible/modules/cloud/docker/docker_swarm_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_facts.py
@@ -21,7 +21,10 @@ description:
   - Retrieves facts about a Docker Swarm.
   - Returns lists of swarm objects names for the services - nodes, services, tasks.
   - The output differs depending on API version available on docker host.
-  - Must be run on Swarm Manager node otherwise module fails with error message.
+  - Must be run on Swarm Manager node; otherwise module fails with error message.
+    It does return boolean flags in on both error and success which indicate whether
+    the docker daemon can be communicated with, whether it is in Swarm mode, and
+    whether it is a Swarm Manager node.
 
 version_added: "2.8"
 
@@ -86,7 +89,17 @@ requirements:
 EXAMPLES = '''
 - name: Get info on Docker Swarm
   docker_swarm_facts:
+  ignore_errors: yes
   register: result
+
+- name: Inform about basic flags
+  debug:
+    msg: |
+      Was able to talk to docker daemon: {{ result.can_talk_to_docker }}
+      Docker in Swarm mode: {{ result.docker_swarm_active }}
+      This is a Manager node: {{ result.docker_swarm_manager }}
+
+- block:
 
 - name: Get info on Docker Swarm and list of registered nodes
   docker_swarm_facts:
@@ -111,6 +124,26 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+can_talk_to_docker:
+    description:
+      - Will be C(true) if the module can talk to the docker daemon.
+    returned: both on success and on error
+    type: bool
+docker_swarm_active:
+    description:
+      - Will be C(true) if the module can talk to the docker daemon,
+        and the docker daemon is in Swarm mode.
+    returned: both on success and on error
+    type: bool
+docker_swarm_manager:
+    description:
+      - Will be C(true) if the module can talk to the docker daemon,
+        the docker daemon is in Swarm mode, and the current node is
+        a manager node.
+      - Only if this one is C(true), the module will not fail.
+    returned: both on success and on error
+    type: bool
+
 docker_swarm_facts:
     description:
       - Facts representing the basic state of the docker Swarm cluster.
@@ -289,7 +322,15 @@ def main():
         supports_check_mode=True,
         min_docker_version='1.10.0',
         min_docker_api_version='1.24',
+        fail_results=dict(
+            can_talk_to_docker=False,
+            docker_swarm_active=False,
+            docker_swarm_manager=False,
+        ),
     )
+    client.fail_results['can_talk_to_docker'] = True
+    client.fail_results['docker_swarm_active'] = client.check_if_swarm_node()
+    client.fail_results['docker_swarm_manager'] = client.check_if_swarm_manager()
 
     results = dict(
         changed=False,
@@ -297,6 +338,7 @@ def main():
     )
 
     DockerSwarmManager(client, results)
+    results.update(client.fail_results)
     client.module.exit_json(**results)
 
 


### PR DESCRIPTION
##### SUMMARY
In case the docker daemon cannot be reached (or does not satisfy the requirements), the modules now also return some basic information. The information for docker_host_facts isn't really helpful (this is already reported by module failing or not), but is kept so that the output is more similar to that of docker_swarm_facts.

Both modules are new in Ansible 2.8, so no changelog fragment is requirement.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_host_facts
docker_swarm_facts
