### PR TITLE
Backport into 2.7 - Katello: Added product to the dict choices

### DIFF
--- a/changelogs/fragments/49776-product_fix_katello_foreman_module.yaml
+++ b/changelogs/fragments/49776-product_fix_katello_foreman_module.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "remote_management foreman - Fixed issue where it was impossible to createdelete a product because product was missing in dict choices ( https://github.com/ansible/ansible/issues/48594 )"

--- a/lib/ansible/modules/remote_management/foreman/katello.py
+++ b/lib/ansible/modules/remote_management/foreman/katello.py
@@ -49,6 +49,7 @@ options:
             - content_view
             - lifecycle_environment
             - activation_key
+            - product
 
         required: true
     action:
@@ -541,7 +542,8 @@ def main():
             username=dict(type='str', required=True, no_log=True),
             password=dict(type='str', required=True, no_log=True),
             entity=dict(type='str', required=True,
-                        choices=['repository', 'manifest', 'repository_set', 'sync_plan', 'content_view', 'lifecycle_environment', 'activation_key']),
+                        choices=['repository', 'manifest', 'repository_set', 'sync_plan',
+                                 'content_view', 'lifecycle_environment', 'activation_key', 'product']),
             action=dict(type='str', choices=['sync', 'publish', 'promote']),
             verify_ssl=dict(type='bool', default=False),
             task_timeout=dict(type='int', default=1000),


### PR DESCRIPTION

##### SUMMARY
This PR is a request to backport this fix that has already been merged into devel in the sole purpose of backporting into 2.7 because this module will be deprecated in 2.8+: https://github.com/ansible/ansible/pull/49776

This will at least let the users of 2.7 use the product function of this plugin.

(cherry picked from commit d3fcdae4add16aa66a09e816f4028492fedfd101)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Katello/foreman module

##### ADDITIONAL INFORMATION

As stated in the original PR in devel (https://github.com/ansible/ansible/pull/49776) :

After reading the code to find why product wasn't recognized I realized all the logic required was there, there was even example in the documentation but in a previous commit, someone added a list of valid choice for entity. They seems to have simply forgot to add "product" to the list

This fixes the [issue 48594](https://github.com/ansible/ansible/issues/48594)