### PR TITLE
Allow setting the username of EC2 instance

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -36,6 +36,10 @@ destination_variable = public_dns_name
 # will still use destination_variable. Tags should be written as 'tag_TAGNAME'.
 #hostname_variable = tag_Name
 
+# This allows you to set the username with an ec2 tag.
+# Tags should be written as 'tag_TAGNAME'.
+#username_variable = tag_Username
+
 # For server inside a VPC, using DNS names may not make sense. When an instance
 # has 'subnet_id' set, this variable is used. If the subnet is public, setting
 # this to 'ip_address' will return the public IP address. For instances in a

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -220,6 +220,7 @@ DEFAULTS = {
     'group_by_tag_none': 'True',
     'group_by_vpc_id': 'True',
     'hostname_variable': '',
+    'username_variable': '',
     'iam_role': '',
     'include_rds_clusters': 'False',
     'nested_groups': 'False',
@@ -367,6 +368,7 @@ class Ec2Inventory(object):
         self.destination_variable = config.get('ec2', 'destination_variable')
         self.vpc_destination_variable = config.get('ec2', 'vpc_destination_variable')
         self.hostname_variable = config.get('ec2', 'hostname_variable')
+        self.username_variable = config.get('ec2', 'username_variable')
 
         if config.has_option('ec2', 'destination_format') and \
            config.has_option('ec2', 'destination_format_tags'):
@@ -1079,6 +1081,14 @@ class Ec2Inventory(object):
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
         self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
+
+        # Set the username
+        if self.username_variable:
+            if self.username_variable.startswith('tag_'):
+                username = instance.tags.get(self.username_variable[4:], None)
+            else:
+                username = getattr(instance, self.username_variable)
+            self.inventory["_meta"]["hostvars"][hostname]['ansible_user'] = username
 
     def add_rds_instance(self, instance, region):
         ''' Adds an RDS instance to the inventory and index, as long as it is


### PR DESCRIPTION
##### SUMMARY
This change allows us to set a username for an EC2 instance based on its tags.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
contrib/inventory/ec2.py

##### ADDITIONAL INFORMATION
The documentation uses the `-u` flag to set the username:
```
ansible -i ec2.py -u ubuntu us-east-1d -m ping
```
I think it is good practice to set a tag 'Username' on an EC2 instances, this allows me to automate connecting to the instance without statically providing a username for each instance.

In playbooks I do something similar to this:
```
    - name: Add instances to inventory
      add_host: 
        hostname: '{{ item.public_ip_address }}'
        ansible_ssh_user: '{{ item.tags.Username }}'
      loop: "{{ ec2.instances }}"
```
