### PR TITLE
VMware: add missing fact about IP network in firewall facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
@@ -67,7 +67,13 @@ hosts_firewall_facts:
                 {
                     "allowed_hosts": {
                         "all_ip": true,
-                        "ip_address": []
+                        "ip_address": [
+                            "10.10.10.1",
+                        ],
+                        "ip_network": [
+                            "11.111.112.0/22",
+                            "192.168.10.1/24"
+                        ],
                     },
                     "enabled": true,
                     "key": "CIMHttpServer",
@@ -117,6 +123,7 @@ class FirewallFactsManager(PyVmomi):
         allowed_host = rule_obj.allowedHosts
         rule_allow_host = dict()
         rule_allow_host['ip_address'] = [ip for ip in allowed_host.ipAddress]
+        rule_allow_host['ip_network'] = [ip.network + "/" + str(ip.prefixLength) for ip in allowed_host.ipNetwork]
         rule_allow_host['all_ip'] = allowed_host.allIp
         rule_dict['allowed_hosts'] = rule_allow_host
         return rule_dict


### PR DESCRIPTION
##### SUMMARY
Fixes: #52526

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py

##### ADDITIONAL INFORMATION

After fix facts looks like - 

```
...
{
                    "allowed_hosts": {
                        "all_ip": false,
                        "ip_address": [],
                        "ip_network": [
                            "11.111.112.0/22",
                            "192.168.10.1/24"
                        ]
                    },
                    "enabled": true,
                    "key": "sshClient",
                    "rule": [
                        {
                            "direction": "outbound",
                            "end_port": null,
                            "port": 22,
                            "port_type": "dst",
                            "protocol": "tcp"
                        }
                    ],
                    "service": null
                },
...
```