### PR TITLE
Re-write linux cpu hardware report to use lscpu

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -183,19 +183,19 @@ class LinuxHardware(Hardware):
 
         cpu_facts['processor'] = []
         cmd = self.module.get_bin_path('lscpu')
-        cmd = cmd + " | egrep '^(Socket|Thread|Core|CPU|Model name)'"
-        rc, lscpu_out, err = self.module.run_command(cmd, use_unsafe_shell=True)
+        # cmd = cmd + " | egrep '^(Socket|Thread|Core|CPU|Model name)'"
+        rc, lscpu_out, err = self.module.run_command(cmd)
         if lscpu_out:
             for line in lscpu_out.splitlines():
                 data = line.split(' ')
-                if line.startswith('Socket'):
+                if line.startswith('Socket(s)'):
                     cpu_facts['processor_count'] = data[-1]
                     continue
-                if line.startswith('Thread'):
-                    cpu_facts['processor_threads_per_core'] = data[-1]
-                    continue
-                if line.startswith('Core'):
+                if line.startswith('Core(s) per socket'):
                     cpu_facts['processor_cores'] = data[-1]
+                    continue
+                if line.startswith('Thread(s) per core'):
+                    cpu_facts['processor_threads_per_core'] = data[-1]
                     continue
                 if line.startswith('Model name'):
                     data = line.split(':')


### PR DESCRIPTION
##### SUMMARY
Re-write linux cpu hardware report to use lscpu instead of manual /proc/cpuinfo parsing.

Fixes #52864
Fixes #41825

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/facts/hardware/linux.py`

##### ADDITIONAL INFORMATION
Parse lscpu output to report cpu information for facts gathering.
Manual parsing sometimes being incorrect.

Current code fallbacks to old parsing of /proc/cpuinfo if somehow vcpu count less than 1. Probably going to be old dead code.

PS: no tests, no idea what and how to test

<!--- Paste verbatim command output below, e.g. before and after your change -->
before
```
$ ansible -m setup gcc114 -a 'filter=ansible_processor*'
gcc114 | SUCCESS => {
    "ansible_facts": {
        "ansible_processor": [
            "AArch64 Processor rev 1 (aarch64)", 
            "0", 
            "1", 
            "2", 
            "3", 
            "4", 
            "5", 
            "6", 
            "7"
        ], 
        "ansible_processor_cores": 1, 
        "ansible_processor_count": 9, 
        "ansible_processor_threads_per_core": 1, 
        "ansible_processor_vcpus": 9
    }, 
    "changed": false
}
$ ansible -m setup nvg5120 -a 'filter=ansible_processor*'
nvg5120 | SUCCESS => {
    "ansible_facts": {
        "ansible_processor": [
            "UltraSparc T2 (Niagara2)"
        ], 
        "ansible_processor_cores": 1, 
        "ansible_processor_count": 64, 
        "ansible_processor_threads_per_core": 1, 
        "ansible_processor_vcpus": 64
    }, 
    "changed": false
}
$ ansible -m setup redpanda -a 'filter=ansible_processor*'       
redpanda | SUCCESS => {
    "ansible_facts": {
        "ansible_processor": [
            "0", 
            "POWER8 (architected), altivec supported", 
            "1", 
            "POWER8 (architected), altivec supported", 
            "2", 
            "POWER8 (architected), altivec supported", 
            "3", 
            "POWER8 (architected), altivec supported", 
            "4", 
            "POWER8 (architected), altivec supported", 
            "5", 
            "POWER8 (architected), altivec supported", 
            "6", 
            "POWER8 (architected), altivec supported", 
            "7", 
            "POWER8 (architected), altivec supported", 
            "8", 
            "POWER8 (architected), altivec supported", 
            "9", 
            "POWER8 (architected), altivec supported", 
            "10", 
            "POWER8 (architected), altivec supported", 
            "11", 
            "POWER8 (architected), altivec supported", 
            "12", 
            "POWER8 (architected), altivec supported", 
            "13", 
            "POWER8 (architected), altivec supported", 
            "14", 
            "POWER8 (architected), altivec supported", 
            "15", 
            "POWER8 (architected), altivec supported", 
            "16", 
            "POWER8 (architected), altivec supported", 
            "17", 
            "POWER8 (architected), altivec supported", 
            "18", 
            "POWER8 (architected), altivec supported", 
            "19", 
            "POWER8 (architected), altivec supported", 
            "20", 
            "POWER8 (architected), altivec supported", 
            "21", 
            "POWER8 (architected), altivec supported", 
            "22", 
            "POWER8 (architected), altivec supported", 
            "23", 
            "POWER8 (architected), altivec supported", 
            "24", 
            "POWER8 (architected), altivec supported", 
            "25", 
            "POWER8 (architected), altivec supported", 
            "26", 
            "POWER8 (architected), altivec supported", 
            "27", 
            "POWER8 (architected), altivec supported", 
            "28", 
            "POWER8 (architected), altivec supported", 
            "29", 
            "POWER8 (architected), altivec supported", 
            "30", 
            "POWER8 (architected), altivec supported", 
            "31", 
            "POWER8 (architected), altivec supported"
        ], 
        "ansible_processor_cores": 1, 
        "ansible_processor_count": 64, 
        "ansible_processor_threads_per_core": 1, 
        "ansible_processor_vcpus": 64
    }, 
    "changed": false
}
```
after
```
$ ansible -m setup gcc114 -a 'filter=ansible_processor*'
gcc114 | SUCCESS => {
    "ansible_facts": {
        "ansible_processor": [], 
        "ansible_processor_cores": "1", 
        "ansible_processor_count": "8", 
        "ansible_processor_threads_per_core": "1", 
        "ansible_processor_vcpus": 8
    }, 
    "changed": false
}
$ ansible -m setup redpanda -a 'filter=ansible_processor*'
redpanda | SUCCESS => {
    "ansible_facts": {
        "ansible_processor": "POWER8 (architected), altivec supported", 
        "ansible_processor_cores": "1", 
        "ansible_processor_count": "4", 
        "ansible_processor_threads_per_core": "8", 
        "ansible_processor_vcpus": 32
    }, 
    "changed": false
}
$ ansible -m setup nvg5120 -a 'filter=ansible_processor*'
nvg5120 | SUCCESS => {
    "ansible_facts": {
        "ansible_processor": "UltraSparc T2 (Niagara2)", 
        "ansible_processor_cores": "16", 
        "ansible_processor_count": "1", 
        "ansible_processor_threads_per_core": "4", 
        "ansible_processor_vcpus": 64
    }, 
    "changed": false
}
```