### PR TITLE
add boto3_tag_list_to_ansible_dict to ec2_vpc_peering_facts.py, and parameter checking to ec2_vpc_peer.py

### DIFF
--- a/changelogs/fragments/ec2_vpc_peer_parameter_checking.yaml
+++ b/changelogs/fragments/ec2_vpc_peer_parameter_checking.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - Added parameter checking before the module attempts to do an action to give helpful error message

--- a/changelogs/fragments/ec2_vpc_peering_facts_tags.yml
+++ b/changelogs/fragments/ec2_vpc_peering_facts_tags.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Changed output of tags dictionary in results by using boto3_tag_list_to_ansible_dict function
+  - Changed output of tags dictionary in results to standard Ansible format

--- a/changelogs/fragments/ec2_vpc_peering_facts_tags.yml
+++ b/changelogs/fragments/ec2_vpc_peering_facts_tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Changed output of tags dictionary in results by using boto3_tag_list_to_ansible_dict function

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -408,8 +408,8 @@ def main():
     if not HAS_BOTO3:
         module.fail_json(msg='json, botocore and boto3 are required.')
     state = module.params.get('state')
-    peering_id = modules.params.get('peering_id')
-    vpc_id = modules.params.get('vpc_id')
+    peering_id = module.params.get('peering_id')
+    vpc_id = module.params.get('vpc_id')
     peer_vpc_id = module.params.get('peer_vpc_id')
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -429,7 +429,7 @@ def main():
         module.exit_json(changed=changed, peering_id=results)
     elif state == 'absent':
         if not peering_id and (not vpc_id or not peer_vpc_id):
-            module.fail_json(msg='state is absent but all of the following are missing: peering_id or [vpc_id, peer_vpc_id]')
+            module.fail_json(msg='state is absent but one of the following is missing: peering_id or [vpc_id, peer_vpc_id]')
 
         remove_peer_connection(client, module)
     else:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peering_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peering_facts.py
@@ -74,7 +74,8 @@ except ImportError:
     pass  # will be picked up by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import (ec2_argument_spec, boto3_conn, get_aws_connection_info,
+from ansible.module_utils.ec2 import (boto3_tag_list_to_ansible_dict,
+                                      ec2_argument_spec, boto3_conn, get_aws_connection_info,
                                       ansible_dict_to_boto3_filter_list, HAS_BOTO3, camel_dict_to_snake_dict)
 
 
@@ -128,7 +129,12 @@ def main():
     except botocore.exceptions.NoCredentialsError as e:
         module.fail_json(msg=str(e))
 
+    # Turn the boto3 result in to ansible friendly_snaked_names
     results = [camel_dict_to_snake_dict(peer) for peer in get_vpc_peers(ec2, module)]
+
+    # Turn the boto3 result in to ansible friendly tag dictionary
+    for peer in results:
+        peer['tags'] = boto3_tag_list_to_ansible_dict(peer.get('tags', []))
 
     module.exit_json(result=results)
 


### PR DESCRIPTION
##### SUMMARY
1) Alter ec2_vpc_peering_facts.py to use boto3_tag_list_to_ansible_dict so tag names don't get altered unexpectedly from the camel_dict_to_snake_dict function that gets used.

I just took code from modules/cloud/amazon/ec2_instance_facts.py and put it in ec2_vpc_peering_facts.py.

Fixes #52305 

2) ec2_vpc_peer.py has unhelpful error messages when you are missing a parameter. This is easily fixable by doing some parameter checking in main(). I copied a similar format from ec2.py to do this error checking.

Fixes #52333
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_vpc_peering_facts.py
modules/cloud/amazon/ec2_vpc_peer_facts.py

##### ADDITIONAL INFORMATION
AWS tag names and values would get altered from the camel_dict_to_snake_dict function in main(). This makes querying for information incorrect. In ec2_instance_facts.py, boto3_tag_list_to_ansible_dict is used to solve this problem. Adding it to ec2_vpc_peering_facts.py would solve the problem for this file as well.
