### PR TITLE
docker_* modules: stop returning ansible_facts

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -183,7 +183,17 @@ Noteworthy module changes
 * The ``digital_ocean`` module has been deprecated in favor of modules that do not require external dependencies.
   This allows for more flexibility and better module support.
 
+* The ``docker_container`` module has deprecated the returned fact ``docker_container``. The same value is
+  available as the returned variable ``docker_container``. The returned fact will be removed in Ansible 2.12.
+* The ``docker_network`` module has deprecated the returned fact ``docker_container``. The same value is
+  available as the returned variable ``docker_network``. The returned fact will be removed in Ansible 2.12.
+* The ``docker_volume`` module has deprecated the returned fact ``docker_container``. The same value is
+  available as the returned variable ``docker_volume``. The returned fact will be removed in Ansible 2.12.
+
 * The ``docker_service`` module was renamed to :ref:`docker_compose <docker_compose_module>`.
+* The renamed ``docker_compose`` module used to return one fact per service, named same as the service. A dictionary
+  of these facts is returned as the regular return value ``service_facts``. The returned facts will be removed in
+  Ansible 2.12.
 
 * The ``docker_swarm_service`` module no longer sets a defaults for the following options:
     * ``user``. Before, the default was ``root``.

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -298,7 +298,7 @@ service_facts:
   - A dictionary mapping the service's name to a dictionary of containers.
   - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
     are also accessible directly. The service's name is the variable with which the container dictionary
-    can be accessed.
+    can be accessed. Note that the returned facts will be removed in Ansible 2.12.
   returned: success
   type: complex
   contains:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -822,7 +822,7 @@ docker_container:
       - Before 2.3 this was 'ansible_docker_container' but was renamed due to conflicts with the connection plugin.
       - Facts representing the current state of the container. Matches the docker inspection output.
       - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
-        are also accessible directly.
+        are also accessible directly. Note that the returned fact will be removed in Ansible 2.12.
       - Empty if C(state) is I(absent)
       - If detached is I(False), will include Output attribute containing any output from container run.
     returned: always

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -250,7 +250,7 @@ docker_network:
     description:
     - Network inspection results for the affected network.
     - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
-      are also accessible directly.
+      are also accessible directly. Note that the returned fact will be removed in Ansible 2.12.
     returned: success
     type: dict
     sample: {}

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -117,7 +117,7 @@ docker_volume:
     description:
     - Volume inspection results for the affected volume.
     - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
-      are also accessible directly.
+      are also accessible directly. Note that the returned fact will be removed in Ansible 2.12.
     returned: success
     type: dict
     sample: {}


### PR DESCRIPTION
##### SUMMARY
Some of the `docker_*` modules returned ansible_facts:
 - `docker_container` returns a fact called `docker_container`;
 - `docker_network` returns a fact called `docker_network`;
 - `docker_volume` returns a fact called `docker_volume`;
 - `docker_service`/`docker_compose` returns one fact named as the service for each service.

While this can be handy when using these modules, it is in general annoying for multiple reasons:
 1. the modules pollute the variables namespace (especially the values they return are not host specific, since there might be more than one container/network/volume/... per host);
 2. when trying to access the data of a registered result, one needs to write `result.ansible_facts.docker_container` when one cannot directly use the `docker_container` fact (for example, when using `docker_container` to start several containers in a loop);
 3. in particular the way `docker_compose` returns facts named according to user input, it can easily happen that random variables are overridden, which is in most cases not what the user expects;
 4. I don't think it was really intended to use facts in this way. Not really a reason, but I think many will agree... :-)

I've already created a PR (merged) which also returns the facts as regular return values, so people can start getting rid of the facts in their playbooks (#51192). I don't think this is enough, though. I want to **deprecate** the returned facts.

I know that in the past, return values of modules have been deprecated; see `The ``win_disk_image`` module has deprecated the return value ``mount_path``, use ``mount_paths[0]`` instead. This will
  be removed in Ansible 2.11.` in the [2.7 porting guide](https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/porting_guides/porting_guide_2.7.rst#noteworthy-module-changes). I guess this hasn't been done for returned facts so far (they have been renamed in the past, though: the facts returned by `docker_container` have been renamed from `ansible_docker_container` to `docker_container` for Ansible 2.3 to avoid conflicts with the connection plugin.) Similarly to returned variables, it is not possible to warn the user when they are used, so that return values and returned facts should be deprecated with care. But I think that for the facts returned by these modules, it is really warranted to deprecate them!

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
docker_network
docker_volume
docker_compose
