### PR TITLE
zypper: fix tests to use new URL for OpenSUSE 15.0 (#52453) - 2.6

### DIFF
--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -4,7 +4,7 @@
 
 - name: set URL of test package
   set_fact:
-    hello_package_url: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/suse/x86_64/hello-{{hello_version.stdout}}.x86_64.rpm
+    hello_package_url: http://download.opensuse.org/repositories/openSUSE:/Leap:/{{ ansible_distribution_version }}/standard/x86_64/hello-{{ hello_version.stdout }}.x86_64.rpm
 
 - debug: var=hello_package_url
 


### PR DESCRIPTION
(cherry picked from commit 4b296da6a29503d250277eea05fcb89d01da6e05)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/52453

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper