### PR TITLE
docker_swarm_service: Remove misinterpretable description

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -15,7 +15,7 @@ module: docker_swarm_service
 author: "Dario Zanzico (@dariko), Jason Witkowski (@jwitko)"
 short_description: docker swarm service
 description:
-  - Manages dockers services via a swarm manager node.
+  - Manages docker services via a swarm manager node.
 version_added: "2.7"
 options:
   name:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -15,7 +15,7 @@ module: docker_swarm_service
 author: "Dario Zanzico (@dariko), Jason Witkowski (@jwitko)"
 short_description: docker swarm service
 description:
-  - Manage docker services. Allows live altering of already defined services.
+  - Manage docker services.
 version_added: "2.7"
 options:
   name:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -15,7 +15,7 @@ module: docker_swarm_service
 author: "Dario Zanzico (@dariko), Jason Witkowski (@jwitko)"
 short_description: docker swarm service
 description:
-  - Manage docker services.
+  - Manages dockers services via a swarm manager node.
 version_added: "2.7"
 options:
   name:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The current module description is as follows:
> Manage docker services. Allows live altering of already defined services

In my opinion this reads like ansible tasks can be "attached" to previously non-ansible defined services without changing the state of that service if not explicitly defined in the task.

This is not the case since the `fetch_current_spec` is not used on `client.update_service`. All non specified options in task will revert to docker-py defaults.

See docs here: https://docker-py.readthedocs.io/en/stable/api.html#docker.api.service.ServiceApiMixin.update_service

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
