### PR TITLE
Allow become_ask_pass from config to work

### DIFF
--- a/lib/ansible/cli/arguments/optparse_helpers.py
+++ b/lib/ansible/cli/arguments/optparse_helpers.py
@@ -328,8 +328,8 @@ def add_runas_prompt_options(parser, runas_group=None):
         runas_group = optparse.OptionGroup(parser, "Privilege Escalation Options",
                                            "control how and which user you become as on target hosts")
 
-    runas_group.add_option('-K', '--ask-become-pass', default=False, dest='become_ask_pass', action='store_true',
-                           help='ask for privilege escalation password')
+    runas_group.add_option('-K', '--ask-become-pass', dest='become_ask_pass', action='store_true',
+                           help='ask for privilege escalation password', default=C.DEFAULT_BECOME_ASK_PASS)
 
     parser.add_option_group(runas_group)
 


### PR DESCRIPTION
##### SUMMARY
Allow become_ask_pass from config to work

In the become plugins PR, we removed `normalize_become_options` which handled this.  Now we need to use `C.DEFAULT_BECOME_ASK_PASS` as a default to the optparse argument.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/arguments/optparse_helpers.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```