### PR TITLE
Introspect systemd unit deps recursively

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -325,6 +325,22 @@ def unit_is_enabled(module, systemctl_executable, systemd_unit, is_initd):
 
     # check systemctl result or if it is a init script
     if rc == 0:
+        indirect = False
+        installed_unit = ''
+        if out.strip().endswith('static'):
+            _rc, cat_out, _err = module.run_command(
+                "%s cat '%s' | grep ^Also= | sed 's#^Also=##'"
+                % (systemctl_executable, systemd_unit),)
+            installed_unit = cat_out.strip()
+            if installed_unit:
+                indirect = True
+        elif out.strip().endswith('indirect'):
+            indirect = True
+        if indirect:
+            return unit_is_enabled(
+                module, systemctl_executable,
+                installed_unit, is_initd,
+            )
         return True
 
     if rc == 1:

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -307,6 +307,39 @@ def parse_systemctl_show(lines):
     return parsed
 
 
+def unit_is_enabled(module, systemctl_executable, systemd_unit, is_initd):
+    """Detect whether given unit is enabled.
+     Args:
+        module (AnsibleModule): Instance of ansible module singleton.
+        systemctl_executable (str): systemctl executable with default
+            arguments pre-filled.
+        systemd_unit (str): Name of systemd unit being checked.
+     Returns:
+        bool: True if systemd unit is enabled, False otherwise.
+    """
+    rc, out, _err = module.run_command(
+        "%s is-enabled '%s'"
+        % (systemctl_executable, systemd_unit),)
+
+    # check systemctl result or if it is a init script
+    if rc == 0:
+        return True
+
+    if rc == 1:
+        # if not a user or global user service and both init script and
+        # unit file exist stdout should have enabled/disabled,
+        # otherwise use rc entries
+        return (
+            module.params['scope'] in (None, 'system') and
+            not module.params['user'] and
+            is_initd and
+            not out.strip().endswith('disabled') and
+            sysv_is_enabled(systemd_unit)
+        )
+
+    return False
+
+
 # ===========================================
 # Main control flow
 
@@ -445,20 +478,7 @@ def main():
             fail_if_missing(module, found, unit, msg='host')
 
             # do we need to enable the service?
-            enabled = False
-            (rc, out, err) = module.run_command("%s is-enabled '%s'" % (systemctl, unit))
-
-            # check systemctl result or if it is a init script
-            if rc == 0:
-                enabled = True
-            elif rc == 1:
-                # if not a user or global user service and both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
-                if module.params['scope'] in (None, 'system') and \
-                        not module.params['user'] and \
-                        is_initd and \
-                        not out.strip().endswith('disabled') and \
-                        sysv_is_enabled(unit):
-                    enabled = True
+            enabled = unit_is_enabled(module, systemctl, unit, is_initd)
 
             # default to current state
             result['enabled'] = enabled

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -309,13 +309,15 @@ def parse_systemctl_show(lines):
 
 def unit_is_enabled(module, systemctl_executable, systemd_unit, is_initd):
     """Detect whether given unit is enabled.
-     Args:
-        module (AnsibleModule): Instance of ansible module singleton.
-        systemctl_executable (str): systemctl executable with default
-            arguments pre-filled.
-        systemd_unit (str): Name of systemd unit being checked.
-     Returns:
-        bool: True if systemd unit is enabled, False otherwise.
+
+    Args:
+       module (AnsibleModule): Instance of ansible module singleton.
+       systemctl_executable (str): systemctl executable with default
+           arguments pre-filled.
+       systemd_unit (str): Name of systemd unit being checked.
+
+    Returns:
+       bool: True if systemd unit is enabled, False otherwise.
     """
     rc, out, _err = module.run_command(
         "%s is-enabled '%s'"
@@ -374,13 +376,15 @@ DO_NOTHING = None
 
 def get_action_from_enabled_flag(requested_state, current_state):
     """Decide final action string from current state.
-     Args:
-        requested_state (str): The desired state, requested via module
-            argument in task.
-        current_state (bool): The initial state of the service.
-            True for running, False for stopped.
-     Returns:
-        str: The actual action this module is going to run.
+
+    Args:
+       requested_state (str): The desired state, requested via module
+           argument in task.
+       current_state (bool): The initial state of the service.
+           True for running, False for stopped.
+
+    Returns:
+       str: The actual action this module is going to run.
     """
     ENABLED_NOW = ENABLE_REQUEST = True
     DISABLED_NOW = DISABLE_REQUEST = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch checks whether the current unit which is being controlled by `systemd` Ansible module has `indirect` state (or `static` state with `Install -> Also` set in the unit for older systemd versions) and introspects its dependencies recursively, if yes.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #46744
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
systemd module
##### ADDITIONAL INFORMATION
N/A