### PR TITLE
Update the default container to version 1.5.2.

### DIFF
--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.5.1 python=3
+default name=quay.io/ansible/default-test-container:1.5.2 python=3
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
 fedora28 name=quay.io/ansible/fedora28-test-container:1.5.0


### PR DESCRIPTION
##### SUMMARY

Update the default container to version 1.5.2.

Resolves https://github.com/ansible/ansible/issues/52349

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
