### PR TITLE
Add voice vlan option to ios_l2_interface module

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -23,6 +23,7 @@ description:
     Cisco IOS devices.
 author:
   - Nathaniel Case (@qalthos)
+  - Chris Smolen (@smolz)
 options:
   name:
     description:

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -45,6 +45,7 @@ options:
     description:
       - Configure given Voice VLAN in access port.
         If C(mode=voice-access), used as the voice VLAN ID.
+    version_added: '2.8'
   trunk_vlans:
     description:
       - List of VLANs to be configured in trunk port.

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -33,6 +33,8 @@ options:
   mode:
     description:
       - Mode in which interface needs to be configured.
+        C(mode=voice-access) will configure both an access vlan
+        and a voice vlan on an interface.
     default: access
     choices: ['access', 'voice-access', 'trunk']
   access_vlan:

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -34,7 +34,7 @@ options:
     description:
       - Mode in which interface needs to be configured.
     default: access
-    choices: ['access', 'voice-access, 'trunk']
+    choices: ['access', 'voice-access', 'trunk']
   access_vlan:
     description:
       - Configure given VLAN in access port.

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -46,7 +46,7 @@ options:
     description:
       - Configure given Voice VLAN in access port.
         If C(mode=voice-access), used as the voice VLAN ID.
-    version_added: '2.8'
+    version_added: '2.9'
   trunk_vlans:
     description:
       - List of VLANs to be configured in trunk port.

--- a/test/units/modules/network/ios/fixtures/ios_l2_interface_config.cfg
+++ b/test/units/modules/network/ios/fixtures/ios_l2_interface_config.cfg
@@ -1,0 +1,6 @@
+!
+interface GigabitEthernet0/5
+ switchport mode access
+ switchport access vlan 10
+ switchport voice vlan 20
+!

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -1,0 +1,73 @@
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from units.compat.mock import patch
+from ansible.modules.network.ios import ios_l2_interface
+from units.modules.utils import set_module_args
+from .ios_module import TestIosModule, load_fixture
+
+
+class TestIosUserModule(TestIosModule):
+
+    module = ios_l2_interface
+
+    def setUp(self):
+        super(TestIosUserModule, self).setUp()
+
+        self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
+        self.load_config = self.mock_load_config.start()
+
+    def tearDown(self):
+        super(TestIosUserModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
+        self.load_config.return_value = dict(diff=None, session='session')
+
+    def test_ios_l2_interface_with_voice_vlan(self):
+        set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access', 'name': 'GigabitEthernet0/5'})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+            'interface GigabitEthernet0/5',
+            'switchport mode access',
+            'switchport access vlan 10',
+            'switchport voice vlan 20',
+        ]
+        self.assertEqual(result['commands'], expected_commands)
+
+    def test_ios_l2_interface_default_interface(self):
+        set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+             'interface GigabitEthernet0/5',
+             'switchport mode access',
+             'switchport access vlan 1',
+             'no switchport voice vlan',
+             'switchport trunk native vlan 1',
+             'switchport trunk allowed vlan all',
+        ]
+        self.assertEqual(result['commands'], expected_commands)

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -28,47 +28,47 @@ from .ios_module import TestIosModule, load_fixture
 
 
 class TestIosUserModule(TestIosModule):
-module = ios_l2_interface
+    module = ios_l2_interface
 
-def setUp(self):
-    super(TestIosUserModule, self).setUp()
+    def setUp(self):
+        super(TestIosUserModule, self).setUp()
 
-    self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
-    self.get_config = self.mock_get_config.start()
+        self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
+        self.get_config = self.mock_get_config.start()
 
-    self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
-    self.load_config = self.mock_load_config.start()
+        self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
+        self.load_config = self.mock_load_config.start()
 
-def tearDown(self):
-    super(TestIosUserModule, self).tearDown()
-    self.mock_get_config.stop()
-    self.mock_load_config.stop()
+    def tearDown(self):
+        super(TestIosUserModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
 
-def load_fixtures(self, commands=None, transport='cli'):
-    self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
-    self.load_config.return_value = dict(diff=None, session='session')
+    def load_fixtures(self, commands=None, transport='cli'):
+        self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
+        self.load_config.return_value = dict(diff=None, session='session')
 
-def test_ios_l2_interface_with_voice_vlan(self):
-    set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access',
-		     'name': 'GigabitEthernet0/5'})
-    result = self.execute_module(changed=True)
-    expected_commands = [
-	    'interface GigabitEthernet0/5',
-	    'switchport mode access',
-	    'switchport access vlan 10',
-	    'switchport voice vlan 20',
-    ]
-    self.assertEqual(result['commands'], expected_commands)
+    def test_ios_l2_interface_with_voice_vlan(self):
+        set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access',
+                         'name': 'GigabitEthernet0/5'})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+            'interface GigabitEthernet0/5',
+            'switchport mode access',
+            'switchport access vlan 10',
+            'switchport voice vlan 20',
+        ]
+        self.assertEqual(result['commands'], expected_commands)
 
-def test_ios_l2_interface_default_interface(self):
-    set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
-    result = self.execute_module(changed=True)
-    expected_commands = [
-	    'interface GigabitEthernet0/5',
-	    'switchport mode access',
-	    'switchport access vlan 1',
-	    'no switchport voice vlan',
-	    'switchport trunk native vlan 1',
-	    'switchport trunk allowed vlan all',
-    ]
-    self.assertEqual(result['commands'], expected_commands)
+    def test_ios_l2_interface_default_interface(self):
+        set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+            'interface GigabitEthernet0/5',
+            'switchport mode access',
+            'switchport access vlan 1',
+            'no switchport voice vlan',
+            'switchport trunk native vlan 1',
+            'switchport trunk allowed vlan all',
+        ]
+        self.assertEqual(result['commands'], expected_commands)

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -28,46 +28,46 @@ from .ios_module import TestIosModule, load_fixture
 
 class TestIosUserModule(TestIosModule):
 
-    module = ios_l2_interface
+	module = ios_l2_interface
 
-    def setUp(self):
-        super(TestIosUserModule, self).setUp()
+	def setUp(self):
+		super(TestIosUserModule, self).setUp()
 
-        self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
-        self.get_config = self.mock_get_config.start()
+		self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
+		self.get_config = self.mock_get_config.start()
 
-        self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
-        self.load_config = self.mock_load_config.start()
+		self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
+		self.load_config = self.mock_load_config.start()
 
-    def tearDown(self):
-        super(TestIosUserModule, self).tearDown()
-        self.mock_get_config.stop()
-        self.mock_load_config.stop()
+	def tearDown(self):
+		super(TestIosUserModule, self).tearDown()
+		self.mock_get_config.stop()
+		self.mock_load_config.stop()
 
-    def load_fixtures(self, commands=None, transport='cli'):
-        self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
-        self.load_config.return_value = dict(diff=None, session='session')
+	def load_fixtures(self, commands=None, transport='cli'):
+		self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
+		self.load_config.return_value = dict(diff=None, session='session')
 
-    def test_ios_l2_interface_with_voice_vlan(self):
-        set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access', 'name': 'GigabitEthernet0/5'})
-        result = self.execute_module(changed=True)
-        expected_commands = [
-            'interface GigabitEthernet0/5',
-            'switchport mode access',
-            'switchport access vlan 10',
-            'switchport voice vlan 20',
-        ]
-        self.assertEqual(result['commands'], expected_commands)
+	def test_ios_l2_interface_with_voice_vlan(self):
+		set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access', 'name': 'GigabitEthernet0/5'})
+		result = self.execute_module(changed=True)
+		expected_commands = [
+			'interface GigabitEthernet0/5',
+			'switchport mode access',
+			'switchport access vlan 10',
+			'switchport voice vlan 20',
+		]
+		self.assertEqual(result['commands'], expected_commands)
 
-    def test_ios_l2_interface_default_interface(self):
-        set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
-        result = self.execute_module(changed=True)
-        expected_commands = [
-             'interface GigabitEthernet0/5',
-             'switchport mode access',
-             'switchport access vlan 1',
-             'no switchport voice vlan',
-             'switchport trunk native vlan 1',
-             'switchport trunk allowed vlan all',
-        ]
-        self.assertEqual(result['commands'], expected_commands)
+	def test_ios_l2_interface_default_interface(self):
+		set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
+		result = self.execute_module(changed=True)
+		expected_commands = [
+			'interface GigabitEthernet0/5',
+			'switchport mode access',
+			'switchport access vlan 1',
+			'no switchport voice vlan',
+			'switchport trunk native vlan 1',
+			'switchport trunk allowed vlan all',
+		]
+		self.assertEqual(result['commands'], expected_commands)

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -28,47 +28,47 @@ from .ios_module import TestIosModule, load_fixture
 
 
 class TestIosUserModule(TestIosModule):
-    module = ios_l2_interface
+module = ios_l2_interface
 
-    def setUp(self):
-        super(TestIosUserModule, self).setUp()
+def setUp(self):
+    super(TestIosUserModule, self).setUp()
 
-	self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
-	self.get_config = self.mock_get_config.start()
+    self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
+    self.get_config = self.mock_get_config.start()
 
-	self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
-	self.load_config = self.mock_load_config.start()
+    self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
+    self.load_config = self.mock_load_config.start()
 
