### PR TITLE
Fix get_disk_inventory() not using Storage resource and add more prop…

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -397,10 +397,10 @@ class RedfishUtils(object):
                 data = response['data']
 
                 for device in data[u'Devices']:
-                    disk_resuilt = {}
+                    disk_result = {}
                     for property in properties:
                         if property in device:
-                            disk_resuilt[property] = device[property]
+                            disk_result[property] = device[property]
                     disk_results.append(disk_result)
             result["entries"].append(disk_results)
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -370,7 +370,8 @@ class RedfishUtils(object):
                         disk_result = {}
                         for property in properties:
                             if property in data:
-                                disk_result[property] = data[property]
+                                if data[property] is not None:
+                                    disk_result[property] = data[property]
                         disk_results.append(disk_result)
             result["entries"] = disk_results
         return result


### PR DESCRIPTION
…erties to output

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request allows the redfish_facts Systems command GetDiskInventory to work as intended, replacing its references to the deprecated `SimpleStorage` resource, and instead searching through the `Storage` resource to find disk details.

The code now loops through each `Storage` resource's `Members` list, and loops through each `Member`'s `Drives` list, returning each `Drive` and its non-null properties as list elements of `entries` in the module output. 

If the Storage resource is not found, a `ret: False` is returned along with a message stating as much.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes half of #51286 , and #52928 fixes the other part

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.243.5.31
    user: USERID
    password: PASSW0RD

  tasks:
    - name: Get Disk inventory
      redfish_facts:
        category: Systems
        command: GetDiskInventory
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"

```

Before:
```
ansible-playbook 2.8.0.dev0
  config file = None  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible  executable location = bin/ansible-playbook  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory pluginshost_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() methodSkipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() methodauto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.yml ********************************************************************************************************************Positional arguments: ../test_redfish_facts.yml
become_user: root
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
tags: (u'all',)
forks: 5
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.yml

PLAY [Test Redfish modules] *************************************************************************************************************************META: ran handlers

TASK [redfish_facts] ********************************************************************************************************************************task path: /mnt/c/Users/amadsen/Coding/redfish/test_redfish_facts.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256 `" && echo ansible-tmp-1548344056.08-90755211161256="` echo /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/redfish/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-725hvzXdP/tmpVOEPBn TO /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/ /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1548344056.08-90755211161256/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => (item=GetStorageControllerInventory) =>   {
                "_ansible_ignore_errors": null,
                "_ansible_item_label": "GetDiskInventory",
                "_ansible_item_result": true,
                "_ansible_no_log": false,
                "_ansible_parsed": true,
                "ansible_facts": {
                    "redfish_facts": {
                        "disk": {
                            "msg": "SimpleStorage resource not found",
                            "ret": false
                        }
                    }
                },
                "changed": false,
                "failed": false,
                "invocation": {
                    "module_args": {
                        "baseuri": "10.243.5.31",
                        "category": [
                            "Systems"
                        ],
                        "command": [
                            "GetDiskInventory"
                        ],
                        "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                        "username": "USERID"
                    }
                },
                "item": "GetDiskInventory"
            }
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```

After:
```
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible
  executable location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.1.yml *******************************************************************************************************************************************************************Positional arguments: ../test_redfish_facts.1.yml
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
forks: 5
tags: (u'all',)
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.1.yml

PLAY [Test Redfish modules] **************************************************************************************************************************************************************************META: ran handlers

