### PR TITLE
redhat_subscription: Exempt register vars from shell expansion

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -378,7 +378,7 @@ class Rhsm(RegistrationBase):
         if release:
             args.extend(['--release', release])
 
-        rc, stderr, stdout = self.module.run_command(args, check_rc=True)
+        rc, stderr, stdout = self.module.run_command(args, check_rc=True, expand_user_and_vars=False)
 
     def unsubscribe(self, serials=None):
         '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes  #52585 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redhat_subscription

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Sets shell to true to avoid performing shell expansion on variables to the `subscription-manager register` command

