### PR TITLE
win_chocolatey - fix beta version parsing

### DIFF
--- a/changelogs/fragments/win_chocolatey-beta-versions.yaml
+++ b/changelogs/fragments/win_chocolatey-beta-versions.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_chocolatey - Fix issue when parsing a beta Chocolatey install - https://github.com/ansible/ansible/issues/52331


### PR DESCRIPTION
##### SUMMARY
The actual Chocolatey version may not follow the strict form of major.minor.revision that [System.Version](https://docs.microsoft.com/en-us/dotnet/api/system.version?view=netframework-4.7.2) expects. This PR will add a warning if it failed to cast the version to a Version object and skip the actual check. If this scenario does occur then a warning is issued to the user saying the module behaviour may be different due to a beta or non standard release being used.

Fixes https://github.com/ansible/ansible/issues/52331

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey