### PR TITLE
docker_swarm update to use shared Swarm library

### DIFF
--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import json
+from time import sleep
 
 try:
     from docker.errors import APIError
@@ -108,23 +109,29 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
             return True
         return False
 
-    def check_if_swarm_node_is_down(self, node_id=None):
+    def check_if_swarm_node_is_down(self, node_id=None, repeat_check=1):
         """
         Checks if node status on Swarm manager is 'down'. If node_id is provided it query manager about
         node specified in parameter, otherwise it query manager itself. If run on Swarm Worker node or
         host that is not part of Swarm it will fail the playbook
 
+        :param repeat_check: number of check attempts with 5 seconds delay between them, by default check only once
         :param node_id: node ID or name, if None then method will try to get node_id of host module run on
         :return:
             True if node is part of swarm but its state is down, False otherwise
         """
 
+        if repeat_check < 1:
+            repeat_check = 1
+
         if node_id is None:
             node_id = self.get_swarm_node_id()
 
-        node_info = self.get_node_inspect(node_id=node_id)
-        if node_info['Status']['State'] == 'down':
-            return True
+        for retry in range(0, repeat_check):
+            node_info = self.get_node_inspect(node_id=node_id)
+            if node_info['Status']['State'] == 'down':
+                return True
+            sleep(5)
         return False
 
     def get_node_inspect(self, node_id=None, skip_missing=False):

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -401,6 +401,9 @@ class SwarmManager(DockerBaseClass):
             self.results['diff'] = diff
 
     def inspect_swarm(self):
+        self.client.module.deprecate(
+            "The 'inspect' state is deprecated, please use 'docker_swarm_facts' to inspect swarm cluster",
+            version='2.12')
         try:
             data = self.client.inspect_swarm()
             json_str = json.dumps(data, ensure_ascii=False)
@@ -491,7 +494,7 @@ class SwarmManager(DockerBaseClass):
             self.client.fail("This node is not a manager.")
 
         try:
-            status_down = self.client.check_if_swarm_node_is_down(repeat_check=5)
+                status_down = self.client.check_if_swarm_node_is_down(repeat_check=5)
         except APIError:
             return
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -494,7 +494,7 @@ class SwarmManager(DockerBaseClass):
             self.client.fail("This node is not a manager.")
 
         try:
-                status_down = self.client.check_if_swarm_node_is_down(repeat_check=5)
+            status_down = self.client.check_if_swarm_node_is_down(repeat_check=5)
         except APIError:
             return
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -393,12 +393,12 @@ class SwarmManager(DockerBaseClass):
             "inspect": self.inspect_swarm
         }
 
-        choice_map.get(self.state)()
-
         if self.state == 'inspect':
             self.client.module.deprecate(
                 "The 'inspect' state is deprecated, please use 'docker_swarm_facts' to inspect swarm cluster",
                 version='2.12')
+
+        choice_map.get(self.state)()
 
         if self.client.module._diff or self.parameters.debug:
             diff = dict()

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -428,7 +428,8 @@ class SwarmManager(DockerBaseClass):
                 self.client.fail("Can not create a new Swarm Cluster: %s" % to_native(exc))
 
         if not self.client.check_if_swarm_manager():
