### PR TITLE
fix AWS plugin credential precedence for environment variables

### DIFF
--- a/changelogs/fragments/fix-aws-plugin-credential-precedence.yaml
+++ b/changelogs/fragments/fix-aws-plugin-credential-precedence.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - AWS plugins - before 2.8 the environment variable precedence was incorrectly reversed.

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -399,8 +399,14 @@ class ConfigManager(object):
         if config in defs:
 
             # direct setting via plugin arguments, can set to None so we bypass rest of processing/defaults
-            if direct and config in direct:
-                value = direct[config]
+            direct_aliases = []
+            if direct:
+                direct_aliases = [direct[alias] for alias in defs[config].get('aliases', []) if alias in direct]
+            if direct and (config in direct or direct_aliases):
+                if config in direct:
+                    value = direct[config]
+                else:
+                    value = direct_aliases[0]
                 origin = 'Direct'
 
             else:

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -402,11 +402,11 @@ class ConfigManager(object):
             direct_aliases = []
             if direct:
                 direct_aliases = [direct[alias] for alias in defs[config].get('aliases', []) if alias in direct]
-            if direct and (config in direct or direct_aliases):
-                if config in direct:
-                    value = direct[config]
-                else:
-                    value = direct_aliases[0]
+            if direct and config in direct:
+                value = direct[config]
+                origin = 'Direct'
+            elif direct and direct_aliases:
+                value = direct_aliases[0]
                 origin = 'Direct'
 
             else:

--- a/lib/ansible/plugins/doc_fragments/aws_credentials.py
+++ b/lib/ansible/plugins/doc_fragments/aws_credentials.py
@@ -6,8 +6,8 @@
 
 class ModuleDocFragment(object):
 
-    # inventory cache
-    DOCUMENTATION = r'''
+# Plugin options for AWS credentials
+DOCUMENTATION = r'''
 options:
   aws_profile:
     description: The AWS profile
@@ -19,6 +19,7 @@ options:
   aws_access_key:
     description: The AWS access key to use.
     type: str
+    aliases: [ aws_access_key_id ]
     env:
       - name: EC2_ACCESS_KEY
       - name: AWS_ACCESS_KEY
@@ -26,6 +27,7 @@ options:
   aws_secret_key:
     description: The AWS secret key that corresponds to the access key.
     type: str
+    aliases: [ aws_secret_access_key ]
     env:
       - name: EC2_SECRET_KEY
       - name: AWS_SECRET_KEY
@@ -37,10 +39,4 @@ options:
       - name: EC2_SECURITY_TOKEN
       - name: AWS_SESSION_TOKEN
       - name: AWS_SECURITY_TOKEN
-  region:
-    description: The region for which to create the connection.
-    type: str
-    env:
-      - name: EC2_REGION
-      - name: AWS_REGION
 '''

--- a/lib/ansible/plugins/doc_fragments/aws_credentials.py
+++ b/lib/ansible/plugins/doc_fragments/aws_credentials.py
@@ -6,8 +6,8 @@
 
 class ModuleDocFragment(object):
 
-# Plugin options for AWS credentials
-DOCUMENTATION = r'''
+    # Plugin options for AWS credentials
+    DOCUMENTATION = r'''
 options:
   aws_profile:
     description: The AWS profile

--- a/lib/ansible/plugins/doc_fragments/aws_credentials.py
+++ b/lib/ansible/plugins/doc_fragments/aws_credentials.py
@@ -14,33 +14,33 @@ options:
     type: str
     aliases: [ boto_profile ]
     env:
-      - name: AWS_PROFILE
       - name: AWS_DEFAULT_PROFILE
+      - name: AWS_PROFILE
   aws_access_key:
     description: The AWS access key to use.
     type: str
     env:
-      - name: AWS_ACCESS_KEY_ID
-      - name: AWS_ACCESS_KEY
       - name: EC2_ACCESS_KEY
+      - name: AWS_ACCESS_KEY
+      - name: AWS_ACCESS_KEY_ID
   aws_secret_key:
     description: The AWS secret key that corresponds to the access key.
     type: str
     env:
-      - name: AWS_SECRET_ACCESS_KEY
-      - name: AWS_SECRET_KEY
       - name: EC2_SECRET_KEY
+      - name: AWS_SECRET_KEY
+      - name: AWS_SECRET_ACCESS_KEY
   aws_security_token:
     description: The AWS security token if using temporary access and secret keys.
     type: str
     env:
-      - name: AWS_SECURITY_TOKEN
-      - name: AWS_SESSION_TOKEN
       - name: EC2_SECURITY_TOKEN
+      - name: AWS_SESSION_TOKEN
+      - name: AWS_SECURITY_TOKEN
   region:
     description: The region for which to create the connection.
     type: str
     env:
-      - name: AWS_REGION
       - name: EC2_REGION
+      - name: AWS_REGION
 '''

