### PR TITLE
docker_swarm: fix idempotency

### DIFF
--- a/changelogs/fragments/52895-docker_swarm-labels.yaml
+++ b/changelogs/fragments/52895-docker_swarm-labels.yaml
@@ -1,2 +1,3 @@
 bugfixes:
 - "docker_swarm - do not crash with older docker daemons (https://github.com/ansible/ansible/issues/51175)."
+- "docker_swarm - improve idempotency checking; ``rotate_worker_token`` and ``rotate_manager_token`` are now also used when all other parameters have not changed."

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -349,7 +349,8 @@ class TaskParameters(DockerBaseClass):
 
     def compare_to_active(self, other, differences):
         for k in self.__dict__:
-            if k in ('advertise_addr', 'listen_addr', 'rotate_worker_token', 'rotate_manager_token', 'spec'):
+            if k in ('advertise_addr', 'listen_addr', 'force_new_cluster', 'remote_addrs',
+                     'join_token', 'force', 'rotate_worker_token', 'rotate_manager_token', 'spec'):
                 continue
             if self.__dict__[k] is None:
                 continue

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -356,6 +356,10 @@ class TaskParameters(DockerBaseClass):
                 continue
             if self.__dict__[k] != other.__dict__[k]:
                 differences.add(k, parameter=self.__dict__[k], active=other.__dict__[k])
+        if self.rotate_worker_token:
+            differences.add('rotate_worker_token', parameter=True, active=False)
+        if self.rotate_manager_token:
+            differences.add('rotate_manager_token', parameter=True, active=False)
         return differences
 
 


### PR DESCRIPTION
##### SUMMARY
The new idempotency checking introduced in #52895 was not completely good: it also considered options like the `force` parameter, which makes no sense.

This PR also fixes the `rotate_worker_token` and `rotate_manager_token` options, which were ignored so far (except if other parameters changed and `update_swarm()` was called because of them).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
