### PR TITLE
ios_user: Revert back to using section

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -357,7 +357,7 @@ def parse_password_type(data):
 
 
 def map_config_to_obj(module):
-    data = get_config(module, flags=['| include username'])
+    data = get_config(module, flags=['| section username'])
 
     match = re.findall(r'(?:^(?:u|\s{2}u))sername (\S+)', data, re.M)
     if not match:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #52877 
- Reverts ansible/ansible#51845
- `include` does not fetch ssh-key information for users
- This reverts back to using `section` instead of `include`, and fall back to fetching the entire config if section is not supported.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ios_user.py
