### PR TITLE
New module: cyberark_credential

### DIFF
--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -50,7 +50,6 @@ options:
                 PolicyID=<platform id managing object>.
         required: True
     client_cert:
-        required: False
         description:
             - A string containing the file location and name of the client certificate used for authentication.
     client_key:

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -76,6 +76,7 @@ EXAMPLES = """
   register: cyberarkcredential
   result:
     '{ api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }'
+
 - name: Retrieve credential from CyberArk Vault using PAS Web Services SDK via Central Credential Provider
   cyberark_credential:
     api_base_url: "{{ web_services_base_url }}"

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -17,7 +17,7 @@ author:
  - Cyberark Bizdev (@cyberark-bizdev)
  - erasmix (@erasmix)
  - James Stutes (@jimmyjamcabd)
-version_added: 2.8
+version_added: "2.8"
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged
       Account Security Web Services SDK by requesting access to a specific object through an Application ID

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -54,7 +54,6 @@ options:
         description:
             - A string containing the file location and name of the client certificate used for authentication.
     client_key:
-        required: False
         description:
             - A string containing the file location and name of the private key of the client certificate used for authentication.
     reason:

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = """
 module: cyberark_credential
-short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
+short_description: Retrieves CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
 author:
  - Edward Nunez (@enunez-cyberark)
  - Cyberark Bizdev (@cyberark-bizdev)

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -57,7 +57,6 @@ options:
         description:
             - A string containing the file location and name of the private key of the client certificate used for authentication.
     reason:
-        required: False
         description:
             - Reason for requesting credential if required by policy.
     state:

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -27,6 +27,7 @@ options:
     api_base_url:
         description:
             - A string containing the base URL of the server hosting the Central Credential Provider
+        type: str
     validate_certs:
         type: bool
         default: 'true'

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -37,6 +37,7 @@ options:
     app_id:
         description:
             - A string containing the Application ID authorized for retrieving the credential.
+        type: str
     query:
         description:
             - A string containing details of the object being queried
@@ -48,16 +49,20 @@ options:
                 Address=<address listed for object>
                 Database=<optional file category for database objects>
                 PolicyID=<platform id managing object>.
+        type: str
         required: True
     client_cert:
         description:
             - A string containing the file location and name of the client certificate used for authentication.
+        type: str
     client_key:
         description:
             - A string containing the file location and name of the private key of the client certificate used for authentication.
+        type: str
     reason:
         description:
             - Reason for requesting credential if required by policy.
+        type: str
     state:
         default: present
         choices: [present]

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -1,0 +1,257 @@
+#!/usr/bin/python
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: cyberark_credential
+short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider 
+author: Edward Nunez @ CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @erasmix)
+version_added: 2.4
+description:
+    - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged 
+      Account Security Web Services SDK by requesting access to a specific object through an Application ID
+      It returns an Ansible fact called I(cyberarkcredential) as a JSON message with object information
+      that can be used by other modules. Every module can use this fact as C(cyberarkcredential) parameter.
+
+
+options:
+    api_base_url:
+        description:
+            - A string containing the base URL of the server hosting the Central Credential Provider
+    validate_certs:
+        type: bool
+        default: 'No'
+        description:
+            - If C(false), SSL certificate chain will not be validated.  This should only
+              set to C(true) if you have a root CA certificate installed on each node.
+    app_id:        
+        description:
+            - A string containing the Application ID authorized for retrieving the credential
+    query:
+        description:
+            - A string containing details of the object being queried
+        parameters:
+            Safe=<safe name>
+            Folder=<folder name within safe>
+            Object=<object name>
+            UserName=<username of object>
+            Address=<address listed for object>
+            Database=<optional file category for database objects>
+            PolicyID=<platform id managing object>
+    client_cert:
+        description:
+        required: 'No'
+            - A string containing the file location and name of the client certificate used for authentication
+    client_key:
+	    description:
+		required: 'No'
+		    - A string containing the file location and name of the private key of the client certificate used for authentication
+	reason:
+	    description:
+        required: 'No'
+            - Reason for requesting credential if required by policy
+'''
+
+EXAMPLES = '''
+- name: Retrieve credential from CyberArk Vault using PAS Web Services SDK via Central Credential Provider
+  cyberark_credential:
+    api_base_url: "{{ web_services_base_url }}"
+    app_id: "{{ application_id }}"
+    query: "Safe=test&UserName=admin"
+  register: cyberarkcredential
+
+  result:
+     { api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }
+
+
+- name: Retrieve credential from CyberArk Vault using PAS Web Services SDK via Central Credential Provider
+  cyberark_credential:
+    api_base_url: "{{ web_services_base_url }}"
+	validate_certs: yes
+	client_cert: /etc/pki/ca-trust/source/client.pem
+	client_key: /etc/pki/ca-trust/source/priv-key.pem
+    app_id: "{{ application_id }}"
+    query: "Safe=test&UserName=admin"
+	reason: "requesting credential for Ansible deployment"
+  register: cyberarkcredential
+
+  result:
+     { api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }
+'''
+
+RETURN = '''
+"cyberark_credential": {
+    "changed": false,
+    "failed": false,
+    "result": {
+        "Address": "string"
+            description: The target address of the credential being queried 
+            type: string
+            returned: if required
+        "Content": "string"
+            description: The password for the object being queried
+            type: string
+            returned: always
+        "CreationMethod": "string"
+            description: This is how the object was created in the Vault
+            type: string
+            returned: always
+        "DeviceType": "string"
+            description: An internal File Category for more granular management of Platforms
+            type: string
+            returned: always
+        "Folder": "string"
+            description: The folder within the Safe where the credential is stored 
+            type: string
+            returned: always
+        "Name": "string"
+            description: The Cyberark unique object ID of the credential being queried 
+            type: string
+            returned: always
+        "PasswordChangeInProcess": "bool"
+            description: If the password has a change flag placed by the CPM 
+            type: bool
+            returned: always
+        "PolicyID": "string"
+            description: Whether or not SSL certificates should be validated.
+            type: string
+            returned: if assigned to a policy
+        "Safe": "string"
+            description: The safe where the queried credential is stored 
+            type: string
+            returned: always
+        "Username": "string"
+            description: The username of the credential being queried 
+            type: string
+            returned: if required
+        "LogonDomain": "string"
+            description: The Address friendly name resolved by the CPM 
+            type: string
+            returned: if populated
+        "CPMDisabled": "string"
+            description: A description of why this vaulted credential is not being managed by the CPM
+            type: string
+            returned: if CPM management is disabled and a reason is given
+        },
+        "status_code": 200
+	}
+}
+'''
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+import json
+import urllib
+try:
+    import httplib
+except ImportError:
+    # Python 3
+    import http.client as httplib
+
+
+def retrieveCredential(module):
+
+    # Getting parameters from module
+
+    api_base_url = module.params["api_base_url"]
+    validate_certs = module.params["validate_certs"]
+    app_id = module.params["app_id"]
+    query = module.params["query"]
+    client_cert = None
+    client_key = None
+    
+    if "client_cert" in module.params:
+        client_cert = module.params["client_cert"]
+    if "client_key" in module.params:
+        client_key = module.params["client_key"]
+
+    end_point = "/AIMWebService/api/Accounts?AppId=%s&Query=%s" % (urllib.quote(app_id), urllib.quote(query))
+    
+    if "reason" in module.params and module.params["reason"] != None:
+        reason = urllib.quote(module.params["reason"])
+        end_point = end_point + "&reason=%s" % reason
+
+    result = None
+    response = None
+
+    try:
+
+        response = open_url(
+            api_base_url + end_point,
+            method="GET",
+            validate_certs=validate_certs,
+            client_cert=client_cert,
+            client_key=client_key)
+
+    except (HTTPError, httplib.HTTPException) as http_exception:
+
+        module.fail_json(
+            msg=("Error while retrieving credential."
+                 "Please validate parameters provided, and permissions for the application and provider in CyberArk."
+                 "\n*** end_point=%s%s\n ==> %s" % (api_base_url, end_point, to_text(http_exception))),
+            status_code=http_exception.code)
+
+    except Exception as unknown_exception:
+
+        module.fail_json(
+            msg=("Unknown error while retrieving credential."
+                 "\n*** end_point=%s%s\n%s" % (api_base_url, end_point, to_text(unknown_exception))),
+            status_code=-1)
+
+    if response.getcode() == 200:  # Success
+
+        # Result token from REST Api uses a different key based
+        try:
+            result = json.loads(response.read())
+        except Exception as e:
+            module.fail_json(
+                msg="Error obtain cyberark credential result from http body\n%s" % (to_text(e)),
+                status_code=-1)
+
+        return (result, response.getcode())
+
+    else:
+        module.fail_json(
+            msg="error in end_point=>" +
+            end_point)
+
+def main():
+
+    fields = {
+        "api_base_url": {"required": True, "type": "str"},
+        "app_id": {"required": True, "type": "str"},
+        "query": {"required": True, "type": "str"},
+        "reason": {"required": False, "type": "str"},
+        "validate_certs": {"type": "bool",
+                           "default": True},
+        "client_cert": {"type": "str", "required": False},
+        "client_key": {"type": "str", "required": False},
+        "state": {"type": "str",
+                  "choices": ["present"],
+                  "default": "present"},
+    }
+
+    module = AnsibleModule(
+        argument_spec=fields,
+        supports_check_mode=True)
+
+    (result, status_code) = retrieveCredential(module)
+
+    module.exit_json(
+        changed=False,
+        result=result,
+        status_code=status_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -255,3 +255,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -9,7 +9,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
 author: Edward Nunez @ CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @erasmix)
@@ -19,58 +19,59 @@ description:
       Account Security Web Services SDK by requesting access to a specific object through an Application ID
       It returns an Ansible fact called I(cyberarkcredential) as a JSON message with object information
       that can be used by other modules. Every module can use this fact as C(cyberarkcredential) parameter.
-
-
 options:
     api_base_url:
         description:
             - A string containing the base URL of the server hosting the Central Credential Provider
     validate_certs:
         type: bool
-        default: 'false'
+        default: 'true'
         description:
             - If C(false), SSL certificate chain will not be validated.  This should only
               set to C(true) if you have a root CA certificate installed on each node.
     app_id:
         description:
-            - A string containing the Application ID authorized for retrieving the credential
+            - A string containing the Application ID authorized for retrieving the credential.
     query:
         description:
             - A string containing details of the object being queried
-        parameters:
-            Safe=<safe name>
-            Folder=<folder name within safe>
-            Object=<object name>
-            UserName=<username of object>
-            Address=<address listed for object>
-            Database=<optional file category for database objects>
-            PolicyID=<platform id managing object>
+              parameters
+                Safe=<safe name>
+                Folder=<folder name within safe>
+                Object=<object name>
+                UserName=<username of object>
+                Address=<address listed for object>
+                Database=<optional file category for database objects>
+                PolicyID=<platform id managing object>.
+        required: True
     client_cert:
+        required: False
         description:
-        required: 'No'
-            - A string containing the file location and name of the client certificate used for authentication
+            - A string containing the file location and name of the client certificate used for authentication.
     client_key:
+        required: False
         description:
-        required: 'No'
-            - A string containing the file location and name of the private key of the client certificate used for authentication
-        reason:
+            - A string containing the file location and name of the private key of the client certificate used for authentication.
+    reason:
+        required: False
         description:
-        required: 'No'
-            - Reason for requesting credential if required by policy
-'''
+            - Reason for requesting credential if required by policy.
+    state:
+        default: present
+        choices: [present]
+        description:
+            - Specifies the state.
+"""
 
-EXAMPLES = '''
+EXAMPLES = """
 - name: Retrieve credential from CyberArk Vault using PAS Web Services SDK via Central Credential Provider
   cyberark_credential:
     api_base_url: "{{ web_services_base_url }}"
     app_id: "{{ application_id }}"
     query: "Safe=test&UserName=admin"
   register: cyberarkcredential
-
   result:
      { api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }
-
-
 - name: Retrieve credential from CyberArk Vault using PAS Web Services SDK via Central Credential Provider
   cyberark_credential:
     api_base_url: "{{ web_services_base_url }}"
@@ -81,12 +82,11 @@ EXAMPLES = '''
     query: "Safe=test&UserName=admin"
     reason: "requesting credential for Ansible deployment"
   register: cyberarkcredential
-
   result:
      { api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }
-'''
+"""
 
-RETURN = '''
+RETURN = """
 "cyberark_credential": {
     "changed": false,
     "failed": false,
@@ -143,7 +143,7 @@ RETURN = '''
         "status_code": 200
     }
 }
-'''
+"""
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
-author: BizDev @ CyberArk('@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd')
+author: BizDev @ CyberArk['@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd']
 version_added: 2.8
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -91,59 +91,59 @@ EXAMPLES = """
 """
 
 RETURN = """
-- cyberark_credential:
-    changed: false
-    failed: false
-    result:
-      Address: string
-        description= The target address of the credential being queried
-        type= string
-        returned= if required
-      Content: string
-        description= The password for the object being queried
-        type= string
-        returned= always
-      CreationMethod: string
-        description= This is how the object was created in the Vault
-        type= string
-        returned= always
-      DeviceType: string
-        description= An internal File Category for more granular management of Platforms
-        type= string
-        returned= always
-      Folder: string
-        description= The folder within the Safe where the credential is stored
-        type= string
-        returned= always
-      Name: string
-        description= The Cyberark unique object ID of the credential being queried
-        type= string
-        returned= always
-      PasswordChangeInProcess: bool
-        description= If the password has a change flag placed by the CPM
-        type= bool
-        returned= always
-      PolicyID: string
-        description= Whether or not SSL certificates should be validated.
-        type= string
-        returned= if assigned to a policy
-      Safe: string
-        description= The safe where the queried credential is stored
-        type= string
-        returned= always
-      Username: string
-        description= The username of the credential being queried
-        type= string
-        returned= if required
-      LogonDomain: string
-        description= The Address friendly name resolved by the CPM
-        type= string
-        returned= if populated
-      CPMDisabled: string
-        description= A description of why this vaulted credential is not being managed by the CPM
-        type= string
-        returned= if CPM management is disabled and a reason is given
-      status_code: 200
+cyberark_credential:
+  changed: false
+  failed: false
+  result:
+    Address: string
+      description: The target address of the credential being queried
+      type: string
+      returned: if required
+    Content: string
+      description: The password for the object being queried
+      type: string
+      returned: always
+    CreationMethod: string
+      description: This is how the object was created in the Vault
+      type: string
+      returned: always
+    DeviceType: string
+      description: An internal File Category for more granular management of Platforms
+      type: string
+      returned: always
+    Folder: string
+      description: The folder within the Safe where the credential is stored
+      type: string
+      returned: always
+    Name: string
+      description: The Cyberark unique object ID of the credential being queried
+      type: string
+      returned: always
+    PasswordChangeInProcess: bool
+      description: If the password has a change flag placed by the CPM
+      type: bool
+      returned: always
+    PolicyID: string
+      description: Whether or not SSL certificates should be validated.
+      type: string
+      returned: if assigned to a policy
+    Safe: string
+      description: The safe where the queried credential is stored
+      type: string
+      returned: always
+    Username: string
+      description: The username of the credential being queried
+      type: string
+      returned: if required
+    LogonDomain: string
+      description: The Address friendly name resolved by the CPM
+      type: string
+      returned: if populated
+    CPMDisabled: string
+      description: A description of why this vaulted credential is not being managed by the CPM
+      type: string
+      returned: if CPM management is disabled and a reason is given
+    status_code: 200
 """
 
 from ansible.module_utils._text import to_text

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -12,7 +12,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
-author: BizDev @ CyberArk['@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd']
+author:
+ - Edward Nunez (@enunez-cyberark)
+ - Cyberark Bizdev (@cyberark-bizdev)
+ - erasmix (@erasmix)
+ - James Stutes (@jimmyjamcabd)
 version_added: 2.8
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -92,58 +92,59 @@ EXAMPLES = """
 
 RETURN = """
 cyberark_credential:
-  changed: false
-  failed: false
-  result:
-    Address: string
-      description: The target address of the credential being queried
-      type: string
-      returned: if required
-    Content: string
-      description: The password for the object being queried
-      type: string
-      returned: always
-    CreationMethod: string
-      description: This is how the object was created in the Vault
-      type: string
-      returned: always
-    DeviceType: string
-      description: An internal File Category for more granular management of Platforms
-      type: string
-      returned: always
-    Folder: string
-      description: The folder within the Safe where the credential is stored
-      type: string
-      returned: always
-    Name: string
-      description: The Cyberark unique object ID of the credential being queried
-      type: string
-      returned: always
-    PasswordChangeInProcess: bool
-      description: If the password has a change flag placed by the CPM
-      type: bool
-      returned: always
-    PolicyID: string
-      description: Whether or not SSL certificates should be validated.
-      type: string
-      returned: if assigned to a policy
-    Safe: string
-      description: The safe where the queried credential is stored
-      type: string
-      returned: always
-    Username: string
-      description: The username of the credential being queried
-      type: string
-      returned: if required
-    LogonDomain: string
-      description: The Address friendly name resolved by the CPM
-      type: string
-      returned: if populated
-    CPMDisabled: string
-      description: A description of why this vaulted credential is not being managed by the CPM
-      type: string
-      returned: if CPM management is disabled and a reason is given
-    status_code: 200
+    description: CyberArk credential retrieved.
+    returned: success
+    type: dict
+    sample:
+      Address:
+        description: The target address of the credential being queried
+        type: string
+        returned: if required
+      Content:
+        description: The password for the object being queried
+        type: string
+        returned: always
+      CreationMethod:
+        description: This is how the object was created in the Vault
+        type: string
+        returned: always
+      DeviceType:
+        description: An internal File Category for more granular management of Platforms
+        type: string
+        returned: always
+      Folder:
+        description: The folder within the Safe where the credential is stored
+        type: string
+        returned: always
+      Name:
+        description: The Cyberark unique object ID of the credential being queried
+        type: string
+        returned: always
+      PasswordChangeInProcess:
+        description: If the password has a change flag placed by the CPM
+        type: bool
+        returned: always
+      PolicyID:
+        description: Whether or not SSL certificates should be validated.
+        type: string
+        returned: if assigned to a policy
+      Safe:
+        description: The safe where the queried credential is stored
+        type: string
+        returned: always
+      Username:
+        description: The username of the credential being queried
+        type: string
+        returned: if required
+      LogonDomain:
+        description: The Address friendly name resolved by the CPM
+        type: string
+        returned: if populated
+      CPMDisabled:
+        description: A description of why this vaulted credential is not being managed by the CPM
+        type: string
+        returned: if CPM management is disabled and a reason is given
+      status_code: 200
 """
 
 from ansible.module_utils._text import to_text

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -10,13 +10,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
----
 module: cyberark_credential
-short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider 
+short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
 author: Edward Nunez @ CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @erasmix)
 version_added: 2.4
 description:
