### PR TITLE
Add slaves parameter for module alternatives.  Bug #24278

### DIFF
--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -53,7 +53,7 @@ options:
       - A list of slaves
       - Each slave needs a name, a link and a path parameter
     type: list
-    version_added: "2.8"
+    version_added: "2.10"
 requirements: [ update-alternatives ]
 '''
 

--- a/test/integration/targets/alternatives/tasks/main.yml
+++ b/test/integration/targets/alternatives/tasks/main.yml
@@ -44,6 +44,18 @@
   # Test that path is checked: alternatives must fail when path is nonexistent
   - import_tasks: path_is_checked.yml
 
+  ##########
+  # Slaves
+  - block:
+    - include_tasks: remove_links.yml
+    - include_tasks: setup_test.yml
+    # at least two iterations again
+    - include_tasks: tests_slaves.yml
+      with_sequence: start=2 end=3
+    vars:
+      with_alternatives: False
+      mode: auto
+
   always:
     - include_tasks: remove_links.yml
 

--- a/test/integration/targets/alternatives/tasks/setup.yml
+++ b/test/integration/targets/alternatives/tasks/setup.yml
@@ -13,3 +13,11 @@
     group: root
     mode: 0755
   with_sequence: start=1 end=4
+
+- template:
+    src: dummy_command
+    dest: '/usr/bin/dummy{{ item }}'
+    owner: root
+    group: root
+    mode: 0755
+  with_sequence: start=1 end=4 format=slave%d

--- a/test/integration/targets/alternatives/tasks/tests_slaves.yml
+++ b/test/integration/targets/alternatives/tasks/tests_slaves.yml
@@ -1,0 +1,21 @@
+- name: update dummy alternative w/ slave
+  alternatives:
+    name: dummy
+    path: '/usr/bin/dummy{{ item }}'
+    link: /usr/bin/dummy
+    priority: '10'
+    slaves:
+      - name: dummyslave
+        path: '/usr/bin/dummyslave{{ item }}'
+        link: /usr/bin/dummyslave
+  register: alternative
+
+- name: execute dummyslave command
+  shell: dummyslave
+  register: cmd
+
+- name: check expected command was executed
+  assert:
+    that:
+      - 'alternative is changed'
+      - 'cmd.stdout == "dummyslave{{ item }}"'


### PR DESCRIPTION
##### SUMMARY

Add a slaves parameter for the alternatives module. This helps creating groups of commands which should be switched together. For example if you switch the ansible version there is more then one binary which should change.

Fixes #24278

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
alternatives

##### ADDITIONAL INFORMATION
Example of how to use it.

```paste below
- name: keytool is a slave of java
  alternatives:
    name: ansible
    link: /usr/bin/ansible
    path: /opt/ansible2.7.7/bin/ansible
    slaves:
      - name: ansible-playbook
        link: /usr/bin/ansible-playbook
        path: /opt/ansible-2.7.7/bin/ansible-playbook
```
