### PR TITLE
Fix error KeyError: LaunchTemplate on terminating instances.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -625,14 +625,13 @@ def get_properties(autoscaling_group):
 
         properties['instances'] = [i['InstanceId'] for i in autoscaling_group_instances]
         for i in autoscaling_group_instances:
-            if i.get('LaunchConfigurationName'):
-                instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
-                                                   'lifecycle_state': i['LifecycleState'],
-                                                   'launch_config_name': i['LaunchConfigurationName']}
-            else:
-                instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
-                                                   'lifecycle_state': i['LifecycleState'],
-                                                   'launch_template': i['LaunchTemplate']}
+            instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
+                                               'lifecycle_state': i['LifecycleState']}
+            if 'LaunchConfigurationName' in i:
+                instance_facts[i['InstanceId']]['launch_config_name'] = i['LaunchConfigurationName']
+            elif 'LaunchTemplate' in i:
+                instance_facts[i['InstanceId']]['launch_template'] = i['LaunchTemplate']
+
             if i['HealthStatus'] == 'Healthy' and i['LifecycleState'] == 'InService':
                 properties['viable_instances'] += 1
             if i['HealthStatus'] == 'Healthy':


### PR DESCRIPTION
This isn't an either-or situation; a node may have neither a LC nor a LT.

##### SUMMARY
A recent change to this module seems to have made the incorrect assumption that autoscaling instances will always have either a LaunchConfigurationName or a LaunchTemplate. This is not true; terminating instances have neither:

```json
        {
            "ProtectedFromScaleIn": false,
            "AvailabilityZone": "us-west-2b",
            "InstanceId": "i-0628a417c2a36c37b",
            "AutoScalingGroupName": "D01-egress-proxy-asg",
            "HealthStatus": "UNHEALTHY",
            "LifecycleState": "Terminating"
        },
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_asg

##### ADDITIONAL INFORMATION

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'LaunchTemplate' fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):
  File \"<stdin>\", line 114, in <module>
  File \"<stdin>\", line 106, in _ansiballz_main
  File \"<stdin>\", line 49, in invoke_module
  File \"/tmp/ansible_ec2_asg_payload_hT8HoF/__main__.py\", line 1672, in <module>
  File\"/tmp/ansible_ec2_asg_payload_hT8HoF/__main__.py\", line 1658, in main
  File \"/tmp/ansible_ec2_asg_payload_hT8HoF/__main__.py\", line 1022, in create_autoscaling_group
  File \"/tmp/ansible_ec2_asg_payload_hT8HoF/__main__.py\", line 635, in get_properties
KeyError: 'LaunchTemplate'
", "module_stdout": "", "msg": "MODULE FAILURE
See stdout/stderr for the exact error", "rc": 1}
```
