### PR TITLE
meraki_network - Change assertion to variable

### DIFF
--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -205,7 +205,7 @@
     assert:
       that:
         - 'net_query_one.data.name == "IntTestNetworkSwitch"'
-        - 'query_config_template.data.name == "DevConfigTemplate"'
+        - 'query_config_template.data.name == "{{ test_template_name }}"'
         
 
 #############################################################################


### PR DESCRIPTION
##### SUMMARY
Changes assertion in integration test to use variable instead of hardcoded value for configuration template.

Fixes #52549

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
meraki_network
