### PR TITLE
Zabbix: clarify how users are specified

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -217,7 +217,7 @@ options:
             send_to_users:
                 type: list
                 description:
-                    - Users to send messages to.
+                    - Users (usernames or aliases) to send messages to.
             message:
                 description:
                     - Operation message text.


### PR DESCRIPTION
##### SUMMARY
Clarify that usernames - which Zabbix API documentation calls "aliases" - are to be specified for recipients

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
zabbix_action