### PR TITLE
LVG: add new parameter pvresize

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -48,7 +48,7 @@ options:
     description:
     - If C(yes) resize the physical volume to the maximum available size
     type: bool
-    default: no
+    default: yes
     version_added: "2.8"
   vg_options:
     description:
@@ -151,7 +151,7 @@ def main():
             pvs=dict(type='list'),
             pesize=dict(type='str', default=4),
             pv_options=dict(type='str', default=''),
-            pvresize=dict(type='bool', default=False),
+            pvresize=dict(type='bool', default=True),
             vg_options=dict(type='str', default=''),
             state=dict(type='str', default='present', choices=['absent', 'present']),
             force=dict(type='bool', default=False),
@@ -267,13 +267,14 @@ def main():
                 for device in current_devs:
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
                     pvdisplay_ops = "--units b --columns --noheadings --nosuffix"
-                    rc, dev_size, err = module.run_command("%s %s %s -o dev_size" % (pvdisplay_cmd, device, pvdisplay_ops))
+                    pvdiplay_cmd_device_options = pvdisplay_cmd+" "+device+" "+pvdisplay_ops
+                    rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + " -o dev_size")
                     dev_size = int(dev_size.replace(" ", ""))
-                    rc, pv_size, err = module.run_command("%s %s %s -o pv_size" % (pvdisplay_cmd, device, pvdisplay_ops))
+                    rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + " -o pv_size")
                     pv_size = int(pv_size.replace(" ", ""))
-                    rc, pe_start, err = module.run_command("%s %s %s -o pe_start " % (pvdisplay_cmd, device, pvdisplay_ops))
+                    rc, pe_start, err = module.run_command(pvdiplay_cmd_device_options + " -o pe_start")
                     pe_start = int(pe_start.replace(" ", ""))
-                    rc, vg_extent_size, err = module.run_command("%s %s %s -o vg_extent_size" % (pvdisplay_cmd, device, pvdisplay_ops))
+                    rc, vg_extent_size, err = module.run_command(pvdiplay_cmd_device_options + " -o vg_extent_size")
                     vg_extent_size = int(vg_extent_size.replace(" ", ""))
                     if (dev_size - (pe_start + pv_size)) > vg_extent_size:
                         if module.check_mode:

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -265,7 +265,6 @@ def main():
         if current_devs:
             if state == 'present' and pvresize:
                 for device in current_devs:
-                    lsblk_cmd = module.get_bin_path('lsblk', True)
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
                     pvdisplay_ops = "--units b --columns --noheadings --nosuffix"
                     rc, dev_size, err = module.run_command("%s %s %s -o dev_size" % (pvdisplay_cmd, device, pvdisplay_ops))

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -46,7 +46,7 @@ options:
     version_added: "2.4"
   pvresize:
     description:
-    - If C(yes) resize the physical volume to the maximum available sizd
+    - If C(yes) resize the physical volume to the maximum available size
     type: bool
     default: no
     version_added: "2.8"

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -267,7 +267,7 @@ def main():
                 for device in current_devs:
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
                     pvdisplay_ops = "--units b --columns --noheadings --nosuffix"
-                    pvdiplay_cmd_device_options = pvdisplay_cmd+" "+device+" "+pvdisplay_ops
+                    pvdiplay_cmd_device_options = pvdisplay_cmd + " " + device + " " + pvdisplay_ops
                     rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + " -o dev_size")
                     dev_size = int(dev_size.replace(" ", ""))
                     rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + " -o pv_size")

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -49,6 +49,7 @@ options:
     - If C(yes) resize the physical volume to the maximum available sizd
     type: bool
     default: no
+    version_added: "2.8"
   vg_options:
     description:
     - Additional options to pass to C(vgcreate) when creating the volume group.

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -274,7 +274,7 @@ def main():
                     pv_size = int(pv_size.replace(" ", ""))
                     rc, pe_start, err = module.run_command(pvdiplay_cmd_device_options + " -o pe_start")
                     pe_start = int(pe_start.replace(" ", ""))
-                    rc, vg_extent_size, err = module.run_command(pvdiplay_cmd_device_options + " -o vg_extent_size")
+                    rc, vg_extent_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "vg_extent_size"])
                     vg_extent_size = int(vg_extent_size.replace(" ", ""))
                     if (dev_size - (pe_start + pv_size)) > vg_extent_size:
                         if module.check_mode:

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -268,7 +268,7 @@ def main():
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
                     pvdisplay_ops = ["--units", "b", "--columns", "--noheadings", "--nosuffix"]
                     pvdiplay_cmd_device_options = [pvdisplay_cmd, device] + pvdisplay_ops
