### PR TITLE
fix(rundeck_acl_policy): compatible python 2 and 3

### DIFF
--- a/changelogs/fragments/rundeck-acl-policy-python-version.yaml
+++ b/changelogs/fragments/rundeck-acl-policy-python-version.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Allow to use rundeck_acl_policy with python 2 and 3

--- a/lib/ansible/modules/web_infrastructure/rundeck_acl_policy.py
+++ b/lib/ansible/modules/web_infrastructure/rundeck_acl_policy.py
@@ -102,6 +102,7 @@ after:
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_text
 import json
 
 
@@ -130,9 +131,9 @@ class RundeckACLManager:
         self.handle_http_code_if_needed(info)
         if resp is not None:
             resp = resp.read()
-            if resp != "":
+            if resp != b"":
                 try:
-                    json_resp = json.loads(resp.decode("utf-8"))
+                    json_resp = json.loads(to_text(resp, errors='surrogate_or_strict'))
                     return json_resp, info
                 except ValueError as e:
                     self.module.fail_json(msg="Rundeck response was not a valid JSON. Exception was: %s. "

--- a/lib/ansible/modules/web_infrastructure/rundeck_acl_policy.py
+++ b/lib/ansible/modules/web_infrastructure/rundeck_acl_policy.py
@@ -132,7 +132,7 @@ class RundeckACLManager:
             resp = resp.read()
             if resp != "":
                 try:
-                    json_resp = json.loads(resp)
+                    json_resp = json.loads(resp.decode("utf-8"))
                     return json_resp, info
                 except ValueError as e:
                     self.module.fail_json(msg="Rundeck response was not a valid JSON. Exception was: %s. "


### PR DESCRIPTION
##### SUMMARY
rundeck_acl_policy module can be used with python 2 but not python 3. This modification allows the use of both versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rundeck_acl_policy

