### PR TITLE
Add workaround for dnf versionlock plugin init failure

### DIFF
--- a/changelogs/fragments/dnf-versionlock-failure.yaml
+++ b/changelogs/fragments/dnf-versionlock-failure.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "dnf gracefully handle versionlock plugin init failures"

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -618,6 +618,8 @@ class DnfModule(YumDnf):
                 rc=1
             )
         except AttributeError as e:
+            # Expected failure string:
+            #   AttributeError: 'NoneType' object has no attribute 'demands'\
             if 'demands' in to_text(e):
                 version_lock_index = None
                 for plugin in base._plugins.plugins:
@@ -625,7 +627,6 @@ class DnfModule(YumDnf):
                         self.module.warn("Disabling dnf versionlock plugin due do known upstream bug: "
                                          "https://github.com/rpm-software-management/dnf-plugins-core/pull/317")
                         self.disable_plugin.append('versionlock')
-                        broken_plugin_found = True
 
                         version_lock_index = base._plugins.plugins.index(plugin)
                 if version_lock_index:

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -635,7 +635,7 @@ class DnfModule(YumDnf):
                     # _unload plugins function doesn't properly clean up after itself
                     del sys.modules['dnf.plugin.dynamic.versionlock']
             else:
-                #re-raise
+                # re-raise
                 raise e
 
         if self.bugfix:


### PR DESCRIPTION
##### SUMMARY

This patch will no longer be necessary once a future version of dnf
is released that includes the patch I submitted upstream[0], but in
the meantime this is a regression in functionality for Ansible
users. Also, since it's all encapsulated in an exception handler, it
shouldn't have any impact otherwise.

Fixes #50237

[0] - https://github.com/rpm-software-management/dnf-plugins-core/pull/317

Signed-off-by: Adam Miller <admiller@redhat.com>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf

