### PR TITLE
fixes the json reading string object instead of byte

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -263,7 +263,8 @@ def request(url, user, passwd, timeout, data=None, method=None):
     body = response.read()
 
     if body:
-        return json.loads(body.decode('utf-8'))
+        return json.loads(to_text(body, errors='surrogate_or_strict'))
+        
     else:
         return {}
 

--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -263,7 +263,7 @@ def request(url, user, passwd, timeout, data=None, method=None):
     body = response.read()
 
     if body:
-        return json.loads(body)
+        return json.loads(body.decode('utf-8'))
     else:
         return {}
 


### PR DESCRIPTION
response.read() returns a bytes object, it needs to be decoded first using .decode() method before passing in to json.loads()

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #51421

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
