### PR TITLE
Fix redfish_facts GetPsuInventory command not returning correct output

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -886,7 +886,7 @@ class RedfishUtils(object):
             if 'Power' in data:
                 power_uri = data[u'Power'][u'@odata.id']
             else:
-                return {'ret': False, 'msg': "Key Power not found"}
+                continue
 
             response = self.get_request(self.root_uri + power_uri)
             data = response['data']
@@ -911,6 +911,8 @@ class RedfishUtils(object):
                 psu_results.append(psu_data)
 
         result["entries"] = psu_results
+        if not result["entries"]:
+            return {'ret': False, 'msg': "No PowerSupply objects found"}
         return result
 
     def get_system_inventory(self):

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -893,11 +893,18 @@ class RedfishUtils(object):
 
             psu_list = data[key]
             for psu in psu_list:
+                psu_not_present = False
                 psu_data = {}
                 for property in properties:
                     if property in psu:
                         if psu[property] is not None:
+                            if property == 'Status':
+                                if 'State' in psu[property]:
+                                    if psu[property]['State'] == 'Absent':
+                                        psu_not_present = True
                             psu_data[property] = psu[property]
+                if psu_not_present:
+                    continue
                 psu_results.append(psu_data)
 
         result["entries"] = psu_results

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -872,7 +872,7 @@ class RedfishUtils(object):
                       'FirmwareVersion', 'PowerCapacityWatts', 'PowerSupplyType',
                       'Status']
 
-        # Get a list of all Chassis and build URIs, then get all PowerSupplies 
+        # Get a list of all Chassis and build URIs, then get all PowerSupplies
         # from each Power entry in the Chassis
         chassis_uri_list = self.chassis_uri_list
         for chassis_uri in chassis_uri_list:
@@ -896,7 +896,8 @@ class RedfishUtils(object):
                 psu_data = {}
                 for property in properties:
                     if property in psu:
-                        psu_data[property] = psu[property]
+                        if psu[property] != None:
+                            psu_data[property] = psu[property]
                 psu_results.append(psu_data)
 
         result["entries"] = psu_results

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -896,7 +896,7 @@ class RedfishUtils(object):
                 psu_data = {}
                 for property in properties:
                     if property in psu:
-                        if psu[property] != None:
+                        if psu[property] is not None:
                             psu_data[property] = psu[property]
                 psu_results.append(psu_data)
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -883,8 +883,11 @@ class RedfishUtils(object):
             result['ret'] = True
             data = response['data']
 
-            power_uri = data[u'Power'][u'@odata.id']
-
+            if 'Power' in data:
+                power_uri = data[u'Power'][u'@odata.id']
+            else:
+                return {'ret': False, 'msg': "Key Power not found"}
+                
             response = self.get_request(self.root_uri + power_uri)
             data = response['data']
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -866,41 +866,39 @@ class RedfishUtils(object):
         result = {}
         psu_list = []
         psu_results = []
-        key = "PoweredBy"
+        key = "PowerSupplies"
         # Get these entries, but does not fail if not found
         properties = ['Name', 'Model', 'SerialNumber', 'PartNumber', 'Manufacturer',
                       'FirmwareVersion', 'PowerCapacityWatts', 'PowerSupplyType',
                       'Status']
 
-        # Get a list of all PSUs and build respective URIs
-        response = self.get_request(self.root_uri + self.systems_uri)
-        if response['ret'] is False:
-            return response
-        result['ret'] = True
-        data = response['data']
-
-        if 'Links' not in data:
-            return {'ret': False, 'msg': "Property not found"}
-        if key not in data[u'Links']:
-            return {'ret': False, 'msg': "Key %s not found" % key}
-
-        for psu in data[u'Links'][u'PoweredBy']:
-            psu_list.append(psu[u'@odata.id'])
-
-        for p in psu_list:
-            psu = {}
-            uri = self.root_uri + p
-            response = self.get_request(uri)
+        # Get a list of all Chassis and build URIs, then get all PowerSupplies 
+        # from each Power entry in the Chassis
+        chassis_uri_list = self.chassis_uri_list
+        for chassis_uri in chassis_uri_list:
+            response = self.get_request(self.root_uri + chassis_uri)
             if response['ret'] is False:
                 return response
 
             result['ret'] = True
             data = response['data']
 
-            for property in properties:
-                if property in data:
-                    psu[property] = data[property]
-            psu_results.append(psu)
+            power_uri = data[u'Power'][u'@odata.id']
+
+            response = self.get_request(self.root_uri + power_uri)
+            data = response['data']
+
+            if key not in data:
+                return {'ret': False, 'msg': "Key %s not found" % key}
+
+            psu_list = data[key]
+            for psu in psu_list:
+                psu_data = {}
+                for property in properties:
+                    if property in psu:
+                        psu_data[property] = psu[property]
+                psu_results.append(psu_data)
+
         result["entries"] = psu_results
         return result
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -887,7 +887,7 @@ class RedfishUtils(object):
                 power_uri = data[u'Power'][u'@odata.id']
             else:
                 return {'ret': False, 'msg': "Key Power not found"}
