### PR TITLE
bugfix. cloudwatchlogs_log_group module wrongly assumes all log group…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group.py
@@ -259,12 +259,15 @@ def main():
                                                retention=module.params['retention'],
                                                module=module)
         elif found_log_group:
-            if module.params['retention'] != found_log_group['retentionInDays']:
+            if 'retentionInDays' in found_log_group or \
+               (module.params.get('retention') and 'retentionInDays' not in found_log_group):
                 changed = True
-                input_retention_policy(client=logs,
-                                       log_group_name=module.params['log_group_name'],
-                                       retention=module.params['retention'],
-                                       module=module)
+                input_retention_policy(
+                    client=logs,
+                    log_group_name=module.params['log_group_name'],
+                    retention=module.params['retention'],
+                    module=module
+                )
                 found_log_group['retentionInDays'] = module.params['retention']
 
         module.exit_json(changed=changed, **camel_dict_to_snake_dict(found_log_group))


### PR DESCRIPTION
…s will have retentionInDays present in dict. not true, so patched.
AWS does not return the key in describe operations if the value has not been set in a previous create (input_retention_policy). Additionally if the user has set a retention param value and the `retentionInDays` key is absent then the module should allow one to be set (which it does not).

##### SUMMARY
cloudwatchlogs_log_group wrongly assumes a dict element of 'retentionInDays' will be present on describe operation. this update allows for an element without retentionInDays to be updated without KeyError.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudwatchlogs_log_group

##### ADDITIONAL INFORMATION
To reproduce
```
    - aws_cloudwatchlogs_log_group:
        state: present
        log_group_name: log_group_example
```
then re-run a playbook with the following:
```
    - aws_cloudwatchlogs_log_group:
        state: present
        log_group_name: log_group_example
        retention: 365
```

You will get KeyError

can provide more info if needed.
