### PR TITLE
Deprecating panos modules; pointing to Galaxy role

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -144,7 +144,7 @@ The following modules will be removed in Ansible 2.12. Please update your playbo
 * ``github_hooks`` use :ref:`github_webhook <github_webhook_module>` and :ref:`github_webhook_facts <github_webhook_facts_module>` instead.
 * ``digital_ocean`` use :ref `digital_ocean_droplet <digital_ocean_droplet_module>` instead.
 * ``gce`` use :ref `gce_compute_instance <gce_compute_instance_module>` instead.
-* ``panos`` use <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks> instead.
+* ``panos`` use `Ansible Galaxy role <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_ instead.
 
 
 Noteworthy module changes

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -201,7 +201,7 @@ Noteworthy module changes
   Please see module ``vmware_vm_facts`` documentation for example.
 
 * The ``panos`` modules have been deprecated in favor of using the Palo Alto Networks `Ansible Galaxy role
-  <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.  Contributions to the role can be made
+  <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.   Contributions to the role can be made
   `here <https://github.com/PaloAltoNetworks/ansible-pan>`_.
 
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -144,6 +144,7 @@ The following modules will be removed in Ansible 2.12. Please update your playbo
 * ``github_hooks`` use :ref:`github_webhook <github_webhook_module>` and :ref:`github_webhook_facts <github_webhook_facts_module>` instead.
 * ``digital_ocean`` use :ref `digital_ocean_droplet <digital_ocean_droplet_module>` instead.
 * ``gce`` use :ref `gce_compute_instance <gce_compute_instance_module>` instead.
+* ``panos`` use <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks> instead.
 
 
 Noteworthy module changes
@@ -198,6 +199,10 @@ Noteworthy module changes
 
 * ``vmware_vm_facts`` used to return dict of dict with virtual machine's facts. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
   Please see module ``vmware_vm_facts`` documentation for example.
+
+* The ``panos`` modules have been deprecated in favor of using the Palo Alto Networks `Ansible Galaxy role
+  <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.  Contributions to the role can be made
+  `here <https://github.com/PaloAltoNetworks/ansible-pan>`_.
 
 
 Plugins

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -201,7 +201,7 @@ Noteworthy module changes
   Please see module ``vmware_vm_facts`` documentation for example.
 
 * The ``panos`` modules have been deprecated in favor of using the Palo Alto Networks `Ansible Galaxy role
-  <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.   Contributions to the role can be made
+  <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.  Contributions to the role can be made
   `here <https://github.com/PaloAltoNetworks/ansible-pan>`_.
 
 

--- a/lib/ansible/modules/network/panos/_panos_admin.py
+++ b/lib/ansible/modules/network/panos/_panos_admin.py
@@ -20,7 +20,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -35,6 +35,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     admin_username:
         description:

--- a/lib/ansible/modules/network/panos/_panos_admin.py
+++ b/lib/ansible/modules/network/panos/_panos_admin.py
@@ -37,7 +37,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     admin_username:

--- a/lib/ansible/modules/network/panos/_panos_admpwd.py
+++ b/lib/ansible/modules/network/panos/_panos_admpwd.py
@@ -30,6 +30,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - paramiko
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     ip_address:
         description:
@@ -74,7 +78,7 @@ status:
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_admpwd.py
+++ b/lib/ansible/modules/network/panos/_panos_admpwd.py
@@ -32,7 +32,7 @@ requirements:
     - paramiko
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     ip_address:

--- a/lib/ansible/modules/network/panos/_panos_cert_gen_ssh.py
+++ b/lib/ansible/modules/network/panos/_panos_cert_gen_ssh.py
@@ -30,6 +30,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - paramiko
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
 options:
@@ -79,7 +83,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_cert_gen_ssh.py
+++ b/lib/ansible/modules/network/panos/_panos_cert_gen_ssh.py
@@ -32,7 +32,7 @@ requirements:
     - paramiko
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_check.py
+++ b/lib/ansible/modules/network/panos/_panos_check.py
@@ -39,12 +39,12 @@ options:
         description:
             - timeout of API calls
         required: false
-        default: "0"
+        default: 0
     interval:
         description:
             - time waited between checks
         required: false
-        default: "0"
+        default: 0
 extends_documentation_fragment: panos
 '''
 

--- a/lib/ansible/modules/network/panos/_panos_check.py
+++ b/lib/ansible/modules/network/panos/_panos_check.py
@@ -21,38 +21,50 @@
 
 DOCUMENTATION = '''
 ---
-module: panos_dag
-short_description: create a dynamic address group
+module: panos_check
+short_description: check if PAN-OS device is ready for configuration
 description:
