### PR TITLE
Use locking for concurrent file access

### DIFF
--- a/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
+++ b/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-- Locking implementation allows concurrent file access by modules
-- lineinfile -- Lock on concurrent file access, fixes #30413
+- change file locking implementation from a class to context manager to allow easy and safe concurrent file access by modules
+- lineinfile - lock on concurrent file access (https://github.com/ansible/ansible/issues/30413)

--- a/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
+++ b/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- "lineinfile now uses FileLock to prevent concurrency issues, fixes #30413"
+- "common.file.FileLocking now properly handles lock_timeout = None and negative int"
+- "common.file.FileLocking now locks the actual file instead of per-user lock files making locks global for processes that supports it"

--- a/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
+++ b/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
@@ -1,4 +1,3 @@
 bugfixes:
-- "lineinfile now uses FileLock to prevent concurrency issues, fixes #30413"
-- "common.file.FileLocking now properly handles lock_timeout = None and negative int"
-- "common.file.FileLocking now locks the actual file instead of per-user lock files making locks global for processes that supports it"
+- Locking implementation allows concurrent file access by modules
+- lineinfile -- Lock on concurrent file access, fixes #30413

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -4,21 +4,15 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import errno
 import os
 import stat
 import re
-import pwd
-import grp
 import time
-import shutil
-import traceback
 import fcntl
-import sys
 
 from contextlib import contextmanager
-from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.six import b, binary_type
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils.six import PY3
 
 try:
     import selinux
@@ -114,89 +108,73 @@ class LockTimeout(Exception):
     pass
 
 
-class FileLock:
+@contextmanager
+def lock(path, lock_timeout=15):
     '''
-    Currently FileLock is implemented via fcntl.flock on a lock file, however this
-    behaviour may change in the future. Avoid mixing lock types fcntl.flock,
-    fcntl.lockf and module_utils.common.file.FileLock as it will certainly cause
-    unwanted and/or unexpected behaviour
+    Context for lock acquisition
     '''
-    def __init__(self):
-        self.lockfd = None
+    fd = set_lock(path, lock_timeout)
+    yield fd
+    unlock(fd)
 
-    @contextmanager
-    def lock_file(self, path, tmpdir, lock_timeout=None):
-        '''
-        Context for lock acquisition
-        '''
-        try:
-            self.set_lock(path, tmpdir, lock_timeout)
-            yield
-        finally:
-            self.unlock()
+def set_lock(path, lock_timeout=15):
+    '''
+    Set lock on given path via fcntl.flock(), note that using
+    locks does not guarantee exclusiveness unless all accessing
+    processes honor locks.
 
-    def set_lock(self, path, tmpdir, lock_timeout=None):
-        '''
-        Create a lock file based on path with flock to prevent other processes
-        using given path.
-        Please note that currently file locking only works when it's executed by
-        the same user, I.E single user scenarios
+    :kw path: Path (file) to lock
+    :kw lock_timeout:
+        Wait n seconds for lock acquisition, fail if timeout is reached.
+        0 = Do not wait, fail if lock cannot be acquired immediately,
+        Less than 0 or None = wait indefinitely until lock is released
+        Default is wait 15s.
+    :returns: True
+    '''
+    b_lock_path = to_bytes(path, errors='surrogate_or_strict')
+    l_wait = 0.01
+    r_exception = IOError
+    if not os.path.exists(b_lock_path):
+        raise IOError('{0} does not exist'.format(path))
 
-        :kw path: Path (file) to lock
-        :kw tmpdir: Path where to place the temporary .lock file
-        :kw lock_timeout:
-            Wait n seconds for lock acquisition, fail if timeout is reached.
-            0 = Do not wait, fail if lock cannot be acquired immediately,
-            Default is None, wait indefinitely until lock is released.
-        :returns: True
-        '''
-        lock_path = os.path.join(tmpdir, 'ansible-{0}.lock'.format(os.path.basename(path)))
-        l_wait = 0.1
-        r_exception = IOError
-        if sys.version_info[0] == 3:
-            r_exception = BlockingIOError
+    if PY3:
+        r_exception = BlockingIOError
 
-        self.lockfd = open(lock_path, 'w')
+    fd = open(b_lock_path, 'ab+')
 
-        if lock_timeout <= 0:
-            fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
-            return True
+    fcntl.lockf(fd, fcntl.LOCK_EX)
+    return fd
 
-        if lock_timeout:
-            e_secs = 0
-            while e_secs < lock_timeout:
-                try:
-                    fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
-                    return True
-                except r_exception:
-                    time.sleep(l_wait)
-                    e_secs += l_wait
-                    continue
+    if lock_timeout is None or lock_timeout < 0:
+        fcntl.lockf(fd, fcntl.LOCK_EX)
+        return fd
 
-            self.lockfd.close()
-            raise LockTimeout('{0} sec'.format(lock_timeout))
+    if lock_timeout > 0:
+        e_secs = 0
+        while e_secs <= lock_timeout:
+            try:
+                fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return fd
+            except r_exception:
+                time.sleep(l_wait)
+                e_secs += l_wait
+                continue
 
-        fcntl.flock(self.lockfd, fcntl.LOCK_EX)
-        os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+        fd.close()
+        raise LockTimeout('{0} sec'.format(lock_timeout))
 
-        return True
+def unlock(fd):
+    '''
+    Make sure lock file is available for everyone and Unlock the file descriptor
+    locked by set_lock
 
-    def unlock(self):
-        '''
-        Make sure lock file is available for everyone and Unlock the file descriptor
-        locked by set_lock
+    :returns: True
+    '''
+    if not fd:
+        return
 
-        :returns: True
-        '''
-        if not self.lockfd:
-            return True
-
-        try:
-            fcntl.flock(self.lockfd, fcntl.LOCK_UN)
-            self.lockfd.close()
-        except ValueError:  # file wasn't opened, let context manager fail gracefully
-            pass
-
-        return True
+    try:
+        fcntl.lockf(fd, fcntl.LOCK_UN)
+        fd.close()
+    except ValueError:  # file wasn't opened, let context manager fail gracefully
+        pass

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -121,12 +121,8 @@ options:
     default: no
     version_added: "2.5"
   others:
-    description:
-      - All arguments accepted by the M(file) module also work here.
-    type: str
-extends_documentation_fragment:
-    - files
-    - validate
+     description:
+       - All arguments accepted by the M(file) module also work here.
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 seealso:
@@ -208,11 +204,12 @@ import tempfile
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.file import lock
 from ansible.module_utils.six import b
 from ansible.module_utils._text import to_bytes, to_native
 
 
-def write_changes(module, b_lines, dest):
+def write_changes(module, fd, b_lines, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
     with open(tmpfile, 'wb') as f:
@@ -229,9 +226,12 @@ def write_changes(module, b_lines, dest):
             module.fail_json(msg='failed to validate: '
                                  'rc:%s error:%s' % (rc, err))
     if valid:
-        module.atomic_move(tmpfile,
-                           to_native(os.path.realpath(to_bytes(dest, errors='surrogate_or_strict')), errors='surrogate_or_strict'),
-                           unsafe_writes=module.params['unsafe_writes'])
+        fd.seek(0)
+        fd.truncate()
+        fd.writelines(b_lines)
+#        module.atomic_move(tmpfile,
+#                           to_native(os.path.realpath(to_bytes(dest, errors='surrogate_or_strict')), errors='surrogate_or_strict'),
+#                           unsafe_writes=module.params['unsafe_writes'])
 
 
 def check_file_attrs(module, changed, message, diff):
@@ -252,10 +252,12 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
 
     diff = {'before': '',
             'after': '',
-            'before_header': '%s (content)' % dest,
-            'after_header': '%s (content)' % dest}
-
+            'before_header': '{0} (content)'.format(dest),
+            'after_header': '{0} (content)'.format(dest)}
+    attr_diff = {}
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
+    backupdest = ''
+
     if not os.path.exists(b_dest):
         if not create:
             module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
@@ -264,15 +266,52 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
             try:
                 os.makedirs(b_destpath)
             except Exception as e:
-                module.fail_json(msg='Error creating %s Error code: %s Error description: %s' % (b_destpath, e[0], e[1]))
+                module.fail_json(msg='Error creating {0} Error code: {1} Error description: {2}'.format(b_destpath, e[0], e[1]))
+        # destination must exist to be able to lock it
+        if not module.check_mode:
+            open(b_dest, 'ab').close()
 
-        b_lines = []
+    if module.check_mode:
+        if create:
+            b_lines = []
+        else:
+            with open(b_dest, 'rb') as fd:
+                b_lines = fd.readlines()
+
+        msg, changed, b_modified_lines = _present_data_manipulator(b_lines, regexp, line, insertafter,
+                                                                   insertbefore, backrefs, firstmatch)
+        if not os.path.exists(b_dest):
+            if module._diff:
+                diff['before'] = to_native(b('').join(b_lines))
+                diff['after'] = to_native(b('').join(b_modified_lines))
+            return msg, changed, backupdest, diff
+
+        msg, changed = check_file_attrs(module, changed, msg, attr_diff)
     else:
-        with open(b_dest, 'rb') as f:
-            b_lines = f.readlines()
+        with lock(dest) as fd:
+            b_lines = fd.readlines()
+
+            msg, changed, b_modified_lines = _present_data_manipulator(b_lines, regexp, line, insertafter,
+                                                                       insertbefore, backrefs, firstmatch)
+
+            if changed:
+                if backup and os.path.exists(b_dest):
+                    backupdest = module.backup_local(dest)
+                write_changes(module, fd, b_modified_lines, dest)
+
+        msg, changed = check_file_attrs(module, changed, msg, attr_diff)
 
     if module._diff:
         diff['before'] = to_native(b('').join(b_lines))
+        diff['after'] = to_native(b('').join(b_modified_lines))
+        attr_diff['before_header'] = '{0} (file attributes)'.format(dest)
+        attr_diff['after_header'] = '{0} (file attributes)'.format(dest)
+    difflist = [diff, attr_diff]
+
+    return msg, changed, backupdest, difflist
+
+
+def _present_data_manipulator(b_lines, regexp, line, insertafter, insertbefore, backrefs, firstmatch):
 
     if regexp is not None:
         bre_m = re.compile(to_bytes(regexp, errors='surrogate_or_strict'))
@@ -392,85 +431,84 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         msg = 'line added'
         changed = True
 
-    if module._diff:
-        diff['after'] = to_native(b('').join(b_lines))
-
-    backupdest = ""
-    if changed and not module.check_mode:
-        if backup and os.path.exists(b_dest):
-            backupdest = module.backup_local(dest)
-        write_changes(module, b_lines, dest)
-
-    if module.check_mode and not os.path.exists(b_dest):
-        module.exit_json(changed=changed, msg=msg, backup=backupdest, diff=diff)
-
-    attr_diff = {}
-    msg, changed = check_file_attrs(module, changed, msg, attr_diff)
-
-    attr_diff['before_header'] = '%s (file attributes)' % dest
-    attr_diff['after_header'] = '%s (file attributes)' % dest
-
-    difflist = [diff, attr_diff]
-    module.exit_json(changed=changed, msg=msg, backup=backupdest, diff=difflist)
+    return msg, changed, b_lines
 
 
 def absent(module, dest, regexp, line, backup):
 
+    diff = {'before': '',
+            'after': '',
+            'before_header': '{0} (content)'.format(dest),
+            'after_header': '{0} (content)'.format(dest)}
+    attr_diff = {}
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
+    backupdest = ''
+
     if not os.path.exists(b_dest):
         module.exit_json(changed=False, msg="file not present")
 
+    if module.check_mode:
+        with open(b_dest, 'rb') as fd:
+            b_lines = fd.readlines()
+
+        msg, changed, b_modified_lines = _absent_data_manipulator(b_lines, regexp, line)
+        found = len(b_lines) - len(b_modified_lines)
+
+        if module._diff:
+            diff['before'] = to_native(b('').join(b_lines))
+            diff['after'] = to_native(b('').join(b_modified_lines))
+
+        return msg, changed, found, backupdest, diff
+
+    else:
+        with lock(dest) as fd:
+            b_lines = fd.readlines()
+
+            msg, changed, b_modified_lines = _absent_data_manipulator(b_lines, regexp, line)
+            if changed:
+                if backup:
+                    backupdest = module.backup_local(dest)
+                write_changes(module, fd, b_modified_lines, dest)
+
+        msg, changed = check_file_attrs(module, changed, msg, attr_diff)
+
+        found = len(b_lines) - len(b_modified_lines)
+
+        if module._diff:
+            diff['before'] = to_native(b('').join(b_lines))
+            diff['after'] = to_native(b('').join(b_modified_lines))
+            attr_diff['before_header'] = '{0} (file attributes)'.format(dest)
+            attr_diff['after_header'] = '{0} (file attributes)'.format(dest)
+        difflist = [diff, attr_diff]
+
+        return msg, changed, found, backupdest, difflist
+
+
+def _absent_data_manipulator(b_lines, regexp, line):
     msg = ''
-    diff = {'before': '',
-            'after': '',
-            'before_header': '%s (content)' % dest,
-            'after_header': '%s (content)' % dest}
-
-    with open(b_dest, 'rb') as f:
-        b_lines = f.readlines()
-
-    if module._diff:
-        diff['before'] = to_native(b('').join(b_lines))
-
-    if regexp is not None:
-        bre_c = re.compile(to_bytes(regexp, errors='surrogate_or_strict'))
-    found = []
-
+    bre_c = None
     b_line = to_bytes(line, errors='surrogate_or_strict')
+    changed = False
 
-    def matcher(b_cur_line):
-        if regexp is not None:
-            match_found = bre_c.search(b_cur_line)
-        else:
-            match_found = b_line == b_cur_line.rstrip(b('\r\n'))
-        if match_found:
-            found.append(b_cur_line)
-        return not match_found
+    if regexp:
+        bre_c = re.compile(to_bytes(regexp, errors='surrogate_or_strict'))
 
-    b_lines = [l for l in b_lines if matcher(l)]
-    changed = len(found) > 0
+    b_lines_new = [l for l in b_lines if _matcher(l, b_line, bre_c)]
+    lines_changed = len(b_lines) - len(b_lines_new)
 
-    if module._diff:
-        diff['after'] = to_native(b('').join(b_lines))
+    if lines_changed > 0:
+        changed = True
+        msg = "{0} line(s) removed".format(lines_changed)
 
-    backupdest = ""
-    if changed and not module.check_mode:
-        if backup:
-            backupdest = module.backup_local(dest)
-        write_changes(module, b_lines, dest)
+    return msg, changed, b_lines_new
 
-    if changed:
-        msg = "%s line(s) removed" % len(found)
 
-    attr_diff = {}
-    msg, changed = check_file_attrs(module, changed, msg, attr_diff)
-
-    attr_diff['before_header'] = '%s (file attributes)' % dest
-    attr_diff['after_header'] = '%s (file attributes)' % dest
-
-    difflist = [diff, attr_diff]
-
-    module.exit_json(changed=changed, found=len(found), msg=msg, backup=backupdest, diff=difflist)
+def _matcher(b_cur_line, b_line, bre_c):
+    if bre_c is not None:
+        match_found = bre_c.search(b_cur_line)
+    else:
+        match_found = b_line == b_cur_line.rstrip(b('\r\n'))
+    return not match_found
 
 
 def main():
@@ -485,7 +523,7 @@ def main():
             backrefs=dict(type='bool', default=False),
             create=dict(type='bool', default=False),
             backup=dict(type='bool', default=False),
-            firstmatch=dict(type='bool', default=False),
+            firstmatch=dict(default=False, type='bool'),
             validate=dict(type='str'),
         ),
         mutually_exclusive=[['insertbefore', 'insertafter']],
