### PR TITLE
uri: Add support for parsing XML payload

### DIFF
--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -315,10 +315,10 @@ import sys
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.six import PY2, iteritems, string_types
 from ansible.module_utils.six.moves.urllib.parse import urlencode, urlsplit
 from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 try:
@@ -329,7 +329,7 @@ except ImportError:
     if PY2:
         sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
 
-JSON_CANDIDATES = ('javascript', 'json')
+JSON_CANDIDATES = ('javascript', 'json', 'text')
 XML_CANDIDATES = ('xhtml', 'xml')
 
 
@@ -545,7 +545,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        # TODO: Remove check_invalid_arguments in 2.9
+        # TODO: Remove check_invalid_arguments in Ansible 2.9
         check_invalid_arguments=False,
         add_file_common_args=True,
         mutually_exclusive=[['body', 'src']],

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
@@ -22,7 +21,7 @@ description:
   - For Windows targets, use the M(win_uri) module instead.
 version_added: "1.1"
 requires:
-- xmltodict (when dealing with XML)
+- xmltodict (when dealing with XML content)
 options:
   url:
     description:
@@ -46,16 +45,18 @@ options:
     aliases: [ password ]
   body:
     description:
-      - The body of the http request/response to the web service. If C(body_format) is set
-        to 'json' it will take an already formatted JSON string or convert a data structure
-        into JSON. If C(body_format) is set to 'form-urlencoded' it will convert a dictionary
-        or list of tuples into an 'application/x-www-form-urlencoded' string. (Added in v2.7)
+      - The body of the HTTP request/response to the web service.
+      - If C(body_format) is set to 'json' it will take an already formatted JSON string or
+        convert a data structure into JSON.
+      - If C(body_format) is set to 'form-urlencoded' it will convert a dictionary or
+        list of tuples into an 'application/x-www-form-urlencoded' string. Added in Ansible 2.7.
     type: raw
   body_format:
     description:
-      - The serialization format of the body. When set to C(json) or C(form-urlencoded), encodes the
-        body argument, if needed, and automatically sets the Content-Type header accordingly.
-        As of C(2.3) it is possible to override the `Content-Type` header, when
+      - The serialization format of the body.
+      - When set to C(json) or C(form-urlencoded), encodes the body argument, if needed, and
+        automatically sets the Content-Type header accordingly.
+      - As of Ansible 2.3 it is possible to override the `Content-Type` header, when
         set to C(json) or C(form-urlencoded) via the I(headers) option.
     type: str
     choices: [ form-urlencoded, json, raw ]
@@ -71,26 +72,30 @@ options:
     description:
       - Whether or not to return the body of the response as a "content" key in
         the dictionary result.
-      - If the reported Content-type is "application/json", then the JSON is
+      - If the reported Content-type is "application/json", then the JSON payload is
         additionally loaded into a key called C(json) in the dictionary results.
+      - If the reported Content-type is "text/xml" or "text/xhtml", then the XML payload is
+        additionally loaded into a key called C(xml) in the dictionary results.
     type: bool
     default: no
   force_basic_auth:
     description:
       - Force the sending of the Basic authentication header upon initial request.
       - The library used by the uri module only sends authentication information when a webservice
-        responds to an initial request with a 401 status. Since some basic auth services do not properly
-        send a 401, logins will fail.
+        responds to an initial request with a 401 status.
+      - Since some basic auth services do not properly send a 401, logins will fail.
     type: bool
     default: no
   follow_redirects:
     description:
-      - Whether or not the URI module should follow redirects. C(all) will follow all redirects.
-        C(safe) will follow only "safe" redirects, where "safe" means that the client is only
-        doing a GET or HEAD on the URI to which it is being redirected. C(none) will not follow
-        any redirects. Note that C(yes) and C(no) choices are accepted for backwards compatibility,
-        where C(yes) is the equivalent of C(all) and C(no) is the equivalent of C(safe). C(yes) and C(no)
-        are deprecated and will be removed in some future version of Ansible.
+      - Whether or not the URI module should follow redirects.
+      - C(all) will follow all redirects.
+      - C(safe) will follow only "safe" redirects, where "safe" means that the client is only
+        doing a GET or HEAD on the URI to which it is being redirected.
+      - C(none) will not follow any redirects.
+      - Note that C(yes) and C(no) choices are accepted for backwards compatibility,
+        where C(yes) is the equivalent of C(all) and C(no) is the equivalent of C(safe).
+      - C(yes) and C(no) are deprecated and will be removed in some future version of Ansible.
     type: str
     choices: [ all, 'none', safe ]
     default: safe
@@ -117,24 +122,24 @@ options:
       - Any parameter starting with "HEADER_" is a sent with your request as a header.
         For example, HEADER_Content-Type="application/json" would send the header
         "Content-Type" along with your request with a value of "application/json".
-      - This option is deprecated as of C(2.1) and will be removed in Ansible 2.9.
+      - This option is deprecated as of Ansible 2.1 and will be removed in Ansible 2.9.
         Use I(headers) instead.
     type: dict
   headers:
     description:
-        - Add custom HTTP headers to a request in the format of a YAML hash. As
-          of C(2.3) supplying C(Content-Type) here will override the header
+        - Add custom HTTP headers to a request in the format of a YAML hash.
+        - As of Ansible 2.3 supplying C(Content-Type) here will override the header
           generated by supplying C(json) or C(form-urlencoded) for I(body_format).
     type: dict
     version_added: '2.1'
   others:
     description:
-      - All arguments accepted by the M(file) module also work here
+      - All arguments accepted by the M(file) module also work here.
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated.
       - This should only set to C(no) used on personally controlled sites using self-signed certificates.
-      - Prior to 1.9.2 the code defaulted to C(no).
+      - Prior to Ansible 1.9.2 the code defaulted to C(no).
     type: bool
     default: yes
     version_added: '1.9.2'
@@ -323,7 +328,7 @@ from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 JSON_CANDIDATES = ('javascript', 'json')
-XML_CANDIDATES = ('soap', 'xhtml', 'xml')
+XML_CANDIDATES = ('xhtml', 'xml')
 
 def format_message(err, resp):
     msg = resp.pop('msg')

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -20,7 +20,7 @@ description:
     HTTP authentication mechanisms.
   - For Windows targets, use the M(win_uri) module instead.
 version_added: "1.1"
-requires:
+requirements:
 - xmltodict (when dealing with XML content)
 options:
   url:
@@ -316,9 +316,9 @@ import tempfile
 
 try:
     import xmltodict
-    HAS_XMLTODICT=True
+    HAS_XMLTODICT = True
 except ImportError:
-    HAS_XMLTODICT=False
+    HAS_XMLTODICT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import PY2, iteritems, string_types
@@ -329,6 +329,7 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 JSON_CANDIDATES = ('javascript', 'json')
 XML_CANDIDATES = ('xhtml', 'xml')
+
 
 def format_message(err, resp):
     msg = resp.pop('msg')

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -314,18 +314,20 @@ import shutil
 import sys
 import tempfile
 
-try:
-    import xmltodict
-    HAS_XMLTODICT = True
-except ImportError:
-    HAS_XMLTODICT = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import PY2, iteritems, string_types
 from ansible.module_utils.six.moves.urllib.parse import urlencode, urlsplit
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.urls import fetch_url, url_argument_spec
+
+try:
+    import xmltodict
+    HAS_XMLTODICT = True
+except ImportError:
+    HAS_XMLTODICT = False
+    if PY2:
+        sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
 
 JSON_CANDIDATES = ('javascript', 'json')
 XML_CANDIDATES = ('xhtml', 'xml')

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -487,24 +487,26 @@
     that:
       - result.json.json[0] == 'JSON Test Pattern pass1'
 
-- name: Get JSON payload
-  uri:
-    url: https://{{ httpbin_host }}/json
-    return_content: yes
-  register: result
-
-- name: Validate JSON payload
-  assert:
-    that:
-    - result.json is defined
-    - result.json.slideshow.author == 'Yours Truly'
-    - result.json.slideshow.slides[0].title == 'Wake up to WonderWidgets!'
+# FIXME: This requires httpbin 0.7.1 or newer
+#- name: Get JSON payload
+#  uri:
+#    url: https://{{ httpbin_host }}/json
+#    return_content: yes
+#  register: result
+#
+#- name: Validate JSON payload
+#  assert:
+#    that:
+#    - result.json is defined
+#    - result.json.slideshow.author == 'Yours Truly'
+#    - result.json.slideshow.slides[0].title == 'Wake up to WonderWidgets!'
 
 - name: Install xmltodict
   pip:
     name: xmltodict
   register: xmltodict
 
+# NOTE: This requires httpbin 0.2.0 or newer
 - name: Get XML payload
   uri:
     url: https://{{ httpbin_host }}/xml

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -487,6 +487,32 @@
     that:
       - result.json.json[0] == 'JSON Test Pattern pass1'
 
+- name: Get JSON payload
+  uri:
+    url: https://{{ httpbin_host }}/json
+    return_content: yes
+  register: result
+
+- name: Validate JSON payload
+  assert:
+    that:
+    - result.json is defined
+    - result.json.slideshow.author == 'Yours Truly'
+    - result.json.slideshow.slides[0].title == 'Wake up to WonderWidgets!'
+
+- name: Get XML payload
+  uri:
+    url: https://{{ httpbin_host }}/xml
+    return_content: yes
+  register: result
+
+- name: Validate XML payload
+  assert:
+    that:
+    - result.xml is defined
+    - result.xml.slideshow['@author'] == 'Yours Truly'
+    - result.xml.slideshow.slide[0].title == 'Wake up to WonderWidgets!'
+
 - name: Test follow_redirects=none
   import_tasks: redirect-none.yml
 

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -500,6 +500,11 @@
     - result.json.slideshow.author == 'Yours Truly'
     - result.json.slideshow.slides[0].title == 'Wake up to WonderWidgets!'
 
+- name: Install xmltodict
+  pip:
+    name: xmltodict
+  register: xmltodict
+
 - name: Get XML payload
   uri:
     url: https://{{ httpbin_host }}/xml
@@ -512,6 +517,12 @@
     - result.xml is defined
     - result.xml.slideshow['@author'] == 'Yours Truly'
     - result.xml.slideshow.slide[0].title == 'Wake up to WonderWidgets!'
+
+- name: Uninstall xmltodict
+  pip:
+    name: xmltodict
+    state: absent
+  when: xmltodict is changed
 
 - name: Test follow_redirects=none
   import_tasks: redirect-none.yml


### PR DESCRIPTION
##### SUMMARY
This PR add support for parsing XML payload useful when automating XML,
XHTML or SOAP payload.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
uri

##### ADDITIONAL INFORMATION
```json
[dwieers@localhost ~]$ ansible -m uri -a 'url=https://c220m4-3/nuova body="<aaaLogin inName=\"admin\" inPassword=\"password\"/>" validate_certs=no method=POST' localhost

localhost | SUCCESS => {
    "changed": false,
    "connection": "close",
    "content_length": "189",
    "content_type": "application/soap+xml;charset=UTF-8",
    "cookies": {},
    "cookies_string": "",
    "date": "Wed, 27 Feb 2019 12:27:43 GMT",
    "elapsed": 2,
    "msg": "OK (189 bytes)",
    "redirected": false,
    "server": "Mbedthis-Appweb/2.4.2",
    "status": 200,
    "url": "https://bdsol-aci51-c220m4-3/nuova",
    "x_frame_options": "SAMEORIGIN",
    "xml": {
        "aaaLogin": {
            "@cookie": "",
            "@outCookie": "1551270463/1946f5e8-82e0-12e0-861f-0ac36c11332c",
            "@outPriv": "admin",
            "@outRefreshPeriod": "600",
            "@outSessionId": "1880",
            "@outVersion": "2.0(13e)",
            "@response": "yes"
        }
    }
}
```