TASK [Get Disk inventory] ****************************************************************************************************************************************************************************task path: /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_facts.1.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1551116427.95-30596972313448 `" && echo ansible-tmp-1551116427.95-30596972313448="` echo /home/xander/.ansible/tmp/ansible-tmp-1551116427.95-30596972313448 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-1404EbL3i5/tmp60b1rH TO /home/xander/.ansible/tmp/ansible-tmp-1551116427.95-30596972313448/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1551116427.95-30596972313448/ /home/xander/.ansible/tmp/ansible-tmp-1551116427.95-30596972313448/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1551116427.95-30596972313448/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1551116427.95-30596972313448/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "disk": {
                "entries": [
                    {
                        "BlockSizeBytes": 512, 
                        "CapableSpeedGbs": 12, 
                        "CapacityBytes": 299999999488, 
                        "EncryptionAbility": "None", 
                        "EncryptionStatus": "Unencrypted", 
                        "FailurePredicted": false, 
                        "HotspareType": "None", 
                        "Id": "Disk.0", 
                        "Identifiers": [
                            {
                                "DurableName": "", 
                                "DurableNameFormat": "UUID"
                            }
                        ], 
                        "Manufacturer": "LENOVO", 
                        "MediaType": "HDD", 
                        "Model": "ST300MM0058", 
                        "Name": "300GB 10K 12Gbps SAS 2.5 HDD", 
                        "PartNumber": "D7A01868", 
                        "PhysicalLocation": {
                            "Info": "Slot 0", 
                            "InfoFormat": "Slot Number"
                        }, 
                        "Protocol": "SAS", 
                        "Revision": "F5A3", 
                        "RotationSpeedRPM": 10500, 
                        "SerialNumber": "W0K01AAH", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "BlockSizeBytes": 512, 
                        "CapableSpeedGbs": 12, 
                        "CapacityBytes": 299999999488, 
                        "EncryptionAbility": "None", 
                        "EncryptionStatus": "Unencrypted", 
                        "FailurePredicted": false, 
                        "HotspareType": "None", 
                        "Id": "Disk.2", 
                        "Identifiers": [
                            {
                                "DurableName": "", 
                                "DurableNameFormat": "UUID"
                            }
                        ], 
                        "Manufacturer": "LENOVO", 
                        "MediaType": "HDD", 
                        "Model": "AL14SEB030N", 
                        "Name": "300GB 10K 12Gbps SAS 2.5 HDD", 
                        "PartNumber": "SH20J34185", 
                        "PhysicalLocation": {
                            "Info": "Slot 2", 
                            "InfoFormat": "Slot Number"
                        }, 
                        "Protocol": "SAS", 
                        "Revision": "TB45", 
                        "RotationSpeedRPM": 10500, 
                        "SerialNumber": "SWN648H2", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "CapacityBytes": 119000000000, 
                        "FailurePredicted": false, 
                        "HotspareType": "None", 
                        "Id": "Drive.M.2_Bay0", 
                        "Identifiers": [
                            {
                                "DurableName": "0000000000000000", 
                                "DurableNameFormat": "UUID"
                            }
                        ], 
                        "Manufacturer": "LEN", 
                        "MediaType": "SSD", 
                        "Model": "LITEON CV3-8D128", 
                        "Name": "119GB M.2 SATA SSD", 
                        "PartNumber": "SSD0L20505", 
                        "PhysicalLocation": {
                            "Info": "M.2 Bay0", 
                            "InfoFormat": "BayId"
                        }, 
                        "Protocol": "SATA", 
                        "Revision": "A34", 
                        "RotationSpeedRPM": 0, 
                        "SerialNumber": "H78101ET", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "CapacityBytes": 119000000000, 
                        "FailurePredicted": false, 
                        "HotspareType": "None", 
                        "Id": "Drive.M.2_Bay1", 
                        "Identifiers": [
                            {
                                "DurableName": "0000000000000000", 
                                "DurableNameFormat": "UUID"
                            }
                        ], 
                        "Manufacturer": "LEN", 
                        "MediaType": "SSD", 
                        "Model": "LITEON CV3-8D128", 
                        "Name": "119GB M.2 SATA SSD", 
                        "PartNumber": "SSD0L20505", 
                        "PhysicalLocation": {
                            "Info": "M.2 Bay1", 
                            "InfoFormat": "BayId"
                        }, 
                        "Protocol": "SATA", 
                        "Revision": "A34", 
                        "RotationSpeedRPM": 0, 
                        "SerialNumber": "H78101EW", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31", 
            "category": [
                "Systems"
            ], 
            "command": [
                "GetDiskInventory"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP *******************************************************************************************************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```

