### PR TITLE
Overhaul ansible-test cloud test plugins.

### DIFF
--- a/test/integration/cloud-config-aws.ini.template
+++ b/test/integration/cloud-config-aws.ini.template
@@ -11,11 +11,12 @@
 #
 # NOTE: Automatic provisioning of AWS credentials requires an ansible-core-ci API key.
 
+[default]
 aws_access_key: @ACCESS_KEY
 aws_secret_key: @SECRET_KEY
 security_token: @SECURITY_TOKEN
 aws_region: @REGION
 # aliases for backwards compatibility with older integration test playbooks
-ec2_access_key: '{{ aws_access_key }}'
-ec2_secret_key: '{{ aws_secret_key }}'
-ec2_region: '{{ aws_region }}'
+ec2_access_key: {{ aws_access_key }}
+ec2_secret_key: {{ aws_secret_key }}
+ec2_region: {{ aws_region }}

--- a/test/integration/cloud-config-azure.ini.template
+++ b/test/integration/cloud-config-azure.ini.template
@@ -13,6 +13,7 @@
 #       1) ansible-core-ci API key in ~/.ansible-core-ci.key
 #       2) Sherlock URL (including API key) in ~/.ansible-sherlock-ci.cfg
 
+[default]
 # Provide either Service Principal or Active Directory credentials below.
 
 # Service Principal

--- a/test/integration/cloud-config-cloudscale.ini.template
+++ b/test/integration/cloud-config-cloudscale.ini.template
@@ -4,5 +4,6 @@
 #
 # 1) Running integration tests without using ansible-test.
 #
+
 [default]
 cloudscale_api_token = @API_TOKEN

--- a/test/integration/cloud-config-cs.ini.template
+++ b/test/integration/cloud-config-cs.ini.template
@@ -11,7 +11,7 @@
 #
 # It is recommended that you DO NOT use this template unless you cannot use the simulator.
 
-[cloudstack]
+[default]
 endpoint = http://@HOST:@PORT/client/api
 key = @KEY
 secret = @SECRET

--- a/test/integration/cloud-config-gcp.ini.template
+++ b/test/integration/cloud-config-gcp.ini.template
@@ -11,6 +11,7 @@
 #
 # It is recommended that you DO NOT use this template unless you cannot use the simulator.
 
+[default]
 gcp_project: @PROJECT
 gcp_cred_file: @CRED_FILE
 gcp_cred_kind: @CRED_KIND

--- a/test/integration/cloud-config-gitlab.ini.template
+++ b/test/integration/cloud-config-gitlab.ini.template
@@ -11,6 +11,7 @@
 #
 # It is recommended that you DO NOT use this template unless you cannot use the simulator.
 
+[default]
 gitlab_host: http://@HOST:@PORT
 gitlab_login_token: @TOKEN
 gitlab_runner_registration_token: @RUNNER_TOKEN

--- a/test/integration/cloud-config-opennebula.ini.template
+++ b/test/integration/cloud-config-opennebula.ini.template
@@ -12,7 +12,7 @@
 # If you run with @FIXTURES enabled (true) then you can decide if you want to
 # run in @REPLAY mode (true) or, record mode (false).
 
-
+[default]
 opennebula_url: @URL
 opennebula_username: @USERNAME
 opennebula_password: @PASSWORD

--- a/test/integration/cloud-config-tower.ini.template
+++ b/test/integration/cloud-config-tower.ini.template
@@ -11,7 +11,7 @@
 #
 # NOTE: Automatic provisioning of Tower credentials requires an ansible-core-ci API key.
 
-[general]
+[default]
 version=@VERSION
 host=@HOST
 username=@USERNAME

--- a/test/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/test/integration/targets/azure_rm_aks/tasks/main.yml
@@ -6,8 +6,8 @@
      dns_prefix: "aks{{ resource_group | hash('md5') | truncate(10, True, '') }}"
      kubernetes_version: 1.7.7
      service_principal:
-         client_id: "{{ lookup('env', 'AZURE_CLIENT_ID') }}"
-         client_secret: "{{ lookup('env', 'AZURE_SECRET') }}"
+         client_id: "{{ azure_client_id }}"
+         client_secret: "{{ azure_secret }}"
      linux_profile:
          admin_username: azureuser
          ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPmiqkvDH1/+MDAVDZT8381aYqp73Odz8cnD5hegNhqtXajqtiH0umVg7HybX3wt1HjcrwKJovZURcIbbcDvzdH2bnYbF93T4OLXA0bIfuIp6M86x1iutFtXdpN3TTicINrmSXEE2Ydm51iMu77B08ZERjVaToya2F7vC+egfoPvibf7OLxE336a5tPCywavvNihQjL8sjgpDT5AAScjb3YqK/6VLeQ18Ggt8/ufINsYkb+9/Ji/3OcGFeflnDXq80vPUyF3u4iIylob6RSZenC38cXmQB05tRNxS1B6BXCjMRdy0v4pa7oKM2GA4ADKpNrr0RI9ed+peRFwmsclH test@ansible
@@ -36,8 +36,8 @@
      dns_prefix: "aks{{ resource_group | hash('md5') | truncate(10, True, '') }}"
      kubernetes_version: 1.7.7
      service_principal:
-         client_id: "{{ lookup('env', 'AZURE_CLIENT_ID') }}"
-         client_secret: "{{ lookup('env', 'AZURE_SECRET') }}"
+         client_id: "{{ azure_client_id }}"
+         client_secret: "{{ azure_secret }}"
      linux_profile:
          admin_username: azureuser
          ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPmiqkvDH1/+MDAVDZT8381aYqp73Odz8cnD5hegNhqtXajqtiH0umVg7HybX3wt1HjcrwKJovZURcIbbcDvzdH2bnYbF93T4OLXA0bIfuIp6M86x1iutFtXdpN3TTicINrmSXEE2Ydm51iMu77B08ZERjVaToya2F7vC+egfoPvibf7OLxE336a5tPCywavvNihQjL8sjgpDT5AAScjb3YqK/6VLeQ18Ggt8/ufINsYkb+9/Ji/3OcGFeflnDXq80vPUyF3u4iIylob6RSZenC38cXmQB05tRNxS1B6BXCjMRdy0v4pa7oKM2GA4ADKpNrr0RI9ed+peRFwmsclH test@ansible
@@ -74,7 +74,7 @@
      dns_prefix: "aks{{ resource_group | hash('md5') | truncate(10, True, '') }}"
      kubernetes_version: 1.7.7
      service_principal:
-         client_id: "{{ lookup('env', 'AZURE_CLIENT_ID') }}"
+         client_id: "{{ azure_client_id }}"
      linux_profile:
          admin_username: azureuser
          ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPmiqkvDH1/+MDAVDZT8381aYqp73Odz8cnD5hegNhqtXajqtiH0umVg7HybX3wt1HjcrwKJovZURcIbbcDvzdH2bnYbF93T4OLXA0bIfuIp6M86x1iutFtXdpN3TTicINrmSXEE2Ydm51iMu77B08ZERjVaToya2F7vC+egfoPvibf7OLxE336a5tPCywavvNihQjL8sjgpDT5AAScjb3YqK/6VLeQ18Ggt8/ufINsYkb+9/Ji/3OcGFeflnDXq80vPUyF3u4iIylob6RSZenC38cXmQB05tRNxS1B6BXCjMRdy0v4pa7oKM2GA4ADKpNrr0RI9ed+peRFwmsclH test@ansible
@@ -98,7 +98,7 @@
      dns_prefix: "aks{{ resource_group | hash('md5') | truncate(10, True, '') }}"
      kubernetes_version: 1.8.1
      service_principal:
-         client_id: "{{ lookup('env', 'AZURE_CLIENT_ID') }}"
+         client_id: "{{ azure_client_id }}"
      linux_profile:
          admin_username: azureuser
          ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPmiqkvDH1/+MDAVDZT8381aYqp73Odz8cnD5hegNhqtXajqtiH0umVg7HybX3wt1HjcrwKJovZURcIbbcDvzdH2bnYbF93T4OLXA0bIfuIp6M86x1iutFtXdpN3TTicINrmSXEE2Ydm51iMu77B08ZERjVaToya2F7vC+egfoPvibf7OLxE336a5tPCywavvNihQjL8sjgpDT5AAScjb3YqK/6VLeQ18Ggt8/ufINsYkb+9/Ji/3OcGFeflnDXq80vPUyF3u4iIylob6RSZenC38cXmQB05tRNxS1B6BXCjMRdy0v4pa7oKM2GA4ADKpNrr0RI9ed+peRFwmsclH test@ansible
@@ -122,7 +122,7 @@
      dns_prefix: "aks{{ resource_group | hash('md5') | truncate(10, True, '') }}"
      kubernetes_version: 1.8.1     
      service_principal:
-         client_id: "{{ lookup('env', 'AZURE_CLIENT_ID') }}"
+         client_id: "{{ azure_client_id }}"
      linux_profile:
          admin_username: azureuser
          ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPmiqkvDH1/+MDAVDZT8381aYqp73Odz8cnD5hegNhqtXajqtiH0umVg7HybX3wt1HjcrwKJovZURcIbbcDvzdH2bnYbF93T4OLXA0bIfuIp6M86x1iutFtXdpN3TTicINrmSXEE2Ydm51iMu77B08ZERjVaToya2F7vC+egfoPvibf7OLxE336a5tPCywavvNihQjL8sjgpDT5AAScjb3YqK/6VLeQ18Ggt8/ufINsYkb+9/Ji/3OcGFeflnDXq80vPUyF3u4iIylob6RSZenC38cXmQB05tRNxS1B6BXCjMRdy0v4pa7oKM2GA4ADKpNrr0RI9ed+peRFwmsclH test@ansible

--- a/test/integration/targets/azure_rm_keyvault/tasks/main.yml
+++ b/test/integration/targets/azure_rm_keyvault/tasks/main.yml
@@ -1,14 +1,8 @@
 - name: Prepare random number
   set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-    tenant_id: "{{ lookup('env','AZURE_TENANT') }}"
+    tenant_id: "{{ azure_tenant }}"
   run_once: yes
-
-- name: set service principal info
-  set_fact:
-    azure_client_id: "{{ lookup('env','AZURE_CLIENT_ID') }}"
-    azure_secret: "{{ lookup('env','AZURE_SECRET') }}"
-  no_log: yes
 
 - name: lookup service principal object id
   set_fact:

--- a/test/integration/targets/cloudscale_volume/tasks/failures.yml
+++ b/test/integration/targets/cloudscale_volume/tasks/failures.yml
@@ -4,7 +4,7 @@
     url: 'https://api.cloudscale.ch/v1/volumes'
     method: POST
     headers:
-      Authorization: 'Bearer {{ lookup("env", "CLOUDSCALE_API_TOKEN") }}'
+      Authorization: 'Bearer {{ cloudscale_api_token }}'
     body:
       name: '{{ cloudscale_resource_prefix }}-duplicate'
       size_gb: 50

--- a/test/integration/targets/inventory_aws_ec2/runme.sh
+++ b/test/integration/targets/inventory_aws_ec2/runme.sh
@@ -16,20 +16,20 @@ export ANSIBLE_INVENTORY=test.aws_ec2.yml
 ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 
 # generate inventory config and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
-ansible-playbook playbooks/test_populating_inventory.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
+ansible-playbook playbooks/create_inventory_config.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/test_populating_inventory.yml -e @../../integration_config.yml "$@"
 
 # generate inventory config with caching and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml' @../../integration_config.yml" "$@" -e "@${ANSIBLE_TEST_CONFIG}"
-ansible-playbook playbooks/populate_cache.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml' @../../integration_config.yml" "$@"
+ansible-playbook playbooks/populate_cache.yml -e @../../integration_config.yml "$@"
 ansible-playbook playbooks/test_inventory_cache.yml "$@"
 
 # remove inventory cache
 rm -r aws_ec2_cache_dir/
 
 # generate inventory config with constructed features and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml' @../../integration_config.yml" "$@" -e "@${ANSIBLE_TEST_CONFIG}"
-ansible-playbook playbooks/test_populating_inventory_with_constructed.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml' @../../integration_config.yml" "$@"
+ansible-playbook playbooks/test_populating_inventory_with_constructed.yml -e @../../integration_config.yml "$@"
 
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"

--- a/test/integration/targets/inventory_aws_ec2/runme.sh
+++ b/test/integration/targets/inventory_aws_ec2/runme.sh
@@ -16,20 +16,20 @@ export ANSIBLE_INVENTORY=test.aws_ec2.yml
 ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 
 # generate inventory config and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e @../../integration_config.yml "$@"
-ansible-playbook playbooks/test_populating_inventory.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
+ansible-playbook playbooks/test_populating_inventory.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
 
 # generate inventory config with caching and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml' @../../integration_config.yml" "$@"
-ansible-playbook playbooks/populate_cache.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml' @../../integration_config.yml" "$@" -e "@${ANSIBLE_TEST_CONFIG}"
+ansible-playbook playbooks/populate_cache.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
 ansible-playbook playbooks/test_inventory_cache.yml "$@"
 
 # remove inventory cache
 rm -r aws_ec2_cache_dir/
 
 # generate inventory config with constructed features and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml' @../../integration_config.yml" "$@"
-ansible-playbook playbooks/test_populating_inventory_with_constructed.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml' @../../integration_config.yml" "$@" -e "@${ANSIBLE_TEST_CONFIG}"
+ansible-playbook playbooks/test_populating_inventory_with_constructed.yml -e @../../integration_config.yml "$@" -e "@${ANSIBLE_TEST_CONFIG}"
 
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"

--- a/test/integration/targets/prepare_nios_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nios_tests/tasks/main.yml
@@ -1,7 +1,0 @@
-- name: create the provider credentials from the cloud script
-  set_fact:
-    nios_provider:
-        host: "{{ lookup('env', 'NIOS_HOST') }}"
-        username: admin
-        password: infoblox
-- debug: var=nios_provider

--- a/test/integration/targets/tower_common/tasks/main.yml
+++ b/test/integration/targets/tower_common/tasks/main.yml
@@ -2,8 +2,6 @@
 - name: Check that SSL is available
   tower_organization:
     name: Default
-  environment:
-    TOWER_HOST: "https://{{ lookup('env', 'TOWER_HOST') }}"
   register: result
 
 - name: Check we haven't changed anything
@@ -14,7 +12,6 @@
   tower_organization:
     name: Default
   environment:
-    TOWER_HOST: "https://{{ lookup('env', 'TOWER_HOST') }}"
     TOWER_CERTIFICATE: /dev/null  # force check failure
   ignore_errors: true
   register: check_ssl_is_used
@@ -42,7 +39,6 @@
       tower_organization:
         name: Default
       environment:
-        TOWER_HOST: "https://{{ lookup('env', 'TOWER_HOST') }}"
         TOWER_CERTIFICATE: /dev/null  # should not fail because verify_ssl is disabled
   always:
     - name: Delete ~/.tower_cli.cfg

--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -16,20 +16,20 @@
 
 - name: Update the project (to clone the git repo)
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/update/"
+    url: "https://{{ tower_host }}/api/v2/projects/{{ result.id }}/update/"
     method: POST
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    user: "{{ tower_username }}"
+    password: "{{ tower_password }}"
     validate_certs: false
     status_code: 202
     force_basic_auth: true
 
 - name: Wait for the project to be status=successful
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/"
+    url: "https://{{ tower_host }}/api/v2/projects/{{ result.id }}/"
     method: GET
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    user: "{{ tower_username }}"
+    password: "{{ tower_password }}"
     validate_certs: false
     force_basic_auth: true
     return_content: true

--- a/test/integration/targets/tower_organization/tasks/main.yml
+++ b/test/integration/targets/tower_organization/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - assert:
     that:
-      - "result.tower_version == '{{ lookup('env', 'TOWER_VERSION') }}'"
+      - "result.tower_version == '{{ tower_version }}'"
 
 - name: Make sure the default Default organization exists
   tower_organization:

--- a/test/integration/targets/tower_project/tasks/create_project_dir.yml
+++ b/test/integration/targets/tower_project/tasks/create_project_dir.yml
@@ -1,8 +1,8 @@
 - name: Fetch project_base_dir
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/config/"
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    url: "https://{{ tower_host}}/api/v2/config/"
+    user: "{{ tower_username }}"
+    password: "{{ tower_password }}"
     validate_certs: false
     return_content: true
   register: awx_config

--- a/test/integration/targets/tower_workflow_launch/tasks/main.yml
+++ b/test/integration/targets/tower_workflow_launch/tasks/main.yml
@@ -1,30 +1,30 @@
 - name: Get unified job template ID for Demo Job Template"
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/unified_job_templates/?name=Demo+Job+Template"
+    url: "https://{{ tower_host }}/api/v2/unified_job_templates/?name=Demo+Job+Template"
     method: GET
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
+    password: "{{ tower_password }}"
+    user: "{{ tower_username }}"
     validate_certs: False
   register: unified_job
 
 - name: Build workflow
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/workflow_job_templates/"
+    url: "https://{{ tower_host }}/api/v2/workflow_job_templates/"
     body: 
       name: "Success Template"
       variables: "---"
       extra_vars: ""
     body_format: 'json'
     method: 'POST'
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    password: "{{ tower_password }}"
     status_code: 201
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
+    user: "{{ tower_username }}"
     validate_certs: False
   register: workflow
 
 - name: Add a node
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/workflow_job_templates/{{ workflow.json.id }}/workflow_nodes/"
+    url: "https://{{ tower_host }}/api/v2/workflow_job_templates/{{ workflow.json.id }}/workflow_nodes/"
     body:
       credential: null
       diff_mode: null
@@ -38,15 +38,15 @@
       verbosity: null
     body_format: 'json'
     method: 'POST'
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    password: "{{ tower_password }}"
     status_code: 201
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
+    user: "{{ tower_username }}"
     validate_certs: False
   register: node1
 
 - name: Add a node
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/workflow_job_templates/{{ workflow.json.id }}/workflow_nodes/"
+    url: "https://{{ tower_host }}/api/v2/workflow_job_templates/{{ workflow.json.id }}/workflow_nodes/"
     body:
       credential: null
       diff_mode: null
@@ -60,19 +60,19 @@
       verbosity: null
     body_format: 'json'
     method: 'POST'
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    password: "{{ tower_password }}"
     status_code: 201
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
+    user: "{{ tower_username }}"
     validate_certs: False
   register: node2
 
 - name: "Link nodes {{ node2.json.id }} to {{ node1.json.id }}"
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/workflow_job_template_nodes/{{ node1.json.id }}/success_nodes/"
+    url: "https://{{ tower_host }}/api/v2/workflow_job_template_nodes/{{ node1.json.id }}/success_nodes/"
     body: '{ "id": {{ node2.json.id }} }'
     body_format: 'json'
     method: 'POST'
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    password: "{{ tower_password }}"
     status_code: 204
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
+    user: "{{ tower_username }}"
     validate_certs: False

--- a/test/integration/targets/tower_workflow_template/tasks/main.yml
+++ b/test/integration/targets/tower_workflow_template/tasks/main.yml
@@ -17,20 +17,20 @@
 
 - name: Update the project (to clone the git repo)
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/update/"
+    url: "https://{{ tower_host }}/api/v2/projects/{{ result.id }}/update/"
     method: POST
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    user: "{{ tower_username }}"
+    password: "{{ tower_password }}"
     validate_certs: false
     status_code: 202
     force_basic_auth: true
 
 - name: Wait for the project to be status=successful
   uri:
-    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/"
+    url: "https://{{ tower_host }}/api/v2/projects/{{ result.id }}/"
     method: GET
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    user: "{{ tower_username }}"
+    password: "{{ tower_password }}"
     validate_certs: false
     force_basic_auth: true
     return_content: true

--- a/test/runner/lib/cloud/__init__.py
+++ b/test/runner/lib/cloud/__init__.py
@@ -390,10 +390,9 @@ class CloudEnvironment(CloudBase):
         pass
 
     @abc.abstractmethod
-    def configure_environment(self, env, cmd):
-        """Configuration which should be done once for each test target.
-        :type env: dict[str, str]
-        :type cmd: list[str]
+    def get_environment_config(self):
+        """
+        :rtype: CloudEnvironmentConfig
         """
         pass
 
@@ -404,9 +403,17 @@ class CloudEnvironment(CloudBase):
         """
         pass
 
-    @property
-    def inventory_hosts(self):
+
+class CloudEnvironmentConfig(object):
+    """Configuration for the environment."""
+    def __init__(self, env_vars=None, ansible_vars=None, ansible_vars_yaml=None, module_defaults=None):
         """
-        :rtype: str | None
+        :type env_vars: dict[str, str] | None
+        :type ansible_vars: dict[str, any] | None
+        :type ansible_vars_yaml: list[str] | None
+        :type module_defaults: dict[str, dict[str, any]] | None
         """
-        return None
+        self.env_vars = env_vars
+        self.ansible_vars = ansible_vars
+        self.ansible_vars_yaml = ansible_vars_yaml
+        self.module_defaults = module_defaults

--- a/test/runner/lib/cloud/__init__.py
+++ b/test/runner/lib/cloud/__init__.py
@@ -406,14 +406,16 @@ class CloudEnvironment(CloudBase):
 
 class CloudEnvironmentConfig(object):
     """Configuration for the environment."""
-    def __init__(self, env_vars=None, ansible_vars=None, ansible_vars_yaml=None, module_defaults=None):
+    def __init__(self, env_vars=None, ansible_vars=None, ansible_vars_yaml=None, module_defaults=None, callback_plugins=None):
         """
         :type env_vars: dict[str, str] | None
         :type ansible_vars: dict[str, any] | None
         :type ansible_vars_yaml: list[str] | None
         :type module_defaults: dict[str, dict[str, any]] | None
+        :type callback_plugins: list[str] | None
         """
         self.env_vars = env_vars
         self.ansible_vars = ansible_vars
         self.ansible_vars_yaml = ansible_vars_yaml
         self.module_defaults = module_defaults
+        self.callback_plugins = callback_plugins

--- a/test/runner/lib/cloud/__init__.py
+++ b/test/runner/lib/cloud/__init__.py
@@ -253,7 +253,7 @@ class CloudProvider(CloudBase):
     """Base class for cloud provider plugins. Sets up cloud resources before delegation."""
     TEST_DIR = 'test/integration'
 
-    def __init__(self, args, config_extension='.yml'):
+    def __init__(self, args, config_extension='.ini'):
         """
         :type args: IntegrationConfig
         :type config_extension: str
@@ -406,16 +406,14 @@ class CloudEnvironment(CloudBase):
 
 class CloudEnvironmentConfig(object):
     """Configuration for the environment."""
-    def __init__(self, env_vars=None, ansible_vars=None, ansible_vars_yaml=None, module_defaults=None, callback_plugins=None):
+    def __init__(self, env_vars=None, ansible_vars=None, module_defaults=None, callback_plugins=None):
         """
         :type env_vars: dict[str, str] | None
         :type ansible_vars: dict[str, any] | None
-        :type ansible_vars_yaml: list[str] | None
         :type module_defaults: dict[str, dict[str, any]] | None
         :type callback_plugins: list[str] | None
         """
         self.env_vars = env_vars
         self.ansible_vars = ansible_vars
-        self.ansible_vars_yaml = ansible_vars_yaml
         self.module_defaults = module_defaults
         self.callback_plugins = callback_plugins

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -7,6 +7,7 @@ import time
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.util import (
@@ -175,12 +176,14 @@ class ACMEProvider(CloudProvider):
 
 class ACMEEnvironment(CloudEnvironment):
     """ACME environment plugin. Updates integration test environment after delegation."""
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
+        ansible_vars = dict(
+            acme_host=self._get_cloud_config('acme_host'),
+        )
 
-        # Send the container IP down to the integration test(s)
-        cmd.append('-e')
-        cmd.append('acme_host=%s' % self._get_cloud_config('acme_host'))
+        return CloudEnvironmentConfig(
+            ansible_vars=ansible_vars,
+        )

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -38,7 +38,7 @@ class ACMEProvider(CloudProvider):
         """
         :type args: TestConfig
         """
-        super(ACMEProvider, self).__init__(args, config_extension='.ini')
+        super(ACMEProvider, self).__init__(args)
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):

--- a/test/runner/lib/cloud/aws.py
+++ b/test/runner/lib/cloud/aws.py
@@ -7,7 +7,7 @@ from lib.util import (
     ApplicationError,
     display,
     is_shippable,
-    read_lines_without_comments,
+    ConfigParser,
 )
 
 from lib.cloud import (
@@ -90,15 +90,17 @@ class AwsCloudEnvironment(CloudEnvironment):
         """
         :rtype: CloudEnvironmentConfig
         """
+        parser = ConfigParser()
+        parser.read(self.config_path)
+
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,
         )
 
-        ansible_vars_yaml = read_lines_without_comments(self.config_path, remove_blank_lines=True)
+        ansible_vars.update(dict(parser.items('default')))
 
         return CloudEnvironmentConfig(
             ansible_vars=ansible_vars,
-            ansible_vars_yaml=ansible_vars_yaml,
         )
 
     def on_failure(self, target, tries):

--- a/test/runner/lib/cloud/aws.py
+++ b/test/runner/lib/cloud/aws.py
@@ -7,11 +7,13 @@ from lib.util import (
     ApplicationError,
     display,
     is_shippable,
+    read_lines_without_comments,
 )
 
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.core_ci import (
@@ -84,16 +86,20 @@ class AwsCloudProvider(CloudProvider):
 
 class AwsCloudEnvironment(CloudEnvironment):
     """AWS cloud environment plugin. Updates integration test environment after delegation."""
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
-        cmd.append('-e')
-        cmd.append('@%s' % self.config_path)
+        ansible_vars = dict(
+            resource_prefix=self.resource_prefix,
+        )
 
-        cmd.append('-e')
-        cmd.append('resource_prefix=%s' % self.resource_prefix)
+        ansible_vars_yaml = read_lines_without_comments(self.config_path, remove_blank_lines=True)
+
+        return CloudEnvironmentConfig(
+            ansible_vars=ansible_vars,
+            ansible_vars_yaml=ansible_vars_yaml,
+        )
 
     def on_failure(self, target, tries):
         """

--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -12,6 +12,7 @@ from lib.util import (
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.http import (
@@ -135,22 +136,22 @@ class AzureCloudProvider(CloudProvider):
 
 class AzureCloudEnvironment(CloudEnvironment):
     """Azure cloud environment plugin. Updates integration test environment after delegation."""
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
-        config = get_config(self.config_path)
+        env_vars = get_config(self.config_path)
 
-        cmd.append('-e')
-        cmd.append('resource_prefix=%s' % self.resource_prefix)
-        cmd.append('-e')
-        cmd.append('resource_group=%s' % config['RESOURCE_GROUP'])
-        cmd.append('-e')
-        cmd.append('resource_group_secondary=%s' % config['RESOURCE_GROUP_SECONDARY'])
+        ansible_vars = dict(
+            resource_prefix=self.resource_prefix,
+            resource_group=env_vars['RESOURCE_GROUP'],
+            resource_group_secondary=env_vars['RESOURCE_GROUP_SECONDARY'],
+        )
 
-        for key in config:
-            env[key] = config[key]
+        return CloudEnvironmentConfig(
+            env_vars=env_vars,
+            ansible_vars=ansible_vars,
+        )
 
     def on_failure(self, target, tries):
         """

--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -144,9 +144,9 @@ class AzureCloudEnvironment(CloudEnvironment):
 
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,
-            resource_group=env_vars['RESOURCE_GROUP'],
-            resource_group_secondary=env_vars['RESOURCE_GROUP_SECONDARY'],
         )
+
+        ansible_vars.update(dict((key.lower(), value) for key, value in env_vars.items()))
 
         return CloudEnvironmentConfig(
             env_vars=env_vars,

--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -126,6 +126,8 @@ class AzureCloudProvider(CloudProvider):
 
             config = '\n'.join('%s: %s' % (key, values[key]) for key in sorted(values))
 
+            config = '[default]\n' + config
+
         self._write_config(config)
 
     def _create_ansible_core_ci(self):

--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -174,7 +174,7 @@ def get_config(config_path):
     parser = ConfigParser()
     parser.read(config_path)
 
-    config = dict(parser.items('default'))
+    config = dict((key.upper(), value) for key, value in parser.items('default'))
 
     rg_vars = (
         'RESOURCE_GROUP',

--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -7,6 +7,7 @@ from lib.util import (
     ApplicationError,
     display,
     is_shippable,
+    ConfigParser,
 )
 
 from lib.cloud import (
@@ -168,9 +169,10 @@ def get_config(config_path):
     :type config_path: str
     :rtype: dict[str, str]
     """
-    with open(config_path, 'r') as config_fd:
-        lines = [line for line in config_fd.read().splitlines() if ':' in line and line.strip() and not line.strip().startswith('#')]
-        config = dict((kvp[0].strip(), kvp[1].strip()) for kvp in [line.split(':', 1) for line in lines])
+    parser = ConfigParser()
+    parser.read(config_path)
+
+    config = dict(parser.items('default'))
 
     rg_vars = (
         'RESOURCE_GROUP',

--- a/test/runner/lib/cloud/cloudscale.py
+++ b/test/runner/lib/cloud/cloudscale.py
@@ -69,6 +69,8 @@ class CloudscaleCloudEnvironment(CloudEnvironment):
             cloudscale_resource_prefix=self.resource_prefix,
         )
 
+        env_vars.update(dict((key.lower(), value) for key, value in env_vars.items()))
+
         return CloudEnvironmentConfig(
             env_vars=env_vars,
             ansible_vars=ansible_vars,

--- a/test/runner/lib/cloud/cloudscale.py
+++ b/test/runner/lib/cloud/cloudscale.py
@@ -26,7 +26,7 @@ class CloudscaleCloudProvider(CloudProvider):
         """
         :type args: TestConfig
         """
-        super(CloudscaleCloudProvider, self).__init__(args, config_extension='.ini')
+        super(CloudscaleCloudProvider, self).__init__(args)
 
     def filter(self, targets, exclude):
         """Filter out the cloud tests when the necessary config and resources are not available.
@@ -69,7 +69,7 @@ class CloudscaleCloudEnvironment(CloudEnvironment):
             cloudscale_resource_prefix=self.resource_prefix,
         )
 
-        env_vars.update(dict((key.lower(), value) for key, value in env_vars.items()))
+        ansible_vars.update(dict((key.lower(), value) for key, value in env_vars.items()))
 
         return CloudEnvironmentConfig(
             env_vars=env_vars,

--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -9,6 +9,7 @@ import time
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.util import (
@@ -262,16 +263,25 @@ class CsCloudProvider(CloudProvider):
 
 class CsCloudEnvironment(CloudEnvironment):
     """CloudStack cloud environment plugin. Updates integration test environment after delegation."""
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
-        changes = dict(
-            CLOUDSTACK_CONFIG=self.config_path,
+        parser = ConfigParser()
+        parser.read(self.config_path)
+
+        env_vars = dict(
+            CLOUDSTACK_ENDPOINT=parser.get('cloudstack', 'endpoint'),
+            CLOUDSTACK_KEY=parser.get('cloudstack', 'key'),
+            CLOUDSTACK_SECRET=parser.get('cloudstack', 'secret'),
+            CLOUDSTACK_TIMEOUT=parser.get('cloudstack', 'timeout'),
         )
 
-        env.update(changes)
+        ansible_vars = dict(
+            cs_resource_prefix=self.resource_prefix,
+        )
 
-        cmd.append('-e')
-        cmd.append('cs_resource_prefix=%s' % self.resource_prefix)
+        return CloudEnvironmentConfig(
+            env_vars=env_vars,
+            ansible_vars=ansible_vars,
+        )

--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -46,7 +46,7 @@ class CsCloudProvider(CloudProvider):
         """
         :type args: TestConfig
         """
-        super(CsCloudProvider, self).__init__(args, config_extension='.ini')
+        super(CsCloudProvider, self).__init__(args)
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
         self.image = 'quay.io/ansible/cloudstack-test-container:1.2.0'
@@ -270,11 +270,13 @@ class CsCloudEnvironment(CloudEnvironment):
         parser = ConfigParser()
         parser.read(self.config_path)
 
+        config = dict(parser.items('default'))
+
         env_vars = dict(
-            CLOUDSTACK_ENDPOINT=parser.get('cloudstack', 'endpoint'),
-            CLOUDSTACK_KEY=parser.get('cloudstack', 'key'),
-            CLOUDSTACK_SECRET=parser.get('cloudstack', 'secret'),
-            CLOUDSTACK_TIMEOUT=parser.get('cloudstack', 'timeout'),
+            CLOUDSTACK_ENDPOINT=config['endpoint'],
+            CLOUDSTACK_KEY=config['key'],
+            CLOUDSTACK_SECRET=config['secret'],
+            CLOUDSTACK_TIMEOUT=config['timeout'],
         )
 
         ansible_vars = dict(

--- a/test/runner/lib/cloud/foreman.py
+++ b/test/runner/lib/cloud/foreman.py
@@ -7,6 +7,7 @@ import os
 from . import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from ..util import (
@@ -175,13 +176,15 @@ class ForemanEnvironment(CloudEnvironment):
 
     Updates integration test environment after delegation.
     """
-
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
+        env_vars = dict(
+            FOREMAN_HOST=self._get_cloud_config('FOREMAN_HOST'),
+            FOREMAN_PORT=self._get_cloud_config('FOREMAN_PORT'),
+        )
 
-        # Send the container IP down to the integration test(s)
-        env['FOREMAN_HOST'] = self._get_cloud_config('FOREMAN_HOST')
-        env['FOREMAN_PORT'] = self._get_cloud_config('FOREMAN_PORT')
+        return CloudEnvironmentConfig(
+            env_vars=env_vars,
+        )

--- a/test/runner/lib/cloud/gcp.py
+++ b/test/runner/lib/cloud/gcp.py
@@ -7,7 +7,7 @@ import os
 
 from lib.util import (
     display,
-    read_lines_without_comments,
+    ConfigParser,
 )
 
 from lib.cloud import (
@@ -47,13 +47,15 @@ class GcpCloudEnvironment(CloudEnvironment):
         """
         :rtype: CloudEnvironmentConfig
         """
+        parser = ConfigParser()
+        parser.read(self.config_path)
+
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,
         )
 
-        ansible_vars_yaml = read_lines_without_comments(self.config_path, remove_blank_lines=True)
+        ansible_vars.update(dict(parser.items('default')))
 
         return CloudEnvironmentConfig(
             ansible_vars=ansible_vars,
-            ansible_vars_yaml=ansible_vars_yaml,
         )

--- a/test/runner/lib/cloud/gcp.py
+++ b/test/runner/lib/cloud/gcp.py
@@ -7,11 +7,13 @@ import os
 
 from lib.util import (
     display,
+    read_lines_without_comments,
 )
 
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 
@@ -41,22 +43,17 @@ class GcpCloudProvider(CloudProvider):
 
 class GcpCloudEnvironment(CloudEnvironment):
     """GCP cloud environment plugin. Updates integration test environment after delegation."""
+    def get_environment_config(self):
+        """
+        :rtype: CloudEnvironmentConfig
+        """
+        ansible_vars = dict(
+            resource_prefix=self.resource_prefix,
+        )
 
-    def configure_environment(self, env, cmd):
-        """
-        :type env: dict[str, str]
-        :type cmd: list[str]
-        """
-        cmd.append('-e')
-        cmd.append('@%s' % self.config_path)
+        ansible_vars_yaml = read_lines_without_comments(self.config_path, remove_blank_lines=True)
 
-        cmd.append('-e')
-        cmd.append('resource_prefix=%s' % self.resource_prefix)
-
-    def on_failure(self, target, tries):
-        """
-        :type target: TestTarget
-        :type tries: int
-        """
-        if not tries and self.managed:
-            display.notice('%s failed' % target.name)
+        return CloudEnvironmentConfig(
+            ansible_vars=ansible_vars,
+            ansible_vars_yaml=ansible_vars_yaml,
+        )

--- a/test/runner/lib/cloud/nios.py
+++ b/test/runner/lib/cloud/nios.py
@@ -7,6 +7,7 @@ import os
 from . import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from ..util import (
@@ -174,12 +175,18 @@ class NiosEnvironment(CloudEnvironment):
 
     Updates integration test environment after delegation.
     """
-
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
+        ansible_vars = dict(
+            nios_provider=dict(
+                host=self._get_cloud_config('NIOS_HOST'),
+                username='admin',
+                password='infoblox',
+            ),
+        )
 
-        # Send the container IP down to the integration test(s)
-        env['NIOS_HOST'] = self._get_cloud_config('NIOS_HOST')
+        return CloudEnvironmentConfig(
+            ansible_vars=ansible_vars,
+        )

--- a/test/runner/lib/cloud/opennebula.py
+++ b/test/runner/lib/cloud/opennebula.py
@@ -8,7 +8,7 @@ from lib.cloud import (
 
 from lib.util import (
     display,
-    read_lines_without_comments,
+    ConfigParser,
 )
 
 
@@ -49,13 +49,15 @@ class OpenNebulaCloudEnvironment(CloudEnvironment):
         """
         :rtype: CloudEnvironmentConfig
         """
+        parser = ConfigParser()
+        parser.read(self.config_path)
+
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,
         )
 
-        ansible_vars_yaml = read_lines_without_comments(self.config_path, remove_blank_lines=True)
+        ansible_vars.update(dict(parser.items('default')))
 
         return CloudEnvironmentConfig(
             ansible_vars=ansible_vars,
-            ansible_vars_yaml=ansible_vars_yaml,
         )

--- a/test/runner/lib/cloud/opennebula.py
+++ b/test/runner/lib/cloud/opennebula.py
@@ -2,11 +2,13 @@
 
 from lib.cloud import (
     CloudProvider,
-    CloudEnvironment
+    CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.util import (
     display,
+    read_lines_without_comments,
 )
 
 
@@ -43,14 +45,17 @@ class OpenNebulaCloudEnvironment(CloudEnvironment):
     """
     Updates integration test environment after delegation. Will setup the config file as parameter.
     """
-
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
-        cmd.append('-e')
-        cmd.append('@%s' % self.config_path)
+        ansible_vars = dict(
+            resource_prefix=self.resource_prefix,
+        )
 
-        cmd.append('-e')
-        cmd.append('resource_prefix=%s' % self.resource_prefix)
+        ansible_vars_yaml = read_lines_without_comments(self.config_path, remove_blank_lines=True)
+
+        return CloudEnvironmentConfig(
+            ansible_vars=ansible_vars,
+            ansible_vars_yaml=ansible_vars_yaml,
+        )

--- a/test/runner/lib/cloud/openshift.py
+++ b/test/runner/lib/cloud/openshift.py
@@ -9,6 +9,7 @@ import time
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.util import (
@@ -211,13 +212,14 @@ class OpenShiftCloudProvider(CloudProvider):
 
 class OpenShiftCloudEnvironment(CloudEnvironment):
     """OpenShift cloud environment plugin. Updates integration test environment after delegation."""
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
-        changes = dict(
+        env_vars = dict(
             K8S_AUTH_KUBECONFIG=self.config_path,
         )
 
-        env.update(changes)
+        return CloudEnvironmentConfig(
+            env_vars=env_vars,
+        )

--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -30,7 +30,7 @@ class TowerCloudProvider(CloudProvider):
         """
         :type args: TestConfig
         """
-        super(TowerCloudProvider, self).__init__(args, config_extension='.cfg')
+        super(TowerCloudProvider, self).__init__(args)
 
         self.aci = None
         self.version = ''
@@ -220,7 +220,7 @@ class TowerConfig(object):
             'password',
         )
 
-        values = dict((k, parser.get('general', k)) for k in keys)
+        values = dict((k, parser.get('default', k)) for k in keys)
         config = TowerConfig(values)
 
         missing = [k for k in keys if not values.get(k)]

--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -16,6 +16,7 @@ from lib.util import (
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.core_ci import (
@@ -162,14 +163,17 @@ class TowerCloudEnvironment(CloudEnvironment):
 
             time.sleep(5)
 
-    def configure_environment(self, env, cmd):
-        """Configuration which should be done once for each test target.
-        :type env: dict[str, str]
-        :type cmd: list[str]
+    def get_environment_config(self):
+        """
+        :rtype: CloudEnvironmentConfig
         """
         config = TowerConfig.parse(self.config_path)
 
-        env.update(config.environment)
+        env_vars = config.environment
+
+        return CloudEnvironmentConfig(
+            env_vars=env_vars,
+        )
 
 
 class TowerConfig(object):

--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -171,8 +171,11 @@ class TowerCloudEnvironment(CloudEnvironment):
 
         env_vars = config.environment
 
+        ansible_vars = dict((key.lower(), value) for key, value in env_vars.items())
+
         return CloudEnvironmentConfig(
             env_vars=env_vars,
+            ansible_vars=ansible_vars,
         )
 
 

--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -6,6 +6,7 @@ import os
 from lib.cloud import (
     CloudProvider,
     CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.util import (
@@ -144,13 +145,19 @@ class VcenterProvider(CloudProvider):
 
 class VcenterEnvironment(CloudEnvironment):
     """VMware vcenter/esx environment plugin. Updates integration test environment after delegation."""
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
-        cmd.append('-e')
-        cmd.append('vcsim=%s' % self._get_cloud_config('vcenter_host'))
+        env_vars = dict(
+            VCENTER_HOST=self._get_cloud_config('vcenter_host'),
+        )
 
-        # Send the container IP down to the integration test(s)
-        env['VCENTER_HOST'] = self._get_cloud_config('vcenter_host')
+        ansible_vars = dict(
+            vcsim=self._get_cloud_config('vcenter_host'),
+        )
+
+        return CloudEnvironmentConfig(
+            env_vars=env_vars,
+            ansible_vars=ansible_vars,
+        )

--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -31,7 +31,7 @@ class VcenterProvider(CloudProvider):
         """
         :type args: TestConfig
         """
-        super(VcenterProvider, self).__init__(args, config_extension='.ini')
+        super(VcenterProvider, self).__init__(args)
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
         if os.environ.get('ANSIBLE_VCSIM_CONTAINER'):

--- a/test/runner/lib/cloud/vultr.py
+++ b/test/runner/lib/cloud/vultr.py
@@ -5,7 +5,8 @@ import os
 
 from lib.cloud import (
     CloudProvider,
-    CloudEnvironment
+    CloudEnvironment,
+    CloudEnvironmentConfig,
 )
 
 from lib.util import ConfigParser
@@ -31,32 +32,34 @@ class VultrCloudProvider(CloudProvider):
         super(VultrCloudProvider, self).filter(targets, exclude)
 
     def setup(self):
+        """Setup the cloud resource before delegation and register a cleanup callback."""
         super(VultrCloudProvider, self).setup()
 
         if os.path.isfile(self.config_static_path):
             self.config_path = self.config_static_path
             self.managed = False
-            return True
-        return False
 
 
 class VultrCloudEnvironment(CloudEnvironment):
     """
     Updates integration test environment after delegation. Will setup the config file as parameter.
     """
-
-    def configure_environment(self, env, cmd):
+    def get_environment_config(self):
         """
-        :type env: dict[str, str]
-        :type cmd: list[str]
+        :rtype: CloudEnvironmentConfig
         """
         parser = ConfigParser()
         parser.read(self.config_path)
 
-        changes = dict(
+        env_vars = dict(
             VULTR_API_KEY=parser.get('default', 'key'),
         )
-        env.update(changes)
 
-        cmd.append('-e')
-        cmd.append('vultr_resource_prefix=%s' % self.resource_prefix)
+        ansible_vars = dict(
+            vultr_resource_prefix=self.resource_prefix,
+        )
+
+        return CloudEnvironmentConfig(
+            env_vars=env_vars,
+            ansible_vars=ansible_vars,
+        )

--- a/test/runner/lib/cloud/vultr.py
+++ b/test/runner/lib/cloud/vultr.py
@@ -19,7 +19,7 @@ class VultrCloudProvider(CloudProvider):
         """
         :type args: TestConfig
         """
-        super(VultrCloudProvider, self).__init__(args, config_extension='.ini')
+        super(VultrCloudProvider, self).__init__(args)
 
     def filter(self, targets, exclude):
         """Filter out the cloud tests when the necessary config and resources are not available.

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1178,9 +1178,7 @@ def command_integration_script(args, target, test_dir, inventory_path):
 
         with integration_test_config_file(args, env_config, test_env.integration_dir) as config_path:
             if config_path:
-                env.update(dict(
-                    ANSIBLE_TEST_CONFIG=config_path,
-                ))
+                cmd += ['-e', '@%s' % config_path]
 
             intercept_command(args, cmd, target_name=target.name, env=env, cwd=cwd)
 
@@ -1259,13 +1257,7 @@ def command_integration_role(args, target, start_at_task, test_dir, inventory_pa
 
             env['ANSIBLE_ROLES_PATH'] = os.path.abspath(os.path.join(test_env.integration_dir, 'targets'))
 
-            with integration_test_config_file(args, env_config, test_env.integration_dir) as config_path:
-                if config_path:
-                    env.update(dict(
-                        ANSIBLE_TEST_CONFIG=config_path,
-                    ))
-
-                intercept_command(args, cmd, target_name=target.name, env=env, cwd=cwd)
+            intercept_command(args, cmd, target_name=target.name, env=env, cwd=cwd)
 
 
 def command_units(args):

--- a/test/runner/lib/integration/__init__.py
+++ b/test/runner/lib/integration/__init__.py
@@ -210,7 +210,7 @@ ansible_test:
        format_yaml(env_config.env_vars),
        format_yaml(env_config.module_defaults))
 
-    config_file = config_file.strip()
+    config_file = config_file.lstrip()
 
     with named_temporary_file(args, 'config-file-', '.yml', integration_dir, config_file) as path:
         filename = os.path.relpath(path, integration_dir)

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -107,36 +107,6 @@ def read_lines_without_comments(path, remove_blank_lines=False):
     return lines
 
 
-def format_yaml(data=None, raw=None, indent=4, have_key=True):
-    """
-    :type data: dict[str, any] | list[any] | str
-    :type raw: list[str]
-    :type indent: int
-    :type have_key: bool
-    :rtype: str
-    """
-    if not data and not raw:
-        return ''
-
-    result = ''
-
-    if raw:
-        result += '\n' + '\n'.join(['%s%s' % (' ' * indent, line) for line in raw])
-
-    if isinstance(data, dict):
-        if have_key:
-            result += '\n'
-
-        result += '\n'.join(['%s%s: %s' % (' ' * indent, key, format_yaml(data=data[key], indent=indent + 2, have_key=True)) for key in sorted(data)])
-    elif isinstance(data, list):
-        result += '\n'
-        result += '\n'.join(['%s- %s' % (' ' * indent, format_yaml(data=item, indent=indent + 2, have_key=False)) for item in data])
-    else:
-        result += '%s' % data
-
-    return result
-
-
 def find_executable(executable, cwd=None, path=None, required=True):
     """
     :type executable: str

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -107,6 +107,36 @@ def read_lines_without_comments(path, remove_blank_lines=False):
     return lines
 
 
+def format_yaml(data=None, raw=None, indent=4, have_key=True):
+    """
+    :type data: dict[str, any] | list[any] | str
+    :type raw: list[str]
+    :type indent: int
+    :type have_key: bool
+    :rtype: str
+    """
+    if not data and not raw:
+        return ''
+
+    result = ''
+
+    if raw:
+        result += '\n' + '\n'.join(['%s%s' % (' ' * indent, line) for line in raw])
+
+    if isinstance(data, dict):
+        if have_key:
+            result += '\n'
+
+        result += '\n'.join(['%s%s: %s' % (' ' * indent, key, format_yaml(data=data[key], indent=indent + 2, have_key=True)) for key in sorted(data)])
+    elif isinstance(data, list):
+        result += '\n'
+        result += '\n'.join(['%s- %s' % (' ' * indent, format_yaml(data=item, indent=indent + 2, have_key=False)) for item in data])
+    else:
+        result += '%s' % data
+
+    return result
+
+
 def find_executable(executable, cwd=None, path=None, required=True):
     """
     :type executable: str


### PR DESCRIPTION
##### SUMMARY

Overhaul ansible-test cloud test plugins.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

This PR changes how "cloud" plugins for ansible-test are able to affect the test environment:

- The command used to execute the tests can no longer be read or altered. Previously this was used to pass `-e` to ansible commands. This is no longer necessary.
- Environment variables passed to tests can only be set. Previously the dictionary of environment variables to pass to tests was accessible, so values could also be read and removed. No current plugins utilized the ability to read or remove environment variables.
- Environment variables are passed to role based tests using the `environment` play keyword. This makes the environment variables available to modules even when the `local` connection plugin is not being used. Previously environment variables were set in the environment used to invoke `ansible-playbook`, which made them available to `ansible-playbook` as well as modules executed using the `local` connection plugin.
- Environment variables are passed to script based tests as regular environment variables. This behavior has not changed.
- Ansible variables for role based tests are passed using the `vars` play keyword. Previously individual variables were passed to tests using `-e key=value` arguments.
- Ansible variables for script based tests are written to a temporary vars YAML file and passed to tests using `-e @path_to_vars_yaml_file` arguments. Previously individual variables were passed to tests using `-e key=value` arguments. Scripts can still access the vars when invoking ansible commands using `$@`.
- Module defaults can now be set by plugins at the play level. Previously this was not possible.
- Script based tests can use module defaults by passing `$@` to `ansible-playbook` and using `module_defaults: '{{ ansible_test.module_defaults }}'`.
- Script based tests can pass environment variables to modules when using connection plugins other than `local` by passing `$@` to `ansible-playbook` and using `environment: '{{ ansible_test.environment }}'`.
- Plugins can now request additional callback plugins be whitelisted when running tests. Previously this would have been done by appending to the `ANSIBLE_CALLBACK_WHITELIST` environment variable, which is no longer possible, since environment variables cannot be read.
- Plugins now default to using INI format for their configuration files. This makes working with the configuration in Python easier, as ConfigParser can be used. Previously plugins used a mix of mostly INI and JSON.
- Most plugins now load their configuration file and read the variables from there. Previously those plugins would reference the configuration file by path using an environment variable. Making these values inline removes the need to transfer the file to the remote system to make it accessible to modules.

These changes are being made to support running integration tests using connection plugins other than `local` where the controller and remote may not even be the same system.