### PR TITLE
Backport/2.7/52540

### DIFF
--- a/changelogs/fragments/52540-fix-vm-facts-crashing-managed-disk.yaml
+++ b/changelogs/fragments/52540-fix-vm-facts-crashing-managed-disk.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- azure_rm_virtualmachine_facts - fixed crash related to attached managed disks (https://github.com/ansible/ansible/issues/52181)

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_facts.py
@@ -324,10 +324,10 @@ class AzureRMVirtualMachineFacts(AzureRMModuleBase):
         disks = result['properties']['storageProfile']['dataDisks']
         for disk_index in range(len(disks)):
             new_result['data_disks'].append({
-                'lun': disks[disk_index]['lun'],
-                'disk_size_gb': disks[disk_index]['diskSizeGB'],
-                'managed_disk_type': disks[disk_index]['managedDisk']['storageAccountType'],
-                'caching': disks[disk_index]['caching']
+                'lun': disks[disk_index].get('lun'),
+                'disk_size_gb': disks[disk_index].get('diskSizeGB'),
+                'managed_disk_type': disks[disk_index].get('managedDisk', {}).get('storageAccountType'),
+                'caching': disks[disk_index].get('caching')
             })
 
         new_result['network_interface_names'] = []


### PR DESCRIPTION
##### SUMMARY
Backporting fix related to vm facts crash when managed data disk attached present.

https://github.com/ansible/ansible/issues/52181

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine_facts

##### ADDITIONAL INFORMATION
