### PR TITLE
nxos_command:run_commands results failure when commands array size >1

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -547,7 +547,11 @@ class HttpApi:
             if response[0] == '{':
                 out[index] = json.loads(response)
 
-        return out
+        if return_timestamps:
+            # workaround until timestamps are implemented
+            return out, list()
+        else:
+            return out
 
     def get_config(self, flags=None):
         """Retrieves the current config from the device or cache


### PR DESCRIPTION
##### SUMMARY
Timestamp support was added to `nxos_command:run_commands` with #50261. That change breaks `HttpApi` for cases where multiple commands are issued.

#50261 added a second variable assignment to the return value of the `run_commands` caller , which in the multiple commands use case causes the array elements to be assigned to each var instead of assigning the entire array to the first var.

The implementation may also be flawed in that this multiple variable assignment approach will only ever work when `return_timestamps` is True. The assignment will always fail if `return_timestamps` is set to false.

***Note that my diff is just a workaround to make `nxos_command` work.***   I believe #50261 really needs another look and should be reworked or reverted. I opened Issue #52671 to address this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- `nxos_command`

##### ADDITIONAL INFORMATION
This is reproduceable with the `greaterthan.yaml` test. 
https://github.com/ansible/ansible/blob/devel/test/integration/targets/nxos_command/tests/common/greaterthan.yaml

Analysis: 
```
     responses, timestamps = run_commands(module, commands, return_timestamps=True)
```
The `HttpApi` problem occurs when `commands` has multiple items (`return_timestamps` is irrelevant in this case since it doesn't have code to handle timestamps). 

The other transports will have a related problem even with single commands  if the caller sets `return_timestamps=False`.

Here are a couple of basic python tests to illustrate what's happening with `run_commands`:

`HttpApi` issue: return an array of two elements to two vars:
```
In [1]: responses,timestamps = ['sh ver output','sh int output']

In [2]: responses
Out[2]: 'sh ver output'

In [3]: timestamps
Out[3]: 'sh int output'
```
Example: Other transports issue: call `run_commands` with single command and set `return_timestamps` to false. It will return a single string value:
```
In [1]: responses,timestamps = 'sh ver output'
ValueError: too many values to unpack