@@ -525,13 +563,15 @@ def main():
         if ins_bef is None and ins_aft is None:
             ins_aft = 'EOF'
 
-        present(module, path, regexp, line,
-                ins_aft, ins_bef, create, backup, backrefs, firstmatch)
+        msg, changed, backupdest, diff = present(module, path, regexp, line, ins_aft, ins_bef, create,
+                                                 backup, backrefs, firstmatch)
+        module.exit_json(changed=changed, msg=msg, backup=backupdest, diff=diff)
     else:
         if regexp is None and line is None:
             module.fail_json(msg='one of line or regexp is required with state=absent')
 
-        absent(module, path, regexp, line, backup)
+        msg, changed, found, backupdest, diff = absent(module, path, regexp, line, backup)
+        module.exit_json(changed=changed, found=found, msg=msg, backup=backupdest, diff=diff)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -121,8 +121,12 @@ options:
     default: no
     version_added: "2.5"
   others:
-     description:
-       - All arguments accepted by the M(file) module also work here.
+    description:
+      - All arguments accepted by the M(file) module also work here.
+    type: str
+extends_documentation_fragment:
+    - files
+    - validate
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 seealso:
@@ -180,6 +184,13 @@ EXAMPLES = r'''
     line: 192.168.1.99 foo.lab.net foo
     create: yes
 
+# Fully quoted because of the ': ' on the line. See the Gotchas in the YAML docs.
+- lineinfile:
+    path: /etc/sudoers
+    state: present
+    regexp: '^%wheel\s'
+    line: '%wheel ALL=(ALL) NOPASSWD: ALL'
+
 # NOTE: Yaml requires escaping backslashes in double quotes but not in single quotes
 - name: Ensure the JBoss memory settings are exactly as needed
   lineinfile:
@@ -204,12 +215,12 @@ import tempfile
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.file import lock
+from ansible.module_utils.common.file import open_locked
 from ansible.module_utils.six import b
 from ansible.module_utils._text import to_bytes, to_native
 
 
-def write_changes(module, fd, b_lines, dest):
+def write_changes(module, b_lines, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
     with open(tmpfile, 'wb') as f:
@@ -226,12 +237,9 @@ def write_changes(module, fd, b_lines, dest):
             module.fail_json(msg='failed to validate: '
                                  'rc:%s error:%s' % (rc, err))
     if valid:
-        fd.seek(0)
-        fd.truncate()
-        fd.writelines(b_lines)
-#        module.atomic_move(tmpfile,
-#                           to_native(os.path.realpath(to_bytes(dest, errors='surrogate_or_strict')), errors='surrogate_or_strict'),
-#                           unsafe_writes=module.params['unsafe_writes'])
+        module.atomic_move(tmpfile,
+                           to_native(os.path.realpath(to_bytes(dest, errors='surrogate_or_strict')), errors='surrogate_or_strict'),
+                           unsafe_writes=module.params['unsafe_writes'])
 
 
 def check_file_attrs(module, changed, message, diff):
@@ -252,12 +260,10 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
 
     diff = {'before': '',
             'after': '',
-            'before_header': '{0} (content)'.format(dest),
-            'after_header': '{0} (content)'.format(dest)}
-    attr_diff = {}
-    b_dest = to_bytes(dest, errors='surrogate_or_strict')
-    backupdest = ''
+            'before_header': '%s (content)' % dest,
+            'after_header': '%s (content)' % dest}
 
+    b_dest = to_bytes(dest, errors='surrogate_or_strict')
     if not os.path.exists(b_dest):
         if not create:
             module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
@@ -266,249 +272,221 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
             try:
                 os.makedirs(b_destpath)
             except Exception as e:
-                module.fail_json(msg='Error creating {0} Error code: {1} Error description: {2}'.format(b_destpath, e[0], e[1]))
+                module.fail_json(msg='Error creating %s Error code: %s Error description: %s' % (b_destpath, e[0], e[1]))
         # destination must exist to be able to lock it
         if not module.check_mode:
             open(b_dest, 'ab').close()
 
-    if module.check_mode:
-        if create:
-            b_lines = []
-        else:
-            with open(b_dest, 'rb') as fd:
-                b_lines = fd.readlines()
-
-        msg, changed, b_modified_lines = _present_data_manipulator(b_lines, regexp, line, insertafter,
-                                                                   insertbefore, backrefs, firstmatch)
-        if not os.path.exists(b_dest):
-            if module._diff:
-                diff['before'] = to_native(b('').join(b_lines))
-                diff['after'] = to_native(b('').join(b_modified_lines))
-            return msg, changed, backupdest, diff
-
-        msg, changed = check_file_attrs(module, changed, msg, attr_diff)
+        b_lines = []
     else:
-        with lock(dest) as fd:
+        b_lines = None
+
+    # NOTE: Avoid opening the same file in this context !
+    with open_locked(dest, module.check_mode) as fd:
+        if b_lines is None:
             b_lines = fd.readlines()
 
-            msg, changed, b_modified_lines = _present_data_manipulator(b_lines, regexp, line, insertafter,
-                                                                       insertbefore, backrefs, firstmatch)
+        if module._diff:
+            diff['before'] = to_native(b('').join(b_lines))
 
-            if changed:
-                if backup and os.path.exists(b_dest):
-                    backupdest = module.backup_local(dest)
-                write_changes(module, fd, b_modified_lines, dest)
-
-        msg, changed = check_file_attrs(module, changed, msg, attr_diff)
-
-    if module._diff:
-        diff['before'] = to_native(b('').join(b_lines))
-        diff['after'] = to_native(b('').join(b_modified_lines))
-        attr_diff['before_header'] = '{0} (file attributes)'.format(dest)
-        attr_diff['after_header'] = '{0} (file attributes)'.format(dest)
-    difflist = [diff, attr_diff]
-
-    return msg, changed, backupdest, difflist
-
-
-def _present_data_manipulator(b_lines, regexp, line, insertafter, insertbefore, backrefs, firstmatch):
-
-    if regexp is not None:
-        bre_m = re.compile(to_bytes(regexp, errors='surrogate_or_strict'))
-
-    if insertafter not in (None, 'BOF', 'EOF'):
-        bre_ins = re.compile(to_bytes(insertafter, errors='surrogate_or_strict'))
-    elif insertbefore not in (None, 'BOF'):
-        bre_ins = re.compile(to_bytes(insertbefore, errors='surrogate_or_strict'))
-    else:
-        bre_ins = None
-
-    # index[0] is the line num where regexp has been found
-    # index[1] is the line num where insertafter/inserbefore has been found
-    index = [-1, -1]
-    m = None
-    b_line = to_bytes(line, errors='surrogate_or_strict')
-    for lineno, b_cur_line in enumerate(b_lines):
         if regexp is not None:
-            match_found = bre_m.search(b_cur_line)
+            bre_m = re.compile(to_bytes(regexp, errors='surrogate_or_strict'))
+
+        if insertafter not in (None, 'BOF', 'EOF'):
+            bre_ins = re.compile(to_bytes(insertafter, errors='surrogate_or_strict'))
+        elif insertbefore not in (None, 'BOF'):
+            bre_ins = re.compile(to_bytes(insertbefore, errors='surrogate_or_strict'))
         else:
-            match_found = b_line == b_cur_line.rstrip(b('\r\n'))
-        if match_found:
-            index[0] = lineno
-            m = match_found
-        elif bre_ins is not None and bre_ins.search(b_cur_line):
-            if insertafter:
-                # + 1 for the next line
-                index[1] = lineno + 1
-                if firstmatch:
-                    break
-            if insertbefore:
-                # index[1] for the previous line
-                index[1] = lineno
-                if firstmatch:
-                    break
+            bre_ins = None
 
-    msg = ''
-    changed = False
-    b_linesep = to_bytes(os.linesep, errors='surrogate_or_strict')
-    # Exact line or Regexp matched a line in the file
-    if index[0] != -1:
-        if backrefs:
-            b_new_line = m.expand(b_line)
-        else:
-            # Don't do backref expansion if not asked.
-            b_new_line = b_line
+        # index[0] is the line num where regexp has been found
+        # index[1] is the line num where insertafter/inserbefore has been found
+        index = [-1, -1]
+        m = None
+        b_line = to_bytes(line, errors='surrogate_or_strict')
+        for lineno, b_cur_line in enumerate(b_lines):
+            if regexp is not None:
+                match_found = bre_m.search(b_cur_line)
+            else:
+                match_found = b_line == b_cur_line.rstrip(b('\r\n'))
+            if match_found:
+                index[0] = lineno
+                m = match_found
+            elif bre_ins is not None and bre_ins.search(b_cur_line):
+                if insertafter:
+                    # + 1 for the next line
+                    index[1] = lineno + 1
+                    if firstmatch:
+                        break
+                if insertbefore:
+                    # index[1] for the previous line
+                    index[1] = lineno
+                    if firstmatch:
+                        break
 
-        if not b_new_line.endswith(b_linesep):
-            b_new_line += b_linesep
+        msg = ''
+        changed = False
+        b_linesep = to_bytes(os.linesep, errors='surrogate_or_strict')
+        # Exact line or Regexp matched a line in the file
+        if index[0] != -1:
+            if backrefs:
+                b_new_line = m.expand(b_line)
+            else:
+                # Don't do backref expansion if not asked.
+                b_new_line = b_line
 
-        # If no regexp was given and no line match is found anywhere in the file,
-        # insert the line appropriately if using insertbefore or insertafter
-        if regexp is None and m is None:
+            if not b_new_line.endswith(b_linesep):
+                b_new_line += b_linesep
 
-            # Insert lines
-            if insertafter and insertafter != 'EOF':
-                # Ensure there is a line separator after the found string
-                # at the end of the file.
-                if b_lines and not b_lines[-1][-1:] in (b('\n'), b('\r')):
-                    b_lines[-1] = b_lines[-1] + b_linesep
+            # If no regexp was given and no line match is found anywhere in the file,
+            # insert the line appropriately if using insertbefore or insertafter
+            if regexp is None and m is None:
 
-                # If the line to insert after is at the end of the file
-                # use the appropriate index value.
-                if len(b_lines) == index[1]:
-                    if b_lines[index[1] - 1].rstrip(b('\r\n')) != b_line:
-                        b_lines.append(b_line + b_linesep)
-                        msg = 'line added'
-                        changed = True
-                elif b_lines[index[1]].rstrip(b('\r\n')) != b_line:
-                    b_lines.insert(index[1], b_line + b_linesep)
-                    msg = 'line added'
-                    changed = True
+                # Insert lines
+                if insertafter and insertafter != 'EOF':
+                    # Ensure there is a line separator after the found string
+                    # at the end of the file.
+                    if b_lines and not b_lines[-1][-1:] in (b('\n'), b('\r')):
+                        b_lines[-1] = b_lines[-1] + b_linesep
 
-            elif insertbefore and insertbefore != 'BOF':
-                # If the line to insert before is at the beginning of the file
-                # use the appropriate index value.
-                if index[1] <= 0:
-                    if b_lines[index[1]].rstrip(b('\r\n')) != b_line:
+                    # If the line to insert after is at the end of the file
+                    # use the appropriate index value.
+                    if len(b_lines) == index[1]:
+                        if b_lines[index[1] - 1].rstrip(b('\r\n')) != b_line:
+                            b_lines.append(b_line + b_linesep)
+                            msg = 'line added'
+                            changed = True
+                    elif b_lines[index[1]].rstrip(b('\r\n')) != b_line:
                         b_lines.insert(index[1], b_line + b_linesep)
                         msg = 'line added'
                         changed = True
 
-                elif b_lines[index[1] - 1].rstrip(b('\r\n')) != b_line:
-                    b_lines.insert(index[1], b_line + b_linesep)
-                    msg = 'line added'
-                    changed = True
+                elif insertbefore and insertbefore != 'BOF':
+                    # If the line to insert before is at the beginning of the file
+                    # use the appropriate index value.
+                    if index[1] <= 0:
+                        if b_lines[index[1]].rstrip(b('\r\n')) != b_line:
+                            b_lines.insert(index[1], b_line + b_linesep)
+                            msg = 'line added'
+                            changed = True
 
-        elif b_lines[index[0]] != b_new_line:
-            b_lines[index[0]] = b_new_line
-            msg = 'line replaced'
+                    elif b_lines[index[1] - 1].rstrip(b('\r\n')) != b_line:
+                        b_lines.insert(index[1], b_line + b_linesep)
+                        msg = 'line added'
+                        changed = True
+
+            elif b_lines[index[0]] != b_new_line:
+                b_lines[index[0]] = b_new_line
+                msg = 'line replaced'
+                changed = True
+
+        elif backrefs:
+            # Do absolutely nothing, since it's not safe generating the line
+            # without the regexp matching to populate the backrefs.
+            pass
+        # Add it to the beginning of the file
+        elif insertbefore == 'BOF' or insertafter == 'BOF':
+            b_lines.insert(0, b_line + b_linesep)
+            msg = 'line added'
+            changed = True
+        # Add it to the end of the file if requested or
+        # if insertafter/insertbefore didn't match anything
+        # (so default behaviour is to add at the end)
+        elif insertafter == 'EOF' or index[1] == -1:
+
+            # If the file is not empty then ensure there's a newline before the added line
+            if b_lines and not b_lines[-1][-1:] in (b('\n'), b('\r')):
+                b_lines.append(b_linesep)
+
+            b_lines.append(b_line + b_linesep)
+            msg = 'line added'
+            changed = True
+        # insert matched, but not the regexp
+        else:
+            b_lines.insert(index[1], b_line + b_linesep)
+            msg = 'line added'
             changed = True
 
-    elif backrefs:
-        # Do absolutely nothing, since it's not safe generating the line
-        # without the regexp matching to populate the backrefs.
-        pass
-    # Add it to the beginning of the file
-    elif insertbefore == 'BOF' or insertafter == 'BOF':
-        b_lines.insert(0, b_line + b_linesep)
-        msg = 'line added'
-        changed = True
-    # Add it to the end of the file if requested or
-    # if insertafter/insertbefore didn't match anything
-    # (so default behaviour is to add at the end)
-    elif insertafter == 'EOF' or index[1] == -1:
+        if module._diff:
+            diff['after'] = to_native(b('').join(b_lines))
 
-        # If the file is not empty then ensure there's a newline before the added line
-        if b_lines and not b_lines[-1][-1:] in (b('\n'), b('\r')):
-            b_lines.append(b_linesep)
+        backupdest = ""
+        if changed and not module.check_mode:
+            if backup and os.path.exists(b_dest):
+                backupdest = module.backup_local(dest)
+            write_changes(module, b_lines, dest)
 
-        b_lines.append(b_line + b_linesep)
-        msg = 'line added'
-        changed = True
-    # insert matched, but not the regexp
-    else:
-        b_lines.insert(index[1], b_line + b_linesep)
-        msg = 'line added'
-        changed = True
+    if module.check_mode and not os.path.exists(b_dest):
+        module.exit_json(changed=changed, msg=msg, backup=backupdest, diff=diff)
 
-    return msg, changed, b_lines
+    attr_diff = {}
+    msg, changed = check_file_attrs(module, changed, msg, attr_diff)
+
+    attr_diff['before_header'] = '%s (file attributes)' % dest
+    attr_diff['after_header'] = '%s (file attributes)' % dest
+
+    difflist = [diff, attr_diff]
+    module.exit_json(changed=changed, msg=msg, backup=backupdest, diff=difflist)
 
 
 def absent(module, dest, regexp, line, backup):
 
-    diff = {'before': '',
-            'after': '',
-            'before_header': '{0} (content)'.format(dest),
-            'after_header': '{0} (content)'.format(dest)}
-    attr_diff = {}
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
-    backupdest = ''
-
     if not os.path.exists(b_dest):
         module.exit_json(changed=False, msg="file not present")
 
-    if module.check_mode:
-        with open(b_dest, 'rb') as fd:
-            b_lines = fd.readlines()
-
-        msg, changed, b_modified_lines = _absent_data_manipulator(b_lines, regexp, line)
-        found = len(b_lines) - len(b_modified_lines)
-
-        if module._diff:
-            diff['before'] = to_native(b('').join(b_lines))
-            diff['after'] = to_native(b('').join(b_modified_lines))
-
-        return msg, changed, found, backupdest, diff
-
-    else:
-        with lock(dest) as fd:
-            b_lines = fd.readlines()
-
-            msg, changed, b_modified_lines = _absent_data_manipulator(b_lines, regexp, line)
-            if changed:
-                if backup:
-                    backupdest = module.backup_local(dest)
-                write_changes(module, fd, b_modified_lines, dest)
-
-        msg, changed = check_file_attrs(module, changed, msg, attr_diff)
-
-        found = len(b_lines) - len(b_modified_lines)
-
-        if module._diff:
-            diff['before'] = to_native(b('').join(b_lines))
-            diff['after'] = to_native(b('').join(b_modified_lines))
-            attr_diff['before_header'] = '{0} (file attributes)'.format(dest)
-            attr_diff['after_header'] = '{0} (file attributes)'.format(dest)
-        difflist = [diff, attr_diff]
-
-        return msg, changed, found, backupdest, difflist
-
-
-def _absent_data_manipulator(b_lines, regexp, line):
     msg = ''
-    bre_c = None
-    b_line = to_bytes(line, errors='surrogate_or_strict')
-    changed = False
+    diff = {'before': '',
+            'after': '',
+            'before_header': '%s (content)' % dest,
+            'after_header': '%s (content)' % dest}
 
-    if regexp:
-        bre_c = re.compile(to_bytes(regexp, errors='surrogate_or_strict'))
+    # NOTE: Avoid opening the same file in this context !
+    with open_locked(dest, module.check_mode) as fd:
+        b_lines = fd.readlines()
 
-    b_lines_new = [l for l in b_lines if _matcher(l, b_line, bre_c)]
-    lines_changed = len(b_lines) - len(b_lines_new)
+        if module._diff:
+            diff['before'] = to_native(b('').join(b_lines))
 
-    if lines_changed > 0:
-        changed = True
-        msg = "{0} line(s) removed".format(lines_changed)
+        if regexp is not None:
+            bre_c = re.compile(to_bytes(regexp, errors='surrogate_or_strict'))
+        found = []
 
-    return msg, changed, b_lines_new
+        b_line = to_bytes(line, errors='surrogate_or_strict')
 
+        def matcher(b_cur_line):
+            if regexp is not None:
+                match_found = bre_c.search(b_cur_line)
+            else:
+                match_found = b_line == b_cur_line.rstrip(b('\r\n'))
+            if match_found:
+                found.append(b_cur_line)
+            return not match_found
 
-def _matcher(b_cur_line, b_line, bre_c):
-    if bre_c is not None:
-        match_found = bre_c.search(b_cur_line)
-    else:
-        match_found = b_line == b_cur_line.rstrip(b('\r\n'))
-    return not match_found
+        b_lines = [l for l in b_lines if matcher(l)]
+        changed = len(found) > 0
+
+        if module._diff:
+            diff['after'] = to_native(b('').join(b_lines))
+
+        backupdest = ""
+        if changed and not module.check_mode:
+            if backup:
+                backupdest = module.backup_local(dest)
+            write_changes(module, b_lines, dest)
+
+    if changed:
+        msg = "%s line(s) removed" % len(found)
+
+    attr_diff = {}
+    msg, changed = check_file_attrs(module, changed, msg, attr_diff)
+
+    attr_diff['before_header'] = '%s (file attributes)' % dest
+    attr_diff['after_header'] = '%s (file attributes)' % dest
+
+    difflist = [diff, attr_diff]
+
+    module.exit_json(changed=changed, found=len(found), msg=msg, backup=backupdest, diff=difflist)
 
 
 def main():
@@ -523,7 +501,7 @@ def main():
             backrefs=dict(type='bool', default=False),
             create=dict(type='bool', default=False),
             backup=dict(type='bool', default=False),
-            firstmatch=dict(default=False, type='bool'),
+            firstmatch=dict(type='bool', default=False),
             validate=dict(type='str'),
         ),
         mutually_exclusive=[['insertbefore', 'insertafter']],
@@ -563,15 +541,13 @@ def main():
         if ins_bef is None and ins_aft is None:
             ins_aft = 'EOF'
 
-        msg, changed, backupdest, diff = present(module, path, regexp, line, ins_aft, ins_bef, create,
-                                                 backup, backrefs, firstmatch)
-        module.exit_json(changed=changed, msg=msg, backup=backupdest, diff=diff)
+        present(module, path, regexp, line,
+                ins_aft, ins_bef, create, backup, backrefs, firstmatch)
     else:
         if regexp is None and line is None:
             module.fail_json(msg='one of line or regexp is required with state=absent')
 
-        msg, changed, found, backupdest, diff = absent(module, path, regexp, line, backup)
-        module.exit_json(changed=changed, found=found, msg=msg, backup=backupdest, diff=diff)
+        absent(module, path, regexp, line, backup)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -84,7 +84,7 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.file import FileLock
+from ansible.module_utils.common.file import lock
 from ansible.module_utils._text import to_bytes, to_native
 
 

--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -84,7 +84,6 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.file import lock
 from ansible.module_utils._text import to_bytes, to_native
 
 

--- a/test/integration/targets/file_lock/aliases
+++ b/test/integration/targets/file_lock/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group2

--- a/test/integration/targets/file_lock/inventory
+++ b/test/integration/targets/file_lock/inventory
@@ -1,0 +1,2 @@
+[lockhosts]
+lockhost[00:99] ansible_connection=local

--- a/test/integration/targets/file_lock/inventory
+++ b/test/integration/targets/file_lock/inventory
@@ -1,2 +1,2 @@
 [lockhosts]
-lockhost[00:99] ansible_connection=local
+lockhost[00:99] ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/file_lock/runme.sh
+++ b/test/integration/targets/file_lock/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook test_filelock.yml -i inventory --forks 10 -v "$@"
+#ansible-playbook test_filelock_timeout.yml -i inventory -v "$@"

--- a/test/integration/targets/file_lock/runme.sh
+++ b/test/integration/targets/file_lock/runme.sh
@@ -2,5 +2,5 @@
 
 set -eux
 
-ansible-playbook test_filelock.yml -i inventory --forks 10 -v "$@"
-#ansible-playbook test_filelock_timeout.yml -i inventory -v "$@"
+ansible-playbook test_filelock.yml -i inventory --forks 10 --diff -v "$@"
+ansible-playbook test_filelock_timeout.yml -i inventory --diff  -v "$@"

--- a/test/integration/targets/file_lock/test_filelock.yml
+++ b/test/integration/targets/file_lock/test_filelock.yml
@@ -1,0 +1,55 @@
+---
+- hosts: lockhosts
+  gather_facts: no
+  vars:
+    testfile: ~/ansible_testing/lock.test
+  tasks:
+  - name: Remove testfile
+    file:
+      path: '{{ testfile }}'
+      state: absent
+    run_once: yes
+
+  - name: Write inventory_hostname to testfile concurrently
+    lineinfile:
+      path: '{{ testfile }}'
+      line: '{{ inventory_hostname }}'
+      create: yes
+      state: present
+#    async: 60
+#    poll: 0
+#    register: write_waiter
+
+#  - name: wait for write jobs to finish
+#    async_status:
+#      jid: "{{ write_waiter.ansible_job_id }}"
+#    register: write_job_result
+#    until: write_job_result.finished
+#    retries: 60
+
+  - debug:
+      msg: "File {{ testfile }} has {{ content.split('\n')|length }} lines for {{ ansible_play_batch|length }} instances"
+    vars:
+      content: "{{ lookup('file', testfile) }}"
+    run_once: yes
+
+  - name: Assert we get the expected number of lines
+    assert:
+      that:
+      - content.split('\n')|length == ansible_play_batch|length
+    vars:
+      content: "{{ lookup('file', testfile) }}"
+    run_once: yes
+
+  - name: Check testfile for inventory_hostname entries
+    lineinfile:
+      path: '{{ testfile }}'
+      line: '{{ inventory_hostname }}'
+      state: present
+    register: check_lockfile
+
+  - name: Assert locking results
+    assert:
+      that:
+      - check_lockfile is not changed
+      - check_lockfile is not failed

--- a/test/integration/targets/file_lock/test_filelock.yml
+++ b/test/integration/targets/file_lock/test_filelock.yml
@@ -2,48 +2,38 @@
 - hosts: lockhosts
   gather_facts: no
   vars:
-    testfile: ~/ansible_testing/lock.test
+    lockfile: ~/ansible_testing/lock.test
   tasks:
-  - name: Remove testfile
+  - name: Remove lockfile
     file:
-      path: '{{ testfile }}'
+      path: '{{ lockfile }}'
       state: absent
     run_once: yes
 
-  - name: Write inventory_hostname to testfile concurrently
+  - name: Write inventory_hostname to lockfile concurrently
     lineinfile:
-      path: '{{ testfile }}'
+      path: '{{ lockfile }}'
       line: '{{ inventory_hostname }}'
       create: yes
       state: present
-#    async: 60
-#    poll: 0
-#    register: write_waiter
-
-#  - name: wait for write jobs to finish
-#    async_status:
-#      jid: "{{ write_waiter.ansible_job_id }}"
-#    register: write_job_result
-#    until: write_job_result.finished
-#    retries: 60
 
   - debug:
-      msg: "File {{ testfile }} has {{ content.split('\n')|length }} lines for {{ ansible_play_batch|length }} instances"
+      msg: File {{ lockfile }} has {{ lines|length }} lines for {{ ansible_play_batch|length }} instances
     vars:
-      content: "{{ lookup('file', testfile) }}"
+      lines: "{{ lookup('file', lockfile).split('\n') }}"
     run_once: yes
 
   - name: Assert we get the expected number of lines
     assert:
       that:
-      - content.split('\n')|length == ansible_play_batch|length
+      - lines|length == ansible_play_batch|length
     vars:
-      content: "{{ lookup('file', testfile) }}"
+      lines: "{{ lookup('file', lockfile).split('\n') }}"
     run_once: yes
 
-  - name: Check testfile for inventory_hostname entries
+  - name: Check lockfile for inventory_hostname entries
     lineinfile:
-      path: '{{ testfile }}'
+      path: '{{ lockfile }}'
       line: '{{ inventory_hostname }}'
       state: present
     register: check_lockfile

--- a/test/integration/targets/file_lock/test_filelock_timeout.yml
+++ b/test/integration/targets/file_lock/test_filelock_timeout.yml
@@ -1,0 +1,51 @@
+---
+- hosts: lockhost0
+  vars:
+    testfile: ~/ansible_testing/locked.file
+  gather_facts: false
+  tasks:
+  - name: create /tmp/locked.file
+    lineinfile:
+      line: "{{ inventory_hostname }}"
+      path: "{{ testfile }}"
+      state: present
+      create: true
+
+  - name: lock testfile with flock and sleep 20s
+    command: flock -x {{ testfile }} -c "sleep 20"
+    async: 60
+    poll: 0
+    register: flock_waiter
+
+  - name: remove inventory_hostname line from testfile
+    lineinfile:
+      path: "{{ testfile }}"
+      line: "{{ inventory_hostname }}"
+      state: absent
+    ignore_errors: true
+    register: rm_line
+
+  - name: assert that removal of inventory_hostname from testfile failed
+    assert:
+      that:
+        - rm_line is failed
+
+  - name: wait for flock job to finish
+    async_status:
+      jid: "{{ flock_waiter.ansible_job_id }}"
+    register: job_result
+    until: job_result.finished
+    retries: 30
+
+  - name: inventory_hostname in testfile
+    lineinfile:
+      path: "{{ testfile }}"
+      line: "{{ inventory_hostname }}"
+      state: present
+    register: check_line
+
+  - name: assert that testfile is unchanged
+    assert:
+      that:
+        - check_line is not changed
+        - check_line is not failed

--- a/test/integration/targets/file_lock/test_filelock_timeout.yml
+++ b/test/integration/targets/file_lock/test_filelock_timeout.yml
@@ -1,50 +1,62 @@
 ---
-- hosts: lockhost0
+- hosts: lockhost00
   vars:
-    testfile: ~/ansible_testing/locked.file
-  gather_facts: false
+    lockfile: ~/ansible_testing/lock_timeout.test
+  gather_facts: no
   tasks:
-  - name: create /tmp/locked.file
-    lineinfile:
-      line: "{{ inventory_hostname }}"
-      path: "{{ testfile }}"
-      state: present
-      create: true
+  - name: Remove lockfile
+    file:
+      path: '{{ lockfile }}'
+      state: absent
+    run_once: yes
 
-  - name: lock testfile with flock and sleep 20s
-    command: flock -x {{ testfile }} -c "sleep 20"
+  - name: Create lockfile
+    lineinfile:
+      line: '{{ inventory_hostname }}'
+      path: '{{ lockfile }}'
+      state: present
+      create: yes
+
+  - name: Lock lockfile with lockf and sleep 20s
+    command: python
+    args:
+      stdin: |
+        import time
+        from ansible.module_utils.common.file import open_locked
+        with open_locked('{{ lockfile | expanduser }}') as fd:
+            time.sleep(20)
     async: 60
     poll: 0
     register: flock_waiter
 
-  - name: remove inventory_hostname line from testfile
+  - name: Remove inventory_hostname line from lockfile
     lineinfile:
-      path: "{{ testfile }}"
-      line: "{{ inventory_hostname }}"
+      path: '{{ lockfile }}'
+      line: '{{ inventory_hostname }}'
       state: absent
-    ignore_errors: true
+    ignore_errors: yes
     register: rm_line
 
-  - name: assert that removal of inventory_hostname from testfile failed
+  - name: Assert that removal of inventory_hostname from lockfile failed
     assert:
       that:
         - rm_line is failed
 
-  - name: wait for flock job to finish
+  - name: Wait for flock job to finish
     async_status:
-      jid: "{{ flock_waiter.ansible_job_id }}"
+      jid: '{{ flock_waiter.ansible_job_id }}'
     register: job_result
     until: job_result.finished
     retries: 30
 
-  - name: inventory_hostname in testfile
+  - name: Inventory_hostname in lockfile
     lineinfile:
-      path: "{{ testfile }}"
-      line: "{{ inventory_hostname }}"
+      path: '{{ lockfile }}'
+      line: '{{ inventory_hostname }}'
       state: present
     register: check_line
 
-  - name: assert that testfile is unchanged
+  - name: Assert that lockfile is unchanged
     assert:
       that:
         - check_line is not changed


### PR DESCRIPTION
##### SUMMARY
This implements locking to be used for modules that are used for concurrent file access, like **lineinfile** or **known_hosts**.

It relates to #47322 and implements ansible/proposals#113.
This fixes #30413

This is based on @acalm's existing lineinfile refactoring work and integration tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
file locking

##### ADDITIONAL INFORMATION
The decision to go with Python **lockf()** (which low-level is **fcntl()** on Linux) is based on the fact that it supports NFS best (contrary to **flock()**) and we can control what happens inside the locked-context.

The downside of locking here is that when a lock is held, no other file descriptor to the same file reference can be closed (deliberately or undeliberately) or we lose the lock, see [this excellent reference](https://stackoverflow.com/questions/28470246/python-lockf-and-flock-behaviour).

On non-Linux platforms (BSD) **flock()** works reliably on NFS and doesn't suffer from this problem.

There are a few ways we mitigate the risk of accidentally losing this lock (by inadvertent opening and closing the same file within this context):
1. Check on close if the file was still locked, if it was not, we warn the user that there is an issue.
2. Test this locking specifically in integration tests so it is widely tested on all CI supported platforms
3. Ensure that the code is properly documented in every module, so people are reminded of the issue

By choosing **lockf()** we raise the bar for quality in our modules (which we control) then giving a diffused message of what may not work (locking my fail on NFS filesystems) especially since it can cause data-loss.

For this reason we changed the interface from a `FileLock` class holding the file descriptor, to a simpler context manager that returns the locked file descriptor `open_locked()` as seen below

```python
    with open_locked(your_file) as fd:
        content = fd.readlines()

        # do something else with this file descriptor
        # NOTE: do not open the same file in this context to not lose the lock on it when it is closed
```

Since Ansible modules are single-threaded, the risk of undeliberately opening/closing of the same file is very low as long as we ensure we reuse the existing file descriptor and use `atomic_move()`, like we tend to do in modules.

For non-Linux operating systems (BSD, Solaris, BSD, AIX, HP-UX) we may have to implement a different locking-mechanism, native to the target.