### PR TITLE
New FortiManager Module: fmgr_fwobj_ippool6

### DIFF
--- a/lib/ansible/modules/network/fortimanager/fmgr_fwobj_ippool6.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwobj_ippool6.py
@@ -122,7 +122,7 @@ RETURN = """
 api_result:
   description: full API response, includes status code and message
   returned: always
-  type: string
+  type: str
 """
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
@@ -130,12 +130,10 @@ from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
 from ansible.module_utils.network.fortimanager.common import FMGBaseException
 from ansible.module_utils.network.fortimanager.common import FMGRCommon
-from ansible.module_utils.network.fortimanager.common import FMGRMethods
 from ansible.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
 from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
 from ansible.module_utils.network.fortimanager.common import prepare_dict
 from ansible.module_utils.network.fortimanager.common import scrub_dict
-
 
 
 def fmgr_fwobj_ippool6_modify(fmgr, paramgram):

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwobj_ippool6.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwobj_ippool6.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fmgr_fwobj_ippool6
+version_added: "2.8"
+notes:
+    - Full Documentation at U(https://ftnt-ansible-docs.readthedocs.io/en/latest/).
+author:
+    - Luke Weighall (@lweighall)
+    - Andrew Welsh (@Ghilli3)
+    - Jim Huber (@p4r4n0y1ng)
+short_description: Allows the editing of IP Pool Objects within FortiManager.
+description:
+  -  Allows users to add/edit/delete IPv6 Pool Objects.
+
+options:
+  adom:
+    description:
+      - The ADOM the configuration should belong to.
+    required: false
+    default: root
+
+  mode:
+    description:
+      - Sets one of three modes for managing the object.
+      - Allows use of soft-adds instead of overwriting existing values
+    choices: ['add', 'set', 'delete', 'update']
+    required: false
+    default: add
+
+  startip:
+    description:
+      - First IPv6 address (inclusive) in the range for the address pool.
+    required: false
+
+  name:
+    description:
+      - IPv6 IP pool name.
+    required: false
+
+  endip:
+    description:
+      - Final IPv6 address (inclusive) in the range for the address pool.
+    required: false
+
+  comments:
+    description:
+      - Comment.
+    required: false
+
+  dynamic_mapping:
+    description:
+      - EXPERTS ONLY! KNOWLEDGE OF FMGR JSON API IS REQUIRED!
+      - List of multiple child objects to be added. Expects a list of dictionaries.
+      - Dictionaries must use FortiManager API parameters, not the ansible ones listed below.
+      - If submitted, all other prefixed sub-parameters ARE IGNORED.
+      - This object is MUTUALLY EXCLUSIVE with its options.
+      - We expect that you know what you are doing with these list parameters, and are leveraging the JSON API Guide.
+      - WHEN IN DOUBT, USE THE SUB OPTIONS BELOW INSTEAD TO CREATE OBJECTS WITH MULTIPLE TASKS
+    required: false
+
+  dynamic_mapping_comments:
+    description:
+      - Dynamic Mapping clone of original suffixed parameter.
+    required: false
+
+  dynamic_mapping_endip:
+    description:
+      - Dynamic Mapping clone of original suffixed parameter.
+    required: false
+
+  dynamic_mapping_startip:
+    description:
+      - Dynamic Mapping clone of original suffixed parameter.
+    required: false
+
+
+'''
+
+EXAMPLES = '''
+- name: ADD FMGR_FIREWALL_IPPOOL6
+  fmgr_firewall_ippool6:
+    mode: "add"
+    adom: "ansible"
+    startip:
+    name: "IPv6 IPPool"
+    endip:
+    comments: "Created by Ansible"
+
+- name: DELETE FMGR_FIREWALL_IPPOOL6
+  fmgr_firewall_ippool6:
+    mode: "delete"
+    adom: "ansible"
+    name: "IPv6 IPPool"
+'''
+
+RETURN = """
+api_result:
+  description: full API response, includes status code and message
+  returned: always
+  type: string
+"""
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
+from ansible.module_utils.network.fortimanager.common import FMGBaseException
+from ansible.module_utils.network.fortimanager.common import FMGRCommon
+from ansible.module_utils.network.fortimanager.common import FMGRMethods
+from ansible.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible.module_utils.network.fortimanager.common import prepare_dict
+from ansible.module_utils.network.fortimanager.common import scrub_dict
+
+
+
+def fmgr_fwobj_ippool6_modify(fmgr, paramgram):
+    """
+    :param fmgr: The fmgr object instance from fortimanager.py
+    :type fmgr: class object
+    :param paramgram: The formatted dictionary of options to process
+    :type paramgram: dict
+    :return: The response from the FortiManager
+    :rtype: dict
+    """
+
+    mode = paramgram["mode"]
+    adom = paramgram["adom"]
+    # INIT A BASIC OBJECTS
+    response = DEFAULT_RESULT_OBJ
+    url = ""
+    datagram = {}
+
+    # EVAL THE MODE PARAMETER FOR SET OR ADD
+    if mode in ['set', 'add', 'update']:
+        url = '/pm/config/adom/{adom}/obj/firewall/ippool6'.format(adom=adom)
+        datagram = scrub_dict(prepare_dict(paramgram))
+
+    # EVAL THE MODE PARAMETER FOR DELETE
+    elif mode == "delete":
+        # SET THE CORRECT URL FOR DELETE
+        url = '/pm/config/adom/{adom}/obj/firewall/ippool6/{name}'.format(adom=adom, name=paramgram["name"])
+        datagram = {}
+
+    response = fmgr.process_request(url, datagram, paramgram["mode"])
+    return response
+
+
+def main():
+    argument_spec = dict(
+        adom=dict(type="str", default="root"),
+        mode=dict(choices=["add", "set", "delete", "update"], type="str", default="add"),
+        startip=dict(required=False, type="str"),
+        name=dict(required=False, type="str"),
+        endip=dict(required=False, type="str"),
+        comments=dict(required=False, type="str"),
+        dynamic_mapping=dict(required=False, type="list"),
+        dynamic_mapping_comments=dict(required=False, type="str"),
+        dynamic_mapping_endip=dict(required=False, type="str"),
+        dynamic_mapping_startip=dict(required=False, type="str"),
+
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False, )
+    # MODULE PARAMGRAM
+    paramgram = {
+        "mode": module.params["mode"],
+        "adom": module.params["adom"],
+        "startip": module.params["startip"],
+        "name": module.params["name"],
+        "endip": module.params["endip"],
+        "comments": module.params["comments"],
+        "dynamic_mapping": {
+            "comments": module.params["dynamic_mapping_comments"],
+            "endip": module.params["dynamic_mapping_endip"],
+            "startip": module.params["dynamic_mapping_startip"],
+        }
+    }
+    module.paramgram = paramgram
+    fmgr = None
+    if module._socket_path:
+        connection = Connection(module._socket_path)
+        fmgr = FortiManagerHandler(connection, module)
+        fmgr.tools = FMGRCommon()
+    else:
+        module.fail_json(**FAIL_SOCKET_MSG)
+
+    list_overrides = ['dynamic_mapping']
+    paramgram = fmgr.tools.paramgram_child_list_override(list_overrides=list_overrides,
+                                                         paramgram=paramgram, module=module)
+
+    results = DEFAULT_RESULT_OBJ
+
+    try:
+        results = fmgr_fwobj_ippool6_modify(fmgr, paramgram)
+        fmgr.govern_response(module=module, results=results,
+                             ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))
+
+    except Exception as err:
+        raise FMGBaseException(err)
+
+    return module.exit_json(**results[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/test/units/modules/network/fortimanager/fixtures/test_fmgr_fwobj_ippool6.json
+++ b/test/units/modules/network/fortimanager/fixtures/test_fmgr_fwobj_ippool6.json
@@ -1,57 +1,57 @@
 {
-   "fmgr_fwobj_ippool6_modify": [
-      {
-         "paramgram_used": {
-            "endip": null, 
-            "name": "IPv6 IPPool", 
-            "adom": "ansible", 
-            "startip": null, 
-            "dynamic_mapping": {
-               "startip": null, 
-               "endip": null, 
-               "comments": null
-            }, 
-            "comments": null, 
-            "mode": "delete"
-         }, 
-         "datagram_sent": {}, 
-         "raw_response": {
-            "status": {
-               "message": "OK", 
-               "code": 0
-            }, 
-            "url": "/pm/config/adom/ansible/obj/firewall/ippool6/IPv6 IPPool"
-         }, 
-         "post_method": "delete"
-      }, 
-      {
-         "raw_response": {
-            "status": {
-               "message": "OK", 
-               "code": 0
-            }, 
-            "url": "/pm/config/adom/ansible/obj/firewall/ippool6"
-         }, 
-         "datagram_sent": {
-            "startip": "fd30:fc67:cb18:ae44::aaaa:aaaa", 
-            "endip": "fd30:fc67:cb18:ae44::ffff:ffff", 
-            "name": "IPv6 IPPool", 
-            "comments": "Created by Ansible"
-         }, 
-         "paramgram_used": {
-            "endip": "fd30:fc67:cb18:ae44::ffff:ffff", 
-            "name": "IPv6 IPPool", 
-            "adom": "ansible", 
-            "startip": "fd30:fc67:cb18:ae44::aaaa:aaaa", 
-            "dynamic_mapping": {
-               "startip": null, 
-               "endip": null, 
-               "comments": null
-            }, 
-            "comments": "Created by Ansible", 
-            "mode": "add"
-         }, 
-         "post_method": "add"
-      }
-   ]
+    "fmgr_fwobj_ippool6_modify": [
+        {
+            "paramgram_used": {
+                "endip": null,
+                "name": "IPv6 IPPool",
+                "adom": "ansible",
+                "startip": null,
+                "dynamic_mapping": {
+                    "startip": null,
+                    "endip": null,
+                    "comments": null
+                },
+                "comments": null,
+                "mode": "delete"
+            },
+            "datagram_sent": {},
+            "raw_response": {
+                "status": {
+                    "message": "OK",
+                    "code": 0
+                },
+                "url": "/pm/config/adom/ansible/obj/firewall/ippool6/IPv6 IPPool"
+            },
+            "post_method": "delete"
+        },
+        {
+            "raw_response": {
+                "status": {
+                    "message": "OK",
+                    "code": 0
+                },
+                "url": "/pm/config/adom/ansible/obj/firewall/ippool6"
+            },
+            "datagram_sent": {
+                "startip": "fd30:fc67:cb18:ae44::aaaa:aaaa",
+                "endip": "fd30:fc67:cb18:ae44::ffff:ffff",
+                "name": "IPv6 IPPool",
+                "comments": "Created by Ansible"
+            },
+            "paramgram_used": {
+                "endip": "fd30:fc67:cb18:ae44::ffff:ffff",
+                "name": "IPv6 IPPool",
+                "adom": "ansible",
+                "startip": "fd30:fc67:cb18:ae44::aaaa:aaaa",
+                "dynamic_mapping": {
+                    "startip": null,
+                    "endip": null,
+                    "comments": null
+                },
+                "comments": "Created by Ansible",
+                "mode": "add"
+            },
+            "post_method": "add"
+        }
+    ]
 }

--- a/test/units/modules/network/fortimanager/fixtures/test_fmgr_fwobj_ippool6.json
+++ b/test/units/modules/network/fortimanager/fixtures/test_fmgr_fwobj_ippool6.json
@@ -1,0 +1,57 @@
+{
+   "fmgr_fwobj_ippool6_modify": [
+      {
+         "paramgram_used": {
+            "endip": null, 
+            "name": "IPv6 IPPool", 
+            "adom": "ansible", 
+            "startip": null, 
+            "dynamic_mapping": {
+               "startip": null, 
+               "endip": null, 
+               "comments": null
+            }, 
+            "comments": null, 
+            "mode": "delete"
+         }, 
+         "datagram_sent": {}, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/pm/config/adom/ansible/obj/firewall/ippool6/IPv6 IPPool"
+         }, 
+         "post_method": "delete"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/pm/config/adom/ansible/obj/firewall/ippool6"
+         }, 
+         "datagram_sent": {
+            "startip": "fd30:fc67:cb18:ae44::aaaa:aaaa", 
+            "endip": "fd30:fc67:cb18:ae44::ffff:ffff", 
+            "name": "IPv6 IPPool", 
+            "comments": "Created by Ansible"
+         }, 
+         "paramgram_used": {
+            "endip": "fd30:fc67:cb18:ae44::ffff:ffff", 
+            "name": "IPv6 IPPool", 
+            "adom": "ansible", 
+            "startip": "fd30:fc67:cb18:ae44::aaaa:aaaa", 
+            "dynamic_mapping": {
+               "startip": null, 
+               "endip": null, 
+               "comments": null
+            }, 
+            "comments": "Created by Ansible", 
+            "mode": "add"
+         }, 
+         "post_method": "add"
+      }
+   ]
+}

--- a/test/units/modules/network/fortimanager/test_fmgr_fwobj_ippool6.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_fwobj_ippool6.py
@@ -47,7 +47,7 @@ def module_mock(mocker):
 
 @pytest.fixture(autouse=True)
 def connection_mock(mocker):
-    connection_class_mock = mocker.patch('ansible.modules.network.fortimanager.fmgr_device.Connection')
+    connection_class_mock = mocker.patch('ansible.modules.network.fortimanager.fmgr_fwobj_ippool6.Connection')
     return connection_class_mock
 
 
@@ -61,28 +61,8 @@ fmg_instance = FortiManagerHandler(connection_mock, module_mock)
 
 
 def test_fmgr_fwobj_ippool6_modify(fixture_data, mocker):
-    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
                  side_effect=fixture_data)
-    #  Fixture sets used:###########################
-
-    ##################################################
-    # endip: None
-    # name: IPv6 IPPool
-    # adom: ansible
-    # startip: None
-    # dynamic_mapping: {'startip': None, 'endip': None, 'comments': None}
-    # comments: None
-    # mode: delete
-    ##################################################
-    ##################################################
-    # endip: fd30:fc67:cb18:ae44::ffff:ffff
-    # name: IPv6 IPPool
-    # adom: ansible
-    # startip: fd30:fc67:cb18:ae44::aaaa:aaaa
-    # dynamic_mapping: {'startip': None, 'endip': None, 'comments': None}
-    # comments: Created by Ansible
-    # mode: add
-    ##################################################
 
     # Test using fixture 1 #
     output = fmgr_fwobj_ippool6.fmgr_fwobj_ippool6_modify(fmg_instance, fixture_data[0]['paramgram_used'])

--- a/test/units/modules/network/fortimanager/test_fmgr_fwobj_ippool6.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_fwobj_ippool6.py
@@ -1,0 +1,92 @@
+# Copyright 2018 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+from ansible.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
+import pytest
+
+try:
+    from ansible.modules.network.fortimanager import fmgr_fwobj_ippool6
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+def load_fixtures():
+    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures') + "/{filename}.json".format(
+        filename=os.path.splitext(os.path.basename(__file__))[0])
+    try:
+        with open(fixture_path, "r") as fixture_file:
+            fixture_data = json.load(fixture_file)
+    except IOError:
+        return []
+    return [fixture_data]
+
+
+@pytest.fixture(autouse=True)
+def module_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.module_utils.basic.AnsibleModule')
+    return connection_class_mock
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortimanager.fmgr_device.Connection')
+    return connection_class_mock
+
+
+@pytest.fixture(scope="function", params=load_fixtures())
+def fixture_data(request):
+    func_name = request.function.__name__.replace("test_", "")
+    return request.param.get(func_name, None)
+
+
+fmg_instance = FortiManagerHandler(connection_mock, module_mock)
+
+
+def test_fmgr_fwobj_ippool6_modify(fixture_data, mocker):
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+                 side_effect=fixture_data)
+    #  Fixture sets used:###########################
+
+    ##################################################
+    # endip: None
+    # name: IPv6 IPPool
+    # adom: ansible
+    # startip: None
+    # dynamic_mapping: {'startip': None, 'endip': None, 'comments': None}
+    # comments: None
+    # mode: delete
+    ##################################################
+    ##################################################
+    # endip: fd30:fc67:cb18:ae44::ffff:ffff
+    # name: IPv6 IPPool
+    # adom: ansible
+    # startip: fd30:fc67:cb18:ae44::aaaa:aaaa
+    # dynamic_mapping: {'startip': None, 'endip': None, 'comments': None}
+    # comments: Created by Ansible
+    # mode: add
+    ##################################################
+
+    # Test using fixture 1 #
+    output = fmgr_fwobj_ippool6.fmgr_fwobj_ippool6_modify(fmg_instance, fixture_data[0]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 2 #
+    output = fmgr_fwobj_ippool6.fmgr_fwobj_ippool6_modify(fmg_instance, fixture_data[1]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A new module for FortiManager to control IP Pool Firewall Objects for IPv6.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
fmgr_fwobj_ippool6.py
test_fmgr_fwobj_ippool6.py
test_fmgr_fwobj_ippool6.json
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
