### PR TITLE
Unixy - Don't display plays if no tasks will run or if no hosts are matched

### DIFF
--- a/changelogs/fragments/52909-unixy_dont_display_empty_plays.yaml
+++ b/changelogs/fragments/52909-unixy_dont_display_empty_plays.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - In the unixy callback plugin, do not display plays that do not match the host limit or that will not execute any tasks

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -100,7 +100,7 @@ class CallbackModule(CallbackBase):
             self._display.display("%s (via handler)... " % self.task_display_name)
 
     def v2_playbook_on_play_start(self, play):
-        if play.get_tasks():
+        if play.get_tasks() and len(play.get_tasks()) > 1:
             name = play.get_name().strip()
             if name and play.hosts:
                 msg = u"\n- %s on hosts: %s -" % (name, ",".join(play.hosts))

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -100,13 +100,15 @@ class CallbackModule(CallbackBase):
             self._display.display("%s (via handler)... " % self.task_display_name)
 
     def v2_playbook_on_play_start(self, play):
-        name = play.get_name().strip()
-        if name and play.hosts:
-            msg = u"\n- %s on hosts: %s -" % (name, ",".join(play.hosts))
+        if play.get_tasks():
+            name = play.get_name().strip()
+            if name and play.hosts:
+                msg = u"\n- %s on hosts: %s -" % (name, ",".join(play.hosts))
+            else:
+                msg = u"---"
+            self._display.display(msg)
         else:
-            msg = u"---"
-
-        self._display.display(msg)
+            pass
 
     def v2_runner_on_skipped(self, result, ignore_errors=False):
         self._preprocess_result(result)
@@ -192,9 +194,6 @@ class CallbackModule(CallbackBase):
                 colorize(u'ignored', t['ignored'], None)),
                 log_only=True
             )
-
-    def v2_playbook_on_no_hosts_matched(self):
-        self._display.display("  No hosts found!", color=C.COLOR_DEBUG)
 
     def v2_playbook_on_no_hosts_remaining(self):
         self._display.display("  Ran out of hosts!", color=C.COLOR_ERROR)


### PR DESCRIPTION
##### SUMMARY
This PR will update `unixy.py` to not display output from plays with no matching hosts or tasks.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
unixy.py

##### ADDITIONAL INFORMATION
Output from empty plays does not spark joy :sparkles: 

```
$ ansible-playbook test.yml -i qa -l lime

# Before
Executing playbook test.yml

- lime -
Gathering Facts...
  lime ok
debug...
  lime ok: {
    "changed": false,
    "msg": "hello world"
} | msg: hello world

- lime -

- purple -
  No hosts found!

- purple -
  No hosts found!

- Play recap -
  lime             : ok=2    changed=0    unreachable=0    failed=0

# After
Executing playbook test.yml
Gathering Facts...
  lime ok
debug...
  lime ok: {
    "changed": false,
    "msg": "hello world"
}

- Play recap -
  lime             : ok=2    changed=0    unreachable=0    failed=0
```
