### PR TITLE
Send openstack inventory logs to stderr (#51827)

### DIFF
--- a/changelogs/fragments/51827-openstack_logs_to_stderr.yml
+++ b/changelogs/fragments/51827-openstack_logs_to_stderr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openstack inventory plugin - send logs from sdk to stderr so they do not combine with output

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -108,6 +108,7 @@ fail_on_errors: yes
 '''
 
 import collections
+import sys
 
 from ansible.errors import AnsibleParserError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
@@ -172,8 +173,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             else:
                 config_files = None
 
-            # TODO(mordred) Integrate shade's logging with ansible's logging
-            sdk.enable_logging()
+            # Redict logging to stderr so it does not mix with output
+            # particular ansible-inventory JSON output
+            # TODO(mordred) Integrate openstack's logging with ansible's logging
+            sdk.enable_logging(stream=sys.stderr)
 
             cloud_inventory = sdk_inventory.OpenStackInventory(
                 config_files=config_files,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport fix that separates openstack inventory plugin logging from stdout
https://github.com/ansible/ansible/pull/51827 (bug is https://github.com/ansible/ansible/issues/50100)

In support of awx adoption of inventory plugins
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openstack inventory plugin


@AlanCoding @s-hertel
