### PR TITLE
Win domain group membership module

### DIFF
--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -9,10 +9,8 @@ try {
     Import-Module ActiveDirectory
 }
 catch {
-    Fail-Json $result "Failed to import ActiveDirectory PowerShell module. This module should be run on a domain controller, and the ActiveDirectory module must be available."
+    Fail-Json $result "win_domain_group_membership requires the ActiveDirectory PS module to be installed"
 }
-
-$ErrorActionPreference = "Stop"
 
 $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
@@ -40,7 +38,6 @@ if ($domain_server -ne $null) {
 
 $result = @{
     changed = $false
-    name = $name
 }
 if ($state -in @("present", "pure")) {
     $result.added = @()

--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -9,7 +9,7 @@ try {
     Import-Module ActiveDirectory
 }
 catch {
-    Fail-Json $result "win_domain_group_membership requires the ActiveDirectory PS module to be installed"
+    Fail-Json -obj @{} -message "win_domain_group_membership requires the ActiveDirectory PS module to be installed"
 }
 
 $params = Parse-Args $args -supports_check_mode $true
@@ -19,52 +19,51 @@ $diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -d
 # Module control parameters
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","pure"
 $domain_username = Get-AnsibleParam -obj $params -name "domain_username" -type "str"
-$domain_password = Get-AnsibleParam -obj $params -name "domain_password" -type "str" -failifempty ($domain_username -ne $null)
+$domain_password = Get-AnsibleParam -obj $params -name "domain_password" -type "str" -failifempty ($null -ne $domain_username)
 $domain_server = Get-AnsibleParam -obj $params -name "domain_server" -type "str"
 
 # Group Membership parameters
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $members = Get-AnsibleParam -obj $params -name "members" -type "list" -failifempty $true
 
+# Filter ADObjects by ObjectClass
+$ad_object_class_filter = "(ObjectClass -eq 'user' -or ObjectClass -eq 'group' -or ObjectClass -eq 'computer' -or ObjectClass -eq 'msDS-ManagedServiceAccount')"
+
 $extra_args = @{}
-if ($domain_username -ne $null) {
+if ($null -ne $domain_username) {
     $domain_password = ConvertTo-SecureString $domain_password -AsPlainText -Force
     $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $domain_username, $domain_password
     $extra_args.Credential = $credential
 }
-if ($domain_server -ne $null) {
+if ($nul -ne $domain_server) {
     $extra_args.Server = $domain_server
 }
 
 $result = @{
     changed = $false
-}
-if ($state -in @("present", "pure")) {
-    $result.added = @()
-}
-if ($state -in @("absent", "pure")) {
-    $result.removed = @()
+    added = [System.Collections.Generic.List`1[String]]@()
+    removed = [System.Collections.Generic.List`1[String]]@()
 }
 if ($diff_mode) {
     $result.diff = @{}
 }
 
 $members_before = Get-AdGroupMember -Identity $name @extra_args
-$pure_members = @()
+$pure_members = [System.Collections.Generic.List`1[String]]@()
 
 foreach ($member in $members) {
-    $group_member = Get-ADObject -Filter "SamAccountName -eq '$member' -and (ObjectClass -eq 'user' -or ObjectClass -eq 'group' -or ObjectClass -eq 'computer' -or ObjectClass -eq 'msDS-ManagedServiceAccount')"
+    $group_member = Get-ADObject -Filter "SamAccountName -eq '$member' -and $ad_object_class_filter" -Properties objectSid, sAMAccountName
     if (!$group_member) {
         Fail-Json -obj $result "Could not find domain user, group, service account or computer named $member"
     }
 
     if ($state -eq "pure") {
-        $pure_members += $group_member
+        $pure_members.Add($group_member.objectSid)
     }
 
     $user_in_group = $false
     foreach ($current_member in $members_before) {
-        if ($current_member.sid -eq $group_member.sid) {
+        if ($current_member.sid -eq $group_member.objectSid) {
             $user_in_group = $true
             break
         }
@@ -72,11 +71,11 @@ foreach ($member in $members) {
 
     if ($state -in @("present", "pure") -and !$user_in_group) {
         Add-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args
-        $result.added += $group_member.SamAccountName
+        $result.added.Add($group_member.SamAccountName)
         $result.changed = $true
     } elseif ($state -eq "absent" -and $user_in_group) {
         Remove-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args -Confirm:$False
-        $result.removed += $group_member.SamAccountName
+        $result.removed.Add($group_member.SamAccountName)
         $result.changed = $true
     }
 }
@@ -88,7 +87,7 @@ if ($state -eq "pure") {
     foreach ($current_member in $current_members) {
         $user_to_remove = $true
         foreach ($pure_member in $pure_members) {
-            if ($pure_member.sid -eq $current_member.sid) {
+            if ($pure_member -eq $current_member.sid) {
                 $user_to_remove = $false
                 break
             }
@@ -96,7 +95,7 @@ if ($state -eq "pure") {
 
         if ($user_to_remove) {
             Remove-ADGroupMember -Identity $name -Members $current_member -WhatIf:$check_mode @extra_args -Confirm:$False
-            $result.removed += $current_member.SamAccountName
+            $result.removed.Add($current_member.SamAccountName)
             $result.changed = $true
         }
     }
@@ -115,10 +114,10 @@ if ($diff_mode -and $result.changed) {
     if (!$check_mode) {
         $result.diff.after = [Array]$final_members.SamAccountName | Out-String
     } else {
-        $after = [System.Collections.ArrayList][Array]$final_members.SamAccountName
-        $result.removed | ForEach-Object { $after.Remove($_) }
-        $result.added | ForEach-Object { $after.Add($_) }
-        $result.diff.after = [Array]$after | Out-String
+        $after = [System.Collections.Generic.List`1[String]]$result.members
+        $result.removed | ForEach-Object { $after.Remove($_) > $null }
+        $after.AddRange($result.added)
+        $result.diff.after = $after | Out-String
     }
 }
 

--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -56,6 +56,8 @@ $current_members = Get-AdGroupMember -Identity $name @extra_args
 $pure_members = @()
 
 foreach ($member in $members) {
+    # Use try/catch as Get-ADUser does not support `-ErrorAction SilentlyContinue`
+    # We do not want to fail but query for group if no user is found
     try {
         $group_member = Get-ADUser -Identity $member @extra_args
     }
@@ -63,7 +65,8 @@ foreach ($member in $members) {
         $group_member = $null
     }
     if (!$group_member) {
-       try {
+        # Use try/catch as Get-ADGroup does not support `-ErrorAction SilentlyContinue`
+        try {
             $group_member = Get-ADGroup -Identity $member @extra_args
         }
         catch {

--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -53,25 +53,9 @@ $members_before = Get-AdGroupMember -Identity $name @extra_args
 $pure_members = @()
 
 foreach ($member in $members) {
-    # Use try/catch as Get-ADUser does not support `-ErrorAction SilentlyContinue`
-    # We do not want to fail but query for group if no user is found
-    try {
-        $group_member = Get-ADUser -Identity $member @extra_args
-    }
-    catch {
-        $group_member = $null
-    }
+    $group_member = Get-ADObject -Filter "SamAccountName -eq '$member' -and (ObjectClass -eq 'user' -or ObjectClass -eq 'group' -or ObjectClass -eq 'computer' -or ObjectClass -eq 'msDS-ManagedServiceAccount')"
     if (!$group_member) {
-        # Use try/catch as Get-ADGroup does not support `-ErrorAction SilentlyContinue`
-        try {
-            $group_member = Get-ADGroup -Identity $member @extra_args
-        }
-        catch {
-            $group_member = $null
-        }
-    }
-    if (!$group_member) {
-        Fail-Json -obj $result "Could not find domain user or group $member"
+        Fail-Json -obj $result "Could not find domain user, group, service account or computer named $member"
     }
 
     if ($state -eq "pure") {

--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -1,0 +1,140 @@
+#!powershell
+
+# Copyright: (c) 2019, Marius Rieder <marius.rieder@scs.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+try {
+    Import-Module ActiveDirectory
+}
+catch {
+    Fail-Json $result "Failed to import ActiveDirectory PowerShell module. This module should be run on a domain controller, and the ActiveDirectory module must be available."
+}
+
+$ErrorActionPreference = "Stop"
+
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+
+# Module control parameters
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","pure"
+$domain_username = Get-AnsibleParam -obj $params -name "domain_username" -type "str"
+$domain_password = Get-AnsibleParam -obj $params -name "domain_password" -type "str" -failifempty ($domain_username -ne $null)
+$domain_server = Get-AnsibleParam -obj $params -name "domain_server" -type "str"
+
+# Group Membership parameters
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$members = Get-AnsibleParam -obj $params -name "members" -type "list" -failifempty $true
+
+$extra_args = @{}
+if ($domain_username -ne $null) {
+    $domain_password = ConvertTo-SecureString $domain_password -AsPlainText -Force
+    $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $domain_username, $domain_password
+    $extra_args.Credential = $credential
+}
+if ($domain_server -ne $null) {
+    $extra_args.Server = $domain_server
+}
+
+$result = @{
+    changed = $false
+    name = $name
+}
+if ($state -in @("present", "pure")) {
+    $result.added = @()
+}
+if ($state -in @("absent", "pure")) {
+    $result.removed = @()
+}
+
+try {
+    $group_obj = Get-ADGroup -Identity $name -Properties * @extra_args
+}
+catch {
+    Fail-Json -obj $result "Could not find domain group $name"
+}
+
+$current_members = Get-AdGroupMember -Identity $name @extra_args
+$pure_members = @()
+
+foreach ($member in $members) {
+    try {
+        $group_member = Get-ADUser -Identity $member @extra_args
+    }
+    catch {
+        $group_member = $null
+    }
+    if (!$group_member) {
+       try {
+            $group_member = Get-ADGroup -Identity $member @extra_args
+        }
+        catch {
+            $group_member = $null
+        }
+    }
+    if (!$group_member) {
+        Fail-Json -obj $result "Could not find domain user or group $member"
+    }
+
+    if ($state -eq "pure") {
+        $pure_members += $group_member
+    }
+
+    $user_in_group = $false
+    foreach ($current_member in $current_members) {
+        if ($current_member.sid -eq $group_member.sid) {
+            $user_in_group = $true
+            break
+        }
+    }
+
+    try {
+        if ($state -in @("present", "pure") -and !$user_in_group) {
+            Add-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args
+            $result.added += $group_member.SamAccountName
+            $result.changed = $true
+        } elseif ($state -eq "absent" -and $user_in_group) {
+            Remove-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args
+            $result.removed += $group_member.SamAccountName
+            $result.changed = $true
+        }
+    } catch {
+        Fail-Json -obj $result -message $_.Exception.Message
+    }
+}
+
+if ($state -eq "pure") {
+    # Perform removals for existing group members not defined in $members
+    $current_members = Get-AdGroupMember -Identity $name @extra_args
+
+    foreach ($current_member in $current_members) {
+        $user_to_remove = $true
+        foreach ($pure_member in $pure_members) {
+            if ($pure_member.sid -eq $current_member.sid) {
+                $user_to_remove = $false
+                break
+            }
+        }
+
+        try {
+            if ($user_to_remove) {
+                Remove-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args
+                $result.removed += $current_member.SamAccountName
+                $result.changed = $true
+            }
+        } catch {
+            Fail-Json -obj $result -message $_.Exception.Message
+        }
+    }
+}
+
+$final_members = Get-AdGroupMember -Identity $name @extra_args
+
+if ($final_members) {
+    $result.members = [Array]$final_members.name
+} else {
+    $result.members = @()
+}
+
+Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -53,7 +53,7 @@ if ($diff_mode) {
 }
 
 try {
-    $group_obj = Get-ADGroup -Identity $name -Properties * @extra_args
+    Get-ADGroup -Identity $name -Properties * @extra_args
 }
 catch {
     Fail-Json -obj $result "Could not find domain group $name"

--- a/lib/ansible/modules/windows/win_domain_group_membership.py
+++ b/lib/ansible/modules/windows/win_domain_group_membership.py
@@ -36,6 +36,23 @@ options:
     type: str
     choices: [ absent, present, pure ]
     default: present
+  domain_username:
+    description:
+    - The username to use when interacting with AD.
+    - If this is not set then the user Ansible used to log in with will be
+      used instead when using CredSSP or Kerberos with credential delegation.
+    type: str
+  domain_password:
+    description:
+    - The password for I(username).
+    type: str
+  domain_server:
+    description:
+    - Specifies the Active Directory Domain Services instance to connect to.
+    - Can be in the form of an FQDN or NetBIOS name.
+    - If not specified then the value is based on the domain of the computer
+      running PowerShell.
+    type: str
 seealso:
 - module: win_domain_user
 - module: win_domain_group

--- a/lib/ansible/modules/windows/win_domain_group_membership.py
+++ b/lib/ansible/modules/windows/win_domain_group_membership.py
@@ -25,7 +25,7 @@ options:
   members:
     description:
       - A list of members to ensure are present/absent from the group.
-      - Prefers users over groups
+      - The given names must be a SmaAccountName of a user, group, service account, or computer
     type: list
     required: yes
   state:
@@ -81,6 +81,13 @@ EXAMPLES = r'''
     members:
       - Bar
     state: pure
+
+- name: Add a computer to a domain group
+  win_domain_group_membership:
+    name: Foo
+    members:
+      - DESKTOP$
+    state: present
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_domain_group_membership.py
+++ b/lib/ansible/modules/windows/win_domain_group_membership.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Andrew Saraceni <andrew.saraceni@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_domain_group_membership
+version_added: "2.8"
+short_description: Manage Windows domain group membership
+description:
+     - Allows the addition and removal of domain users
+       and domain groups from/to a domain group.
+options:
+  name:
+    description:
+      - Name of the domain group to manage membership on.
+    type: str
+    required: yes
+  members:
+    description:
+      - A list of members to ensure are present/absent from the group.
+      - Prefers users over groups
+    type: list
+    required: yes
+  state:
+    description:
+      - Desired state of the members in the group.
+      - When C(state) is C(pure), only the members specified will exist,
+        and all other existing members not specified are removed.
+    type: str
+    choices: [ absent, present, pure ]
+    default: present
+seealso:
+- module: win_domain_user
+- module: win_domain_group
+author:
+    - Marius Rieder (@jiuka)
+'''
+
+EXAMPLES = r'''
+- name: Add a domain user/group to a domain group
+  win_domain_group_membership:
+    name: Foo
+    members:
+      - Bar
+    state: present
+
+- name: Remove a domain user/group from a domain group
+  win_domain_group_membership:
+    name: Foo
+    members:
+      - Bar
+    state: absent
+
+- name: Ensure only a domain user/group exists in a domain group
+  win_domain_group_membership:
+    name: Foo
+    members:
+      - Bar
+    state: pure
+'''
+
+RETURN = r'''
+name:
+    description: The name of the target domain group.
+    returned: always
+    type: str
+    sample: Domain-Admins
+added:
+    description: A list of members added when C(state) is C(present) or
+      C(pure); this is empty if no members are added.
+    returned: success and C(state) is C(present) or C(pure)
+    type: list
+    sample: ["UserName", "GroupName"]
+removed:
+    description: A list of members removed when C(state) is C(absent) or
+      C(pure); this is empty if no members are removed.
+    returned: success and C(state) is C(absent) or C(pure)
+    type: list
+    sample: ["UserName", "GroupName"]
+members:
+    description: A list of all domain group members at completion; this is empty
+      if the group contains no members.
+    returned: success
+    type: list
+    sample: ["UserName", "GroupName"]
+'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With `win_domain_user` it is possible to as a ADUser to a group, but it's not possible to add build and manage ADGroup hierarchies or manage the group membership independent of a user.

This new module `win_domain_group_membership` has the the same parameters/behaviour as the `win_group_membership` module but for AD users instead.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

win_domain_group_membership

##### ADDITIONAL INFORMATION
Example Play
```paste below
---
- name: win_domain_group_member Example
  hosts: adserver
  gather_facts: no
  tasks:
    - name: Add UserName to GroupName
      win_domain_group_membership:
        name: GroupName
        members:
          - UserName
      register: win_domain_group_membership_return

    - name: "Display win_domain_group_membership return"
      debug:
          msg: '{{ win_domain_group_membership_return }}'
```
Example Output
```
PLAY [win_domain_group_member Example] ***********************************************

TASK [Add UserName to GroupName] *******************************************
[GroupName]
+Member = UserName
changed: [adserver]

TASK [DEBUG] *******************************************************************
ok: [adserver] => {
    "msg": {
        "added": [
            "UserName"
        ],
        "changed": true,
        "diff": {
            "prepared": "[GroupName]\n+Member = UserName\n"
        },
        "failed": false,
        "members": [
            "UserName"
        ],
        "name": "GroupName"
    }
}
```