### PR TITLE
docker_swarm_service: Remove defaults

### DIFF
--- a/changelogs/fragments/52420-docker_swarm_service-remove-update-defaults.yml
+++ b/changelogs/fragments/52420-docker_swarm_service-remove-update-defaults.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "docker_swarm_service - Don't set ``1`` as default for ``update_parallelism``."
+  - "docker_swarm_service - Don't set ``10`` as default for ``update_delay``."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -184,11 +184,10 @@ Noteworthy module changes
 
 * The ``docker_service`` module was renamed to :ref:`docker_compose <docker_compose_module>`.
 
-* The ``docker_swarm_service`` module no longer sets a default for the ``user`` option. Before, the default was ``root``.
-
-* The ``docker_swarm_service`` module no longer sets a default for the ``update_delay`` option. Before, the default was ``10``.
-
-* The ``docker_swarm_service`` module no longer sets a default for the ``update_parallelism`` option. Before, the default was ``1``.
+* The ``docker_swarm_service`` module no longer sets a defaults for the following options:
+    * ``user``. Before, the default was ``root``.
+    * ``update_delay``. Before, the default was ``10``.
+    * ``update_parallelism``. Before, the default was ``1``.
 
 * ``vmware_vm_facts`` used to return dict of dict with virtual machine's facts. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
   Please see module ``vmware_vm_facts`` documentation for example.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -186,6 +186,10 @@ Noteworthy module changes
 
 * The ``docker_swarm_service`` module no longer sets a default for the ``user`` option. Before, the default was ``root``.
 
+* The ``docker_swarm_service`` module no longer sets a default for the ``update_delay`` option. Before, the default was ``10``.
+
+* The ``docker_swarm_service`` module no longer sets a default for the ``update_parallelism`` option. Before, the default was ``1``.
+
 * ``vmware_vm_facts`` used to return dict of dict with virtual machine's facts. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
   Please see module ``vmware_vm_facts`` documentation for example.
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -409,7 +409,6 @@ options:
       - Corresponds to the C(--update-delay) option of C(docker service create).
   update_parallelism:
     type: int
-    default: 1
     description:
       - Rolling update parallelism.
       - Corresponds to the C(--update-parallelism) option of C(docker service create).
@@ -1712,7 +1711,7 @@ def main():
         restart_policy_attempts=dict(type='int'),
         restart_policy_window=dict(type='int'),
         update_delay=dict(default=10, type='int'),
-        update_parallelism=dict(default=1, type='int'),
+        update_parallelism=dict(type='int'),
         update_failure_action=dict(choices=['continue', 'pause']),
         update_monitor=dict(type='int'),
         update_max_failure_ratio=dict(type='float'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -406,11 +406,13 @@ options:
     description:
       - Rolling update delay in nanoseconds.
       - Corresponds to the C(--update-delay) option of C(docker service create).
+      - Before Ansible 2.8, the default value for this option was C(10).
   update_parallelism:
     type: int
     description:
       - Rolling update parallelism.
       - Corresponds to the C(--update-parallelism) option of C(docker service create).
+      - Before Ansible 2.8, the default value for this option was C(1).
   update_failure_action:
     type: str
     description:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -403,7 +403,6 @@ options:
       - Corresponds to the C(--restart-window) option of C(docker service create).
   update_delay:
     type: int
-    default: 10
     description:
       - Rolling update delay in nanoseconds.
       - Corresponds to the C(--update-delay) option of C(docker service create).
@@ -1710,7 +1709,7 @@ def main():
         restart_policy_delay=dict(type='int'),
         restart_policy_attempts=dict(type='int'),
         restart_policy_window=dict(type='int'),
-        update_delay=dict(default=10, type='int'),
+        update_delay=dict(type='int'),
         update_parallelism=dict(type='int'),
         update_failure_action=dict(choices=['continue', 'pause']),
         update_monitor=dict(type='int'),

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -38,10 +38,10 @@ service_expected_output:
   restart_policy_delay: null
   restart_policy_window: null
   tty: null
-  update_delay: 10
+  update_delay: null
   update_failure_action: null
   update_max_failure_ratio: null
   update_monitor: null
   update_order: null
-  update_parallelism: 1
+  update_parallelism: null
   working_dir: null


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This PR continues the work in #51216 where we left the defaults from `update_delay` and `update_parallelism` as they did not align with the docker-py defaults.

`update_delay` having a default of `10` could be regarded as a bug since it is in nanoseconds and thus does make sense. `0` is the default in both docker-py and docker service command line.

`update_parallelism` having a default of `1` aligns with the docker service command line but docker-py has a default of `0` (update all at once).

If I correctly understand the process of breaking backwards compability we need to update the module documentation, add a changelog fragment and update the porting guide.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
