### PR TITLE
test - add setup target that creates the nobody user

### DIFF
--- a/test/integration/targets/copy/meta/main.yml
+++ b/test/integration/targets/copy/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_nobody

--- a/test/integration/targets/file/meta/main.yml
+++ b/test/integration/targets/file/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_nobody

--- a/test/integration/targets/setup_nobody/handlers/main.yml
+++ b/test/integration/targets/setup_nobody/handlers/main.yml
@@ -3,8 +3,3 @@
   user:
     name: nobody
     state: absent
-
-- name: remove nobody group
-  group:
-    name: nobody
-    state: absent

--- a/test/integration/targets/setup_nobody/handlers/main.yml
+++ b/test/integration/targets/setup_nobody/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: remove nobody user
+  user:
+    name: nobody
+    state: absent
+
+- name: remove nobody group
+  group:
+    name: nobody
+    state: absent

--- a/test/integration/targets/setup_nobody/tasks/main.yml
+++ b/test/integration/targets/setup_nobody/tasks/main.yml
@@ -1,14 +1,7 @@
 ---
-- name: create nobody group
-  group:
-    name: nobody
-    state: present
-  notify: remove nobody group
-
 - name: create nobody user
   user:
     name: nobody
-    comment: nobody
-    group: nobody
+    create_home: no
     state: present
   notify: remove nobody user

--- a/test/integration/targets/setup_nobody/tasks/main.yml
+++ b/test/integration/targets/setup_nobody/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: create nobody group
   group:
     name: nobody
-    gid: 65534
     state: present
   notify: remove nobody group
 
@@ -11,6 +10,5 @@
     name: nobody
     comment: nobody
     group: nobody
-    uid: 65534
     state: present
   notify: remove nobody user

--- a/test/integration/targets/setup_nobody/tasks/main.yml
+++ b/test/integration/targets/setup_nobody/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: create nobody group
+  group:
+    name: nobody
+    gid: 65534
+    state: present
+  notify: remove nobody group
+
+- name: create nobody user
+  user:
+    name: nobody
+    comment: nobody
+    group: nobody
+    uid: 65534
+    state: present
+  notify: remove nobody user

--- a/test/integration/targets/template/meta/main.yml
+++ b/test/integration/targets/template/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_nobody


### PR DESCRIPTION
##### SUMMARY
The nobody user is not guaranteed to be present on all test containers. This PR adds a setup_nobody test target that will create and remove a nobody user for tests that require it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
copy
file
template