### PR TITLE
get_url: return no change in check mode when checksum matches

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -566,12 +566,6 @@ def main():
             filename = url_filename(info['url'])
         dest = os.path.join(dest, filename)
 
-    # If the remote URL exists, we're done with check mode
-    if module.check_mode:
-        os.remove(tmpsrc)
-        result['changed'] = True
-        module.exit_json(msg=info.get('msg', ''), **result)
-
     # raise an error if there is no tmpsrc file
     if not os.path.exists(tmpsrc):
         os.remove(tmpsrc)
@@ -598,6 +592,13 @@ def main():
         if not os.access(os.path.dirname(dest), os.W_OK):
             os.remove(tmpsrc)
             module.fail_json(msg="Destination %s is not writable" % (os.path.dirname(dest)), **result)
+
+    if module.check_mode:
+        if os.path.exists(tmpsrc):
+            os.remove(tmpsrc)
+        result['changed'] = ('checksum_dest' not in result or
+                             result['checksum_src'] != result['checksum_dest'])
+        module.exit_json(msg=info.get('msg', ''), **result)
 
     backup_file = None
     if result['checksum_src'] != result['checksum_dest']:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -268,6 +268,19 @@
     that:
       - result is not changed
 
+- name: test checksum match in check mode
+  get_url:
+    url: 'https://{{ httpbin_host }}/get'
+    dest: '{{ remote_tmp_dir }}/test'
+    checksum: 'sha256:7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.'
+  check_mode: True
+  register: result
+
+- name: Assert that check mode was green
+  assert:
+    that:
+      - result is not changed
+
 # https://github.com/ansible/ansible/issues/27617
 
 - name: set role facts


### PR DESCRIPTION
##### SUMMARY

In check_mode, `get_url` does not compare the checksum with the destination file, so it produces spurious `changed` results which turn out to be green when check_mode is False.

This change moves the check_mode logic a little bit later in get_url so that the destination file checksum is available for comparison with the source file checksum.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
get_url

##### ADDITIONAL INFORMATION

I have updated the get_url test with a case that illustrates this problem and fix.
