### PR TITLE
Revert Clear failed state in always only if we did rescue

### DIFF
--- a/changelogs/fragments/52561-fix-handlers-on-failed-hosts-with-always-section.yaml
+++ b/changelogs/fragments/52561-fix-handlers-on-failed-hosts-with-always-section.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - Fix handlers on failed hosts with always section (https://github.com/ansible/ansible/issues/52561)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -484,7 +484,7 @@ class PlayIterator:
         elif state.fail_state != self.FAILED_NONE:
             if state.run_state == self.ITERATING_RESCUE and state.fail_state & self.FAILED_RESCUE == 0:
                 return False
-            elif state.run_state == self.ITERATING_ALWAYS and state.fail_state & self.FAILED_ALWAYS == 0 and state.did_rescue:
+            elif state.run_state == self.ITERATING_ALWAYS and state.fail_state & self.FAILED_ALWAYS == 0:
                 return False
             else:
                 return not state.did_rescue

--- a/test/integration/targets/blocks/block_fail.yml
+++ b/test/integration/targets/blocks/block_fail.yml
@@ -1,0 +1,5 @@
+---
+- name: Include tasks that have a failure in a block
+  hosts: localhost
+  tasks:
+  - include_tasks: block_fail_tasks.yml

--- a/test/integration/targets/blocks/block_fail_tasks.yml
+++ b/test/integration/targets/blocks/block_fail_tasks.yml
@@ -1,0 +1,9 @@
+- block:
+  - name: fail task
+    fail:
+      msg: failure
+
+  always:
+  - name: run always task
+    debug:
+      msg: TEST COMPLETE

--- a/test/integration/targets/blocks/block_fail_tasks.yml
+++ b/test/integration/targets/blocks/block_fail_tasks.yml
@@ -1,5 +1,5 @@
 - block:
-  - name: fail task
+  - name: EXPECTED FAILURE
     fail:
       msg: failure
 

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -26,3 +26,11 @@ env python -c \
     'import sys, re; sys.stdout.write(re.sub("\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]", "", sys.stdin.read()))' \
     <block_test.out >block_test_wo_colors.out
 [ "$(grep -c 'TEST COMPLETE' block_test.out)" = "$(egrep '^[0-9]+ plays in' block_test_wo_colors.out | cut -f1 -d' ')" ]
+
+# run test that includes tasks that fail inside a block with always
+rm -f block_test.out block_test_wo_colors.out
+ansible-playbook -vv block_fail.yml -i ../../inventory "$@" | tee block_test.out
+env python -c \
+    'import sys, re; sys.stdout.write(re.sub("\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]", "", sys.stdin.read()))' \
+    <block_test.out >block_test_wo_colors.out
+[ "$(grep -c 'TEST COMPLETE' block_test.out)" = "$(egrep '^[0-9]+ plays in' block_test_wo_colors.out | cut -f1 -d' ')" ]


### PR DESCRIPTION
##### SUMMARY
The change in https://github.com/ansible/ansible/pull/52829 causes Ansible to crash when including a task that contains a failure inside a block. This PR reverts the change to get devel working again as well as including a test case for this issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
blocks