### PR TITLE
git: kill gpg-agent in tests on newer OpenSUSE hosts (#52476) - 2.7

### DIFF
--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -182,7 +182,7 @@
 
 - name: GPG-VERIFICATION | Stop gpg-agent so we can remove any locks on the GnuPG dir
   command: gpgconf --kill gpg-agent
-  when: ansible_os_family != 'Suse'  # OpenSUSE ships with an older version of gpg-agent that doesn't support this
+  when: ansible_os_family != 'Suse' or ansible_distribution_version != '42.3'  # OpenSUSE 42.3 ships with an older version of gpg-agent that doesn't support this
   environment:
     GNUPGHOME: "{{ git_gpg_gpghome }}"
 


### PR DESCRIPTION
(cherry picked from commit bb0a69e0845e2bd34cb715c05b977e1a8b31cfe2)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/52476

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
git