### PR TITLE
Red Hat Satellite subscription module

### DIFF
--- a/lib/ansible/module_utils/satellite.py
+++ b/lib/ansible/module_utils/satellite.py
@@ -41,13 +41,14 @@ def request(module, url, pagination=False, params=None):
     per_page = 200
     if not params:
         params = dict()
+        req_url = url
     if params != {} or pagination:
         params.update(page=1, per_page=per_page, paged=True)
+        req_url = '{0}?{1}'.format(url, urlencode(params))
 
     results = []
     done = 0
-    url = '{0}?{1}'.format(url, urlencode(params))
-    resp, info = fetch_url(module, url, timeout=timeout)
+    resp, info = fetch_url(module, req_url, timeout=timeout)
     if info["status"] == 200:
         response = json.loads(resp.read())
     else:
@@ -61,8 +62,8 @@ def request(module, url, pagination=False, params=None):
             while done < response["subtotal"]:
                 response = None
                 params["page"] += 1
-                url = '{0}?{1}'.format(url, urlencode(params))
-                resp, info = fetch_url(module, url, timeout=timeout)
+                req_url = '{0}?{1}'.format(url, urlencode(params))
+                resp, info = fetch_url(module, req_url, timeout=timeout)
                 if info["status"] == 200:
                     response = json.loads(resp.read())
                     results.extend(response["results"])

--- a/lib/ansible/module_utils/satellite.py
+++ b/lib/ansible/module_utils/satellite.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 # (c) 2018, Luc Stroobant (luc.stroobant@wdc.com)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -60,14 +57,14 @@ def request(url, user, password, verify=True, pagination=False, params={}):
         items.extend(response["results"])
         if response["subtotal"]:
             while done < response["subtotal"]:
-                    response = None
-                    params["page"] += 1
-                    req = requests.get(url, timeout=60, verify=verify, params=params,
-                                       auth=HTTPBasicAuth(user, password))
-                    req.raise_for_status()
-                    response = req.json()
-                    items.extend(response["results"])
-                    done += per_page
+                response = None
+                params["page"] += 1
+                req = requests.get(url, timeout=60, verify=verify, params=params,
+                                   auth=HTTPBasicAuth(user, password))
+                req.raise_for_status()
+                response = req.json()
+                items.extend(response["results"])
+                done += per_page
     # not pagination: just return the response
     else:
         return response

--- a/lib/ansible/module_utils/satellite.py
+++ b/lib/ansible/module_utils/satellite.py
@@ -15,7 +15,7 @@ except ImportError:
     requests_available = False
 
 
-def host_list(sat_url, user, password, org, verify, content_host=None):
+def host_list(sat_url, user, password, org, validate_certs, content_host=None):
     """Get a list of hosts from the satellite"""
 
     apicall = "{0}/api/hosts".format(sat_url)
@@ -32,12 +32,12 @@ def host_list(sat_url, user, password, org, verify, content_host=None):
             # treat other patterns as hostnames
             params["search"] = "name={0}".format(content_host)
 
-    hosts = request(apicall, user, password, verify, True, params)
+    hosts = request(apicall, user, password, validate_certs, True, params)
 
     return hosts
 
 
-def request(url, user, password, verify=True, pagination=False, params=None):
+def request(url, user, password, validate_certs=True, pagination=False, params=None):
     """"Execute a Satellite GET API request"""
 
     per_page = 200
@@ -50,7 +50,7 @@ def request(url, user, password, verify=True, pagination=False, params=None):
 
     items = []
     done = 0
-    req = requests.get(url, timeout=60, verify=verify, params=params,
+    req = requests.get(url, timeout=60, verify=validate_certs, params=params,
                        auth=HTTPBasicAuth(user, password))
     req.raise_for_status()
     response = req.json()
@@ -63,7 +63,7 @@ def request(url, user, password, verify=True, pagination=False, params=None):
             while done < response["subtotal"]:
                 response = None
                 params["page"] += 1
-                req = requests.get(url, timeout=60, verify=verify, params=params,
+                req = requests.get(url, timeout=60, verify=validate_certs, params=params,
                                    auth=HTTPBasicAuth(user, password))
                 req.raise_for_status()
                 response = req.json()
@@ -76,10 +76,10 @@ def request(url, user, password, verify=True, pagination=False, params=None):
     return items
 
 
-def put(url, user, password, data, verify=True):
+def put(url, user, password, data, validate_certs=True):
     """"Execute a Satellite PUT API request"""
 
-    req = requests.put(url, timeout=60, verify=verify, json=data,
+    req = requests.put(url, timeout=60, verify=validate_certs, json=data,
                        auth=HTTPBasicAuth(user, password))
     req.raise_for_status()
 

--- a/lib/ansible/module_utils/satellite.py
+++ b/lib/ansible/module_utils/satellite.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, Luc Stroobant (luc.stroobant@wdc.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+try:
+    import requests
+    from requests.auth import HTTPBasicAuth
+    requests.packages.urllib3.disable_warnings()
+    requests_available = True
+except ImportError:
+    requests_available = False
+
+
+def host_list(sat_url, user, password, org, verify, content_host=None):
+    """Get a list of hosts from the satellite"""
+
+    apicall = "{}/api/hosts".format(sat_url)
+    params = dict(
+        organization_id=org,
+        sort_by="name",
+        sort_order="ASC"
+    )
+    if content_host:
+        if '=' in content_host:
+            # this is a already a search query, don't search for hostnames
+            params["search"] = str(content_host)
+        else:
+            # treat other patterns as hostnames
+            params["search"] = "name={}".format(content_host)
+
+    hosts = request(apicall, user, password, verify, True, params)
+
+    return hosts
+
+
+def request(url, user, password, verify=True, pagination=False, params={}):
+    """"Execute a Satellite GET API request"""
+
+    per_page = 200
+    if params != {} or pagination:
+        params["page"] = 1
+        params["paged"] = True
+        params["per_page"] = per_page
+
+    items = []
+    done = 0
+    req = requests.get(url, timeout=60, verify=verify, params=params,
+                       auth=HTTPBasicAuth(user, password))
+    req.raise_for_status()
+    response = req.json()
+
+    done += per_page
+    # pagination: check if we need more requests
+    if pagination:
+        items.extend(response["results"])
+        if response["subtotal"]:
+            while done < response["subtotal"]:
+                    response = None
+                    params["page"] += 1
+                    req = requests.get(url, timeout=60, verify=verify, params=params,
+                                       auth=HTTPBasicAuth(user, password))
+                    req.raise_for_status()
+                    response = req.json()
+                    items.extend(response["results"])
+                    done += per_page
+    # not pagination: just return the response
+    else:
+        return response
+
+    return items
+
+
+def put(url, user, password, data, verify=True):
+    """"Execute a Satellite PUT API request"""
+
+    req = requests.put(url, timeout=60, verify=verify, json=data,
+                       auth=HTTPBasicAuth(user, password))
+    req.raise_for_status()
+
+    return req.json()

--- a/lib/ansible/module_utils/satellite.py
+++ b/lib/ansible/module_utils/satellite.py
@@ -16,7 +16,7 @@ except ImportError:
 def host_list(sat_url, user, password, org, verify, content_host=None):
     """Get a list of hosts from the satellite"""
 
-    apicall = "{}/api/hosts".format(sat_url)
+    apicall = "{0}/api/hosts".format(sat_url)
     params = dict(
         organization_id=org,
         sort_by="name",
@@ -28,17 +28,19 @@ def host_list(sat_url, user, password, org, verify, content_host=None):
             params["search"] = str(content_host)
         else:
             # treat other patterns as hostnames
-            params["search"] = "name={}".format(content_host)
+            params["search"] = "name={0}".format(content_host)
 
     hosts = request(apicall, user, password, verify, True, params)
 
     return hosts
 
 
-def request(url, user, password, verify=True, pagination=False, params={}):
+def request(url, user, password, verify=True, pagination=False, params=None):
     """"Execute a Satellite GET API request"""
 
     per_page = 200
+    if not params:
+        params = dict()
     if params != {} or pagination:
         params["page"] = 1
         params["paged"] = True

--- a/lib/ansible/module_utils/satellite.py
+++ b/lib/ansible/module_utils/satellite.py
@@ -1,4 +1,6 @@
-# (c) 2018, Luc Stroobant (luc.stroobant@wdc.com)
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Luc Stroobant <luc.stroobant@wdc.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -30,19 +30,22 @@ options:
   hostname:
     description:
       - The name or IP address of the Red Hat Satellite server.
-      type: str
+    type: str
     required: yes
   user:
     description:
       - Satellite server user.
+    type: str
     required: yes
   password:
     description:
       - Satellite server password.
+    type: str
     required: yes
   org_id:
     description:
       - Satellite organization ID to work on
+    type: int
     required: yes
   state:
     description:
@@ -55,13 +58,14 @@ options:
          remove all other subscriptions assigned to the guests. Useful if you configured a VDC
          subscription on a hypervisor that didn't have it before."
       - "optimize: use to replace subscriptions on physical servers with a higher multiplier with subscriptions with a lower multiplier."
+    type: str
     choices: [absent, autoattach, disable_autoattach, optimize, present, vdcguests]
     default: autoattach
   content_hosts:
     description:
       - A list of content hosts to use.
       - This can also be a hostname search pattern accepted by the satellite.
-      type: list
+    type: list
   subscription:
     description:
       - List of subscriptions to assign or remove
@@ -69,6 +73,7 @@ options:
       - "This field is used for the search for subscriptions, it can contain (part of) the subscription
          name, eg 'Red Hat Enterprise Linux Server Entry Level, Self-support' or another search query
          as used in the satellite, eg: 'product_id=RH00005S'"
+    type: list
   unique:
     description:
      - Whether to remove all subscriptions to this host.
@@ -163,16 +168,11 @@ EXAMPLES = """
 """
 
 RETURN = """
-stdout:
+msg:
   description: The result of the requested action
   returned: success
   type: str
   sample: Subscription assigned
-stderr:
-  description: Errors when trying to execute action
-  returned: success
-  type: str
-  sample: Authentication failed
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -437,7 +437,7 @@ def main():
                         # skip to next host
                         break
 
-    module.exit_json(changed=changed, data=result, stderr=errors)
+    module.exit_json(changed=changed, msg=result)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -16,7 +16,7 @@ DOCUMENTATION = """
 module: satellite_subscription
 short_description: Manage host subscriptions (licenses) on Red Hat Satellite
 description:
-  - This module allows to assign or remove subscriptions to hosts in the satellite
+  - This module allows to assign or remove subscriptions to hosts in Red Hat Satellite.
   - It works on the Satellite side, so not from the client side like redhat_subscription.
     Your hosts or hypervisors should be in the Satellite already. The module will run subscription
     related tasks (assign, remove, autoattach or replace with hypervisor subscriptions) for the

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -30,6 +30,7 @@ options:
   hostname:
     description:
       - The name or IP address of the Red Hat Satellite server.
+      type: str
     required: yes
   user:
     description:
@@ -58,8 +59,9 @@ options:
     default: autoattach
   content_hosts:
     description:
-      - List of content hosts to work with
-      - Can also be a hostname search pattern accepted by the satellite.
+      - A list of content hosts to use.
+      - This can also be a hostname search pattern accepted by the satellite.
+      type: list
   subscription:
     description:
       - List of subscriptions to assign or remove
@@ -133,7 +135,7 @@ EXAMPLES = """
     content_hosts: server1
     org_id: 1
 
-- name: assign VDC guest subscriptions to Satellite content hosts
+- name: Assign VDC guest subscriptions to Satellite content hosts
   satellite_subscription:
     hostname: satellite.domain.local
     user: admin

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = """
 ---
 module: satellite_subscription
-short_description: Red Hat Satellite subcription (license) mangement module
+short_description: Manage host subscriptions (licenses) on Red Hat Satellite
 description:
   - This module allows to assign or remove subscriptions to hosts in the satellite
   - It works on the Satellite side, so not from the client side like redhat_subscription.

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -17,7 +17,7 @@ module: satellite_subscription
 short_description: Manage host subscriptions (licenses) on Red Hat Satellite
 description:
   - This module allows to assign or remove subscriptions to hosts in Red Hat Satellite.
-  - It works on the Satellite side, so not from the client side like redhat_subscription.
+  - It operates using the Red Hat Satellite REST API, rather than make changes directly to target systems like M(redhat_subscription).
     Your hosts or hypervisors should be in the Satellite already. The module will run subscription
     related tasks (assign, remove, autoattach or replace with hypervisor subscriptions) for the
     hosts through the Satellite API.
@@ -29,7 +29,7 @@ author:
 options:
   satellite_hostname:
     description:
-      - Red Hat Satelite server (6.x) hostname
+      - The name or IP address of the Red Hat Satellite server.
     required: true
   username:
     description:
@@ -69,9 +69,10 @@ options:
          as used in the satellite, eg: 'product_id=RH00005S'"
   unique:
     description:
-     - Set to true to remove all other subscriptions attached to the host
+     - Whether to remove all subscriptions to this host.
+     - When set to C(yes) remove all other subscriptions attached to this host.
     type: bool
-    default: False
+    default: no
   verify_ssl:
     description:
       - Check ssl certificates?
@@ -91,7 +92,7 @@ EXAMPLES = """
       - product_id=RH000XX
       - name=EPEL
       - name=Extra
-    unique: true
+    unique: yes
     organization: 1
   delegate_to: localhost
 
@@ -263,15 +264,15 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            satellite_hostname=dict(required=True),
+            satellite_hostname=dict(type='str', required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),
             organization=dict(required=True, type=int),
             state=dict(
                 default="autoattach",
-                choices=["present", "absent", "autoattach", "disable_autoattach", "vdcguests", "optimize"],
+                choices=['absent', 'autoattach', 'disable_autoattach', 'optimize', 'present', 'vdcguests'],
             ),
-            content_host=dict(type=list, required=True),
+            content_host=dict(type='list', required=True),
             subscription=dict(type=list),
             unique=dict(type='bool', default=False),
             verify_ssl=dict(type='bool', default=True),

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -1,0 +1,436 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2019, Luc Stroobant (luc.stroobant@wdc.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+
+DOCUMENTATION = """
+---
+module: satellite_subscription
+short_description: Red Hat Satellite subcription (license) mangement module
+description:
+  - This module allows to assign or remove subscriptions to hosts in the satellite
+  - It works on the Satellite side, so not from the client side like redhat_subscription.
+    Your hosts or hypervisors should be in the Satellite already. The module will run subscription
+    related tasks (assign, remove, autoattach or replace with hypervisor subscriptions) for the
+    hosts through the Satellite API.
+version_added: "2.7"
+requirements:
+  - requests
+author:
+  - Luc Stroobant (@stroobl)
+options:
+  satellite_hostname:
+    description:
+      - Red Hat Satelite server (6.x) hostname
+    required: true
+  username:
+    description:
+      - Satellite server username
+    required: true
+  password:
+    description:
+      - Satellite server password
+    required: true
+  organization:
+    description:
+      - Satellite organization ID to work on
+    required: true
+  state:
+    description:
+      - "present: assign a subscription of subscription_type to host"
+      - "absent: remove subscription of subscription_type from host"
+      - "autoattach: run subscription autoattach for host (autoattach will be enabled if necessary)"
+      - "disable_autoattach: disable subscription autoattach for host"
+      - "vdcguests: remove all Red Hat subscriptions from a hypervisor's guests and run autoattach to replace them with virtual guest subscriptions. Run this against a virt-who hypervisor to remove all other subscriptions assigned to the guests. Useful if you configured a VDC subscription on a hypervisor that didn't have it before."
+      - "optimize: use to replace subscriptions on physical servers with a higher multiplier with subscriptions with a lower multiplier."
+    choices: [present, absent, autoattach, disable_autoattach, vdcguests, optimize]
+    default: autoattach
+  content_host:
+    description:
+      - List of content hosts to work with
+      - Can also be a hostname search pattern accepted by the satellite.
+  subscription:
+    description:
+      - List of subscriptions to assign or remove
+      - Required when action is assign or remove
+      - "This field is used for the search for subscriptions, it can contain (part of) the subscription name, eg 'Red Hat Enterprise Linux Server Entry Level, Self-support' or another search query as used in the satellite, eg: 'product_id=RH00005S'"
+  unique:
+    description:
+     - Set to true to remove all other subscriptions attached to the host
+    type: bool
+    default: False
+  verify_ssl:
+    description:
+      - Check ssl certificates?
+    type: bool
+    default: True
+"""
+
+EXAMPLES = """
+- name: Assign subscriptions, remove all existing subscriptions (run against localhost)
+  satellite_subscription:
+    satellite_hostname: "{{ satellite_fqdn }}"
+    username: "{{ satellite_admin_user }}"
+    password: "{{ satellite_admin_pass }}"
+    state: present
+    content_host: "{{ groups.rhel_servers }}"
+    subscription:
+      - product_id=RH000XX
+      - name=EPEL
+      - name=Extra
+    unique: True
+    organization: 1
+  delegate_to: localhost
+
+- name: Assign subscriptions rhel servers, remove all existing subscriptions (run against inventory hosts/group)
+  satellite_subscription:
+    satellite_hostname: "{{ satellite_fqdn }}"
+    username: "{{ satellite_admin_user }}"
+    password: "{{ satellite_admin_pass }}"
+    state: present
+    content_host:
+      - "{{ inventory_hostname }}"
+    subscription: "{{ redhat_subscriptions }}"
+    unique: True
+    organization: 1
+  delegate_to: localhost
+
+- name: remove a subscription from hosts
+  satellite_subscription:
+    satellite_hostname: "{{ satellite_fqdn }}"
+    username: "{{ satellite_admin_user }}"
+    password: "{{ satellite_admin_pass }}"
+    state: absent
+    content_host:
+      - server1
+      - server2
+    subscription:
+      - "Red Hat Enterprise Linux Server Entry Level, Self-support"
+    organization: 1
+
+- name: run auto-attach for a host
+  satellite_subscription:
+    satellite_hostname: "{{ satellite_fqdn }}"
+    username: "{{ satellite_admin_user }}"
+    password: "{{ satellite_admin_pass }}"
+    state: autoattach
+    content_host: server1
+    organization: 1
+
+- name: assign VDC guest subscriptions to Satellite content hosts
+  satellite_subscription:
+    satellite_hostname: "{{ satellite_fqdn }}"
+    username: "{{ satellite_admin_user }}"
+    password: "{{ satellite_admin_pass }}"
+    state: vdcguests
+    content_host:
+      - "{{ inventory_hostname }}"
+    organization: "{{ satellite_organization_id }}"
+    verify_ssl: "{{ satellite_verify_ssl }}"
+  delegate_to: localhost
+
+- name: Optimize by replacing multiple entitlements from subscription_id 242 with the new subscription (no changes on hosts consuming a single entitlement)
+  satellite_subscription:
+    satellite_hostname: "{{ satellite_fqdn }}"
+    username: "{{ satellite_admin_user }}"
+    password: "{{ satellite_admin_pass }}"
+    state: optimize
+    content_host:
+      - "subscription_id=242"
+    subscription:
+      - "Red Hat Enterprise Linux Server Entry Level, Self-support"
+    organization: "{{ satellite_organization_id }}"
+    verify_ssl: "{{ satellite_verify_ssl }}"
+  delegate_to: localhost
+"""
+
+RETURN = """
+stdout:
+  description: The result of the requested action
+  returned: success
+  type: str
+  sample: Subscription assigned
+stderr:
+  description: Errors when trying to execute action
+  returned: success
+  type: str
+  sample: Authentication failed
+"""
+
+from ansible.module_utils import six
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.satellite import requests_available, request, host_list, put
+
+if not requests_available:
+    module.fail_json(msg="Library 'requests' is required.")
+
+
+def subscription_assign(sat_url, user, password, matched_subscriptions, host, module, verify):
+
+    result = []
+    error = False
+    # check for available subsciptions in our list(s)
+    for subsearch in matched_subscriptions:
+        available_subscription = None
+        for sub in matched_subscriptions[subsearch]:
+            if sub["available"] != 0:
+                # subscription found: stop searching
+                available_subscription = dict(sub)
+                break
+        if not available_subscription:
+            result.append(
+                "Errors: Sorry, no more subscriptions available of this type. Please adjust your subscription search."
+            )
+            error = True
+            break
+
+        # format json data for request
+        data = {"id": host["id"], "subscriptions": [{"id": available_subscription["id"], "quantity": 1}]}
+
+        # attach the available subscription to this host
+        apicall = "{}/api/hosts/{}/subscriptions/add_subscriptions".format(sat_url, host["id"])
+        put(apicall, user, password, data, verify)
+
+        result.append([host["name"], "Assigned: {}".format(sub["name"])])
+
+    return result, error
+
+
+def subscription_search(sat_url, user, password, org, subscription, module, verify):
+    """Search for subscriptions and return them"""
+
+    matched_subscriptions = {}
+    for subsearch in subscription:
+        # only search for normal subscriptions to avoid returning assigned ones
+        params = {"search": "type=NORMAL and ({})".format(subsearch)}
+        apicall = "{}/katello/api/organizations/{}/subscriptions".format(sat_url, org)
+        matched_subscriptions[subsearch] = request(apicall, user, password, verify, True, params)
+        if matched_subscriptions[subsearch] == []:
+            errors = "Sorry, no subscriptions matched. Please adjust your subscription search"
+            module.fail_json(msg=errors)
+
+    return matched_subscriptions
+
+
+def subscription_remove(sat_url, user, password, host, sub, verify):
+    """Remove a subscription from a host"""
+
+    apicall = "{}/api/hosts/{}/subscriptions/remove_subscriptions".format(sat_url, host["id"])
+    data = {"id": host["id"], "subscriptions": [{"id": sub["id"], "quantity": sub["quantity_consumed"]}]}
+    result = put(apicall, user, password, data, verify)
+
+    return result
+
+
+def subscription_configure_autoattach(sat_url, user, password, host, autoheal, verify):
+    """Configure autoattach for a host (autoheal = bool)"""
+    data = {
+        "id": host["id"],
+        "subscription_facet_attributes": {
+            "autoheal": autoheal,
+            "id": host["subscription_facet_attributes"]["id"],
+            "release_version": "",
+            "service_level": "",
+        },
+    }
+    apicall = "{}/api/hosts/{}".format(sat_url, host["id"])
+    req = put(apicall, user, password, data, verify)
+
+    return req
+
+
+def subscription_autoattach(sat_url, user, password, host, verify):
+    """Run subscription autoattach for host"""
+
+    data = {"id": host["id"]}
+    apicall = "{}/api/hosts/{}/subscriptions/auto_attach".format(sat_url, host["id"])
+    req = put(apicall, user, password, data, verify)
+
+    return req["results"]
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            satellite_hostname=dict(required=True),
+            username=dict(required=True),
+            password=dict(required=True, no_log=True),
+            organization=dict(required=True, type=int),
+            state=dict(
+                default="autoattach",
+                choices=["present", "absent", "autoattach", "disable_autoattach", "vdcguests", "optimize"],
+            ),
+            content_host=dict(type=list, required=True),
+            subscription=dict(type=list),
+            unique=dict(type=bool, default=False),
+            verify_ssl=dict(type=bool, default=True),
+        ),
+        supports_check_mode=False,
+    )
+
+    sat = module.params["satellite_hostname"]
+    state = module.params["state"]
+    user = module.params["username"]
+    password = module.params["password"]
+    org = module.params["organization"]
+    content_host = module.params["content_host"]
+    subscription = module.params["subscription"]
+    unique = module.params["unique"]
+    verify = module.params["verify_ssl"]
+
+    errors = None
+    changed = False
+    result = []
+
+    sat_url = "https://{}".format(sat)
+
+    # get the list of hosts to work on
+    hosts = []
+    for ch in content_host:
+        hl = host_list(sat_url, user, password, org, verify, ch)
+        hosts.extend(hl)
+
+    if state == "autoattach":
+        for host in hosts:
+            # run auto attach if enabled
+            if host["subscription_facet_attributes"]["autoheal"]:
+                subs = subscription_autoattach(sat_url, user, password, host, verify)
+                result.append("Triggered auto-attach run, attached subscriptions:")
+                for sub in subs:
+                    result.append(sub["product_name"])
+                changed = True
+            # or enable and run auto attach if disabled
+            else:
+                subscription_configure_autoattach(sat_url, user, password, host, True, verify)
+                subs = subscription_autoattach(sat_url, user, password, host, verify)
+                result.append("Enabled and triggered auto-attach run, attached subscriptions:")
+                for sub in subs:
+                    result.append(sub["product_name"])
+                changed = True
+
+    if state == "disable_autoattach":
+        for host in hosts:
+            if host["subscription_facet_attributes"]["autoheal"]:
+                subscription_configure_autoattach(sat_url, user, password, host, False, verify)
+                result.append("Auto-attach disabled")
+                changed = True
+            else:
+                result.append("Auto-attach already disabled")
+
+    elif state == "present":
+
+        # loop over hosts to assign
+        for host in hosts:
+
+            if unique:
+                # get existing subscriptions on host
+                apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, host["id"])
+                hostsubs = request(apicall, user, password, verify)
+                # and remove them
+                for sub in hostsubs["results"]:
+                    subscription_remove(sat_url, user, password, host, sub, verify)
+                    result.append([host["name"], "Removed: {}".format(sub["name"])])
+
+            # search for our subscriptions
+            matched_subscriptions = subscription_search(sat_url, user, password, org, subscription, module, verify)
+
+            # assign the free subscription(s) to host
+            res, error = subscription_assign(sat_url, user, password, matched_subscriptions, host, module, verify)
+            result.append(res)
+            if not error:
+                changed = True
+            else:
+                module.fail_json(msg=result)
+
+    elif state == "absent":
+        # loop over hosts to remove
+        for host in hosts:
+            # get existing subscriptions on host
+            apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, host["id"])
+            hostsubs = request(apicall, user, password, verify)
+            for sub in hostsubs["results"]:
+                for subsearch in subscription:
+                    if "=" in subsearch:
+                        # this is a search with a key, get the key and value
+                        (key, value) = subsearch.split("=")
+                        if value in sub[key]:
+                            subscription_remove(sat_url, user, password, host, sub, verify)
+                            result.append([host["name"], "Removed: {}".format(sub["name"])])
+                            changed = True
+                    else:
+                        # only match on name if no key is given
+                        if subsearch in sub["name"]:
+                            subscription_remove(sat_url, user, password, host, sub, verify)
+                            result.append([host["name"], "Removed: {}".format(sub["name"])])
+                            changed = True
+
+    elif state == "vdcguests":
+        # loop over hypervisors
+        for host in hosts:
+            # request detailed info for host
+            apicall = "{}/api/hosts/{}".format(sat_url, host["id"])
+            host_info = request(apicall, user, password, verify, False)
+            # loop over guests on hypervisor
+            for guest in host_info["subscription_facet_attributes"]["virtual_guests"]:
+                # get existing guest subscriptions
+                apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, guest["id"])
+                guest_subs = request(apicall, user, password, verify)
+                # remove existing Red Hat subscriptions, except the ones from the hypervisor
+                for sub in guest_subs["results"]:
+                    if "hypervisor" not in sub and sub["account_number"]:
+                        subscription_remove(sat_url, user, password, guest, sub, verify)
+                        result.append([guest["name"], "removed: {}".format(sub["name"])])
+                # run autoattach
+                subscription_autoattach(sat_url, user, password, guest, verify)
+
+    elif state == "optimize":
+        # loop over hosts
+        for host in hosts:
+            # skip virtual machines - TODO only tested with VMware ("VMware Virtual Platform")
+            if host["model_name"] and "Virtual" in host["model_name"]:
+                continue
+            else:
+                # get existing subscriptions on host
+                apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, host["id"])
+                hostsubs = request(apicall, user, password, verify)
+                for sub in hostsubs["results"]:
+                    # remove subscription if it's using an entitlment per socket
+                    if (
+                        sub["account_number"]
+                        and sub["sockets"] != "1"
+                        and sub["quantity_consumed"] == int(sub["sockets"])
+                    ):
+                        # search for our subscriptions
+                        matched_subscriptions = subscription_search(
+                            sat_url, user, password, org, subscription, module, verify
+                        )
+                        # assign the free subscription(s) to host
+                        res, error = subscription_assign(
+                            sat_url, user, password, matched_subscriptions, host, module, verify
+                        )
+                        result.append(res)
+                        if not error:
+                            changed = True
+                        else:
+                            module.fail_json(msg=result)
+                        # remove the original subscription
+                        subscription_remove(sat_url, user, password, host, sub, verify)
+                        result.append([host["name"], "Removed: {} {}".format(sub["quantity_consumed"], sub["name"])])
+                        changed = True
+                        # skip to next host
+                        break
+
+    module.exit_json(changed=changed, data=result, stderr=errors)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -91,7 +91,7 @@ EXAMPLES = """
       - product_id=RH000XX
       - name=EPEL
       - name=Extra
-    unique: True
+    unique: true
     organization: 1
   delegate_to: localhost
 
@@ -104,7 +104,7 @@ EXAMPLES = """
     content_host:
       - "{{ inventory_hostname }}"
     subscription: "{{ redhat_subscriptions }}"
-    unique: True
+    unique: true
     organization: 1
   delegate_to: localhost
 
@@ -198,10 +198,10 @@ def subscription_assign(sat_url, user, password, matched_subscriptions, host, mo
         data = {"id": host["id"], "subscriptions": [{"id": available_subscription["id"], "quantity": 1}]}
 
         # attach the available subscription to this host
-        apicall = "{}/api/hosts/{}/subscriptions/add_subscriptions".format(sat_url, host["id"])
+        apicall = "{0}/api/hosts/{1}/subscriptions/add_subscriptions".format(sat_url, host["id"])
         put(apicall, user, password, data, verify)
 
-        result.append([host["name"], "Assigned: {}".format(sub["name"])])
+        result.append([host["name"], "Assigned: {0}".format(sub["name"])])
 
     return result, error
 
@@ -212,8 +212,8 @@ def subscription_search(sat_url, user, password, org, subscription, module, veri
     matched_subscriptions = {}
     for subsearch in subscription:
         # only search for normal subscriptions to avoid returning assigned ones
-        params = {"search": "type=NORMAL and ({})".format(subsearch)}
-        apicall = "{}/katello/api/organizations/{}/subscriptions".format(sat_url, org)
+        params = {"search": "type=NORMAL and ({0})".format(subsearch)}
+        apicall = "{0}/katello/api/organizations/{1}/subscriptions".format(sat_url, org)
         matched_subscriptions[subsearch] = request(apicall, user, password, verify, True, params)
         if matched_subscriptions[subsearch] == []:
             errors = "Sorry, no subscriptions matched. Please adjust your subscription search"
@@ -225,7 +225,7 @@ def subscription_search(sat_url, user, password, org, subscription, module, veri
 def subscription_remove(sat_url, user, password, host, sub, verify):
     """Remove a subscription from a host"""
 
-    apicall = "{}/api/hosts/{}/subscriptions/remove_subscriptions".format(sat_url, host["id"])
+    apicall = "{0}/api/hosts/{1}/subscriptions/remove_subscriptions".format(sat_url, host["id"])
     data = {"id": host["id"], "subscriptions": [{"id": sub["id"], "quantity": sub["quantity_consumed"]}]}
     result = put(apicall, user, password, data, verify)
 
@@ -243,7 +243,7 @@ def subscription_configure_autoattach(sat_url, user, password, host, autoheal, v
             "service_level": "",
         },
     }
-    apicall = "{}/api/hosts/{}".format(sat_url, host["id"])
+    apicall = "{0}/api/hosts/{1}".format(sat_url, host["id"])
     req = put(apicall, user, password, data, verify)
 
     return req
@@ -253,7 +253,7 @@ def subscription_autoattach(sat_url, user, password, host, verify):
     """Run subscription autoattach for host"""
 
     data = {"id": host["id"]}
-    apicall = "{}/api/hosts/{}/subscriptions/auto_attach".format(sat_url, host["id"])
+    apicall = "{0}/api/hosts/{1}/subscriptions/auto_attach".format(sat_url, host["id"])
     req = put(apicall, user, password, data, verify)
 
     return req["results"]
@@ -296,7 +296,7 @@ def main():
     changed = False
     result = []
 
-    sat_url = "https://{}".format(sat)
+    sat_url = "https://{0}".format(sat)
 
     # get the list of hosts to work on
     hosts = []
@@ -338,12 +338,12 @@ def main():
 
             if unique:
                 # get existing subscriptions on host
-                apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, host["id"])
+                apicall = "{0}/api/hosts/{1}/subscriptions".format(sat_url, host["id"])
                 hostsubs = request(apicall, user, password, verify)
                 # and remove them
                 for sub in hostsubs["results"]:
                     subscription_remove(sat_url, user, password, host, sub, verify)
-                    result.append([host["name"], "Removed: {}".format(sub["name"])])
+                    result.append([host["name"], "Removed: {0}".format(sub["name"])])
 
             # search for our subscriptions
             matched_subscriptions = subscription_search(sat_url, user, password, org, subscription, module, verify)
@@ -360,7 +360,7 @@ def main():
         # loop over hosts to remove
         for host in hosts:
             # get existing subscriptions on host
-            apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, host["id"])
+            apicall = "{0}/api/hosts/{1}/subscriptions".format(sat_url, host["id"])
             hostsubs = request(apicall, user, password, verify)
             for sub in hostsubs["results"]:
                 for subsearch in subscription:
@@ -369,31 +369,31 @@ def main():
                         (key, value) = subsearch.split("=")
                         if value in sub[key]:
                             subscription_remove(sat_url, user, password, host, sub, verify)
-                            result.append([host["name"], "Removed: {}".format(sub["name"])])
+                            result.append([host["name"], "Removed: {0}".format(sub["name"])])
                             changed = True
                     else:
                         # only match on name if no key is given
                         if subsearch in sub["name"]:
                             subscription_remove(sat_url, user, password, host, sub, verify)
-                            result.append([host["name"], "Removed: {}".format(sub["name"])])
+                            result.append([host["name"], "Removed: {0}".format(sub["name"])])
                             changed = True
 
     elif state == "vdcguests":
         # loop over hypervisors
         for host in hosts:
             # request detailed info for host
-            apicall = "{}/api/hosts/{}".format(sat_url, host["id"])
+            apicall = "{0}/api/hosts/{1}".format(sat_url, host["id"])
             host_info = request(apicall, user, password, verify, False)
             # loop over guests on hypervisor
             for guest in host_info["subscription_facet_attributes"]["virtual_guests"]:
                 # get existing guest subscriptions
-                apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, guest["id"])
+                apicall = "{0}/api/hosts/{1}/subscriptions".format(sat_url, guest["id"])
                 guest_subs = request(apicall, user, password, verify)
                 # remove existing Red Hat subscriptions, except the ones from the hypervisor
                 for sub in guest_subs["results"]:
                     if "hypervisor" not in sub and sub["account_number"]:
                         subscription_remove(sat_url, user, password, guest, sub, verify)
-                        result.append([guest["name"], "removed: {}".format(sub["name"])])
+                        result.append([guest["name"], "removed: {0}".format(sub["name"])])
                 # run autoattach
                 subscription_autoattach(sat_url, user, password, guest, verify)
 
@@ -405,7 +405,7 @@ def main():
                 continue
             else:
                 # get existing subscriptions on host
-                apicall = "{}/api/hosts/{}/subscriptions".format(sat_url, host["id"])
+                apicall = "{0}/api/hosts/{1}/subscriptions".format(sat_url, host["id"])
                 hostsubs = request(apicall, user, password, verify)
                 for sub in hostsubs["results"]:
                     # remove subscription if it's using an entitlment per socket
@@ -429,7 +429,7 @@ def main():
                             module.fail_json(msg=result)
                         # remove the original subscription
                         subscription_remove(sat_url, user, password, host, sub, verify)
-                        result.append([host["name"], "Removed: {} {}".format(sub["quantity_consumed"], sub["name"])])
+                        result.append([host["name"], "Removed: {0} {1}".format(sub["quantity_consumed"], sub["name"])])
                         changed = True
                         # skip to next host
                         break

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -21,7 +21,7 @@ description:
     Your hosts or hypervisors should be in the Satellite already. The module will run subscription
     related tasks (assign, remove, autoattach or replace with hypervisor subscriptions) for the
     hosts through the Satellite API.
-version_added: "2.7"
+version_added: "2.8"
 requirements:
   - requests
 author:
@@ -49,7 +49,10 @@ options:
       - "absent: remove subscription of subscription_type from host"
       - "autoattach: run subscription autoattach for host (autoattach will be enabled if necessary)"
       - "disable_autoattach: disable subscription autoattach for host"
-      - "vdcguests: remove all Red Hat subscriptions from a hypervisor's guests and run autoattach to replace them with virtual guest subscriptions. Run this against a virt-who hypervisor to remove all other subscriptions assigned to the guests. Useful if you configured a VDC subscription on a hypervisor that didn't have it before."
+      - "vdcguests: remove all Red Hat subscriptions from a hypervisor's guests and run autoattach
+         to replace them with virtual guest subscriptions. Run this against a virt-who hypervisor to
+         remove all other subscriptions assigned to the guests. Useful if you configured a VDC
+         subscription on a hypervisor that didn't have it before."
       - "optimize: use to replace subscriptions on physical servers with a higher multiplier with subscriptions with a lower multiplier."
     choices: [present, absent, autoattach, disable_autoattach, vdcguests, optimize]
     default: autoattach
@@ -61,7 +64,9 @@ options:
     description:
       - List of subscriptions to assign or remove
       - Required when action is assign or remove
-      - "This field is used for the search for subscriptions, it can contain (part of) the subscription name, eg 'Red Hat Enterprise Linux Server Entry Level, Self-support' or another search query as used in the satellite, eg: 'product_id=RH00005S'"
+      - "This field is used for the search for subscriptions, it can contain (part of) the subscription
+         name, eg 'Red Hat Enterprise Linux Server Entry Level, Self-support' or another search query
+         as used in the satellite, eg: 'product_id=RH00005S'"
   unique:
     description:
      - Set to true to remove all other subscriptions attached to the host
@@ -169,9 +174,6 @@ from ansible.module_utils import six
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.satellite import requests_available, request, host_list, put
 
-if not requests_available:
-    module.fail_json(msg="Library 'requests' is required.")
-
 
 def subscription_assign(sat_url, user, password, matched_subscriptions, host, module, verify):
 
@@ -271,11 +273,14 @@ def main():
             ),
             content_host=dict(type=list, required=True),
             subscription=dict(type=list),
-            unique=dict(type=bool, default=False),
-            verify_ssl=dict(type=bool, default=True),
+            unique=dict(type='bool', default=False),
+            verify_ssl=dict(type='bool', default=True),
         ),
         supports_check_mode=False,
     )
+
+    if not requests_available:
+        module.fail_json(msg="Library 'requests' is required.")
 
     sat = module.params["satellite_hostname"]
     state = module.params["state"]

--- a/lib/ansible/modules/packaging/os/satellite_subscription.py
+++ b/lib/ansible/modules/packaging/os/satellite_subscription.py
@@ -56,7 +56,7 @@ options:
       - "optimize: use to replace subscriptions on physical servers with a higher multiplier with subscriptions with a lower multiplier."
     choices: [absent, autoattach, disable_autoattach, optimize, present, vdcguests]
     default: autoattach
-  content_host:
+  content_hosts:
     description:
       - List of content hosts to work with
       - Can also be a hostname search pattern accepted by the satellite.
@@ -88,7 +88,7 @@ EXAMPLES = """
     user: admin
     password: adminpass
     state: present
-    content_host: "{{ groups.rhel_servers }}"
+    content_hosts: "{{ groups.rhel_servers }}"
     subscription:
       - product_id=RH000XX
       - name=EPEL
@@ -103,7 +103,7 @@ EXAMPLES = """
     user: admin
     password: adminpass
     state: present
-    content_host:
+    content_hosts:
       - "{{ inventory_hostname }}"
     subscription:
       - "Red Hat Enterprise Linux Server Entry Level, Standard"
@@ -117,7 +117,7 @@ EXAMPLES = """
     user: admin
     password: adminpass
     state: absent
-    content_host:
+    content_hosts:
       - server1
       - server2
     subscription:
@@ -130,7 +130,7 @@ EXAMPLES = """
     user: admin
     password: adminpass
     state: autoattach
-    content_host: server1
+    content_hosts: server1
     org_id: 1
 
 - name: assign VDC guest subscriptions to Satellite content hosts
@@ -139,7 +139,7 @@ EXAMPLES = """
     user: admin
     password: adminpass
     state: vdcguests
-    content_host:
+    content_hosts:
       - "{{ inventory_hostname }}"
     org_id: 1
     validate_certs: false
@@ -151,7 +151,7 @@ EXAMPLES = """
     user: admin
     password: adminpass
     state: optimize
-    content_host:
+    content_hosts:
       - "subscription_id=242"
     subscription:
       - "Red Hat Enterprise Linux Server Entry Level, Self-support"
@@ -273,7 +273,7 @@ def main():
                 type='str', default="autoattach",
                 choices=['absent', 'autoattach', 'disable_autoattach', 'optimize', 'present', 'vdcguests'],
             ),
-            content_host=dict(type='list', required=True),
+            content_hosts=dict(type='list', required=True),
             subscription=dict(type='list'),
             unique=dict(type='bool', default=False),
             validate_certs=dict(type='bool', default=True),
@@ -289,7 +289,7 @@ def main():
     user = module.params["user"]
     password = module.params["password"]
     org = module.params["org_id"]
-    content_host = module.params["content_host"]
+    content_hosts = module.params["content_hosts"]
     subscription = module.params["subscription"]
     unique = module.params["unique"]
     validate_certs = module.params["validate_certs"]
@@ -302,7 +302,7 @@ def main():
 
     # get the list of hosts to work on
     hosts = []
-    for ch in content_host:
+    for ch in content_hosts:
         hl = host_list(sat_url, user, password, org, validate_certs, ch)
         hosts.extend(hl)
 

--- a/lib/ansible/modules/remote_management/satellite/satellite_subscription.py
+++ b/lib/ansible/modules/remote_management/satellite/satellite_subscription.py
@@ -30,18 +30,18 @@ options:
       - The name or IP address of the Red Hat Satellite server.
     type: str
     required: yes
-  user:
+  url_username:
     description:
       - Satellite server user.
     type: str
     required: yes
-    aliases: [url_username]
-  password:
+    aliases: [username]
+  url_password:
     description:
       - Satellite server password.
     type: str
     required: yes
-    aliases: [url_password]
+    aliases: [password]
   org_id:
     description:
       - Satellite organization ID to work on
@@ -269,7 +269,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             hostname=dict(type='str', required=True),
-            url_username=dict(type='str', required=True, aliases=['user']),
+            url_username=dict(type='str', required=True, aliases=['username']),
             url_password=dict(type='str', required=True, no_log=True, aliases=['password']),
             org_id=dict(type='int', required=True),
             state=dict(


### PR DESCRIPTION
##### SUMMARY
This is an Ansible module to manage subscriptions (licenses) for content hosts in a Red Hat Satellite 6 server (Katello). The subscriptions can be assigned with variables in the inventory. The module will search for a free subscription in the pool that matches your search query and assign it to a host. The module can also be used to check if virtual guests only have subscriptions from the hypervisor attached.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
Red Hat Satellite subcription (license) mangement module

##### ADDITIONAL INFORMATION
The satellite.py module_utils file contains functions also used by another Satellite (reporting) module that we want to contribute.
