### PR TITLE
Add toggle to control invalid character substitution in group names

### DIFF
--- a/changelogs/fragments/togggle_invalid_group_chars.yml
+++ b/changelogs/fragments/togggle_invalid_group_chars.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - add toggle to allow user to override invalid group character filter

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1439,6 +1439,18 @@ INTERPRETER_PYTHON_FALLBACK:
   - python
   # FUTURE: add inventory override once we're sure it can't be abused by a rogue target
   version_added: "2.8"
+TRANSFORM_INVALID_GROUP_CHARS:
+  name: Transform invalid characters in group names
+  default: False
+  description:
+    - Make ansible transform invalid characters in group names supplied by inventory sources.
+    - If 'false' it will allow for the group name but warn about the issue.
+    - When 'true' it will replace any invalid charachters with '_' (underscore).
+  env: [{name: ANSIBLE__TRANSFORM_INVALID_GROUP_CHARS}]
+  ini:
+  - {key: force_valid_group_names, section: defaults}
+  type: bool 
+  version_added: '2.8'
 INVALID_TASK_ATTRIBUTE_FAILED:
   name: Controls whether invalid attributes for a task result in errors instead of warnings
   default: True

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1446,10 +1446,10 @@ TRANSFORM_INVALID_GROUP_CHARS:
     - Make ansible transform invalid characters in group names supplied by inventory sources.
     - If 'false' it will allow for the group name but warn about the issue.
     - When 'true' it will replace any invalid charachters with '_' (underscore).
-  env: [{name: ANSIBLE__TRANSFORM_INVALID_GROUP_CHARS}]
+  env: [{name: ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS}]
   ini:
   - {key: force_valid_group_names, section: defaults}
-  type: bool 
+  type: bool
   version_added: '2.8'
 INVALID_TASK_ATTRIBUTE_FAILED:
   name: Controls whether invalid attributes for a task result in errors instead of warnings

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -116,7 +116,7 @@ RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python')
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
-VALID_VARIABLE_NAMES = r'[a-zA-Z_][a-zA-Z0-9_]*'
+INVALID_VARIABLE_NAMES = r'[^a-zA-Z_][^a-zA-Z0-9_]*'
 
 # FIXME: remove once play_context mangling is removed
 # the magic variable mapping dictionary below is used to translate

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -116,7 +116,7 @@ RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python')
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
-INVALID_VARIABLE_NAMES = r'^[^a-zA-Z_][^a-zA-Z0-9_]*'
+INVALID_VARIABLE_NAMES = r'^[^a-zA-Z_]|[^a-zA-Z0-9_]'
 
 # FIXME: remove once play_context mangling is removed
 # the magic variable mapping dictionary below is used to translate

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import re
 
 from ast import literal_eval
 from jinja2 import Template
@@ -116,7 +117,7 @@ RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python')
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
-INVALID_VARIABLE_NAMES = r'^[^a-zA-Z_]|[^a-zA-Z0-9_]'
+INVALID_VARIABLE_NAMES = re.compile(r'^[^a-zA-Z_]|[^a-zA-Z0-9_]')
 
 # FIXME: remove once play_context mangling is removed
 # the magic variable mapping dictionary below is used to translate

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -116,6 +116,7 @@ RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python')
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
+VALID_VARIABLE_NAMES = r'[a-zA-Z_][a-zA-Z0-9_]*'
 
 # FIXME: remove once play_context mangling is removed
 # the magic variable mapping dictionary below is used to translate

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -116,7 +116,7 @@ RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python')
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
-INVALID_VARIABLE_NAMES = r'[^a-zA-Z_][^a-zA-Z0-9_]*'
+INVALID_VARIABLE_NAMES = r'^[^a-zA-Z_][^a-zA-Z0-9_]*'
 
 # FIXME: remove once play_context mangling is removed
 # the magic variable mapping dictionary below is used to translate

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -117,6 +117,8 @@ RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python')
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
+
+# This matches a string that cannot be used as a valid python variable name i.e 'not-valid', 'not!valid@either' '1_nor_This'
 INVALID_VARIABLE_NAMES = re.compile(r'^[^a-zA-Z_]|[^a-zA-Z0-9_]')
 
 # FIXME: remove once play_context mangling is removed