-    - Create a dynamic address group object in the firewall used for policy rules
+    - Check if PAN-OS device is ready for being configured (no pending jobs).
+    - The check could be done once or multiple times until the device is ready.
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
-    dag_name:
+    timeout:
         description:
-            - name of the dynamic address group
-        required: true
-    dag_filter:
+            - timeout of API calls
+        required: false
+        default: "0"
+    interval:
         description:
-            - dynamic filter user by the dynamic address group
-        required: true
-    commit:
-        description:
-            - commit if changed
-        type: bool
-        default: 'yes'
+            - time waited between checks
+        required: false
+        default: "0"
 extends_documentation_fragment: panos
 '''
 
 EXAMPLES = '''
-- name: dag
-  panos_dag:
+# single check on 192.168.1.1 with credentials admin/admin
+- name: check if ready
+  panos_check:
     ip_address: "192.168.1.1"
     password: "admin"
-    dag_name: "dag-1"
-    dag_filter: "'aws-tag.aws:cloudformation:logical-id.ServerInstance' and 'instanceState.running'"
+
+# check for 10 times, every 30 seconds, if device 192.168.1.1
+# is ready, using credentials admin/admin
+- name: wait for reboot
+  panos_check:
+    ip_address: "192.168.1.1"
+    password: "admin"
+  register: result
+  until: result is not failed
+  retries: 10
+  delay: 30
 '''
 
 RETURN = '''
@@ -60,11 +72,12 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
 from ansible.module_utils.basic import AnsibleModule
+import time
 
 try:
     import pan.xapi
@@ -72,33 +85,17 @@ try:
 except ImportError:
     HAS_LIB = False
 
-_ADDRGROUP_XPATH = "/config/devices/entry[@name='localhost.localdomain']" +\
-                   "/vsys/entry[@name='vsys1']/address-group/entry[@name='%s']"
 
-
-def addressgroup_exists(xapi, group_name):
-    xapi.get(_ADDRGROUP_XPATH % group_name)
-    e = xapi.element_root.find('.//entry')
-    if e is None:
-        return False
-    return True
-
-
-def add_dag(xapi, dag_name, dag_filter):
-    if addressgroup_exists(xapi, dag_name):
-        return False
-
-    # setup the non encrypted part of the monitor
-    exml = []
-
-    exml.append('<dynamic>')
-    exml.append('<filter>%s</filter>' % dag_filter)
-    exml.append('</dynamic>')
-
-    exml = ''.join(exml)
-    xapi.set(xpath=_ADDRGROUP_XPATH % dag_name, element=exml)
-
-    return True
+def check_jobs(jobs, module):
+    job_check = False
+    for j in jobs:
+        status = j.find('.//status')
+        if status is None:
+            return False
+        if status.text != 'FIN':
+            return False
+        job_check = True
+    return job_check
 
 
 def main():
@@ -106,9 +103,8 @@ def main():
         ip_address=dict(required=True),
         password=dict(required=True, no_log=True),
         username=dict(default='admin'),
-        dag_name=dict(required=True),
-        dag_filter=dict(required=True),
-        commit=dict(type='bool', default=True)
+        timeout=dict(default=0, type='int'),
+        interval=dict(default=0, type='int')
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
     if not HAS_LIB:
@@ -117,23 +113,33 @@ def main():
     ip_address = module.params["ip_address"]
     password = module.params["password"]
     username = module.params['username']
+    timeout = module.params['timeout']
+    interval = module.params['interval']
 
     xapi = pan.xapi.PanXapi(
         hostname=ip_address,
         api_username=username,
-        api_password=password
+        api_password=password,
+        timeout=60
     )
 
-    dag_name = module.params['dag_name']
-    dag_filter = module.params['dag_filter']
-    commit = module.params['commit']
+    checkpnt = time.time() + timeout
+    while True:
+        try:
+            xapi.op(cmd="show jobs all", cmd_xml=True)
+        except Exception:
+            pass
+        else:
+            jobs = xapi.element_root.findall('.//job')
+            if check_jobs(jobs, module):
+                module.exit_json(changed=True, msg="okey dokey")
 
-    changed = add_dag(xapi, dag_name, dag_filter)
+        if time.time() > checkpnt:
+            break
 
-    if changed and commit:
-        xapi.commit(cmd="<commit></commit>", sync=True, interval=1)
+        time.sleep(interval)
 
-    module.exit_json(changed=changed, msg="okey dokey")
+    module.fail_json(msg="Timeout")
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/panos/_panos_check.py
+++ b/lib/ansible/modules/network/panos/_panos_check.py
@@ -32,7 +32,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     timeout:

