### PR TITLE
validate-modules: Expect added_version as string when changed

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1394,12 +1394,14 @@ class ModuleValidator(Validator):
                     if existing_version:
                         break
                 current_version = details.get('version_added')
-                if current_version != existing_version:
+
+                # We expect the added_version to be a string, not a float
+                if current_version and existing_version and current_version != str(existing_version):
                     self.reporter.error(
                         path=self.object_path,
                         code=309,
                         msg=('version_added for new option (%s) should '
-                             'be %r. Currently %r' %
+                             'be \'%r\'. Currently %r' %
                              (option, existing_version, current_version))
                     )
                 continue

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1401,8 +1401,8 @@ class ModuleValidator(Validator):
                         path=self.object_path,
                         code=309,
                         msg=('version_added for new option (%s) should '
-                             'be \'%r\'. Currently %r' %
-                             (option, existing_version, current_version))
+                             'be %r. Currently %r' %
+                             (option, str(existing_version), current_version))
                     )
                 continue
 


### PR DESCRIPTION
##### SUMMARY
This ensure that we expect the `added_version` value to be a string.
This will only be tested when this key is added or is modified.

Basically we prevent from new `added_version` entries are added as
float.

And we will not complain when someone changes an existing
`added_version` from float to a string.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
validate-modules