### PR TITLE
Note that `az login` works for Ansible, too.

### DIFF
--- a/lib/ansible/plugins/doc_fragments/azure.py
+++ b/lib/ansible/plugins/doc_fragments/azure.py
@@ -94,7 +94,7 @@ requirements:
 
 notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
-      in ~/.azure/credentials, or log in with C(az login). Authentication is possible using a service principal or Active Directory user.
+      in ~/.azure/credentials, or log in before you run your tasks or playbook with C(az login). Authentication is possible using a service principal or Active Directory user.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and

--- a/lib/ansible/plugins/doc_fragments/azure.py
+++ b/lib/ansible/plugins/doc_fragments/azure.py
@@ -94,7 +94,8 @@ requirements:
 
 notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
-      in ~/.azure/credentials, or log in before you run your tasks or playbook with C(az login). Authentication is possible using a service principal or Active Directory user.
+      in ~/.azure/credentials, or log in before you run your tasks or playbook with C(az login).
+    - Authentication is also possible using a service principal or Active Directory user.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and

--- a/lib/ansible/plugins/doc_fragments/azure.py
+++ b/lib/ansible/plugins/doc_fragments/azure.py
@@ -93,9 +93,9 @@ requirements:
     - azure >= 2.0.0
 
 notes:
-    - For authentication with Azure you can pass parameters, set environment variables or use a profile stored
-      in ~/.azure/credentials. Authentication is possible using a service principal or Active Directory user.
-      To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
+    - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
+      in ~/.azure/credentials, or log in with C(az login). Authentication is possible using a service principal or Active Directory user.
+    - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and
       AZURE_PASSWORD in the environment.
@@ -103,4 +103,9 @@ notes:
       a [default] section and the following keys: subscription_id, client_id, secret and tenant or
       subscription_id, ad_user and password. It is also possible to add additional profiles. Specify the profile
       by passing profile or setting AZURE_PROFILE in the environment."
+
+seealso:
+    - name: Sign in with Azure CLI
+      link: https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest
+      description: How to authenticate using the C(az login) command.
     '''


### PR DESCRIPTION
##### SUMMARY
Explain that one can use the `az login` command from the Azure CLI to authenticate Ansible to Azure.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Azure modules.