### PR TITLE
kubevirt: Fix cloud_init in kubevirt_vm

### DIFF
--- a/lib/ansible/module_utils/kubevirt.py
+++ b/lib/ansible/module_utils/kubevirt.py
@@ -255,11 +255,13 @@ class KubeVirtRawModule(KubernetesRawModule):
         if machine_type:
             template_spec['domain']['machine']['type'] = machine_type
 
-        # Define cloud init disk if defined:
-        self._define_cloud_init(cloud_init_nocloud, template_spec)
-
         # Define disks
         self._define_disks(disks, template_spec)
+
+        # Define cloud init disk if defined:
+        # Note, that this must be called after _define_disks, so the cloud_init
+        # is not first in order and it's not used as boot disk:
+        self._define_cloud_init(cloud_init_nocloud, template_spec)
 
         # Define interfaces:
         self._define_interfaces(interfaces, template_spec)

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_vm.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_vm.py
@@ -159,8 +159,8 @@ EXAMPLES = '''
       namespace: vms
       memory: 1024M
       cloud_init_nocloud:
-        #cloud-config
         userData: |-
+          #cloud-config
           password: fedora
           chpasswd: { expire: False }
       disks:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Cloud init definition must be after other volumes definition, so it's not used as boot disk.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kubevirt_vm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
