### PR TITLE
k8s_auth: use group module defaults in example

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s_auth.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_auth.py
@@ -74,42 +74,37 @@ requirements:
 '''
 
 EXAMPLES = '''
-- block:
-  # It's good practice to store login credentials in a secure vault and not
-  # directly in playbooks.
-  - include_vars: k8s_passwords.yml
-
-  - name: Log in (obtain access token)
-    k8s_auth:
+- hosts: localhost
+  module_defaults:
+    group/k8s:
       host: https://k8s.example.com/
       ssl_ca_cert: ca.pem
-      username: admin
-      password: "{{ k8s_admin_password }}"
-    register: k8s_auth_results
+  tasks:
+  - block:
+    # It's good practice to store login credentials in a secure vault and not
+    # directly in playbooks.
+    - include_vars: k8s_passwords.yml
 
-  - name: Preserve auth info as both a fact and a yaml anchor for easy access later
-    # Both the fact and the anchor are called 'k8s_auth_params'
-    set_fact:
-      k8s_auth_params: &k8s_auth_params
-        host: "{{ k8s_auth_results.k8s_auth.host }}"
-        ssl_ca_cert: "{{ k8s_auth_results.k8s_auth.ssl_ca_cert }}"
-        verify_ssl: "{{ k8s_auth_results.k8s_auth.verify_ssl }}"
+    - name: Log in (obtain access token)
+      k8s_auth:
+        username: admin
+        password: "{{ k8s_admin_password }}"
+      register: k8s_auth_results
+
+    # Previous task provides the token/api_key, while all other parameters
+    # are taken from module_defaults
+    - name: Get a list of all pods from any namespace
+      k8s_facts:
         api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        kind: Pod
+      register: pod_list
 
-  # Previous task generated I(k8s_auth) fact, which you can then use
-  # in k8s modules like this:
-  - name: Get a list of all pods from any namespace
-    k8s_facts:
-      <<: *k8s_auth_params
-      kind: Pod
-    register: pod_list
-
-  always:
-  - name: If login succeeded, try to log out (revoke access token)
-    when: k8s_auth_params is defined
-    k8s_auth:
-      state: absent
-      <<: *k8s_auth_params
+    always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: k8s_auth_results.k8s_auth.api_key is defined
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
 '''
 
 # Returned value names need to match k8s modules parameter names, to make it


### PR DESCRIPTION
##### SUMMARY
The yaml anchor thing was just a stopgap until all the module defaults group stuff got merged. Which it did.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
modules/k8s/k8s_auth
