### PR TITLE
Fix redfish_facts Storage command GetStorageControllerInventory - SimpleStorage not found

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -280,7 +280,10 @@ class RedfishUtils(object):
         controller_list = []
         controller_results = []
         # Get these entries, but does not fail if not found
-        properties = ['Name', 'Status']
+        properties = ['CacheSummary', 'FirmwareVersion', 'Identifiers',
+                      'Location', 'Manufacturer', 'Model', 'Name',
+                      'PartNumber', 'SerialNumber', 'SpeedGbps', 'Status']
+        key = "StorageControllers"
 
         # Find Storage service
         response = self.get_request(self.root_uri + self.systems_uri)
@@ -288,41 +291,45 @@ class RedfishUtils(object):
             return response
         data = response['data']
 
-        if 'SimpleStorage' not in data:
-            return {'ret': False, 'msg': "SimpleStorage resource not found"}
+        if 'Storage' not in data:
+            return {'ret': False, 'msg': "Storage resource not found"}
 
         # Get a list of all storage controllers and build respective URIs
-        storage_uri = data["SimpleStorage"]["@odata.id"]
+        storage_uri = data['Storage']["@odata.id"]
         response = self.get_request(self.root_uri + storage_uri)
         if response['ret'] is False:
             return response
         result['ret'] = True
         data = response['data']
 
-        for controller in data[u'Members']:
-            controller_list.append(controller[u'@odata.id'])
+        # Loop through Members and their StorageControllers
+        # and gather properties from each StorageController
+        if data[u'Members']:
+            for storage_member in data[u'Members']:
+                storage_member_uri = storage_member[u'@odata.id']
+                response = self.get_request(self.root_uri + storage_member_uri)
+                data = response['data']
 
-        for c in controller_list:
-            controller = {}
-            uri = self.root_uri + c
-            response = self.get_request(uri)
-            if response['ret'] is False:
-                return response
-            data = response['data']
-
-            for property in properties:
-                if property in data:
-                    controller[property] = data[property]
-            controller_results.append(controller)
-        result["entries"] = controller_results
-        return result
+                if key in data:
+                    controller_list = data[key]
+                    for controller in controller_list:
+                        controller_result = {}
+                        for property in properties:
+                            if property in controller:
+                                controller_result[property] = controller[property]
+                        controller_results.append(controller_result)
+                result['entries'] = controller_results
+            return result
+        else:
+            return {'ret': False, 'msg': "Storage resource not found"}
 
     def get_disk_inventory(self):
         result = {}
         controller_list = []
         disk_results = []
         # Get these entries, but does not fail if not found
-        properties = ['Name', 'Manufacturer', 'Model', 'Status', 'CapacityBytes']
+        properties = ['Name', 'Manufacturer', 'Model', 'Status',
+                      'CapacityBytes']
 
         # Find Storage service
         response = self.get_request(self.root_uri + self.systems_uri)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request allows the redfish_facts Systems command GetStorageControllerInventory to work as intended, replacing its references to the deprecated `SimpleStorage` resource, and instead searching through the `Storage` resource to find storage controller details.

The code now loops through each `Storage` resource's `Members` list, and loops through each `Member`'s `StorageControllers` list, returning each `StorageController` and its properties as list elements of `entries` in the module output.

If the Storage resource is not found, a `ret: False` is returned along with a message stating as much.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes half of #51286 , the other half is fixed by #52939 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils
redfish_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.243.5.31
    user: USERID
    password: PASSW0RD

  tasks:
    - name: Get Storage Controller inventory
      redfish_facts:
        category: Systems
        command: GetStorageControllerInventory
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"
```

Before:
```
ansible-playbook 2.8.0.dev0
  config file = None  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible  executable location = bin/ansible-playbook  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory pluginshost_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() methodSkipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() methodauto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.yml ********************************************************************************************************************Positional arguments: ../test_redfish_facts.yml
become_user: root
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
tags: (u'all',)
forks: 5
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.yml

PLAY [Test Redfish modules] *************************************************************************************************************************META: ran handlers

TASK [redfish_facts] ********************************************************************************************************************************task path: /mnt/c/Users/amadsen/Coding/redfish/test_redfish_facts.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256 `" && echo ansible-tmp-1548344056.08-90755211161256="` echo /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-725hvzXdP/tmpVOEPBn TO /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/ /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => (item=GetStorageControllerInventory) => {
    "ansible_facts": {
        "redfish_facts": {
            "storage_controller": {
                "msg": "SimpleStorage resource not found",
                "ret": false
            }
        }
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "baseuri": "10.240.50.78",
            "category": [
                "Systems"
            ],
            "command": [
                "GetStorageControllerInventory"
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "username": "USERID"
        }
    },
    "item": "GetStorageControllerInventory"
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```

After:
```
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible
  executable location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.1.yml **************************************************************************************************************************************************************************************************Positional arguments: ../test_redfish_facts.1.yml
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
forks: 5
tags: (u'all',)
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.1.yml

PLAY [Test Redfish modules] *********************************************************************************************************************************************************************************************************META: ran handlers

TASK [Get Storage Controller inventory] *********************************************************************************************************************************************************************************************task path: /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_facts.1.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1551109455.82-239082994177190 `" && echo ansible-tmp-1551109455.82-239082994177190="` echo /home/xander/.ansible/tmp/ansible-tmp-1551109455.82-239082994177190 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-9175oUCSb/tmpnOpTnm TO /home/xander/.ansible/tmp/ansible-tmp-1551109455.82-239082994177190/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1551109455.82-239082994177190/ /home/xander/.ansible/tmp/ansible-tmp-1551109455.82-239082994177190/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1551109455.82-239082994177190/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1551109455.82-239082994177190/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "storage_controller": {
                "entries": [
                    {
                        "CacheSummary": {
                            "Status": {
                                "State": "Disabled"
                            }, 
                            "TotalCacheSizeMiB": 0
                        }, 
                        "FirmwareVersion": "3.125.11.0", 
                        "Identifiers": [
                            {
                                "DurableName": "97CFBEFAC1C5418586AE130E6CBC5131", 
                                "DurableNameFormat": "UUID"
                            }
                        ], 
                        "Location": {
                            "Info": "Slot 7", 
                            "InfoFormat": "Slot X"
                        }, 
                        "Model": "SAS3408", 
                        "Name": "ThinkSystem 430-8i SAS/SATA 12Gb HBA", 
                        "PartNumber": "SR17A04509", 
                        "SerialNumber": "L2ST76KS481"
                    }, 
                    {
                        "CacheSummary": {
                            "Status": {
                                "State": "Disabled"
                            }, 
                            "TotalCacheSizeMiB": 0
                        }, 
                        "FirmwareVersion": "2.3.10.1085", 
                        "Identifiers": [
                            {
                                "DurableName": "241F1DFA677611E78AE9F4DA8AA0D0DB", 
                                "DurableNameFormat": "UUID"
                            }
                        ], 
                        "Location": {
                            "Info": "Slot 8", 
                            "InfoFormat": "Slot X"
                        }, 
                        "Model": "88SE9230", 
                        "Name": "ThinkSystem M.2 with Mirroring Enablement Kit", 
                        "PartNumber": "SR17A04514", 
                        "SerialNumber": "W1ZS77B00SB"
                    }
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31", 
            "category": [
                "Systems"
            ], 
            "command": [
                "GetStorageControllerInventory"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP **************************************************************************************************************************************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```
