### PR TITLE
Fix ec2_asg_facts so it doesn't fail  …

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -363,7 +363,8 @@ def find_asgs(conn, module, name=None, tags=None):
         if matched_name and matched_tags:
             asg = camel_dict_to_snake_dict(asg)
             # compatibility with ec2_asg module
-            asg['launch_config_name'] = asg['launch_configuration_name']
+            if 'launch_configuration_name' in asg:
+                asg['launch_config_name'] = asg['launch_configuration_name']
             # workaround for https://github.com/ansible/ansible/pull/25015
             if 'target_group_ar_ns' in asg:
                 asg['target_group_arns'] = asg['target_group_ar_ns']


### PR DESCRIPTION
when using templates instead of configurations

##### SUMMARY
ec2_asg_facts attempts to create a key `launch_config_name` based off `launch_configuration_name`, but `launch_configuration_name` doesn't exist when launch templates are being used instead of launch configurations.  With this (one-line) patch, the module no longer attempts to create `launch_config_name` when `launch_configuration_name` doesn't exist

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_asg_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
fatal: [...]
File "/var/folders/pp/6dsttjzx4mb2sk3brgmc26s8trsq7b/T/ansible_pv_ec2_asg_facts_payload_fgl__3j1/__main__.py", line 366, in find_asgs
[...]
KeyError: 'launch_template_id'
```
after: module doesn't fail
