### PR TITLE
cloudstack: test: ensure network is implemented

### DIFF
--- a/test/integration/targets/cs_firewall/tasks/main.yml
+++ b/test/integration/targets/cs_firewall/tasks/main.yml
@@ -11,6 +11,20 @@
     that:
     - net is successful
 
+- name: setup instance to get network in implementation state
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-cs-firewall"
+    template: "{{ cs_common_template }}"
+    service_offering: "{{ cs_common_service_offering }}"
+    zone: "{{ cs_common_zone_adv }}"
+    networks:
+      - "{{ net.name }}"
+  register: instance
+- name: verify instance setup
+  assert:
+    that:
+    - instance is successful
+
 - name: public ip address setup
   cs_ip_address:
     network: ansible test
@@ -443,6 +457,17 @@
     that:
     - fw is successful
     - fw is not changed
+
+- name: cleanup instance
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-cs-firewall"
+    zone: "{{ cs_common_zone_adv }}"
+    state: expunged
+  register: instance
+- name: verify instance cleanup
+  assert:
+    that:
+    - instance is successful
 
 - name: network cleanup
   cs_network:

--- a/test/integration/targets/cs_firewall/tasks/main.yml
+++ b/test/integration/targets/cs_firewall/tasks/main.yml
@@ -20,6 +20,9 @@
     networks:
       - "{{ net.name }}"
   register: instance
+  until: instance is success
+  retries: 10
+  delay: 5
 - name: verify instance setup
   assert:
     that:

--- a/test/integration/targets/cs_ip_address/tasks/network.yml
+++ b/test/integration/targets/cs_ip_address/tasks/network.yml
@@ -26,6 +26,9 @@
     networks:
       - "{{ base_network.name }}"
   register: instance
+  until: instance is success
+  retries: 10
+  delay: 5
 - name: verify instance setup
   assert:
     that:

--- a/test/integration/targets/cs_ip_address/tasks/network.yml
+++ b/test/integration/targets/cs_ip_address/tasks/network.yml
@@ -17,6 +17,20 @@
     that:
     - base_network is successful
 
+- name: setup instance to get network in implementation state
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-cs-ip-address"
+    template: "{{ cs_common_template }}"
+    service_offering: "{{ cs_common_service_offering }}"
+    zone: "{{ cs_common_zone_adv }}"
+    networks:
+      - "{{ base_network.name }}"
+  register: instance
+- name: verify instance setup
+  assert:
+    that:
+    - instance is successful
+
 - name: setup clean ip_address with tags
   cs_ip_address:
     state: absent
@@ -204,6 +218,17 @@
     that:
     - ip_address is successful
     - ip_address is not changed
+
+- name: cleanup instance
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-cs-ip-address"
+    zone: "{{ cs_common_zone_adv }}"
+    state: expunged
+  register: instance
+- name: verify instance cleanup
+  assert:
+    that:
+    - instance is successful
 
 - name: clean the test network
   cs_network:


### PR DESCRIPTION
##### SUMMARY

In ACS 4.12, it is no longer possbile to acquire IPs to a (...) network
not already in implemented state.

With deployment of a VM instance, we enforce the implementation of the
network. Also see https://github.com/apache/cloudstack/commit/323f791efca6f1d5b8bb63573d9e385c97c427e1


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudstack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
