### PR TITLE
cron: adjust deprecated version

### DIFF
--- a/changelogs/fragments/52322-cron_fix_missing_deprecation_warn.yaml
+++ b/changelogs/fragments/52322-cron_fix_missing_deprecation_warn.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Added missing derprecation warning for param 'reboot' and use without param 'name' to the cron module."

--- a/changelogs/fragments/52322-cron_fix_missing_deprecation_warn.yaml
+++ b/changelogs/fragments/52322-cron_fix_missing_deprecation_warn.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- "Added missing derprecation warning for param 'reboot' and use without param 'name' to the cron module."
+- "Added missing deprecation warning for param 'reboot' and use without param 'name' to the cron module."

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -613,12 +613,12 @@ def main():
     if not name:
         module.deprecate(
             msg="The 'name' parameter will be required in future releases.",
-            version='2.10'
+            version='2.12'
         )
     if reboot:
         module.deprecate(
             msg="The 'reboot' parameter will be removed in future releases. Use 'special_time' option instead.",
-            version='2.10'
+            version='2.12'
         )
 
     if module._diff:


### PR DESCRIPTION
##### SUMMARY
The missing deprecation warning was added for the 2.8 release, to my calc this going to be removed in 2.12 then. 

extends #52322

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cron

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
