### PR TITLE
Format dict keys need to be bytes

### DIFF
--- a/lib/ansible/plugins/callback/cgroup_perf_recap.py
+++ b/lib/ansible/plugins/callback/cgroup_perf_recap.py
@@ -256,10 +256,10 @@ class CallbackModule(CallbackBase):
 
         for feature in self._features:
             data = {
-                'counter': to_bytes(self._counter),
-                'task_uuid': to_bytes(task_uuid),
-                'feature': to_bytes(feature),
-                'ext': to_bytes(output_format)
+                b'counter': to_bytes(self._counter),
+                b'task_uuid': to_bytes(task_uuid),
+                b'feature': to_bytes(feature),
+                b'ext': to_bytes(output_format)
             }
 
             if self._files.get(feature):


### PR DESCRIPTION
##### SUMMARY
Format dict keys need to be bytes since we are doing printf style formatting on a bytestring

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/cgroup_pref_recap.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```