--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -156,7 +156,7 @@ class InventoryData(object):
         return matching_host
 
     def add_group(self, group):
-        ''' adds a group to inventory if not there already '''
+        ''' adds a group to inventory if not there already, returns named actually used '''
 
         group = to_safe_group_name(group)
         if group:
@@ -171,6 +171,8 @@ class InventoryData(object):
                 display.debug("group %s already in inventory" % group)
         else:
             raise AnsibleError("Invalid empty/false group name provided: %s" % group)
+
+        return group
 
     def remove_group(self, group):
 
@@ -189,6 +191,8 @@ class InventoryData(object):
         if host:
             if not isinstance(host, string_types):
                 raise AnsibleError("Invalid host name supplied, expected a string but got %s for %s" % (type(host), host))
+
+            # TODO: add to_safe_host_name
             g = None
             if group:
                 if group in self.groups:
@@ -223,6 +227,8 @@ class InventoryData(object):
                 display.debug("Added host %s to group %s" % (host, group))
         else:
             raise AnsibleError("Invalid empty host name provided: %s" % host)
+
+        return host
 
     def remove_host(self, host):
 

--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -23,7 +23,7 @@ import sys
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.inventory.group import Group
+from ansible.inventory.group import Group, to_safe_group_name
 from ansible.inventory.host import Host
 from ansible.module_utils.six import iteritems, string_types
 from ansible.utils.display import Display
@@ -158,6 +158,7 @@ class InventoryData(object):
     def add_group(self, group):
         ''' adds a group to inventory if not there already '''
 
+        group = to_safe_group_name(group)
         if group:
             if not isinstance(group, string_types):
                 raise AnsibleError("Invalid group name supplied, expected a string but got %s for %s" % (type(group), group))

--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -23,7 +23,7 @@ import sys
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.inventory.group import Group, to_safe_group_name
+from ansible.inventory.group import Group
 from ansible.inventory.host import Host
 from ansible.module_utils.six import iteritems, string_types
 from ansible.utils.display import Display
@@ -158,15 +158,16 @@ class InventoryData(object):
     def add_group(self, group):
         ''' adds a group to inventory if not there already, returns named actually used '''
 
-        group = to_safe_group_name(group)
         if group:
             if not isinstance(group, string_types):
                 raise AnsibleError("Invalid group name supplied, expected a string but got %s for %s" % (type(group), group))
             if group not in self.groups:
                 g = Group(group)
-                self.groups[group] = g
-                self._groups_dict_cache = {}
-                display.debug("Added group %s to inventory" % group)
+                if g.name not in self.groups:
+                    self.groups[g.name] = g
+                    self._groups_dict_cache = {}
+                    display.debug("Added group %s to inventory" % group)
+                group = g.name
             else:
                 display.debug("group %s already in inventory" % group)
         else:

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -43,8 +43,9 @@ def to_safe_group_name(name, replacer="_"):
         name = _UNSAFE_GROUP.sub(replacer, name, replace_and_warn)
     else:
         matched = _UNSAFE_GROUP.search(name)
-        for match in set(matched.groups):
-            display.deprecated('Ignoring invalid character (%s) in group name, in the future this will be an error' % to_text(matched), version='2.12')
+        if matched is not None:
+            for match in set(matched.groups):
+                display.deprecated('Ignoring invalid character (%s) in group name, in the future this will be an error' % to_text(matched), version='2.12')
     return name
 
 

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -28,7 +28,7 @@ from ansible.module_utils._text import to_native, to_text
 from ansible.utils.display import Display
 
 display = Display()
