### PR TITLE
Fix junos terminal regex for cluster srx devices

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -541,12 +541,11 @@ class Connection(NetworkConnectionBase):
         for line in resp.splitlines():
             if command and line.strip() == command.strip():
                 continue
-            ignore_line = False
+
             for prompt in self._matched_prompt.strip().splitlines():
                 if prompt.strip() in line:
-                    ignore_line = True
                     break
-            if not ignore_line:
+            else:
                 cleaned.append(line)
         return b'\n'.join(cleaned).strip()
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -539,9 +539,15 @@ class Connection(NetworkConnectionBase):
         '''
         cleaned = []
         for line in resp.splitlines():
-            if (command and line.strip() == command.strip()) or self._matched_prompt.strip() in line:
+            if command and line.strip() == command.strip():
                 continue
-            cleaned.append(line)
+            ignore_line = False
+            for prompt in self._matched_prompt.strip().splitlines():
+                if prompt.strip() in line:
+                    ignore_line = True
+                    break
+            if not ignore_line:
+                cleaned.append(line)
         return b'\n'.join(cleaned).strip()
 
     def _find_prompt(self, response):

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -32,7 +32,7 @@ display = Display()
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w@+\-\.:\/\[\]]+[>#%] ?$"),
+        re.compile(br"({primary:node\d+})?[\r\n]?[\w@+\-\.:\/\[\]]+[>#%] ?$"),
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #50726

*  Modify junos terminal regex to match for
   string `{primary:node0}` which is also part of the
   prompt.
*  Modify network_cli connection plugin to ignore
   multiple prompt matched lines.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/junos.py
plugins/connection/network_cli.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
