### PR TITLE
NXOS: Manually Configurable Route-Target

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -32,9 +32,9 @@ author: Gabriele Gerbino (@GGabriele)
 notes:
   - Tested against NXOSv 7.3.(0)D1(1) on VIRL
   - Default, where supported, restores params default value.
-  - In case of `state=absent' the options ['route_target_both_auto_evpn',
-    'route_target_import', 'route_target_export', 'route_target_both'] are
-    ignored.
+  - In case of C(state=absent) the address-family configuration will be absent.
+    Therefore the options C(route_target_both_auto_evpn), C(route_target_import)
+    , C(route_target_export) and C(route_target_both) are ignored.
 options:
   vrf:
     description:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -57,7 +57,7 @@ options:
         route-target, the direction (import|export|both) and state of each
         route-target. Default direction is C(direction=both). See examples.
     type: list
-    version_added: "2.8"
+    version_added: "2.10"
   state:
     description:
       - Determines whether the config should be present or

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -51,15 +51,18 @@ options:
     description:
       - Specify the route-targets which should be imported under the AF
     type: list
+    version_added: "2.8"
   route_target_export:
     description:
       - Specify the route-targets which should be exported under the AF
     type: list
+    version_added: "2.8"
   route_target_both:
     description:
       - Specify the route-targets which should be imported & exported
         under the AF
     type: list
+    version_added: "2.8"
   state:
     description:
       - Determines whether the config should be present or

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -33,8 +33,8 @@ notes:
   - Tested against NXOSv 7.3.(0)D1(1) on VIRL
   - Default, where supported, restores params default value.
   - In case of C(state=absent) the address-family configuration will be absent.
-    Therefore the options C(route_target_both_auto_evpn), C(route_target_import)
-    , C(route_target_export) and C(route_target_both) are ignored.
+    Therefore the options C(route_target_both_auto_evpn) and C(route_targets)
+    are ignored.
 options:
   vrf:
     description:
@@ -50,26 +50,12 @@ options:
       - Enable/Disable the EVPN route-target 'auto' setting for both
         import and export target communities.
     type: bool
-  route_target_import:
+  route_targets:
     description:
-      - Specify the route-targets which should be imported under the AF.
-        This argument accepts a list of dicts that specify the route-target
-        and state of each route-target. See examples.
-    type: list
-    version_added: "2.8"
-  route_target_export:
-    description:
-      - Specify the route-targets which should be exported under the AF.
-        This argument accepts a list of dicts that specify the route-target
-        and state of each route-target. See examples.
-    type: list
-    version_added: "2.8"
-  route_target_both:
-    description:
-      - Specify the route-targets which should be imported & exported
-        under the AF.
-        This argument accepts a list of dicts that specify the route-target
-        and state of each route-target. See examples.
+      - Specify the route-targets which should be imported and/or exported under
+        the AF. This argument accepts a list of dicts that specify the
+        route-target, the direction (import|export|both) and state of each
+        route-target. Default direction is C(direction=both). See examples.
     type: list
     version_added: "2.8"
   state:
@@ -90,41 +76,50 @@ EXAMPLES = '''
 - nxos_vrf_af:
     vrf: ntc
     afi: ipv4
-    route_target_import:
+    route_targets:
       - rt: '65000:1000'
+        direction: import
       - rt: '65001:1000'
+        direction: import
 
 - nxos_vrf_af:
     vrf: ntc
     afi: ipv4
-    route_target_import:
+    route_targets:
       - rt: '65000:1000'
+        direction: import
       - rt: '65001:1000'
         state: absent
 
 - nxos_vrf_af:
     vrf: ntc
     afi: ipv4
-    route_target_export:
+    route_targets:
       - rt: '65000:1000'
+        direction: export
       - rt: '65001:1000'
+        direction: export
 
 - nxos_vrf_af:
     vrf: ntc
     afi: ipv4
-    route_target_export:
+    route_targets:
       - rt: '65000:1000'
+        direction: export
         state: absent
 
 - nxos_vrf_af:
     vrf: ntc
     afi: ipv4
-    route_target_both:
+    route_targets:
       - rt: '65000:1000'
+        direction: both
         state: present
       - rt: '65001:1000'
+        direction: import
         state: present
       - rt: '65002:1000'
+        direction: both
         state: absent
 '''
 

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -210,7 +210,7 @@ def main():
 
         if module.params['route_targets'] is not None:
             for rt in module.params['route_targets']:
-                if rt.get('direction') == 'both':
+                if rt.get('direction') == 'both' or not rt.get('direction'):
                     rt_commands = match_current_rt(rt, 'import', current, rt_commands)
                     rt_commands = match_current_rt(rt, 'export', current, rt_commands)
                 else:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -160,26 +160,12 @@ def main():
         afi=dict(required=True, choices=['ipv4', 'ipv6']),
         route_target_both_auto_evpn=dict(required=False, type='bool'),
         state=dict(choices=['present', 'absent'], default='present'),
-        route_target_import=dict(
+        route_targets=dict(
             rt=dict(type='str'),
-            state=dict(
-                choices=['present', 'absent'],
-                default='present'
+            direction=dict(
+                choices=['import', 'export', 'both'],
+                default='both'
             ),
-            elements='dict',
-            type='list'
-        ),
-        route_target_export=dict(
-            rt=dict(type='str'),
-            state=dict(
-                choices=['present', 'absent'],
-                default='present'
-            ),
-            elements='dict',
-            type='list'
-        ),
-        route_target_both=dict(
-            rt=dict(type='str'),
             state=dict(
                 choices=['present', 'absent'],
                 default='present'
@@ -227,18 +213,13 @@ def main():
             elif have_auto_evpn and not want_auto_evpn:
                 commands.append('no route-target both auto evpn')
 
-        if module.params['route_target_import'] is not None:
-            for rt in module.params['route_target_import']:
-                rt_commands = match_current_rt(rt, 'import', current, rt_commands)
-
-        if module.params['route_target_export'] is not None:
-            for rt in module.params['route_target_export']:
-                rt_commands = match_current_rt(rt, 'export', current, rt_commands)
-
-        if module.params['route_target_both'] is not None:
-            for rt in module.params['route_target_both']:
-                rt_commands = match_current_rt(rt, 'import', current, rt_commands)
-                rt_commands = match_current_rt(rt, 'export', current, rt_commands)
+        if module.params['route_targets'] is not None:
+            for rt in module.params['route_targets']:
+                if rt.get('direction') == 'both':
+                    rt_commands = match_current_rt(rt, 'import', current, rt_commands)
+                    rt_commands = match_current_rt(rt, 'export', current, rt_commands)
+                else:
+                    rt_commands = match_current_rt(rt, rt.get('direction'), current, rt_commands)
 
         if rt_commands:
             commands.extend(rt_commands)

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -56,6 +56,29 @@ options:
         the AF. This argument accepts a list of dicts that specify the
         route-target, the direction (import|export|both) and state of each
         route-target. Default direction is C(direction=both). See examples.
+    suboptions:
+      rt:
+        description:
+          - Defindes the route-target itself
+        required: true
+        type: str
+      direction:
+        description:
+          - Indicates the direction of the route-target (import|export|both)
+        choices:
+          - import
+          - export
+          - both
+        default: both
+      state:
+        description:
+          - Determines whether the route-target with the given direction
+            should be present or not on the device.
+        choices:
+          - present
+          - absent
+        default: present
+    elements: dict
     type: list
     version_added: "2.10"
   state:
@@ -156,17 +179,19 @@ def main():
         route_target_both_auto_evpn=dict(required=False, type='bool'),
         state=dict(choices=['present', 'absent'], default='present'),
         route_targets=dict(
-            rt=dict(type='str'),
-            direction=dict(
-                choices=['import', 'export', 'both'],
-                default='both'
-            ),
-            state=dict(
-                choices=['present', 'absent'],
-                default='present'
-            ),
+            type='list',
             elements='dict',
-            type='list'
+            options=dict(
+                rt=dict(type='str'),
+                direction=dict(
+                    choices=['import', 'export', 'both'],
+                    default='both'
+                ),
+                state=dict(
+                    choices=['present', 'absent'],
+                    default='present'
+                ),
+            )
         ),
     )
 

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -32,6 +32,9 @@ author: Gabriele Gerbino (@GGabriele)
 notes:
   - Tested against NXOSv 7.3.(0)D1(1) on VIRL
   - Default, where supported, restores params default value.
+  - In case of `state=absent' the options ['route_target_both_auto_evpn',
+    'route_target_import', 'route_target_export', 'route_target_both'] are
+    ignored.
 options:
   vrf:
     description:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -49,18 +49,24 @@ options:
     type: bool
   route_target_import:
     description:
-      - Specify the route-targets which should be imported under the AF
+      - Specify the route-targets which should be imported under the AF.
+        This argument accepts a list of dicts that specify the route-target
+        and state of each route-target. See examples.
     type: list
     version_added: "2.8"
   route_target_export:
     description:
-      - Specify the route-targets which should be exported under the AF
+      - Specify the route-targets which should be exported under the AF.
+        This argument accepts a list of dicts that specify the route-target
+        and state of each route-target. See examples.
     type: list
     version_added: "2.8"
   route_target_both:
     description:
       - Specify the route-targets which should be imported & exported
-        under the AF
+        under the AF.
+        This argument accepts a list of dicts that specify the route-target
+        and state of each route-target. See examples.
     type: list
     version_added: "2.8"
   state:

--- a/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
@@ -13,3 +13,10 @@ vrf context vrf21
     route-target export 65000:1000
     route-target export 65001:1000
     route-target export 65002:1000
+
+vrf context vrf31
+  address-family ipv4 unicast
+    route-target import 65000:1000
+    route-target export 65001:1000
+    route-target import 65002:1000
+    route-target export 65003:1000

--- a/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
@@ -1,0 +1,6 @@
+vrf context vrf1
+  address-family ipv4 unicast
+
+vrf context vrf11
+  address-family ipv4 unicast
+    route-target both auto evpn

