### PR TITLE
VMware: Fix KeyError in vmware_host_config_manager

### DIFF
--- a/changelogs/fragments/44561-vmware_host_config_manager-fix_key_error.yml
+++ b/changelogs/fragments/44561-vmware_host_config_manager-fix_key_error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixed issue when a supported option isn't already set (https://github.com/ansible/ansible/issues/44561).

--- a/changelogs/fragments/44561-vmware_host_config_manager-fix_key_error.yml
+++ b/changelogs/fragments/44561-vmware_host_config_manager-fix_key_error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- Fixed issue when a supported option isn't already set (https://github.com/ansible/ansible/issues/44561).
+- Fixed KeyError issue in vmware_host_config_manager when a supported option isn't already set (https://github.com/ansible/ansible/issues/44561).

--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
@@ -129,46 +129,42 @@ class VmwareConfigManager(PyVmomi):
         for host in self.hosts:
             option_manager = host.configManager.advancedOption
             host_facts = {}
-            for option in option_manager.QueryOptions():
-                host_facts[option.key] = dict(value=option.value)
-
             for s_option in option_manager.supportedOption:
-                host_facts[s_option.key].update(
-                    option_type=s_option.optionType,
-                )
+                host_facts[s_option.key] = dict(option_type=s_option.optionType, value=None)
+
+            for option in option_manager.QueryOptions():
+                if option.key in host_facts:
+                    host_facts[option.key].update(
+                        value=option.value,
+                    )
 
             change_option_list = []
             for option_key, option_value in self.options.items():
                 if option_key in host_facts:
-                    # Make sure option_type is defined some values do not have
-                    # it defined and appear to be read only.
-                    if 'option_type' in host_facts[option_key]:
-                        # We handle all supported types here so we can give meaningful errors.
-                        option_type = host_facts[option_key]['option_type']
-                        if self.is_boolean(option_value) and isinstance(option_type, vim.option.BoolOption):
-                            option_value = self.is_truthy(option_value)
-                        elif (isinstance(option_value, integer_types) or self.is_integer(option_value))\
-                                and isinstance(option_type, vim.option.IntOption):
-                            option_value = VmomiSupport.vmodlTypes['int'](option_value)
-                        elif (isinstance(option_value, integer_types) or self.is_integer(option_value, 'long'))\
-                                and isinstance(option_type, vim.option.LongOption):
-                            option_value = VmomiSupport.vmodlTypes['long'](option_value)
-                        elif isinstance(option_value, float) and isinstance(option_type, vim.option.FloatOption):
-                            pass
-                        elif isinstance(option_value, string_types) and isinstance(option_type, (vim.option.StringOption, vim.option.ChoiceOption)):
-                            pass
-                        else:
-                            self.module.fail_json(msg="Provided value is of type %s."
-                                                      " Option %s expects: %s" % (type(option_value), option_key, type(option_type)))
+                    # We handle all supported types here so we can give meaningful errors.
+                    option_type = host_facts[option_key]['option_type']
+                    if self.is_boolean(option_value) and isinstance(option_type, vim.option.BoolOption):
+                        option_value = self.is_truthy(option_value)
+                    elif (isinstance(option_value, integer_types) or self.is_integer(option_value))\
+                            and isinstance(option_type, vim.option.IntOption):
+                        option_value = VmomiSupport.vmodlTypes['int'](option_value)
+                    elif (isinstance(option_value, integer_types) or self.is_integer(option_value, 'long'))\
+                            and isinstance(option_type, vim.option.LongOption):
+                        option_value = VmomiSupport.vmodlTypes['long'](option_value)
+                    elif isinstance(option_value, float) and isinstance(option_type, vim.option.FloatOption):
+                        pass
+                    elif isinstance(option_value, string_types) and isinstance(option_type, (vim.option.StringOption, vim.option.ChoiceOption)):
+                        pass
                     else:
-                        self.module.fail_json(msg="Cannot change read only option %s to %s." % (option_key, option_value))
+                        self.module.fail_json(msg="Provided value is of type %s."
+                                                  " Option %s expects: %s" % (type(option_value), option_key, type(option_type)))
 
                     if option_value != host_facts[option_key]['value']:
                         change_option_list.append(vim.option.OptionValue(key=option_key, value=option_value))
                         changed = True
                         changed_list.append(option_key)
                 else:  # Don't silently drop unknown options. This prevents typos from falling through the cracks.
-                    self.module.fail_json(msg="Unknown option %s" % option_key)
+                    self.module.fail_json(msg="Unsupported option %s" % option_key)
             if changed:
                 if self.module.check_mode:
                     changed_suffix = ' would be changed.'


### PR DESCRIPTION
##### SUMMARY
option_manager.supportedOption may return options that aren't set which results in a KeyError

Fixes #44561

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_config_manager

##### ADDITIONAL INFORMATION
The problem is that _first_ all options that are set are retrieved and _then_ this list is updated with every option's type. When 'Vpx.Vpxa.config.log.level' is supported but not set, this results in a KeyError because `host_facts[Vpx.Vpxa.config.log.level']` doesn't exist.

I think it is better to _first_ get a list of all supported options and _then_ update this list with every option's actual value.