### PR TITLE
Add TLS client certificate and CA support to mongodb modules

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_parameter.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_parameter.py
@@ -53,6 +53,30 @@ options:
             - Whether to use an SSL connection when connecting to the database
         type: bool
         default: 'no'
+    ssl_cert_reqs:
+        description:
+            - Specifies whether a certificate is required from the other side of the connection, and whether it will be validated if provided.
+        required: false
+        default: "CERT_REQUIRED"
+        choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
+    ssl_ca_certs:
+        version_added: "2.7"
+        description:
+            - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
+            - Implies ssl=True
+    ssl_certfile:
+        version_added: "2.7"
+        description:
+            - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
+            - If the private key is not in this file, ssl_keyfile is required
+            - Only required when using TLS client certificates for "TLS mutual authentication"
+            - Implies ssl=True
+    ssl_keyfile:
+        version_added: "2.7"
+        description:
+            - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
+            - If the private key is already in the ssl_certfile, this parameter is optional
+            - Only required when using TLS client certificates for "TLS mutual authentication"
     param:
         description:
             - MongoDB administrative parameter to modify
@@ -93,6 +117,7 @@ after:
 '''
 
 import os
+import ssl as ssl_lib
 import traceback
 
 try:
@@ -152,6 +177,10 @@ def main():
             value=dict(default=None, required=True),
             param_type=dict(default="str", choices=['str', 'int']),
             ssl=dict(default=False, type='bool'),
+            ssl_cert_reqs=dict(default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),
+            ssl_certfile=dict(default=None),
+            ssl_keyfile=dict(default=None),
+            ssl_ca_certs=dict(default=None),
         )
     )
 
@@ -166,6 +195,9 @@ def main():
 
     replica_set = module.params['replica_set']
     ssl = module.params['ssl']
+    ssl_certfile = module.params['ssl_certfile']
+    ssl_keyfile = module.params['ssl_keyfile']
+    ssl_ca_certs = module.params['ssl_ca_certs']
 
     param = module.params['param']
     param_type = module.params['param_type']
@@ -179,10 +211,25 @@ def main():
         module.fail_json(msg="value '%s' is not %s" % (value, param_type))
 
     try:
+        connection_params = {
+            "host": login_host,
+            "port": int(login_port)
+        }
+
         if replica_set:
-            client = MongoClient(login_host, int(login_port), replicaset=replica_set, ssl=ssl)
-        else:
-            client = MongoClient(login_host, int(login_port), ssl=ssl)
+            connection_params["replicaset"] = replica_set
+
+        if ssl:
+            connection_params["ssl"] = ssl
+            connection_params["ssl_cert_reqs"] = getattr(ssl_lib, module.params['ssl_cert_reqs'])
+        if ssl_certfile:
+            connection_params["ssl_certfile"] = ssl_certfile
+        if ssl_keyfile:
+            connection_params["ssl_keyfile"] = ssl_keyfile
+        if ssl_ca_certs:
+            connection_params["ssl_ca_certs"] = ssl_ca_certs
+
+        client = MongoClient(**connection_params)
 
         if login_user is None and login_password is None:
             mongocnf_creds = load_mongocnf()

--- a/lib/ansible/modules/database/mongodb/mongodb_parameter.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_parameter.py
@@ -54,7 +54,7 @@ options:
         type: bool
         default: 'no'
     ssl_cert_reqs:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - Specifies whether a certificate is required from the other side of the connection, and whether it will be validated if provided.
         required: false
@@ -65,7 +65,7 @@ options:
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
-        type: str    
+        type: str
     ssl_certfile:
         version_added: "2.10"
         description:

--- a/lib/ansible/modules/database/mongodb/mongodb_parameter.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_parameter.py
@@ -60,19 +60,19 @@ options:
         default: "CERT_REQUIRED"
         choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
     ssl_ca_certs:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
     ssl_certfile:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
             - If the private key is not in this file, ssl_keyfile is required
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
     ssl_keyfile:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
             - If the private key is already in the ssl_certfile, this parameter is optional

--- a/lib/ansible/modules/database/mongodb/mongodb_parameter.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_parameter.py
@@ -54,6 +54,7 @@ options:
         type: bool
         default: 'no'
     ssl_cert_reqs:
+        version_added: "2.8"
         description:
             - Specifies whether a certificate is required from the other side of the connection, and whether it will be validated if provided.
         required: false

--- a/lib/ansible/modules/database/mongodb/mongodb_parameter.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_parameter.py
@@ -61,23 +61,26 @@ options:
         default: "CERT_REQUIRED"
         choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
     ssl_ca_certs:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
+        type: str    
     ssl_certfile:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
             - If the private key is not in this file, ssl_keyfile is required
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
+        type: str
     ssl_keyfile:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
             - If the private key is already in the ssl_certfile, this parameter is optional
             - Only required when using TLS client certificates for "TLS mutual authentication"
+        type: str
     param:
         description:
             - MongoDB administrative parameter to modify

--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -71,24 +71,27 @@ options:
     default: CERT_REQUIRED
     choices: [ CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED ]
   ssl_ca_certs:
-    version_added: "2.8"
+    version_added: "2.10"
     description:
         - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
         - Implies ssl=True
+    type: str
   ssl_certfile:
-    version_added: "2.8"
+    version_added: "2.10"
     description:
         - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
         - If the private key is not in this file, ssl_keyfile is required
         - Only required when using TLS client certificates for "TLS mutual authentication"
         - Implies ssl=True
+    type: str
   ssl_keyfile:
-    version_added: "2.8"
+    version_added: "2.10"
     description:
         - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
         - If the private key is already in the ssl_certfile, this parameter is optional
         - Only required when using TLS client certificates for "TLS mutual authentication"
         - Implies ssl=True
+    type: str    
   arbiter_at_index:
     description:
     - Identifies the position of the member in the array that is an arbiter.

--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -91,7 +91,7 @@ options:
         - If the private key is already in the ssl_certfile, this parameter is optional
         - Only required when using TLS client certificates for "TLS mutual authentication"
         - Implies ssl=True
-    type: str    
+    type: str
   arbiter_at_index:
     description:
     - Identifies the position of the member in the array that is an arbiter.

--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -70,6 +70,25 @@ options:
     type: str
     default: CERT_REQUIRED
     choices: [ CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED ]
+  ssl_ca_certs:
+    version_added: "2.8"
+    description:
+        - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
+        - Implies ssl=True
+  ssl_certfile:
+    version_added: "2.8"
+    description:
+        - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
+        - If the private key is not in this file, ssl_keyfile is required
+        - Only required when using TLS client certificates for "TLS mutual authentication"
+        - Implies ssl=True
+  ssl_keyfile:
+    version_added: "2.8"
+    description:
+        - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
+        - If the private key is already in the ssl_certfile, this parameter is optional
+        - Only required when using TLS client certificates for "TLS mutual authentication"
+        - Implies ssl=True
   arbiter_at_index:
     description:
     - Identifies the position of the member in the array that is an arbiter.
@@ -304,6 +323,9 @@ def main():
             validate=dict(type='bool', default=True),
             ssl=dict(type='bool', default=False),
             ssl_cert_reqs=dict(type='str', default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),
+            ssl_certfile=dict(default=None),
+            ssl_keyfile=dict(default=None),
+            ssl_ca_certs=dict(default=None),
             protocol_version=dict(type='int', default=1, choices=[0, 1]),
             chaining_allowed=dict(type='bool', default=True),
             heartbeat_timeout_secs=dict(type='int', default=10),
@@ -325,6 +347,9 @@ def main():
     arbiter_at_index = module.params['arbiter_at_index']
     validate = module.params['validate']
     ssl = module.params['ssl']
+    ssl_certfile = module.params['ssl_certfile']
+    ssl_keyfile = module.params['ssl_keyfile']
+    ssl_ca_certs = module.params['ssl_ca_certs']
     protocol_version = module.params['protocol_version']
     chaining_allowed = module.params['chaining_allowed']
     heartbeat_timeout_secs = module.params['heartbeat_timeout_secs']
@@ -349,6 +374,12 @@ def main():
     if ssl:
         connection_params["ssl"] = ssl
         connection_params["ssl_cert_reqs"] = getattr(ssl_lib, module.params['ssl_cert_reqs'])
+    if ssl_certfile:
+        connection_params["ssl_certfile"] = ssl_certfile
+    if ssl_keyfile:
+        connection_params["ssl_keyfile"] = ssl_keyfile
+    if ssl_ca_certs:
+        connection_params["ssl_ca_certs"] = ssl_ca_certs
 
     try:
         client = MongoClient(**connection_params)

--- a/lib/ansible/modules/database/mongodb/mongodb_shard.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_shard.py
@@ -62,24 +62,27 @@ options:
         default: "CERT_REQUIRED"
         choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
     ssl_ca_certs:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
+        type: str
     ssl_certfile:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
             - If the private key is not in this file, ssl_keyfile is required
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
+        type: str
     ssl_keyfile:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
             - If the private key is already in the ssl_certfile, this parameter is optional
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
+        type: str    
     state:
         description:
             - Whether the shard should be present or absent from the Cluster.

--- a/lib/ansible/modules/database/mongodb/mongodb_shard.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_shard.py
@@ -82,7 +82,7 @@ options:
             - If the private key is already in the ssl_certfile, this parameter is optional
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
-        type: str    
+        type: str
     state:
         description:
             - Whether the shard should be present or absent from the Cluster.

--- a/lib/ansible/modules/database/mongodb/mongodb_shard.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_shard.py
@@ -62,19 +62,19 @@ options:
         default: "CERT_REQUIRED"
         choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
     ssl_ca_certs:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
     ssl_certfile:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
             - If the private key is not in this file, ssl_keyfile is required
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
     ssl_keyfile:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
             - If the private key is already in the ssl_certfile, this parameter is optional

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -69,24 +69,27 @@ options:
         default: "CERT_REQUIRED"
         choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
     ssl_ca_certs:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
+        type: str    
     ssl_certfile:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
             - If the private key is not in this file, ssl_keyfile is required
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
+        type: str
     ssl_keyfile:
-        version_added: "2.8"
+        version_added: "2.10"
         description:
             - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
             - If the private key is already in the ssl_certfile, this parameter is optional
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
+        type: str
     roles:
         version_added: "1.3"
         description:

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -69,19 +69,19 @@ options:
         default: "CERT_REQUIRED"
         choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
     ssl_ca_certs:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
     ssl_certfile:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
             - If the private key is not in this file, ssl_keyfile is required
             - Only required when using TLS client certificates for "TLS mutual authentication"
             - Implies ssl=True
     ssl_keyfile:
-        version_added: "2.7"
+        version_added: "2.8"
         description:
             - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
             - If the private key is already in the ssl_certfile, this parameter is optional

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -73,7 +73,7 @@ options:
         description:
             - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
             - Implies ssl=True
-        type: str    
+        type: str
     ssl_certfile:
         version_added: "2.10"
         description:

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -68,6 +68,25 @@ options:
             - Specifies whether a certificate is required from the other side of the connection, and whether it will be validated if provided.
         default: "CERT_REQUIRED"
         choices: ["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"]
+    ssl_ca_certs:
+        version_added: "2.7"
+        description:
+            - The path to a file containing certificate(s) of CA(s) that may be trusted to create the SSL cert presented by the MongoDB server
+            - Implies ssl=True
+    ssl_certfile:
+        version_added: "2.7"
+        description:
+            - Path to the file containing a TLS client certificate and (optionally) private key, in PEM encoding
+            - If the private key is not in this file, ssl_keyfile is required
+            - Only required when using TLS client certificates for "TLS mutual authentication"
+            - Implies ssl=True
+    ssl_keyfile:
+        version_added: "2.7"
+        description:
+            - Path to the file containing the private key corresponding to the certificate specified via ssl_certfile, in PEM encoding
+            - If the private key is already in the ssl_certfile, this parameter is optional
+            - Only required when using TLS client certificates for "TLS mutual authentication"
+            - Implies ssl=True
     roles:
         version_added: "1.3"
         description:
@@ -342,10 +361,13 @@ def main():
             name=dict(required=True, aliases=['user']),
             password=dict(aliases=['pass'], no_log=True),
             ssl=dict(default=False, type='bool'),
+            ssl_cert_reqs=dict(default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),
+            ssl_certfile=dict(default=None),
+            ssl_keyfile=dict(default=None),
+            ssl_ca_certs=dict(default=None),
             roles=dict(default=None, type='list'),
             state=dict(default='present', choices=['absent', 'present']),
             update_password=dict(default="always", choices=["always", "on_create"]),
-            ssl_cert_reqs=dict(default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),
         ),
         supports_check_mode=True
     )
@@ -367,6 +389,9 @@ def main():
     roles = module.params['roles'] or []
     state = module.params['state']
     update_password = module.params['update_password']
+    ssl_certfile = module.params['ssl_certfile']
+    ssl_keyfile = module.params['ssl_keyfile']
+    ssl_ca_certs = module.params['ssl_ca_certs']
 
     try:
         connection_params = {
@@ -380,6 +405,12 @@ def main():
         if ssl:
             connection_params["ssl"] = ssl
             connection_params["ssl_cert_reqs"] = getattr(ssl_lib, module.params['ssl_cert_reqs'])
+        if ssl_certfile:
+            connection_params["ssl_certfile"] = ssl_certfile
+        if ssl_keyfile:
+            connection_params["ssl_keyfile"] = ssl_keyfile
+        if ssl_ca_certs:
+            connection_params["ssl_ca_certs"] = ssl_ca_certs
 
         client = MongoClient(**connection_params)
 

--- a/test/integration/targets/mongodb_replicaset/defaults/main.yml
+++ b/test/integration/targets/mongodb_replicaset/defaults/main.yml
@@ -17,6 +17,7 @@ mongodb_nodes:
   - 3002
   - 3003
 mongod_auth: false
+mongo_ssl: false
 kill_signal: SIGTERM
 # Should be one of
 mongod_storage_engine_opts: "--storageEngine wiredTiger --wiredTigerEngineConfigString='cache_size=200M'"

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -159,7 +159,7 @@
     login_database: "admin"
     replica_set: "{{ mongodb_replicaset1 }}"
     ssl_cert_reqs: CERT_OPTIONAL
-    ssl_ca_certs: "{{ remote_tmp_dir }}/mongo_ca.pem"
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca.pem"
     ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
     heartbeat_timeout_secs: 1
     election_timeout_millis: 1000
@@ -169,7 +169,7 @@
      - "localhost:3003"
 
 - name: Get replicaset info
-  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/mongo_ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --eval "rs.status()" --port 3001
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --eval "rs.status()" --port 3001
   register: mongo_output
 
 - name: Assert replicaset name is in mongo_output

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -147,6 +147,9 @@
 - set_fact:
     mongo_ssl: true
 
+- set_fact:
+    mongod_auth: false
+
 - name: Execute mongod script to restart with SSL enabled
   include_tasks: mongod_replicaset.yml
 

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -145,7 +145,7 @@
 - include_tasks: mongod_teardown.yml
 
 - set_fact:
-    mongod_ssl: true
+    mongo_ssl: true
 
 - name: Execute mongod script to restart with SSL enabled
   include_tasks: mongod_replicaset.yml

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -142,8 +142,52 @@
       - "'Authentication failed' in mongodb_replicaset_bad_pw.module_stderr"
 
   #############################################################
+- include_tasks: mongod_teardown.yml
+
+- set_fact:
+    mongod_ssl: true
+
+- name: Execute mongod script to restart with SSL enabled
+  include_tasks: mongod_replicaset.yml
+
+- name: Create replicaset with module
+  mongodb_replicaset:
+    login_user: admin
+    login_password: secret
+    login_host: "localhost"
+    login_port: 3001
+    login_database: "admin"
+    replica_set: "{{ mongodb_replicaset1 }}"
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/mongo_ca.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
+    heartbeat_timeout_secs: 1
+    election_timeout_millis: 1000
+    members:
+     - "localhost:3001"
+     - "localhost:3002"
+     - "localhost:3003"
+
+- name: Get replicaset info
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/mongo_ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --eval "rs.status()" --port 3001
+  register: mongo_output
+
+- name: Assert replicaset name is in mongo_output
+  assert:
+    that:
+      - "mongo_output.changed == true"
+      - "'{{ mongodb_replicaset1 }}' in mongo_output.stdout"
+      - "'localhost:3001' in mongo_output.stdout"
+      - "'localhost:3002' in mongo_output.stdout"
+      - "'localhost:3003' in mongo_output.stdout"
+
+
+  #############################################################
 
 - include_tasks: mongod_teardown.yml
+
+- set_fact:
+    mongod_ssl: false
 
 - set_fact:
     current_replicaset: "{{ mongodb_replicaset2 }}"

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -161,7 +161,7 @@
     login_port: 3001
     login_database: "admin"
     replica_set: "{{ mongodb_replicaset1 }}"
-    ssl_cert_reqs: CERT_NONE
+    ssl_cert_reqs: CERT_OPTIONAL
     ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
     ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
     heartbeat_timeout_secs: 1

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -190,7 +190,7 @@
 - include_tasks: mongod_teardown.yml
 
 - set_fact:
-    mongod_ssl: false
+    mongo_ssl: false
 
 - set_fact:
     current_replicaset: "{{ mongodb_replicaset2 }}"

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -162,7 +162,7 @@
     login_database: "admin"
     replica_set: "{{ mongodb_replicaset1 }}"
     ssl_cert_reqs: CERT_OPTIONAL
-    ssl_ca_certs: "{{ remote_tmp_dir }}/ca.pem"
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
     ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
     heartbeat_timeout_secs: 1
     election_timeout_millis: 1000

--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -161,7 +161,7 @@
     login_port: 3001
     login_database: "admin"
     replica_set: "{{ mongodb_replicaset1 }}"
-    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_cert_reqs: CERT_NONE
     ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
     ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
     heartbeat_timeout_secs: 1

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -71,6 +71,7 @@
   args:
     chdir: "{{remote_tmp_dir}}"
   with_items:
+    - ca
     - mongo
     - mongo-client
   when: mongo_ssl == True

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -39,7 +39,7 @@
     country_name: US
     organization_name: Ansible
     email_address: integration-tests@ansible.com
-    common_name: "{{item}}.ansible.com"
+    common_name: "localhost"
   with_items:
     - ca
     - mongo

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -39,11 +39,54 @@
     country_name: US
     organization_name: Ansible
     email_address: integration-tests@ansible.com
-    common_name: "localhost"
+    common_name: "{{ item }}.ansible.com"
+    extended_key_usage:
+      - clientAuth
+      - serverAuth
+    keyUsage:
+      - digitalSignature
+      - keyAgreement
+      - keyCertSign
+  with_items:
+    - mongo-client
+  when: mongo_ssl == True
+
+- name: Generate CSRs
+  openssl_csr:
+    path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    privatekey_path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
+    country_name: US
+    organization_name: Ansible
+    email_address: integration-tests@ansible.com
+    common_name: "{{ item }}.ansible.com"
+    extended_key_usage:
+      - clientAuth
+      - serverAuth
+    keyUsage:
+      - digitalSignature
+      - keyAgreement
+      - keyCertSign
   with_items:
     - ca
+  when: mongo_ssl == True
+
+- name: Generate CSRs
+  openssl_csr:
+    path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    privatekey_path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
+    country_name: US
+    organization_name: Ansible
+    email_address: integration-tests@ansible.com
+    common_name: "localhost"
+    extended_key_usage:
+      - clientAuth
+      - serverAuth
+    keyUsage:
+      - digitalSignature
+      - keyAgreement
+      - keyCertSign
+  with_items:
     - mongo
-    - mongo-client
   when: mongo_ssl == True
 
 - name: Generate a Self Signed OpenSSL CA certificate
@@ -91,14 +134,14 @@
   when: mongod_auth == True  and mongo_ssl == False
 
 - name: Spawn mongod process without auth and with SSL
-  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
+  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca-chain.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
   when: mongod_auth == False and mongo_ssl == True
 
 - name: Spawn mongod process with auth and with SSL
-  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
+  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca-chain.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -23,19 +23,85 @@
     mode: 0600
   when: mongod_auth == True
 
+- name: generate openssl keys
+  openssl_privatekey:
+    path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
+  with_items:
+    - ca
+    - mongo
+    - mongo-client
+  when: mongo_ssl = True
+
+- name: Generate CSRs
+  openssl_csr:
+    path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    privatekey_path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
+    country_name: US
+    organization_name: Ansible
+    email_address: integration-tests@ansible.com
+    common_name: "{{item}}.ansible.com"
+  with_items:
+    - ca
+    - mongo
+    - mongo-client
+  when: mongo_ssl = True
+
+- name: Generate a Self Signed OpenSSL CA certificate
+  openssl_certificate:
+    path: "{{ remote_tmp_dir }}/ca.pem"
+    privatekey_path: "{{ remote_tmp_dir }}/ca-key.pem"
+    csr_path: "{{ remote_tmp_dir }}/ca.csr"
+    provider: selfsigned
+  when: mongo_ssl = True
+
+- name: Generate an OpenSSL certificate signed with your own CA certificate
+  openssl_certificate:
+    path: "{{ remote_tmp_dir }}/{{item}}.pem"
+    csr_path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    ownca_path: "{{ remote_tmp_dir }}/ca.pem"
+    ownca_privatekey_path: "{{ remote_tmp_dir }}/ca-key.pem"
+    provider: ownca
+  with_items:
+    - mongo
+    - mongo-client
+  when: mongo_ssl = True
+
+- name: create cert chains
+  shell: "cat {{ item }}.pem {{ item }}-key.pem > {{ item }}-chain.pem"
+  args:
+    chdir: "{{remote_tmp_dir}}"
+  with_items:
+    - mongo
+    - mongo-client
+  when: mongo_ssl = True
+
 - name: Spawn mongod process without auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False
+  when: mongod_auth == False AND mongo_ssl = False
 
 - name: Spawn mongod process with auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True
+  when: mongod_auth == True  AND mongo_ssl = False
+
+- name: Spawn mongod process without auth and with SSL
+  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
+  args:
+    chdir: "{{ remote_tmp_dir }}"
+  with_items: "{{ mongodb_nodes | sort }}"
+  when: mongod_auth == False AND mongo_ssl = True
+
+- name: Spawn mongod process with auth and with SSL
+  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
+  args:
+    chdir: "{{ remote_tmp_dir }}"
+  with_items: "{{ mongodb_nodes | sort }}"
+  when: mongod_auth == True AND mongo_ssl = True
 
 - name: Wait for mongod to start responding
   wait_for:

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -30,7 +30,7 @@
     - ca
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Generate CSRs
   openssl_csr:
@@ -44,7 +44,7 @@
     - ca
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Generate a Self Signed OpenSSL CA certificate
   openssl_certificate:
@@ -52,7 +52,7 @@
     privatekey_path: "{{ remote_tmp_dir }}/ca-key.pem"
     csr_path: "{{ remote_tmp_dir }}/ca.csr"
     provider: selfsigned
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Generate an OpenSSL certificate signed with your own CA certificate
   openssl_certificate:
@@ -64,7 +64,7 @@
   with_items:
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: create cert chains
   shell: "cat {{ item }}.pem {{ item }}-key.pem > {{ item }}-chain.pem"
@@ -73,7 +73,7 @@
   with_items:
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Spawn mongod process without auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
@@ -94,14 +94,14 @@
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl = True
+  when: mongod_auth == False AND mongo_ssl == True
 
 - name: Spawn mongod process with auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True AND mongo_ssl = True
+  when: mongod_auth == True AND mongo_ssl == True
 
 - name: Wait for mongod to start responding
   wait_for:

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -80,14 +80,14 @@
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl = False
+  when: mongod_auth == False AND mongo_ssl == False
 
 - name: Spawn mongod process with auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True  AND mongo_ssl = False
+  when: mongod_auth == True  AND mongo_ssl == False
 
 - name: Spawn mongod process without auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -80,28 +80,28 @@
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl == False
+  when: mongod_auth == False and mongo_ssl == False
 
 - name: Spawn mongod process with auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True  AND mongo_ssl == False
+  when: mongod_auth == True  and mongo_ssl == False
 
 - name: Spawn mongod process without auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl == True
+  when: mongod_auth == False and mongo_ssl == True
 
 - name: Spawn mongod process with auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True AND mongo_ssl == True
+  when: mongod_auth == True and mongo_ssl == True
 
 - name: Wait for mongod to start responding
   wait_for:

--- a/test/integration/targets/mongodb_shard/defaults/main.yml
+++ b/test/integration/targets/mongodb_shard/defaults/main.yml
@@ -8,6 +8,7 @@ mongodb_admin_user: test_root
 mongodb_admin_password: saE_Rr9!gE6gh#e~R#nZ
 debug: yes
 mongod_auth: false
+mongo_ssl: false
 kill_signal: SIGTERM
 # Should be one of
 # --storageEngine wiredTiger --wiredTigerEngineConfigString="cache_size=200M"

--- a/test/integration/targets/mongodb_shard/tasks/main.yml
+++ b/test/integration/targets/mongodb_shard/tasks/main.yml
@@ -548,14 +548,20 @@
     login_user: admin
     login_password: admin
     shard: "{{ mongodb_replicaset1 }}/localhost:3001"
-    state: present
-
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
+    
 - name: Add shard 2
   mongodb_shard:
     login_user: admin
     login_password: admin
     shard: "{{ mongodb_replicaset2 }}/localhost:3004"
     state: present
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
+
 
 # TODO - Readd this test once we support serverSelectionTimeoutMS / connectTimeoutMS
 #- name: Run test with unknown host

--- a/test/integration/targets/mongodb_shard/tasks/main.yml
+++ b/test/integration/targets/mongodb_shard/tasks/main.yml
@@ -441,7 +441,7 @@
  # SSL testing
  ############################################################
 
- - include_tasks: mongod_teardown.yml
+- include_tasks: mongod_teardown.yml
 
 - set_fact:
     mongo_ssl: True

--- a/test/integration/targets/mongodb_shard/tasks/main.yml
+++ b/test/integration/targets/mongodb_shard/tasks/main.yml
@@ -488,7 +488,7 @@
     login_user: admin
     login_password: secret
     login_host: "localhost"
-    login_port: 3001
+    login_port: 3004
     login_database: "admin"
     replica_set: "{{ mongodb_replicaset2 }}"
     ssl_cert_reqs: CERT_OPTIONAL

--- a/test/integration/targets/mongodb_shard/tasks/main.yml
+++ b/test/integration/targets/mongodb_shard/tasks/main.yml
@@ -437,6 +437,31 @@
       - "'{{ mongodb_replicaset2 }}/localhost:3004,localhost:3005,localhost:3006' not in mongo_output.stdout"
       - "'balancer' in mongo_output.stdout"
 
+ ############################################################
+ # SSL testing
+ ############################################################
+
+ - include_tasks: mongod_teardown.yml
+
+- set_fact:
+    mongo_ssl: True
+
+- set_fact:
+    current_replicaset: "{{ mongodb_replicaset1 }}"
+
+- set_fact:
+    mongodb_nodes: [ 3001, 3002, 3003 ]
+
+- include_tasks: mongod_replicaset.yml
+
+- set_fact:
+    current_replicaset: "{{ mongodb_replicaset2 }}"
+
+- set_fact:
+    mongodb_nodes: [ 3004, 3005, 3006 ]
+
+- include_tasks: mongod_replicaset.yml
+
 # TODO - Readd this test once we support serverSelectionTimeoutMS / connectTimeoutMS
 #- name: Run test with unknown host
 #  mongodb_shard:

--- a/test/integration/targets/mongodb_shard/tasks/main.yml
+++ b/test/integration/targets/mongodb_shard/tasks/main.yml
@@ -502,7 +502,7 @@
      - "localhost:3006"
 
 - name: Launch cfg server
-  command: mongod --configsvr --port 4000 --dbpath {{ remote_tmp_dir }}/config --logpath {{ remote_tmp_dir }}/config.log --smallfiles --replSet "{{ configsrv_replicaset }}" --fork
+  command: mongod  --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --configsvr --port 4000 --dbpath {{ remote_tmp_dir }}/config --logpath {{ remote_tmp_dir }}/config.log --smallfiles --replSet "{{ configsrv_replicaset }}" --fork
 
 - name: Create config srv replicaset with module
   mongodb_replicaset:
@@ -511,12 +511,15 @@
     login_port: 4000
     login_database: "admin"
     replica_set: "{{ configsrv_replicaset }}"
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
     validate: no
     members:
      - "localhost:4000"
 
 - name: Get config server replset mongo_output
-  command: mongo admin --port 4000 --eval "rs.status();"
+  command: mongo --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem admin --port 4000 --eval "rs.status();"
   register: cfg_replset_output
 
 - name: Assert that replset is a config server
@@ -526,7 +529,7 @@
       - "'\"set\" : \"{{ configsrv_replicaset }}\"' in cfg_replset_output.stdout"
 
 - name: Launch mongos
-  command: mongos --configdb "{{ configsrv_replicaset }}/localhost:4000" --logpath "{{ remote_tmp_dir }}/tests/mongos.log" --port 27017 --fork
+  command: mongos --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --configdb "{{ configsrv_replicaset }}/localhost:4000" --logpath "{{ remote_tmp_dir }}/tests/mongos.log" --port 27017 --fork
 
 - name: Ensure is_primary script exists on host
   copy:
@@ -541,27 +544,86 @@
   command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --port 3004 "{{ remote_tmp_dir }}/tests/is_primary.js"
 
 - name: Ensure host reaches primary before proceeding 4000
-  command: mongo admin --port 4000 "{{ remote_tmp_dir }}/tests/is_primary.js"
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem  --port 4000 "{{ remote_tmp_dir }}/tests/is_primary.js"
 
 - name: Add shard 1
   mongodb_shard:
     login_user: admin
     login_password: admin
     shard: "{{ mongodb_replicaset1 }}/localhost:3001"
+    ssl: true
     ssl_cert_reqs: CERT_OPTIONAL
     ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
     ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
-    
+
 - name: Add shard 2
   mongodb_shard:
     login_user: admin
     login_password: admin
     shard: "{{ mongodb_replicaset2 }}/localhost:3004"
     state: present
+    ssl: true
     ssl_cert_reqs: CERT_OPTIONAL
     ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
     ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
 
+- name: Get replicaset info
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --eval "sh.status()" --port 27017
+  register: mongo_output
+
+- name: Assert shard name is in mongo_output
+  assert:
+    that:
+      - "mongo_output.changed == true"
+      - "'{{ mongodb_replicaset1 }}/localhost:3001,localhost:3002,localhost:3003' in mongo_output.stdout"
+      - "'{{ mongodb_replicaset2 }}/localhost:3004,localhost:3005,localhost:3006' in mongo_output.stdout"
+      - "'balancer' in mongo_output.stdout"
+
+- name: Remove shard 2
+  mongodb_shard:
+    login_user: admin
+    login_password: admin
+    shard: "{{ mongodb_replicaset2 }}"
+    state: absent
+    ssl: true
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
+
+- name: Get replicaset info
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --eval "sh.status()" --port 27017
+  register: mongo_output
+
+- name: Assert shard 2 is draining
+  assert:
+    that:
+      - "mongo_output.changed == true"
+      - "'{{ mongodb_replicaset1 }}/localhost:3001,localhost:3002,localhost:3003' in mongo_output.stdout"
+      - "'\"draining\" : true' in mongo_output.stdout"
+      - "'balancer' in mongo_output.stdout"
+
+- name: Run remove command again to finalize shard removal
+  mongodb_shard:
+    login_user: admin
+    login_password: admin
+    shard: "{{ mongodb_replicaset2 }}"
+    state: absent
+    ssl: true
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
+
+- name: Get replicaset info
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --eval "sh.status()" --port 27017
+  register: mongo_output
+
+- name: Assert shard 2 is not present
+  assert:
+    that:
+      - "mongo_output.changed == true"
+      - "'{{ mongodb_replicaset1 }}/localhost:3001,localhost:3002,localhost:3003' in mongo_output.stdout"
+      - "'{{ mongodb_replicaset2 }}/localhost:3004,localhost:3005,localhost:3006' not in mongo_output.stdout"
+      - "'balancer' in mongo_output.stdout"
 
 # TODO - Readd this test once we support serverSelectionTimeoutMS / connectTimeoutMS
 #- name: Run test with unknown host

--- a/test/integration/targets/mongodb_shard/tasks/main.yml
+++ b/test/integration/targets/mongodb_shard/tasks/main.yml
@@ -444,7 +444,10 @@
 - include_tasks: mongod_teardown.yml
 
 - set_fact:
-    mongo_ssl: True
+    mongo_ssl: true
+
+- set_fact:
+    mongod_auth: false
 
 - set_fact:
     current_replicaset: "{{ mongodb_replicaset1 }}"
@@ -461,6 +464,98 @@
     mongodb_nodes: [ 3004, 3005, 3006 ]
 
 - include_tasks: mongod_replicaset.yml
+
+- name: Create replicaset with module
+  mongodb_replicaset:
+    login_user: admin
+    login_password: secret
+    login_host: "localhost"
+    login_port: 3001
+    login_database: "admin"
+    replica_set: "{{ mongodb_replicaset1 }}"
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
+    heartbeat_timeout_secs: 1
+    election_timeout_millis: 1000
+    members:
+     - "localhost:3001"
+     - "localhost:3002"
+     - "localhost:3003"
+
+- name: Create replicaset with module
+  mongodb_replicaset:
+    login_user: admin
+    login_password: secret
+    login_host: "localhost"
+    login_port: 3001
+    login_database: "admin"
+    replica_set: "{{ mongodb_replicaset2 }}"
+    ssl_cert_reqs: CERT_OPTIONAL
+    ssl_ca_certs: "{{ remote_tmp_dir }}/ca-chain.pem"
+    ssl_certfile: "{{ remote_tmp_dir }}/mongo-client-chain.pem"
+    heartbeat_timeout_secs: 1
+    election_timeout_millis: 1000
+    members:
+     - "localhost:3004"
+     - "localhost:3005"
+     - "localhost:3006"
+
+- name: Launch cfg server
+  command: mongod --configsvr --port 4000 --dbpath {{ remote_tmp_dir }}/config --logpath {{ remote_tmp_dir }}/config.log --smallfiles --replSet "{{ configsrv_replicaset }}" --fork
+
+- name: Create config srv replicaset with module
+  mongodb_replicaset:
+    login_user: "{{ mongodb_admin_user }}"
+    login_password: "{{ mongodb_admin_password }}"
+    login_port: 4000
+    login_database: "admin"
+    replica_set: "{{ configsrv_replicaset }}"
+    validate: no
+    members:
+     - "localhost:4000"
+
+- name: Get config server replset mongo_output
+  command: mongo admin --port 4000 --eval "rs.status();"
+  register: cfg_replset_output
+
+- name: Assert that replset is a config server
+  assert:
+    that:
+      - "'\"configsvr\" : true' in cfg_replset_output.stdout"
+      - "'\"set\" : \"{{ configsrv_replicaset }}\"' in cfg_replset_output.stdout"
+
+- name: Launch mongos
+  command: mongos --configdb "{{ configsrv_replicaset }}/localhost:4000" --logpath "{{ remote_tmp_dir }}/tests/mongos.log" --port 27017 --fork
+
+- name: Ensure is_primary script exists on host
+  copy:
+    src: js/is_primary.js
+    dest: "{{ remote_tmp_dir }}/tests/is_primary.js"
+
+
+- name: Ensure host reaches primary before proceeding 3001
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --port 3001 "{{ remote_tmp_dir }}/tests/is_primary.js"
+
+- name: Ensure host reaches primary before proceeding 3004
+  command: mongo admin --ssl --sslAllowInvalidHostnames --sslCAFile {{ remote_tmp_dir }}/ca.pem  --sslPEMKeyFile {{ remote_tmp_dir }}/mongo-client-chain.pem --port 3004 "{{ remote_tmp_dir }}/tests/is_primary.js"
+
+- name: Ensure host reaches primary before proceeding 4000
+  command: mongo admin --port 4000 "{{ remote_tmp_dir }}/tests/is_primary.js"
+
+- name: Add shard 1
+  mongodb_shard:
+    login_user: admin
+    login_password: admin
+    shard: "{{ mongodb_replicaset1 }}/localhost:3001"
+    state: present
+
+- name: Add shard 2
+  mongodb_shard:
+    login_user: admin
+    login_password: admin
+    shard: "{{ mongodb_replicaset2 }}/localhost:3004"
+    state: present
 
 # TODO - Readd this test once we support serverSelectionTimeoutMS / connectTimeoutMS
 #- name: Run test with unknown host

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -38,7 +38,7 @@
     - ca
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Generate CSRs
   openssl_csr:
@@ -52,7 +52,7 @@
     - ca
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Generate a Self Signed OpenSSL CA certificate
   openssl_certificate:
@@ -60,7 +60,7 @@
     privatekey_path: "{{ remote_tmp_dir }}/ca_key.pem"
     csr_path: "{{ remote_tmp_dir }}/ca.csr"
     provider: selfsigned
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Generate an OpenSSL certificate signed with your own CA certificate
   openssl_certificate:
@@ -72,7 +72,7 @@
   with_items:
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: create cert chains
   shell: "cat {{ item }}.pem {{ item }}_key.pem > {{ item }}-chain.pem"
@@ -81,7 +81,7 @@
   with_items:
     - mongo
     - mongo-client
-  when: mongo_ssl = True
+  when: mongo_ssl == True
 
 - name: Spawn mongod process without auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
@@ -102,14 +102,14 @@
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl = True
+  when: mongod_auth == False AND mongo_ssl == True
 
 - name: Spawn mongod process with auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True AND mongo_ssl = True
+  when: mongod_auth == True AND mongo_ssl == True
 
 - name: Wait for mongod to start responding
   wait_for:

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -31,15 +31,62 @@
     mode: 0600
   when: mongod_auth == True
 
+- name: generate openssl keys
+  openssl_privatekey:
+    path: "{{ remote_tmp_dir }}/{{item}}_key.pem"
+  with_items:
+    - ca
+    - mongo
+    - mongo-client
+
+- name: Generate CSRs
+  openssl_csr:
+    path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    privatekey_path: "{{ remote_tmp_dir }}/{{item}}_key.pem"
+    country_name: US
+    organization_name: Ansible
+    email_address: integration-tests@ansible.com
+    common_name: "{{item}}.ansible.com"
+  with_items:
+    - ca
+    - mongo
+    - mongo-client
+
+- name: Generate a Self Signed OpenSSL CA certificate
+  openssl_certificate:
+    path: "{{ remote_tmp_dir }}/ca.pem"
+    privatekey_path: "{{ remote_tmp_dir }}/ca_key.pem"
+    csr_path: "{{ remote_tmp_dir }}/ca.csr"
+    provider: selfsigned
+
+- name: Generate an OpenSSL certificate signed with your own CA certificate
+  openssl_certificate:
+    path: "{{ remote_tmp_dir }}/{{item}}.pem"
+    csr_path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    ownca_path: "{{ remote_tmp_dir }}/ca.pem"
+    ownca_privatekey_path: "{{ remote_tmp_dir }}/ca_key.pem"
+    provider: ownca
+  with_items:
+    - mongo
+    - mongo-client
+    
+- name: create cert chains
+  shell: "cat {{ item }}.pem {{ item }}_key.pem > {{ item }}-chain.pem"
+  args:
+    chdir: "{{remote_tmp_dir}}"
+  with_items:
+    - mongo
+    - mongo-client
+
 - name: Spawn mongod process without auth
-  command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
+  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongochain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
   when: mongod_auth == False
 
 - name: Spawn mongod process with auth
-  command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
+  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongochain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -79,14 +79,14 @@
     - mongo-client
 
 - name: Spawn mongod process without auth
-  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
+  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
   when: mongod_auth == False
 
 - name: Spawn mongod process with auth
-  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
+  command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -69,7 +69,7 @@
   with_items:
     - mongo
     - mongo-client
-    
+
 - name: create cert chains
   shell: "cat {{ item }}.pem {{ item }}_key.pem > {{ item }}-chain.pem"
   args:
@@ -79,14 +79,14 @@
     - mongo-client
 
 - name: Spawn mongod process without auth
-  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongochain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
+  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
   when: mongod_auth == False
 
 - name: Spawn mongod process with auth
-  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongochain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
+  command: mongod --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -88,14 +88,14 @@
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl = False
+  when: mongod_auth == False AND mongo_ssl == False
 
 - name: Spawn mongod process with auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True  AND mongo_ssl = False
+  when: mongod_auth == True  AND mongo_ssl == False
 
 - name: Spawn mongod process without auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -88,28 +88,28 @@
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl == False
+  when: mongod_auth == False and mongo_ssl == False
 
 - name: Spawn mongod process with auth
   command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True  AND mongo_ssl == False
+  when: mongod_auth == True  and mongo_ssl == False
 
 - name: Spawn mongod process without auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False AND mongo_ssl == True
+  when: mongod_auth == False and mongo_ssl == True
 
 - name: Spawn mongod process with auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True AND mongo_ssl == True
+  when: mongod_auth == True and mongo_ssl == True
 
 - name: Wait for mongod to start responding
   wait_for:

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -38,6 +38,7 @@
     - ca
     - mongo
     - mongo-client
+  when: mongo_ssl = True
 
 - name: Generate CSRs
   openssl_csr:
@@ -51,6 +52,7 @@
     - ca
     - mongo
     - mongo-client
+  when: mongo_ssl = True
 
 - name: Generate a Self Signed OpenSSL CA certificate
   openssl_certificate:
@@ -58,6 +60,7 @@
     privatekey_path: "{{ remote_tmp_dir }}/ca_key.pem"
     csr_path: "{{ remote_tmp_dir }}/ca.csr"
     provider: selfsigned
+  when: mongo_ssl = True
 
 - name: Generate an OpenSSL certificate signed with your own CA certificate
   openssl_certificate:
@@ -69,6 +72,7 @@
   with_items:
     - mongo
     - mongo-client
+  when: mongo_ssl = True
 
 - name: create cert chains
   shell: "cat {{ item }}.pem {{ item }}_key.pem > {{ item }}-chain.pem"
@@ -77,20 +81,35 @@
   with_items:
     - mongo
     - mongo-client
+  when: mongo_ssl = True
 
 - name: Spawn mongod process without auth
+  command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
+  args:
+    chdir: "{{ remote_tmp_dir }}"
+  with_items: "{{ mongodb_nodes | sort }}"
+  when: mongod_auth == False AND mongo_ssl = False
+
+- name: Spawn mongod process with auth
+  command: mongod --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
+  args:
+    chdir: "{{ remote_tmp_dir }}"
+  with_items: "{{ mongodb_nodes | sort }}"
+  when: mongod_auth == True  AND mongo_ssl = False
+
+- name: Spawn mongod process without auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == False
+  when: mongod_auth == False AND mongo_ssl = True
 
-- name: Spawn mongod process with auth
+- name: Spawn mongod process with auth and with SSL
   command: mongod --sslMode requireSSL --sslAllowConnectionsWithoutCertificates --sslCAFile {{ remote_tmp_dir }}/ca.pem --sslPEMKeyFile  {{ remote_tmp_dir }}/mongo-chain.pem --sslAllowInvalidHostnames --shardsvr --smallfiles {{ mongod_storage_engine_opts }} --dbpath mongod{{ item }} --port {{ item }} --replSet {{ current_replicaset }} --logpath mongod{{ item }}/log.log --fork --auth --keyFile my.key
   args:
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
-  when: mongod_auth == True
+  when: mongod_auth == True AND mongo_ssl = True
 
 - name: Wait for mongod to start responding
   wait_for:

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -33,7 +33,7 @@
 
 - name: generate openssl keys
   openssl_privatekey:
-    path: "{{ remote_tmp_dir }}/{{item}}_key.pem"
+    path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
   with_items:
     - ca
     - mongo
@@ -43,21 +43,64 @@
 - name: Generate CSRs
   openssl_csr:
     path: "{{ remote_tmp_dir }}/{{item}}.csr"
-    privatekey_path: "{{ remote_tmp_dir }}/{{item}}_key.pem"
+    privatekey_path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
     country_name: US
     organization_name: Ansible
     email_address: integration-tests@ansible.com
-    common_name: localhost"
+    common_name: "{{ item }}.ansible.com"
+    extended_key_usage:
+      - clientAuth
+      - serverAuth
+    keyUsage:
+      - digitalSignature
+      - keyAgreement
+      - keyCertSign
+  with_items:
+    - mongo-client
+  when: mongo_ssl == True
+
+- name: Generate CSRs
+  openssl_csr:
+    path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    privatekey_path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
+    country_name: US
+    organization_name: Ansible
+    email_address: integration-tests@ansible.com
+    common_name: "{{ item }}.ansible.com"
+    extended_key_usage:
+      - clientAuth
+      - serverAuth
+    keyUsage:
+      - digitalSignature
+      - keyAgreement
+      - keyCertSign
   with_items:
     - ca
+  when: mongo_ssl == True
+
+- name: Generate CSRs
+  openssl_csr:
+    path: "{{ remote_tmp_dir }}/{{item}}.csr"
+    privatekey_path: "{{ remote_tmp_dir }}/{{item}}-key.pem"
+    country_name: US
+    organization_name: Ansible
+    email_address: integration-tests@ansible.com
+    common_name: "localhost"
+    extended_key_usage:
+      - clientAuth
+      - serverAuth
+    keyUsage:
+      - digitalSignature
+      - keyAgreement
+      - keyCertSign
+  with_items:
     - mongo
-    - mongo-client
   when: mongo_ssl == True
 
 - name: Generate a Self Signed OpenSSL CA certificate
   openssl_certificate:
     path: "{{ remote_tmp_dir }}/ca.pem"
-    privatekey_path: "{{ remote_tmp_dir }}/ca_key.pem"
+    privatekey_path: "{{ remote_tmp_dir }}/ca-key.pem"
     csr_path: "{{ remote_tmp_dir }}/ca.csr"
     provider: selfsigned
   when: mongo_ssl == True
@@ -67,7 +110,7 @@
     path: "{{ remote_tmp_dir }}/{{item}}.pem"
     csr_path: "{{ remote_tmp_dir }}/{{item}}.csr"
     ownca_path: "{{ remote_tmp_dir }}/ca.pem"
-    ownca_privatekey_path: "{{ remote_tmp_dir }}/ca_key.pem"
+    ownca_privatekey_path: "{{ remote_tmp_dir }}/ca-key.pem"
     provider: ownca
   with_items:
     - mongo
@@ -75,10 +118,11 @@
   when: mongo_ssl == True
 
 - name: create cert chains
-  shell: "cat {{ item }}.pem {{ item }}_key.pem > {{ item }}-chain.pem"
+  shell: "cat {{ item }}.pem {{ item }}-key.pem > {{ item }}-chain.pem"
   args:
     chdir: "{{remote_tmp_dir}}"
   with_items:
+    - ca
     - mongo
     - mongo-client
   when: mongo_ssl == True

--- a/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_replicaset.yml
@@ -47,7 +47,7 @@
     country_name: US
     organization_name: Ansible
     email_address: integration-tests@ansible.com
-    common_name: "{{item}}.ansible.com"
+    common_name: localhost"
   with_items:
     - ca
     - mongo

--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -47,5 +47,4 @@ redhat_packages_py3:
 pip_packages:
   - psutil
   - pymongo
-  - cryptography
   - PyOpenSSL

--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -47,3 +47,5 @@ redhat_packages_py3:
 pip_packages:
   - psutil
   - pymongo
+  - cryptography
+  - PyOpenSSL

--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -33,6 +33,7 @@ debian_packages_py36:
   - python3.6-dev
   - python3-setuptools
   - python3-pip
+  - ca-certificates
 
 redhat_packages_py2:
   - python-devel
@@ -48,3 +49,4 @@ pip_packages:
   - psutil
   - pymongo
   - PyOpenSSL
+  - certifi

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -185,3 +185,9 @@
     name: "{{ pip_packages }}"
     state: present
   notify: remove mongodb pip packages
+
+- name: Fix 3.6 certificates
+  shell: export SSL_CERT_FILE=$(python3.6 -c "import certifi; print(certifi.where())")
+  when:
+    - ansible_distribution_version == "18.04"
+    - ansible_distribution == 'Ubuntu'  


### PR DESCRIPTION
##### SUMMARY
Add TLS client certificate and CA list support to mongodb modules

Also copied the ssl_cert_reqs option (and option parsing style) to mongodb_parameter.py from the other mongo modules

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Add TLS client cert and CA support to MongoDB modules

##### ADDITIONAL INFORMATION
Specifying a CA file is required when using Amazon DocumentDB. We're using the CA option like this:
```
mongodb_user:
    ssl_ca_certs: "{{role_path}}/files/rds-combined-ca-bundle.pem"
```
(I misunderstood the internal need and first added mutually-authenticated "client certificate" TLS support, when what we really needed was CA support.  I left the client cert support in the PR because... why not?  Someone will use it.)