### PR TITLE
Extreme modules - update slxos_vlan for new SLX-OS versions, linting fixes

### DIFF
--- a/lib/ansible/modules/network/exos/exos_config.py
+++ b/lib/ansible/modules/network/exos/exos_config.py
@@ -221,13 +221,10 @@ backup_path:
 
 """
 import re
-import time
 
 from ansible.module_utils.network.exos.exos import run_commands, get_config, load_config
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
-from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_text
 
 __metaclass__ = type

--- a/lib/ansible/modules/network/exos/exos_facts.py
+++ b/lib/ansible/modules/network/exos/exos_facts.py
@@ -310,7 +310,6 @@ class Interfaces(FactsBase):
         return facts
 
     def populate_interface_descriptions(self, data):
-        facts = dict()
         for elem in data:
             if 'show_ports_description' not in elem:
                 continue
@@ -444,7 +443,7 @@ def main():
 
     warnings = list()
 
-    module.exit_json(ansible_facts=ansible_facts)
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -180,8 +180,7 @@ backup_path:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.ironware.ironware import ironware_argument_spec, check_args
 from ansible.module_utils.network.ironware.ironware import get_config, load_config, run_commands
-from ansible.module_utils.network.common.config import NetworkConfig, dumps, ConfigLine
-from ansible.module_utils._text import to_native
+from ansible.module_utils.network.common.config import NetworkConfig, dumps
 
 
 def get_candidate(module):
@@ -280,8 +279,6 @@ def main():
     result = {'changed': False}
 
     check_args(module)
-
-    config = None
 
     if module.params['backup']:
         result['__backup__'] = get_config(module)

--- a/lib/ansible/modules/network/ironware/ironware_facts.py
+++ b/lib/ansible/modules/network/ironware/ironware_facts.py
@@ -138,7 +138,6 @@ from ansible.module_utils.network.ironware.ironware import run_commands
 from ansible.module_utils.network.ironware.ironware import ironware_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.six.moves import zip
 
 
 class FactsBase(object):
@@ -320,14 +319,14 @@ class MPLS(FactsBase):
         facts = list()
         regex = r'End-point[0-9 ]*: +(?P<tagged>tagged|untagged) +(vlan +(?P<vlan>[0-9]+) +)?(inner- vlan +(?P<innervlan>[0-9]+) +)?(?P<port>e [0-9/]+|--)'
         matches = re.finditer(regex, data, re.IGNORECASE | re.DOTALL)
-        for n, match in enumerate(matches):
+        for match in matches:
             f = match.groupdict()
             f['type'] = 'local'
             facts.append(f)
 
         regex = r'Vll-Peer +: +(?P<vllpeer>[0-9\.]+).*Tunnel LSP +: +(?P<lsp>\S+)'
         matches = re.finditer(regex, data, re.IGNORECASE | re.DOTALL)
-        for n, match in enumerate(matches):
+        for match in matches:
             f = match.groupdict()
             f['type'] = 'remote'
             facts.append(f)
@@ -343,14 +342,14 @@ class MPLS(FactsBase):
         facts = list()
         regex = r'Vlan (?P<vlanid>[0-9]+)\s(?: +(?:L2.*)\s| +Tagged: (?P<tagged>.+)+\s| +Untagged: (?P<untagged>.+)\s)*'
         matches = re.finditer(regex, data, re.IGNORECASE)
-        for n, match in enumerate(matches):
+        for match in matches:
             f = match.groupdict()
             f['type'] = 'local'
             facts.append(f)
 
         regex = r'Peer address: (?P<vllpeer>[0-9\.]+)'
         matches = re.finditer(regex, data, re.IGNORECASE)
-        for n, match in enumerate(matches):
+        for match in matches:
             f = match.groupdict()
             f['type'] = 'remote'
             facts.append(f)

--- a/lib/ansible/modules/network/nos/nos_facts.py
+++ b/lib/ansible/modules/network/nos/nos_facts.py
@@ -281,7 +281,7 @@ class Interfaces(FactsBase):
             primary_address = addresses = []
             primary_address = re.findall(r'Primary Internet Address is (\S+)', value, re.M)
             addresses = re.findall(r'Secondary Internet Address is (\S+)', value, re.M)
-            if len(primary_address) == 0:
+            if not primary_address:
                 continue
             addresses.append(primary_address[0])
             for address in addresses:
@@ -311,7 +311,7 @@ class Interfaces(FactsBase):
     def parse_neighbors(self, neighbors):
         facts = dict()
         lines = neighbors.split('Local Interface: ')
-        if len(lines) == 0:
+        if not lines:
             return facts
         for line in lines:
             match = re.search(r'(\w+ \S+)\s+\(Local Int.+?\)[\s\S]+Remote Interface: (\S+.+?) \(Remote Int.+?\)[\s\S]+System Name: (\S+)', line, re.M)
@@ -452,7 +452,7 @@ def main():
 
     warnings = list()
 
-    module.exit_json(ansible_facts=ansible_facts)
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -254,14 +254,10 @@ backup_path:
   type: str
   sample: /playbooks/ansible/backup/slxos_config.2018-02-12@18:26:34
 """
