### PR TITLE
fix filesystem tests on OpenSUSE 15+

### DIFF
--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -37,4 +37,8 @@
     # https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ReleaseNotes
     - 'not (item.0.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
     - 'not (item.1 == "overwrite_another_fs" and ansible_system == "FreeBSD")'
+
+    # The xfsprogs package on newer versions of OpenSUSE (15+) require Python 3, we skip this on our Python 2 container
+    # OpenSUSE 42.3 Python2 and the other py3 containers are not affected so we will continue to run that
+    - 'not (item.0.key == "xfs" and ansible_os_family == "Suse" and ansible_python.version.major == 2 and ansible_distribution_major_version|int != 42)'
   loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'overwrite_another_fs'])|list }}"

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -2,6 +2,8 @@
   package:
     name: '{{ item }}'
     state: present
+  # xfsprogs on OpenSUSE requires Python 3, skip this for our newer Py2 OpenSUSE builds
+  when: not (item == 'xfsprogs' and ansible_os_family == 'Suse' and ansible_python.version.major == 2 and ansible_distribution_major_version|int != 42)
   with_items:
     - e2fsprogs
     - xfsprogs
@@ -29,7 +31,7 @@
       state: present
     when: ansible_os_family == 'Suse'
     with_items:
-      - python-xml
+      - python{{ ansible_python.version.major }}-xml
       - btrfsprogs
 
   - name: install ocfs2 (Debian)


### PR DESCRIPTION
##### SUMMARY
The filesystem tests on the latest OpenSUSE test containers fail as they install a different version of Python. This PR changes;

* Will install the proper python-xml package based on the Python version
* Will skip the xfs tests on the Python 2 container as `xfsprogs` now relies on Python 3

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
filesystem