### PR TITLE
support for older versions of ansible

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -13,7 +13,14 @@ import json
 
 from os.path import expanduser
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from ansible.module_utils.basic import missing_required_lib
+except Exception:
+    def missing_required_lib(msg, reason=None, url=None):
+        return msg
+
 try:
     from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION
 except Exception:

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -18,8 +18,10 @@ from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.basic import missing_required_lib
 except Exception:
+    # This is to support older versions of Ansible.
+    # azure_rm_common.py file is used by azure/azure_preview_modules role which may be used with older Ansible versions.
     def missing_required_lib(msg, reason=None, url=None):
-        return msg
+        return "Missing required library: " + msg
 
 try:
     from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION


### PR DESCRIPTION
##### SUMMARY
This change is to make sure the same version of azure_rm_common may be uses with older version of ansible in azure_preview_modules.
basic.py in versions < 2.8 doesn't have definition of **missing_required_lib** so I am just adding a stub in case of failure.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common

##### ADDITIONAL INFORMATION
