### PR TITLE
postgresql_privs change fail to warn if role(s) does not exist

### DIFF
--- a/changelogs/fragments/52574-postgresql_privs-add_warn_if_role_not_exist.yml
+++ b/changelogs/fragments/52574-postgresql_privs-add_warn_if_role_not_exist.yml
@@ -1,2 +1,5 @@
 bugfixes:
   - postgresql_privs - change fail to warn if PostgreSQL role does not exist (https://github.com/ansible/ansible/issues/46168).
+
+minor_changes:
+  - postgresql_privs - add fail_on_role parameter to control the behavior (fail or warn) when target role does not exist.

--- a/changelogs/fragments/52574-postgresql_privs-add_warn_if_role_not_exist.yml
+++ b/changelogs/fragments/52574-postgresql_privs-add_warn_if_role_not_exist.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_privs - change fail to warn if PostgreSQL role does not exist (https://github.com/ansible/ansible/issues/46168).

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -300,8 +300,7 @@ def role_exists(module, cursor, rolname):
     query = "SELECT 1 FROM pg_roles WHERE rolname = '%s'" % rolname
     try:
         cursor.execute(query)
-        if cursor.rowcount > 0:
-            return True
+        return cursor.rowcount > 0
 
     except Exception as e:
         module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
@@ -567,6 +566,9 @@ class Connection(object):
                 else:
                     for_whom.append(pg_quote_identifier(r, 'role'))
 
+            if not for_whom:
+                return False
+
             for_whom = ','.join(for_whom)
 
         status_before = get_status(objs)
@@ -798,7 +800,6 @@ def main():
         else:
             roles = p.roles.split(',')
 
-        if roles != 'PUBLIC':
             if len(roles) == 1 and not role_exists(module, conn.cursor, roles[0]):
                 module.warn("Role '%s' does not exist, nothing to do" % roles[0].strip())
                 module.exit_json(changed=False)

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -294,6 +294,7 @@ VALID_DEFAULT_OBJS = {'TABLES': ('ALL', 'SELECT', 'INSERT', 'UPDATE', 'DELETE', 
 class Error(Exception):
     pass
 
+
 def role_exists(module, cursor, rolname):
     """Check user exists or not"""
     query = "SELECT 1 FROM pg_roles WHERE rolname = '%s'" % rolname
@@ -306,6 +307,7 @@ def role_exists(module, cursor, rolname):
         module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
 
     return False
+
 
 # We don't have functools.partial in Python < 2.5
 def partial(f, *args, **kwargs):


### PR DESCRIPTION
##### SUMMARY
To solve the problem from https://github.com/ansible/ansible/issues/46168
Shortly, If you pass not existing role(s) to the module, it fails during execution with "role doesn't exist" error.
I changed this behavior in this PR to warning message and continuing execution. 
If one role is passed, it warns and exit with changed false.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_privs
##### EXAMPLE

If passed roles do not exist, the module won't fail, just show the warning:
```
TASK [postgresql_privs] 
 [WARNING]: Role 'hellooooo' does not exist, pass it

 [WARNING]: Role 'yahooo' does not exist, pass it

ok: [spblnx125]

PLAY RECAP *******************************************
testdb                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0   
```
Similarly, if a single role is passed and it doesn't exist:
```
TASK [postgresql_privs] ******************************
 [WARNING]: Role 'yahooo' does not exist, nothing to do
ok: [spblnx125]

PLAY RECAP **********************************************
testdb                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```