### PR TITLE
tests: cloudstack: wait longer for template to be ready

### DIFF
--- a/test/integration/targets/cs_firewall/tasks/main.yml
+++ b/test/integration/targets/cs_firewall/tasks/main.yml
@@ -21,7 +21,7 @@
       - "{{ net.name }}"
   register: instance
   until: instance is success
-  retries: 10
+  retries: 20
   delay: 5
 - name: verify instance setup
   assert:

--- a/test/integration/targets/cs_ip_address/tasks/network.yml
+++ b/test/integration/targets/cs_ip_address/tasks/network.yml
@@ -27,7 +27,7 @@
       - "{{ base_network.name }}"
   register: instance
   until: instance is success
-  retries: 10
+  retries: 20
   delay: 5
 - name: verify instance setup
   assert:


### PR DESCRIPTION
##### SUMMARY
Template is still not always ready. wait a bit longer. See #52730 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudstack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
