### PR TITLE
Modify the correct variable when setting available hashing algorithms

### DIFF
--- a/changelogs/fragments/51357-module_utils-basic.yml
+++ b/changelogs/fragments/51357-module_utils-basic.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-    - ansible.module_utils.basic - fix handling of md5 in algorithms tuple for FIPS compatibility (https://github.com/ansible/ansible/issues/51355)

--- a/changelogs/fragments/md5-hash-algorithms-pop-fix.yaml
+++ b/changelogs/fragments/md5-hash-algorithms-pop-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - basic - modify the correct variable when determining available hashing algorithms to avoid errors when md5 is not available (https://github.com/ansible/ansible/issues/51355)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -140,7 +140,7 @@ try:
     try:
         hashlib.md5()
     except ValueError:
-        algorithms.pop('md5', None)
+        AVAILABLE_HASH_ALGORITHMS.pop('md5', None)
 except Exception:
     import sha
     AVAILABLE_HASH_ALGORITHMS = {'sha1': sha.sha}

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -129,12 +129,10 @@ try:
     for attribute in ('available_algorithms', 'algorithms'):
         algorithms = getattr(hashlib, attribute, None)
         if algorithms:
-            # convert algorithms to list instead of immutable tuple so md5 can be removed if not available
-            algorithms = list(algorithms)
             break
     if algorithms is None:
         # python 2.5+
-        algorithms = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+        algorithms = ('md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512')
     for algorithm in algorithms:
         AVAILABLE_HASH_ALGORITHMS[algorithm] = getattr(hashlib, algorithm)
 
@@ -142,7 +140,7 @@ try:
     try:
         hashlib.md5()
     except ValueError:
-        algorithms.remove('md5')
+        algorithms.pop('md5', None)
 except Exception:
     import sha
     AVAILABLE_HASH_ALGORITHMS = {'sha1': sha.sha}


### PR DESCRIPTION
##### SUMMARY

We were modifying the incorrect variable when `md5` was unavailable. That variable is a tuple which has no `.pop()` method. The intended variable to be modified was `AVAILABLE_HASH_ALGORITHMS` which is a dictionary and has a `.pop()` method.

Fixes #51355
Replaces #51357
Reverts c459f040da88004b2fb0faa646cdd6530e99e2fe

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/module_utils/basic.py`