--- a/lib/ansible/plugins/doc_fragments/aws_region.py
+++ b/lib/ansible/plugins/doc_fragments/aws_region.py
@@ -6,8 +6,8 @@
 
 class ModuleDocFragment(object):
 
-# AWS plugin region setting
-DOCUMENTATION = r'''
+    # Plugin option for AWS region
+    DOCUMENTATION = r'''
 options:
   region:
     description: The region for which to create the connection.

--- a/lib/ansible/plugins/doc_fragments/aws_region.py
+++ b/lib/ansible/plugins/doc_fragments/aws_region.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017,  Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+
+# AWS plugin region setting
+DOCUMENTATION = r'''
+options:
+  region:
+    description: The region for which to create the connection.
+    type: str
+    env:
+      - name: EC2_REGION
+      - name: AWS_REGION
+'''

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -14,6 +14,7 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
         - inventory_cache
         - constructed
+        - aws_credentials
     description:
         - Get inventory hosts from Amazon Web Services EC2.
         - Uses a YAML configuration file that ends with aws_ec2.(yml|yaml).
@@ -25,34 +26,6 @@ DOCUMENTATION = '''
             description: token that ensures this is a source file for the 'aws_ec2' plugin.
             required: True
             choices: ['aws_ec2']
-        boto_profile:
-          description:
-              - The boto profile to use.
-              - This plugin supports boto3-style credentials, so the profile may be sourced from ~/.aws/config for assuming an IAM role.
-              - See U(https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) for details.
-          env:
-              - name: AWS_DEFAULT_PROFILE
-              - name: AWS_PROFILE
-        aws_access_key_id:
-          description: The AWS access key to use. If you have specified a profile, you don't need to provide
-              an access key/secret key/session token.
-          env:
-              - name: EC2_ACCESS_KEY
-              - name: AWS_ACCESS_KEY
-              - name: AWS_ACCESS_KEY_ID
-        aws_secret_access_key:
-          description: The AWS secret key that corresponds to the access key. If you have specified a profile,
-              you don't need to provide an access key/secret key/session token.
-          env:
-              - name: EC2_SECRET_KEY
-              - name: AWS_SECRET_KEY
-              - name: AWS_SECRET_ACCESS_KEY
-        aws_security_token:
-          description: The AWS security token if using temporary access and secret keys.
-          env:
-              - name: EC2_SECURITY_TOKEN
-              - name: AWS_SESSION_TOKEN
-              - name: AWS_SECURITY_TOKEN
         regions:
           description:
               - A list of regions in which to describe EC2 instances.

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -31,28 +31,28 @@ DOCUMENTATION = '''
               - This plugin supports boto3-style credentials, so the profile may be sourced from ~/.aws/config for assuming an IAM role.
               - See U(https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) for details.
           env:
-              - name: AWS_PROFILE
               - name: AWS_DEFAULT_PROFILE
+              - name: AWS_PROFILE
         aws_access_key_id:
           description: The AWS access key to use. If you have specified a profile, you don't need to provide
               an access key/secret key/session token.
           env:
-              - name: AWS_ACCESS_KEY_ID
-              - name: AWS_ACCESS_KEY
               - name: EC2_ACCESS_KEY
+              - name: AWS_ACCESS_KEY
+              - name: AWS_ACCESS_KEY_ID
         aws_secret_access_key:
           description: The AWS secret key that corresponds to the access key. If you have specified a profile,
               you don't need to provide an access key/secret key/session token.
           env:
-              - name: AWS_SECRET_ACCESS_KEY
-              - name: AWS_SECRET_KEY
               - name: EC2_SECRET_KEY
+              - name: AWS_SECRET_KEY
+              - name: AWS_SECRET_ACCESS_KEY
         aws_security_token:
           description: The AWS security token if using temporary access and secret keys.
           env:
-              - name: AWS_SECURITY_TOKEN
-              - name: AWS_SESSION_TOKEN
               - name: EC2_SECURITY_TOKEN
+              - name: AWS_SESSION_TOKEN
+              - name: AWS_SECURITY_TOKEN
         regions:
           description:
               - A list of regions in which to describe EC2 instances.

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -528,9 +528,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :param config_data: contents of the inventory config file
         '''
 
-        self.boto_profile = self.get_option('boto_profile')
-        self.aws_access_key_id = self.get_option('aws_access_key_id')
-        self.aws_secret_access_key = self.get_option('aws_secret_access_key')
+        self.boto_profile = self.get_option('aws_profile')
+        self.aws_access_key_id = self.get_option('aws_access_key')
+        self.aws_secret_access_key = self.get_option('aws_secret_key')
         self.aws_security_token = self.get_option('aws_security_token')
 
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):

--- a/lib/ansible/plugins/inventory/aws_rds.py
+++ b/lib/ansible/plugins/inventory/aws_rds.py
@@ -12,32 +12,6 @@ DOCUMENTATION = '''
         - Get instances and clusters from Amazon Web Services RDS.
         - Uses a YAML configuration file that ends with aws_rds.(yml|yaml).
     options:
-        boto_profile:
-          description: The boto profile to use. The plugin will look for an instance role if no credentials
-              are provided.
-          env:
-              - name: AWS_DEFAULT_PROFILE
-              - name: AWS_PROFILE
-        aws_access_key_id:
-          description: The AWS access key to use. If you have specified a profile, you don't need to provide
-              an access key/secret key/session token.
-          env:
-              - name: EC2_ACCESS_KEY
-              - name: AWS_ACCESS_KEY
-              - name: AWS_ACCESS_KEY_ID
-        aws_secret_access_key:
-          description: The AWS secret key that corresponds to the access key. If you have specified a profile,
-              you don't need to provide an access key/secret key/session token.
-          env:
-              - name: EC2_SECRET_KEY
-              - name: AWS_SECRET_KEY
-              - name: AWS_SECRET_ACCESS_KEY
-        aws_security_token:
-          description: The AWS security token if using temporary access and secret keys.
-          env:
-              - name: EC2_SECURITY_TOKEN
-              - name: AWS_SESSION_TOKEN
-              - name: AWS_SECURITY_TOKEN
         regions:
           description: A list of regions in which to describe RDS instances and clusters. Available regions are listed here
               U(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
@@ -65,6 +39,7 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
         - inventory_cache
         - constructed
+        - aws_credentials
     requirements:
         - boto3
         - botocore

--- a/lib/ansible/plugins/inventory/aws_rds.py
+++ b/lib/ansible/plugins/inventory/aws_rds.py
@@ -246,9 +246,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         '''
             :param config_data: contents of the inventory config file
         '''
-        self.boto_profile = self.get_option('boto_profile')
-        aws_access_key_id = self.get_option('aws_access_key_id')
-        aws_secret_access_key = self.get_option('aws_secret_access_key')
+        self.boto_profile = self.get_option('aws_profile')
+        aws_access_key_id = self.get_option('aws_access_key')
+        aws_secret_access_key = self.get_option('aws_secret_key')
         aws_security_token = self.get_option('aws_security_token')
 
         if not self.boto_profile and not (aws_access_key_id and aws_secret_access_key):

--- a/lib/ansible/plugins/inventory/aws_rds.py
+++ b/lib/ansible/plugins/inventory/aws_rds.py
@@ -16,28 +16,28 @@ DOCUMENTATION = '''
           description: The boto profile to use. The plugin will look for an instance role if no credentials
               are provided.
           env:
-              - name: AWS_PROFILE
               - name: AWS_DEFAULT_PROFILE
+              - name: AWS_PROFILE
         aws_access_key_id:
           description: The AWS access key to use. If you have specified a profile, you don't need to provide
               an access key/secret key/session token.
           env:
-              - name: AWS_ACCESS_KEY_ID
-              - name: AWS_ACCESS_KEY
               - name: EC2_ACCESS_KEY
+              - name: AWS_ACCESS_KEY
+              - name: AWS_ACCESS_KEY_ID
         aws_secret_access_key:
           description: The AWS secret key that corresponds to the access key. If you have specified a profile,
               you don't need to provide an access key/secret key/session token.
           env:
-              - name: AWS_SECRET_ACCESS_KEY
-              - name: AWS_SECRET_KEY
               - name: EC2_SECRET_KEY
+              - name: AWS_SECRET_KEY
+              - name: AWS_SECRET_ACCESS_KEY
         aws_security_token:
           description: The AWS security token if using temporary access and secret keys.
           env:
-              - name: AWS_SECURITY_TOKEN
-              - name: AWS_SESSION_TOKEN
               - name: EC2_SECURITY_TOKEN
+              - name: AWS_SESSION_TOKEN
+              - name: AWS_SECURITY_TOKEN
         regions:
           description: A list of regions in which to describe RDS instances and clusters. Available regions are listed here
               U(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)

--- a/lib/ansible/plugins/lookup/aws_account_attribute.py
+++ b/lib/ansible/plugins/lookup/aws_account_attribute.py
@@ -13,6 +13,7 @@ requirements:
   - botocore
 extends_documentation_fragment:
   - aws_credentials
+  - aws_region
 short_description: Look up AWS account attributes.
 description:
   - Describes attributes of your AWS account. You can specify one of the listed

--- a/test/units/plugins/inventory/test_aws_ec2.py
+++ b/test/units/plugins/inventory/test_aws_ec2.py
@@ -129,9 +129,9 @@ def test_get_boto_attr_chain(inventory):
 
 
 def test_boto3_conn(inventory):
-    inventory._options = {"boto_profile": "first_precedence",
-                          "aws_access_key_id": "test_access_key",
-                          "aws_secret_access_key": "test_secret_key",
+    inventory._options = {"aws_profile": "first_precedence",
+                          "aws_access_key": "test_access_key",
+                          "aws_secret_key": "test_secret_key",
                           "aws_security_token": "test_security_token"}
     inventory._set_credentials()
     with pytest.raises(AnsibleError) as error_message:
@@ -151,10 +151,10 @@ def test_get_hostname(inventory):
 
 
 def test_set_credentials(inventory):
-    inventory._options = {'aws_access_key_id': 'test_access_key',
-                          'aws_secret_access_key': 'test_secret_key',
+    inventory._options = {'aws_access_key': 'test_access_key',
+                          'aws_secret_key': 'test_secret_key',
                           'aws_security_token': 'test_security_token',
-                          'boto_profile': 'test_profile'}
+                          'aws_profile': 'test_profile'}
     inventory._set_credentials()
 
     assert inventory.boto_profile == "test_profile"
@@ -165,10 +165,10 @@ def test_set_credentials(inventory):
 
 def test_insufficient_credentials(inventory):
     inventory._options = {
-        'aws_access_key_id': None,
-        'aws_secret_access_key': None,
+        'aws_access_key': None,
+        'aws_secret_key': None,
         'aws_security_token': None,
-        'boto_profile': None
+        'aws_profile': None
     }
     with pytest.raises(AnsibleError) as error_message:
         inventory._set_credentials()


### PR DESCRIPTION
##### SUMMARY
The environment variable precedence was incorrectly reversed

This is the way the precedence works:
```
env:
    - name: fallback
    - name: highest_precedence
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
AWS plugins