-_UNSAFE_GROUP = re.compile(C.VALID_VARIABLE_NAMES)
+_UNSAFE_GROUP = re.compile(C.INVALID_VARIABLE_NAMES)
 
 
 def to_safe_group_name(name, replacer="_", force=False, silent=False):

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -25,7 +25,10 @@ from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 
-_UNSAFE_GROUP = re.compile(C.INVALID_GROUP_CHARS)
+try:
+    _UNSAFE_GROUP = re.compile(C.INVALID_GROUP_CHARS)
+except Exception as e:
+    raise AnsibleError('Invalid regex suplied for "invalid group names" (%s): %s ' % (to_native(C.INVALID_GROUP_CHARS), to_native(e)))
 
 
 def to_safe_group_name(name, replacer="_"):

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -34,7 +34,7 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
     if name:  # when deserializing we might not have name yet
         invalid_chars = C.INVALID_VARIABLE_NAMES.findall(name)
         if invalid_chars:
-            msg = 'invalid character(s) "%s" in group name (%s)' % (to_text(invalid_chars), to_text(name))
+            msg = 'invalid character(s) "%s" in group name (%s)' % (to_text(set(invalid_chars)), to_text(name))
             if C.TRANSFORM_INVALID_GROUP_CHARS or force:
                 name = C.INVALID_VARIABLE_NAMES.sub(replacer, name)
                 if not silent:

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -39,13 +39,14 @@ def replace_and_warn(match):
 def to_safe_group_name(name, replacer="_"):
     ''' Converts 'bad' characters in a string to underscores so they can be used as Ansible hosts or groups '''
 
-    if C.TRANSFORM_INVALID_GROUP_CHARS:
-        name = _UNSAFE_GROUP.sub(replacer, name, replace_and_warn)
-    else:
-        invalid_chars = _UNSAFE_GROUP.findall(name)
-        if invalid_chars:
-            display.deprecated('Ignoring invalid character(s) "%s" in group (%s), in the future this will be an error' % to_text(invalid_chars, to_text(name)),
-                               version='2.12')
+    if name: # when deserializing we might not have name yet
+        if C.TRANSFORM_INVALID_GROUP_CHARS:
+            name = _UNSAFE_GROUP.sub(replacer, name, replace_and_warn)
+        else:
+            invalid_chars = _UNSAFE_GROUP.findall(name)
+            if invalid_chars:
+                display.deprecated('Ignoring invalid character(s) "%s" in group (%s), in the future this will be an error' % to_text(invalid_chars, to_text(name)),
+                                   version='2.12')
     return name
 
 

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -31,7 +31,7 @@ display = Display()
 _UNSAFE_GROUP = re.compile("[^A-Za-z0-9_]")
 
 
-def to_safe_group_name(name, replacer="_", force=False):
+def to_safe_group_name(name, replacer="_", force=False, silent=False):
     # Converts 'bad' characters in a string to underscores (or provided replacer) so they can be used as Ansible hosts or groups
 
     if name:  # when deserializing we might not have name yet
@@ -40,7 +40,8 @@ def to_safe_group_name(name, replacer="_", force=False):
             msg = 'invalid character(s) "%s" in group name (%s)' % (to_text(invalid_chars), to_text(name))
             if C.TRANSFORM_INVALID_GROUP_CHARS or force:
                 name = _UNSAFE_GROUP.sub(replacer, name)
-                display.warning('Replacing ' + msg)
+                if not silent:
+                    display.warning('Replacing ' + msg)
             else:
                 display.deprecated('Ignoring ' + msg, version='2.12')
     return name

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -42,7 +42,7 @@ def to_safe_group_name(name, replacer="_"):
     if C.TRANSFORM_INVALID_GROUP_CHARS:
         name = _UNSAFE_GROUP.sub(replacer, name, replace_and_warn)
     else:
-        matched = _UNSAFE_GROUP.search()
+        matched = _UNSAFE_GROUP.search(name)
         for match in set(matched.groups):
             display.deprecated('Ignoring invalid character (%s) in group name, in the future this will be an error' % to_text(matched), version='2.12')
     return name

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -28,7 +28,7 @@ from ansible.module_utils._text import to_native, to_text
 from ansible.utils.display import Display
 
 display = Display()
-_UNSAFE_GROUP = re.compile("[^A-Za-z0-9_]")
+_UNSAFE_GROUP = re.compile(C.VALID_VARIABLE_NAMES)
 
 
 def to_safe_group_name(name, replacer="_", force=False, silent=False):

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -39,13 +39,14 @@ def replace_and_warn(match):
 def to_safe_group_name(name, replacer="_"):
     ''' Converts 'bad' characters in a string to underscores so they can be used as Ansible hosts or groups '''
 
-    if name: # when deserializing we might not have name yet
+    if name:  # when deserializing we might not have name yet
         if C.TRANSFORM_INVALID_GROUP_CHARS:
             name = _UNSAFE_GROUP.sub(replacer, name, replace_and_warn)
         else:
             invalid_chars = _UNSAFE_GROUP.findall(name)
             if invalid_chars:
-                display.deprecated('Ignoring invalid character(s) "%s" in group (%s), in the future this will be an error' % to_text(invalid_chars), to_text(name)),
+                display.deprecated('Ignoring invalid character(s) "%s" in group (%s), in the future this will be an error' % (to_text(invalid_chars),
+                                                                                                                              to_text(name)),
                                    version='2.12')
     return name
 

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -17,8 +17,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import re
-
 from itertools import chain
 
 from ansible import constants as C
@@ -28,18 +26,17 @@ from ansible.module_utils._text import to_native, to_text
 from ansible.utils.display import Display
 
 display = Display()
-_UNSAFE_GROUP = re.compile(C.INVALID_VARIABLE_NAMES)
 
 
 def to_safe_group_name(name, replacer="_", force=False, silent=False):
     # Converts 'bad' characters in a string to underscores (or provided replacer) so they can be used as Ansible hosts or groups
 
     if name:  # when deserializing we might not have name yet
-        invalid_chars = _UNSAFE_GROUP.findall(name)
+        invalid_chars = C.INVALID_VARIABLE_NAMES.findall(name)
         if invalid_chars:
             msg = 'invalid character(s) "%s" in group name (%s)' % (to_text(invalid_chars), to_text(name))
             if C.TRANSFORM_INVALID_GROUP_CHARS or force:
-                name = _UNSAFE_GROUP.sub(replacer, name)
+                name = C.INVALID_VARIABLE_NAMES.sub(replacer, name)
                 if not silent:
                     display.warning('Replacing ' + msg)
             else:

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -45,7 +45,7 @@ def to_safe_group_name(name, replacer="_"):
         else:
             invalid_chars = _UNSAFE_GROUP.findall(name)
             if invalid_chars:
-                display.deprecated('Ignoring invalid character(s) "%s" in group (%s), in the future this will be an error' % to_text(invalid_chars, to_text(name)),
+                display.deprecated('Ignoring invalid character(s) "%s" in group (%s), in the future this will be an error' % to_text(invalid_chars), to_text(name)),
                                    version='2.12')
     return name
 

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -316,8 +316,8 @@ class Constructable(object):
         if groups and isinstance(groups, dict):
             self.templar.set_available_variables(variables)
             for group_name in groups:
-                group_name = to_safe_group_name(group_name)
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
+                group_name = to_safe_group_name(group_name)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -41,7 +41,7 @@ display = Display()
 # Helper methods
 def to_safe_group_name(name):
     # placeholder for backwards compat
-    return original_safe(name, force=True)
+    return original_safe(name, force=True, silent=True)
 
 
 def detect_range(line=None):

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -316,6 +316,7 @@ class Constructable(object):
         if groups and isinstance(groups, dict):
             self.templar.set_available_variables(variables)
             for group_name in groups:
+                group_name = to_safe_group_name(group_name)
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
                 try:
                     result = boolean(self.templar.template(conditional))
@@ -325,8 +326,8 @@ class Constructable(object):
                     continue
 
                 if result:
-                    # ensure group exists
-                    self.inventory.add_group(group_name)
+                    # ensure group exists, use sanatized name
+                    group_name = self.inventory.add_group(group_name)
                     # add host to group
                     self.inventory.add_child(group_name, host)
 

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -21,10 +21,10 @@ __metaclass__ = type
 
 import hashlib
 import os
-import re
 import string
 
 from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.inventory.group import to_safe_group_name as original_safe
 from ansible.parsing.utils.addresses import parse_address
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.cache import InventoryFileCacheModule
@@ -37,13 +37,11 @@ from ansible.utils.display import Display
 
 display = Display()
 
-_SAFE_GROUP = re.compile("[^A-Za-z0-9_]")
-
 
 # Helper methods
 def to_safe_group_name(name):
-    ''' Converts 'bad' characters in a string to underscores so they can be used as Ansible hosts or groups '''
-    return _SAFE_GROUP.sub("_", name)
+    # placeholder for backwards compat
+    return original_safe(name)
 
 
 def detect_range(line=None):

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -41,7 +41,7 @@ display = Display()
 # Helper methods
 def to_safe_group_name(name):
     # placeholder for backwards compat
-    return original_safe(name)
+    return original_safe(name, force=True)
 
 
 def detect_range(line=None):

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -446,7 +446,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _populate(self, groups, hostnames):
         for group in groups:
-            self.inventory.add_group(group)
+            group = self.inventory.add_group(group)
             self._add_hosts(hosts=groups[group], group=group, hostnames=hostnames)
             self.inventory.add_child('all', group)
 

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -191,7 +191,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 self.inventory.add_host(host['name'])
 
                 # create directly mapped groups
