### PR TITLE
[stable-2.7] Use list instead of tuple and remove md5 on ValueError (#51357)

### DIFF
--- a/changelogs/fragments/51357-module_utils-basic.yml
+++ b/changelogs/fragments/51357-module_utils-basic.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - ansible.module_utils.basic - fix handling of md5 in algorithms tuple for FIPS compatibility (https://github.com/ansible/ansible/issues/51355)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -128,10 +128,12 @@ try:
     for attribute in ('available_algorithms', 'algorithms'):
         algorithms = getattr(hashlib, attribute, None)
         if algorithms:
+            # convert algorithms to list instead of immutable tuple so md5 can be removed if not available
+            algorithms = list(algorithms)
             break
     if algorithms is None:
         # python 2.5+
-        algorithms = ('md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512')
+        algorithms = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
     for algorithm in algorithms:
         AVAILABLE_HASH_ALGORITHMS[algorithm] = getattr(hashlib, algorithm)
 
@@ -139,7 +141,7 @@ try:
     try:
         hashlib.md5()
     except ValueError:
-        algorithms.pop('md5', None)
+        algorithms.remove('md5')
 except Exception:
     import sha
     AVAILABLE_HASH_ALGORITHMS = {'sha1': sha.sha}


### PR DESCRIPTION
##### SUMMARY
Backport of #51357 for Ansible 2.7

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/basic.py`