### PR TITLE
Fixed win_file crash with hidden files

### DIFF
--- a/changelogs/fragments/win_file-hidden.yaml
+++ b/changelogs/fragments/win_file-hidden.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_file - Fix issue when managing hidden files and directories - https://github.com/ansible/ansible/issues/42466

--- a/lib/ansible/modules/windows/win_file.ps1
+++ b/lib/ansible/modules/windows/win_file.ps1
@@ -102,7 +102,7 @@ if ($state -eq "touch") {
 }
 
 if (Test-Path -LiteralPath $path) {
-    $fileinfo = Get-Item -LiteralPath $path
+    $fileinfo = Get-Item -LiteralPath $path -force
     if ($state -eq "absent") {
         Remove-File -file $fileinfo -checkmode $check_mode
         $result.changed = $true

--- a/lib/ansible/modules/windows/win_file.ps1
+++ b/lib/ansible/modules/windows/win_file.ps1
@@ -102,7 +102,7 @@ if ($state -eq "touch") {
 }
 
 if (Test-Path -LiteralPath $path) {
-    $fileinfo = Get-Item -LiteralPath $path -force
+    $fileinfo = Get-Item -LiteralPath $path -Force
     if ($state -eq "absent") {
         Remove-File -file $fileinfo -checkmode $check_mode
         $result.changed = $true

--- a/test/integration/targets/win_file/tasks/main.yml
+++ b/test/integration/targets/win_file/tasks/main.yml
@@ -570,7 +570,7 @@
 
 # Need to use shell to create the file as win_file doesn't support setting attributes
 - name: create hidden file
-  win_shell: $file = New-Item -Path "{{ win_output_dir }}\hidden.txt" -ItemType File; $file.Attributes += "Hidden"
+  win_shell: $file = New-Item -Path "{{ win_output_dir }}\hidden.txt" -ItemType File; $file.Attributes = "Hidden"
 
 - name: delete hidden file
   win_file:

--- a/test/integration/targets/win_file/tasks/main.yml
+++ b/test/integration/targets/win_file/tasks/main.yml
@@ -568,6 +568,27 @@
        - file_result.changed
        - "stat_result.stat.exists == False"
 
+# Need to use shell to create the file as win_file doesn't support setting attributes
+- name: create hidden file
+  win_shell: $file = New-Item -Path "{{ win_output_dir }}\hidden.txt" -ItemType File; $file.Attributes += "Hidden"
+
+- name: delete hidden file
+  win_file:
+    path: '{{ win_output_dir }}\hidden.txt'
+    state: absent
+  register: delete_hidden
+
+- name: get result of delete hidden file
+  win_stat:
+    path: '{{ win_output_dir }}\hidden.txt'
+  register: delete_hidden_actual
+
+- name: assert delete hidden file
+  assert:
+    that:
+    - delete_hidden is changed
+    - not delete_hidden_actual.stat.exists
+
 - name: create folder to point set symbolic link for
   win_file:
     path: "{{win_output_dir}}/link-test/link-target"


### PR DESCRIPTION
##### SUMMARY
Fixes #42466
Fixes: not getting file info on hidden files
added "-force" parameter on "Get-Item" cmdlet. this is needed to get file info if the file is "hidden" 
without this option modules like win_file, win_template, win_copy crashes on hidden files. this is because with "test-path" it sees that the file exists, but "get-item" can't get the file info. 
for more information on "-force option": https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-item

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_file.ps1

##### ADDITIONAL INFORMATION
found this problem while using "win_template" on a hidden file which gave the following error:
```
failed: [ansibletest.contoso.com] (item={'value': {u'path': u'c:\\programdata\\test', u'file': u'hiddenfile.txt'}, 'key': u'hiddenfile'}) => {
    "changed": false,
    "checksum": "672238a011a121de6be6c0b74f0f9cee2ee707e4",
    "diff": [],
    "item": {
        "key": "hiddenfile",
        "value": {
            "file": "hiddenfile.txt",
            "path": "c:\\programdata\\test"
        }
    },
    "module_stderr": "Exception calling \"Run\" with \"1\" argument(s): \"Exception calling \"Invoke\" with \"0\" argument(s): \"The running command \r\nstopped because the preference variable \"ErrorActionPreference\" or common parameter is set to Stop: Could not find \r\nitem C:\\programdata\\test\\hiddenfile.txt.\"\"\r\nAt line:65 char:5\r\n+     $output = $entrypoint.Run($payload)\r\n+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n    + CategoryInfo
     : NotSpecified: (:) [], ParentContainsErrorRecordException\r\n    + FullyQualifiedErrorId : ScriptMethodRuntimeException\r\n \r\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```

and with the addition of "-force"
```
ok: [ansibletest.contoso.com] =>  (item={'value': {u'path': u'c:\\programdata\\test', u'file': u'hiddenfile.txt'}, 'key': u'hiddenfile'}) => {
    "changed": false,
    "checksum": "672238a011a121de6be6c0b74f0f9cee2ee707e4",
    "diff": [],
    "invocation": {
        "dest": "c:\\programdata\\test\\hiddenfile.txt",
        "follow": false,
        "mode": null,
        "src": "/root/.ansible/tmp/ansible-local-1703mOM36_/tmp2HbTLT/hiddenfile.txt.j2"
    },
    "item": {
        "key": "hiddenfile",
        "value": {
            "file": "hiddenfile.txt",
            "path": "c:\\programdata\\test"
        }
    }
}
```

extra info on the "-force" parameter of "get-item" from Microsoft
```
-Force
Indicates that this cmdlet gets items that cannot otherwise be accessed, such as hidden items. Implementation varies from provider to provider. For more information, see about_Providers. Even using the Force parameter, the cmdlet cannot override security restrictions.
```