### PR TITLE
docker_swarm: fix option types for signing_ca_cert and signing_ca_key

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -127,11 +127,13 @@ options:
   signing_ca_cert:
     description:
       - The desired signing CA certificate for all swarm node TLS leaf certificates, in PEM format.
-    type: path
+      - This must not be a path to a certificate, but the contents of the certificate.
+    type: str
   signing_ca_key:
     description:
       - The desired signing CA key for all swarm node TLS leaf certificates, in PEM format.
-    type: path
+      - This must not be a path to a key, but the contents of the key.
+    type: str
   ca_force_rotate:
     description:
       - An integer whose purpose is to force swarm to generate a new signing CA certificate and key,
@@ -530,8 +532,8 @@ def main():
         node_cert_expiry=dict(type='int'),
         name=dict(type='str'),
         labels=dict(type='dict'),
-        signing_ca_cert=dict(type='path'),
-        signing_ca_key=dict(type='path'),
+        signing_ca_cert=dict(type='str'),
+        signing_ca_key=dict(type='str'),
         ca_force_rotate=dict(type='int'),
         autolock_managers=dict(type='bool'),
         node_id=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
These were accidentally changed in #52422. Also improves docs that these options are about key content, not key path.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_swarm
