### PR TITLE
docker_swarm_service: Use inspect_service to get service data

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -652,9 +652,13 @@ try:
     from docker.utils import (
         parse_repository_tag,
         parse_env_file,
-        format_environment
+        format_environment,
     )
-    from docker.errors import APIError, DockerException
+    from docker.errors import (
+        APIError,
+        DockerException,
+        NotFound,
+    )
 except ImportError:
     # missing docker-py handled in ansible.module_utils.docker.common
     pass
@@ -1320,7 +1324,10 @@ class DockerServiceManager(object):
         return [{'name': n['Name'], 'id': n['Id']} for n in self.client.networks()]
 
     def get_service(self, name):
-        raw_data = self.client.inspect_service(name)
+        try:
+            raw_data = self.client.inspect_service(name)
+        except NotFound:
+            return
         ds = DockerService()
 
         task_template_data = raw_data['Spec']['TaskTemplate']

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1327,7 +1327,7 @@ class DockerServiceManager(object):
         try:
             raw_data = self.client.inspect_service(name)
         except NotFound:
-            return
+            return None
         ds = DockerService()
 
         task_template_data = raw_data['Spec']['TaskTemplate']

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1320,20 +1320,7 @@ class DockerServiceManager(object):
         return [{'name': n['Name'], 'id': n['Id']} for n in self.client.networks()]
 
     def get_service(self, name):
-        # The Docker API allows filtering services by name but the filter looks
-        # for a substring match, not an exact match. (Filtering for "foo" would
-        # return information for services "foobar" and "foobuzz" even if the
-        # service "foo" doesn't exist.) Avoid incorrectly determining that a
-        # service is present by filtering the list of services returned from the
-        # Docker API so that the name must be an exact match.
-        raw_data = [
-            service for service in self.client.services(filters={'name': name})
-            if service['Spec']['Name'] == name
-        ]
-        if len(raw_data) == 0:
-            return None
-
-        raw_data = raw_data[0]
+        raw_data = self.client.inspect_service(name)
         ds = DockerService()
 
         task_template_data = raw_data['Spec']['TaskTemplate']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Use `client.inspect_service` instead of `client.services` to fetch service data. This will reduce the amount of traffic needed to be transfered in cases like described in #50665 and it feels more right to let docker pick the correct unique service by name.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
