### PR TITLE
zypper_repository: fix return check on newer OpenSUSE versions

### DIFF
--- a/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -90,7 +90,7 @@
 
 - assert:
     that:
-      - "zypper_result1.rc == 6"
+      - "zypper_result1.rc != 0"
       - "'not found' in zypper_result1.stderr"
       - "zypper_result2.rc == 0"
       - "'http://dl.google.com/linux/chrome/rpm/stable/x86_64' in zypper_result2.stdout"


### PR DESCRIPTION
##### SUMMARY
Newer versions of `zypper` don't return an rc of 6, just make sure it wasn't 0 as the next assertion is the one that really matters

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository