### PR TITLE
Netbox Inventory: Group By Platforms

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -222,7 +222,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def extract_platform(self, host):
         try:
-            return self.platforms_lookup[host["platform"]["id"]]
+            return [self.platforms_lookup[host["platform"]["id"]]]
         except Exception:
             return
 
@@ -345,6 +345,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.refresh_tenants_lookup,
             self.refresh_racks_lookup,
             self.refresh_device_roles_lookup,
+            self.refresh_platforms_lookup,
             self.refresh_device_types_lookup,
             self.refresh_manufacturers_lookup,
         )


### PR DESCRIPTION
##### SUMMARY
Fixes the functionality group_by **platforms**. Adds the call to **self.refresh_platforms_lookup** and adds square brackets to return a list instead of a string.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Netbox inventory plugin.

##### ADDITIONAL INFORMATION

**@platforms_nxos** is the output we're looking for with this change.

###### Before
```$ ansible-inventory --graph
@all:
  |--@device_roles_edge:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@device_types_Nexus 93180YC-EX:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@manufacturers_cisco:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@racks_105:
  |  |--n9k-inet02
  |--@racks_106:
  |  |--n9k-inet01
  |--@sites_ABC:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@tenants_customer1:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@ungrouped:
  |  |-----
```

###### After
```$ ansible-inventory --graph
@all:
  |--@device_roles_edge:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@device_types_Nexus 93180YC-EX:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@manufacturers_cisco:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@platforms_nxos:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@racks_105:
  |  |--n9k-inet02
  |--@racks_106:
  |  |--n9k-inet01
  |--@sites_ABC:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@tenants_customer1:
  |  |--n9k-inet01
  |  |--n9k-inet02
  |--@ungrouped:
  |  |-----
```