### PR TITLE
cloudscale_volume: fail fast on volume type change

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -261,17 +261,18 @@ def main():
         volume.delete()
 
     if module.params['state'] == 'present':
+        if (module.params['type'] is not None
+           and volume.info['type'] != module.params['type']):
+            module.fail_json(
+                msg='Cannot change type of an existing volume.',
+            )
+
         for param, conv in (('server_uuids', set), ('size_gb', int)):
             if module.params[param] is None:
                 continue
             if conv(volume.info[param]) != conv(module.params[param]):
                 volume.update(param)
 
-        if (module.params['type'] is not None
-           and volume.info['type'] != module.params['type']):
-            module.fail_json(
-                msg='Cannot change type of an existing volume.',
-            )
 
     module.exit_json(changed=volume.changed, **volume.info)
 

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -273,7 +273,6 @@ def main():
             if conv(volume.info[param]) != conv(module.params[param]):
                 volume.update(param)
 
-
     module.exit_json(changed=volume.changed, **volume.info)
 
 


### PR DESCRIPTION
##### SUMMARY
Currently a volume gets resized before the type change check. With this
change, we check early and ensure we fail before any changes made.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudscale_volume

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
