### PR TITLE
network.py:ActionModule:run: does not honor _handle_src_option failures

### DIFF
--- a/lib/ansible/plugins/action/network.py
+++ b/lib/ansible/plugins/action/network.py
@@ -40,9 +40,7 @@ class ActionModule(_ActionModule):
     def run(self, task_vars=None):
         config_module = hasattr(self, '_config_module') and self._config_module
         if config_module and self._task.args.get('src'):
-            src_result = self._handle_src_option()
-            if src_result:
-                return src_result
+            self._handle_src_option()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 

--- a/lib/ansible/plugins/action/network.py
+++ b/lib/ansible/plugins/action/network.py
@@ -40,7 +40,9 @@ class ActionModule(_ActionModule):
     def run(self, task_vars=None):
         config_module = hasattr(self, '_config_module') and self._config_module
         if config_module and self._task.args.get('src'):
-            self._handle_src_option()
+            src_result = self._handle_src_option()
+            if src_result:
+                return src_result
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 

--- a/test/integration/targets/nxos_config/tests/common/src_basic.yaml
+++ b/test/integration/targets/nxos_config/tests/common/src_basic.yaml
@@ -1,8 +1,7 @@
 ---
 - debug: msg="START common/src_basic.yaml on connection={{ ansible_connection }}"
 
-# Select interface for test
-- set_fact: intname="{{ nxos_int1 }}"
+- set_fact: intname="loopback1"
 
 - name: setup
   nxos_config:
@@ -16,13 +15,9 @@
 
 - name: configure device with config
   nxos_config:
-    commands:
-      - description this is a test
-      - shutdown
-    parents:
-      - "interface {{ intname }}"
-    defaults: yes
+    src: basic/config.j2
     provider: "{{ connection }}"
+    defaults: yes
   register: result
 
 - assert:
@@ -33,12 +28,7 @@
 
 - name: check device with config
   nxos_config:
-    commands:
-      - description this is a test
-      - shutdown
-    parents:
-      - "interface {{ intname }}"
-    defaults: yes
+    src: basic/config.j2
     provider: "{{ connection }}"
   register: result
 

--- a/test/integration/targets/nxos_config/tests/common/src_invalid.yaml
+++ b/test/integration/targets/nxos_config/tests/common/src_invalid.yaml
@@ -12,7 +12,6 @@
 
 - assert:
     that:
-      - "result.changed == false"
       - "result.failed == true"
       - "result.msg == 'path specified in src not found'"
 


### PR DESCRIPTION
##### SUMMARY
PR #50301 moved template error handling out of run() and into its own method in `handle_src_option`; however, after the change run() ignores the return value so any errors are ignored.

My fix looks for error state and returns it if present. Verified fix with `nxos_config/tests/common/src_*` tests.

Ref:
    https://github.com/ansible/ansible/commit/71113ee291aa51f5363486537b3407204acb5a99#diff-7477bf046013758366cc85b06f90709aR43

Also updated the `src_basic.yaml` test which didn't actually test with `src:` before.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/action/network`

##### ADDITIONAL INFORMATION
Reproduceable with `nxos_config/tests/common/src_invalid.yaml`. The symptom is that the src: string fails the template handling (as expected) but the string is sent to the device anyway.

From `src_invalid.yaml`:
```
- name: configure with invalid src
  nxos_config:
    src: basic/foobar.j2
    provider: "{{ connection }}"
  register: result
  ignore_errors: yes
```

Test output:
```paste below
    "msg": "basic/foobar.j2\r\r\n                   ^\r\n% Invalid command at '^' marker.\r\n\rn9k-109(config)# "
...
fatal: [n9k-109.cisco.com]: FAILED! => {
    "assertion": "result.msg == 'path specified in src not found'",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
```