-import re
-import time
 
 from ansible.module_utils.network.slxos.slxos import run_commands, get_config, load_config
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
-from ansible.module_utils.six import iteritems
 
 __metaclass__ = type
 

--- a/lib/ansible/modules/network/slxos/slxos_facts.py
+++ b/lib/ansible/modules/network/slxos/slxos_facts.py
@@ -279,7 +279,7 @@ class Interfaces(FactsBase):
             primary_address = addresses = []
             primary_address = re.findall(r'Primary Internet Address is (\S+)', value, re.M)
             addresses = re.findall(r'Secondary Internet Address is (\S+)', value, re.M)
-            if len(primary_address) == 0:
+            if not primary_address:
                 continue
             addresses.append(primary_address[0])
             for address in addresses:
@@ -309,7 +309,7 @@ class Interfaces(FactsBase):
     def parse_neighbors(self, neighbors):
         facts = dict()
         lines = neighbors.split('Local Interface: ')
-        if len(lines) == 0:
+        if not lines:
             return facts
         for line in lines:
             match = re.search(r'(\w+ \S+)\s+\(Local Int.+?\)[\s\S]+Remote Interface: (\S+.+?) \(Remote Int.+?\)[\s\S]+System Name: (\S+)', line, re.M)
@@ -450,7 +450,7 @@ def main():
 
     warnings = list()
 
-    module.exit_json(ansible_facts=ansible_facts)
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/slxos/slxos_vlan.py
+++ b/lib/ansible/modules/network/slxos/slxos_vlan.py
@@ -35,7 +35,7 @@ description:
   - This module provides declarative management of VLANs
     on Extreme SLX-OS network devices.
 notes:
-  - Tested against SLX-OS 17s.1.02
+  - Tested against SLX-OS 18r.1.00
 options:
   name:
     description:
@@ -105,7 +105,6 @@ from ansible.module_utils.network.slxos.slxos import load_config, run_commands
 
 
 def search_obj_in_list(vlan_id, lst):
-    obj = list()
     for o in lst:
         if o['vlan_id'] == vlan_id:
             return o
@@ -217,16 +216,16 @@ def map_config_to_obj(module):
     obj = {}
 
     for l in lines:
-        splitted_line = re.split(r'([0-9]+)? +(\S.{14})? +(ACTIVE|INACTIVE\(.+?\))? +(Eth .+?|Po .+?)\([ut]\)\s*$', l.rstrip())
+        splitted_line = re.split(r'([0-9]+)? +(\S.{14})? +(ACTIVE|INACTIVE\(.+?\))?.*(Eth .+?|Po .+?|Tu .+?)\([ut]\).*$', l.rstrip())
         if len(splitted_line) == 1:
             # Handle situation where VLAN is configured, but has no associated ports
-            inactive = re.match(r'([0-9]+)? +(\S.{14}) +INACTIVE\(no member port\)$', l.rstrip())
+            inactive = re.match(r'([0-9]+)? +(\S.{14}) +INACTIVE\(no member port\).*$', l.rstrip())
             if inactive:
                 splitted_line = ['', inactive.groups()[0], inactive.groups()[1], '', '']
             else:
                 continue
 
