### PR TITLE
postgresql_db - fix 40424 issue

### DIFF
--- a/changelogs/fragments/40424_postgresql_db_not_failed_when_dump_err.yml
+++ b/changelogs/fragments/40424_postgresql_db_not_failed_when_dump_err.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_db - the module fails not always when pg_dump errors occured (https://github.com/ansible/ansible/issues/40424).

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -496,7 +496,7 @@ def main():
                 if rc != 0:
                     module.fail_json(msg=stderr, stdout=stdout, rc=rc, cmd=cmd)
 
-                elif stderr and ('FATAL' in stderr or 'ERROR' in stderr):
+                elif stderr and ('FATAL' in str(stderr) or 'ERROR' in str(stderr)):
                     module.fail_json(msg=stderr, stdout=stdout, rc=1, cmd=cmd)
 
                 else:

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -494,13 +494,16 @@ def main():
             try:
                 rc, stdout, stderr, cmd = method(module, target, target_opts, db, **kw)
                 if rc != 0:
-                    module.fail_json(msg=stderr, stdout=stdout, rc=rc, cmd=cmd)
+                    module.fail_json(msg='Dump of database %s failed' % db,
+                                     stdout=stdout, stderr=stderr, rc=rc, cmd=cmd)
 
-                elif stderr and ('FATAL' in str(stderr) or 'ERROR' in str(stderr)):
-                    module.fail_json(msg=stderr, stdout=stdout, rc=1, cmd=cmd)
+                elif stderr and ('FATAL' in stderr or 'ERROR' in stderr):
+                    module.fail_json(msg='Dump of database %s failed' % db,
+                                     stdout=stdout, stderr=stderr, rc=1, cmd=cmd)
 
                 else:
-                    module.exit_json(changed=True, msg=stdout, stderr=stderr, rc=rc, cmd=cmd)
+                    module.exit_json(changed=True, msg='Dump of database %s has been done' % db,
+                                     stdout=stdout, stderr=stderr, rc=rc, cmd=cmd)
             except SQLParseError as e:
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -497,7 +497,7 @@ def main():
                     module.fail_json(msg='Dump of database %s failed' % db,
                                      stdout=stdout, stderr=stderr, rc=rc, cmd=cmd)
 
-                elif stderr and ('FATAL' in str(stderr) or 'ERROR' in str(stderr)):
+                elif stderr:
                     module.fail_json(msg='Dump of database %s failed' % db,
                                      stdout=stdout, stderr=stderr, rc=1, cmd=cmd)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -497,7 +497,7 @@ def main():
                     module.fail_json(msg='Dump of database %s failed' % db,
                                      stdout=stdout, stderr=stderr, rc=rc, cmd=cmd)
 
-                elif stderr:
+                elif stderr and 'warning' not in str(stderr):
                     module.fail_json(msg='Dump of database %s failed' % db,
                                      stdout=stdout, stderr=stderr, rc=1, cmd=cmd)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -497,7 +497,7 @@ def main():
                     module.fail_json(msg='Dump of database %s failed' % db,
                                      stdout=stdout, stderr=stderr, rc=rc, cmd=cmd)
 
-                elif stderr and ('FATAL' in stderr or 'ERROR' in stderr):
+                elif stderr and ('FATAL' in str(stderr) or 'ERROR' in str(stderr)):
                     module.fail_json(msg='Dump of database %s failed' % db,
                                      stdout=stdout, stderr=stderr, rc=1, cmd=cmd)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -495,6 +495,10 @@ def main():
                 rc, stdout, stderr, cmd = method(module, target, target_opts, db, **kw)
                 if rc != 0:
                     module.fail_json(msg=stderr, stdout=stdout, rc=rc, cmd=cmd)
+
+                elif stderr and ('FATAL' in stderr or 'ERROR' in stderr):
+                    module.fail_json(msg=stderr, stdout=stdout, rc=1, cmd=cmd)
+
                 else:
                     module.exit_json(changed=True, msg=stdout, stderr=stderr, rc=rc, cmd=cmd)
             except SQLParseError as e:


### PR DESCRIPTION
##### SUMMARY
fix https://github.com/ansible/ansible/issues/40424

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 ##### ADDITIONAL INFORMATION
It's related to pg_dump bug that I found - it  return rc 0 if there are errors related with pg_hba.conf file.
```
-bash-4.2$ /usr/bin/pg_dump acme --port=5432 --username=postgres|/usr/bin/bzip2 > examplecom-2018-05-18T2334.sql.bz2
pg_dump: [archiver (db)] connection to database "acme" failed: FATAL:  pg_hba.conf rejects connection for host "[local]", user "postgres", database "acme", SSL off
-bash-4.2$ echo $?
0
```
So, we need to parse stderr to catch it.

In other cases, pg_dump returns non zero code as expected.