### PR TITLE
zabbix_action: Adding an option for pausing operations while in maintenance

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -790,7 +790,7 @@ class Action(object):
                 'enabled',
                 'disabled'], kwargs['status'])
         }
-        if float(self._zapi.api_version().rsplit('.',1)[0]) >= 4.0:
+        if float(self._zapi.api_version().rsplit('.', 1)[0]) >= 4.0:
             _params['pause_suppressed'] = '1' if kwargs['pause_in_maintenance'] else '0'
         else:
             _params['maintenance_mode'] = '1' if kwargs['pause_in_maintenance'] else '0'

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -54,6 +54,12 @@ options:
             - Status of the action.
         choices: ['enabled', 'disabled']
         default: 'enabled'
+    pause_in_maintenance:
+        description:
+            - Whether to pause escalation during maintenance periods or not.
+            - Can be used when I(event_source=trigger).
+        type: 'bool'
+        default: true
     esc_period:
         description:
             - Default operation step duration. Must be greater than 60 seconds. Accepts seconds, time unit with suffix and user macro.
@@ -761,7 +767,8 @@ class Action(object):
         Returns:
             dict: dictionary of specified parameters
         """
-        return {
+
+        _params = {
             'name': kwargs['name'],
             'eventsource': to_numeric_value([
                 'trigger',
@@ -783,6 +790,12 @@ class Action(object):
                 'enabled',
                 'disabled'], kwargs['status'])
         }
+        if float(self._zapi.api_version().rsplit('.',1)[0]) >= 4.0:
+            _params['pause_suppressed'] = '1' if kwargs['pause_in_maintenance'] else '0'
+        else:
+            _params['maintenance_mode'] = '1' if kwargs['pause_in_maintenance'] else '0'
+
+        return _params
 
     def check_difference(self, **kwargs):
         """Check difference between action and user specified parameters.
@@ -1609,6 +1622,7 @@ def main():
             event_source=dict(type='str', required=True, choices=['trigger', 'discovery', 'auto_registration', 'internal']),
             state=dict(type='str', required=False, default='present', choices=['present', 'absent']),
             status=dict(type='str', required=False, default='enabled', choices=['enabled', 'disabled']),
+            pause_in_maintenance=dict(type='bool', required=False, default=True),
             default_message=dict(type='str', required=False, default=None),
             default_subject=dict(type='str', required=False, default=None),
             recovery_default_message=dict(type='str', required=False, default=None),
@@ -1640,6 +1654,7 @@ def main():
     event_source = module.params['event_source']
     state = module.params['state']
     status = module.params['status']
+    pause_in_maintenance = module.params['pause_in_maintenance']
     default_message = module.params['default_message']
     default_subject = module.params['default_subject']
     recovery_default_message = module.params['recovery_default_message']
@@ -1682,6 +1697,7 @@ def main():
                 event_source=event_source,
                 esc_period=esc_period,
                 status=status,
+                pause_in_maintenance=pause_in_maintenance,
                 default_message=default_message,
                 default_subject=default_subject,
                 recovery_default_message=recovery_default_message,
@@ -1711,6 +1727,7 @@ def main():
                 event_source=event_source,
                 esc_period=esc_period,
                 status=status,
+                pause_in_maintenance=pause_in_maintenance,
                 default_message=default_message,
                 default_subject=default_subject,
                 recovery_default_message=recovery_default_message,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding support for `maintenance_mode` option (`pause_suppressed` for zabbix>=4.0)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51303

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_action

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