-        splitted_line[4] = splitted_line[4].replace('Eth', 'Ethernet').replace('Po', 'Port-channel')
+        splitted_line[4] = splitted_line[4].replace('Eth', 'Ethernet').replace('Po', 'Port-channel').replace('Tu', 'Tunnel')
 
         if splitted_line[1] is None:
             obj['interfaces'].append(splitted_line[4])

--- a/lib/ansible/modules/network/voss/voss_facts.py
+++ b/lib/ansible/modules/network/voss/voss_facts.py
@@ -311,7 +311,7 @@ class Interfaces(FactsBase):
     def populate_ipv6_interfaces(self, data):
         addresses = re.split(r'-{3,}', data)[1].lstrip()
         for line in addresses.split('\n'):
-            if len(line) == 0:
+            if not line:
                 break
 
             match = re.match(r'^([\da-f:]+)/(\d+)\s+([CV])-(\d+)\s+.+$', line)
@@ -350,7 +350,7 @@ class Interfaces(FactsBase):
     def parse_neighbors(self, neighbors):
         facts = dict()
         lines = neighbors.split('Port: ')
-        if len(lines) == 0:
+        if not lines:
             return facts
         for line in lines:
             match = re.search(r'^(\w.*?)\s+Index.*IfName\s+(\w.*)$\s+SysName\s+:\s(\S+)', line, (re.M | re.S))
@@ -368,7 +368,7 @@ class Interfaces(FactsBase):
         parsed = dict()
         interfaces = re.split(r'-{3,}', data)[1].lstrip()
         for line in interfaces.split('\n'):
-            if len(line) == 0:
+            if not line or re.match('^All', line):
                 break
             else:
                 match = re.split(r'^(\S+)\s+', line)

--- a/test/units/modules/network/exos/test_exos_command.py
+++ b/test/units/modules/network/exos/test_exos_command.py
@@ -22,8 +22,8 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from ansible.modules.network.exos import exos_command
 from units.modules.utils import set_module_args
+from ansible.modules.network.exos import exos_command
 from .exos_module import TestExosModule, load_fixture
 
 

--- a/test/units/modules/network/exos/test_exos_config.py
+++ b/test/units/modules/network/exos/test_exos_config.py
@@ -20,8 +20,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.modules.network.exos import exos_config
 from units.modules.utils import set_module_args
+from ansible.modules.network.exos import exos_config
 from .exos_module import TestExosModule, load_fixture
 
 

--- a/test/units/modules/network/exos/test_exos_facts.py
+++ b/test/units/modules/network/exos/test_exos_facts.py
@@ -20,12 +20,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import json
 
 from units.compat.mock import patch
-from ansible.modules.network.exos import exos_facts
 from units.modules.utils import set_module_args
-from .exos_module import TestExosModule, load_fixture
+from ansible.modules.network.exos import exos_facts
+from .exos_module import TestExosModule
 
 
 class TestExosFactsModule(TestExosModule):

--- a/test/units/modules/network/ironware/ironware_module.py
+++ b/test/units/modules/network/ironware/ironware_module.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 import os
 import json
 
-from ansible.module_utils import basic
 from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase
 
 

--- a/test/units/modules/network/ironware/test_ironware_command.py
+++ b/test/units/modules/network/ironware/test_ironware_command.py
@@ -20,8 +20,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.modules.network.ironware import ironware_command
 from units.modules.utils import set_module_args
+from ansible.modules.network.ironware import ironware_command
 from .ironware_module import TestIronwareModule, load_fixture
 
 

--- a/test/units/modules/network/ironware/test_ironware_config.py
+++ b/test/units/modules/network/ironware/test_ironware_config.py
@@ -20,12 +20,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
-
 from units.compat.mock import patch
+from units.modules.utils import set_module_args
 from ansible.modules.network.ironware import ironware_config
 from .ironware_module import TestIronwareModule, load_fixture
-from units.modules.utils import set_module_args
 
 
 class TestIronwareConfigModule(TestIronwareModule):
@@ -143,7 +141,7 @@ class TestIronwareConfigModule(TestIronwareModule):
         set_module_args(dict(lines=lines, match='none'))
         self.execute_module(changed=True, updates=lines)
 
-    def test_ironware_config_match_none(self):
+    def test_ironware_config_match_none_parents(self):
         lines = ['ip address 1.2.3.4 255.255.255.0', 'port-name test string']
         parents = ['interface ethernet 1/1']
         set_module_args(dict(lines=lines, parents=parents, match='none'))

