### PR TITLE
fix pydoc example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -110,7 +110,8 @@ EXAMPLES = '''
       statement_id: lambda-s3-myBucket-create-data-log
       action: lambda:InvokeFunction
       principal: s3.amazonaws.com
-      source_arn: arn:aws:s3:eu-central-1:123456789012:bucketName
+      source_arn: arn:aws:s3:::bucketName
+      region: eu-central-1
       source_account: 123456789012
 
   - name: show results


### PR DESCRIPTION
The example, as given does not work.
It creates some association, but that association does not work as intended.
The change here ensures that it does work as intended, that is, triggering lambda function executions upon object creation in the specified s3 bucket. 

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
