### PR TITLE
doc - skip/windows for integration tests

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -72,6 +72,11 @@ Platform versions, as specified using the ``--remote`` option with ``/`` removed
 - ``skip/freebsd11.1`` - Skip tests on FreeBSD 11.1.
 - ``skip/rhel7.6`` - Skip tests on RHEL 7.6.
 
+Windows verssions, as specified using the ``--windows`` option can also be skipped:
+
+- ``skip/windows/2008`` - Skip tests on Windows Server 2008.
+- ``skip/windows/2012-R2`` - Skip tests on Windows Server 2012 R2.
+
 Aliases can be used to skip Python major versions using one of the following:
 
 - ``skip/python2`` - Skip tests on Python 2.x.


### PR DESCRIPTION
##### SUMMARY
Document the ability to skip Windows versions in integration tests.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs