### PR TITLE
docker_node: labels operation fails when parameter 'labels' is None

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -229,15 +229,16 @@ class SwarmNodeManager(DockerBaseClass):
 
             if self.parameters.labels_to_remove is not None:
                 for key in self.parameters.labels_to_remove:
-                    if not self.parameters.labels.get(key):
-                        if node_spec['Labels'].get(key):
-                            node_spec['Labels'].pop(key)
-                            changed = True
-                    else:
-                        self.client.module.warn(
-                            "Label '%s' listed both in 'labels' and 'labels_to_remove'. "
-                            "Keeping the assigned label value."
-                            % to_native(key))
+                    if self.parameters.labels is not None:
+                        if not self.parameters.labels.get(key):
+                            if node_spec['Labels'].get(key):
+                                node_spec['Labels'].pop(key)
+                                changed = True
+                        else:
+                            self.client.module.warn(
+                                "Label '%s' listed both in 'labels' and 'labels_to_remove'. "
+                                "Keeping the assigned label value."
+                                % to_native(key))
 
         if changed is True:
             if not self.check_mode:

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -239,6 +239,10 @@ class SwarmNodeManager(DockerBaseClass):
                                 "Label '%s' listed both in 'labels' and 'labels_to_remove'. "
                                 "Keeping the assigned label value."
                                 % to_native(key))
+                    else:
+                        if node_spec['Labels'].get(key):
+                            node_spec['Labels'].pop(key)
+                            changed = True
 
         if changed is True:
             if not self.check_mode:


### PR DESCRIPTION
##### SUMMARY
This PR fixes problem found during integration tests preparation when parameter 'labels' is empty but 'labels_to_remove' contains values - in such case labels are not removed due to non-matching conditional. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_node

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example of such task tested on Python3.7 on latestFedora Linux

```
  - name: Try to remove single existing label from swarm node
    docker_node:
      hostname: "{{ nodeid }}"
      labels_to_remove:
        - label1
    register: output
```
