### PR TITLE
Add environment argument to command module

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -53,6 +53,16 @@ options:
     description:
       - Change into this directory before running the command.
     version_added: "0.6"
+  environment:
+    type: dict
+    description:
+      - Set these environment variables before running the command.
+      - Using this option does not unset existing environment variables.
+    sample:
+      environment:
+        DISPLAY: ":1.0"
+        LANG: C
+    version_added: "2.8"
   warn:
     description:
       - Enable or disable task warnings.
@@ -212,6 +222,7 @@ def main():
             _uses_shell=dict(type='bool', default=False),
             argv=dict(type='list'),
             chdir=dict(type='path'),
+            environment=dict(type='dict'),
             executable=dict(),
             creates=dict(type='path'),
             removes=dict(type='path'),
@@ -225,6 +236,7 @@ def main():
     )
     shell = module.params['_uses_shell']
     chdir = module.params['chdir']
+    environment = module.params['environment']
     executable = module.params['executable']
     args = module.params['_raw_params']
     argv = module.params['argv']
@@ -288,7 +300,7 @@ def main():
     startd = datetime.datetime.now()
 
     if not module.check_mode:
-        rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin, binary_data=(not stdin_add_newline))
+        rc, out, err = module.run_command(args, environ_update=environment, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin, binary_data=(not stdin_add_newline))
     elif creates or removes:
         rc = 0
         out = err = b'Command would have run if not in check mode'


### PR DESCRIPTION
This change adds an optional argument, "environment," to the command module, allowing environment variables to be set for simple command invocations without the use of wrapper scripts.

##### SUMMARY
At present, the `command` module does not support setting environment variables, forcing the use of wrapper scripts in situations where they're not otherwise necessary.  This change expands the API of the `command` module to include an `environment` argument, which is then passed to the `environ_update` kwarg already present in `AnsibleModule.run_command`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`command`