-            self.client.fail("Swarm not created or other error!")
+            if not self.check_mode:
+                self.client.fail("Swarm not created or other error!")
         self.inspect_swarm()
         self.results['actions'].append("New Swarm cluster created: %s" % (self.swarm_info.get('ID')))
         self.differences.add('state', parameter='absent', active='present')

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -229,7 +229,7 @@ actions:
 '''
 
 import json
-from time import sleep
+
 try:
     from docker.errors import APIError
 except ImportError:
@@ -237,10 +237,12 @@ except ImportError:
     pass
 
 from ansible.module_utils.docker.common import (
-    AnsibleDockerClient,
     DockerBaseClass,
     DifferenceTracker,
 )
+
+from ansible.module_utils.docker.swarm import AnsibleDockerSwarmClient
+
 from ansible.module_utils._text import to_native
 
 
@@ -253,6 +255,7 @@ class TaskParameters(DockerBaseClass):
         self.force_new_cluster = None
         self.remote_addrs = None
         self.join_token = None
+        self.force = None
 
         # Spec
         self.snapshot_interval = None
@@ -396,15 +399,6 @@ class SwarmManager(DockerBaseClass):
             diff['before'], diff['after'] = self.differences.get_before_after()
             self.results['diff'] = diff
 
-    def __isSwarmManager(self):
-        try:
-            data = self.client.inspect_swarm()
-            json_str = json.dumps(data, ensure_ascii=False)
-            self.swarm_info = json.loads(json_str)
-            return True
-        except APIError:
-            return False
-
     def inspect_swarm(self):
         try:
             data = self.client.inspect_swarm()
@@ -416,7 +410,8 @@ class SwarmManager(DockerBaseClass):
             return
 
     def init_swarm(self):
-        if self.__isSwarmManager():
+        if self.client.check_if_swarm_manager():
+            self.inspect_swarm()
             self.__update_swarm()
             return
 
@@ -428,7 +423,9 @@ class SwarmManager(DockerBaseClass):
             except APIError as exc:
                 self.client.fail("Can not create a new Swarm Cluster: %s" % to_native(exc))
 
-        self.__isSwarmManager()
+        if not self.client.check_if_swarm_manager():
+            self.client.fail("Swarm not created or other error!")
+        self.inspect_swarm()
         self.results['actions'].append("New Swarm cluster created: %s" % (self.swarm_info.get('ID')))
         self.differences.add('state', parameter='absent', active='present')
         self.results['changed'] = True
@@ -460,26 +457,15 @@ class SwarmManager(DockerBaseClass):
         self.results['actions'].append("Swarm cluster updated")
         self.results['changed'] = True
 
-    def __isSwarmNode(self):
-        info = self.client.info()
-        if info:
-            json_str = json.dumps(info, ensure_ascii=False)
-            self.swarm_info = json.loads(json_str)
-            if self.swarm_info['Swarm']['NodeID']:
-                return True
-            if self.swarm_info['Swarm']['LocalNodeState'] in ('active', 'pending', 'locked'):
-                return True
-        return False
-
     def join(self):
-        if self.__isSwarmNode():
+        if self.client.check_if_swarm_node():
             self.results['actions'].append("This node is already part of a swarm.")
             return
         if not self.check_mode:
             try:
                 self.client.join_swarm(
-                    remote_addrs=self.parameters.remote_addrs, join_token=self.parameters.join_token, listen_addr=self.parameters.listen_addr,
-                    advertise_addr=self.parameters.advertise_addr)
+                    remote_addrs=self.parameters.remote_addrs, join_token=self.parameters.join_token,
+                    listen_addr=self.parameters.listen_addr, advertise_addr=self.parameters.advertise_addr)
             except APIError as exc:
                 self.client.fail("Can not join the Swarm Cluster: %s" % to_native(exc))
         self.results['actions'].append("New node is added to swarm cluster")
@@ -487,7 +473,7 @@ class SwarmManager(DockerBaseClass):
         self.results['changed'] = True
 
     def leave(self):
-        if not(self.__isSwarmNode()):
+        if not(self.client.check_if_swarm_node()):
             self.results['actions'].append("This node is not part of a swarm.")
             return
         if not self.check_mode:
@@ -499,33 +485,16 @@ class SwarmManager(DockerBaseClass):
         self.differences.add('joined', parameter='absent', active='present')
         self.results['changed'] = True
 
-    def __get_node_info(self):
-        try:
-            node_info = self.client.inspect_node(node_id=self.parameters.node_id)
-        except APIError as exc:
-            raise exc
-        json_str = json.dumps(node_info, ensure_ascii=False)
-        node_info = json.loads(json_str)
-        return node_info
-
-    def __check_node_is_down(self):
-        for _x in range(0, 5):
-            node_info = self.__get_node_info()
-            if node_info['Status']['State'] == 'down':
-                return True
-            sleep(5)
-        return False
-
     def remove(self):
-        if not(self.__isSwarmManager()):
+        if not(self.client.check_if_swarm_manager()):
             self.client.fail("This node is not a manager.")
 
         try:
-            status_down = self.__check_node_is_down()
+            status_down = self.client.check_if_swarm_node_is_down()
         except APIError:
             return
 
-        if not(status_down):
+        if not status_down:
             self.client.fail("Can not remove the node. The status node is ready and not down.")
 
         if not self.check_mode:
@@ -577,7 +546,7 @@ def main():
         ca_force_rotate=dict(docker_api_version='1.30'),
     )
 
-    client = AnsibleDockerClient(
+    client = AnsibleDockerSwarmClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if,

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -158,6 +158,7 @@ requirements:
   - "docker >= 2.6.0"
   - Docker API >= 1.25
 author:
+  - Piotr Wojciechowski (@WojciechowskiPiotr)
   - Thierry Bouvet (@tbouvet)
 '''
 
@@ -490,7 +491,7 @@ class SwarmManager(DockerBaseClass):
             self.client.fail("This node is not a manager.")
 
         try:
-            status_down = self.client.check_if_swarm_node_is_down()
+            status_down = self.client.check_if_swarm_node_is_down(repeat_check=5)
         except APIError:
             return
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -158,8 +158,8 @@ requirements:
   - "docker >= 2.6.0"
   - Docker API >= 1.25
 author:
-  - Piotr Wojciechowski (@WojciechowskiPiotr)
   - Thierry Bouvet (@tbouvet)
+  - Piotr Wojciechowski (@WojciechowskiPiotr)
 '''
 
 EXAMPLES = '''
@@ -395,15 +395,17 @@ class SwarmManager(DockerBaseClass):
 
         choice_map.get(self.state)()
 
+        if self.state == 'inspect':
+            self.client.module.deprecate(
+                "The 'inspect' state is deprecated, please use 'docker_swarm_facts' to inspect swarm cluster",
+                version='2.12')
+
         if self.client.module._diff or self.parameters.debug:
             diff = dict()
             diff['before'], diff['after'] = self.differences.get_before_after()
             self.results['diff'] = diff
 
     def inspect_swarm(self):
-        self.client.module.deprecate(
-            "The 'inspect' state is deprecated, please use 'docker_swarm_facts' to inspect swarm cluster",
-            version='2.12')
         try:
             data = self.client.inspect_swarm()
             json_str = json.dumps(data, ensure_ascii=False)
@@ -415,7 +417,6 @@ class SwarmManager(DockerBaseClass):
 
     def init_swarm(self):
         if self.client.check_if_swarm_manager():
-            self.inspect_swarm()
             self.__update_swarm()
             return
 


### PR DESCRIPTION
##### SUMMARY
Update the `docker_swarm` module so it use the `ansible.module_utils.docker.swarm` class `AnsibleDockerSwarmClient` for client connectivity as the rest of the Swarm modules. It also updates the library for this module specific call of method `check_if_swarm_node_is_down` and adds deprecation warning for `state: inspect`

There is no new feature nor change in usage so changelog update is not required

Discussed in ansible/community#408

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_swarm
