### PR TITLE
ovirt_disk: Don't pass "initial_size" while adding the disk

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -504,7 +504,7 @@ class DisksModule(BaseModule):
                 ],
             ) if logical_unit else None,
         )
-        if hasattr(disk, 'initial_size'):
+        if hasattr(disk, 'initial_size') and self._module.params['upload_image_path']:
             disk.initial_size = convert_to_bytes(
                 self._module.params.get('size')
             )


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, we are passing "initial_size" while creating the disk for
block based storage domains. Since this is equal to the size of the
disk, all the thin provisioned disk which is created using this
module will be having the size equal to the virtual size of the disk.
The "initial_size" is only required while uploading the image. The
patch take care of the same.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1678658

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_disk
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
