### PR TITLE
Update Redis Lookup Plugin

### DIFF
--- a/lib/ansible/plugins/lookup/redis.py
+++ b/lib/ansible/plugins/lookup/redis.py
@@ -106,6 +106,7 @@ class LookupModule(LookupBase):
                 if res is None:
                     res = ""
                 ret.append(to_text(res))
-            except Exception:
-                ret.append("")  # connection failed or key not found
+            except Exception as e:
+                # connection failed or key not found
+                raise AnsibleError('Encountered exception while fetching {0}: {1}'.format(term, e))
         return ret

--- a/lib/ansible/plugins/lookup/redis.py
+++ b/lib/ansible/plugins/lookup/redis.py
@@ -75,6 +75,7 @@ try:
 except ImportError:
     pass
 
+from ansible.module_utils._text import to_text
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
@@ -104,7 +105,7 @@ class LookupModule(LookupBase):
                 res = conn.get(term)
                 if res is None:
                     res = ""
-                ret.append(res)
+                ret.append(to_text(res))
             except Exception:
                 ret.append("")  # connection failed or key not found
         return ret

--- a/lib/ansible/plugins/lookup/redis.py
+++ b/lib/ansible/plugins/lookup/redis.py
@@ -28,7 +28,7 @@ DOCUMENTATION = """
             key: host
       port:
         description: port on which Redis is listening on
-        default: 6379A
+        default: 6379
         type: int
         env:
           - name: ANSIBLE_REDIS_PORT


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes several problems with the Redis Lookup Plugin:

  * The default port is not an integer (`6379A`) which causes an error unless overridden
  * The values returned by the `redis-py` library are `bytes` objects and are returned as `"b'some-value'"` instead of `"some-value"`
  * The errors are suppressed silently

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Redis Lookup Plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Simple playbook to reproduce the error:

```
---

- hosts: localhost
  gather_facts: no
  tasks:
    - name: Repro redis failure
      set_fact: some_fact="{{ lookup('redis', 'some_key') }}"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```bash
# Before change
$ systemctl start redis
$ ansible-playbook -i local_hosts -v repro.yml
PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Repro redis failure] ******************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'redis'. Error was a <class 'ansible.errors.AnsibleOptionsError'>, original message: Invalid type for configuration option port: invalid literal for int() with base 10: '6379A'"}
        to retry, use: --limit @/home/jkerry/interactive/infrastructure/repro.retry

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
$ export ANSIBLE_REDIS_PORT=6379
$ ansible-playbook -i local_hosts -v repro.yml
PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Repro redis failure] ******************************************************************************************************************************************************************************************************************
ok: [localhost] => {"ansible_facts": {"some_fact": "b'some_value'"}, "changed": false}

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
$ systemctl stop redis
$ ansible-playbook -i local_hosts -v repro.yml
PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Repro redis failure] ******************************************************************************************************************************************************************************************************************
ok: [localhost] => {"ansible_facts": {"some_fact": ""}, "changed": false}

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   


# Cleanup
$ redis-cli del some_key

# After change

$ systemctl start redis
$ ansible-playbook -i local_hosts -v repro.yml
PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Repro redis failure] ******************************************************************************************************************************************************************************************************************
ok: [localhost] => {"ansible_facts": {"some_fact": ""}, "changed": false}

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
$ redis-cli set some_key some_value
$ ansible-playbook -i local_hosts -v repro.yml
PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Repro redis failure] ******************************************************************************************************************************************************************************************************************
ok: [localhost] => {"ansible_facts": {"some_fact": "some_value"}, "changed": false}

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
$ systemctl stop redis
$ ansible-playbook -i local_hosts -v repro.yml
PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Repro redis failure] ******************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'redis'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Encountered exception while fetching some_key: Error 111 connecting to 127.0.0.1:6379. Connection refused."}
        to retry, use: --limit @/home/jkerry/interactive/infrastructure/repro.retry

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```

Tested on Python 3.7.2 with Ansible 2.7.8 (on branch `stable-2.7`).