-    def tearDown(self):
-	super(TestIosUserModule, self).tearDown()
-	self.mock_get_config.stop()
-	self.mock_load_config.stop()
+def tearDown(self):
+    super(TestIosUserModule, self).tearDown()
+    self.mock_get_config.stop()
+    self.mock_load_config.stop()
 
-    def load_fixtures(self, commands=None, transport='cli'):
-	self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
-	self.load_config.return_value = dict(diff=None, session='session')
+def load_fixtures(self, commands=None, transport='cli'):
+    self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
+    self.load_config.return_value = dict(diff=None, session='session')
 
-    def test_ios_l2_interface_with_voice_vlan(self):
-	set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access',
-			 'name': 'GigabitEthernet0/5'})
-	result = self.execute_module(changed=True)
-	expected_commands = [
-		'interface GigabitEthernet0/5',
-		'switchport mode access',
-		'switchport access vlan 10',
-		'switchport voice vlan 20',
-	]
-	self.assertEqual(result['commands'], expected_commands)
+def test_ios_l2_interface_with_voice_vlan(self):
+    set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access',
+		     'name': 'GigabitEthernet0/5'})
+    result = self.execute_module(changed=True)
+    expected_commands = [
+	    'interface GigabitEthernet0/5',
+	    'switchport mode access',
+	    'switchport access vlan 10',
+	    'switchport voice vlan 20',
+    ]
+    self.assertEqual(result['commands'], expected_commands)
 
-    def test_ios_l2_interface_default_interface(self):
-	set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
-	result = self.execute_module(changed=True)
-	expected_commands = [
-		'interface GigabitEthernet0/5',
-		'switchport mode access',
-		'switchport access vlan 1',
-		'no switchport voice vlan',
-		'switchport trunk native vlan 1',
-		'switchport trunk allowed vlan all',
-	]
-	self.assertEqual(result['commands'], expected_commands)
+def test_ios_l2_interface_default_interface(self):
+    set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
+    result = self.execute_module(changed=True)
+    expected_commands = [
+	    'interface GigabitEthernet0/5',
+	    'switchport mode access',
+	    'switchport access vlan 1',
+	    'no switchport voice vlan',
+	    'switchport trunk native vlan 1',
+	    'switchport trunk allowed vlan all',
+    ]
+    self.assertEqual(result['commands'], expected_commands)

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -17,6 +17,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 import json
@@ -27,47 +28,47 @@ from .ios_module import TestIosModule, load_fixture
 
 
 class TestIosUserModule(TestIosModule):
+    module = ios_l2_interface
 
-	module = ios_l2_interface
+    def setUp(self):
+        super(TestIosUserModule, self).setUp()
 
-	def setUp(self):
-		super(TestIosUserModule, self).setUp()
+	self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
+	self.get_config = self.mock_get_config.start()
 
-		self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
-		self.get_config = self.mock_get_config.start()
+	self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
+	self.load_config = self.mock_load_config.start()
 
-		self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
-		self.load_config = self.mock_load_config.start()
+    def tearDown(self):
+	super(TestIosUserModule, self).tearDown()
+	self.mock_get_config.stop()
+	self.mock_load_config.stop()
 
-	def tearDown(self):
-		super(TestIosUserModule, self).tearDown()
-		self.mock_get_config.stop()
-		self.mock_load_config.stop()
+    def load_fixtures(self, commands=None, transport='cli'):
+	self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
+	self.load_config.return_value = dict(diff=None, session='session')
 
-	def load_fixtures(self, commands=None, transport='cli'):
-		self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
-		self.load_config.return_value = dict(diff=None, session='session')
+    def test_ios_l2_interface_with_voice_vlan(self):
+	set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access',
+			 'name': 'GigabitEthernet0/5'})
+	result = self.execute_module(changed=True)
+	expected_commands = [
+		'interface GigabitEthernet0/5',
+		'switchport mode access',
+		'switchport access vlan 10',
+		'switchport voice vlan 20',
+	]
+	self.assertEqual(result['commands'], expected_commands)
 
-	def test_ios_l2_interface_with_voice_vlan(self):
-		set_module_args({'state': 'present', 'voice_vlan': '20', 'access_vlan': '10', 'mode': 'voice-access', 'name': 'GigabitEthernet0/5'})
-		result = self.execute_module(changed=True)
-		expected_commands = [
-			'interface GigabitEthernet0/5',
-			'switchport mode access',
-			'switchport access vlan 10',
-			'switchport voice vlan 20',
-		]
-		self.assertEqual(result['commands'], expected_commands)
-
-	def test_ios_l2_interface_default_interface(self):
-		set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
-		result = self.execute_module(changed=True)
-		expected_commands = [
-			'interface GigabitEthernet0/5',
-			'switchport mode access',
-			'switchport access vlan 1',
-			'no switchport voice vlan',
-			'switchport trunk native vlan 1',
-			'switchport trunk allowed vlan all',
-		]
-		self.assertEqual(result['commands'], expected_commands)
+    def test_ios_l2_interface_default_interface(self):
+	set_module_args({'state': 'unconfigured', 'name': 'GigabitEthernet0/5'})
+	result = self.execute_module(changed=True)
+	expected_commands = [
+		'interface GigabitEthernet0/5',
+		'switchport mode access',
+		'switchport access vlan 1',
+		'no switchport voice vlan',
+		'switchport trunk native vlan 1',
+		'switchport trunk allowed vlan all',
+	]
+	self.assertEqual(result['commands'], expected_commands)

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -27,11 +27,11 @@ from units.modules.utils import set_module_args
 from .ios_module import TestIosModule, load_fixture
 
 