-    - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged 
+    - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged
       Account Security Web Services SDK by requesting access to a specific object through an Application ID
       It returns an Ansible fact called I(cyberarkcredential) as a JSON message with object information
       that can be used by other modules. Every module can use this fact as C(cyberarkcredential) parameter.
@@ -28,11 +27,11 @@ options:
             - A string containing the base URL of the server hosting the Central Credential Provider
     validate_certs:
         type: bool
-        default: 'No'
+        default: 'false'
         description:
             - If C(false), SSL certificate chain will not be validated.  This should only
               set to C(true) if you have a root CA certificate installed on each node.
-    app_id:        
+    app_id:
         description:
             - A string containing the Application ID authorized for retrieving the credential
     query:
@@ -93,7 +92,7 @@ RETURN = '''
     "failed": false,
     "result": {
         "Address": "string"
-            description: The target address of the credential being queried 
+            description: The target address of the credential being queried
             type: string
             returned: if required
         "Content": "string"
@@ -109,15 +108,15 @@ RETURN = '''
             type: string
             returned: always
         "Folder": "string"
-            description: The folder within the Safe where the credential is stored 
+            description: The folder within the Safe where the credential is stored
             type: string
             returned: always
         "Name": "string"
-            description: The Cyberark unique object ID of the credential being queried 
+            description: The Cyberark unique object ID of the credential being queried
             type: string
             returned: always
         "PasswordChangeInProcess": "bool"
-            description: If the password has a change flag placed by the CPM 
+            description: If the password has a change flag placed by the CPM
             type: bool
             returned: always
         "PolicyID": "string"
@@ -125,15 +124,15 @@ RETURN = '''
             type: string
             returned: if assigned to a policy
         "Safe": "string"
-            description: The safe where the queried credential is stored 
+            description: The safe where the queried credential is stored
             type: string
             returned: always
         "Username": "string"
-            description: The username of the credential being queried 
+            description: The username of the credential being queried
             type: string
             returned: if required
         "LogonDomain": "string"
-            description: The Address friendly name resolved by the CPM 
+            description: The Address friendly name resolved by the CPM
             type: string
             returned: if populated
         "CPMDisabled": "string"
@@ -224,6 +223,7 @@ def retrieveCredential(module):
         module.fail_json(
             msg="error in end_point=>" +
             end_point)
+
 
 def main():
 

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
-author: "CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd)"
+author: BizDev @ CyberArk('@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd')
 version_added: 2.8
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged
@@ -92,53 +92,53 @@ RETURN = """
     failed: false
     result:
       Address: string
-        description: The target address of the credential being queried
-        type: string
-        returned: if required
+        description= The target address of the credential being queried
+        type= string
+        returned= if required
       Content: string
-        description: The password for the object being queried
-        type: string
-        returned: always
+        description= The password for the object being queried
+        type= string
+        returned= always
       CreationMethod: string
-        description: This is how the object was created in the Vault
-        type: string
-        returned: always
+        description= This is how the object was created in the Vault
+        type= string
+        returned= always
       DeviceType: string
-        description: An internal File Category for more granular management of Platforms
-        type: string
-        returned: always
+        description= An internal File Category for more granular management of Platforms
+        type= string
+        returned= always
       Folder: string
-        description: The folder within the Safe where the credential is stored
-        type: string
-        returned: always
+        description= The folder within the Safe where the credential is stored
+        type= string
+        returned= always
       Name: string
-        description: The Cyberark unique object ID of the credential being queried
-        type: string
-        returned: always
+        description= The Cyberark unique object ID of the credential being queried
+        type= string
+        returned= always
       PasswordChangeInProcess: bool
-        description: If the password has a change flag placed by the CPM
-        type: bool
-        returned: always
+        description= If the password has a change flag placed by the CPM
+        type= bool
+        returned= always
       PolicyID: string
-        description: Whether or not SSL certificates should be validated.
-        type: string
-        returned: if assigned to a policy
+        description= Whether or not SSL certificates should be validated.
+        type= string
+        returned= if assigned to a policy
       Safe: string
-        description: The safe where the queried credential is stored
-        type: string
-        returned: always
+        description= The safe where the queried credential is stored
+        type= string
+        returned= always
       Username: string
-        description: The username of the credential being queried
-        type: string
-        returned: if required
+        description= The username of the credential being queried
+        type= string
+        returned= if required
       LogonDomain: string
-        description: The Address friendly name resolved by the CPM
-        type: string
-        returned: if populated
+        description= The Address friendly name resolved by the CPM
+        type= string
+        returned= if populated
       CPMDisabled: string
-        description: A description of why this vaulted credential is not being managed by the CPM
-        type: string
-         returned: if CPM management is disabled and a reason is given
+        description= A description of why this vaulted credential is not being managed by the CPM
+        type= string
+        returned= if CPM management is disabled and a reason is given
       status_code: 200
 """
 

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -12,8 +12,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
-author: Edward Nunez @ CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @erasmix)
-version_added: 2.4
+author: Edward Nunez @ CyberArk BizDev(@enunez-cyberark, @cyberark-bizdev, @erasmix)
+version_added: 2.8
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged
       Account Security Web Services SDK by requesting access to a specific object through an Application ID
@@ -71,7 +71,7 @@ EXAMPLES = """
     query: "Safe=test&UserName=admin"
   register: cyberarkcredential
   result:
-     { api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }
+    '{ api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }'
 - name: Retrieve credential from CyberArk Vault using PAS Web Services SDK via Central Credential Provider
   cyberark_credential:
     api_base_url: "{{ web_services_base_url }}"
@@ -83,7 +83,7 @@ EXAMPLES = """
     reason: "requesting credential for Ansible deployment"
   register: cyberarkcredential
   result:
-     { api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }
+    '{ api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&"{ query }'
 """
 
 RETURN = """
@@ -142,7 +142,6 @@ RETURN = """
         },
         "status_code": 200
     }
-}
 """
 
 from ansible.module_utils._text import to_text

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -51,11 +51,11 @@ options:
         required: 'No'
             - A string containing the file location and name of the client certificate used for authentication
     client_key:
-	    description:
-		required: 'No'
-		    - A string containing the file location and name of the private key of the client certificate used for authentication
-	reason:
-	    description:
+        description:
+        required: 'No'
+            - A string containing the file location and name of the private key of the client certificate used for authentication
+        reason:
+        description:
         required: 'No'
             - Reason for requesting credential if required by policy
 '''
