### PR TITLE
Onesixtyone inventory plugin (Fixes #41443)

### DIFF
--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -62,7 +62,6 @@ import subprocess
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import is_executable
 from ansible.module_utils.common.process import get_bin_path
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2019, Victor da Costa <vdacosta@redhat.com>
-# Copyright (c) 2019 Ansible Project
+# Copyright (c) 2019, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -8,16 +8,17 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: onesixtyone
     plugin_type: inventory
-    version_added: "2.9"
-    short_description: Uses onesityone to find hosts to target
+    version_added: "2.8"
+    short_description: Uses onesixtyone to find hosts to target
     description:
-        - Uses a YAML configuration file with a valid YAML extension.
+        - Uses any YAML file which ends with onesixtyone.yml or onesixtyone.yaml as a configuration file.
     extends_documentation_fragment:
       - constructed
       - inventory_cache
     requirements:
       - onesixtyone CLI installed
       - python-gevent installed
+      - netaddr python library installed
     options:
         addresses:
             description: List of CIDRs and IPs to scan.
@@ -43,7 +44,7 @@ DOCUMENTATION = '''
           required: false
     notes:
       - Only discover devices running SNMPv2.
-      - TODO: Add cache support.
+      - TODO: Add caching support.
 '''
 EXAMPLES = '''
     # onesixtyone.yaml or any other YAML file-extension
@@ -52,7 +53,6 @@ EXAMPLES = '''
     addresses:
       - 192.168.0.0/24
 '''
-
 
 import os
 import re
@@ -65,18 +65,21 @@ from ansible.module_utils._text import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
 try:
-  import gevent
-  from gevent import socket
+    from netaddr import IPSet
 except:
-  raise Exception('this inventory plugin requires the gevent library. Try: yum install python-gevent')
+    raise AnsibleParserError('this inventory plugin requires the netapp library. Try: pip install netaddr')
+
+try:
+    import gevent
+    from gevent import socket
+except:
+    raise AnsibleParserError('this inventory plugin requires the gevent library. Try: yum install python-gevent')
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
-
     NAME = 'onesixtyone'
 
     def __init__(self):
-
         self._onesixtyone = None
         for path in os.environ.get('PATH').split(':'):
             candidate = os.path.join(path, 'onesixtyone')
@@ -87,30 +90,33 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).__init__()
 
     def verify_file(self, path):
+        """ Verify the existence of plugin's configuration file """
+        if not super(InventoryModule, self).verify_file(path):
+            return False
 
-        if super(InventoryModule, self).verify_file(path):
-          for fn in ('onesixtyone'):
-              for suffix in ('yaml', 'yml'):
-                  maybe = '{fn}.{suffix}'.format(fn=fn, suffix=suffix)
-                  if path.endswith(maybe):
-                      return True
-
-        return False
+        for suffix in ('yaml', 'yml'):
+            maybe = '{fn}.{suffix}'.format(fn=self.NAME, suffix=suffix)
+            if path.endswith(maybe):
+                return True
 
     def parse(self, inventory, loader, path, cache=False):
         super(InventoryModule, self).parse(inventory, loader, path, cache=cache)
         self._read_config_data(path)
 
         try:
-          jobs = [ gevent.spawn(self._add_device, self, device) for device in self._discovery() ]
-          gevent.joinall(jobs, timeout=20)
+            # Using gevent to pallelize reverse dns lookups and adding entries to inventory
+            jobs = [gevent.spawn(self._add_device, self, device) for device in self._discovery()]
+            gevent.joinall(jobs, timeout=20)
 
         except Exception as e:
             raise AnsibleParserError("failed to parse %s: %s " % (to_native(path), to_native(e)))
 
     def _match_platform(self, text):
-        ''' Matches platforms against text in sysDescr
-        '''
+        """ Matches platforms against text in sysDescr and return the platform.
+
+        Keyword arguments:
+        text -- sysdescr text
+        """
         platforms = {
             'asa': re.compile(r'^Cisco\sAdaptive\sSecurity\sAppliance'),
             'ios': re.compile(r'^Cisco\sIOS\sSoftware'),
@@ -121,16 +127,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'aruba': re.compile(r'^Aruba\sOperating\sSystem\sSoftware'),
             'eos': re.compile(r'^Arista')
         }
-
         platforms.update(self.get_option('platform'))
 
         for platform, rule in platforms.items():
             if rule.match(text):
-              return platform
-        
+                return platform
+
         return 'unknown'
 
     def _discovery(self):
+        """ Run onesixtyone and parse the output to extract host, community and sysdescr """
         if self._onesixtyone is None:
             raise AnsibleParserError('onesixtyone inventory plugin requires the onesixtyone cli tool to work')
 
@@ -142,62 +148,94 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # Create communities temporary file
         with tempfile.NamedTemporaryFile() as communities_tempfile:
-          communities = self._options.get("communities")
-          communities_tempfile.write("\n".join(communities) + "\n")
-          communities_tempfile.flush()
-          cmd.append('-c')
-          cmd.append(communities_tempfile.name)
+            communities = self._options.get("communities")
+            [communities_tempfile.write("%s\n" % community) for community in communities]
+            communities_tempfile.flush()
 
-          # Create hosts temporary file
-          with tempfile.NamedTemporaryFile() as addresses_tempfile:
-            addresses = self.get_option("addresses")
-            addresses_tempfile.write("\n".join(addresses) + "\n")
-            addresses_tempfile.flush()
-            cmd.append('-i')
-            cmd.append(addresses_tempfile.name)
+            # add command-line option -c
+            cmd.append('-c')
+            cmd.append(communities_tempfile.name)
 
-            cmd.append('-w')
-            cmd.append("%s" % self.get_option("wait"))
+            # Create hosts temporary file
+            with tempfile.NamedTemporaryFile() as addresses_tempfile:
+                addresses = self.get_option("addresses")
+                [addresses_tempfile.write("%s\n" % ip) for ip in IPSet(addresses)]
+                addresses_tempfile.flush()
 
-            self.display.vvv("command: {cmd})".format(cmd=cmd))
+                # add command-line option -i
+                cmd.append('-i')
+                cmd.append(addresses_tempfile.name)
 
-            # execute
-            try:
-              cmd_output = subprocess.check_output(" ".join(cmd), stderr=subprocess.STDOUT, shell=True)
+                # add command-line option -w
+                cmd.append('-w')
+                cmd.append("%s" % self.get_option("wait"))
 
-            except subprocess.CalledProcessError as p:
-                raise AnsibleParserError('Failed to run onesixtyone, rc=%s: %s' % (p.returncode, to_native(p.output)))
+                cmd_string = " ".join(cmd)
 
-            # parse command output
-            entries = []
-            matches = None
-            for line in cmd_output.splitlines():
-              self.display.vvv("output (line): {output}".format(output=line))
-              matches = find_entry.match(line)
-              if matches is not None:
-                entries.append({
-                  'host': matches.group(1),
-                  'community': matches.group(2),
-                  'sysdescr': matches.group(3),
-                })
+                # execute
+                try:
+                    self.display.vvv("running command: {cmd}".format(cmd=cmd_string))
+                    cmd_output = subprocess.check_output(cmd_string, stderr=subprocess.STDOUT, shell=True)
+
+                except subprocess.CalledProcessError as p:
+                    raise AnsibleParserError('Failed to run onesixtyone, rc=%s: %s' % (p.returncode, to_native(p.output)))
+
+                # parse command output
+                entries = []
+                matches = None
+
+                for line in cmd_output.splitlines():
+                    self.display.vvv("parsing output line: {line}".format(line=line))
+                    matches = find_entry.match(line)
+                    if matches is not None:
+                        entries.append({
+                            'host': matches.group(1),
+                            'community': matches.group(2),
+                            'sysdescr': matches.group(3),
+                        })
 
         return entries
 
     @staticmethod
     def _add_device(obj, device):
+        """ Match the sysdescr text against known platforms and add to the inventory.
 
-      # Inventory Group
-      platform = obj._match_platform(device.get('sysdescr'))
-      obj.display.vvv("platform: {platform}".format(platform=platform))
+        Keyword arguments:
+        obj -- InventoryModule object
+        device -- the entry containing the keys: host, community and sysdescr.
+        """
+        # Inventory Group
+        platform = obj._match_platform(device.get('sysdescr'))
+        obj.display.vvv("platform identified as `{platform}`".format(platform=platform))
 
-      obj.inventory.add_group(platform)
-      obj.inventory.set_variable(platform, 'ansible_network_os', platform)
+        obj.display.vvv("creating group `{group}`".format(group=platform))
+        obj.inventory.add_group(platform)
 
-      # Inventory Host
-      ansible_host = device.get('host')
-      host = socket.gethostbyaddr(ansible_host)[0] or ansible_host
-      obj.display.vvv("host: {host}".format(host=host))
-      obj.inventory.add_host(host, group=platform)
-      obj.inventory.set_variable(host, 'ansible_host', ansible_host)
-      obj.inventory.set_variable(host, 'snmp_community', device.get('community'))
-      obj.inventory.set_variable(host, 'snmp_sysdescr', device.get('sysdescr'))
+        obj.display.vvv("setting group {group} variable `ansible_network_os: \"{group}\"`".format(group=platform))
+        obj.inventory.set_variable(platform, 'ansible_network_os', platform)
+
+        # Inventory Host
+        ansible_host = device.get('host')
+        snmp_community = device.get('community')
+        snmp_sysdescr = device.get('sysdescr')
+
+        try:
+            host = socket.gethostbyaddr(ansible_host)[0]
+            if host.endswith('.in-addr.arpa'):
+                obj.display.vvv("Reverse DNS for host {host} contains 'in-addr.arpa', using {ansible_host}`".format(host=host, ansible_host=ansible_host))
+                host = ansible_host
+        except Exception:
+            obj.display.vvv("Reverse DNS does not exists for host `{host}`, using {ansible_host}".format(host=host, ansible_host=ansible_host))
+            host = ansible_host
+
+        obj.display.vvv("adding {host} to {group}".format(host=host, group=platform))
+        obj.inventory.add_host(host, group=platform)
+
+        obj.display.vvv("setting host {host} variable `ansible_host: \"{ansible_host}\"`".format(host=host, ansible_host=ansible_host))
+        obj.inventory.set_variable(host, 'ansible_host', ansible_host)
+
+        obj.display.vvv("setting host {host} variable `snmp_community: \"{snmp_community}\"`".format(host=host, snmp_community=snmp_community))
+        obj.inventory.set_variable(host, 'snmp_community', snmp_community)
+
+        obj.display.vvv("setting host {host} variable `snmp_sysdescr: \"{snmp_sysdescr}\"`".format(host=host, snmp_sysdescr=snmp_sysdescr))
+        obj.inventory.set_variable(host, 'snmp_sysdescr', snmp_sysdescr)

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -36,7 +36,7 @@ DOCUMENTATION = '''
           type: int
           default: 10
           required: false
-        platforms:
+        platform:
           description: Dict containing additional mappings between Platform (key) and regex to match in sysDescr (value).
           type: dict
           default: {}
@@ -122,7 +122,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'eos': re.compile(r'^Arista')
         }
 
-        platforms.update(self.get_option('platforms'))
+        platforms.update(self.get_option('platform'))
 
         for platform, rule in platforms.items():
             if rule.match(text):

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2019, Victor da Costa <vdacosta@redhat.com>
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: onesixtyone
+    plugin_type: inventory
+    version_added: "2.9"
+    short_description: Uses onesityone to find hosts to target
+    description:
+        - Uses a YAML configuration file with a valid YAML extension.
+    extends_documentation_fragment:
+      - constructed
+      - inventory_cache
+    requirements:
+      - onesixtyone CLI installed
+      - python-gevent installed
+    options:
+        addresses:
+            description: List of CIDRs and IPs to scan.
+            type: list
+            required: false
+            default:
+              - 192.168.0.0/24
+        communities:
+            description: List of communities to query per device.
+            type: list
+            required: false
+            default:
+              - "public"
+        wait:
+          description: wait n milliseconds (1/1000 of a second) between sending packets.
+          type: int
+          default: 10
+          required: false
+        platforms:
+          description: Dict containing additional mappings between Platform (key) and regex to match in sysDescr (value).
+          type: dict
+          default: {}
+          required: false
+    notes:
+      - Only discover devices running SNMPv2.
+      - TODO: Add cache support.
+'''
+EXAMPLES = '''
+    # onesixtyone.yaml or any other YAML file-extension
+    plugin: onesixtyone
+    strict: False
+    addresses:
+      - 192.168.0.0/24
+'''
+
+
+import os
+import re
+import tempfile
+import subprocess
+
+from ansible import constants as C
+from ansible.errors import AnsibleParserError
+from ansible.module_utils._text import to_native
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+
+try:
+  import gevent
+  from gevent import socket
+except:
+  raise Exception('this inventory plugin requires the gevent library. Try: yum install python-gevent')
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+
+    NAME = 'onesixtyone'
+
+    def __init__(self):
+
+        self._onesixtyone = None
+        for path in os.environ.get('PATH').split(':'):
+            candidate = os.path.join(path, 'onesixtyone')
+            if os.path.exists(candidate):
+                self._onesixtyone = candidate
+                break
+
+        super(InventoryModule, self).__init__()
+
+    def verify_file(self, path):
+
+        if super(InventoryModule, self).verify_file(path):
+          for fn in ('onesixtyone'):
+              for suffix in ('yaml', 'yml'):
+                  maybe = '{fn}.{suffix}'.format(fn=fn, suffix=suffix)
+                  if path.endswith(maybe):
+                      return True
+
+        return False
+
+    def parse(self, inventory, loader, path, cache=False):
+        super(InventoryModule, self).parse(inventory, loader, path, cache=cache)
+        self._read_config_data(path)
+
+        try:
+          jobs = [ gevent.spawn(self._add_device, self, device) for device in self._discovery() ]
+          gevent.joinall(jobs, timeout=20)
+
+        except Exception as e:
+            raise AnsibleParserError("failed to parse %s: %s " % (to_native(path), to_native(e)))
+
+    def _match_platform(self, text):
+        ''' Matches platforms against text in sysDescr
+        '''
+        platforms = {
+            'asa': re.compile(r'^Cisco\sAdaptive\sSecurity\sAppliance'),
+            'ios': re.compile(r'^Cisco\sIOS\sSoftware'),
+            'iosxr': re.compile(r'^Cisco\sIOS\sXR\sSoftware'),
+            'nxos': re.compile(r'^Cisco\sNexus\sOperating\sSystem'),
+            'dellos': re.compile(r'^Dell\sApplication\sSoftware'),
+            'junos': re.compile(r'^JUNOS'),
+            'aruba': re.compile(r'^Aruba\sOperating\sSystem\sSoftware'),
+            'eos': re.compile(r'^Arista')
+        }
+
+        platforms.update(self.get_option('platforms'))
+
+        for platform, rule in platforms.items():
+            if rule.match(text):
+              return platform
+        
+        return 'unknown'
+
+    def _discovery(self):
+        if self._onesixtyone is None:
+            raise AnsibleParserError('onesixtyone inventory plugin requires the onesixtyone cli tool to work')
+
+        # setup command
+        cmd = [self._onesixtyone]
+
+        #                                ip.ip.ip                       [community] <text>
+        find_entry = re.compile(r'^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s\[(\w+)\]\s(.*)')
+
+        # Create communities temporary file
+        with tempfile.NamedTemporaryFile() as communities_tempfile:
+          communities = self._options.get("communities")
+          communities_tempfile.write("\n".join(communities) + "\n")
+          communities_tempfile.flush()
+          cmd.append('-c')
+          cmd.append(communities_tempfile.name)
+
+          # Create hosts temporary file
+          with tempfile.NamedTemporaryFile() as addresses_tempfile:
+            addresses = self.get_option("addresses")
+            addresses_tempfile.write("\n".join(addresses) + "\n")
+            addresses_tempfile.flush()
+            cmd.append('-i')
+            cmd.append(addresses_tempfile.name)
+
+            cmd.append('-w')
+            cmd.append("%s" % self.get_option("wait"))
+
+            self.display.vvv("command: {cmd})".format(cmd=cmd))
+
+            # execute
+            try:
+              cmd_output = subprocess.check_output(" ".join(cmd), stderr=subprocess.STDOUT, shell=True)
+
+            except subprocess.CalledProcessError as p:
+                raise AnsibleParserError('Failed to run onesixtyone, rc=%s: %s' % (p.returncode, to_native(p.output)))
+
+            # parse command output
+            entries = []
+            matches = None
+            for line in cmd_output.splitlines():
+              self.display.vvv("output (line): {output}".format(output=line))
+              matches = find_entry.match(line)
+              if matches is not None:
+                entries.append({
+                  'host': matches.group(1),
+                  'community': matches.group(2),
+                  'sysdescr': matches.group(3),
+                })
+
+        return entries
+
+    @staticmethod
+    def _add_device(obj, device):
+
+      # Inventory Group
+      platform = obj._match_platform(device.get('sysdescr'))
+      obj.display.vvv("platform: {platform}".format(platform=platform))
+
+      obj.inventory.add_group(platform)
+      obj.inventory.set_variable(platform, 'ansible_network_os', platform)
+
+      # Inventory Host
+      ansible_host = device.get('host')
+      host = socket.gethostbyaddr(ansible_host)[0] or ansible_host
+      obj.display.vvv("host: {host}".format(host=host))
+      obj.inventory.add_host(host, group=platform)
+      obj.inventory.set_variable(host, 'ansible_host', ansible_host)
+      obj.inventory.set_variable(host, 'snmp_community', device.get('community'))
+      obj.inventory.set_variable(host, 'snmp_sysdescr', device.get('sysdescr'))

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -78,6 +78,7 @@ try:
 except Exception:
     HAS_GEVENT = False
 
+
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = 'onesixtyone'
 
@@ -101,7 +102,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if not HAS_NETADDR:
             raise AnsibleParserError('this inventory plugin requires the netaddr library. Try: pip install netaddr')
-        
+
         if not HAS_GEVENT:
             raise AnsibleParserError('this inventory plugin requires the gevent library. Try: yum install python-gevent')
 

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -44,7 +44,7 @@ DOCUMENTATION = '''
           required: false
     notes:
       - Only discover devices running SNMPv2.
-      - TODO: Add caching support.
+      - 'TODO: Add caching support.'
 '''
 EXAMPLES = '''
     # onesixtyone.yaml or any other YAML file-extension

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -107,7 +107,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             raise AnsibleParserError('this inventory plugin requires the gevent library. Try: yum install python-gevent')
 
         try:
-            # Using gevent to pallelize reverse dns lookups and adding entries to inventory
+            # Using gevent to parallelize reverse dns lookups and adding entries to inventory
             jobs = [gevent.spawn(self._add_device, self, device) for device in self._discovery()]
             gevent.joinall(jobs, timeout=20)
 

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -62,6 +62,7 @@ import subprocess
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.process import get_bin_path
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
 try:
@@ -80,14 +81,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = 'onesixtyone'
 
     def __init__(self):
-        self._onesixtyone = None
-        for path in os.environ.get('PATH').split(':'):
-            candidate = os.path.join(path, 'onesixtyone')
-            if os.path.exists(candidate):
-                self._onesixtyone = candidate
-                break
-
         super(InventoryModule, self).__init__()
+        self._onesixtyone = get_bin_path(self.NAME, True)
 
     def verify_file(self, path):
         """ Verify the existence of plugin's configuration file """

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -67,13 +67,13 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cachea
 
 try:
     from netaddr import IPSet
-except:
+except Exception:
     raise AnsibleParserError('this inventory plugin requires the netapp library. Try: pip install netaddr')
 
 try:
     import gevent
     from gevent import socket
-except:
+except Exception:
     raise AnsibleParserError('this inventory plugin requires the gevent library. Try: yum install python-gevent')
 
 

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -62,7 +62,7 @@ import subprocess
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.common.process import get_bin_path
+from ansible.module_utils.basic import is_executable
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
 try:
@@ -85,6 +85,43 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def __init__(self):
         super(InventoryModule, self).__init__()
 
+    @staticmethod
+    def get_bin_path(arg, required=False, opt_dirs=None):
+        '''
+        find system executable in PATH.
+        Optional arguments:
+           - required:  if executable is not found and required is true, fail_json
+           - opt_dirs:  optional list of directories to search in addition to PATH
+        if found return full path; otherwise return None
+        '''
+        opt_dirs = [] if opt_dirs is None else opt_dirs
+
+        sbin_paths = ['/sbin', '/usr/sbin', '/usr/local/sbin']
+        paths = []
+        for d in opt_dirs:
+            if d is not None and os.path.exists(d):
+                paths.append(d)
+
+        paths += os.environ.get('PATH', '').split(os.pathsep)
+        bin_path = None
+        # mangle PATH to include /sbin dirs
+        for p in sbin_paths:
+            if p not in paths and os.path.exists(p):
+                paths.append(p)
+
+        for d in paths:
+            if not d:
+                continue
+            path = os.path.join(d, arg)
+            if os.path.exists(path) and not os.path.isdir(path) and is_executable(path):
+                bin_path = path
+                break
+
+        if required and bin_path is None:
+            raise AnsibleParserError('Failed to find required executable %s in paths: %s' % (arg, os.pathsep.join(paths)))
+
+        return bin_path
+
     def verify_file(self, path):
         """ Verify the existence of plugin's configuration file """
         if not super(InventoryModule, self).verify_file(path):
