### PR TITLE
Fortinet's FortiOS wireless controller utm profile

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_utm_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_utm_profile.py
@@ -197,10 +197,8 @@ version:
 
 from ansible.module_utils.basic import AnsibleModule
 
-fos = None
 
-
-def login(data):
+def login(data, fos):
     host = data['host']
     username = data['username']
     password = data['password']
@@ -261,7 +259,7 @@ def wireless_controller_utm_profile(data, fos):
 
 
 def fortios_wireless_controller(data, fos):
-    login(data)
+    login(data, fos)
 
     if data['wireless_controller_utm_profile']:
         resp = wireless_controller_utm_profile(data, fos)
@@ -304,7 +302,6 @@ def main():
     except ImportError:
         module.fail_json(msg="fortiosapi module is required")
 
-    global fos
     fos = FortiOSAPI()
 
     is_error, has_changed, result = fortios_wireless_controller(module.params, fos)

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_utm_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_utm_profile.py
@@ -1,0 +1,319 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_wireless_controller_utm_profile
+short_description: Configure UTM (Unified Threat Management) profile in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by allowing the
+      user to set and modify wireless_controller feature and utm_profile category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip address.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: true
+    wireless_controller_utm_profile:
+        description:
+            - Configure UTM (Unified Threat Management) profile.
+        default: null
+        suboptions:
+            state:
+                description:
+                    - Indicates whether to create or remove the object
+                choices:
+                    - present
+                    - absent
+            antivirus-profile:
+                description:
+                    - AntiVirus profile name. Source antivirus.profile.name.
+            application-list:
+                description:
+                    - Application control list name. Source application.list.name.
+            comment:
+                description:
+                    - Comment.
+            ips-sensor:
+                description:
+                    - IPS sensor name. Source ips.sensor.name.
+            name:
+                description:
+                    - UTM profile name.
+                required: true
+            scan-botnet-connections:
+                description:
+                    - Block or monitor connections to Botnet servers or disable Botnet scanning.
+                choices:
+                    - disable
+                    - block
+                    - monitor
+            utm-log:
+                description:
+                    - Enable/disable UTM logging.
+                choices:
+                    - enable
+                    - disable
+            webfilter-profile:
+                description:
+                    - WebFilter profile name. Source webfilter.profile.name.
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Configure UTM (Unified Threat Management) profile.
+    fortios_wireless_controller_utm_profile:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      wireless_controller_utm_profile:
+        state: "present"
+        antivirus-profile: "<your_own_value> (source antivirus.profile.name)"
+        application-list: "<your_own_value> (source application.list.name)"
+        comment: "Comment."
+        ips-sensor: "<your_own_value> (source ips.sensor.name)"
+        name: "default_name_7"
+        scan-botnet-connections: "disable"
+        utm-log: "enable"
+        webfilter-profile: "<your_own_value> (source webfilter.profile.name)"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+fos = None
+
+
+def login(data):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_wireless_controller_utm_profile_data(json):
+    option_list = ['antivirus-profile', 'application-list', 'comment',
+                   'ips-sensor', 'name', 'scan-botnet-connections',
+                   'utm-log', 'webfilter-profile']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def flatten_multilists_attributes(data):
+    multilist_attrs = []
+
+    for attr in multilist_attrs:
+        try:
+            path = "data['" + "']['".join(elem for elem in attr) + "']"
+            current_val = eval(path)
+            flattened_val = ' '.join(elem for elem in current_val)
+            exec(path + '= flattened_val')
+        except BaseException:
+            pass
+
+    return data
+
+
+def wireless_controller_utm_profile(data, fos):
+    vdom = data['vdom']
+    wireless_controller_utm_profile_data = data['wireless_controller_utm_profile']
+    flattened_data = flatten_multilists_attributes(wireless_controller_utm_profile_data)
+    filtered_data = filter_wireless_controller_utm_profile_data(flattened_data)
+    if wireless_controller_utm_profile_data['state'] == "present":
+        return fos.set('wireless-controller',
+                       'utm-profile',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif wireless_controller_utm_profile_data['state'] == "absent":
+        return fos.delete('wireless-controller',
+                          'utm-profile',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def fortios_wireless_controller(data, fos):
+    login(data)
+
+    if data['wireless_controller_utm_profile']:
+        resp = wireless_controller_utm_profile(data, fos)
+
+    fos.logout()
+    return not resp['status'] == "success", resp['status'] == "success", resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "wireless_controller_utm_profile": {
+            "required": False, "type": "dict",
+            "options": {
+                "state": {"required": True, "type": "str",
+                          "choices": ["present", "absent"]},
+                "antivirus-profile": {"required": False, "type": "str"},
+                "application-list": {"required": False, "type": "str"},
+                "comment": {"required": False, "type": "str"},
+                "ips-sensor": {"required": False, "type": "str"},
+                "name": {"required": True, "type": "str"},
+                "scan-botnet-connections": {"required": False, "type": "str",
+                                            "choices": ["disable", "block", "monitor"]},
+                "utm-log": {"required": False, "type": "str",
+                            "choices": ["enable", "disable"]},
+                "webfilter-profile": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    global fos
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_wireless_controller(module.params, fos)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY

Fortinet is adding Ansible support for FortiOS and FortiGate products. This module follows the same structure, guidelines and ideas given in previous approved module for a parallel feature of FortiGate (webfiltering): https://github.com/ansible/ansible/pull/37196 
In this case we are providing a different functionality: "Wireless Controller UTM Profile".

Please note that this will be part of other modules to come for FortiGate, including different functionalities: system, wireless-controller, firewall, webfilter, ips, web-proxy, wanopt, application, dlp spamfilter, log, vpn, certificate, user, dnsfilter, antivirus, report, waf, authentication, switch controller, endpoint-control and router. We plan to follow the same style, structure and usage as in the previous module in order to make it easier to comply with Ansible guidelines.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

fortios_wireless_controller_utm_profile

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (new_module ddbbe5dfa5) last updated 2018/09/24 14:54:57 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/magonzalez/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/magonzalez/ansible/lib/ansible
  executable location = /home/magonzalez/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```