--- a/lib/ansible/modules/network/panos/_panos_commit.py
+++ b/lib/ansible/modules/network/panos/_panos_commit.py
@@ -36,7 +36,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     ip_address:

--- a/lib/ansible/modules/network/panos/_panos_commit.py
+++ b/lib/ansible/modules/network/panos/_panos_commit.py
@@ -34,6 +34,10 @@ author:
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     ip_address:
         description:
@@ -119,7 +123,7 @@ panos_commit:
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_dag.py
+++ b/lib/ansible/modules/network/panos/_panos_dag.py
@@ -31,7 +31,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     dag_name:

--- a/lib/ansible/modules/network/panos/_panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/_panos_dag_tags.py
@@ -21,7 +21,7 @@
 #  limitations under the License.
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
@@ -35,6 +35,10 @@ version_added: "2.5"
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
     - Panorama is not supported.

--- a/lib/ansible/modules/network/panos/_panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/_panos_dag_tags.py
@@ -37,7 +37,7 @@ requirements:
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_import.py
+++ b/lib/ansible/modules/network/panos/_panos_import.py
@@ -36,7 +36,7 @@ requirements:
     - requests_toolbelt
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     category:

--- a/lib/ansible/modules/network/panos/_panos_import.py
+++ b/lib/ansible/modules/network/panos/_panos_import.py
@@ -34,6 +34,10 @@ requirements:
     - pan-python
     - requests
     - requests_toolbelt
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     category:
         description:
@@ -71,7 +75,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_interface.py
+++ b/lib/ansible/modules/network/panos/_panos_interface.py
@@ -36,7 +36,7 @@ requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_interface.py
+++ b/lib/ansible/modules/network/panos/_panos_interface.py
@@ -20,7 +20,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -34,6 +34,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
 options:

--- a/lib/ansible/modules/network/panos/_panos_lic.py
+++ b/lib/ansible/modules/network/panos/_panos_lic.py
@@ -33,7 +33,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     auth_code:

--- a/lib/ansible/modules/network/panos/_panos_lic.py
+++ b/lib/ansible/modules/network/panos/_panos_lic.py
@@ -31,6 +31,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     auth_code:
         description:
@@ -70,7 +74,7 @@ serialnumber:
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_loadcfg.py
+++ b/lib/ansible/modules/network/panos/_panos_loadcfg.py
@@ -29,6 +29,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     file:
         description:
@@ -62,7 +66,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_loadcfg.py
+++ b/lib/ansible/modules/network/panos/_panos_loadcfg.py
@@ -31,7 +31,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     file:

--- a/lib/ansible/modules/network/panos/_panos_match_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_match_rule.py
@@ -61,7 +61,10 @@ options:
     rule_type:
         description:
             - Type of rule. Valid types are I(security) or I(nat).
-        default: "security"
+        required: true
+        choices:
+            - security
+            - nat
     source_zone:
         description:
             - The source zone.

--- a/lib/ansible/modules/network/panos/_panos_match_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_match_rule.py
@@ -21,7 +21,7 @@
 #  limitations under the License.
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
@@ -35,6 +35,10 @@ version_added: "2.5"
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
     - Panorama NOT is supported.

--- a/lib/ansible/modules/network/panos/_panos_match_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_match_rule.py
@@ -37,7 +37,7 @@ requirements:
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_mgtconfig.py
+++ b/lib/ansible/modules/network/panos/_panos_mgtconfig.py
@@ -29,6 +29,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     dns_server_primary:
         description:
@@ -66,7 +70,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_mgtconfig.py
+++ b/lib/ansible/modules/network/panos/_panos_mgtconfig.py
@@ -31,7 +31,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     dns_server_primary:

--- a/lib/ansible/modules/network/panos/_panos_nat_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_nat_rule.py
@@ -19,6 +19,10 @@ version_added: "2.4"
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
     - Panorama is supported.
@@ -126,7 +130,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 # import pydevd

--- a/lib/ansible/modules/network/panos/_panos_nat_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_nat_rule.py
@@ -21,7 +21,7 @@ requirements:
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_nat_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_nat_rule.py
@@ -45,10 +45,22 @@ options:
     operation:
         description:
             - The action to be taken.  Supported values are I(add)/I(update)/I(find)/I(delete).
+        required: true
+        choices:
+            - add
+            - update
+            - delete
+            - find
+    devicegroup:
+        description:
+            - If Panorama, the device group to put this rule in.
     rule_name:
         description:
             - name of the SNAT rule
         required: true
+    description:
+        description:
+            - The description
     source_zone:
         description:
             - list of source zones
@@ -72,10 +84,17 @@ options:
     snat_type:
         description:
             - type of source translation
+        choices:
+            - static-ip
+            - dynamic-ip-and-port
+            - dynamic-ip
     snat_address_type:
         description:
             - type of source translation. Supported values are I(translated-address)/I(translated-address).
-        default: 'translated-address'
+        default: 'interface-address'
+        choices:
+            - interface-address
+            - translated-address
     snat_static_address:
         description:
             - Source NAT translated address. Used with Static-IP translation.
@@ -99,6 +118,13 @@ options:
     dnat_port:
         description:
             - dnat translated port
+    tag_name:
+        description:
+            - Tag for the NAT rule.
+    to_interface:
+        description:
+            - Destination interface.
+        default: 'any'
     commit:
         description:
             - Commit configuration if changed.

--- a/lib/ansible/modules/network/panos/_panos_object.py
+++ b/lib/ansible/modules/network/panos/_panos_object.py
@@ -63,6 +63,11 @@ options:
         description:
             - The operation to be performed.  Supported values are I(add)/I(delete)/I(find).
         required: true
+        choices:
+            - add
+            - update
+            - delete
+            - find
     addressobject:
         description:
             - The name of the address object.
@@ -72,6 +77,11 @@ options:
     address_type:
         description:
             - The type of address object definition.  Valid types are I(ip-netmask) and I(ip-range).
+        default: 'ip-netmask'
+        choices:
+            - ip-netmask
+            - ip-range
+            - fqdn
     addressgroup:
         description:
             - A static group of address objects or dynamic address group.
@@ -93,6 +103,9 @@ options:
     protocol:
         description:
             - The IP protocol to be used in a service object definition.  Valid values are I(tcp) or I(udp).
+        choices:
+            - tcp
+            - udp
     servicegroup:
         description:
             - A group of service objects.
@@ -109,6 +122,23 @@ options:
         description: >
             - The color of the tag object.  Valid values are I(red, green, blue, yellow, copper, orange, purple, gray,
             light green, cyan, light gray, blue gray, lime, black, gold, and brown).
+        choices:
+            - red
+            - green
+            - blue
+            - yellow
+            - copper
+            - orange
+            - purple
+            - gray
+            - light green
+            - cyan
+            - light gray
+            - blue gray
+            - lime
+            - black
+            - gold
+            - brown
     devicegroup:
         description: >
             - The name of the Panorama device group. The group must exist on Panorama. If device group is not defined it

--- a/lib/ansible/modules/network/panos/_panos_object.py
+++ b/lib/ansible/modules/network/panos/_panos_object.py
@@ -38,7 +38,7 @@ requirements:
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_object.py
+++ b/lib/ansible/modules/network/panos/_panos_object.py
@@ -21,7 +21,7 @@
 #  limitations under the License.
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
@@ -36,6 +36,10 @@ version_added: "2.4"
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
     - Panorama is supported.

--- a/lib/ansible/modules/network/panos/_panos_op.py
+++ b/lib/ansible/modules/network/panos/_panos_op.py
@@ -35,7 +35,7 @@ requirements:
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is NOT supported.

--- a/lib/ansible/modules/network/panos/_panos_op.py
+++ b/lib/ansible/modules/network/panos/_panos_op.py
@@ -20,7 +20,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
@@ -33,6 +33,10 @@ version_added: "2.5"
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is NOT supported.
     - Panorama is NOT supported.

--- a/lib/ansible/modules/network/panos/_panos_pg.py
+++ b/lib/ansible/modules/network/panos/_panos_pg.py
@@ -29,6 +29,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     pg_name:
         description:
@@ -80,7 +84,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_pg.py
+++ b/lib/ansible/modules/network/panos/_panos_pg.py
@@ -31,7 +31,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     pg_name:

--- a/lib/ansible/modules/network/panos/_panos_query_rules.py
+++ b/lib/ansible/modules/network/panos/_panos_query_rules.py
@@ -21,7 +21,7 @@
 #  limitations under the License.
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
@@ -38,6 +38,10 @@ requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
     - xmltodict can be obtains from PyPI U(https://pypi.org/project/xmltodict/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
     - Panorama is supported.

--- a/lib/ansible/modules/network/panos/_panos_query_rules.py
+++ b/lib/ansible/modules/network/panos/_panos_query_rules.py
@@ -85,6 +85,9 @@ options:
     protocol:
         description:
             - The protocol used to be queried.  Must be either I(tcp) or I(udp).
+        choices:
+            - tcp
+            - udp
     tag_name:
         description:
             - Name of the rule tag to be queried.

--- a/lib/ansible/modules/network/panos/_panos_query_rules.py
+++ b/lib/ansible/modules/network/panos/_panos_query_rules.py
@@ -40,7 +40,7 @@ requirements:
     - xmltodict can be obtains from PyPI U(https://pypi.org/project/xmltodict/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_restart.py
+++ b/lib/ansible/modules/network/panos/_panos_restart.py
@@ -29,6 +29,10 @@ author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
     - pan-python
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 extends_documentation_fragment: panos
 '''
 
@@ -48,7 +52,7 @@ status:
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 

--- a/lib/ansible/modules/network/panos/_panos_restart.py
+++ b/lib/ansible/modules/network/panos/_panos_restart.py
@@ -31,7 +31,7 @@ requirements:
     - pan-python
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 extends_documentation_fragment: panos
 '''

--- a/lib/ansible/modules/network/panos/_panos_sag.py
+++ b/lib/ansible/modules/network/panos/_panos_sag.py
@@ -43,10 +43,10 @@ options:
         description:
             - name of the dynamic address group
         required: true
-    static_match_filter:
+    sag_match_filter:
         description:
             - Static filter user by the address group
-        required: true
+        type: list
     devicegroup:
         description: >
             - The name of the Panorama device group. The group must exist on Panorama. If device group is not defined
@@ -66,6 +66,10 @@ options:
         description:
             - The operation to perform Supported values are I(add)/I(list)/I(delete).
         required: true
+        choices:
+            - add
+            - list
+            - delete
 extends_documentation_fragment: panos
 '''
 

--- a/lib/ansible/modules/network/panos/_panos_sag.py
+++ b/lib/ansible/modules/network/panos/_panos_sag.py
@@ -31,6 +31,10 @@ requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
     - xmltodict can be obtained from PyPI U(https://pypi.org/project/xmltodict/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 options:
     api_key:
         description:
@@ -81,7 +85,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/panos/_panos_sag.py
+++ b/lib/ansible/modules/network/panos/_panos_sag.py
@@ -33,7 +33,7 @@ requirements:
     - xmltodict can be obtained from PyPI U(https://pypi.org/project/xmltodict/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 options:
     api_key:

--- a/lib/ansible/modules/network/panos/_panos_security_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_security_rule.py
@@ -28,7 +28,7 @@ requirements:
     - xmltodict can be obtained from PyPI U(https://pypi.org/project/xmltodict/)
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 notes:
     - Checkmode is not supported.

--- a/lib/ansible/modules/network/panos/_panos_security_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_security_rule.py
@@ -53,6 +53,16 @@ options:
         description:
             - The action to be taken.  Supported values are I(add)/I(update)/I(find)/I(delete).
         default: 'add'
+        choices:
+            - add
+            - update
+            - delete
+            - find
+    category:
+        description:
+            - The category.
+        type: list
+        default: ['any']
     rule_name:
         description:
             - Name of the security rule.

--- a/lib/ansible/modules/network/panos/_panos_security_rule.py
+++ b/lib/ansible/modules/network/panos/_panos_security_rule.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -26,6 +26,10 @@ requirements:
     - pan-python can be obtained from PyPI U(https://pypi.org/project/pan-python/)
     - pandevice can be obtained from PyPI U(https://pypi.org/project/pandevice/)
     - xmltodict can be obtained from PyPI U(https://pypi.org/project/xmltodict/)
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 notes:
     - Checkmode is not supported.
     - Panorama is supported.

--- a/lib/ansible/modules/network/panos/_panos_set.py
+++ b/lib/ansible/modules/network/panos/_panos_set.py
@@ -43,7 +43,7 @@ author: "Jasper Mackenzie (@spmp)"
 version_added: "2.7"
 deprecated:
     alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: Consolidating code base.
 requirements:
   - pan-python

--- a/lib/ansible/modules/network/panos/_panos_set.py
+++ b/lib/ansible/modules/network/panos/_panos_set.py
@@ -41,6 +41,10 @@ description:
   - The 'element' is "<timezone>Australia/Melbourne</timezone>"
 author: "Jasper Mackenzie (@spmp)"
 version_added: "2.7"
+deprecated:
+    alternative: Use U(https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks) instead.
+    removed_in: "2.11"
+    why: Consolidating code base.
 requirements:
   - pan-python
 options:
@@ -99,7 +103,7 @@ RETURN = '''
 '''
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Deprecating all `panos` modules, pointing to our Ansible Galaxy role instead to consolidate code bases into a single place.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

All `panos_` modules that are in the PaloAltoNetworks.paloaltonetworks Ansible Galaxy role.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