-                group_name = host.get('hostgroup_title', host.get('hostgroup_name')
+                group_name = host.get('hostgroup_title', host.get('hostgroup_name'))
                 if group_name:
                     group_name = to_safe_group_name('%s%s' % (self.get_option('group_prefix'), group_name.lower().replace(" ", "")))
                     group_name = self.inventory.add_group(group_name)
@@ -214,7 +214,8 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                         try:
                             self.inventory.set_variable(host['name'], p['name'], p['value'])
                         except ValueError as e:
-                            self.display.warning("Could not set parameter hostvar for %s, skipping %s: %s" % (host, p['name'], to_native(p['value'])))
+                            self.display.warning("Could not set hostvar %s to '%s' for the '%s' host, skipping:  %s" %
+                                                 (p['name'], to_native(p['value']), host, to_native(e)))
 
                 # set host vars from facts
                 if self.get_option('want_facts'):

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -65,7 +65,7 @@ from distutils.version import LooseVersion
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable
+from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, to_safe_group_name
 
 # 3rd party imports
 try:
@@ -191,9 +191,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 self.inventory.add_host(host['name'])
 
                 # create directly mapped groups
-                group_name = host.get('hostgroup_title', host.get('hostgroup_name'))
+                group_name = host.get('hostgroup_title', host.get('hostgroup_name')
                 if group_name:
-                    group_name = self.inventory.add_group('%s%s' % (self.get_option('group_prefix'), group_name.lower().replace(" ", "")))
+                    group_name = to_safe_group_name('%s%s' % (self.get_option('group_prefix'), group_name.lower().replace(" ", "")))
+                    group_name = self.inventory.add_group(group_name)
                     self.inventory.add_child(group_name, host['name'])
 
                 # set host vars from host info

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -193,7 +193,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 # create directly mapped groups
                 group_name = host.get('hostgroup_title', host.get('hostgroup_name'))
                 if group_name:
-                    group_name = self.inventory.add_group('%s%s' % (self.get_option('group_prefix'), group_name.lower().replace(" ","")))
+                    group_name = self.inventory.add_group('%s%s' % (self.get_option('group_prefix'), group_name.lower().replace(" ", "")))
                     self.inventory.add_child(group_name, host['name'])
 
                 # set host vars from host info

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -60,8 +60,6 @@ password: secure
 validate_certs: False
 '''
 
-import re
-
 from distutils.version import LooseVersion
 
 from ansible.errors import AnsibleError
@@ -185,14 +183,6 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             raise ValueError("More than one set of facts returned for '%s'" % host)
         return facts
 
-    def to_safe(self, word):
-        '''Converts 'bad' characters in a string to underscores so they can be used as Ansible groups
-        #> ForemanInventory.to_safe("foo-bar baz")
-        'foo_barbaz'
-        '''
-        regex = r"[^A-Za-z0-9\_]"
-        return re.sub(regex, "_", word.replace(" ", ""))
-
     def _populate(self):
 
         for host in self._get_hosts():
@@ -203,8 +193,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 # create directly mapped groups
                 group_name = host.get('hostgroup_title', host.get('hostgroup_name'))
                 if group_name:
-                    group_name = self.to_safe('%s%s' % (self.get_option('group_prefix'), group_name.lower()))
-                    self.inventory.add_group(group_name)
+                    group_name = self.inventory.add_group('%s%s' % (self.get_option('group_prefix'), group_name.lower().replace(" ","")))
                     self.inventory.add_child(group_name, host['name'])
 
                 # set host vars from host info

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
 import ast
 import re
 
-from ansible.plugins.inventory import BaseFileInventoryPlugin
+from ansible.plugins.inventory import BaseFileInventoryPlugin, to_safe_group_name
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_bytes, to_text
@@ -170,6 +170,8 @@ class InventoryModule(BaseFileInventoryPlugin):
             m = self.patterns['section'].match(line)
             if m:
                 (groupname, state) = m.groups()
+
+                groupname = to_safe_group_name(groupname)
 
                 state = state or 'hosts'
                 if state not in ['hosts', 'children', 'vars']:

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -77,7 +77,8 @@ EXAMPLES = '''
 import ast
 import re
 
-from ansible.plugins.inventory import BaseFileInventoryPlugin, to_safe_group_name
+from ansible.inventory.group import to_safe_group_name
+from ansible.plugins.inventory import BaseFileInventoryPlugin
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_bytes, to_text

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -188,7 +188,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         if group != '_meta' and isinstance(data, dict) and 'children' in data:
             for child_name in data['children']:
-                child_name = to_safe_group_names(group)
+                child_name = to_safe_group_name(group)
                 self.inventory.add_group(child_name)
                 self.inventory.add_child(group, child_name)
 

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -46,7 +46,7 @@ from ansible.module_utils.basic import json_dict_bytes_to_unicode
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable
+from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, to_safe_group_name
 
 
 class InventoryModule(BaseInventoryPlugin, Cacheable):
@@ -162,6 +162,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
     def _parse_group(self, group, data):
 
+        group = to_safe_group_names(group)
         self.inventory.add_group(group)
 
         if not isinstance(data, dict):
@@ -187,6 +188,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         if group != '_meta' and isinstance(data, dict) and 'children' in data:
             for child_name in data['children']:
+                child_name = to_safe_group_names(group)
                 self.inventory.add_group(child_name)
                 self.inventory.add_child(group, child_name)
 

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -46,7 +46,7 @@ from ansible.module_utils.basic import json_dict_bytes_to_unicode
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, to_safe_group_name
+from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable
 
 
 class InventoryModule(BaseInventoryPlugin, Cacheable):
@@ -162,8 +162,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
     def _parse_group(self, group, data):
 
-        group = to_safe_group_name(group)
-        self.inventory.add_group(group)
+        group = self.inventory.add_group(group)
 
         if not isinstance(data, dict):
             data = {'hosts': data}
@@ -188,8 +187,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         if group != '_meta' and isinstance(data, dict) and 'children' in data:
             for child_name in data['children']:
-                child_name = to_safe_group_name(group)
-                self.inventory.add_group(child_name)
+                child_name = self.inventory.add_group(child_name)
                 self.inventory.add_child(group, child_name)
 
     def get_host_variables(self, path, host):

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -153,7 +153,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                     try:
                         got = data_from_meta.get(host, {})
                     except AttributeError as e:
-                        raise AnsibleError("Improperly formatted host information for %s: %s" % (host, to_native(e)))
+                        raise AnsibleError("Improperly formatted host information for %s: %s" % (host, to_native(e)), orig_exc=e)
 
                 self._populate_host_vars([host], got)
 

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -162,7 +162,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
     def _parse_group(self, group, data):
 
-        group = to_safe_group_names(group)
+        group = to_safe_group_name(group)
         self.inventory.add_group(group)
 
         if not isinstance(data, dict):

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -163,7 +163,7 @@ class InventoryModule(BaseFileInventoryPlugin):
             self.display.warning("Skipping '%s' as this is not a valid group definition" % group)
             return
 
-        self.inventory.add_group(group)
+        group = self.inventory.add_group(group)
         if group_data is None:
             return
 

--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -107,7 +107,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if group == 'all':
                 continue
             else:
-                self.inventory.add_group(group)
+                group = self.inventory.add_group(group)
                 hosts = source_data[group].get('hosts', [])
                 for host in hosts:
                     self._populate_host_vars([host], hostvars.get(host, {}), group)
@@ -162,10 +162,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             elif k == 'Groups':
                 for group in v.split('/'):
                     if group:
+                        group = self.inventory.add_group(group)
+                        self.inventory.add_child(group, current_host)
                         if group not in cacheable_results:
                             cacheable_results[group] = {'hosts': []}
-                        self.inventory.add_group(group)
-                        self.inventory.add_child(group, current_host)
                         cacheable_results[group]['hosts'].append(current_host)
                 continue
 

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -124,7 +124,7 @@ class InventoryModule(BaseFileInventoryPlugin):
         if isinstance(group_data, (MutableMapping, NoneType)):
 
             try:
-                self.inventory.add_group(group)
+                group = self.inventory.add_group(group)
             except AnsibleError as e:
                 raise AnsibleParserError("Unable to add group %s: %s" % (group, to_text(e)))
 

--- a/test/units/regex/test_invalid_var_names.py
+++ b/test/units/regex/test_invalid_var_names.py
@@ -1,0 +1,27 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat import unittest
+
+from ansible import constants as C
+
+
+test_cases = (('not-valid', ['-'], 'not_valid'), ('not!valid@either', ['!', '@'], 'not_valid_either'), ('1_nor_This', ['1'], '__nor_This'))
+
+
+class TestInvalidVars(unittest.TestCase):
+
+    def test_positive_matches(self):
+
+        for name, invalid, sanitized in test_cases:
+            self.assertEqual(C.INVALID_VARIABLE_NAMES.findall(name), invalid)
+
+    def test_negative_matches(self):
+        for name in ('this_is_valid', 'Also_1_valid', 'noproblem'):
+            self.assertEqual(C.INVALID_VARIABLE_NAMES.findall(name), [])
+
+    def test_get_setting(self):
+
+        for name, invalid, sanitized in test_cases:
+            self.assertEqual(C.INVALID_VARIABLE_NAMES.sub('_', name), sanitized)


### PR DESCRIPTION
 - move group name sanitation to inventory itself instead of plugins
 - create new toggle to allow user to customize 'valid names' WARNING, this can break plays bad characters are allowed.
 
Allows for  ansible/ansible#40581 to be implemented in aws_ec2 plugin

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
inventory