### PR TITLE
[wip] K8s wait module

### DIFF
--- a/lib/ansible/module_utils/k8s/wait.py
+++ b/lib/ansible/module_utils/k8s/wait.py
@@ -1,0 +1,105 @@
+import copy
+
+from ansible.module_utils.k8s.common import AUTH_ARG_SPEC, COMMON_ARG_SPEC
+from ansible.module_utils.six import string_types
+from ansible.module_utils.k8s.common import KubernetesAnsibleModule
+
+try:
+    import yaml
+except ImportError:
+    # Exceptions handled in common
+    pass
+
+
+class KubernetesWaitModule(KubernetesAnsibleModule):
+
+    @property
+    def field_spec(self):
+        return dict(
+            name=dict(),
+            operator=dict(choices=['=', '!=', '>', '<', '<=', '>='], default='='),
+            value=dict(type='raw')
+        )
+
+    @property
+    def condition_spec(self):
+        return dict(
+            type=dict(),
+            status=dict(choices=[True, False, "Unknown"], default=True),
+            reason=dict()
+        )
+
+    @property
+    def argspec(self):
+        argument_spec = copy.deepcopy(COMMON_ARG_SPEC)
+        argument_spec.update(copy.deepcopy(AUTH_ARG_SPEC))
+        argument_spec.pop('resource_definition')
+        argument_spec.pop('src')
+        argument_spec['timeout'] = dict(type='int', default=120)
+        argument_spec['field'] = dict(type='dict', default=None, options=self.field_spec)
+        argument_spec['condition'] = dict(type='dict', default=None, options=self.condition_spec)
+        argument_spec['label_selectors'] = dict(type='list', default=[])
+        argument_spec['field_selectors'] = dict(type='list', default=[])
+        return argument_spec
+
+    def __init__(self, k8s_kind=None, *args, **kwargs):
+        self.client = None
+
+        KubernetesAnsibleModule.__init__(self, *args,
+                                         supports_check_mode=True,
+                                         **kwargs)
+        self.kind = k8s_kind or self.params.get('kind')
+        self.api_version = self.params.get('api_version')
+        self.name = self.params.get('name')
+        self.namespace = self.params.get('namespace')
+        self.label_selectors = self.params.get('label_selectors')
+        self.field_selectors = self.params.get('field_selectors')
+        self.condition = self.params.get('condition')
+        self.field = self.params.get('field')
+
+    def predicate(self):
+        def _condition_func(resource):
+            if not resource.status or not resource.status.conditions:
+                return False
+            match = [x for x in resource.status.conditions if x.type == self.condition['type']]
+            if not match:
+                return False
+            # There should never be more than one condition of a specific type
+            match = match[0]
+            if match.status == 'Unknown':
+                return False
+            status = True if match.status == 'True' else False
+            if status == self.condition['status']:
+                if self.condition.get('reason'):
+                    return match.reason == self.condition['reason']
+                return True
+            return False
+
+        def _field_func(resource):
+            operators = {
+                '=': lambda x, y: x == y,
+                '!=': lambda x, y: x != y,
+                '>': lambda x, y: x > y,
+                '<': lambda x, y: x < y,
+                '>=': lambda x, y: x >= y,
+                '<=': lambda x, y: x <= y
+            }
+            if not resource.status:
+                return False
+            current = getattr(resource.status, self.field['name'], None)
+            return operators[self.field['operator']](current, self.field['value'])
+
+    def execute_module(self):
+        self.client = self.get_api_client()
+        resource = self.find_resource(self.kind, self.api_version, fail=True)
+        success, resource, duration = self.wait(
+            resource,
+            predicate=self.predicate(),
+            name=self.name,
+            namespace=self.namespace,
+            label_selectors=self.label_selectors,
+            field_selectors=self.field_selectors,
+        )
+        if success:
+            self.exit_json(changed=False, duration=duration, **resource)
+        self.fail(msg="Timeout: waited {0}s for Kubernetes resource to match desired state")

--- a/lib/ansible/module_utils/k8s/wait.py
+++ b/lib/ansible/module_utils/k8s/wait.py
@@ -77,12 +77,12 @@ class KubernetesWaitModule(KubernetesAnsibleModule):
 
         def _field_func(resource):
             operators = {
-                '=': lambda x, y: x == y,
-                '!=': lambda x, y: x != y,
-                '>': lambda x, y: x > y,
-                '<': lambda x, y: x < y,
-                '>=': lambda x, y: x >= y,
-                '<=': lambda x, y: x <= y
+                'eq': lambda x, y: x == y,
+                'neq': lambda x, y: x != y,
+                'gt': lambda x, y: x > y,
+                'lt': lambda x, y: x < y,
+                'gte': lambda x, y: x >= y,
+                'lte': lambda x, y: x <= y
             }
             if not resource.status:
                 return False

