### PR TITLE
Added port_security_enabled option to openstack port

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -89,7 +89,7 @@ options:
    port_security_enabled:
      description:
         - Should port_security_enabled be set on this port.
-    version_added: "2.9"     
+     version_added: "2.9"
 '''
 
 EXAMPLES = '''
@@ -321,7 +321,7 @@ def main():
         extra_dhcp_opts=dict(type='list', default=None),
         device_owner=dict(default=None),
         device_id=dict(default=None),
-        port_security_enabled=dict(default=True, type='bool'),        
+        port_security_enabled=dict(default=True, type='bool'),
         state=dict(default='present', choices=['absent', 'present']),
         vnic_type=dict(default='normal',
                        choices=['normal', 'direct', 'direct-physical',

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -86,6 +86,10 @@ options:
      choices: [normal, direct, direct-physical, macvtap, baremetal, virtio-forwarder]
      default: normal
      version_added: "2.8"
+   port_security_enabled:
+     description:
+        - Should port_security_enabled be set on this port.
+    version_added: "2.9"     
 '''
 
 EXAMPLES = '''
@@ -217,6 +221,7 @@ def _needs_update(module, port, cloud):
                       'mac_address',
                       'device_owner',
                       'device_id',
+                      'port_security_enabled'
                       'binding:vnic_type']
     compare_dict = ['allowed_address_pairs',
                     'extra_dhcp_opts']
@@ -283,7 +288,8 @@ def _compose_port_args(module, cloud):
                            'extra_dhcp_opts',
                            'device_owner',
                            'device_id',
-                           'binding:vnic_type']
+                           'binding:vnic_type',
+                           'port_security_enabled']
     for optional_param in optional_parameters:
         if module.params[optional_param] is not None:
             port_kwargs[optional_param] = module.params[optional_param]
@@ -315,6 +321,7 @@ def main():
         extra_dhcp_opts=dict(type='list', default=None),
         device_owner=dict(default=None),
         device_id=dict(default=None),
+        port_security_enabled=dict(default=True, type='bool'),        
         state=dict(default='present', choices=['absent', 'present']),
         vnic_type=dict(default='normal',
                        choices=['normal', 'direct', 'direct-physical',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Its useful to be able to set port_security_enabled to false in some specific network configuration.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openstack
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I made the matching fix in shade https://github.com/openstack-infra/shade/pull/8 and i am waiting for the merge
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
