### PR TITLE
docker_swarm: fix force when state==present

### DIFF
--- a/changelogs/fragments/53003-docker_swarm-force-new-cluster.yml
+++ b/changelogs/fragments/53003-docker_swarm-force-new-cluster.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm - the ``force`` option was ignored when ``state: present``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -253,7 +253,6 @@ class TaskParameters(DockerBaseClass):
 
         self.advertise_addr = None
         self.listen_addr = None
-        self.force_new_cluster = None
         self.remote_addrs = None
         self.join_token = None
 
@@ -352,8 +351,8 @@ class TaskParameters(DockerBaseClass):
 
     def compare_to_active(self, other, differences):
         for k in self.__dict__:
-            if k in ('advertise_addr', 'listen_addr', 'force_new_cluster', 'remote_addrs',
-                     'join_token', 'force', 'rotate_worker_token', 'rotate_manager_token', 'spec'):
+            if k in ('advertise_addr', 'listen_addr', 'remote_addrs', 'join_token',
+                     'rotate_worker_token', 'rotate_manager_token', 'spec'):
                 continue
             if self.__dict__[k] is None:
                 continue
@@ -415,7 +414,7 @@ class SwarmManager(DockerBaseClass):
             return
 
     def init_swarm(self):
-        if self.client.check_if_swarm_manager():
+        if not self.force and self.client.check_if_swarm_manager():
             self.__update_swarm()
             return
 
@@ -423,7 +422,7 @@ class SwarmManager(DockerBaseClass):
             try:
                 self.client.init_swarm(
                     advertise_addr=self.parameters.advertise_addr, listen_addr=self.parameters.listen_addr,
-                    force_new_cluster=self.parameters.force_new_cluster, swarm_spec=self.parameters.spec)
+                    force_new_cluster=self.force, swarm_spec=self.parameters.spec)
             except APIError as exc:
                 self.client.fail("Can not create a new Swarm Cluster: %s" % to_native(exc))
 

--- a/test/integration/targets/docker_swarm/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/basic.yml
@@ -61,6 +61,23 @@
   diff: yes
   register: output_4
 
+- name: Create a Swarm cluster (force re-create)
+  docker_swarm:
+    state: present
+    advertise_addr: "{{ansible_default_ipv4.address}}"
+    force: yes
+  diff: yes
+  register: output_5
+
+- name: Create a Swarm cluster (force re-create, check mode)
+  docker_swarm:
+    state: present
+    advertise_addr: "{{ansible_default_ipv4.address}}"
+    force: yes
+  check_mode: yes
+  diff: yes
+  register: output_6
+
 - name: assert changed when create a new swarm cluster
   assert:
     that:
@@ -79,6 +96,12 @@
        - 'output_4 is not changed'
        - 'output_4.diff.before is defined'
        - 'output_4.diff.after is defined'
+       - 'output_5 is changed'
+       - 'output_5.diff.before is defined'
+       - 'output_5.diff.after is defined'
+       - 'output_6 is changed'
+       - 'output_6.diff.before is defined'
+       - 'output_6.diff.after is defined'
 
 ####################################################################
 ## Removal #########################################################


### PR DESCRIPTION
##### SUMMARY
The documentation claims about the `force` option: `Use with state C(present) to force creating a new Swarm, even if already part of one.`

Unfortunately, that doesn't work:
 1. When the daemon is already in swarm mode, `init_swarm()` will never be called;
 2. The `force_new_cluster` argument of `init_swarm()` is set to `self.parameters.force_new_cluster`, which is only ever set to `None`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
