### PR TITLE
Alias ansible_model to ansible_product_name for Darwin

### DIFF
--- a/changelogs/fragments/mac-product-name.yaml
+++ b/changelogs/fragments/mac-product-name.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- facts - Alias ``ansible_model`` to ``ansible_product_name`` to more closely match other OSes
+  (https://github.com/ansible/ansible/issues/52233)

--- a/lib/ansible/module_utils/facts/hardware/darwin.py
+++ b/lib/ansible/module_utils/facts/hardware/darwin.py
@@ -64,7 +64,7 @@ class DarwinHardware(Hardware):
         mac_facts = {}
         rc, out, err = self.module.run_command("sysctl hw.model")
         if rc == 0:
-            mac_facts['model'] = out.splitlines()[-1].split()[1]
+            mac_facts['model'] = mac_facts['product_name'] = out.splitlines()[-1].split()[1]
         mac_facts['osversion'] = self.sysctl['kern.osversion']
         mac_facts['osrevision'] = self.sysctl['kern.osrevision']
 


### PR DESCRIPTION
##### SUMMARY
Alias ansible_model to ansible_product_name for Darwin. Fixes #52233

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/hardware/darwin.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```