### PR TITLE
Fix az command to get object id

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_keyvault.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_keyvault.py
@@ -63,7 +63,7 @@ options:
                 description:
                     - "The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be
                        unique for the list of access policies."
-                    - Please note this is not application id. Object id can be obtained by running "az ad show sp --id <application id>".
+                    - Please note this is not application id. Object id can be obtained by running "az ad sp show --id <application id>".
                 required: True
             application_id:
                 description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`az ad show sp --id <application id>` is not a valid az command. The correct one is in this pr.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_keyvault