### PR TITLE
Feature/issue 52329 lineinfile insertafter before regex match

### DIFF
--- a/changelogs/fragments/52329-lineinfile-adds-new-line-on-each-iteration-insertafter-before-regexp.yaml
+++ b/changelogs/fragments/52329-lineinfile-adds-new-line-on-each-iteration-insertafter-before-regexp.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lineinfile - Do not add the same line with each playbook run if insertafter/insertbefore with firstmatch: yes matches before regexp does

--- a/changelogs/fragments/52329-lineinfile-adds-new-line-on-each-iteration-insertafter-before-regexp.yaml
+++ b/changelogs/fragments/52329-lineinfile-adds-new-line-on-each-iteration-insertafter-before-regexp.yaml
@@ -1,2 +1,3 @@
+---
 bugfixes:
-  - lineinfile - Do not add the same line with each playbook run if insertafter/insertbefore with firstmatch: yes matches before regexp does
+  - "lineinfile - Do not add the same line with each playbook run if insertafter/insertbefore with firstmatch: yes matches before regexp does"

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -299,19 +299,26 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         elif bre_ins is not None and bre_ins.search(b_cur_line):
             if insertafter:
                 if firstmatch and index[1] == -1:
-                    # first time insertafter regex matched; update index[1]
+                    # first time insertafter regex matches; update index[1]
                     index[1] = lineno + 1
                 elif firstmatch and index[1] != -1:
                     # insertafter regex matched already; don't update index[1]
                     continue
                 elif not firstmatch:
+                    # = firstmatch is false; update index[1] 
                     # + 1 for the next line
                     index[1] = lineno + 1
             if insertbefore:
-                # index[1] for the previous line
-                index[1] = lineno
-                if firstmatch:
-                    break
+                if firstmatch and index[1] == -1:
+                    # first time insertbefore regex matches; update index[1]
+                    index[1] = lineno
+                elif firstmatch and index[1] != -1:
+                    # insertbefore regex matched already; don't update index[1]
+                    continue
+                else: 
+                    # = firstmatch is false; update index[1] 
+                    # index[1] for the previous line
+                    index[1] = lineno
 
     msg = ''
     changed = False

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -298,10 +298,15 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
             m = match_found
         elif bre_ins is not None and bre_ins.search(b_cur_line):
             if insertafter:
-                # + 1 for the next line
-                index[1] = lineno + 1
-                if firstmatch:
-                    break
+                if firstmatch and index[1] == -1:
+                    # first time insertafter regex matched; update index[1]
+                    index[1] = lineno + 1
+                elif firstmatch and index[1] != -1:
+                    # insertafter regex matched already; don't update index[1]
+                    continue
+                elif not firstmatch:
+                    # + 1 for the next line
+                    index[1] = lineno + 1
             if insertbefore:
                 # index[1] for the previous line
                 index[1] = lineno

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -305,7 +305,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
                     # insertafter regex matched already; don't update index[1]
                     continue
                 elif not firstmatch:
-                    # = firstmatch is false; update index[1] 
+                    # = firstmatch is false; update index[1]
                     # + 1 for the next line
                     index[1] = lineno + 1
             if insertbefore:
@@ -315,8 +315,8 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
                 elif firstmatch and index[1] != -1:
                     # insertbefore regex matched already; don't update index[1]
                     continue
-                else: 
-                    # = firstmatch is false; update index[1] 
+                else:
+                    # = firstmatch is false; update index[1]
                     # index[1] for the previous line
                     index[1] = lineno
 


### PR DESCRIPTION
##### SUMMARY
Fixes #52329 

The `break` if the `insertafter` regex matched the current line prevented the module from finding the line that matches the `regex` if this line appeared after the line that matched the `insertafter` regex.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lineinfile

##### ADDITIONAL INFORMATION
I realized that the same unexpected result would appear if `insertbefore` is used with `firstmatch: yes` if `regexp` regex matches later than `insertbefore`. So I changed the behaviour for both cases.
