### PR TITLE
Type should be a string, not callable bool

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_vscan_on_demand_task.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vscan_on_demand_task.py
@@ -167,7 +167,7 @@ class NetAppOntapVscanOnDemandTask(object):
             report_directory=dict(required=False, type='str'),
             report_log_level=dict(required=False, choices=['verbose', 'info', 'error'], default='error'),
             request_timeout=dict(required=False, type='str'),
-            scan_files_with_no_ext=dict(required=False, type=bool, default=True),
+            scan_files_with_no_ext=dict(required=False, type='bool', default=True),
             scan_paths=dict(required=False, type="list"),
             scan_priority=dict(required=False, choices=['low', 'normal'], default='low'),
             schedule=dict(required=False, type="str"),


### PR DESCRIPTION
##### SUMMARY
Type should be a string, not callable bool

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/storage/netapp/na_ontap_vscan_on_demand_task.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```