### PR TITLE
Add fw via panorama connectivity to panos connection

### DIFF
--- a/lib/ansible/module_utils/network/panos/panos.py
+++ b/lib/ansible/module_utils/network/panos/panos.py
@@ -97,7 +97,7 @@ class ConnectionHelper(object):
                     _vstr(self.min_pandevice_version)))
 
         pan_device_auth, serial_number = None, None
-        if module.params.get('provider', {}).get('ip_address') is not None:
+        if module.params['provider'] and module.params['provider']['ip_address']:
             pan_device_auth = (
                 module.params['provider']['ip_address'],
                 module.params['provider']['username'],
@@ -106,7 +106,7 @@ class ConnectionHelper(object):
                 module.params['provider']['port'],
             )
             serial_number = module.params['provider']['serial_number']
-        elif module.params.get('ip_address') is not None:
+        elif module.params.get('ip_address', None) is not None:
             pan_device_auth = (
                 module.params['ip_address'],
                 module.params['username'],
@@ -114,6 +114,8 @@ class ConnectionHelper(object):
                 module.params['api_key'],
                 module.params['port'],
             )
+            msg = 'Classic provider params are deprecated; use "provider" instead'
+            module.deprecate(msg, '2.12')
         else:
             module.fail_json(msg='Provider params are required.')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding additional functionality to allow the panos connection to connect to a firewall through a Panorama that is managing it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
panos.py

##### ADDITIONAL INFORMATION
`pandevice` implements firewall via Panorama connectivity as a `firewall.Firewall` child of a `panorama.Panorama`, where the `firewall.Firewall` only has a serial number specified.  This update implements that to support this additional connection option to the user.
