### PR TITLE
[2.7] Filter DNSimple request by record name. (#49981)

### DIFF
--- a/changelogs/fragments/49981-filter-dnsimple-request-by-record-name.yaml
+++ b/changelogs/fragments/49981-filter-dnsimple-request-by-record-name.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - fix DNSimple to ensure check works even when the number of records is larger than 100

--- a/lib/ansible/modules/net_tools/dnsimple.py
+++ b/lib/ansible/modules/net_tools/dnsimple.py
@@ -236,7 +236,7 @@ def main():
 
         # need the not none check since record could be an empty string
         if domain and record is not None:
-            records = [r['record'] for r in client.records(str(domain))]
+            records = [r['record'] for r in client.records(str(domain), params={'name': record})]
 
             if not record_type:
                 module.fail_json(msg="Missing the record type")


### PR DESCRIPTION
##### SUMMARY
Backport of #49981

* Filter DNSimple request by record name.

The request was not filtered and DNSimple returns only the first 100
records so if the number of records is larger the check could fail.

This patch fixes the issue and also makes the check to perform better.

* Add changelog fragment.

(cherry picked from commit e0274adafeb8398b4c163e0b540ee9c9a6eed15d)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnssimple

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
