### PR TITLE
os_subnet: allow using non-default subnet pool

### DIFF
--- a/changelogs/fragments/os_subnet-subnetpool-id-allowed.yaml
+++ b/changelogs/fragments/os_subnet-subnetpool-id-allowed.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- >
+  os_subnet - it is valid to specify an explicit ``subnetpool_id`` rather than
+  ``use_default_subnetpool`` or ``cidr``

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -269,9 +269,10 @@ def main():
     if state == 'present':
         if not module.params['network_name']:
             module.fail_json(msg='network_name required with present state')
-        if not module.params['cidr'] and not use_default_subnetpool:
-            module.fail_json(msg='cidr or use_default_subnetpool required '
-                                 'with present state')
+        if (not module.params['cidr'] and not use_default_subnetpool and
+                not extra_specs.get('subnetpool_id', False)):
+            module.fail_json(msg='cidr or use_default_subnetpool or '
+                                 'subnetpool_id required with present state')
 
     if pool_start and pool_end:
         pool = [dict(start=pool_start, end=pool_end)]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
os_subnet currently errors out if you pass a `subnetpool_id` rather than `use_default_subnetpool` or `cidr`.  This change also allows `subnetpool_id` in case the other two are absent.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_subnet
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