@@ -97,7 +134,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def parse(self, inventory, loader, path, cache=False):
         super(InventoryModule, self).parse(inventory, loader, path, cache=cache)
-        self._onesixtyone = get_bin_path(self.NAME, True)
+        self._onesixtyone = self.get_bin_path(self.NAME, True)
         self._read_config_data(path)
 
         if not HAS_NETADDR:

--- a/lib/ansible/plugins/inventory/onesixtyone.py
+++ b/lib/ansible/plugins/inventory/onesixtyone.py
@@ -118,11 +118,11 @@ class InventoryModule(BaseInventoryPlugin):
         try:
             # Using gevent to parallelize reverse dns lookups and adding entries to inventory
             jobs = [gevent.spawn(self._add_device, self, device) for device in self._discovery()]
-            gevent.joinall(jobs, timeout=20)            
-        
+            gevent.joinall(jobs, timeout=20)
+
         # Exception raised by gevent
         except LoopExit as e:
-            raise AnsibleParserError('gevent library exception, this should not happen: %s', to_native(e))
+            raise AnsibleParserError('gevent library exception, this should not happen: %s' % to_native(e))
 
     def _match_platform(self, text):
         """ Matches platforms against text in sysDescr and return the platform.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add inventory plugin for _onesixtyone_, which is lightweight and fast in discovery of devices running SNMP.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #41443 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
onesixtyone

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-inventory -i inventory --list
{
    "_meta": {
        "hostvars": {
            "ip-172-16-96-168.eu-central-1.compute.internal": {
                "ansible_host": "172.16.96.168", 
                "ansible_network_os": "ios", 
                "snmp_community": "public", 
                "snmp_sysdescr": "Cisco IOS Software [Gibraltar], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.10.1b, RELEASE SOFTWARE (fc1)  Technical Support: http://www.cisco.com/techsupport  Copyright (c) 1986-2018 by Cisco Systems, Inc.  Compiled Wed 12-Dec-18 02"
            }
        }
    }, 
    "all": {
        "children": [
            "ios", 
            "ungrouped"
        ]
    }, 
    "ios": {
        "hosts": [
            "ip-172-16-96-168.eu-central-1.compute.internal"
        ]
    }, 
    "ungrouped": {}
}
```
