### PR TITLE
win_certificate_store - Fix exception handling typo

### DIFF
--- a/changelogs/fragments/win_certificate_store-excp.yaml
+++ b/changelogs/fragments/win_certificate_store-excp.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_certificate_store - Fix exception handling typo

--- a/lib/ansible/modules/windows/win_certificate_store.ps1
+++ b/lib/ansible/modules/windows/win_certificate_store.ps1
@@ -109,7 +109,7 @@ Function New-CertFile($module, $cert, $path, $type, $password) {
             $module.FailJson("Failed to write cert to file, cert was null: $($_.Exception.Message)", $_)
         } catch [System.IO.IOException] {
             $module.FailJson("Failed to write cert to file due to IO Exception: $($_.Exception.Message)", $_)
-        } catch [System.UnauthorizedAccessException, System>Security.SecurityException] {
+        } catch [System.UnauthorizedAccessException, System.Security.SecurityException] {
             $module.FailJson("Failed to write cert to file due to permissions: $($_.Exception.Message)", $_)
         } catch {
             $module.FailJson("Failed to write cert to file: $($_.Exception.Message)", $_)


### PR DESCRIPTION
##### SUMMARY
A small typo stopped SecurityExceptions from being caught with a proper error message. This just fixes the typo so one of these exceptions will present to the user with a related error message.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_certificate_store