### PR TITLE
Allow using env for foreman options

### DIFF
--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -25,12 +25,21 @@ DOCUMENTATION = '''
       url:
         description: url to foreman
         default: 'http://localhost:3000'
+        env:
+            - name: FOREMAN_SERVER
+              version_added: "2.8"
       user:
         description: foreman authentication user
         required: True
+        env:
+            - name: FOREMAN_USER
+              version_added: "2.8"
       password:
         description: foreman authentication password
         required: True
+        env:
+            - name: FOREMAN_PASSWORD
+              version_added: "2.8"
       validate_certs:
         description: verify SSL certificate if using https
         type: boolean


### PR DESCRIPTION
##### SUMMARY
This allows using environment variables to specify options for the foreman inventory script.

Connect https://github.com/ansible/ansible/issues/52672

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/foreman.py

##### ADDITIONAL INFORMATION
For naming, I see `foremancli`

https://projects.theforeman.org/projects/foreman/wiki/Foremancli

https://manpages.debian.org/testing/foremancli/foremancli.1.en.html
