### PR TITLE
Update elb_target_group.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -99,9 +99,8 @@ options:
     default: lb_cookie
   successful_response_codes:
     description:
-      - The HTTP codes to use when checking for a successful response from a target. 
-      - Accepts multiple values (for example, "200,202") or a range of
-        values (for example, "200-299").
+      - The HTTP codes to use when checking for a successful response from a target.
+      - Accepts multiple values (for example, "200,202") or a range of         values (for example, "200-299").
       - Requires the I(health_check_protocol) parameter to be set.
     required: false
   tags:

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -99,8 +99,10 @@ options:
     default: lb_cookie
   successful_response_codes:
     description:
-      - The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of
-        values (for example, "200-299"). Requires the I(health_check_protocol) parameter to be set.
+      - The HTTP codes to use when checking for a successful response from a target. 
+      - Accepts multiple values (for example, "200,202") or a range of
+        values (for example, "200-299").
+      - Requires the I(health_check_protocol) parameter to be set.
     required: false
   tags:
     description:

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -100,7 +100,7 @@ options:
   successful_response_codes:
     description:
       - The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of
-        values (for example, "200-299").
+        values (for example, "200-299"). Requires the I(health_check_protocol) parameter to be set.
     required: false
   tags:
     description:


### PR DESCRIPTION
`successful_response_codes` only gets set when the `health_check_protocol` parameter is set (per [the code at line 432 ](https://github.com/ansible/ansible/blob/a54b9487307243d6716685f15794da110e6e5d96/lib/ansible/modules/cloud/amazon/elb_target_group.py#L429-L436)

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elb_target_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
