### PR TITLE
fix ec2 regression when assigning a private IP without a public IP

### DIFF
--- a/changelogs/fragments/ec2_fix_assigning_private_without_public_ip.yml
+++ b/changelogs/fragments/ec2_fix_assigning_private_without_public_ip.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ec2 - if the private_ip has been provided for the new network interface it shouldn't also be added to top level
+    parameters for run_instances()

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1112,7 +1112,7 @@ def create_instances(module, ec2, vpc, override_count=None):
 
             # check to see if we're using spot pricing first before starting instances
             if not spot_price:
-                if assign_public_ip and private_ip:
+                if assign_public_ip is not None and private_ip:
                     params.update(
                         dict(
                             min_count=count_remaining,


### PR DESCRIPTION
If the private_ip has been provided for the new network interface it shouldn't also be added to top level parameters for run_instances

changelog

##### SUMMARY
Fixes #48109. Introduced in #43954 (nice spotting @gamuniz) so this should be backported to 2.7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

