### PR TITLE
VMware: Handle failure when timeout exceeded in shutdownguest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2616,6 +2616,9 @@ def main():
             if not tmp_result["failed"]:
                 result["failed"] = False
             result['instance'] = tmp_result['instance']
+            if tmp_result["failed"]:
+                result["failed"] = True
+                result["msg"] = tmp_result["msg"]
         else:
             # This should not happen
             raise AssertionError()


### PR DESCRIPTION
If the state_change_timeout was exceeded in shutdownguest, there was no failure.  This adds a failure in that case.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
