### PR TITLE
zypper_repository: fix return check on newer OpenSUSE versions (#52457) - 2.6

### DIFF
--- a/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -90,7 +90,7 @@
 
 - assert:
     that:
-      - "zypper_result1.rc == 6"
+      - "zypper_result1.rc != 0"
       - "'not found' in zypper_result1.stderr"
       - "zypper_result2.rc == 0"
       - "'http://dl.google.com/linux/chrome/rpm/stable/x86_64' in zypper_result2.stdout"


### PR DESCRIPTION
(cherry picked from commit d6453a79f5a9fa8d12eb1d12cd1a1b50ee72602a)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/52457

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository