### PR TITLE
validate-modules: Harmonize error messages

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1163,7 +1163,7 @@ class ModuleValidator(Validator):
                 self.reporter.error(
                     path=self.object_path,
                     code=331,
-                    msg="argument '%s' in argument_spec must be a dictionary/hash when used" % arg,
+                    msg="Argument '%s' in argument_spec must be a dictionary/hash when used" % arg,
                 )
                 continue
             if not data.get('removed_in_version', None):
@@ -1182,9 +1182,8 @@ class ModuleValidator(Validator):
                 self.reporter.error(
                     path=self.object_path,
                     code=317,
-                    msg=('"%s" is marked as required but specifies '
-                         'a default. Arguments with a default '
-                         'should not be marked as required' % arg)
+                    msg=("Argument '%s' in argument_spec is marked as required "
+                         "but specifies a default. Arguments with a default should not be marked as required" % arg)
                 )
 
             if arg in provider_args:
@@ -1208,12 +1207,13 @@ class ModuleValidator(Validator):
                     self.reporter.error(
                         path=self.object_path,
                         code=329,
-                        msg=('Default value from the argument_spec (%r) is not compatible '
-                             'with type %r defined in the argument_spec' % (data['default'], _type))
+                        msg=("Argument '%s' in argument_spec defines default as (%r) "
+                             "but this is incompatible with parameter type %r" % (arg, data['default'], _type))
                     )
                     continue
             elif data.get('default') is None and _type == 'bool' and 'options' not in data:
                 arg_default = False
+
             try:
                 doc_default = None
                 doc_options_arg = docs.get('options', {}).get(arg, {})
@@ -1226,8 +1226,8 @@ class ModuleValidator(Validator):
                 self.reporter.error(
                     path=self.object_path,
                     code=327,
-                    msg=('Default value from the documentation (%r) is not compatible '
-                         'with type %r defined in the argument_spec' % (doc_options_arg.get('default'), _type))
+                    msg=("Argument '%s' in documentation defines default as (%r) "
+                         "but this is incompatible with parameter type %r" % (arg, doc_options_arg.get('default'), _type))
                 )
                 continue
 
@@ -1235,7 +1235,8 @@ class ModuleValidator(Validator):
                 self.reporter.error(
                     path=self.object_path,
                     code=324,
-                    msg=("argument_spec for '%s' defines default as '%s' but documentation defines default as '%s'" % (arg, arg_default, doc_default))
+                    msg=("Argument '%s' in argument_spec defines default as (%r) "
+                         "but documentation defines default as (%r)" % (arg, arg_default, doc_default))
                 )
 
             # TODO: needs to recursively traverse suboptions
@@ -1245,14 +1246,16 @@ class ModuleValidator(Validator):
                     self.reporter.error(
                         path=self.object_path,
                         code=325,
-                        msg="argument_spec for '%s' defines type as '%s' but documentation defines type as '%s'" % (arg, data['type'], doc_type)
+                        msg="Argument '%s' in argument_spec defines type as %r "
+                            "but documentation defines type as %r" % (arg, data['type'], doc_type)
                     )
             else:
                 if doc_type != 'str' and doc_type is not None:
                     self.reporter.error(
                         path=self.object_path,
                         code=335,
-                        msg="argument_spec for '%s' implies type as 'str' but documentation defines as '%s'" % (arg, doc_type)
+                        msg="Argument '%s' in argument_spec implies type as 'str' "
+                            "but documentation defines as %r" % (arg, doc_type)
                     )
 
             # TODO: needs to recursively traverse suboptions
@@ -1266,8 +1269,8 @@ class ModuleValidator(Validator):
                         self.reporter.error(
                             path=self.object_path,
                             code=328,
-                            msg=('Choices value from the documentation (%r) is not compatible '
-                                 'with type %r defined in the argument_spec' % (choice, _type))
+                            msg=("Argument '%s' in documentation defines choices as (%r) "
+                                 "but this is incompatible with argument type %r" % (arg, choice, _type))
                         )
                         raise StopIteration()
             except StopIteration:
@@ -1283,8 +1286,8 @@ class ModuleValidator(Validator):
                         self.reporter.error(
                             path=self.object_path,
                             code=330,
-                            msg=('Choices value from the argument_spec (%r) is not compatible '
-                                 'with type %r defined in the argument_spec' % (choice, _type))
+                            msg=("Argument '%s' in argument_spec defines choices as (%r) "
+                                 "but this is incompatible with argument type %r" % (arg, choice, _type))
                         )
                         raise StopIteration()
             except StopIteration:
@@ -1294,7 +1297,8 @@ class ModuleValidator(Validator):
                 self.reporter.error(
                     path=self.object_path,
                     code=326,
-                    msg=("argument_spec for '%s' defines choices as '%s' but documentation defines choices as '%s'" % (arg, arg_choices, doc_choices))
+                    msg=("Argument '%s' in argument_spec defines choices as (%r) "
+                         "but documentation defines choices as (%r)" % (arg, arg_choices, doc_choices))
                 )
 
         if docs:
@@ -1322,7 +1326,8 @@ class ModuleValidator(Validator):
                 self.reporter.error(
                     path=self.object_path,
                     code=322,
-                    msg='"%s" is listed in the argument_spec, but not documented in the module' % arg
+                    msg="Argument '%s' is listed in the argument_spec, "
+                        "but not documented in the module documentation" % arg
                 )
             for arg in docs_missing_from_args:
                 # args_from_docs contains argument not in the argument_spec
@@ -1332,7 +1337,8 @@ class ModuleValidator(Validator):
                 self.reporter.error(
                     path=self.object_path,
                     code=323,
-                    msg='"%s" is listed in DOCUMENTATION.options, but not accepted by the module' % arg
+                    msg="Argument '%s' is listed in DOCUMENTATION.options, "
+                        "but not accepted by the module argument_spec" % arg
                 )
 
     def _check_for_new_args(self, doc, metadata):
@@ -1359,9 +1365,7 @@ class ModuleValidator(Validator):
                 self.reporter.warning(
                     path=self.object_path,
                     code=391,
-                    msg=('Unknown pre-existing DOCUMENTATION '
-                         'error, see TRACE. Submodule refs may '
-                         'need updated')
+                    msg=('Unknown pre-existing DOCUMENTATION error, see TRACE. Submodule refs may need updated')
                 )
                 return
 


### PR DESCRIPTION
##### SUMMARY
When fixing known errors, the error messages did not make it easy to
find what parameter was having issues (because it was not in the error).

Now it consistently starts with the parameter name, and then shows first
the argspec and then the documentation values.

This helps quick assessments.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
validate-modules