### PR TITLE
Fix traceback on passing argument '--all' to 'ansible-doc' command (#52034)

### DIFF
--- a/changelogs/fragments/52034-fix-traceback-on_ansible-doc_-all.yaml
+++ b/changelogs/fragments/52034-fix-traceback-on_ansible-doc_-all.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-doc - Fix traceback on providing arguemnt --all to ansible-doc command

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -117,7 +117,7 @@ class DocCLI(CLI):
 
         # process all plugins of type
         if self.options.all_plugins:
-            self.args = self.get_all_plugins_of_type(plugin_type, loader)
+            self.args = self.get_all_plugins_of_type(plugin_type)
 
         # dump plugin metadata as JSON
         if self.options.json_dump:

--- a/test/units/cli/test_doc.py
+++ b/test/units/cli/test_doc.py
@@ -1,0 +1,12 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.cli.doc import DocCLI
+
+
+def test_parsing_all_option():
+    doc_cli = DocCLI(['/n/ansible-doc', '-a'])
+    doc_cli.parse()


### PR DESCRIPTION
* Remove redundant argument from the function caller
* Add unit test
* Add changelog

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently in stable-2.7 release ansible-doc command throws traceback for argument -a, --all. 
As mentioned in #52034 #52039 . This patch fixes that. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
$ ansible-doc --help 
...
Options - 
:   -a, --all             **For internal testing only** Show documentation for all plugins.
...
