### PR TITLE
Revert "foreman: Use generic python in test run (#52544)"

### DIFF
--- a/test/integration/targets/inventory_foreman_script/foreman.sh
+++ b/test/integration/targets/inventory_foreman_script/foreman.sh
@@ -2,7 +2,7 @@
 # Wrapper to use the correct Python interpreter and support code coverage.
 
 REL_SCRIPT="../../../../contrib/inventory/foreman.py"
-ABS_SCRIPT="$("python.py" -c "import os; print(os.path.abspath('${REL_SCRIPT}'))")"
+ABS_SCRIPT="$("${ANSIBLE_TEST_PYTHON_INTERPRETER}" -c "import os; print(os.path.abspath('${REL_SCRIPT}'))")"
 
 # Make sure output written to current directory ends up in the temp dir.
 cd "${OUTPUT_DIR}"


### PR DESCRIPTION
##### SUMMARY

Revert "foreman: Use generic python in test run (#52544)"

Cannot use `python.py` with `-c` when coverage is enabled.

This reverts commit 2991c5d47cccc3e436a420bc96940e851dd9b5cb.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

inventory_foreman_script integration test
