### PR TITLE
Make vars plugin configurable

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -104,9 +104,9 @@ DEFAULT_REMOTE_PASS = None
 DEFAULT_SUBSET = None
 DEFAULT_SU_PASS = None
 # FIXME: expand to other plugins, but never doc fragments
-CONFIGURABLE_PLUGINS = ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'shell')
+CONFIGURABLE_PLUGINS = ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'shell', 'vars')
 # NOTE: always update the docs/docsite/Makefile to match
-DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module', 'strategy', 'vars')
+DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module', 'strategy')
 IGNORE_FILES = ("COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION", "GUIDELINES")  # ignore during module search
 INTERNAL_RESULT_KEYS = ('add_host', 'add_group')
 LOCALHOST = ('127.0.0.1', 'localhost', '::1')

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -18,13 +18,14 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.plugins import AnsiblePlugin
 from ansible.utils.path import basedir
 from ansible.utils.display import Display
 
 display = Display()
 
 
-class BaseVarsPlugin(object):
+class BaseVarsPlugin(AnsiblePlugin):
 
     """
     Loads variables for groups and/or hosts
@@ -32,7 +33,13 @@ class BaseVarsPlugin(object):
 
     def __init__(self):
         """ constructor """
-        self._display = display
+        super(BaseVarsPlugin, self).__init__()
+        self.display = display
+
+    @property
+    def _display(self):
+        self.display.deprecated('Instead of self._display, use self.display', '2.9')
+        return self.display
 
     def get_vars(self, loader, path, entities):
         """ Gets variables. """

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -86,11 +86,11 @@ class VarsModule(BaseVarsPlugin):
                         # no need to do much if path does not exist for basedir
                         if os.path.exists(b_opath):
                             if os.path.isdir(b_opath):
-                                self._display.debug("\tprocessing dir %s" % opath)
+                                self.display.debug("\tprocessing dir %s" % opath)
                                 found_files = loader.find_vars_files(opath, entity.name)
                                 FOUND[key] = found_files
                             else:
-                                self._display.warning("Found %s that is not a directory, skipping: %s" % (subdir, opath))
+                                self.display.warning("Found %s that is not a directory, skipping: %s" % (subdir, opath))
 
                     for found in found_files:
                         new_data = loader.load_from_file(found, cache=True, unsafe=True)


### PR DESCRIPTION
##### SUMMARY
This change adds vars plugins to the `CONFIGURABLE_PLUGINS` so it's users can benefit from the documented settings interface and so that it matches the documentation. 

The [developing plugins](https://docs.ansible.com/ansible/devel/dev_guide/developing_plugins.html#vars-plugins) documentation points to the [host_group_vars](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/vars/host_group_vars.py) as an example. The host_group_vars plugin appears to use the same documentation as settings interface as other plugins but it does not. The documented plugin setting is never loaded and only functions because it is also defined as the global setting [YAML_FILENAME_EXTENSIONS](https://github.com/ansible/ansible/blob/devel/lib/ansible/config/base.yml#L1686).

Note: It also renames the internal display attribute from `self._display` to `self.display` to match that of the more widely used inventory plugin. There is no reason to hide the attribute or discourage it's use by developers of vars plugins and is there as a convenience. This attribute was introduced in the unreleased 2.8 version but I've added a backwards compatible property with a deprecating warning regardless.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
vars plugin settings and interface.

