### PR TITLE
cron - adds deprecation warnings (#37355).

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -38,6 +38,7 @@ options:
       - Description of a crontab entry or, if env is set, the name of environment variable.
         Required if state=absent. Note that if name is not set and state=present, then a
         new crontab entry will always be created, regardless of existing ones.
+        This parameter will always be required in future releases.
   user:
     description:
       - The specific user whose crontab should be modified.
@@ -608,6 +609,17 @@ def main():
     crontab = CronTab(module, user, cron_file)
 
     module.debug('cron instantiated - name: "%s"' % name)
+
+    if not name:
+        module.deprecate(
+            msg="The 'name' parameter will be required in future releases.",
+            version='2.10'
+        )
+    if reboot:
+        module.deprecate(
+            msg="The 'reboot' parameter will be removed in future releases. Use 'special_time' option instead.",
+            version='2.10'
+        )
 
     if module._diff:
         diff = dict()


### PR DESCRIPTION
This change adds deprecation warnings for both 'name', and 'reboot' option (although not related to this change, it has been deprecated for quite a while).

Adds notification of fix for #37355

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
cron module

##### ADDITIONAL INFORMATION

This PR was requested on #37355 since the bugfix itself will make the 'name' parameter required.