### PR TITLE
VMware: fix customization.hostname handling

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/customization_hostname_validation.yml
+++ b/test/integration/targets/vmware_guest/tasks/customization_hostname_validation.yml
@@ -1,0 +1,121 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Diego Morales <dgmorales@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- debug: var=vcsim_instance
+
+- name: Set a bunch of name styles and wheter they should be accepted or not
+  set_fact:
+    vm_items:
+      - { name: "DC0-H0-VMWARE1", should_fail: "never" }
+      - { name: "DC0_H0_VMWARE2", should_fail: "if_not_forced" }
+      - { name: "Vmware03", should_fail: "never" }
+      - { name: "vmware04.example.com", should_fail: "if_not_forced" }
+      - { name: "vmware 05", should_fail: "if_not_forced" }
+      - { name: "006", should_fail: "always" }
+      - { name: "-7", should_fail: "always" }
+      - { name: "v-8", should_fail: "never" }
+      - { name: "V", should_fail: "never" }
+
+- name: create new VMs from vm.items
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "VM {{ i }}"
+    guest_id: centos64Guest
+    datacenter: "DC0"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 1gb
+          type: thin
+          autoselect_datastore: True
+    networks:
+        - name: VM Network
+    state: poweredoff
+    folder: "DC0/vm"
+    customization:
+      hostname: "{{ item.name }}"
+  loop: "{{ vm_items }}"
+  loop_control:
+    index_var: i
+  register: register_new_vms
+  ignore_errors: yes
+
+- debug: var=register_new_vms
+
+- name: Assert that the test cases had the expected outcome (force==no)
+  assert:
+    msg: "Test case {{i}}({{item.name}}) failed? {{register_new_vms.results[i].failed}}. Expected was {{item.should_fail == 'always' or item.should_fail == 'if_not_forced'}}."
+    that:
+        - "register_new_vms.results[i].failed|bool == (item.should_fail == 'always' or item.should_fail == 'if_not_forced')|bool"
+        - "(not register_new_vms.results[i].failed) or ('The hostname you have set is not valid for use with vmware guest customization' in register_new_vms.results[i].msg)"
+  loop: "{{ vm_items }}"
+  loop_control:
+    label: "{{ item.name }}"
+    index_var: i
+
+- name: create new VMs from vm.items (forcing)
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "VM {{ i }} forced"
+    guest_id: centos64Guest
+    datacenter: "DC0"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 1gb
+          type: thin
+          autoselect_datastore: True
+    networks:
+        - name: VM Network
+    state: poweredoff
+    folder: "DC0/vm"
+    force: True
+    customization:
+      hostname: "{{ item.name }}"
+  loop: "{{ vm_items }}"
+  loop_control:
+    index_var: i
+  register: register_new_vms_force
+  ignore_errors: yes
+
+- debug: var=register_new_vms_force
+
+- name: Assert that the test cases had the expected outcome (force==yes)
+  assert:
+    msg: "Test case {{i}}({{item.name}}) failed? {{register_new_vms_force.results[i].failed}}. Expected was {{item.should_fail == 'always'}}."
+    that:
+        - "register_new_vms_force.results[i].failed|bool == (item.should_fail == 'always')|bool"
+        - "(not register_new_vms_force.results[i].failed) or ('The hostname you have set is not valid for use with vmware guest customization' in register_new_vms_force.results[i].msg)"
+  loop: "{{ vm_items }}"
+  loop_control:
+    label: "{{ item.name }}"
+    index_var: i

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -46,6 +46,8 @@
           netmask: 255.255.255.0
           gateway: 192.168.10.254
           mac: aa:bb:cc:dd:aa:42
+    customization:
+      hostname: DC0-H0-VM12
     state: poweredoff
     folder: "{{ item | dirname }}"
   with_items:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Stops silently mangling of the user supplied customization.hostname to fit VMware API requirements (unless --force is set). Instead it throws a helpful error message if the name does not fit the requirements.

This PR is an alternative proposal to https://github.com/ansible/ansible/pull/46056.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ADDITIONAL INFORMATION

This is related to a discussion that started in https://github.com/ansible/ansible/pull/38005#issuecomment-420568723 and was followed up on PR https://github.com/ansible/ansible/pull/46056.

In the code proposed here:

* customization.hostname is not required, get it's default from vm name
* if force==False, no silently hostname mangling is done. If name is not valid, a helpful message is throw
* Also checks that the name contains at least one letter, as said in the [vmware doc](https://pubs.vmware.com/vsphere-51/index.jsp?topic=%2Fcom.vmware.vsphere.vm_admin.doc%2FGUID-9A5093A5-C54F-4502-941B-3F9C0F573A39.html).
* if force==True, silently mangle the name or customization.hostname as currently done (unless name has no letter)

I didn't test it against a VMware enviroment yet. I will do it soon on the following days. But I did try to test the logic mocking an object with a params attribute. Here's the results of my testing:

_(first hostname is **vm name**, followed by FAILED or final hostname)_

With customization.hostname unset and force==False:
```text
hostname "vmware01.example.com" ... FAILED
hostname "host.d" ... FAILED
hostname "a xyz" ... FAILED
hostname "90921" ... FAILED
hostname "-0" ... FAILED
hostname "a" ... a
hostname "A" ... A
hostname "xyz-aa-0" ... xyz-aa-0
hostname "2a131" ... 2a131
hostname "vmware01" ... vmware01
hostname "Vmware" ... Vmware
```

With customization.hostname unset and force==True
```text
hostname "vmware01.example.com" ... vmware01
hostname "host.d" ... host
hostname "a xyz" ... axyz
hostname "90921" ... FAILED
hostname "-0" ... FAILED
hostname "a" ... a
hostname "A" ... A
hostname "xyz-aa-0" ... xyz-aa-0
hostname "2a131" ... 2a131
hostname "vmware01" ... vmware01
hostname "Vmware" ... Vmware
```

Also: 
- Setting customization.hostname to "vmware-01.example.com" and Force==False fails every case
- Setting customization.hostname to "vmware-01.example.com" and Force==True returns "vmware-01" to every case
