### PR TITLE
inventory: find required binary for plugin to work

### DIFF
--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -54,6 +54,7 @@ from ansible.errors import AnsibleParserError
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+from ansible.module_utils.common.process import get_bin_path
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
@@ -62,10 +63,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = 'virtualbox'
     VBOX = b"VBoxManage"
 
+    def __init__(self):
+        self._vbox_path = None
+        super(InventoryModule, self).__init__()
+
     def _query_vbox_data(self, host, property_path):
         ret = None
         try:
-            cmd = [self.VBOX, b'guestproperty', b'get', to_bytes(host, errors='surrogate_or_strict'), to_bytes(property_path, errors='surrogate_or_strict')]
+            cmd = [self._vbox_path, b'guestproperty', b'get',
+                   to_bytes(host, errors='surrogate_or_strict'),
+                   to_bytes(property_path, errors='surrogate_or_strict')]
             x = Popen(cmd, stdout=PIPE)
             ipinfo = to_text(x.stdout.read(), errors='surrogate_or_strict')
             if 'Value' in ipinfo:
@@ -216,6 +223,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def parse(self, inventory, loader, path, cache=True):
 
+        try:
+            self._vbox_path = get_bin_path(self.VBOX, True)
+        except ValueError as e:
+            raise AnsibleParserError(e)
+
         super(InventoryModule, self).parse(inventory, loader, path)
 
         cache_key = self.get_cache_key(path)
@@ -241,7 +253,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             running = self.get_option('running_only')
 
             # start getting data
-            cmd = [self.VBOX, b'list', b'-l']
+            cmd = [self._vbox_path, b'list', b'-l']
             if running:
                 cmd.append(b'runningvms')
             else:


### PR DESCRIPTION
##### SUMMARY
Use existing "get_bin_path" API to find the binary path
required for inventory plugins to work.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/nmap.py
lib/ansible/plugins/inventory/virtualbox.py
