### PR TITLE
ansible-galaxy init does create a sub directory

### DIFF
--- a/docs/docsite/rst/reference_appendices/galaxy.rst
+++ b/docs/docsite/rst/reference_appendices/galaxy.rst
@@ -222,21 +222,24 @@ The above will create the following directory structure in the current working d
 
 ::
 
-   README.md
-   .travis.yml
-   defaults/
-       main.yml
-   files/
-   handlers/
-       main.yml
-   meta/
-       main.yml
-   templates/
-   tests/
-       inventory
-       test.yml
-   vars/
-       main.yml
+   role_name/
+       README.md
+       .travis.yml
+       defaults/
+           main.yml
+       files/
+       handlers/
+           main.yml
+       meta/
+           main.yml
+       templates/
+       tests/
+           inventory
+           test.yml
+       vars/
+           main.yml
+
+If you want to create a repository for the role the repository root should be `role_name`.
 
 Force
 =====


### PR DESCRIPTION
##### SUMMARY
Fixing the directory structure of `ansible-galaxy init` and adding documentation for repository creation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible-galaxy init

##### ADDITIONAL INFORMATION
`ansible-galaxy init` creates a directory named `role_name` (in the given example) instead of adding the structure in the current working directory.

Additionally adding a clarification for repository creation as the proper repository root is not described yet.

+label: docsite_pr