### PR TITLE
docker_swarm_service: Don’t remove service when networks change

### DIFF
--- a/changelogs/fragments/52634-docker_swarm_service-dont_remove_service_on_network.yml
+++ b/changelogs/fragments/52634-docker_swarm_service-dont_remove_service_on_network.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - Don't recreate service when ``networks`` parameter changes when running Docker API >= 1.29."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1543,14 +1543,15 @@ class DockerServiceManager(object):
                 resolve=module.params['resolve_image']
             )
         except DockerException as e:
-            return self.client.fail(
+            self.client.fail(
                 'Error looking for an image named %s: %s'
                 % (image, e)
             )
+
         try:
             current_service = self.get_service(module.params['name'])
         except Exception as e:
-            return self.client.fail(
+            self.client.fail(
                 'Error looking for service named %s: %s'
                 % (module.params['name'], e)
             )

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -12,7 +12,10 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: docker_swarm_service
-author: "Dario Zanzico (@dariko), Jason Witkowski (@jwitko)"
+author:
+  - "Dario Zanzico (@dariko)"
+  - "Jason Witkowski (@jwitko)"
+  - "Hannes Ljungberg (@hannseman)"
 short_description: docker swarm service
 description:
   - Manages docker services via a swarm manager node.

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1561,6 +1561,16 @@
       - "{{ network_name_2 }}"
   register: networks_3
 
+- name: networks (change more idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    networks:
+      - "{{ network_name_1 }}"
+      - "{{ network_name_2 }}"
+  register: networks_4
+
 - name: networks (change less)
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -1568,7 +1578,16 @@
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
       - "{{ network_name_2 }}"
-  register: networks_4
+  register: networks_5
+
+- name: networks (change less idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    networks:
+      - "{{ network_name_2 }}"
+  register: networks_6
 
 - name: networks (empty)
   docker_swarm_service:
@@ -1576,7 +1595,7 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
-  register: networks_5
+  register: networks_7
 
 - name: networks (empty idempotency)
   docker_swarm_service:
@@ -1584,7 +1603,7 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
-  register: networks_6
+  register: networks_8
 
 - name: cleanup
   docker_swarm_service:
@@ -1597,20 +1616,22 @@
       - networks_1 is changed
       - networks_2 is not changed
       - networks_3 is changed
-      - networks_4 is changed
+      - networks_4 is not changed
       - networks_5 is changed
       - networks_6 is not changed
+      - networks_7 is changed
+      - networks_8 is not changed
 
 - assert:
     that:
     - networks_3.rebuilt == false
-    - networks_4.rebuilt == false
+    - networks_5.rebuilt == false
   when: docker_api_version is version('1.29', '>=')
 
 - assert:
     that:
     - networks_3.rebuilt == true
-    - networks_4.rebuilt == true
+    - networks_5.rebuilt == true
   when: docker_api_version is version('1.29', '<')
 
 ####################################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1551,13 +1551,32 @@
       - "{{ network_name_1 }}"
   register: networks_2
 
+- name: networks (change more)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    networks:
+      - "{{ network_name_1 }}"
+      - "{{ network_name_2 }}"
+  register: networks_3
+
+- name: networks (change less)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    networks:
+      - "{{ network_name_2 }}"
+  register: networks_4
+
 - name: networks (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
-  register: networks_3
+  register: networks_5
 
 - name: networks (empty idempotency)
   docker_swarm_service:
@@ -1565,7 +1584,7 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
-  register: networks_4
+  register: networks_6
 
 - name: cleanup
   docker_swarm_service:
@@ -1578,7 +1597,21 @@
       - networks_1 is changed
       - networks_2 is not changed
       - networks_3 is changed
-      - networks_4 is not changed
+      - networks_4 is changed
+      - networks_5 is changed
+      - networks_6 is not changed
+
+- assert:
+    that:
+    - networks_3.rebuilt == false
+    - networks_4.rebuilt == false
+  when: docker_api_version is version('1.29', '>=')
+
+- assert:
+    that:
+    - networks_3.rebuilt == true
+    - networks_4.rebuilt == true
+  when: docker_api_version is version('1.29', '<')
 
 ####################################################################
 ## stop_signal #####################################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The current behaviour when changing networks on an already created service is to remove the service and recreate it. This was required prior to Docker API version 1.29 as it did not support adding/removing networks on already created services. 

See:
https://github.com/moby/moby/issues/25876
https://github.com/docker/swarmkit/issues/1029

This PR will enable updating networks for users running >= 1.29. Also added a note about the removal and recreation of services to the `networks` documentation and to the `mode` documentation as this is a pretty destructive thing to do implicitly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service