### PR TITLE
mysql_user: fix malformed regex used to check current privileges

### DIFF
--- a/changelogs/fragments/52278-mysql_user-fix-regex
+++ b/changelogs/fragments/52278-mysql_user-fix-regex
@@ -1,0 +1,2 @@
+bugfixes:
+  - "mysql_user: fix the working but incorrect regex used to check the user privileges."

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -427,7 +427,7 @@ def privileges_get(cursor, user, host):
             return x
 
     for grant in grants:
-        res = re.match("""GRANT (.+) ON (.+) TO (['`"]).*\\3@(['`"]).*\\4( IDENTIFIED BY PASSWORD (['`"]).+\5)? ?(.*)""", grant[0])
+        res = re.match("""GRANT (.+) ON (.+) TO (['`"]).*\\3@(['`"]).*\\4( IDENTIFIED BY PASSWORD (['`"]).+\\6)? ?(.*)""", grant[0])
         if res is None:
             raise InvalidPrivsError('unable to parse the MySQL grant string: %s' % grant[0])
         privileges = res.group(1).split(", ")


### PR DESCRIPTION
##### SUMMARY
The regex introduced in pr #40092 works because it matches all the groups we’re interested in but it’s not formally correct.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user
