### PR TITLE
Add support for deep merge of argument spec to module_utils.api

### DIFF
--- a/lib/ansible/module_utils/api.py
+++ b/lib/ansible/module_utils/api.py
@@ -43,30 +43,38 @@ The 'api' module provides the following common argument specs:
 """
 import time
 
+from ansible.module_utils.common.dict_transformations import dict_merge
 
-def rate_limit_argument_spec(spec=None):
+
+def rate_limit_argument_spec(spec=None, merge=False):
     """Creates an argument spec for working with rate limiting"""
     arg_spec = (dict(
         rate=dict(type='int'),
         rate_limit=dict(type='int'),
     ))
     if spec:
-        arg_spec.update(spec)
+        if not merge:
+            arg_spec.update(spec)
+        else:
+            arg_spec = dict_merge(arg_spec, spec)
     return arg_spec
 
 
-def retry_argument_spec(spec=None):
+def retry_argument_spec(spec=None, merge=False):
     """Creates an argument spec for working with retrying"""
     arg_spec = (dict(
         retries=dict(type='int'),
         retry_pause=dict(type='float', default=1),
     ))
     if spec:
-        arg_spec.update(spec)
+        if not merge:
+            arg_spec.update(spec)
+        else:
+            arg_spec = dict_merge(arg_spec, spec)
     return arg_spec
 
 
-def basic_auth_argument_spec(spec=None):
+def basic_auth_argument_spec(spec=None, merge=False):
     arg_spec = (dict(
         api_username=dict(type='str'),
         api_password=dict(type='str', no_log=True),
@@ -74,7 +82,10 @@ def basic_auth_argument_spec(spec=None):
         validate_certs=dict(type='bool', default=True)
     ))
     if spec:
-        arg_spec.update(spec)
+        if not merge:
+            arg_spec.update(spec)
+        else:
+            arg_spec = dict_merge(arg_spec, spec)
     return arg_spec
 
 

--- a/lib/ansible/module_utils/api.py
+++ b/lib/ansible/module_utils/api.py
@@ -53,10 +53,10 @@ def rate_limit_argument_spec(spec=None, merge=False):
         rate_limit=dict(type='int'),
     ))
     if spec:
-        if not merge:
-            arg_spec.update(spec)
-        else:
+        if merge:
             arg_spec = dict_merge(arg_spec, spec)
+        else:
+            arg_spec.update(spec)
     return arg_spec
 
 
@@ -67,10 +67,10 @@ def retry_argument_spec(spec=None, merge=False):
         retry_pause=dict(type='float', default=1),
     ))
     if spec:
-        if not merge:
-            arg_spec.update(spec)
-        else:
+        if merge:
             arg_spec = dict_merge(arg_spec, spec)
+        else:
+            arg_spec.update(spec)
     return arg_spec
 
 
@@ -82,10 +82,10 @@ def basic_auth_argument_spec(spec=None, merge=False):
         validate_certs=dict(type='bool', default=True)
     ))
     if spec:
-        if not merge:
-            arg_spec.update(spec)
-        else:
+        if merge:
             arg_spec = dict_merge(arg_spec, spec)
+        else:
+            arg_spec.update(spec)
     return arg_spec
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When building a custom module, I wanted to use the pre-built argument_spec from `ansible.module_utils.api`, but to modify the existing arguments, not completely replace them which `dict().update()` will do. Here I use the `dict_merge` function from `ansible.module_utils.common.dict_transformations` to do that.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.module_utils.api

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

