### PR TITLE
zypper: fix tests to use new URL for OpenSUSE 15.0

### DIFF
--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -4,7 +4,7 @@
 
 - name: set URL of test package
   set_fact:
-    hello_package_url: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/suse/x86_64/hello-{{hello_version.stdout}}.x86_64.rpm
+    hello_package_url: http://download.opensuse.org/repositories/openSUSE:/Leap:/{{ ansible_distribution_version }}/standard/x86_64/hello-{{ hello_version.stdout }}.x86_64.rpm
 
 - debug: var=hello_package_url
 


### PR DESCRIPTION
##### SUMMARY
The URL used in the `zypper` integration tests are no longer valid for newer versions of OpenSUSE. This PR changes the URL to something that is supported in both the older and newer OpenSUSE distributinos.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper