### PR TITLE
Change the retry_files_enabled to False and modify the comments to reflect that this has been disabled

### DIFF
--- a/changelogs/fragments/52581-change-default-behaviour-of-retry_files_enabled.yaml
+++ b/changelogs/fragments/52581-change-default-behaviour-of-retry_files_enabled.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - retry_files_enabled now defaults to False instead of True.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -61,6 +61,12 @@ Command line facts
 ``cmdline`` facts returned in system will be deprecated in favor of ``proc_cmdline``. This change handles special case where Kernel command line parameter
 contains multiple values with the same key.
 
+Retry File Creation default
+---------------------------
+
+In Ansible 2.8, ``retry_files_enabled`` now defaults to ``False`` instead of ``True``.  The behavior can be
+modified to previous version by editing the default ``ansible.cfg`` file and setting the value to ``True``.
+
 Command Line
 ============
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -255,7 +255,7 @@
 # You can enable this feature by setting retry_files_enabled to True
 # and you can change the location of the files by setting retry_files_save_path
 
-retry_files_enabled = False
+#retry_files_enabled = False
 #retry_files_save_path = ~/.ansible-retry
 
 # squash actions

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -251,11 +251,11 @@
 
 
 # retry files
-# When a playbook fails by default a .retry file will be created in ~/
-# You can disable this feature by setting retry_files_enabled to False
+# When a playbook fails a .retry file can be created that will be placed in ~/
+# You can enable this feature by setting retry_files_enabled to True
 # and you can change the location of the files by setting retry_files_save_path
 
-#retry_files_enabled = False
+retry_files_enabled = False
 #retry_files_save_path = ~/.ansible-retry
 
 # squash actions

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1606,7 +1606,7 @@ PYTHON_MODULE_RLIMIT_NOFILE:
   version_added: '2.8'
 RETRY_FILES_ENABLED:
   name: Retry files
-  default: True
+  default: False
   description: This controls whether a failed Ansible playbook should create a .retry file.
   env: [{name: ANSIBLE_RETRY_FILES_ENABLED}]
   ini:


### PR DESCRIPTION

##### SUMMARY
This change modifies the default setting of `retry_files_enabled` to `False` and changes the
comments to reflect this change.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
Changes ansible/examples/ansible.cfg

##### ADDITIONAL INFORMATION
The following
```
# retry files
# When a playbook fails by default a .retry file will be created in ~/
# You can disable this feature by setting retry_files_enabled to False
# and you can change the location of the files by setting retry_files_save_path

#retry_files_enabled = False
#retry_files_save_path = ~/.ansible-retry
```
was changed to:
```
# retry files
# When a playbook fails a .retry file can be created that will be placed in ~/
# You can enable this feature by setting retry_files_enabled to True
# and you can change the location of the files by setting retry_files_save_path

retry_files_enabled = False
#retry_files_save_path = ~/.ansible-retry
```