-class TestIosUserModule(TestIosModule):
+class TestIosL2Module(TestIosModule):
     module = ios_l2_interface
 
     def setUp(self):
-        super(TestIosUserModule, self).setUp()
+        super(TestIosL2Module, self).setUp()
         self.mock_run_commands = patch('ansible.modules.network.ios.ios_l2_interface.run_commands')
         self.run_commands = self.mock_run_commands.start()
         self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -32,10 +32,8 @@ class TestIosUserModule(TestIosModule):
 
     def setUp(self):
         super(TestIosUserModule, self).setUp()
-        
         self.mock_run_commands = patch('ansible.modules.network.ios.ios_l2_interface.run_commands')
         self.run_commands = self.mock_run_commands.start()
-        
         self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
         self.get_config = self.mock_get_config.start()
 

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -45,7 +45,7 @@ class TestIosL2Module(TestIosModule):
         self.mock_run_commands.stop()
 
     def load_fixtures(self, commands=None, transport='cli'):
-        self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')
+        self.run_commands.return_value = load_fixture('ios_l2_interface_config.cfg')
         self.load_config.return_value = dict(diff=None, session='session')
 
     def test_ios_l2_interface_with_voice_vlan(self):

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -33,8 +33,8 @@ class TestIosUserModule(TestIosModule):
     def setUp(self):
         super(TestIosUserModule, self).setUp()
         
-        self.mock_get_connection = patch('ansible.module_utils.network.ios.ios.get_connection')
-        self.get_connection = self.mock_get_connection.start()
+        self.mock_run_commands = patch('ansible.modules.network.ios.ios_l2_interface.run_commands')
+        self.run_commands = self.mock_run_commands.start()
         
         self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
         self.get_config = self.mock_get_config.start()

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -32,7 +32,10 @@ class TestIosUserModule(TestIosModule):
 
     def setUp(self):
         super(TestIosUserModule, self).setUp()
-
+        
+        self.mock_get_connection = patch('ansible.module_utils.network.ios.ios.get_connection')
+        self.get_connection = self.mock_get_connection.start()
+        
         self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
         self.get_config = self.mock_get_config.start()
 

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -32,18 +32,17 @@ class TestIosL2Module(TestIosModule):
 
     def setUp(self):
         super(TestIosL2Module, self).setUp()
+
         self.mock_run_commands = patch('ansible.modules.network.ios.ios_l2_interface.run_commands')
         self.run_commands = self.mock_run_commands.start()
-        self.mock_get_config = patch('ansible.modules.network.ios.ios_l2_interface.get_config')
-        self.get_config = self.mock_get_config.start()
 
         self.mock_load_config = patch('ansible.modules.network.ios.ios_l2_interface.load_config')
         self.load_config = self.mock_load_config.start()
 
     def tearDown(self):
         super(TestIosL2Module, self).tearDown()
-        self.mock_get_config.stop()
         self.mock_load_config.stop()
+        self.mock_run_commands.stop()
 
     def load_fixtures(self, commands=None, transport='cli'):
         self.get_config.return_value = load_fixture('ios_l2_interface_config.cfg')

--- a/test/units/modules/network/ios/test_ios_l2_interface.py
+++ b/test/units/modules/network/ios/test_ios_l2_interface.py
@@ -41,7 +41,7 @@ class TestIosL2Module(TestIosModule):
         self.load_config = self.mock_load_config.start()
 
     def tearDown(self):
-        super(TestIosUserModule, self).tearDown()
+        super(TestIosL2Module, self).tearDown()
         self.mock_get_config.stop()
         self.mock_load_config.stop()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add an option to the ios_l2_interface module to include a voice vlan on an interface
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #38873
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l2_interface
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:
interface GigabitEthernet1/0/14
 description DATA PORTS
 switchport access vlan 10
 switchport mode access

After:
interface GigabitEthernet1/0/14
 description DATA PORTS
 switchport access vlan 10
 switchport mode access
 switchport voice vlan 20
```
