### PR TITLE
BOTMETA: Add hannseman as docker_swarm_service maintainer

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -123,6 +123,9 @@ files:
   $modules/cloud/docker/docker_network.py:
     <<: *docker
     maintainers: $team_docker olsaki
+  $modules/cloud/docker/docker_swarm_service.py:
+    <<: *docker
+    maintainers: $team_docker hannseman
   $modules/cloud/google/:
     supershipit: $team_google
     maintainers: $team_google


### PR DESCRIPTION
##### SUMMARY
I propose to add @hannseman as a maintainer for docker_swarm_service.

@hannseman: this gives you `shipit` rights on docker_swarm_service PRs, and ansibot will CC you on any PR or issue referring to docker_swarm_service. If you want this (or not), please state so in this PR.

(If you ever want to stop down from this role, you can simply say so or create a PR similar to this one. So by saying yes, you're not selling your soul or something :) )

CC @jwitko @dariko

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