-                    rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + " -o dev_size")
+                    rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "dev_size"])
                     dev_size = int(dev_size.replace(" ", ""))
                     rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "pv_size"])
                     pv_size = int(pv_size.replace(" ", ""))

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -272,7 +272,7 @@ def main():
                     dev_size = int(dev_size.replace(" ", ""))
                     rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + " -o pv_size")
                     pv_size = int(pv_size.replace(" ", ""))
-                    rc, pe_start, err = module.run_command(pvdiplay_cmd_device_options + " -o pe_start")
+                    rc, pe_start, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "pe_start"])
                     pe_start = int(pe_start.replace(" ", ""))
                     rc, vg_extent_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "vg_extent_size"])
                     vg_extent_size = int(vg_extent_size.replace(" ", ""))

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -281,7 +281,7 @@ def main():
                             changed = True
                         else:
                             pvresize_cmd = module.get_bin_path('pvresize', True)
-                            rc, _, err = module.run_command("%s %s" % (pvresize_cmd, device))
+                            rc, _, err = module.run_command([pvresize_cmd, device])
                             if rc != 0:
                                 module.fail_json(msg="Failed executing pvresize command.", rc=rc, err=err)
                             else:

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -48,8 +48,8 @@ options:
     description:
     - If C(yes) resize the physical volume to the maximum available size
     type: bool
-    default: yes
-    version_added: "2.8"
+    default: false
+    version_added: "2.10"
   vg_options:
     description:
     - Additional options to pass to C(vgcreate) when creating the volume group.

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -267,7 +267,7 @@ def main():
                 for device in current_devs:
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
                     pvdisplay_ops = "--units b --columns --noheadings --nosuffix"
-                    pvdiplay_cmd_device_options = pvdisplay_cmd + " " + device + " " + pvdisplay_ops
+                    pvdiplay_cmd_device_options = [pvdisplay_cmd, device] + pvdisplay_ops
                     rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + " -o dev_size")
                     dev_size = int(dev_size.replace(" ", ""))
                     rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + " -o pv_size")

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -266,7 +266,7 @@ def main():
             if state == 'present' and pvresize:
                 for device in current_devs:
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
-                    pvdisplay_ops = "--units b --columns --noheadings --nosuffix"
+                    pvdisplay_ops = ["--units", "b", "--columns", "--noheadings", "--nosuffix"]
                     pvdiplay_cmd_device_options = [pvdisplay_cmd, device] + pvdisplay_ops
                     rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + " -o dev_size")
                     dev_size = int(dev_size.replace(" ", ""))

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -270,7 +270,7 @@ def main():
                     pvdiplay_cmd_device_options = [pvdisplay_cmd, device] + pvdisplay_ops
                     rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + " -o dev_size")
                     dev_size = int(dev_size.replace(" ", ""))
-                    rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + " -o pv_size")
+                    rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "pv_size"])
                     pv_size = int(pv_size.replace(" ", ""))
                     rc, pe_start, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "pe_start"])
                     pe_start = int(pe_start.replace(" ", ""))

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -44,6 +44,11 @@ options:
     - Additional options to pass to C(pvcreate) when creating the volume group.
     type: str
     version_added: "2.4"
+  pvresize:
+    description:
+    - If C(yes) resize the physical volume to the maximum available sizd
+    type: bool
+    default: no
   vg_options:
     description:
     - Additional options to pass to C(vgcreate) when creating the volume group.
@@ -145,6 +150,7 @@ def main():
             pvs=dict(type='list'),
             pesize=dict(type='str', default=4),
             pv_options=dict(type='str', default=''),
+            pvresize=dict(type='bool', default=False),
             vg_options=dict(type='str', default=''),
             state=dict(type='str', default='present', choices=['absent', 'present']),
             force=dict(type='bool', default=False),
@@ -155,6 +161,7 @@ def main():
     vg = module.params['vg']
     state = module.params['state']
     force = module.boolean(module.params['force'])
+    pvresize = module.boolean(module.params['pvresize'])
     pesize = module.params['pesize']
     pvoptions = module.params['pv_options'].split()
     vgoptions = module.params['vg_options'].split()
