### PR TITLE
nxos_hsrp: fix 'sh_preempt': <unknown enum:>

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -248,7 +248,7 @@ def get_hsrp_group_unknown_enum(module, command, hsrp_table):
     'sh_preempt' is currently the only attr affected. Add checks for other attrs as needed.
     '''
     if 'unknown enum:' in hsrp_table['sh_preempt']:
-        cmd = {'output':'text', 'command': command.split('|')[0]}
+        cmd = {'output': 'text', 'command': command.split('|')[0]}
         out = run_commands(module, cmd)[0]
         hsrp_table['sh_preempt'] = 'enabled' if ('may preempt' in out) else 'disabled'
     return hsrp_table

--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -211,6 +211,8 @@ def get_hsrp_group(group, interface, module):
     try:
         body = run_commands(module, [command])[0]
         hsrp_table = body['TABLE_grp_detail']['ROW_grp_detail']
+        if 'unknown enum:' in str(hsrp_table):
+            hsrp_table = get_hsrp_group_unknown_enum(module, command, hsrp_table)
     except (AttributeError, IndexError, TypeError, KeyError):
         return {}
 
@@ -237,6 +239,19 @@ def get_hsrp_group(group, interface, module):
             return parsed_hsrp
 
     return hsrp
+
+
+def get_hsrp_group_unknown_enum(module, command, hsrp_table):
+    '''Some older NXOS images fail to set the attr values when using structured output and
+    instead set the values to <unknown enum>. This fallback method is a workaround that
+    uses an unstructured (text) request to query the device a second time.
+    'sh_preempt' is currently the only attr affected. Add checks for other attrs as needed.
+    '''
+    if 'unknown enum:' in hsrp_table['sh_preempt']:
+        cmd = {'output':'text', 'command': command.split('|')[0]}
+        out = run_commands(module, cmd)[0]
+        hsrp_table['sh_preempt'] = 'enabled' if ('may preempt' in out) else 'disabled'
+    return hsrp_table
 
 
 def get_commands_remove_hsrp(group, interface):

--- a/test/integration/targets/nxos_hsrp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_hsrp/tests/common/sanity.yaml
@@ -9,7 +9,7 @@
 
 - block:
   - name: "Enable feature hsrp"
-    nxos_feature: 
+    nxos_feature:
       feature: hsrp
       provider: "{{ connection }}"
       state: enabled
@@ -155,7 +155,7 @@
 
   always:
   - name: "Disable feature hsrp"
-    nxos_feature: 
+    nxos_feature:
       feature: hsrp
       provider: "{{ connection }}"
       state: disabled


### PR DESCRIPTION
##### SUMMARY
Some older nxos images fail to set this attr value. This fix checks for unknown enum and issues a second (unstructured) call to the device to get the data.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`network/nxos/nxos_hsrp`

##### ADDITIONAL INFORMATION
Issue seen with N9000 NXOS version 7.0(3)I7(4).

The `nxos_hsrp/tests/common/sanity.yaml` test will fail with idempotency issues. 
The output from the defective image will display `show hsrp group 100 all | json` as shown:

```
n9k(config-if-hsrp)# show hsrp group 100 all | json
{"TABLE_grp_detail": {"ROW_grp_detail": {"sh_if_index": "Ethernet1/1",
...
, "sh_preempt": "unknown enum:<1919252225>", 
...
```
`sh_preempt` is the only affected attr but I've written the fix to allow for additional attrs as needed.

`nxos_hsrp` tests are now 100% pass rate with this fix.