### PR TITLE
Helm force option, to force update the application

### DIFF
--- a/lib/ansible/modules/cloud/misc/helm.py
+++ b/lib/ansible/modules/cloud/misc/helm.py
@@ -149,7 +149,7 @@ def install(module, tserver):
     installed_release = next(r_matches, None)
     if installed_release:
         if installed_release.chart.metadata.version != chart['version'] or force:
-            tserver.update_release(chartb.get_helm_chart(), dry_run=False
+            tserver.update_release(chartb.get_helm_chart(), dry_run=False,
                                    namespace=namespace, name=name, values=values)
             changed = True
     else:

--- a/lib/ansible/modules/cloud/misc/helm.py
+++ b/lib/ansible/modules/cloud/misc/helm.py
@@ -48,6 +48,7 @@ options:
       - Force upgrade when values are changed
     type: bool
     default: 'no'
+    version_added: '2.8'
   chart:
     description: |
       A map describing the chart to install. See examples for available options.


### PR DESCRIPTION
##### SUMMARY
When you want to upgrade the values of an helm kubernetes package but the version is the same nothing will happen. By adding a force option the packages will be update anyways, and the the new values will be applied.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
helm module

##### ADDITIONAL INFORMATION
By adding the force option it will re-apply the chart changes and customize the chart values. If nothing is changed in the packages, it won't actually change anything on the kubernetes cluster. 

```paste below
- name: Install helm chart
  helm:
    host: localhost
    force: yes
    chart:
      name: memcached
      version: 0.4.0
      source:
        type: repo
        location: https://kubernetes-charts.storage.googleapis.com
    state: installed
    name: my-memcached
    namespace: default
    values:
     persistent:
       enabled: true
```
