### PR TITLE
validate-modules: Fix some files modules

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'core'}
 
 
-DOCUMENTATION = """
+DOCUMENTATION = r'''
 ---
 module: lineinfile
 short_description: Manage lines in text files
@@ -61,6 +61,7 @@ options:
       - If C(backrefs) is set, may contain backreferences that will get
         expanded with the C(regexp) capture groups if the regexp matches.
     type: str
+    aliases: [ value ]
   backrefs:
     description:
       - Used with C(state=present).
@@ -68,7 +69,7 @@ options:
         that will get populated if the C(regexp) matches.
       - This parameter changes the operation of the module slightly;
         C(insertbefore) and C(insertafter) will be ignored, and if the C(regexp)
-        doesn't match anywhere in the file, the file will be left unchanged.
+        does not match anywhere in the file, the file will be left unchanged.
       - If the C(regexp) does match, the last matching line will be replaced by
         the expanded line parameter.
     type: bool
@@ -137,22 +138,24 @@ seealso:
 author:
     - Daniel Hokka Zakrissoni (@dhozac)
     - Ahti Kitsik (@ahtik)
-"""
+'''
 
-EXAMPLES = r"""
-# Before 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
-- lineinfile:
+EXAMPLES = r'''
+# NOTE: Before 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
+- name: Ensure SELinux is set to enforcing mode
+  lineinfile:
     path: /etc/selinux/config
     regexp: '^SELINUX='
     line: SELINUX=enforcing
 
-- lineinfile:
+- name: Make sure group wheel is not in the sudoers configuration
+  lineinfile:
     path: /etc/sudoers
     state: absent
     regexp: '^%wheel'
 
-# Searches for a line that begins with 127.0.0.1 and replaces it with the value of the 'line' parameter
-- lineinfile:
+- name: Replace a localhost entry with our own
+  lineinfile:
     path: /etc/hosts
     regexp: '^127\.0\.0\.1'
     line: 127.0.0.1 localhost
@@ -160,46 +163,43 @@ EXAMPLES = r"""
     group: root
     mode: '0644'
 
-- lineinfile:
+- name: Ensure the default Apache port is 8080
+  lineinfile:
     path: /etc/httpd/conf/httpd.conf
     regexp: '^Listen '
     insertafter: '^#Listen '
     line: Listen 8080
 
-- lineinfile:
+- name: Ensure we have our own comment added to /etc/services
+  lineinfile:
     path: /etc/services
     regexp: '^# port for http'
     insertbefore: '^www.*80/tcp'
     line: '# port for http by default'
 
-# Add a line to a file if the file does not exist, without passing regexp
-- lineinfile:
+- name: Add a line to a file if the file does not exist, without passing regexp
+  lineinfile:
     path: /tmp/testfile
     line: 192.168.1.99 foo.lab.net foo
     create: yes
 
-# Fully quoted because of the ': ' on the line. See the Gotchas in the YAML docs.
-- lineinfile:
-    path: /etc/sudoers
-    state: present
-    regexp: '^%wheel\s'
-    line: '%wheel ALL=(ALL) NOPASSWD: ALL'
-
-# Yaml requires escaping backslashes in double quotes but not in single quotes
-- lineinfile:
+# NOTE: Yaml requires escaping backslashes in double quotes but not in single quotes
+- name: Ensure the JBoss memory settings are exactly as needed
+  lineinfile:
     path: /opt/jboss-as/bin/standalone.conf
     regexp: '^(.*)Xms(\\d+)m(.*)$'
     line: '\1Xms${xms}m\3'
     backrefs: yes
 
-# Validate the sudoers file before saving
-- lineinfile:
+# NOTE: Fully quoted because of the ': ' on the line. See the Gotchas in the YAML docs.
+- name: Validate the sudoers file before saving
+  lineinfile:
     path: /etc/sudoers
     state: present
     regexp: '^%ADMIN ALL='
     line: '%ADMIN ALL=(ALL) NOPASSWD: ALL'
     validate: /usr/sbin/visudo -cf %s
-"""
+'''
 
 import os
 import re

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -41,8 +41,10 @@ options:
     description:
       - Port number for ssh on the destination host.
       - Prior to Ansible 2.0, the ansible_ssh_port inventory var took precedence over this value.
+      - This parameter defaults to the value of C(ansible_ssh_port) or C(ansible_port),
+        the C(remote_port) config setting or the value from ssh client configuration
+        if none of the former have been set.
     type: int
-    default: Value of ansible_ssh_port for this host, remote_port config setting, or the value from ssh client configuration if none of those are set
     version_added: "1.5"
   mode:
     description:
@@ -91,13 +93,13 @@ options:
   recursive:
     description:
       - Recurse into directories.
+      - This parameter defaults to the value of the archive option.
     type: bool
-    default: the value of the archive option
   links:
     description:
       - Copy symlinks as symlinks.
+      - This parameter defaults to the value of the archive option.
     type: bool
-    default: the value of the archive option
   copy_links:
     description:
       - Copy symlinks as the item that they point to (the referent) is copied, rather than the symlink.
@@ -106,23 +108,23 @@ options:
   perms:
     description:
       - Preserve permissions.
+      - This parameter defaults to the value of the archive option.
     type: bool
-    default: the value of the archive option
   times:
     description:
       - Preserve modification times.
+      - This parameter defaults to the value of the archive option.
     type: bool
-    default: the value of the archive option
   owner:
     description:
       - Preserve owner (super user only).
+      - This parameter defaults to the value of the archive option.
     type: bool
-    default: the value of the archive option
   group:
     description:
       - Preserve group.
+      - This parameter defaults to the value of the archive option.
     type: bool
-    default: the value of the archive option
   rsync_path:
     description:
       - Specify the rsync command to run on the remote host. See C(--rsync-path) on the rsync man page.
@@ -384,7 +386,7 @@ def main():
             private_key=dict(type='path'),
             rsync_path=dict(type='str'),
             _local_rsync_path=dict(type='path', default='rsync'),
-            _local_rsync_password=dict(type='str', default=None, no_log=True),
+            _local_rsync_password=dict(type='str', no_log=True),
             _substitute_controller=dict(type='bool', default=False),
             archive=dict(type='bool', default=True),
             checksum=dict(type='bool', default=False),

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -389,7 +389,6 @@ lib/ansible/modules/files/file.py E322
 lib/ansible/modules/files/file.py E324
 lib/ansible/modules/files/ini_file.py E323
 lib/ansible/modules/files/iso_extract.py E324
-lib/ansible/modules/files/lineinfile.py E322
 lib/ansible/modules/files/lineinfile.py E323
 lib/ansible/modules/files/lineinfile.py E324
 lib/ansible/modules/files/lineinfile.py E326
@@ -397,7 +396,6 @@ lib/ansible/modules/files/replace.py E323
 lib/ansible/modules/files/synchronize.py E322
 lib/ansible/modules/files/synchronize.py E323
 lib/ansible/modules/files/synchronize.py E324
-lib/ansible/modules/files/synchronize.py E327
 lib/ansible/modules/files/unarchive.py E323
 lib/ansible/modules/identity/cyberark/cyberark_user.py E324
 lib/ansible/modules/identity/keycloak/keycloak_client.py E324


### PR DESCRIPTION
##### SUMMARY
This PR includes:
- fixes to validate-modules issues

All modules already include parameter types.

The remaining files-modules have action plugins, so comparing to the arg_spec only is incorrect.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lineinfile
synchronize