--- a/test/units/modules/network/ironware/test_ironware_facts.py
+++ b/test/units/modules/network/ironware/test_ironware_facts.py
@@ -22,9 +22,9 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from .ironware_module import TestIronwareModule, load_fixture
-from ansible.modules.network.ironware import ironware_facts
 from units.modules.utils import set_module_args
+from ansible.modules.network.ironware import ironware_facts
+from .ironware_module import TestIronwareModule, load_fixture
 
 
 class TestIronwareFacts(TestIronwareModule):

--- a/test/units/modules/network/nos/test_nos_command.py
+++ b/test/units/modules/network/nos/test_nos_command.py
@@ -22,8 +22,8 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from ansible.modules.network.nos import nos_command
 from units.modules.utils import set_module_args
+from ansible.modules.network.nos import nos_command
 from .nos_module import TestNosModule, load_fixture
 
 

--- a/test/units/modules/network/nos/test_nos_config.py
+++ b/test/units/modules/network/nos/test_nos_config.py
@@ -20,8 +20,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.modules.network.nos import nos_config
 from units.modules.utils import set_module_args
+from ansible.modules.network.nos import nos_config
 from .nos_module import TestNosModule, load_fixture
 
 
@@ -113,7 +113,7 @@ class TestNosConfigModule(TestNosModule):
         set_module_args(dict(lines=lines, match='none'))
         self.execute_module(changed=True, commands=lines)
 
-    def test_nos_config_match_none(self):
+    def test_nos_config_match_none_parents(self):
         lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
         parents = ['interface TenGigabitEthernet 104/0/0']
         set_module_args(dict(lines=lines, parents=parents, match='none'))

--- a/test/units/modules/network/nos/test_nos_facts.py
+++ b/test/units/modules/network/nos/test_nos_facts.py
@@ -20,8 +20,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.modules.network.nos import nos_facts
 from units.modules.utils import set_module_args
+from ansible.modules.network.nos import nos_facts
 from .nos_module import TestNosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/fixtures/show_vlan_brief
+++ b/test/units/modules/network/slxos/fixtures/show_vlan_brief
@@ -1,16 +1,17 @@
-Total Number of VLANs configured    : 3
-VLAN             Name            State                      Ports           Classification
-(R)-RSPAN                                                   (u)-Untagged
-                                                            (t)-Tagged
+Total Number of VLANs configured    : 2
+VLAN             Name            State                      Config status         Ports           Classification
+(R)-RSPAN                                                                         (u)-Untagged
+                                                                                  (t)-Tagged
 ================ =============== ========================== =============== ====================
-1                default         INACTIVE(member port down) Eth 0/45(u)
-                                                            Eth 0/3(u)
-                                                            Eth 0/4(u)
+1                default         ACTIVE                     Static                Eth 1/5(t)
 
-22               VLAN0022        INACTIVE(no member port)
+22               VLAN0022        INACTIVE(no member port)   Static
 
+5                VLAN0005        ACTIVE                     Static                Tu 61442(t)     vni 5
+                                                                                  Tu 61443(t)     vni 5
 
-200              VLAN0200        INACTIVE(member port down) Eth 0/8(t)
-                                                            Po 200(u)
+200              VLAN0200        ACTIVE                     Dynamic (MVRP)        Po 60(t)
 
-1001             VLAN1001        INACTIVE(no member port)
+1000             VLAN1000        ACTIVE                     Dynamic (EP tracking) Po 60(t)
+
+4090             VLAN4090        INACTIVE(no member port)   Static

--- a/test/units/modules/network/slxos/test_slxos_command.py
+++ b/test/units/modules/network/slxos/test_slxos_command.py
@@ -22,8 +22,8 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_command
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_command
 from .slxos_module import TestSlxosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/test_slxos_config.py
+++ b/test/units/modules/network/slxos/test_slxos_config.py
@@ -20,8 +20,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_config
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_config
 from .slxos_module import TestSlxosModule, load_fixture
 
 
@@ -141,7 +141,7 @@ class TestSlxosConfigModule(TestSlxosModule):
         set_module_args(dict(lines=lines, match='none'))
         self.execute_module(changed=True, commands=lines)
 
