### PR TITLE
gcp_compute: use env variables on inventory script

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -14,6 +14,7 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
         - constructed
         - inventory_cache
+        - gcp
     description:
         - Get inventory hosts from Google Cloud Platform GCE.
         - Uses a YAML configuration file that ends with gcp_compute.(yml|yaml) or gcp.(yml|yaml).
@@ -95,6 +96,10 @@ class GcpMockModule(object):
     def __init__(self, params):
         self.params = params
         self._set_fallbacks()
+
+        if 'service_account_file' in self.params:
+            self.params['service_account_file'] = os.path.expanduser(self.params['service_account_file'])
+
 
     def fail_json(self, *args, **kwargs):
         raise AnsibleError(kwargs['msg'])

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -86,6 +86,7 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils.gcp_utils import GcpSession, navigate_hash, GcpRequestException
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
 import json
+import os
 
 
 # The mappings give an array of keys to get from the filter name to the value
@@ -93,9 +94,22 @@ import json
 class GcpMockModule(object):
     def __init__(self, params):
         self.params = params
+        self._set_fallbacks()
 
     def fail_json(self, *args, **kwargs):
         raise AnsibleError(kwargs['msg'])
+
+    def _set_fallbacks(self):
+        self._set_fallback('project', 'GCP_PROJECT')
+        self._set_fallback('auth_kind', 'GCP_AUTH_KIND')
+        self._set_fallback('service_account_email', 'GCP_SERVICE_ACCOUNT_EMAIL')
+        self._set_fallback('service_account_file', 'GCP_SERVICE_ACCOUNT_FILE')
+        self._set_fallback('scopes', 'GCP_SCOPES')
+
+    def _set_fallback(self, param, env_value):
+        if param not in self.params:
+            if env_value in os.environ:
+                self.params[param] = os.environ[env_value]
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -100,7 +100,6 @@ class GcpMockModule(object):
         if 'service_account_file' in self.params:
             self.params['service_account_file'] = os.path.expanduser(self.params['service_account_file'])
 
-
     def fail_json(self, *args, **kwargs):
         raise AnsibleError(kwargs['msg'])
 


### PR DESCRIPTION
##### SUMMARY
Use environment variables on gcp_compute inventory script.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
gcp_compute

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
