### PR TITLE
Fix the example plugin paths in "Adding modules and plugins locally" doc

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_locally.rst
+++ b/docs/docsite/rst/dev_guide/developing_locally.rst
@@ -75,8 +75,8 @@ Ansible loads plugins automatically too, loading each type of plugin separately 
 You can create or add a local plugin in any of these locations:
 
 * any directory added to the relevant ``ANSIBLE_plugin_type_PLUGINS`` environment variable (these variables, such as ``$ANSIBLE_INVENTORY_PLUGINS`` and ``$ANSIBLE_VARS_PLUGINS`` take colon-separated lists like ``$PATH``)
-* the directory named for the correct ``plugin_type`` within ``~/.ansible/plugins/`` - for example, ``~/.ansible/plugins/callback_plugins``
-* the directory named for the correct ``plugin_type`` within ``/usr/share/ansible/plugins/`` - for example, ``/usr/share/ansible/plugins/plugin_type/action_plugins``
+* the directory named for the correct ``plugin_type`` within ``~/.ansible/plugins/`` - for example, ``~/.ansible/plugins/callback``
+* the directory named for the correct ``plugin_type`` within ``/usr/share/ansible/plugins/`` - for example, ``/usr/share/ansible/plugins/action``
 
 Once your plugin file is in one of these locations, Ansible will load it and you can use it in a any local module, task, playbook, or role.
 


### PR DESCRIPTION
##### SUMMARY

Based on https://docs.ansible.com/ansible/latest/reference_appendices/config.html
for instance `DEFAULT_CALLBACK_PLUGIN_PATH` is `~/.ansible/plugins/callback:/usr/share/ansible/plugins/callback` and `DEFAULT_ACTION_PLUGIN_PATH` is `~/.ansible/plugins/action:/usr/share/ansible/plugins/action`

Thus the `~/.ansible/plugins/callback_plugins` and `/usr/share/ansible/plugins/plugin_type/action_plugins` are incorrect.

I've verified on 2.7.5 that by default `plugins/action` works and `plugins/action_plugins` does not

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dev_guide
