### PR TITLE
foreman: Use generic python in test run

### DIFF
--- a/test/integration/targets/inventory_foreman_script/foreman.sh
+++ b/test/integration/targets/inventory_foreman_script/foreman.sh
@@ -2,7 +2,7 @@
 # Wrapper to use the correct Python interpreter and support code coverage.
 
 REL_SCRIPT="../../../../contrib/inventory/foreman.py"
-ABS_SCRIPT="$("${ANSIBLE_TEST_PYTHON_INTERPRETER}" -c "import os; print(os.path.abspath('${REL_SCRIPT}'))")"
+ABS_SCRIPT="$("python.py" -c "import os; print(os.path.abspath('${REL_SCRIPT}'))")"
 
 # Make sure output written to current directory ends up in the temp dir.
 cd "${OUTPUT_DIR}"


### PR DESCRIPTION
##### SUMMARY
Don't use ANSIBLE_TEST_PYTHON_INTERPRETER in test script, just call python directory

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.py