### PR TITLE
win_certificate_store - Fix exception handling typo (#52906) - 2.7

### DIFF
--- a/changelogs/fragments/win_certificate_store-excp.yaml
+++ b/changelogs/fragments/win_certificate_store-excp.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_certificate_store - Fix exception handling typo

--- a/lib/ansible/modules/windows/win_certificate_store.ps1
+++ b/lib/ansible/modules/windows/win_certificate_store.ps1
@@ -108,7 +108,7 @@ Function New-CertFile($cert, $path, $type, $password) {
             Fail-Json -obj $result -message "Failed to write cert to file, cert was null: $($_.Exception.Message)"
         } catch [System.IO.IOException] {
             Fail-Json -obj $result -message "Failed to write cert to file due to IO exception: $($_.Exception.Message)"
-        } catch [System.UnauthorizedAccessException, System>Security.SecurityException] {
+        } catch [System.UnauthorizedAccessException, System.Security.SecurityException] {
             Fail-Json -obj $result -message "Failed to write cert to file due to permission: $($_.Exception.Message)"
         } catch {
             Fail-Json -obj $result -message "Failed to write cert to file: $($_.Exception.Message)"


### PR DESCRIPTION
(cherry picked from commit 1126f76d4db3192051ea4da8d0b3bfbad2e6fca2)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/52906

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_certificate_store