### PR TITLE
Turn 'actionable' into a thin wrapper for 'default'

### DIFF
--- a/lib/ansible/plugins/callback/actionable.py
+++ b/lib/ansible/plugins/callback/actionable.py
@@ -22,9 +22,31 @@ DOCUMENTATION = '''
       - default_callback
     requirements:
       - set as stdout callback in configuration
+    # Override defaults from 'default' callback plugin
+    options:
+      display_skipped_hosts:
+        name: Show skipped hosts
+        description: "Toggle to control displaying skipped task/host results in a task"
+        type: bool
+        default: no
+        env:
+          - name: DISPLAY_SKIPPED_HOSTS
+        ini:
+          - key: display_skipped_hosts
+            section: defaults
+      display_ok_hosts:
+        name: Show 'ok' hosts
+        description: "Toggle to control displaying 'ok' task/host results in a task"
+        type: bool
+        default: no
+        env:
+          - name: ANSIBLE_DISPLAY_OK_HOSTS
+        ini:
+          - key: display_ok_hosts
+            section: defaults
+        version_added: '2.7'
 '''
 
-from ansible import constants as C
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
 
@@ -33,82 +55,3 @@ class CallbackModule(CallbackModule_default):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'actionable'
-
-    def __init__(self):
-        self.super_ref = super(CallbackModule, self)
-        self.super_ref.__init__()
-        self.last_task = None
-        self.last_task_banner = None
-        self.shown_title = False
-
-    def v2_playbook_on_handler_task_start(self, task):
-        self.super_ref.v2_playbook_on_handler_task_start(task)
-        self.shown_title = True
-
-    def v2_playbook_on_task_start(self, task, is_conditional):
-        self.last_task = task
-        self.last_task_banner = self._get_task_banner(task)
-        self.shown_title = False
-
-    def display_task_banner(self):
-        if not self.shown_title:
-            self.super_ref.v2_playbook_on_task_start(self.last_task, None)
-            self.shown_title = True
-
-    def _print_task_banner(self, task):
-        self._display.banner(self.last_task_banner)
-        self._print_task_path(self.last_task)
-        self._last_task_banner = self.last_task._uuid
-
-    def _print_task_path(self, task):
-        if self._display.verbosity >= 2:
-            path = task.get_path()
-            if path:
-                self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
-
-    def _get_task_banner(self, task):
-        # args can be specified as no_log in several places: in the task or in
-        # the argument spec.  We can check whether the task is no_log but the
-        # argument spec can't be because that is only run on the target
-        # machine and we haven't run it thereyet at this time.
-        #
-        # So we give people a config option to affect display of the args so
-        # that they can secure this if they feel that their stdout is insecure
-        # (shoulder surfing, logging stdout straight to a file, etc).
-        args = ''
-        if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
-            args = u', '.join(u'%s=%s' % a for a in task.args.items())
-            args = u' %s' % args
-
-        return u"TASK [%s%s]" % (task.get_name().strip(), args)
-
-    def v2_runner_on_failed(self, result, ignore_errors=False):
-        self.display_task_banner()
-        self.super_ref.v2_runner_on_failed(result, ignore_errors)
-
-    def v2_runner_on_ok(self, result):
-        if result._result.get('changed', False):
-            self.display_task_banner()
-            self.super_ref.v2_runner_on_ok(result)
-
-    def v2_runner_on_unreachable(self, result):
-        self.display_task_banner()
-        self.super_ref.v2_runner_on_unreachable(result)
-
-    def v2_runner_on_skipped(self, result):
-        pass
-
-    def v2_playbook_on_include(self, included_file):
-        pass
-
-    def v2_runner_item_on_ok(self, result):
-        if result._result.get('changed', False):
-            self.display_task_banner()
-            self.super_ref.v2_runner_item_on_ok(result)
-
-    def v2_runner_item_on_skipped(self, result):
-        pass
-
-    def v2_runner_item_on_failed(self, result):
-        self.display_task_banner()
-        self.super_ref.v2_runner_item_on_failed(result)


### PR DESCRIPTION
##### SUMMARY
The `default` action plugin now implements this functionality, so the `actionable` plugin doesn't need any of its own logic (which was interacting poorly with the new `default` plugin logic to do the same things).

This fixes #51533 and #47353

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
actionable callback plugin

##### ADDITIONAL INFORMATION
N/A
