### PR TITLE
git: kill gpg-agent in tests on newer OpenSUSE hosts

### DIFF
--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -182,7 +182,7 @@
 
 - name: GPG-VERIFICATION | Stop gpg-agent so we can remove any locks on the GnuPG dir
   command: gpgconf --kill gpg-agent
-  when: ansible_os_family != 'Suse'  # OpenSUSE ships with an older version of gpg-agent that doesn't support this
+  when: ansible_os_family != 'Suse' or ansible_distribution_version != '42.3'  # OpenSUSE 42.3 ships with an older version of gpg-agent that doesn't support this
   environment:
     GNUPGHOME: "{{ git_gpg_gpghome }}"
 


### PR DESCRIPTION
##### SUMMARY
Newer OpenSUSE hosts have an updated gpg-agent which we need to kill for the tests to cleanup the temp directories.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
git