--- a/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
@@ -10,3 +10,6 @@ vrf context vrf21
     route-target import 65000:1000
     route-target import 65001:1000
     route-target import 65002:1000
+    route-target export 65000:1000
+    route-target export 65001:1000
+    route-target export 65002:1000

--- a/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_vrf_af/config.cfg
@@ -4,3 +4,9 @@ vrf context vrf1
 vrf context vrf11
   address-family ipv4 unicast
     route-target both auto evpn
+
+vrf context vrf21
+  address-family ipv4 unicast
+    route-target import 65000:1000
+    route-target import 65001:1000
+    route-target import 65002:1000

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -95,8 +95,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[{"rt": "65000:1000",
-                                                   "state": "present"}]))
+                             route_targets=[{"rt": "65000:1000",
+                                             "direction": "import",
+                                             "state": "present"}]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
                                               'address-family ipv4 unicast',
@@ -105,8 +106,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[{
+                             route_targets=[{
                                  "rt": "65000:1000",
+                                 "direction": "import",
                                  "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
@@ -115,13 +117,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[{
-                                 "rt": "65000:1000",
-                                 "state": "present"}, {
-                                 "rt": "65001:1000",
-                                 "state": "present"}, {
-                                 "rt": "65002:1000",
-                                 "state": "present"}]))
+                             route_targets=[
+                                 {
+                                    "rt": "65000:1000",
+                                    "direction": "import",
+                                    "state": "present"
+                                 },
+                                 {
+                                    "rt": "65001:1000",
+                                    "direction": "import",
+                                    "state": "present"
+                                 },
+                                 {
+                                    "rt": "65002:1000",
+                                    "direction": "import",
+                                    "state": "present"
+                                 }]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
                                               'address-family ipv4 unicast',
@@ -132,13 +143,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[{
-                                 "rt": "65000:1000",
-                                 "state": "present"}, {
-                                 "rt": "65001:1000",
-                                 "state": "present"}, {
-                                 "rt": "65002:1000",
-                                 "state": "present"}
+                             route_targets=[
+                                 {
+                                    "rt": "65000:1000",
+                                    "direction": "import",
+                                    "state": "present"
+                                 },
+                                 {
+                                    "rt": "65001:1000",
+                                    "direction": "import",
+                                    "state": "present"
+                                 },
+                                 {
+                                    "rt": "65002:1000",
+                                    "direction": "import",
+                                    "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -146,8 +166,10 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
+                                 "direction": "import",
                                  "state": "absent"}
                              ]))
         result = self.execute_module(changed=False)
@@ -156,8 +178,10 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
+                                 "direction": "import",
                                  "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
@@ -168,13 +192,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}, {
+                                 "direction": "import",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "absent"}, {
+                                 "direction": "import",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}
+                                 "direction": "import",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -182,13 +215,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}, {
+                                 "direction": "import",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "absent"}, {
+                                 "direction": "import",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}
+                                 "direction": "import",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -200,17 +242,32 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_absent_current_mix(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "import",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "import",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}, {
+                                 "direction": "import",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65003:1000",
-                                 "state": "present"}, {
+                                 "direction": "import",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65004:1000",
-                                 "state": "absent"}
+                                 "direction": "import",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -221,9 +278,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}
+                                 "direction": "export",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -233,9 +293,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}
+                                 "direction": "export",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -243,13 +306,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "export",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "export",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "present"}
+                                 "direction": "export",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -261,13 +333,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "export",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "export",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "present"}
+                                 "direction": "export",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -275,9 +356,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}
+                                 "direction": "export",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -285,9 +369,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}
+                                 "direction": "export",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -297,13 +384,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}, {
+                                 "direction": "export",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "absent"}, {
+                                 "direction": "export",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}
+                                 "direction": "export",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -311,13 +407,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}, {
+                                 "direction": "export",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "absent"}, {
+                                 "direction": "export",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}
+                                 "direction": "export",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -329,17 +434,32 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_absent_current_mix(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "export",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "export",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}, {
+                                 "direction": "export",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65003:1000",
-                                 "state": "present"}, {
+                                 "direction": "export",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65004:1000",
-                                 "state": "absent"}
+                                 "direction": "export",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -350,9 +470,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}
+                                 "direction": "both",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -363,9 +486,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}
+                                 "direction": "both",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -373,13 +499,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "present"}
+                                 "direction": "both",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -394,13 +529,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "present"}
+                                 "direction": "both",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -408,9 +552,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}
+                                 "direction": "both",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -418,9 +565,12 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}
+                                 "direction": "both",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -431,13 +581,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}, {
+                                 "direction": "both",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "absent"}, {
+                                 "direction": "both",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}
+                                 "direction": "both",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -445,13 +604,22 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "absent"}, {
+                                 "direction": "both",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "absent"}, {
+                                 "direction": "both",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}
+                                 "direction": "both",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -466,17 +634,32 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_absent_current_mix(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}, {
+                                 "direction": "both",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65003:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65004:1000",
-                                 "state": "absent"}
+                                 "direction": "both",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -489,15 +672,27 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_current_only_import_or_export(self):
         set_module_args(dict(vrf='vrf31',
                              afi='ipv4',
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65001:1000",
-                                 "state": "present"}, {
+                                 "direction": "both",
+                                 "state": "present"
+                             },
+                             {
                                  "rt": "65002:1000",
-                                 "state": "absent"}, {
+                                 "direction": "both",
+                                 "state": "absent"
+                             },
+                             {
                                  "rt": "65003:1000",
-                                 "state": "absent"}
+                                 "direction": "both",
+                                 "state": "absent"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf31',
@@ -511,9 +706,12 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_target_both_auto_evpn=True,
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}
+                                 "direction": "both",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -527,9 +725,12 @@ class TestNxosVrfafModule(TestNxosModule):
                              afi='ipv4',
                              state='absent',
                              route_target_both_auto_evpn=True,
-                             route_target_both=[{
+                             route_targets=[
+                             {
                                  "rt": "65000:1000",
-                                 "state": "present"}
+                                 "direction": "both",
+                                 "state": "present"
+                             }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -119,19 +119,19 @@ class TestNxosVrfafModule(TestNxosModule):
                              afi='ipv4',
                              route_targets=[
                                  {
-                                    "rt": "65000:1000",
-                                    "direction": "import",
-                                    "state": "present"
+                                     "rt": "65000:1000",
+                                     "direction": "import",
+                                     "state": "present"
                                  },
                                  {
-                                    "rt": "65001:1000",
-                                    "direction": "import",
-                                    "state": "present"
+                                     "rt": "65001:1000",
+                                     "direction": "import",
+                                     "state": "present"
                                  },
                                  {
-                                    "rt": "65002:1000",
-                                    "direction": "import",
-                                    "state": "present"
+                                     "rt": "65002:1000",
+                                     "direction": "import",
+                                     "state": "present"
                                  }]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -145,19 +145,19 @@ class TestNxosVrfafModule(TestNxosModule):
                              afi='ipv4',
                              route_targets=[
                                  {
-                                    "rt": "65000:1000",
-                                    "direction": "import",
-                                    "state": "present"
+                                     "rt": "65000:1000",
+                                     "direction": "import",
+                                     "state": "present"
                                  },
                                  {
-                                    "rt": "65001:1000",
-                                    "direction": "import",
-                                    "state": "present"
+                                     "rt": "65001:1000",
+                                     "direction": "import",
+                                     "state": "present"
                                  },
                                  {
-                                    "rt": "65002:1000",
-                                    "direction": "import",
-                                    "state": "present"
+                                     "rt": "65002:1000",
+                                     "direction": "import",
+                                     "state": "present"
                                  }
                              ]))
         result = self.execute_module(changed=False)
