### PR TITLE
[2.7] cloudscale: fix compatibilty with older py3 versions (#52822)

### DIFF
--- a/changelogs/fragments/52822-cloudscale_fix-py3.yaml
+++ b/changelogs/fragments/52822-cloudscale_fix-py3.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- cloudscale - Fix compatibilty with Python3 in version 3.5 and lower.

--- a/lib/ansible/module_utils/cloudscale.py
+++ b/lib/ansible/module_utils/cloudscale.py
@@ -6,10 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import json
-
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_text
 
 API_URL = 'https://api.cloudscale.ch/v1/'
 
@@ -35,7 +34,7 @@ class AnsibleCloudscaleBase(object):
                                timeout=self._module.params['api_timeout'])
 
         if info['status'] == 200:
-            return json.loads(resp.read())
+            return self._module.from_json(to_text(resp.read()))
         elif info['status'] == 404:
             return None
         else:
@@ -56,7 +55,7 @@ class AnsibleCloudscaleBase(object):
                                timeout=self._module.params['api_timeout'])
 
         if info['status'] in (200, 201):
-            return json.loads(resp.read())
+            return self._module.from_json(to_text(resp.read()))
         elif info['status'] == 204:
             return None
         else:

--- a/lib/ansible/module_utils/cloudscale.py
+++ b/lib/ansible/module_utils/cloudscale.py
@@ -34,7 +34,7 @@ class AnsibleCloudscaleBase(object):
                                timeout=self._module.params['api_timeout'])
 
         if info['status'] == 200:
-            return self._module.from_json(to_text(resp.read()))
+            return self._module.from_json(to_text(resp.read(), errors='surrogate_or_strict'))
         elif info['status'] == 404:
             return None
         else:
@@ -55,7 +55,7 @@ class AnsibleCloudscaleBase(object):
                                timeout=self._module.params['api_timeout'])
 
         if info['status'] in (200, 201):
-            return self._module.from_json(to_text(resp.read()))
+            return self._module.from_json(to_text(resp.read(), errors='surrogate_or_strict'))
         elif info['status'] == 204:
             return None
         else:


### PR DESCRIPTION
##### SUMMARY
backport of #52822 

* cloudscale: fix compatibilty with older py3 versions
* add doc fragment
(cherry picked from commit ee416fd01d2182747c70083996e0f546eb94ae7f)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudscale

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
