### PR TITLE
opensuse - install password-store from specific repo

### DIFF
--- a/test/integration/targets/lookup_passwordstore/tasks/package.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/package.yml
@@ -3,21 +3,34 @@
     name: pass
     state: present
   when: ansible_pkg_mgr == 'apt'
+
 - name: "Install package"
   yum:
     name: pass
     state: present
   when: ansible_pkg_mgr == 'yum'
+
 - name: "Install package"
   dnf:
     name: pass
     state: present
   when: ansible_pkg_mgr == 'dnf'
-- name: "Install package"
-  zypper:
-    name: password-store
-    state: present
+
+- block:
+  # OpenSUSE Leap>=15.0 don't include password-store in main repo
+  - name: add security:privacy repo
+    template:
+      src: security-privacy.repo.j2
+      dest: /etc/zypp/repos.d/security:privacy.repo
+
+  - name: "Install package"
+    zypper:
+      name: password-store
+      state: present
+      update_cache: yes
+      disable_gpg_check: yes
   when: ansible_pkg_mgr == 'zypper'
+
 - name: "Install package"
   pkgng:
     name: "{{ item }}"

--- a/test/integration/targets/lookup_passwordstore/templates/security-privacy.repo.j2
+++ b/test/integration/targets/lookup_passwordstore/templates/security-privacy.repo.j2
@@ -1,0 +1,7 @@
+[security_privacy]
+name=Crypto applications and utilities (openSUSE_Leap_{{ ansible_distribution_version }})
+type=rpm-md
+baseurl=http://download.opensuse.org/repositories/security:/privacy/openSUSE_Leap_{{ ansible_distribution_version }}/
+gpgcheck=1
+gpgkey=http://download.opensuse.org/repositories/security:/privacy/openSUSE_Leap_{{ ansible_distribution_version }}/repodata/repomd.xml.key
+enabled=1


### PR DESCRIPTION
##### SUMMARY
Install password-store from the security:privacy repo as it isn't contained in the main repo for newer versions of OpenSUSE. This enables testing on OpenSUSE 15.0 in our CI.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lookup_passwordstore