### PR TITLE
Added 'newline_char' and 'exit_cmd' options

### DIFF
--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -45,6 +45,7 @@ class ActionModule(ActionBase):
             pause = self._task.args.get('pause', 1)
 
             send_newline = self._task.args.get('send_newline', False)
+            newline_char = self._task.args.get('newline_char', b"\n")
 
             login_prompt = self._task.args.get('login_prompt', "login: ")
             password_prompt = self._task.args.get('password_prompt', "Password: ")
@@ -61,20 +62,20 @@ class ActionModule(ActionBase):
                 output = []
                 try:
                     if send_newline:
-                        tn.write(b'\n')
+                        tn.write(newline_char)
 
                     tn.read_until(to_bytes(login_prompt))
-                    tn.write(to_bytes(user + "\n"))
+                    tn.write(to_bytes(user + newline_char))
 
                     if password:
                         tn.read_until(to_bytes(password_prompt))
-                        tn.write(to_bytes(password + "\n"))
+                        tn.write(to_bytes(password + newline_char))
 
                     tn.expect(list(map(to_bytes, prompts)))
 
                     for cmd in commands:
                         display.vvvvv('>>> %s' % cmd)
-                        tn.write(to_bytes(cmd + "\n"))
+                        tn.write(to_bytes(cmd + newline_char))
                         index, match, out = tn.expect(list(map(to_bytes, prompts)))
                         display.vvvvv('<<< %s' % cmd)
                         output.append(out)

--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -46,6 +46,7 @@ class ActionModule(ActionBase):
 
             send_newline = self._task.args.get('send_newline', False)
             newline_char = self._task.args.get('newline_char', b"\n")
+            exit_cmd = self._task.args.get('exit_cmd', b'exit')
 
             login_prompt = self._task.args.get('login_prompt', "login: ")
             password_prompt = self._task.args.get('password_prompt', "Password: ")
@@ -81,7 +82,7 @@ class ActionModule(ActionBase):
                         output.append(out)
                         sleep(pause)
 
-                    tn.write(b"exit\n")
+                    tn.write(exit_cmd + newline_char)
 
                 except EOFError as e:
                     result['failed'] = True


### PR DESCRIPTION
##### SUMMARY
I am working on a device that does not use the UNIX convention where the linefeed character is the line terminator; instead it uses CR.  (The LF character acts as an "abort action", similar to ^U on a UNIX system, where all characters typed into the terminal line left of the cursor are deleted.) I need a way to specify the newline character.

In addition, the unit does not recognize 'exit\r' as a valid command to terminate the session; only 'logout' is accepted.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/action/telnet.py

##### ADDITIONAL INFORMATION
- Added a new variable, **newline_char**
- newline_char is initialized from **self._task.args.get('newline_char')** so that it can be specified in playbooks.  Default is b"\n"
- Removed the hardcoded b"\n" string within the telnet.py module, replaced with the variable
- Added a second new variable, **exit_cmd**
- exit_cmd is initialized from **self._task.args.get('exit_cmd')** so that it can be specified in playbooks.  Default is b"exit"
- Removed the hardcoded b"exit" string within the telnet.py module, replaced with the variable

Before the change, here is what I would see in debug output when I connect to the device.  The device would backspace over my line, and the change would not take:
```
TASK [perle-common : Set server name] ****************************************************
task path: /etc/ansible/roles/perle-common/tasks/main.yml:4
>>> set server name MTS1.CPELab
<<< set server name MTS1.CPELab
changed: [MTS1.CPELab] => {
    "changed": true, 
    "output": [
        "set server name MTS1.CPELab\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\rSCS32# "
    ]
}
```
After I made the changes in telnet.py, and updated my playbook to include **newline_char: "\r"** in my job step, I now see better results, and the server's name has been changed:
```
TASK [perle-common : Set server name] ****************************************************
task path: /home/bknight/ansible/ansible-config/roles/perle-common/tasks/main.yml:4
>>> set server name MTS1.CPELab
<<< set server name MTS1.CPELab
changed: [MTS1.CPELab] => {
    "changed": true, 
    "output": [
        "set server name MTS1.CPELab\r\nSCS32# "
    ]
}
```

Please be gentle, this is my first time ever forking a project, contributing a fix, creating a pull request, etc etc. Thanks.