### PR TITLE
VMware: add support for HTTP proxy in connection API

### DIFF
--- a/changelogs/fragments/52936-vmware-proxy-support.yaml
+++ b/changelogs/fragments/52936-vmware-proxy-support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware - The VMware modules can now access a server behind a HTTP proxy (https://github.com/ansible/ansible/pull/52936)

--- a/lib/ansible/plugins/doc_fragments/vmware.py
+++ b/lib/ansible/plugins/doc_fragments/vmware.py
@@ -46,6 +46,22 @@ options:
       type: int
       default: 443
       version_added: '2.5'
+    proxy_host:
+      description:
+      - Address of a proxy that will receive all HTTPS requests and relay them.
+      - The format is a hostname or a IP.
+      - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_HOST) will be used instead.
+      - This feature depends on a version of pyvmomi greater than v6.7.1.2018.12
+      type: str
+      version_added: '2.9'
+      required: False
+    proxy_port:
+      description:
+      - Port of the HTTP proxy that will receive all HTTPS requests and relay them.
+      - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_PORT) will be used instead.
+      type: int
+      version_added: '2.9'
+      required: False
 '''
 
     # This doc fragment is specific to vcenter modules like vcenter_license
@@ -87,4 +103,19 @@ options:
       type: int
       default: 443
       version_added: '2.5'
+    proxy_host:
+      description:
+      - Address of a proxy that will receive all HTTPS requests and relay them.
+      - The format is a hostname or a IP.
+      - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_HOST) will be used instead.
+      type: str
+      version_added: '2.9'
+      required: False
+    proxy_port:
+      description:
+      - Port of the HTTP proxy that will receive all HTTPS requests and relay them.
+      - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_PORT) will be used instead.
+      type: int
+      version_added: '2.9'
+      required: False
     '''

--- a/test/units/module_utils/test_vmware.py
+++ b/test/units/module_utils/test_vmware.py
@@ -54,6 +54,25 @@ test_data = [
         ),
         "Unknown error while connecting to vCenter or ESXi API at esxi1:443"
     ),
+    (
+        dict(
+            username='Administrator@vsphere.local',
+            password='Esxi@123$%',
+            hostname='esxi1',
+            proxy_host='myproxyserver.com',
+            proxy_port=80,
+            validate_certs=False,
+        ),
+        " [proxy: myproxyserver.com:80]"
+    ),
+]
+
+test_ids = [
+    'hostname',
+    'username',
+    'password',
+    'validate_certs',
+    'valid_http_proxy',
 ]
 
 
@@ -115,7 +134,7 @@ def test_requests_lib_exists(mocker, fake_ansible_module):
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason="requires python2.7 and greater")
-@pytest.mark.parametrize("params, msg", test_data, ids=['hostname', 'username', 'password', 'validate_certs'])
+@pytest.mark.parametrize("params, msg", test_data, ids=test_ids)
 def test_required_params(request, params, msg, fake_ansible_module):
     """ Test if required params are correct or not"""
     fake_ansible_module.params = params


### PR DESCRIPTION
##### SUMMARY

This commit allows users to access a vCenter or a ESXi through a
HTTP CONNECT based proxy.

To do so, the users have to set the `proxy_host` and `proxy_port`
variables.

The can also use the `VMWARE_PROXY_HOST` and `VMWARE_PROXY_PORT`
environment variables.

This feature depends on pyvmomi > v6.7.1.2018.12.

Fixes: #42221

Co-Author: Abhijeet Kasurde <akasurde@redhat.com>
Co-Author: Gonéri Le Bouder <goneri@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py
lib/ansible/plugins/doc_fragments/vmware.py
test/units/module_utils/test_vmware.py

### Note

- Related issue: https://github.com/vmware/pyvmomi/pull/799