### PR TITLE
Fix typo in key name returned by module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_host_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_facts.py
@@ -232,7 +232,7 @@ class DockerHostManager(DockerBaseClass):
             if self.verbose_output:
                 return self.client.df()
             else:
-                return dict(LayerSize=self.client.df()['LayersSize'])
+                return dict(LayersSize=self.client.df()['LayersSize'])
         except APIError as exc:
             self.client.fail("Error inspecting docker host: %s" % to_native(exc))
 


### PR DESCRIPTION
##### SUMMARY
There is a typo (missing character) in key name returned by the module

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_host_facts

##### ADDITIONAL INFORMATION
Missing character in key name