--- a/lib/ansible/modules/clustering/k8s/k8s_wait.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_wait.py
@@ -45,10 +45,10 @@ options:
   field:
     description:
     - Specifies a field, operator, and comparison value to wait for on the status field of a resource.
-    - Comparison is done like: C(name) C(operator) C(value)
+    - Comparison is processed as C(name) C(operator) C(value)
     - For example, to check that there are more than two replicas in a stateful set, C(name) would be replicas,
       C(operator) would be gt, and C(value) would be 2
-    - The comparison then would be processed as: status.replicas > 2
+    - This would be processed as status.replicas > 2
     suboptions:
       name:
         description:

--- a/lib/ansible/modules/clustering/k8s/k8s_wait.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_wait.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2019, Fabian von Feilitzsch <@fabianvf>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+
+module: k8s_wait
+
+short_description: Wait for Kubernetes resources to reach a desired state
+
+version_added: "2.8"
+
+author:
+    - "Fabian von Feilitzsch (@fabianvf)"
+
+description:
+  - Use the OpenShift Python client to perform read operations on K8s objects.
+  - Pass the object definition from a source file or inline. See examples for reading
+    files and using Jinja templates or vault-encrypted files.
+  - Access to the full range of K8s APIs.
+  - Use the M(k8s) module to perform create, update, or delete resources
+  - Use the M(k8s_facts) module to obtain a list of items about an object of type C(kind)
+  - Authenticate using either a config file, certificates, password or token.
+  - Supports check mode.
+  - Implemented for C(state=present) for C(Deployment), C(DaemonSet) and C(Pod), and for C(state=absent) for all resource kinds.
+  - For resource kinds without an implementation, returns immediately unless C(condition) or C(field) is set.
+
+extends_documentation_fragment:
+  - k8s_state_options
+  - k8s_name_options
+  - k8s_auth_options
+
+options:
+  field:
+    description:
+    - Specifies a field, operator, and comparison value to wait for on the status field of a resource.
+    - Comparison is done like: C(name) C(operator) C(value)
+    - For example, to check that there are more than two replicas in a stateful set, C(name) would be replicas,
+      C(operator) would be >, and C(value) would be 2
+    - The comparison then would be processed as: status.replicas > 2
+    suboptions:
+      name:
+        description:
+        - The name of the status field.
+        - For example, on a C(StatefulSet), the C(readyReplicas) and C(updatedReplicas) might be set in the status.
+      operator:
+        description:
+        - The operator to use to compare the status field and the provided value.
+        - >, >=, < and <= will only work on numerical values. = and != will work with all fields.
+        choices:
+        - =
+        - !=
+        - >
+        - <
+        - >=
+        - <=
+        default: =
+      value:
+        description:
+        - The value to compare with the the status field. Can be any type.
+  condition:
+    description:
+    - Specifies a custom condition on the status to wait for.
+    suboptions:
+      type:
+        description:
+        - The type of condition to wait for. For example, the C(Pod) resource will set the C(Ready) condition (among others)
+        - Required if you are specifying a C(condition). If left empty, the C(condition) field will be ignored.
+        - The possible types for a condition are specific to each resource type in Kubernetes. See the API documentation of the status field
+          for a given resource to see possible choices.
+      status:
+        description:
+        - The value of the status field in your desired condition.
+        - For example, if a C(Deployment) is paused, the C(Progressing) C(type) will have the C(Unknown) status.
+        choices:
+        - True
+        - False
+        - Unknown
+      reason:
+        description:
+        - The value of the reason field in your desired condition
+        - For example, if a C(Deployment) is paused, The C(Progressing) C(type) will have the C(DeploymentPaused) reason.
+        - The possible reasons in a condition are specific to each resource type in Kubernetes. See the API documentation of the status field
+          for a given resource to see possible choices.
+  timeout:
+    description:
+    - How long in seconds to wait for the resource to end up in the desired state.
+    default: 120
+  label_selectors:
+    description: List of label selectors to use to filter resources
+  field_selectors:
+    description: List of field selectors to use to filter resources
+requirements:
+  - "python >= 2.7"
+  - "openshift >= 0.6"
+  - "PyYAML >= 3.11"
+'''
+
+EXAMPLES = '''
+- name: Create a StatefulSet
+  k8s:
+    definition: '{{ lookup("template", "statefulset.yaml.j2") }}'
+
+- name: Wait for 2 replicas to report as ready
+  k8s_wait:
+    definition: '{{ lookup("template", "statefulset.yaml.j2") }}'
+    field:
+      name: readyReplicas
+      operator: >=
+      value: 2
+
+- name: Pause an existing Deployment
+  k8s:
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: test-deploy
+        namespace: default
+      spec:
+        pause: True
+
+- name: Verify the Deployment has reported the pause in its conditions
+  k8s_wait:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: default
+    name: test-deploy
+    condition:
+      type: Progressing
+      status: Unknown
+      reason: DeploymentPaused
+    timeout: 30
+
+- name: Wait for all pods labeled app=web to report ready
+  k8s_wait:
+    kind: Pod
+    label_selectors:
+      - app = web
+    condition:
+      type: ContainersReady
+      status: True
+'''
+
+RETURN = '''
+result:
+  description:
+  - The object(s) being examined
+  returned: success
+  type: complex
+  contains:
+     api_version:
+       description: The versioned schema of this representation of an object.
+       returned: success
+       type: str
+     kind:
+       description: Represents the REST resource this object represents.
+       returned: success
+       type: str
+     metadata:
+       description: Standard object metadata. Includes name, namespace, annotations, labels, etc.
+       returned: success
+       type: complex
+     spec:
+       description: Specific attributes of the object. Will vary based on the I(api_version) and I(kind).
+       returned: success
+       type: complex
+     status:
+       description: Current status details for the object.
+       returned: success
+       type: complex
+     items:
+       description: Returned only when multiple yaml documents are passed to src or resource_definition
+       returned: when resource_definition or src contains list of objects
+       type: list
+duration:
+  description:
+  - elapsed time of task in seconds
+  returned: success
+  type: int
+  sample: 48
+'''
+
+from ansible.module_utils.k8s.wait import KubernetesWaitModule
+
+
+def main():
+    KubernetesWaitModule().execute_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/clustering/k8s/k8s_wait.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_wait.py
@@ -47,7 +47,7 @@ options:
     - Specifies a field, operator, and comparison value to wait for on the status field of a resource.
     - Comparison is done like: C(name) C(operator) C(value)
     - For example, to check that there are more than two replicas in a stateful set, C(name) would be replicas,
-      C(operator) would be >, and C(value) would be 2
+      C(operator) would be gt, and C(value) would be 2
     - The comparison then would be processed as: status.replicas > 2
     suboptions:
       name:
@@ -57,15 +57,15 @@ options:
       operator:
         description:
         - The operator to use to compare the status field and the provided value.
-        - >, >=, < and <= will only work on numerical values. = and != will work with all fields.
+        - gt, gte, lt and lte will only work on numerical values. eq and neq will work with all fields.
         choices:
-        - =
-        - !=
-        - >
-        - <
-        - >=
-        - <=
-        default: =
+        - eq
+        - neq
+        - gt
+        - lt
+        - gte
+        - lte
+        default: eq
       value:
         description:
         - The value to compare with the the status field. Can be any type.
@@ -117,7 +117,7 @@ EXAMPLES = '''
     definition: '{{ lookup("template", "statefulset.yaml.j2") }}'
     field:
       name: readyReplicas
