### PR TITLE
group - fix explicit git scenario

### DIFF
--- a/changelogs/fragments/group-gid.yaml
+++ b/changelogs/fragments/group-gid.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- group - fix issue when creating a group with an explicit gid

--- a/changelogs/fragments/group-gid.yaml
+++ b/changelogs/fragments/group-gid.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- group - fix issue when creating a group with an explicit gid

--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -70,6 +70,7 @@ EXAMPLES = '''
 import grp
 
 from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
+from ansible.module_utils._text import to_native
 
 
 class Group(object):
@@ -120,7 +121,7 @@ class Group(object):
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
-                cmd.append(kwargs[key])
+                cmd.append(to_native(kwargs[key]))
             elif key == 'system' and kwargs[key] is True:
                 cmd.append('-r')
         cmd.append(self.name)
@@ -137,7 +138,7 @@ class Group(object):
             if key == 'gid':
                 if kwargs[key] is not None and info[2] != int(kwargs[key]):
                     cmd.append('-g')
-                    cmd.append(kwargs[key])
+                    cmd.append(to_native(kwargs[key]))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -182,7 +183,7 @@ class SunOS(Group):
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
-                cmd.append(kwargs[key])
+                cmd.append(to_native(kwargs[key]))
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -211,7 +212,7 @@ class AIX(Group):
         cmd = [self.module.get_bin_path('mkgroup', True)]
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
-                cmd.append('id=' + kwargs[key])
+                cmd.append('id=' + to_native(kwargs[key]))
             elif key == 'system' and kwargs[key] is True:
                 cmd.append('-a')
         cmd.append(self.name)
@@ -223,7 +224,7 @@ class AIX(Group):
         for key in kwargs:
             if key == 'gid':
                 if kwargs[key] is not None and info[2] != int(kwargs[key]):
-                    cmd.append('id=' + kwargs[key])
+                    cmd.append('id=' + to_native(kwargs[key]))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -256,7 +257,7 @@ class FreeBsdGroup(Group):
         cmd = [self.module.get_bin_path('pw', True), 'groupadd', self.name]
         if self.gid is not None:
             cmd.append('-g')
-            cmd.append('%d' % int(self.gid))
+            cmd.append(to_native(self.gid))
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
@@ -265,7 +266,7 @@ class FreeBsdGroup(Group):
         cmd_len = len(cmd)
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
-            cmd.append('%d' % int(self.gid))
+            cmd.append(to_native(self.gid))
         # modify the group if cmd will do anything
         if cmd_len != len(cmd):
             if self.module.check_mode:
@@ -304,12 +305,12 @@ class DarwinGroup(Group):
         cmd = [self.module.get_bin_path('dseditgroup', True)]
         cmd += ['-o', 'create']
         if self.gid is not None:
-            cmd += ['-i', self.gid]
+            cmd += ['-i', to_native(self.gid)]
         elif 'system' in kwargs and kwargs['system'] is True:
             gid = self.get_lowest_available_system_gid()
             if gid is not False:
-                self.gid = str(gid)
-                cmd += ['-i', self.gid]
+                self.gid = to_native(gid)
+                cmd += ['-i', to_native(self.gid)]
         cmd += ['-L', self.name]
         (rc, out, err) = self.execute_command(cmd)
         return (rc, out, err)
@@ -327,7 +328,7 @@ class DarwinGroup(Group):
             cmd = [self.module.get_bin_path('dseditgroup', True)]
             cmd += ['-o', 'edit']
             if gid is not None:
-                cmd += ['-i', gid]
+                cmd += ['-i', to_native(gid)]
             cmd += ['-L', self.name]
             (rc, out, err) = self.execute_command(cmd)
             return (rc, out, err)
@@ -376,7 +377,7 @@ class OpenBsdGroup(Group):
         cmd = [self.module.get_bin_path('groupadd', True)]
         if self.gid is not None:
             cmd.append('-g')
-            cmd.append('%d' % int(self.gid))
+            cmd.append(to_native(self.gid))
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -385,7 +386,7 @@ class OpenBsdGroup(Group):
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
-            cmd.append('%d' % int(self.gid))
+            cmd.append(to_native(self.gid))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -418,7 +419,7 @@ class NetBsdGroup(Group):
         cmd = [self.module.get_bin_path('groupadd', True)]
         if self.gid is not None:
             cmd.append('-g')
-            cmd.append('%d' % int(self.gid))
+            cmd.append(to_native(self.gid))
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -427,7 +428,7 @@ class NetBsdGroup(Group):
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
-            cmd.append('%d' % int(self.gid))
+            cmd.append(to_native(self.gid))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:

--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -70,7 +70,6 @@ EXAMPLES = '''
 import grp
 
 from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
-from ansible.module_utils._text import to_native
 
 
 class Group(object):
@@ -121,7 +120,7 @@ class Group(object):
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
-                cmd.append(to_native(kwargs[key]))
+                cmd.append(str(kwargs[key]))
             elif key == 'system' and kwargs[key] is True:
                 cmd.append('-r')
         cmd.append(self.name)
@@ -138,7 +137,7 @@ class Group(object):
             if key == 'gid':
                 if kwargs[key] is not None and info[2] != int(kwargs[key]):
                     cmd.append('-g')
-                    cmd.append(to_native(kwargs[key]))
+                    cmd.append(str(kwargs[key]))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -183,7 +182,7 @@ class SunOS(Group):
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
-                cmd.append(to_native(kwargs[key]))
+                cmd.append(str(kwargs[key]))
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -212,7 +211,7 @@ class AIX(Group):
         cmd = [self.module.get_bin_path('mkgroup', True)]
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
-                cmd.append('id=' + to_native(kwargs[key]))
+                cmd.append('id=' + str(kwargs[key]))
             elif key == 'system' and kwargs[key] is True:
                 cmd.append('-a')
         cmd.append(self.name)
@@ -224,7 +223,7 @@ class AIX(Group):
         for key in kwargs:
             if key == 'gid':
                 if kwargs[key] is not None and info[2] != int(kwargs[key]):
-                    cmd.append('id=' + to_native(kwargs[key]))
+                    cmd.append('id=' + str(kwargs[key]))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -257,7 +256,7 @@ class FreeBsdGroup(Group):
         cmd = [self.module.get_bin_path('pw', True), 'groupadd', self.name]
         if self.gid is not None:
             cmd.append('-g')
-            cmd.append(to_native(self.gid))
+            cmd.append(str(self.gid))
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
@@ -266,7 +265,7 @@ class FreeBsdGroup(Group):
         cmd_len = len(cmd)
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
-            cmd.append(to_native(self.gid))
+            cmd.append(str(self.gid))
         # modify the group if cmd will do anything
         if cmd_len != len(cmd):
             if self.module.check_mode:
@@ -305,12 +304,12 @@ class DarwinGroup(Group):
         cmd = [self.module.get_bin_path('dseditgroup', True)]
         cmd += ['-o', 'create']
         if self.gid is not None:
-            cmd += ['-i', to_native(self.gid)]
+            cmd += ['-i', str(self.gid)]
         elif 'system' in kwargs and kwargs['system'] is True:
             gid = self.get_lowest_available_system_gid()
             if gid is not False:
-                self.gid = to_native(gid)
-                cmd += ['-i', to_native(self.gid)]
+                self.gid = str(gid)
+                cmd += ['-i', str(self.gid)]
         cmd += ['-L', self.name]
         (rc, out, err) = self.execute_command(cmd)
         return (rc, out, err)
@@ -328,7 +327,7 @@ class DarwinGroup(Group):
             cmd = [self.module.get_bin_path('dseditgroup', True)]
             cmd += ['-o', 'edit']
             if gid is not None:
-                cmd += ['-i', to_native(gid)]
+                cmd += ['-i', str(gid)]
             cmd += ['-L', self.name]
             (rc, out, err) = self.execute_command(cmd)
             return (rc, out, err)
@@ -377,7 +376,7 @@ class OpenBsdGroup(Group):
         cmd = [self.module.get_bin_path('groupadd', True)]
         if self.gid is not None:
             cmd.append('-g')
-            cmd.append(to_native(self.gid))
+            cmd.append(str(self.gid))
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -386,7 +385,7 @@ class OpenBsdGroup(Group):
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
-            cmd.append(to_native(self.gid))
+            cmd.append(str(self.gid))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -419,7 +418,7 @@ class NetBsdGroup(Group):
         cmd = [self.module.get_bin_path('groupadd', True)]
         if self.gid is not None:
             cmd.append('-g')
