### PR TITLE
Fixes typo of formating to formatting

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -594,7 +594,7 @@ class FilterModule(object):
             'bool': to_bool,
             'to_datetime': to_datetime,
 
-            # date formating
+            # date formatting
             'strftime': strftime,
 
             # quote string for shell usage


### PR DESCRIPTION
Fixes typo of `formating` to `formatting`

cc @Akasurde 