### PR TITLE
Backport/2.7/52166

### DIFF
--- a/changelogs/fragments/52166-fix_rabbitmq_plugin_idempotence.yml
+++ b/changelogs/fragments/52166-fix_rabbitmq_plugin_idempotence.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix rabbitmq_plugin idempotence due to information message in new version of rabbitmq
+    (https://github.com/ansible/ansible/pull/52166)

--- a/lib/ansible/modules/messaging/rabbitmq_plugin.py
+++ b/lib/ansible/modules/messaging/rabbitmq_plugin.py
@@ -141,6 +141,8 @@ def main():
     if state == 'enabled':
         if not new_only:
             for plugin in enabled_plugins:
+                if " " in plugin:
+                    continue
                 if plugin not in names:
                     rabbitmq_plugins.disable(plugin)
                     disabled.append(plugin)


### PR DESCRIPTION
* Fix rabbitmq_plugin idempotence due to information message in new version of rabbitmq (https://github.com/ansible/ansible/pull/52166)  

cherry pick from 540b07b