### PR TITLE
Unfreeze six in test constraints.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -37,6 +37,5 @@ isort == 4.3.4
 lazy-object-proxy == 1.3.1
 mccabe == 0.6.1
 pylint == 2.1.1
-six == 1.11.0
 typed-ast == 1.1.0
 wrapt == 1.10.11


### PR DESCRIPTION
##### SUMMARY

Unfreeze six in test constraints.

This avoids re-installation during integration test runs.

Pinning this requirement shouldn't be needed for consistent test results when running pylint.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