-            cmd.append(to_native(self.gid))
+            cmd.append(str(self.gid))
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -428,7 +427,7 @@ class NetBsdGroup(Group):
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
-            cmd.append(to_native(self.gid))
+            cmd.append(str(self.gid))
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:

--- a/test/integration/targets/group/files/gidget.py
+++ b/test/integration/targets/group/files/gidget.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import grp
+
+gids = [g.gr_gid for g in grp.getgrall()]
+
+i = 0
+while True:
+    if i not in gids:
+        print(i)
+        break
+    i += 1

--- a/test/integration/targets/group/tasks/main.yml
+++ b/test/integration/targets/group/tasks/main.yml
@@ -16,92 +16,28 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: ensure test groups are deleted before the test
+  group:
+    name: '{{ item }}'
+    state: absent
+  loop:
+  - ansibullgroup
+  - ansibullgroup2
+
 - name: get the jinja2 version
   shell: python -c 'import jinja2; print(jinja2.__version__)'
   register: jinja2_version
   delegate_to: localhost
-- debug: var=jinja2_version
 
-##
-## group add
-##
+- block:
+  - name: run tests
+    include_tasks: tests.yml
 
-- name: try to create group
-  group:
-      name: ansibullgroup
-      state: present
-  register: group_test0
-
-- name: make a list of groups
-  script: grouplist.sh "{{ ansible_distribution }}"
-  register: group_names
-
-- name: show group names
-  debug: var=group_names
-- name: validate results for testcase 0
-  assert:
-      that:
-          - '"ansibullgroup" in group_names.stdout_lines'
-
-##
-## group check
-##
-
-- name: run existing group check tests
-  group:
-      name: "{{ group_names.stdout_lines|random }}"
-      state: present
-  with_sequence: start=1 end=5
-  register: group_test1
-- debug: var=group_test1
-
-- name: validate results for testcase 1
-  assert:
-      that:
-          - 'group_test1.results is defined'
-          - 'group_test1.results|length == 5'
-
-- name: validate change results for testcase 1 (jinja2 >= 2.6)
-  assert:
-      that:
-          - "group_test1.results|map(attribute='changed')|unique|list == [False]"
-          - "group_test1.results|map(attribute='state')|unique|list == ['present']"
-  when: "jinja2_version.stdout is version('2.6', '>=')"
-
-- name: validate change results for testcase 1 (jinja2 < 2.6)
-  assert:
-      that:
-          - "not group_test1.results[0]['changed']"
-          - "not group_test1.results[1]['changed']"
-          - "not group_test1.results[2]['changed']"
-          - "not group_test1.results[3]['changed']"
-          - "not group_test1.results[4]['changed']"
-  when: "jinja2_version.stdout is version('2.6', '<')"
-
-
-
-##
-## group remove
-##
-            
-- name: try to delete the group
-  group:
-      name: ansibullgroup
+  always:
+  - name: remove test groups after test
+    group:
+      name: '{{ item }}'
       state: absent
-  register: group_test2
-
-- name: make a new list of groups
-  shell: |
-      cat /etc/group | cut -d: -f1
-  register: group_names2
-  when: 'ansible_distribution != "MacOSX"'
-
-- name: make a list of groups
-  script: grouplist.sh "{{ ansible_distribution }}"
-  register: group_names2
-
-- debug: var=group_names2
-- name: validate results for testcase 2
-  assert:
-      that:
-          - '"ansibullgroup" not in group_names2.stdout_lines'
+    loop:
+    - ansibullgroup
+    - ansibullgroup2

--- a/test/integration/targets/group/tasks/main.yml
+++ b/test/integration/targets/group/tasks/main.yml
@@ -24,11 +24,6 @@
   - ansibullgroup
   - ansibullgroup2
 
-- name: get the jinja2 version
-  shell: python -c 'import jinja2; print(jinja2.__version__)'
-  register: jinja2_version
-  delegate_to: localhost
-
 - block:
   - name: run tests
     include_tasks: tests.yml

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -1,0 +1,184 @@
+---
+##
+## group add
+##
+
+- name: create group (check mode)
+  group:
+    name: ansibullgroup
+    state: present
+  register: create_group_check
+  check_mode: True
+
+- name: get result of create group (check mode)
+  script: grouplist.sh "{{ ansible_distribution }}"
+  register: create_group_actual_check
+
+- name: assert create group (check mode)
+  assert:
+    that:
+    - create_group_check is changed
+    - '"ansibullgroup" not in create_group_actual_check.stdout_lines'
+
+- name: create group
+  group:
+    name: ansibullgroup
+    state: present
+  register: create_group
+
+- name: get result of create group
+  script: grouplist.sh "{{ ansible_distribution }}"
+  register: create_group_actual
+
+- name: assert create group
+  assert:
+    that:
+    - create_group is changed
+    - create_group.gid is defined
+    - '"ansibullgroup" in create_group_actual.stdout_lines'
+
+- name: create group (idempotent)
+  group:
+    name: ansibullgroup
+    state: present
+  register: create_group_again
+
+- name: assert create group (idempotent)
+  assert:
+    that:
+    - not create_group_again is changed
+
+##
+## group check
+##
+
+- name: run existing group check tests
+  group:
+    name: "{{ create_group_actual.stdout_lines|random }}"
+    state: present
+  with_sequence: start=1 end=5
+  register: group_test1
+
+- name: validate results for testcase 1
+  assert:
+      that:
+          - 'group_test1.results is defined'
+          - 'group_test1.results|length == 5'
+
+- name: validate change results for testcase 1 (jinja2 >= 2.6)
+  assert:
+      that:
+          - "group_test1.results|map(attribute='changed')|unique|list == [False]"
+          - "group_test1.results|map(attribute='state')|unique|list == ['present']"
+  when: "jinja2_version.stdout is version('2.6', '>=')"
+
+- name: validate change results for testcase 1 (jinja2 < 2.6)
+  assert:
+      that:
+          - "not group_test1.results[0]['changed']"
+          - "not group_test1.results[1]['changed']"
+          - "not group_test1.results[2]['changed']"
+          - "not group_test1.results[3]['changed']"
+          - "not group_test1.results[4]['changed']"
+  when: "jinja2_version.stdout is version('2.6', '<')"
+
+##
+## group add with gid
+##
+
+- name: create a group with a gid (check mode)
+  group:
+    name: ansibullgroup2
+    gid: 666
+    state: present
+  register: create_group_gid_check
+  check_mode: True
+
+- name: get result of create a group with a gid (check mode)
+  script: grouplist.sh "{{ ansible_distribution }}"
+  register: create_group_gid_actual_check
+
+- name: assert create group with a gid (check mode)
+  assert:
+      that:
+      - create_group_gid_check is changed
+      - '"ansibullgroup2" not in create_group_gid_actual_check.stdout_lines'
+
+- name: create a group with a gid
+  group:
+    name: ansibullgroup2
+    gid: 666
+    state: present
+  register: create_group_gid
+
+- name: get gid of created group
+  command: "{{ ansible_python_interpreter | quote }} -c \"import grp; print(grp.getgrnam('ansibullgroup2').gr_gid)\""
+  register: create_group_gid_actual
+
+- name: assert create group with a gid
+  assert:
+      that:
+      - create_group_gid is changed
+      - create_group_gid.gid == 666
+      - create_group_gid_actual.stdout | trim | int == 666
+
+- name: create a group with a gid (idempotent)
+  group:
+    name: ansibullgroup2
+    gid: 666
+    state: present
+  register: create_group_gid_again
+
+- name: assert create group with a gid (idempotent)
+  assert:
+      that:
+      - not create_group_gid_again is changed
+      - create_group_gid_again.gid == 666
+
+##
+## group remove
+##
+
+- name: delete group (check mode)
+  group:
+    name: ansibullgroup
+    state: absent
+  register: delete_group_check
+  check_mode: True
+
+- name: get result of delete group (check mode)
+  script: grouplist.sh "{{ ansible_distribution }}"
+  register: delete_group_actual_check
+
+- name: assert delete group (check mode)
+  assert:
+    that:
+    - delete_group_check is changed
+    - '"ansibullgroup" in delete_group_actual_check.stdout_lines'
+
+- name: delete group
+  group:
+    name: ansibullgroup
+    state: absent
+  register: delete_group
+
+- name: get result of delete group
+  script: grouplist.sh "{{ ansible_distribution }}"
+  register: delete_group_actual
+
+- name: assert delete group
+  assert:
+      that:
+      - delete_group is changed
+      - '"ansibullgroup" not in delete_group_actual.stdout_lines'
+
+- name: delete group (idempotent)
+  group:
+    name: ansibullgroup
+    state: absent
+  register: delete_group_again
+
+- name: assert delete group (idempotent)
+  assert:
+    that:
+    - not delete_group_again is changed

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -61,35 +61,29 @@
 
 - name: validate results for testcase 1
   assert:
-      that:
-          - 'group_test1.results is defined'
-          - 'group_test1.results|length == 5'
+    that:
+    - group_test1.results is defined
+    - group_test1.results|length == 5
 
-- name: validate change results for testcase 1 (jinja2 >= 2.6)
+- name: validate change results for testcase 1
   assert:
-      that:
-          - "group_test1.results|map(attribute='changed')|unique|list == [False]"
-          - "group_test1.results|map(attribute='state')|unique|list == ['present']"
-  when: "jinja2_version.stdout is version('2.6', '>=')"
-
-- name: validate change results for testcase 1 (jinja2 < 2.6)
-  assert:
-      that:
-          - "not group_test1.results[0]['changed']"
-          - "not group_test1.results[1]['changed']"
-          - "not group_test1.results[2]['changed']"
-          - "not group_test1.results[3]['changed']"
-          - "not group_test1.results[4]['changed']"
-  when: "jinja2_version.stdout is version('2.6', '<')"
+    that:
+    - not group_test1 is changed
 
 ##
 ## group add with gid
 ##
 
+- name: get the next available gid
+  script: gidget.py
+  args:
+    executable: '{{ ansible_python_interpreter }}'
+  register: gid
+
 - name: create a group with a gid (check mode)
   group:
     name: ansibullgroup2
-    gid: 666
+    gid: '{{ gid.stdout_lines[0] }}'
     state: present
   register: create_group_gid_check
   check_mode: True
@@ -107,7 +101,7 @@
 - name: create a group with a gid
   group:
     name: ansibullgroup2
-    gid: 666
+    gid: '{{ gid.stdout_lines[0] }}'
     state: present
   register: create_group_gid
 
@@ -119,13 +113,13 @@
   assert:
       that:
       - create_group_gid is changed
-      - create_group_gid.gid == 666
-      - create_group_gid_actual.stdout | trim | int == 666
+      - create_group_gid.gid | int == gid.stdout_lines[0] | int
+      - create_group_gid_actual.stdout | trim | int == gid.stdout_lines[0] | int
 
 - name: create a group with a gid (idempotent)
   group:
     name: ansibullgroup2
-    gid: 666
+    gid: '{{ gid.stdout_lines[0] }}'
     state: present
   register: create_group_gid_again
 
@@ -133,7 +127,7 @@
   assert:
       that:
       - not create_group_gid_again is changed
-      - create_group_gid_again.gid == 666
+      - create_group_gid_again.gid | int == gid.stdout_lines[0] | int
 
 ##
 ## group remove


### PR DESCRIPTION
##### SUMMARY
Fix issue when trying to create a group with an explicit gid. Also expands the tests to cover this behaviour and other check/idempotent tests.

Before this, `group` would fail with

```
                          Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1550784232.861226-258575225811013/AnsiballZ_group.py", line 128, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1550784232.861226-258575225811013/AnsiballZ_group.py", line 120, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1550784232.861226-258575225811013/AnsiballZ_group.py", line 63, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/usr/lib/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.6/imp.py", line 170, in load_source
    module = _exec(spec, sys.modules[name])
  File "<frozen importlib._bootstrap>", line 618, in _exec
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/tmp/ansible_group_payload_6svsumki/__main__.py", line 505, in <module>
  File "/tmp/ansible_group_payload_6svsumki/__main__.py", line 480, in main
  File "/tmp/ansible_group_payload_6svsumki/__main__.py", line 127, in group_add
  File "/tmp/ansible_group_payload_6svsumki/__main__.py", line 104, in execute_command
  File "/tmp/ansible_group_payload_6svsumki/ansible_group_payload.zip/ansible/module_utils/basic.py", line 2790, in run_command
  File "/tmp/ansible_group_payload_6svsumki/ansible_group_payload.zip/ansible/module_utils/basic.py", line 2790, in <listcomp>
  File "/usr/lib/python3.6/posixpath.py", line 281, in expandvars
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not int
```

This only affects devel as the issue was caused by https://github.com/ansible/ansible/pull/52209/files#diff-0b72e79451c61d21f598aa3da352c8ef. The change from a `str` to `int` means when the gid is passed to `run_command` it was an int in some cases and certain helpers in `run_command` would fail on this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
group