-    def test_slxos_config_match_none(self):
+    def test_slxos_config_match_none_parents(self):
         lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
         parents = ['interface Ethernet 0/0']
         set_module_args(dict(lines=lines, parents=parents, match='none'))

--- a/test/units/modules/network/slxos/test_slxos_facts.py
+++ b/test/units/modules/network/slxos/test_slxos_facts.py
@@ -20,8 +20,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_facts
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_facts
 from .slxos_module import TestSlxosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/test_slxos_interface.py
+++ b/test/units/modules/network/slxos/test_slxos_interface.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_interface
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_interface
 from .slxos_module import TestSlxosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/test_slxos_l2_interface.py
+++ b/test/units/modules/network/slxos/test_slxos_l2_interface.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_l2_interface
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_l2_interface
 from .slxos_module import TestSlxosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/test_slxos_l3_interface.py
+++ b/test/units/modules/network/slxos/test_slxos_l3_interface.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_l3_interface
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_l3_interface
 from .slxos_module import TestSlxosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/test_slxos_linkagg.py
+++ b/test/units/modules/network/slxos/test_slxos_linkagg.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_linkagg
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_linkagg
 from .slxos_module import TestSlxosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/test_slxos_lldp.py
+++ b/test/units/modules/network/slxos/test_slxos_lldp.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_lldp
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_lldp
 from .slxos_module import TestSlxosModule, load_fixture
 
 

--- a/test/units/modules/network/slxos/test_slxos_vlan.py
+++ b/test/units/modules/network/slxos/test_slxos_vlan.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from units.compat.mock import patch
-from ansible.modules.network.slxos import slxos_vlan
 from units.modules.utils import set_module_args
+from ansible.modules.network.slxos import slxos_vlan
 from .slxos_module import TestSlxosModule, load_fixture
 
 
@@ -116,7 +115,7 @@ class TestSlxosVlanModule(TestSlxosModule):
             }
         )
 
-    def test_slxos_vlan_state_absent_nonexistant_vlan(self, *args, **kwargs):
+    def test_slxos_vlan_state_absent_nonexistent_vlan(self, *args, **kwargs):
         set_module_args(dict(
             vlan_id=100,
             state='absent'

--- a/test/units/modules/network/voss/test_voss_command.py
+++ b/test/units/modules/network/voss/test_voss_command.py
@@ -22,8 +22,8 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from ansible.modules.network.voss import voss_command
 from units.modules.utils import set_module_args
+from ansible.modules.network.voss import voss_command
 from .voss_module import TestVossModule, load_fixture
 
 

--- a/test/units/modules/network/voss/test_voss_config.py
+++ b/test/units/modules/network/voss/test_voss_config.py
@@ -21,9 +21,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch, MagicMock
+from units.modules.utils import set_module_args
 from ansible.modules.network.voss import voss_config
 from ansible.plugins.cliconf.voss import Cliconf
-from units.modules.utils import set_module_args
 from .voss_module import TestVossModule, load_fixture
 
 

--- a/test/units/modules/network/voss/test_voss_facts.py
+++ b/test/units/modules/network/voss/test_voss_facts.py
@@ -18,8 +18,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.modules.network.voss import voss_facts
 from units.modules.utils import set_module_args
+from ansible.modules.network.voss import voss_facts
 from .voss_module import TestVossModule, load_fixture
 
 


### PR DESCRIPTION
##### SUMMARY

Update `slxos_vlan` to match new `show vlan brief` output. 

Fixed `voss_facts` for devices with no IPv4 addresses

Minor linting fixes across Extreme modules - remove unused imports & variables, change import order, change `len(lines) == 0` to `if not lines`, etc.

Fixed duplicate test method names.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`exos_config`
`exos_facts`
`ironware_config`
`ironware_facts`
`nos_facts`
`slxos_config`
`slxos_facts`
`slxos_vlan`
`voss_facts`

##### ADDITIONAL INFORMATION

For most changes, there is no change in functionality, just a few linting errors removed. 

For `slxos_vlan`, it works the same as before, but now also works with newer SLX-OS code versions (18.x). Previously it only worked for 17.x

`voss_facts` would fail on devices with no IPv4 addresses (other than the mgmt interface). `voss_facts` now handles this situation.