### PR TITLE
Don't document a type for an argument which uses a callable

### DIFF
--- a/lib/ansible/plugins/doc_fragments/k8s_resource_options.py
+++ b/lib/ansible/plugins/doc_fragments/k8s_resource_options.py
@@ -14,7 +14,6 @@ options:
     description:
     - "Provide a valid YAML definition (either as a string, list, or dict) for an object when creating or updating. NOTE: I(kind), I(api_version), I(name),
       and I(namespace) will be overwritten by corresponding values found in the provided I(resource_definition)."
-    type: str
     aliases:
     - definition
     - inline

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -161,9 +161,6 @@ lib/ansible/modules/cloud/google/gcpubsub_facts.py E322
 lib/ansible/modules/cloud/google/gcpubsub_facts.py E324
 lib/ansible/modules/cloud/google/gcpubsub_facts.py E326
 lib/ansible/modules/cloud/google/gcspanner.py E322
-lib/ansible/modules/cloud/kubevirt/kubevirt_preset.py E325
-lib/ansible/modules/cloud/kubevirt/kubevirt_rs.py E325
-lib/ansible/modules/cloud/kubevirt/kubevirt_vm.py E325
 lib/ansible/modules/cloud/linode/linode.py E322
 lib/ansible/modules/cloud/linode/linode.py E324
 lib/ansible/modules/cloud/lxc/lxc_container.py E210
@@ -346,8 +343,6 @@ lib/ansible/modules/clustering/etcd3.py E326
 lib/ansible/modules/clustering/k8s/_kubernetes.py E322
 lib/ansible/modules/clustering/k8s/_kubernetes.py E323
 lib/ansible/modules/clustering/k8s/_kubernetes.py E324
-lib/ansible/modules/clustering/k8s/k8s.py E325
-lib/ansible/modules/clustering/k8s/k8s_scale.py E325
 lib/ansible/modules/clustering/znode.py E326
 lib/ansible/modules/commands/command.py E322
 lib/ansible/modules/commands/command.py E323


### PR DESCRIPTION
##### SUMMARY
Don't document a type for an argument which uses a callable
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/doc_fragments/k8s_resource_options.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```