### PR TITLE
Backport: Raise AnsibleConnectionError on winrm connnection errors

### DIFF
--- a/changelogs/fragments/winrm-ansible-conn-error.yaml
+++ b/changelogs/fragments/winrm-ansible-conn-error.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Raise AnsibleConnectionError on winrm connnection errors

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -134,6 +134,7 @@ try:
     import winrm
     from winrm import Response
     from winrm.protocol import Protocol
+    import requests.exceptions
     HAS_WINRM = True
 except ImportError as e:
     HAS_WINRM = False
@@ -479,6 +480,8 @@ class Connection(ConnectionBase):
                 raise AnsibleError('winrm send_input failed; \nstdout: %s\nstderr %s' % (to_native(response.std_out), to_native(stderr)))
 
             return response
+        except requests.exceptions.ConnectionError as exc:
+            raise AnsibleConnectionFailure('winrm connection error: %s' % exc)
         finally:
             if command_id:
                 self.protocol.cleanup_command(self.shell_id, command_id)

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -481,7 +481,7 @@ class Connection(ConnectionBase):
 
             return response
         except requests.exceptions.ConnectionError as exc:
-            raise AnsibleConnectionFailure('winrm connection error: %s' % exc)
+            raise AnsibleConnectionFailure('winrm connection error: %s' % to_native(exc))
         finally:
             if command_id:
                 self.protocol.cleanup_command(self.shell_id, command_id)


### PR DESCRIPTION
##### SUMMARY
Currently all uncaught exceptions of the requests library that is used in winrm will lead to an "Unexpected failure during module execution".

Instead of letting all exceptions bubble up we catch the connection related errors (inkl. timeouts) and re-raise them as `AnsibleConnectionError` so Ansible will mark the host as unreachable and exit with the correct return code.

This is especially important for Zuul (https://zuul-ci.org) to distinguish between failures and connection/host related errors.

Backport of https://github.com/ansible/ansible/pull/51744.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
winrm

##### ADDITIONAL INFORMATION
```
fatal: [win-node]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout": ""}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='xxx.xxx.xxx.xxx', port=5986): Read timed out. (read timeout=120)

Traceback (most recent call last):
  File "/opt/zuul/lib/python3.6/site-packages/urllib3/connectionpool.py", line 384, in _make_request
    six.raise_from(e, None)
  File "<string>", line 2, in raise_from
  File "/opt/zuul/lib/python3.6/site-packages/urllib3/connectionpool.py", line 380, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/lib/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/lib/python3.6/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.6/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib/python3.6/ssl.py", line 1012, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib/python3.6/ssl.py", line 874, in read
    return self._sslobj.read(len, buffer)
  File "/usr/lib/python3....ib/python3.6/site-packages/winrm/protocol.py", line 417, in _raw_get_command_output
    res = self.send_message(xmltodict.unparse(req))
  File "/opt/zuul/lib/python3.6/site-packages/winrm/protocol.py", line 234, in send_message
    resp = self.transport.send_message(message)
  File "/opt/zuul/lib/python3.6/site-packages/winrm/transport.py", line 256, in send_message
    response = self._send_message_request(prepared_request, message)
  File "/opt/zuul/lib/python3.6/site-packages/winrm/transport.py", line 261, in _send_message_request
    response = self.session.send(prepared_request, timeout=self.read_timeout_sec)
  File "/opt/zuul/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/opt/zuul/lib/python3.6/site-packages/requests/adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host="xxx.xxx.xxx.xxx", port=5986): Read timed out. (read timeout=120)
```