-                
+
             response = self.get_request(self.root_uri + power_uri)
             data = response['data']
 

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -129,10 +129,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.redfish_utils import RedfishUtils
 
 CATEGORY_COMMANDS_ALL = {
-    "Systems": ["GetSystemInventory", "GetPsuInventory", "GetCpuInventory",
+    "Systems": ["GetSystemInventory", "GetCpuInventory",
                 "GetNicInventory", "GetStorageControllerInventory",
                 "GetDiskInventory", "GetBiosAttributes", "GetBootOrder"],
-    "Chassis": ["GetFanInventory"],
+    "Chassis": ["GetFanInventory", "GetPsuInventory"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory"],
     "Manager": ["GetManagerNicInventory", "GetLogs"],
@@ -211,8 +211,6 @@ def main():
             for command in command_list:
                 if command == "GetSystemInventory":
                     result["system"] = rf_utils.get_system_inventory()
-                elif command == "GetPsuInventory":
-                    result["psu"] = rf_utils.get_psu_inventory()
                 elif command == "GetCpuInventory":
                     result["cpu"] = rf_utils.get_cpu_inventory()
                 elif command == "GetNicInventory":
@@ -235,6 +233,8 @@ def main():
             for command in command_list:
                 if command == "GetFanInventory":
                     result["fan"] = rf_utils.get_fan_inventory()
+                elif command == "GetPsuInventory":
+                    result["psu"] = rf_utils.get_psu_inventory()
 
         elif category == "Accounts":
             # execute only if we find an Account service resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
   - name: Get several inventories
     redfish_facts:
       category: Systems
-      command: GetNicInventory,GetPsuInventory,GetBiosAttributes
+      command: GetNicInventory,GetBiosAttributes
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request fixes the redfish_facts module not returning the correct data in its Systems command, GetPsuInventory. (Fixes #50937)

Previously, the redfish_facts command GetPsuInventory was looping through `Systems['PoweredBy']` to try and get power supply entries, but was only returning a JSON with a list with `{'Name': 'Power'}`, one for each existing power supply, with no details at all. 

The first main change is moving the `GetPsuInventory` command from the `Systems` category to the `Chassis` category in redfish_facts.py, per @mraineri's suggestion to iterate over the Redfish Chassis resource instead of Systems. This allows the `get_psu_inventory()` function to access `self.chassis_uri_list` in the same manner that `GetFanInventory` uses it.  

The other major change is in the `get_psu_inventory()` function in redfish_utils.py. Here, we now loop through the `self.chassis_uri_list`, drill down into the Power resource for each Chassis, and then loop through each entry in PowerSupplies.

Edit: I updated my design decision so that we do **not** include power supply entries that are `Status['State'] == Absent`, since by not being present they are not part of an "inventory".



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.243.5.31
    user: USERID
    password: PASSW0RD

  tasks:
    - name: Get PSU inventory
      redfish_facts:
        category: Chassis
        command: GetPsuInventory
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"
```



<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible
  executable location = bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.yml ********************************************************************************************************************Positional arguments: ../test_redfish_facts.yml
become_user: root
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
tags: (u'all',)
forks: 5
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.yml

PLAY [Test Redfish modules] *************************************************************************************************************************META: ran handlers

TASK [Get all information available in Update category] *********************************************************************************************task path: /mnt/c/Users/amadsen/Coding/redfish/test_redfish_facts.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1547569586.77-132727627392331 `" && echo ansible-tmp-1547569586.77-132727627392331="` echo /home/xander/.ansible/tmp/ansible-tmp-1547569586.77-132727627392331 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-714vymIlR/tmpcsShk3 TO /home/xander/.ansible/tmp/ansible-tmp-1547569586.77-132727627392331/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1547569586.77-132727627392331/ /home/xander/.ansible/tmp/ansible-tmp-1547569586.77-132727627392331/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1547569586.77-132727627392331/AnsiballZ_redfish_facts.py && sleep
0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1547569586.77-132727627392331/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "psu": {
                "entries": [
                    {
                        "Name": "Power"
                    },
                    {
                        "Name": "Power"
                    }
                ],
                "ret": true
            }
        }
    },
    "changed": false,
    "failed_when_result": false,
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31",
            "category": [
                "Systems"
            ],
            "command": [
                "GetPsuInventory"
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "username": "USERID"
        }
    }
}
```

After
```
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible
  executable location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.1.yml **************************************************************************************************************************Positional arguments: ../test_redfish_facts.1.yml
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
forks: 5
tags: (u'all',)
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.1.yml

PLAY [Test Redfish modules] *********************************************************************************************************************************META: ran handlers

TASK [Get PSU inventory] ************************************************************************************************************************************task path: /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_facts.1.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1550695076.51-133388496378873 `" && echo ansible-tmp-1550695076.51-133388496378873="` echo /home/xander/.ansible/tmp/ansible-tmp-1550695076.51-133388496378873 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-1005tobE5i/tmpkiggIq TO /home/xander/.ansible/tmp/ansible-tmp-1550695076.51-133388496378873/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1550695076.51-133388496378873/ /home/xander/.ansible/tmp/ansible-tmp-1550695076.51-133388496378873/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1550695076.51-133388496378873/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1550695076.51-133388496378873/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "psu": {
                "entries": [
                    {
                        "FirmwareVersion": "4.51", 
                        "Manufacturer": "ACBE", 
                        "Model": "LENOVO-SP57A02023", 
                        "Name": "PSU1", 
                        "PartNumber": "SP57A02023", 
                        "PowerCapacityWatts": 1050, 
                        "PowerSupplyType": "AC", 
                        "SerialNumber": "A3DB78B10JH", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FirmwareVersion": "4.51", 
                        "Manufacturer": "ACBE", 
                        "Model": "LENOVO-SP57A02023", 
                        "Name": "PSU2", 
                        "PartNumber": "SP57A02023", 
                        "PowerCapacityWatts": 1050, 
                        "PowerSupplyType": "AC", 
                        "SerialNumber": "A3DB78B10TP", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31", 
            "category": [
                "Chassis"
            ], 
            "command": [
                "GetPsuInventory"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP **************************************************************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```

