### PR TITLE
Add k8s_auth and kubevirt_vm to the k8s group

### DIFF
--- a/changelogs/fragments/k8s_module_defaults_group.yml
+++ b/changelogs/fragments/k8s_module_defaults_group.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - A k8s module defaults group has now been added to reduce the amount of parameters required for multiple k8s tasks.
-    This group contains all non-deprecated kubernetes modules - `k8s`, `k8s_facts`, `k8s_scale` and `k8s_service`.
+    This group contains all non-deprecated kubernetes modules - `k8s`, `k8s_auth`, `k8s_facts`, `k8s_scale` and
+    `k8s_service` as well as the CRD-handling `kubevirt_*` modules.

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -596,9 +596,13 @@ groupings:
   - azure
   k8s:
   - k8s
+  k8s_auth:
+  - k8s
   k8s_facts:
   - k8s
   k8s_service:
   - k8s
   k8s_scale:
+  - k8s
+  kubevirt_vm:
   - k8s


### PR DESCRIPTION
##### SUMMARY
All modules that operate on objects in kubernetes clusters should share as many parameter names as possible (especially the auth–related ones) and be part of the `k8s` group to simplify playbook creation.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
module defaults for groups