@@ -167,10 +167,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "import",
-                                 "state": "absent"}
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -179,10 +180,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "import",
-                                 "state": "absent"}
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -193,21 +195,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -216,21 +218,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -243,31 +245,31 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "import",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "import",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65003:1000",
-                                 "direction": "import",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65004:1000",
-                                 "direction": "import",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "import",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "import",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65003:1000",
+                                     "direction": "import",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65004:1000",
+                                     "direction": "import",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -279,11 +281,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -294,11 +296,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -307,21 +309,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -334,21 +336,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -357,11 +359,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -370,11 +372,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -385,21 +387,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -408,21 +410,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -435,31 +437,31 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65003:1000",
-                                 "direction": "export",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65004:1000",
-                                 "direction": "export",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65003:1000",
+                                     "direction": "export",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65004:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -471,11 +473,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -487,11 +489,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -500,21 +502,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -530,21 +532,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -553,11 +555,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -566,11 +568,11 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -582,21 +584,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -605,21 +607,21 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -635,31 +637,31 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65003:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65004:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65003:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65004:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -673,26 +675,26 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf31',
                              afi='ipv4',
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65001:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             },
-                             {
-                                 "rt": "65002:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             },
-                             {
-                                 "rt": "65003:1000",
-                                 "direction": "both",
-                                 "state": "absent"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65003:1000",
+                                     "direction": "both",
+                                     "state": "absent"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf31',
@@ -707,11 +709,11 @@ class TestNxosVrfafModule(TestNxosModule):
                              afi='ipv4',
                              route_target_both_auto_evpn=True,
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -726,11 +728,11 @@ class TestNxosVrfafModule(TestNxosModule):
                              state='absent',
                              route_target_both_auto_evpn=True,
                              route_targets=[
-                             {
-                                 "rt": "65000:1000",
-                                 "direction": "both",
-                                 "state": "present"
-                             }
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 }
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -103,12 +103,33 @@ class TestNxosVrfafModule(TestNxosModule):
                                               'address-family ipv4 unicast',
                                               'route-target import 65000:1000'])
 
