### PR TITLE
Test FreeBSD 11.2 in CI using Azure.

### DIFF
--- a/changelogs/fragments/user-freebsd-expire-utc.yaml
+++ b/changelogs/fragments/user-freebsd-expire-utc.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - on FreeBSD set the user expiration time as seconds since the epoch in UTC to avoid timezone issues

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -404,6 +404,7 @@ uid:
 
 import errno
 import grp
+import calendar
 import os
 import re
 import pty
@@ -1150,7 +1151,7 @@ class FreeBsdUser(User):
             if self.expires < time.gmtime(0):
                 cmd.append('0')
             else:
-                cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
+                cmd.append(str(calendar.timegm(self.expires)))
 
         # system cannot be handled currently - should we error if its requested?
         # create the user
@@ -1268,7 +1269,7 @@ class FreeBsdUser(User):
                 # Current expires is negative or we compare year, month, and day only
                 if current_expires <= 0 or current_expire_date[:3] != self.expires[:3]:
                     cmd.append('-e')
-                    cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
+                    cmd.append(str(calendar.timegm(self.expires)))
 
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):

--- a/shippable.yml
+++ b/shippable.yml
@@ -52,7 +52,7 @@ matrix:
     - env: T=osx/10.11/1
     - env: T=rhel/7.6/1
     - env: T=rhel/8.0/1
-    - env: T=freebsd/11.1/1
+    - env: T=freebsd/11.2/1 P=azure
     - env: T=freebsd/12.0/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
@@ -67,7 +67,7 @@ matrix:
     - env: T=osx/10.11/2
     - env: T=rhel/7.6/2
     - env: T=rhel/8.0/2
-    - env: T=freebsd/11.1/2
+    - env: T=freebsd/11.2/2 P=azure
     - env: T=freebsd/12.0/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
@@ -82,7 +82,7 @@ matrix:
     - env: T=osx/10.11/3
     - env: T=rhel/7.6/3
     - env: T=rhel/8.0/3
-    - env: T=freebsd/11.1/3
+    - env: T=freebsd/11.2/3 P=azure
     - env: T=freebsd/12.0/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -364,7 +364,7 @@
     - name: BSD | Ensure proper expiration date was set
       assert:
         that:
-          - bsd_account_expiration.stdout == '2529878400'
+          - bsd_account_expiration.stdout == '2529881062'
   when: ansible_facts.os_family == 'FreeBSD'
 
 - name: Change timezone


### PR DESCRIPTION
##### SUMMARY

Test FreeBSD 11.2 in CI using Azure.

Hopefully the FreeBSD 11.2 image on Azure will start reliably, unlike the one on AWS. If not, we'll need to roll back to testing FreeBSD 11.1 or come up with another solution.

Resolves https://github.com/ansible/ansible/issues/48782

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml
