### PR TITLE
[WIP] Extended foreman inventory and cache to work with redis

### DIFF
--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -247,3 +247,4 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                 # set host vars from facts
                 if self.get_option('want_facts'):
                     self.inventory.set_variable(host['name'], 'ansible_facts', self._get_facts(host))
+                    

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -246,4 +246,4 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
 
                 # set host vars from facts
                 if self.get_option('want_facts'):
-                    self.inventory.set_variable(host['name'], 'ansible_facts', self._get_facts(host))    
+                    self.inventory.set_variable(host['name'], 'ansible_facts', self._get_facts(host))

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -199,12 +199,12 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             # Try json
             try:
                 value = json.loads(param['value'])
-            except json.JSONDecodeError:
+            except ValueError:
                 # Not JSON, try YAML
                 pass
             try:
                 value = yaml.load(param['value'])
-            except ValueError:
+            except yaml.YAMLError:
                 # Not YAML or JSON, return plain string
                 key = value
 

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -247,4 +247,3 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                 # set host vars from facts
                 if self.get_option('want_facts'):
                     self.inventory.set_variable(host['name'], 'ansible_facts', self._get_facts(host))
-                    

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -222,10 +222,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         # read config from file, this sets 'options'
         self._read_config_data(path)
 
-        # get connection host
+        # set config variables
         self.foreman_url = self.get_option('url')
         self.use_cache = cache and self.get_option('cache')
-        self.cache_key = self.get_option('cache_key')
+        self.cache_key = self.get_cache_key(path)
 
         hosts = self._get_all_hosts()
 

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -129,7 +129,11 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
     def _get_all_hosts(self):
 
         if self.use_cache:
-            inventory = self._cache[self.cache_key]
+            try:
+                inventory = self._cache[self.cache_key]
+            except KeyError:
+                # The cache key expired or does not exist yet
+                inventory = None
 
             if inventory is not None:
                 return inventory

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -182,9 +182,9 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
 
         return results
 
-    def to_safe(self, word):
+    def to_safe_group_name(self, word):
         '''Converts 'bad' characters in a string to underscores so they can be used as Ansible groups
-        #> ForemanInventory.to_safe("foo-bar baz")
+        #> ForemanInventory.to_safe_group_name("foo-bar baz")
         'foo_barbaz'
         '''
         regex = r"[^A-Za-z0-9\_]"
@@ -232,7 +232,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         self.use_cache = cache and self.get_option('cache')
         self.cache_key = self.get_cache_key(path)
 
-        hosts = self._get_all_hosts(self.foreman_url)
+        hosts = self._get_all_hosts("%s/api/v2/hosts" % self.foreman_url)
 
         for host in hosts:
             if host.get('name'):
@@ -241,7 +241,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                 # create directly mapped groups
                 group_name = host.get('hostgroup_title', host.get('hostgroup_name'))
                 if group_name:
-                    group_name = self.to_safe('%s%s' % (self.get_option('group_prefix'), group_name.lower()))
+                    group_name = self.to_safe_group_name('%s%s' % (self.get_option('group_prefix'), group_name.lower()))
                     self.inventory.add_group(group_name)
                     self.inventory.add_child(group_name, host['name'])
 

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -212,9 +212,8 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
 
         ret = s.get("%s/api/v2/hosts/%s/facts" % (self.foreman_url, host))
         ret.raise_for_status()
-        
-        return ret.json()
 
+        return ret.json()
 
     def parse(self, inventory, loader, path, cache=True):
 

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -148,29 +148,29 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             json = ret.json()
 
             # process results
-                # FIXME: This assumes 'return type' matches a specific query,
-                #        it will break if we expand the queries and they dont have different types
-                if 'results' not in json:
-                    # /hosts/:id dos not have a 'results' key
-                    results = json
-                    break
-                elif isinstance(json['results'], MutableMapping):
-                    # /facts are returned as dict in 'results'
-                    results = json['results']
-                    break
-                else:
-                    # /hosts 's 'results' is a list of all hosts, returned is paginated
-                    results = results + json['results']
+            # FIXME: This assumes 'return type' matches a specific query,
+            #        it will break if we expand the queries and they dont have different types
+            if 'results' not in json:
+                # /hosts/:id dos not have a 'results' key
+                results = json
+                break
+            elif isinstance(json['results'], MutableMapping):
+                # /facts are returned as dict in 'results'
+                results = json['results']
+                break
+            else:
+                # /hosts 's 'results' is a list of all hosts, returned is paginated
+                results = results + json['results']
 
-                    # check for end of paging
-                    if len(results) >= json['subtotal']:
-                        break
-                    if len(json['results']) == 0:
-                        self.display.warning("Did not make any progress during loop. expected %d got %d" % (json['subtotal'], len(results)))
-                        break
+                # check for end of paging
+                if len(results) >= json['subtotal']:
+                    break
+                if len(json['results']) == 0:
+                    self.display.warning("Did not make any progress during loop. expected %d got %d" % (json['subtotal'], len(results)))
+                    break
 
-                    # get next page
-                    params['page'] += 1
+                # get next page
+                params['page'] += 1
 
         if self.use_cache:
             self.cache.set(self.cache_key, results)

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -134,7 +134,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             except KeyError:
                 # The cache key expired or does not exist yet
                 inventory = None
-                self._cache[self.cache_key]= {url: ''} 
+                self._cache[self.cache_key] = {url: ''}
 
             if inventory is not None:
                 return inventory

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -126,14 +126,15 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             self.session.verify = self.get_option('validate_certs')
         return self.session
 
-    def _get_all_hosts(self):
+    def _get_all_hosts(self, url):
 
         if self.use_cache:
             try:
-                inventory = self._cache[self.cache_key]
+                inventory = self._cache[self.cache_key][url]
             except KeyError:
                 # The cache key expired or does not exist yet
                 inventory = None
+                self._cache[self.cache_key]= {url: ''} 
 
             if inventory is not None:
                 return inventory
@@ -177,7 +178,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                 params['page'] += 1
 
         if self.use_cache:
-            self._cache[self.cache_key] = results
+            self._cache[self.cache_key][url] = results
 
         return results
 
@@ -231,7 +232,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         self.use_cache = cache and self.get_option('cache')
         self.cache_key = self.get_cache_key(path)
 
-        hosts = self._get_all_hosts()
+        hosts = self._get_all_hosts(self.foreman_url)
 
         for host in hosts:
             if host.get('name'):


### PR DESCRIPTION
##### SUMMARY
With the change from Foreman inventory script to Ansible inventory plugin we discovered enourmous problems regarding our inventory and host parameters. Things like chopped strings, wrong data types and so on. For this reason we fixed the issue using the resolving function for parameters from the old script and used some improvements of the Foreman API. After this we recognized that caching inventories only worked with jsonfile. In this first step we made the Foreman inventory cache working with redis. We want to work on this topic but this PR is only the beginning. The code is functional and tested in a big environment of about 600 machines, speeding up playbooks around 40%. 

The next step we need help integrating a clean solution on this topic. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Inventory Module
Cache Module

##### ADDITIONAL INFORMATION

