### PR TITLE
Add docker_prune sample to remove everything, including non-dangling images

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_prune.py
+++ b/lib/ansible/modules/cloud/docker/docker_prune.py
@@ -105,6 +105,15 @@ EXAMPLES = '''
     networks: yes
     volumes: yes
     builder_cache: yes
+    
+- name: Prune everything (including non-dangling images)
+  docker_prune:
+    containers: yes
+    images: yes
+      dangling: false
+    networks: yes
+    volumes: yes
+    builder_cache: yes
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/docker/docker_prune.py
+++ b/lib/ansible/modules/cloud/docker/docker_prune.py
@@ -105,7 +105,7 @@ EXAMPLES = '''
     networks: yes
     volumes: yes
     builder_cache: yes
-    
+
 - name: Prune everything (including non-dangling images)
   docker_prune:
     containers: yes

--- a/lib/ansible/modules/cloud/docker/docker_prune.py
+++ b/lib/ansible/modules/cloud/docker/docker_prune.py
@@ -110,6 +110,7 @@ EXAMPLES = '''
   docker_prune:
     containers: yes
     images: yes
+    images_filters:
       dangling: false
     networks: yes
     volumes: yes


### PR DESCRIPTION
##### SUMMARY
Add `docker_prune` example to remove everything, including non-dangling images.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY

Given the condition that (by default) `docker system prune` only removes dangling images, it would be a good idea to show an example using `dangling=true` filter.


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`docker_prune.py`

##### ADDITIONAL INFORMATION
N/A
