### PR TITLE
fixed deallocated vm facts problem

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_facts.py
@@ -347,10 +347,10 @@ class AzureRMVirtualMachineFacts(AzureRMModuleBase):
         disks = result['properties']['storageProfile']['dataDisks']
         for disk_index in range(len(disks)):
             new_result['data_disks'].append({
-                'lun': disks[disk_index]['lun'],
-                'disk_size_gb': disks[disk_index]['diskSizeGB'],
-                'managed_disk_type': disks[disk_index]['managedDisk']['storageAccountType'],
-                'caching': disks[disk_index]['caching']
+                'lun': disks[disk_index].get('lun'),
+                'disk_size_gb': disks[disk_index].get('diskSizeGB'),
+                'managed_disk_type': disks[disk_index].get('managedDisk', {}).get('storageAccountType'),
+                'caching': disks[disk_index].get('caching')
             })
 
         new_result['network_interface_names'] = []


### PR DESCRIPTION
##### SUMMARY
This PR adds some checks.
This is first part of the fix that is supposed to be backported.
I will add another PR with additional return values which won't be backported, as changes in the UX can't be backported.

https://github.com/ansible/ansible/issues/52181

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine_facts

##### ADDITIONAL INFORMATION