+    def test_nxos_vrf_af_route_target_default_direction_present_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_targets=[{"rt": "65000:1000",
+                                             "state": "present"}]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target import 65000:1000',
+                                              'route-target export 65000:1000'])
+
     def test_nxos_vrf_af_route_target_import_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
                              route_targets=[{
                                  "rt": "65000:1000",
                                  "direction": "import",
+                                 "state": "present"}
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_default_direction_present_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_targets=[{
+                                 "rt": "65000:1000",
                                  "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
@@ -702,6 +723,37 @@ class TestNxosVrfafModule(TestNxosModule):
                                               'route-target export 65000:1000',
                                               'route-target import 65001:1000',
                                               'no route-target import 65002:1000',
+                                              'no route-target export 65003:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_direction_current_only_import_or_export(self):
+        set_module_args(dict(vrf='vrf31',
+                             afi='ipv4',
+                             route_targets=[
+                                 {
+                                     "rt": "65000:1000",
+                                     "direction": "both",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65001:1000",
+                                     "state": "present"
+                                 },
+                                 {
+                                     "rt": "65002:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 },
+                                 {
+                                     "rt": "65003:1000",
+                                     "direction": "export",
+                                     "state": "absent"
+                                 }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf31',
+                                              'address-family ipv4 unicast',
+                                              'route-target export 65000:1000',
+                                              'route-target import 65001:1000',
                                               'no route-target export 65003:1000'])
 
     def test_nxos_vrf_af_auto_evpn_route_target_and_manual_route_target(self):

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -56,7 +56,7 @@ class TestNxosVrfafModule(TestNxosModule):
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
 
-    def test_nxos_vrf_af_route_target(self):
+    def test_nxos_vrf_af_auto_evpn_route_target(self):
         set_module_args(dict(vrf='ntc', afi='ipv4', route_target_both_auto_evpn=True))
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result['commands']), sorted(['vrf context ntc',

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -91,3 +91,174 @@ class TestNxosVrfafModule(TestNxosModule):
         set_module_args(dict(vrf='vrf1', afi='ipv4', route_target_both_auto_evpn=False))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_import_present_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target import 65000:1000'])
+
+    def test_nxos_vrf_af_route_target_import_present_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_multi_import_present_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target import 65000:1000',
+                                              'route-target import 65001:1000',
+                                              'route-target import 65002:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_import_present_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_import_absent_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_import_absent_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target import 65000:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_import_absent_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_multi_import_absent_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target import 65000:1000',
+                                              'no route-target import 65001:1000',
+                                              'no route-target import 65002:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_import_absent_current_mix(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_import=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65003:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65004:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target import 65002:1000',
+                                              'route-target import 65003:1000'])

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -433,3 +433,214 @@ class TestNxosVrfafModule(TestNxosModule):
                                               'address-family ipv4 unicast',
                                               'no route-target export 65002:1000',
                                               'route-target export 65003:1000'])
+
+    def test_nxos_vrf_af_route_target_both_present_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target import 65000:1000',
+                                              'route-target export 65000:1000'])
+
+    def test_nxos_vrf_af_route_target_both_present_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_multi_both_present_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target import 65000:1000',
+                                              'route-target export 65000:1000',
+                                              'route-target import 65001:1000',
+                                              'route-target export 65001:1000',
+                                              'route-target import 65002:1000',
+                                              'route-target export 65002:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_both_present_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_both_absent_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_both_absent_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target import 65000:1000',
+                                              'no route-target export 65000:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_both_absent_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_multi_both_absent_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target import 65000:1000',
+                                              'no route-target export 65000:1000',
+                                              'no route-target import 65001:1000',
+                                              'no route-target export 65001:1000',
+                                              'no route-target import 65002:1000',
+                                              'no route-target export 65002:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_both_absent_current_mix(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65003:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65004:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target import 65002:1000',
+                                              'no route-target export 65002:1000',
+                                              'route-target import 65003:1000',
+                                              'route-target export 65003:1000'])
+
+
+    def test_nxos_vrf_af_route_target_multi_both_current_only_import_or_export(self):
+        set_module_args(dict(vrf='vrf31',
+                             afi='ipv4',
+                             route_target_both=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65003:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf31',
+                                              'address-family ipv4 unicast',
+                                              'route-target export 65000:1000',
+                                              'route-target import 65001:1000',
+                                              'no route-target import 65002:1000',
+                                              'no route-target export 65003:1000'])

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -262,3 +262,174 @@ class TestNxosVrfafModule(TestNxosModule):
                                               'address-family ipv4 unicast',
                                               'no route-target import 65002:1000',
                                               'route-target import 65003:1000'])
+
+    def test_nxos_vrf_af_route_target_export_present_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target export 65000:1000'])
+
+    def test_nxos_vrf_af_route_target_export_present_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_multi_export_present_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target export 65000:1000',
+                                              'route-target export 65001:1000',
+                                              'route-target export 65002:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_export_present_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "present"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_export_absent_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_export_absent_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target export 65000:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_export_absent_current_non_existing(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result['commands'], [])
+
+    def test_nxos_vrf_af_route_target_multi_export_absent_current_existing(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target export 65000:1000',
+                                              'no route-target export 65001:1000',
+                                              'no route-target export 65002:1000'])
+
+    def test_nxos_vrf_af_route_target_multi_export_absent_current_mix(self):
+        set_module_args(dict(vrf='vrf21',
+                             afi='ipv4',
+                             route_target_export=[
+                               {
+                                 "rt": "65000:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65001:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65002:1000",
+                                 "state": "absent"
+                               },
+                               {
+                                 "rt": "65003:1000",
+                                 "state": "present"
+                               },
+                               {
+                                 "rt": "65004:1000",
+                                 "state": "absent"
+                               }
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf21',
+                                              'address-family ipv4 unicast',
+                                              'no route-target export 65002:1000',
+                                              'route-target export 65003:1000'])

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -521,3 +521,16 @@ class TestNxosVrfafModule(TestNxosModule):
                                               'route-target both auto evpn',
                                               'route-target import 65000:1000',
                                               'route-target export 65000:1000'])
