### PR TITLE
Fix redfish_facts Chassis command GetFanInventory returning duplicates of the same Fan entity

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -734,11 +734,10 @@ class RedfishUtils(object):
         fan_results = []
         key = "Thermal"
         # Get these entries, but does not fail if not found
-        properties = ['FanName', 'Reading', 'Status']
+        properties = ['FanName', 'Reading', 'ReadingUnits', 'Status']
 
         # Go through list
         for chassis_uri in self.chassis_uri_list:
-            fan = {}
             response = self.get_request(self.root_uri + chassis_uri)
             if response['ret'] is False:
                 return response
@@ -754,12 +753,12 @@ class RedfishUtils(object):
                 data = response['data']
 
                 for device in data[u'Fans']:
+                    fan = {}
                     for property in properties:
                         if property in device:
                             fan[property] = device[property]
-
                     fan_results.append(fan)
-                result["entries"] = fan_results
+        result["entries"] = fan_results
         return result
 
     def get_cpu_inventory(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request fixes a bug in the redfish_facts `Chassis` command `GetFanInventory` where the `get_fan_inventory()` function in redfish_utils.py was returning a list of one fan instance repeated a number of times equal to the number of fan objects found by redfish.

If multiple chassis objects were found to loop over, the `result['entries'] = fan_results` would be set multiple times, rather than just once at the end, so I outdented that line to run only after all chassis were looped over.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.240.50.79
    user: USERID
    password: PASSW0RD

  tasks:
    - name: Get Fan inventory
      redfish_facts:
        category: Chassis
        command: GetFanInventory
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"

```


```
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible
  executable location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.1.yml **********************************************************************************Positional arguments: ../test_redfish_facts.1.yml
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
forks: 5
tags: (u'all',)
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.1.yml

PLAY [Test Redfish modules] *****************************************************************************************META: ran handlers

TASK [Get Fan inventory] ********************************************************************************************task path: /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_facts.1.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524 `" && echo ansible-tmp-1551125853.04-192166449626524="` echo /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-1764r1mlDa/tmpNZflVm TO /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/ /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "fan": {
                "entries": [
                    {
                        "FanName": "Fan 6 Tach", 
                        "Reading": 25, 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 6 Tach", 
                        "Reading": 25, 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 6 Tach", 
                        "Reading": 25, 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 6 Tach", 
                        "Reading": 25, 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 6 Tach", 
                        "Reading": 25, 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 6 Tach", 
                        "Reading": 25, 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.240.50.79", 
            "category": [
                "Chassis"
            ], 
            "command": [
                "GetFanInventory"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```


After:
```
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible
  executable location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_facts.1.yml **********************************************************************************Positional arguments: ../test_redfish_facts.1.yml
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
forks: 5
tags: (u'all',)
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_facts.1.yml

PLAY [Test Redfish modules] *****************************************************************************************META: ran handlers

TASK [Get Fan inventory] ********************************************************************************************task path: /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_facts.1.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524 `" && echo ansible-tmp-1551125853.04-192166449626524="` echo /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-1764r1mlDa/tmpNZflVm TO /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/ /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1551125853.04-192166449626524/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "fan": {
                "entries": [
                    {
                        "FanName": "Fan 1 Tach", 
                        "Reading": 25, 
                        "ReadingUnits": "Percent", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 2 Tach", 
                        "Reading": 24, 
                        "ReadingUnits": "Percent", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 3 Tach", 
                        "Reading": 23, 
                        "ReadingUnits": "Percent", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 4 Tach", 
                        "Reading": 24, 
                        "ReadingUnits": "Percent", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 5 Tach", 
                        "Reading": 25, 
                        "ReadingUnits": "Percent", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }, 
                    {
                        "FanName": "Fan 6 Tach", 
                        "Reading": 25, 
                        "ReadingUnits": "Percent", 
                        "Status": {
                            "Health": "OK", 
                            "State": "Enabled"
                        }
                    }
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.240.50.79", 
            "category": [
                "Chassis"
            ], 
            "command": [
                "GetFanInventory"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```