-      operator: >=
+      operator: gte
       value: 2
 
 - name: Pause an existing Deployment
@@ -147,7 +147,7 @@ EXAMPLES = '''
   k8s_wait:
     kind: Pod
     label_selectors:
-      - app = web
+    - app=web
     condition:
       type: ContainersReady
       status: True

--- a/test/integration/targets/k8s/playbooks/roles/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/tasks/waiter.yml
@@ -266,7 +266,7 @@
           reason: DeploymentPaused
         field:
           name: replicas
-          operator: =
+          operator: eq
           value: 2
       register: pause_deploy
 

--- a/test/integration/targets/k8s/playbooks/roles/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/tasks/waiter.yml
@@ -242,6 +242,43 @@
           - deploy.result.status.availableReplicas == deploy.result.status.replicas
           - updated_deploy_pods.resources[0].spec.containers[0].image.endswith(":2")
 
+    - name: patch deployment
+      k8s:
+        definition:
+          apiVersion: extensions/v1beta1
+          kind: Deployment
+          metadata:
+            name: wait-deploy
+            namespace: "{{ wait_namespace }}"
+          spec:
+            paused: True
+            replicas: 2
+
+    - name: Wait for Deployment to report that it was paused and 2 replicas
+      k8s_wait:
+        api_version: extensions/v1beta1
+        kind: Deployment
+        name: wait-deploy
+        namespace: '{{ wait_namespace }}'
+        condition:
+          type: Progressing
+          status: Unknown
+          reason: DeploymentPaused
+        field:
+          name: replicas
+          operator: =
+          value: 2
+      register: pause_deploy
+
+    - name: check that paused deployment wait worked
+      assert:
+        that:
+          - condition.reason == "DeploymentPaused"
+          - condition.status == "Unknown"
+          - pause_deploy.status.replicas == 2
+      vars:
+        condition: '{{ pause_deploy.result.status.conditions | selectattr("type", "Progressing")).0 }}'
+
     - name: add a service based on the deployment
       k8s:
         definition:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows users to wait for a custom condition or top level field value on a Kubernetes resource status. This provides a similar functionality to the `kubectl wait` command. This is an alternative to adding it as a feature of the `k8s` module, as #52185 does. This is still very much a WIP, and needs a good amount of refinement.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_wait
