### PR TITLE
Support "force_subnet_association" parameter on na_ontap_interface

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_interface.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_interface.py
@@ -163,6 +163,7 @@ class NetAppOntapInterface(object):
 
         self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
 <<<<<<< HEAD
+<<<<<<< HEAD
         self.argument_spec.update(dict(
             state=dict(required=False, choices=[
                        'present', 'absent'], default='present'),
@@ -179,7 +180,7 @@ class NetAppOntapInterface(object):
             subnet_name=dict(required=False, type='str'),
             is_auto_revert=dict(required=False, type='bool', default=None),
             protocols=dict(required=False, type='list'),
-            force_subnet_association=dict(required=False, type=bool, default=None)
+            force_subnet_association=dict(required=False, type='bool', default=None)
         ))
 
         self.module = AnsibleModule(

--- a/lib/ansible/modules/storage/netapp/na_ontap_interface.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_interface.py
@@ -162,8 +162,6 @@ class NetAppOntapInterface(object):
     def __init__(self):
 
         self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
-<<<<<<< HEAD
-<<<<<<< HEAD
         self.argument_spec.update(dict(
             state=dict(required=False, choices=[
                        'present', 'absent'], default='present'),

--- a/lib/ansible/modules/storage/netapp/na_ontap_interface.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_interface.py
@@ -98,6 +98,12 @@ options:
        migration capability is disabled automatically
     type: bool
 
+  force_subnet_association:
+    description:
+       Set this to true to acquire the address from the named subnet and assign the subnet to the LIF.
+    type: bool
+    version_added: '2.9'
+
   protocols:
     description:
     - Specifies the list of data protocols configured on the LIF. By default, the values in this element are nfs, cifs and fcache.
@@ -156,6 +162,7 @@ class NetAppOntapInterface(object):
     def __init__(self):
 
         self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
+<<<<<<< HEAD
         self.argument_spec.update(dict(
             state=dict(required=False, choices=[
                        'present', 'absent'], default='present'),
@@ -171,7 +178,8 @@ class NetAppOntapInterface(object):
             admin_status=dict(required=False, choices=['up', 'down']),
             subnet_name=dict(required=False, type='str'),
             is_auto_revert=dict(required=False, type='bool', default=None),
-            protocols=dict(required=False, type='list')
+            protocols=dict(required=False, type='list'),
+            force_subnet_association=dict(required=False, type=bool, default=None)
         ))
 
         self.module = AnsibleModule(
@@ -245,6 +253,8 @@ class NetAppOntapInterface(object):
             options['is-auto-revert'] = 'true' if parameters['is_auto_revert'] is True else 'false'
         if parameters.get('admin_status') is not None:
             options['administrative-status'] = parameters['admin_status']
+        if parameters.get('force_subnet_association') is not None:
+            options['force-subnet-association'] = 'true' if parameters['force_subnet_association'] else 'false'
 
     def set_protocol_option(self, required_keys):
         """ set protocols for create """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This small patch adds a new parameter `force_subnet_association` to the *na_ontap_interface* module.
In our storage provisioning workflow, we're creating a subnet with a fixed network range so we need to force the ip association of a LIF to the provisioned subnet. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_interface.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.7.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Oct 30 2018, 23:45:53) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]

```
