### PR TITLE
[Backport 2.7] Add missing ConnectionError imports

### DIFF
--- a/changelogs/fragments/52885-edgeos-connectionError_fix.yaml
+++ b/changelogs/fragments/52885-edgeos-connectionError_fix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add missing import for ConnectionError in edge and routeros module_utils.

--- a/lib/ansible/module_utils/network/edgeos/edgeos.py
+++ b/lib/ansible/module_utils/network/edgeos/edgeos.py
@@ -28,7 +28,7 @@
 import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import to_list
-from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import Connection, ConnectionError
 
 _DEVICE_CONFIGS = None
 

--- a/lib/ansible/module_utils/network/routeros/routeros.py
+++ b/lib/ansible/module_utils/network/routeros/routeros.py
@@ -29,7 +29,7 @@ import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network.common.utils import to_list, ComplexList
-from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import Connection, ConnectionError
 
 _DEVICE_CONFIGS = {}
 


### PR DESCRIPTION
##### SUMMARY
Small fix

Fixes: #52885

(cherry picked from commit 51c5e60e4954cf15df6fec262fc36f61e141ec7b)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/52885-edgeos-connectionError_fix.yaml
lib/ansible/module_utils/network/edgeos/edgeos.py
lib/ansible/module_utils/network/routeros/routeros.py
