### PR TITLE
Add constraint for pyone to keep tests passing.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -27,6 +27,7 @@ xmltodict < 0.12.0 ; python_version < '2.7' # xmltodict 0.12.0 and later require
 lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 or later
 pyvmomi < 6.0.0 ; python_version < '2.7' # pyvmomi 6.0.0 and later require python 2.7 or later
 pytest < 3.10.0 ; python_version >= '2.7' # pytest 3.10.0+ causes some tests to crash, pytest 4.2.0+ causes internal errors in pytest-forked
+pyone == 1.1.9 # newer versions do not pass current integration tests
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.0.4


### PR DESCRIPTION
##### SUMMARY

Add constraint for pyone to keep tests passing.

This freezes the pyone version at 1.1.9. When tested against a newer version, 5.7.85, the current tests do not pass: https://app.shippable.com/github/ansible/ansible/runs/107429/104/tests

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
