### PR TITLE
Fix a bug that caused exception on XenServer 7.1 with Cummulative Update

### DIFF
--- a/lib/ansible/module_utils/xenserver.py
+++ b/lib/ansible/module_utils/xenserver.py
@@ -17,9 +17,6 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils._text import to_text
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.six import integer_types, iteritems, string_types
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION
 
@@ -408,7 +405,7 @@ def gather_vm_params(module, vm_ref):
         # Detect customization agent.
         xenserver_version = get_xenserver_version(module)
 
-        if (int(xenserver_version[0]) >= 7 and int(xenserver_version[1]) >= 0 and vm_params.get('guest_metrics') and
+        if (xenserver_version[0] >= 7 and xenserver_version[1] >= 0 and vm_params.get('guest_metrics') and
                 "feature-static-ip-setting" in vm_params['guest_metrics']['other']):
             vm_params['customization_agent'] = "native"
         else:
@@ -756,12 +753,19 @@ def get_xenserver_version(module):
         module: Reference to Ansible module object.
 
     Returns:
-        list: Element [0] is major version. Element [1] i minor version.
+        list: Element [0] is major version. Element [1] is minor version.
+        Element [2] is update number.
     """
     xapi_session = XAPI.connect(module)
 
     host_ref = xapi_session.xenapi.session.get_this_host(xapi_session._session)
-    return xapi_session.xenapi.host.get_software_version(host_ref)['product_version_text_short'].split('.')
+
+    try:
+        xenserver_version = [int(version_number) for version_number in xapi_session.xenapi.host.get_software_version(host_ref)['product_version'].split('.')]
+    except ValueError:
+        xenserver_version = [0, 0, 0]
+
+    return xenserver_version
 
 
 class XAPI(object):

--- a/test/units/module_utils/xenserver/test_gather_vm_params_and_facts.py
+++ b/test/units/module_utils/xenserver/test_gather_vm_params_and_facts.py
@@ -68,7 +68,7 @@ def test_gather_vm_params_and_facts(mocker, fake_ansible_module, XenAPI, xenserv
 
     mocked_xenapi.configure_mock(**mocked_returns)
 
-    mocker.patch('ansible.module_utils.xenserver.get_xenserver_version', return_value=['7', '2'])
+    mocker.patch('ansible.module_utils.xenserver.get_xenserver_version', return_value=[7, 2, 0])
 
     vm_ref = list(fixture_data_from_file[params_file]['VM'].keys())[0]
 

--- a/test/units/module_utils/xenserver/test_xenserverobject.py
+++ b/test/units/module_utils/xenserver/test_xenserverobject.py
@@ -39,7 +39,7 @@ def test_xenserverobject(mocker, fake_ansible_module, XenAPI, xenserver):
         "pool.get_all.return_value": [fake_xenapi_ref('pool')],
         "pool.get_default_SR.return_value": fake_xenapi_ref('SR'),
         "session.get_this_host.return_value": fake_xenapi_ref('host'),
-        "host.get_software_version.return_value": {"product_version_text_short": "7.2"},
+        "host.get_software_version.return_value": {"product_version": "7.2.0"},
     }
 
     mocked_xenapi.configure_mock(**mocked_returns)
@@ -47,4 +47,4 @@ def test_xenserverobject(mocker, fake_ansible_module, XenAPI, xenserver):
     xso = xenserver.XenServerObject(fake_ansible_module)
 
     assert xso.pool_ref == fake_xenapi_ref('pool')
-    assert xso.xenserver_version == ['7', '2']
+    assert xso.xenserver_version == [7, 2, 0]


### PR DESCRIPTION
 - xenserver module_util: fixed a bug in gather_vm_params function where
   an exception was generated if XenServer product_version_text_short
   parameter contained non numeric characters, e.g. "7.1 CU1" on
   XenServer version 7.1 with Cummulative Update 1. Code was changed
   to use product_version parameter instead which is all numeric.
 - xenserver module_util: get_xenserver_version function is changed
   to return a list of integers for major, minor and update version
   instead of list of strings.
 - xenserver module_util: unit tests are updated according to changes.
 - xenserver module_util: removed unused imports.

##### SUMMARY
Fixes a bug with XenServer version 7.1 with installed Cumulative Update. Also some code cleanup an typo fixes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xenserver

##### ADDITIONAL INFORMATION
XenServer host parameter product_version_text_short was used to determine XenServer version. On most versions of XenServer this parameter uses all numeric characters. On XenServer 7.1 with Cumulative Update 1 or 2, there are extra non numeric characters found in product_version_text_short parameter e.g. "7.1 CU1". This caused a ValueError exception in gather_vm_params function when converting version string to integers. To fix the issue, product_version parameter was used instead which is expected to alway be numeric.