@@ -75,12 +75,12 @@ EXAMPLES = '''
 - name: Retrieve credential from CyberArk Vault using PAS Web Services SDK via Central Credential Provider
   cyberark_credential:
     api_base_url: "{{ web_services_base_url }}"
-	validate_certs: yes
-	client_cert: /etc/pki/ca-trust/source/client.pem
-	client_key: /etc/pki/ca-trust/source/priv-key.pem
+    validate_certs: yes
+    client_cert: /etc/pki/ca-trust/source/client.pem
+    client_key: /etc/pki/ca-trust/source/priv-key.pem
     app_id: "{{ application_id }}"
     query: "Safe=test&UserName=admin"
-	reason: "requesting credential for Ansible deployment"
+    reason: "requesting credential for Ansible deployment"
   register: cyberarkcredential
 
   result:
@@ -142,7 +142,7 @@ RETURN = '''
             returned: if CPM management is disabled and a reason is given
         },
         "status_code": 200
-	}
+    }
 }
 '''
 
@@ -169,15 +169,15 @@ def retrieveCredential(module):
     query = module.params["query"]
     client_cert = None
     client_key = None
-    
+
     if "client_cert" in module.params:
         client_cert = module.params["client_cert"]
     if "client_key" in module.params:
         client_key = module.params["client_key"]
 
     end_point = "/AIMWebService/api/Accounts?AppId=%s&Query=%s" % (urllib.quote(app_id), urllib.quote(query))
-    
-    if "reason" in module.params and module.params["reason"] != None:
+
+    if "reason" in module.params and module.params["reason"] is not None:
         reason = urllib.quote(module.params["reason"])
         end_point = end_point + "&reason=%s" % reason
 
@@ -255,4 +255,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
-author: Edward Nunez @ CyberArk BizDev(@enunez-cyberark, @cyberark-bizdev, @erasmix)
+author: Edward Nunez @ CyberArk BizDev('@enunez-cyberark, @cyberark-bizdev, @erasmix, @jammyjamcabd')
 version_added: 2.8
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
-author: CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd)
+author: "CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd)"
 version_added: 2.8
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged
@@ -90,56 +90,56 @@ RETURN = """
 - cyberark_credential:
     changed: false
     failed: false
-    result: 
-        Address: string
-            description: The target address of the credential being queried
-            type: string
-            returned: if required
-        Content: string
-            description: The password for the object being queried
-            type: string
-            returned: always
-        CreationMethod: string
-            description: This is how the object was created in the Vault
-            type: string
-            returned: always
-        DeviceType: string
-            description: An internal File Category for more granular management of Platforms
-            type: string
-            returned: always
-        Folder: string
-            description: The folder within the Safe where the credential is stored
-            type: string
-            returned: always
-        Name: string
-            description: The Cyberark unique object ID of the credential being queried
-            type: string
-            returned: always
-        PasswordChangeInProcess: bool
-            description: If the password has a change flag placed by the CPM
-            type: bool
-            returned: always
-        PolicyID: string
-            description: Whether or not SSL certificates should be validated.
-            type: string
-            returned: if assigned to a policy
-        Safe: string
-            description: The safe where the queried credential is stored
-            type: string
-            returned: always
-        Username: string
-            description: The username of the credential being queried
-            type: string
-            returned: if required
-        LogonDomain: string
-            description: The Address friendly name resolved by the CPM
-            type: string
-            returned: if populated
-        CPMDisabled: string
-            description: A description of why this vaulted credential is not being managed by the CPM
-            type: string
-            returned: if CPM management is disabled and a reason is given
-        status_code: 200
+    result:
+      Address: string
+        description: The target address of the credential being queried
+        type: string
+        returned: if required
+      Content: string
+        description: The password for the object being queried
+        type: string
+        returned: always
+      CreationMethod: string
+        description: This is how the object was created in the Vault
+        type: string
+        returned: always
+      DeviceType: string
+        description: An internal File Category for more granular management of Platforms
+        type: string
+        returned: always
+      Folder: string
+        description: The folder within the Safe where the credential is stored
+        type: string
+        returned: always
+      Name: string
+        description: The Cyberark unique object ID of the credential being queried
+        type: string
+        returned: always
+      PasswordChangeInProcess: bool
+        description: If the password has a change flag placed by the CPM
+        type: bool
+        returned: always
+      PolicyID: string
+        description: Whether or not SSL certificates should be validated.
+        type: string
+        returned: if assigned to a policy
+      Safe: string
+        description: The safe where the queried credential is stored
+        type: string
+        returned: always
+      Username: string
+        description: The username of the credential being queried
+        type: string
+        returned: if required
+      LogonDomain: string
+        description: The Address friendly name resolved by the CPM
+        type: string
+        returned: if populated
+      CPMDisabled: string
+        description: A description of why this vaulted credential is not being managed by the CPM
+        type: string
+         returned: if CPM management is disabled and a reason is given
+      status_code: 200
 """
 
 from ansible.module_utils._text import to_text

--- a/lib/ansible/modules/identity/cyberark/cyberark_credential.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_credential.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 module: cyberark_credential
 short_description: Module for retrieval of CyberArk vaulted credential using PAS Web Services SDK through the Central Credential Provider
-author: Edward Nunez @ CyberArk BizDev('@enunez-cyberark, @cyberark-bizdev, @erasmix, @jammyjamcabd')
+author: CyberArk BizDev (@enunez-cyberark, @cyberark-bizdev, @jimmyjamcabd)
 version_added: 2.8
 description:
     - Creates a URI for retrieving a credential from the Cyberark Vault through the Privileged
@@ -87,61 +87,59 @@ EXAMPLES = """
 """
 
 RETURN = """
-"cyberark_credential": {
-    "changed": false,
-    "failed": false,
-    "result": {
-        "Address": "string"
+- cyberark_credential:
+    changed: false
+    failed: false
+    result: 
+        Address: string
             description: The target address of the credential being queried
             type: string
             returned: if required
-        "Content": "string"
+        Content: string
             description: The password for the object being queried
             type: string
             returned: always
-        "CreationMethod": "string"
+        CreationMethod: string
             description: This is how the object was created in the Vault
             type: string
             returned: always
-        "DeviceType": "string"
+        DeviceType: string
             description: An internal File Category for more granular management of Platforms
             type: string
             returned: always
-        "Folder": "string"
+        Folder: string
             description: The folder within the Safe where the credential is stored
             type: string
             returned: always
-        "Name": "string"
+        Name: string
             description: The Cyberark unique object ID of the credential being queried
             type: string
             returned: always
-        "PasswordChangeInProcess": "bool"
+        PasswordChangeInProcess: bool
             description: If the password has a change flag placed by the CPM
             type: bool
             returned: always
-        "PolicyID": "string"
+        PolicyID: string
             description: Whether or not SSL certificates should be validated.
             type: string
             returned: if assigned to a policy
-        "Safe": "string"
+        Safe: string
             description: The safe where the queried credential is stored
             type: string
             returned: always
-        "Username": "string"
+        Username: string
             description: The username of the credential being queried
             type: string
             returned: if required
-        "LogonDomain": "string"
+        LogonDomain: string
             description: The Address friendly name resolved by the CPM
             type: string
             returned: if populated
-        "CPMDisabled": "string"
+        CPMDisabled: string
             description: A description of why this vaulted credential is not being managed by the CPM
             type: string
             returned: if CPM management is disabled and a reason is given
-        },
-        "status_code": 200
-    }
+        status_code: 200
 """
 
 from ansible.module_utils._text import to_text


### PR DESCRIPTION
cyberark_credential
================

Module to retrieve privileged credential from CyberArk Vault using Web Services SDK through Central Credential Provider.

Requirements
------------

- CyberArk Privileged Account Security Web Services SDK.
- CyberArk AIM Central Credential Provider

Role Variables
--------------

cyberark.modules

Provided Modules
----------------

- **cyberark_credential**: Module for CyberArk credential retrieval using Cyberark Central Credential Provider. 
 

Example Playbook
----------------

**NOTE**: These playbooks are examples of retrieving credentials with CCP using a client cert and assumes that you have implemented SSL authentication for you CCP server.  For more information on this capability reference the **Configure Client Authentication with client certificates** section of the **Central Credential Provider Implementation Guide**.

1) Example playbook showing the use of cyberark_credential module for retrieving a least privileged credential using a client certificate.

```yaml
---
- hosts: all

  roles:
    - role: cyberark.modules

  tasks:

    - cyberark_credential:
        api_base_url: "https://components.cyberark.local"
        validate_certs: no
        client_cert: "/home/user/certs/cert.cer"
        client_key: "/home/user/certs/priv.key"
        app_id: "app_ansible"
        query: "safe=Linux Root Accounts;folder=root;UserName=root;address={{ inventory_hostname }}"
        reason: "Testing Ansible Playbook"
      register: cyberark_response
      delegate_to: localhost

    - name: set response to fact named cyberark_secret
      set_fact:
        cyberark_secret: "{{ cyberark_response.result.Content }}"
      no_log: true
```
2) Example playbook showing the use of cyberark_credential module for retrieving a least privileged SSH Key using a client certificate and setting it as the ssh credential for Ansible to SSH to the hosts.

```yaml
---
- hosts: all
  connection: local
  gather_facts: false

  tasks:

    - name: Cyberark Credential retrieval
      include_role:
        name: cyberark.modules

    - name: Fetch password from Cyberark Vault
      cyberark_credential:
        api_base_url: "https://components.cyberark.local"
        validate_certs: no
        client_cert: "/home/user/certs/cert.cer"
        client_key: "/home/user/certs/priv.key"
        app_id: "app_ansible"
        query: "safe=Linux Root Accounts;folder=root;UserName=root;address={{ inventory_hostname }}"
        reason: "Testing Ansible Playbook"
      register: cyberark_response
      delegate_to: localhost
      no_log: true

    - name: Set response to fact named cyberark_secret
      set_fact:
        cyberark_secret: "{{ cyberark_response.result.Content }}"
      no_log: true


- hosts: all
  connection: local
  gather_facts: false
  vars:
    ansible_ssh_pass: "{{ cyberark_secret }}"
```
3) Example playbook showing the use of cyberark_credential module to retrieve a least privilege SSH Key using a client certificate, connecting to host, then retrieving an elevated credential from the hosts to elevate the session on the host, adhering to the Best Practice model.

```yaml
---

- hosts: all
  connection: local
  gather_facts: true

  roles:
    - role: cyberark.modules

  tasks:

    - name: Fetch SSH Key content from CyberArk Vault
      cyberark_credential:
        api_base_url: "https://components.cyberark.local"
        validate_certs: no
        client_cert: "{{ CYBERARK_CLIENT_CERT }}"
        client_key: "{{ CYBERARK_PRIV_KEY }}"
        app_id: "app_ansible"
        query: "safe=SSH Private Keys;folder=root;address={{ inventory_hostname }}"
        reason: "Testing Ansible Playbook"
      register: cyberark_response
      delegate_to: localhost
      no_log: true

    - name: tempfile module to define file variable
      tempfile:
        state: file
        suffix: key
      register: temp_key
      no_log: true

    - name: writing key contents to a temp file
      copy:
        dest: "{{ temp_key.path }}"
        content: "{{ cyberark_response.result.Content }}"
      delegate_to: localhost
      changed_when: false
      no_log: true

- hosts: all
  gather_facts: true
  vars:
    ansible_ssh_user: "{{ cyberark_response.result.UserName }}"
    ansible_ssh_private_key_file: "{{ temp_key.path }}"

  tasks:

    - name: Fetch root credential for sudo privilege escalation
      cyberark_credential:
        api_base_url: "https://components.cyberark.local"
        app_id: "sudo_privilege"
        validate_certs: no
        query: "safe=Linux Root Accounts;folder=root;address={{ inventory_hostname }}"
        reason: "testing escalation in shell module"
      register: sudo_cred
      no_log: false

    - name: Setting the become variable
      set_fact:
        become_user: "{{ sudo_cred.result.UserName }}"
        ansible_become_pass: "{{ sudo_cred.result.Content }}"
      no_log: false

    - name: Switch User to root
      become: true
      become_method: su
      shell: whoami
      changed_when: false
```

License
-------

MIT

Author Information
------------------

- Cyberark Business Developement Technical Team (BizDevTech@cyberark.com)