### PR TITLE
Revert "use get_options instead of play_context for user"

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -125,26 +125,6 @@ DOCUMENTATION = """
         ini:
           - section: defaults
             key: use_persistent_connections
-      port:
-        description:
-            - Port on which ssh server is listening on
-        default: 22
-        type: int
-        vars:
-            - name: ansible_port
-            - name: ansible_ssh_port
-            - name: ansible_paramiko_port
-              version_added: '2.8'
-        env:
-          - name: ANSIBLE_REMOTE_PORT
-          - name: ANSIBLE_PARAMIKO_REMOTE_PORT
-            version_added: '2.8'
-        ini:
-          - key: remote_port
-            section: defaults
-          - key: remote_port
-            section: paramiko_connection
-            version_added: '2.8'
 # TODO:
 #timeout=self._play_context.timeout,
 """
@@ -162,6 +142,7 @@ from termios import tcflush, TCIFLUSH
 from distutils.version import LooseVersion
 from binascii import hexlify
 
+from ansible import constants as C
 from ansible.errors import (
     AnsibleAuthenticationFailure,
     AnsibleConnectionFailure,
@@ -264,7 +245,7 @@ class Connection(ConnectionBase):
     _log_channel = None
 
     def _cache_key(self):
-        return "%s__%s__" % (self._play_context.remote_addr, self.get_option('remote_user'))
+        return "%s__%s__" % (self._play_context.remote_addr, self._play_context.remote_user)
 
     def _connect(self):
         cache_key = self._cache_key()
@@ -309,7 +290,7 @@ class Connection(ConnectionBase):
             replacers = {
                 '%h': self._play_context.remote_addr,
                 '%p': port,
-                '%r': self.get_option('remote_user')
+                '%r': self._play_context.remote_user
             }
             for find, replace in replacers.items():
                 proxy_command = proxy_command.replace(find, str(replace))
@@ -329,8 +310,8 @@ class Connection(ConnectionBase):
         if not HAVE_PARAMIKO:
             raise AnsibleError("paramiko is not installed: %s" % to_native(PARAMIKO_IMP_ERR))
 
-        port = self.get_option('port')
-        display.vvv("ESTABLISH PARAMIKO SSH CONNECTION FOR USER: %s on PORT %s TO %s" % (self.get_option('remote_user'), port, self._play_context.remote_addr),
+        port = self._play_context.port or 22
+        display.vvv("ESTABLISH PARAMIKO SSH CONNECTION FOR USER: %s on PORT %s TO %s" % (self._play_context.remote_user, port, self._play_context.remote_addr),
                     host=self._play_context.remote_addr)
 
         ssh = paramiko.SSHClient()
@@ -371,7 +352,7 @@ class Connection(ConnectionBase):
 
             ssh.connect(
                 self._play_context.remote_addr.lower(),
-                username=self.get_option('remote_user'),
+                username=self._play_context.remote_user,
                 allow_agent=allow_agent,
                 look_for_keys=self.get_option('look_for_keys'),
                 key_filename=key_filename,
@@ -391,7 +372,7 @@ class Connection(ConnectionBase):
                 raise AnsibleError("paramiko version issue, please upgrade paramiko on the machine running ansible")
             elif u"Private key file is encrypted" in msg:
                 msg = 'ssh %s@%s:%s : %s\nTo connect as a different user, use -u <username>.' % (
-                    self.get_option('remote_user'), self._play_context.remote_addr, port, msg)
+                    self._play_context.remote_user, self._play_context.remote_addr, port, msg)
                 raise AnsibleConnectionFailure(msg)
             else:
                 raise AnsibleConnectionFailure(msg)
@@ -444,7 +425,7 @@ class Connection(ConnectionBase):
                     display.debug("chunk is: %s" % chunk)
                     if not chunk:
                         if b'unknown user' in become_output:
-                            raise AnsibleError('user %s does not exist' % self._.become_user)
+                            raise AnsibleError('user %s does not exist' % self._play_context.become_user)
                         else:
                             break
                             # raise AnsibleError('ssh connection closed waiting for password prompt')
@@ -498,7 +479,7 @@ class Connection(ConnectionBase):
 
     def _connect_sftp(self):
 
-        cache_key = "%s__%s__" % (self._play_context.remote_addr, self.get_option('remote_user'))
+        cache_key = "%s__%s__" % (self._play_context.remote_addr, self._play_context.remote_user)
         if cache_key in SFTP_CONNECTION_CACHE:
             return SFTP_CONNECTION_CACHE[cache_key]
         else:


### PR DESCRIPTION
Reverts ansible/ansible#52604

network connections fail as they don't source the correct variables for the 'sub connection'