### PR TITLE
vault: Read stdin data as binary on python3

### DIFF
--- a/changelogs/fragments/52229-vault-python3-binary-stdin.yml
+++ b/changelogs/fragments/52229-vault-python3-binary-stdin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vault - Support reading raw binary data from stdin under python3

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1038,7 +1038,10 @@ class VaultEditor:
 
         try:
             if filename == '-':
-                data = sys.stdin.read()
+                if PY3:
+                    data = sys.stdin.buffer.read()
+                else:
+                    data = sys.stdin.read()
             else:
                 with open(filename, "rb") as fh:
                     data = fh.read()

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 
 import os
 import tempfile
+from io import BytesIO, StringIO
 
 import pytest
 
@@ -32,6 +33,7 @@ from ansible import errors
 from ansible.parsing import vault
 from ansible.parsing.vault import VaultLib, VaultEditor, match_encrypt_secret
 
+from ansible.module_utils.six import PY3
 from ansible.module_utils._text import to_bytes, to_text
 
 from units.mock.vault_helper import TextVaultSecret
@@ -112,6 +114,21 @@ class TestVaultEditor(unittest.TestCase):
         b_ciphertext = ve._edit_file_helper(src_file_path, self.vault_secret)
 
         self.assertNotEqual(src_contents, b_ciphertext)
+
+    def test_stdin_binary(self):
+        stdin_data = '\0'
+
+        if PY3:
+            fake_stream = StringIO(stdin_data)
+            fake_stream.buffer = BytesIO(to_bytes(stdin_data))
+        else:
+            fake_stream = BytesIO(to_bytes(stdin_data))
+
+        with patch('sys.stdin', fake_stream):
+            ve = self._vault_editor()
+            data = ve.read_data('-')
+
+        self.assertEqual(data, b'\0')
 
     @patch('ansible.parsing.vault.subprocess.call')
     def test_edit_file_helper_call_exception(self, mock_sp_call):


### PR DESCRIPTION
##### SUMMARY

On python3 sys.stdin is an encoded file and does not support reading raw data. Use the buffer object of the file object to read raw binary data.

Signed-off-by: Sven Wegener <sven.wegener@inovex.de>
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vault
