### PR TITLE
Don't error on type changes, cast to string and compare

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1404,7 +1404,7 @@ class ModuleValidator(Validator):
                     if existing_version:
                         break
                 current_version = details.get('version_added')
-                if current_version != existing_version:
+                if str(current_version) != str(existing_version):
                     self.reporter.error(
                         path=self.object_path,
                         code=309,


### PR DESCRIPTION
##### SUMMARY
Don't error on type changes, cast to string and compare

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```