@@ -253,6 +260,30 @@ def main():
         current_devs = [os.path.realpath(pv['name']) for pv in pvs if pv['vg_name'] == vg]
         devs_to_remove = list(set(current_devs) - set(dev_list))
         devs_to_add = list(set(dev_list) - set(current_devs))
+
+        if current_devs:
+            if state == 'present' and pvresize:
+                for device in current_devs:
+                    lsblk_cmd = module.get_bin_path('lsblk', True)
+                    pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
+                    rc, dev_size, err = module.run_command("%s %s ---units b --columns -o dev_size --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    dev_size = int(dev_size.replace(" ", ""))
+                    rc, pv_size, err = module.run_command("%s %s ---units b --columns -o pv_size --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    pv_size = int(pv_size.replace(" ", ""))
+                    rc, pe_start, err = module.run_command("%s %s ---units b --columns -o pe_start --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    pe_start = int(pe_start.replace(" ", ""))
+                    rc, vg_extent_size, err = module.run_command("%s %s ---units b --columns -o vg_extent_size --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    vg_extent_size = int(vg_extent_size.replace(" ", ""))
+                    if (dev_size - (pe_start + pv_size)) > vg_extent_size:
+                        if module.check_mode:
+                            changed = True
+                        else:
+                            pvresize_cmd = module.get_bin_path('pvresize', True)
+                            rc, _, err = module.run_command("%s %s" % (pvresize_cmd, device))
+                            if rc != 0:
+                                module.fail_json(msg="Failed executing pvresize command.", rc=rc, err=err)
+                            else:
+                                changed = True
 
         if devs_to_add or devs_to_remove:
             if module.check_mode:

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -264,14 +264,16 @@ def main():
         if current_devs:
             if state == 'present' and pvresize:
                 for device in current_devs:
+                    lsblk_cmd = module.get_bin_path('lsblk', True)
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
-                    rc, dev_size, err = module.run_command("%s %s ---units b --columns -o dev_size --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    pvdisplay_ops = "--units b --columns --noheadings --nosuffix"
+                    rc, dev_size, err = module.run_command("%s %s %s -o dev_size" % (pvdisplay_cmd, device, pvdisplay_ops))
                     dev_size = int(dev_size.replace(" ", ""))
-                    rc, pv_size, err = module.run_command("%s %s ---units b --columns -o pv_size --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    rc, pv_size, err = module.run_command("%s %s %s -o pv_size" % (pvdisplay_cmd, device, pvdisplay_ops))
                     pv_size = int(pv_size.replace(" ", ""))
-                    rc, pe_start, err = module.run_command("%s %s ---units b --columns -o pe_start --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    rc, pe_start, err = module.run_command("%s %s %s -o pe_start " % (pvdisplay_cmd, device, pvdisplay_ops))
                     pe_start = int(pe_start.replace(" ", ""))
-                    rc, vg_extent_size, err = module.run_command("%s %s ---units b --columns -o vg_extent_size --noheadings --nosuffix" % (pvdisplay_cmd, device))
+                    rc, vg_extent_size, err = module.run_command("%s %s %s -o vg_extent_size" % (pvdisplay_cmd, device, pvdisplay_ops))
                     vg_extent_size = int(vg_extent_size.replace(" ", ""))
                     if (dev_size - (pe_start + pv_size)) > vg_extent_size:
                         if module.check_mode:

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -264,7 +264,6 @@ def main():
         if current_devs:
             if state == 'present' and pvresize:
                 for device in current_devs:
-                    lsblk_cmd = module.get_bin_path('lsblk', True)
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
                     rc, dev_size, err = module.run_command("%s %s ---units b --columns -o dev_size --noheadings --nosuffix" % (pvdisplay_cmd, device))
                     dev_size = int(dev_size.replace(" ", ""))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Prior to this adjustment, if the underlying physical device was resized, the physical volume built on it would not be resized. 

An additional (optional) parameter was added with default to "yes" for ansible 2.8. When backporting, would probably change the default for "no" hence preserving compatibility only for already shipped versions. This is an important conceptual change, once the current behavior is misleading as described in the bug description.

In order to detect if the physical volume must be resized, a simple check verifies if the difference between the physical device size and the sum of the physical volume size and extent start size (reserved for metadata) is greater than one extent. If that is the case, the resize occurs

Fixes #29139

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lvg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
