### PR TITLE
Fix multiple host objects/lun conflict issue for netapp_lun_mapping.

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_lun_mapping.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_lun_mapping.py
@@ -202,9 +202,10 @@ class LunMapping(object):
         # Verify that when a lun is specified that it does not match an existing lun value unless it is associated with
         # the specified volume (ie for an update)
         if self.lun and any((self.lun == lun_mapping["lun"] and
+                             self.target == self.mapping_info["target_by_reference"][lun_mapping["map_reference"]] and
                              self.volume != self.mapping_info["volume_by_reference"][lun_mapping["volume_reference"]]
                              ) for lun_mapping in self.mapping_info["lun_mapping"]):
-            self.module.fail_json(msg="Option lun value is already in use! Id [%s]." % self.ssid)
+            self.module.fail_json(msg="Option lun value is already in use for target! Array Id [%s]." % self.ssid)
 
         # Verify that when target_type is specified then it matches the target's actually type
         if self.target and self.target_type and self.target in self.mapping_info["target_type_by_name"].keys() and \

--- a/lib/ansible/modules/storage/netapp/netapp_e_lun_mapping.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_lun_mapping.py
@@ -247,7 +247,7 @@ class LunMapping(object):
                     target = None if not self.target else self.mapping_info["target_by_name"][self.target]
                     if target:
                         body.update(dict(targetId=target))
-                    if self.lun:
+                    if self.lun is not None:
                         body.update(dict(lun=self.lun))
 
                     if lun_reference:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch fixes an issue of when multiple hosts are created and then
subsequently volume(s) are mapped to them using the same specified number.
    
Also, multiple tests have been added to the module's integration test.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_lun_mapping

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Create multiple host objects and a volume on a NetApp E-Series storage system. Next map the volume to each host using the same LUN number using netapp_e_lun_mapping module.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.8.0.dev0 (lun_mapping_upstream_dev 04cb6453f4) last updated 2019/02/22 11:34:50 (GMT -500)
  config file = None
  configured module search path = [u'/home/swartzn/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/ansible-dev/lib/ansible
  executable location = /home/swartzn/ansible-dev/bin/ansible
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
```