+
+    def test_nxos_vrf_af_auto_evpn_route_target_and_manual_route_targets_with_absent_vrf(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             state='absent',
+                             route_target_both_auto_evpn=True,
+                             route_target_both=[{
+                                 "rt": "65000:1000",
+                                 "state": "present"}
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'no address-family ipv4 unicast'])

--- a/test/units/modules/network/nxos/test_nxos_vrf_af.py
+++ b/test/units/modules/network/nxos/test_nxos_vrf_af.py
@@ -95,12 +95,8 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[
-                               {
-                                 "rt": "65000:1000",
-                                 "state": "present"
-                               }
-                             ]))
+                             route_target_import=[{"rt": "65000:1000",
+                                                   "state": "present"}]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
                                               'address-family ipv4 unicast',
@@ -109,11 +105,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -121,20 +115,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "present"
-                               }
-                             ]))
+                                 "state": "present"}]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
                                               'address-family ipv4 unicast',
@@ -145,19 +132,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -165,11 +146,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -177,11 +156,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_import_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -191,19 +168,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65001:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -211,19 +182,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65001:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -235,27 +200,17 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_import_absent_current_mix(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_import=[
-                               {
+                             route_target_import=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65003:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65004:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -266,11 +221,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -280,11 +233,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -292,19 +243,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -316,19 +261,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -336,11 +275,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -348,11 +285,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_export_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -362,19 +297,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65001:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -382,19 +311,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65001:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -406,27 +329,17 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_export_absent_current_mix(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65003:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65004:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -437,11 +350,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -452,11 +363,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_export=[
-                               {
+                             route_target_export=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -464,19 +373,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_present_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf1',
@@ -491,19 +394,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_present_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "present"
-                               }
+                                 "state": "present"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -511,11 +408,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -523,11 +418,9 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_both_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -538,19 +431,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_absent_current_non_existing(self):
         set_module_args(dict(vrf='vrf1',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65001:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=False)
         self.assertEqual(result['commands'], [])
@@ -558,19 +445,13 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_absent_current_existing(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65001:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -585,27 +466,17 @@ class TestNxosVrfafModule(TestNxosModule):
     def test_nxos_vrf_af_route_target_multi_both_absent_current_mix(self):
         set_module_args(dict(vrf='vrf21',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65003:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65004:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf21',
@@ -615,27 +486,18 @@ class TestNxosVrfafModule(TestNxosModule):
                                               'route-target import 65003:1000',
                                               'route-target export 65003:1000'])
 
-
     def test_nxos_vrf_af_route_target_multi_both_current_only_import_or_export(self):
         set_module_args(dict(vrf='vrf31',
                              afi='ipv4',
-                             route_target_both=[
-                               {
+                             route_target_both=[{
                                  "rt": "65000:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65001:1000",
-                                 "state": "present"
-                               },
-                               {
+                                 "state": "present"}, {
                                  "rt": "65002:1000",
-                                 "state": "absent"
-                               },
-                               {
+                                 "state": "absent"}, {
                                  "rt": "65003:1000",
-                                 "state": "absent"
-                               }
+                                 "state": "absent"}
                              ]))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['vrf context vrf31',
@@ -644,3 +506,18 @@ class TestNxosVrfafModule(TestNxosModule):
                                               'route-target import 65001:1000',
                                               'no route-target import 65002:1000',
                                               'no route-target export 65003:1000'])
+
+    def test_nxos_vrf_af_auto_evpn_route_target_and_manual_route_target(self):
+        set_module_args(dict(vrf='vrf1',
+                             afi='ipv4',
+                             route_target_both_auto_evpn=True,
+                             route_target_both=[{
+                                 "rt": "65000:1000",
+                                 "state": "present"}
+                             ]))
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], ['vrf context vrf1',
+                                              'address-family ipv4 unicast',
+                                              'route-target both auto evpn',
+                                              'route-target import 65000:1000',
+                                              'route-target export 65000:1000'])


### PR DESCRIPTION
##### SUMMARY
Provides the option to manually add route-targets under an address family on Cisco Nexus (NXOS) Devices.

Fixes #41397

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nxos_vrf_af

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
