### PR TITLE
Update task CPU and MEM limits support in AWS ECS task definition

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -390,7 +390,8 @@ def main():
 
                 return True
 
-            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_cpu_limit, requested_mem_limit, existing_task_definition):
+            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn,
+                                         requested_cpu_limit, requested_mem_limit, existing_task_definition):
                 if td['status'] != "ACTIVE":
                     return None
 
@@ -447,7 +448,8 @@ def main():
                 requested_task_role_arn = module.params['task_role_arn']
                 requested_cpu_limit = module.params['cpu']
                 requested_mem_limit = module.params['memory']
-                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_cpu_limit, requested_mem_limit, td)
+                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn,
+                                                    requested_cpu_limit, requested_mem_limit, td)
 
                 if existing:
                     break

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -390,8 +390,14 @@ def main():
 
                 return True
 
-            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, existing_task_definition):
+            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_cpu_limit, requested_mem_limit, existing_task_definition):
                 if td['status'] != "ACTIVE":
+                    return None
+
+                # Check if task limits have been changed.
+                if requested_cpu_limit != td.get('cpu', None):
+                    return None
+                if requested_mem_limit != td.get('memory', None):
                     return None
 
                 if requested_task_role_arn != td.get('taskRoleArn', ""):
@@ -439,7 +445,9 @@ def main():
                 requested_volumes = module.params['volumes'] or []
                 requested_containers = module.params['containers'] or []
                 requested_task_role_arn = module.params['task_role_arn']
-                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, td)
+                requested_cpu_limit = module.params['cpu']
+                requested_mem_limit = module.params['memory']
+                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_cpu_limit, requested_mem_limit, td)
 
                 if existing:
                     break


### PR DESCRIPTION
##### SUMMARY
An AWS ECS task definition can set the maximum amount of CPU shares and Memory used by all containers within that task definition. Currently it only works at creation time but any subsequent update will not update these limits. This PR is meant to add this support to Ansible. Now with this PR if you change the task CPU and/or MEM limits then it will update the TaskDef accordingly.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- Amazon ECS

##### ADDITIONAL INFORMATION
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
