### PR TITLE
luks_device: add allow_to_remove_last_key option

### DIFF
--- a/lib/ansible/modules/crypto/luks_device.py
+++ b/lib/ansible/modules/crypto/luks_device.py
@@ -90,7 +90,7 @@ options:
         type: path
     allow_to_remove_last_key:
         description:
-            - "If set to C(yes), allows to remove the last key from a container."
+            - "If set to C(yes), allows removing the last key from a container."
             - "BEWARE that when the last key has been removed from a container,
               the container can no longer be opened!"
         type: bool

--- a/lib/ansible/modules/crypto/luks_device.py
+++ b/lib/ansible/modules/crypto/luks_device.py
@@ -70,6 +70,9 @@ options:
               Needs I(keyfile) option for authorization. LUKS container
               supports up to 8 keys. Parameter value is the path
               to the keyfile with the passphrase."
+            - "NOTE that adding additional keys is I(not idempotent).
+              A new keyslot will be used even if another keyslot already
+              exists for this keyfile."
             - "BEWARE that working with keyfiles in plaintext is dangerous.
               Make sure that they are protected."
         type: path
@@ -78,12 +81,20 @@ options:
             - "Removes given key from the container on I(device). Does not
               remove the keyfile from filesystem.
               Parameter value is the path to the keyfile with the passphrase."
-            - "BEWARE that it is possible to remove even the last key from the
-              container. Data in there will be irreversibly lost
-              without a warning."
+            - "NOTE that removing keys is I(not idempotent). Trying to remove
+              a key which no longer exists results in an error."
+            - "NOTE that to remove the last key from a LUKS container, the
+              I(allow_to_remove_last_key) option must be set to C(yes)."
             - "BEWARE that working with keyfiles in plaintext is dangerous.
               Make sure that they are protected."
         type: path
+    allow_to_remove_last_key:
+        description:
+            - "If set to C(yes), allows to remove the last key from a container."
+            - "BEWARE that when the last key has been removed from a container,
+              the container can no longer be opened!"
+        type: bool
+        default: no
 
 requirements:
     - "cryptsetup"
@@ -284,10 +295,32 @@ class CryptHandler(Handler):
             raise ValueError('Error while adding new LUKS key to %s: %s'
                              % (device, result[STDERR]))
 
-    def run_luks_remove_key(self, device, keyfile):
+    def run_luks_remove_key(self, device, keyfile, allow_to_remove_last_key=False):
         ''' Remove key from given device
             Raises ValueError when command fails
         '''
+        if not allow_to_remove_last_key:
+            result = self._run_command([self._cryptsetup_bin, 'luksDump', device])
+            if result[RETURN_CODE] != 0:
+                raise ValueError('Error while dumping LUKS header from %s'
+                                 % (device, ))
+            keyslot_count = 0
+            keyslot_area = False
+            for line in result[STDOUT].splitlines():
+                if line.startswith('Keyslots:'):
+                    keyslot_area = True
+                elif line.startswith('  '):
+                    if keyslot_area and line[2] in '0123456789':
+                        keyslot_count += 1
+                elif line.startswith('\t'):
+                    pass
+                else:
+                    keyslot_area = False
+            if keyslot_count < 2:
+                self._module.fail_json(msg="LUKS device %s has less than two active keyslots. "
+                                           "To be able to remove a key, please set "
+                                           "`allow_to_remove_last_key` to `yes`." % device)
+
         result = self._run_command([self._cryptsetup_bin, 'luksRemoveKey', device,
                                     '-q', '--key-file', keyfile])
         if result[RETURN_CODE] != 0:
@@ -412,7 +445,8 @@ def run_module():
         name=dict(type='str'),
         keyfile=dict(type='path'),
         new_keyfile=dict(type='path'),
-        remove_keyfile=dict(type='path')
+        remove_keyfile=dict(type='path'),
+        allow_to_remove_last_key=dict(type='bool', default=False),
     )
 
     # seed the result dict in the object
@@ -491,7 +525,8 @@ def run_module():
     if conditions.luks_remove_key():
         try:
             crypt.run_luks_remove_key(module.params['device'],
-                                      module.params['remove_keyfile'])
+                                      module.params['remove_keyfile'],
+                                      allow_to_remove_last_key=module.params['allow_to_remove_last_key'])
         except ValueError as e:
             module.fail_json(msg="luks_device error: %s" % e)
         result['changed'] = True

--- a/test/integration/targets/luks_device/tasks/tests/key-management.yml
+++ b/test/integration/targets/luks_device/tasks/tests/key-management.yml
@@ -62,6 +62,9 @@
     device: "{{ cryptfile_device }}"
     state: closed
 
+- name: Dump LUKS header
+  command: "cryptsetup luksDump {{ cryptfile_device }}"
+
 - name: Remove access from keyfile1
   luks_device:
     device: "{{ cryptfile_device }}"
@@ -99,6 +102,9 @@
   luks_device:
     device: "{{ cryptfile_device }}"
     state: closed
+
+- name: Dump LUKS header
+  command: "cryptsetup luksDump {{ cryptfile_device }}"
 
 - name: Remove access from keyfile2
   luks_device:

--- a/test/integration/targets/luks_device/tasks/tests/key-management.yml
+++ b/test/integration/targets/luks_device/tasks/tests/key-management.yml
@@ -107,6 +107,39 @@
     keyfile: "{{ role_path }}/files/keyfile2"
     remove_keyfile: "{{ role_path }}/files/keyfile2"
   become: yes
+  ignore_errors: yes
+  register: remove_last_key
+- assert:
+    that:
+    - remove_last_key is failed
+    - "'allow_to_remove_last_key' in remove_last_key.msg"
+
+# Access: keyfile2
+
+- name: Try to open with keyfile2
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    state: opened
+    keyfile: "{{ role_path }}/files/keyfile2"
+  become: yes
+  ignore_errors: yes
+  register: open_try
+- assert:
+    that:
+    - open_try is not failed
+- name: Close
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    state: closed
+
+- name: Remove access from keyfile2
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    state: closed
+    keyfile: "{{ role_path }}/files/keyfile2"
+    remove_keyfile: "{{ role_path }}/files/keyfile2"
+    allow_to_remove_last_key: yes
+  become: yes
 
 # Access: none
 

--- a/test/integration/targets/luks_device/tasks/tests/key-management.yml
+++ b/test/integration/targets/luks_device/tasks/tests/key-management.yml
@@ -118,7 +118,7 @@
 - assert:
     that:
     - remove_last_key is failed
-    - "'allow_to_remove_last_key' in remove_last_key.msg"
+    - "'force_remove_last_key' in remove_last_key.msg"
 
 # Access: keyfile2
 
@@ -144,7 +144,7 @@
     state: closed
     keyfile: "{{ role_path }}/files/keyfile2"
     remove_keyfile: "{{ role_path }}/files/keyfile2"
-    allow_to_remove_last_key: yes
+    force_remove_last_key: yes
   become: yes
 
 # Access: none


### PR DESCRIPTION
##### SUMMARY
Adds `allow_to_remove_last_key` option to `luks_device` as discussed [here](https://github.com/ansible/ansible/pull/48991#discussion_r255516337).

NOTE: this currently contains all commits of #52359 (integration tests). Will rebase once that PR is merged.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
luks_device
