### PR TITLE
test - add Python 3 package for OpenSUSE in setup_openssl

### DIFF
--- a/test/integration/targets/setup_openssl/vars/Suse.yml
+++ b/test/integration/targets/setup_openssl/vars/Suse.yml
@@ -1,1 +1,2 @@
 pyopenssl_package_name: python-pyOpenSSL
+pyopenssl_package_name_python3: python3-pyOpenSSL


### PR DESCRIPTION
##### SUMMARY
Add the Python 3 equivalent package in OpenSUSE for pyOpenSSL.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup_openssl