### PR TITLE
Fortinet FortiManager Module_Utils MINOR Update

### DIFF
--- a/lib/ansible/module_utils/network/fortimanager/fortimanager.py
+++ b/lib/ansible/module_utils/network/fortimanager/fortimanager.py
@@ -39,12 +39,16 @@ try:
 except ImportError:
     HAS_PYFMGR = False
 
-# check for debug lib
-try:
-    from ansible.module_utils.network.fortimanager.fortimanager_debug import debug_dump
-    HAS_FMGR_DEBUG = True
-except ImportError:
-    HAS_FMGR_DEBUG = False
+# ACTIVE BUG WITH OUR DEBUG IMPORT CALL -- BECAUSE IT'S UNDER MODULE_UTILITIES
+# WHEN module_common.recursive_finder() runs under the module loader, it looks for this namespace debug import
+# and because it's not there, it always fails, regardless of it being under a try/catch here.
+# we're going to move it to a different namespace.
+# # check for debug lib
+# try:
+#     from ansible.module_utils.network.fortimanager.fortimanager_debug import debug_dump
+#     HAS_FMGR_DEBUG = True
+# except:
+#     HAS_FMGR_DEBUG = False
 
 
 # BEGIN HANDLER CLASSES
@@ -71,11 +75,11 @@ class FortiManagerHandler(object):
         data = self._tools.format_request(method, url, **datagram)
         response = self._conn.send_request(method, data)
 
-        if HAS_FMGR_DEBUG:
-            try:
-                debug_dump(response, datagram, self._module.paramgram, url, method)
-            except BaseException:
-                pass
+        # if HAS_FMGR_DEBUG:
+        #     try:
+        #         debug_dump(response, datagram, self._module.paramgram, url, method)
+        #     except BaseException:
+        #         pass
 
         return response
 
@@ -86,7 +90,7 @@ class FortiManagerHandler(object):
         """
         This function will attempt to apply default values to canned responses from FortiManager we know of.
         This saves time, and turns the response in the module into a "one-liner", while still giving us...
-        the flexibility to directly use return_response in modules if we have too.
+        the flexibility to directly use return_response in modules if we have too. This function saves repeated code.
 
         :param module: The Ansible Module CLASS object, used to run fail/exit json
         :type module: object

--- a/lib/ansible/module_utils/network/fortimanager/fortimanager.py
+++ b/lib/ansible/module_utils/network/fortimanager/fortimanager.py
@@ -49,9 +49,9 @@ except ImportError:
 
 # BEGIN HANDLER CLASSES
 class FortiManagerHandler(object):
-    def __init__(self, conn, check_mode=False):
+    def __init__(self, conn, module):
         self._conn = conn
-        self._check_mode = check_mode
+        self._module = module
         self._tools = FMGRCommon
 
     def process_request(self, url, datagram, method):
@@ -70,9 +70,10 @@ class FortiManagerHandler(object):
         """
         data = self._tools.format_request(method, url, **datagram)
         response = self._conn.send_request(method, data)
+
         if HAS_FMGR_DEBUG:
             try:
-                debug_dump(response, datagram, url, method)
+                debug_dump(response, datagram, self._module.paramgram, url, method)
             except BaseException:
                 pass
 

--- a/lib/ansible/module_utils/network/fortimanager/fortimanager.py
+++ b/lib/ansible/module_utils/network/fortimanager/fortimanager.py
@@ -86,7 +86,7 @@ class FortiManagerHandler(object):
         """
         This function will attempt to apply default values to canned responses from FortiManager we know of.
         This saves time, and turns the response in the module into a "one-liner", while still giving us...
-        the flexibility to directly use return_response in modules if we have too. This function saves repeated code.
+        the flexibility to directly use return_response in modules if we have too.
 
         :param module: The Ansible Module CLASS object, used to run fail/exit json
         :type module: object


### PR DESCRIPTION
Now accepts entire module as input, so it can use those data points for decisions later. This update is entirely related to our debugging and should have zero impact on existing modules.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A minor update to our mod_utils to enable a streamlined debug process for capturing fixtures for unit tests. Has no impact on existing modules, very very small change that allows for the entire AnsibleModule object to be passed to it upon init, allowing for the passing of certain data points to our debug library.

Please approve with haste. Very minor update.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/fortimanager/fortimanager.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
