### PR TITLE
Only reference module cache when module is defined

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -535,17 +535,19 @@ class PluginLoader:
                 continue
 
             if path not in self._module_cache:
+                module = None
                 try:
                     module = self._load_module_source(name, path)
                     self._load_config_defs(basename, module, path)
                 except Exception as e:
                     display.warning("Skipping plugin (%s) as it seems to be invalid: %s" % (path, to_text(e)))
-                self._module_cache[path] = module
+                else:
+                    self._module_cache[path] = module
                 found_in_cache = False
 
             try:
                 obj = getattr(self._module_cache[path], self.class_name)
-            except AttributeError as e:
+            except (KeyError, AttributeError) as e:
                 display.warning("Skipping plugin (%s) as it seems to be invalid: %s" % (path, to_text(e)))
                 continue
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: https://github.com/ansible/ansible/issues/52752
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Plugin loader

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Add an `else` clause to continue with `_module_cache` work if the `try` clause succeeds. Include a catch of the `KeyError` exception in the next block down.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->