### PR TITLE
[backport 2.7] fix no_log indentation for AWS tests

### DIFF
--- a/changelogs/fragments/aws_ec2_inventory_integration_tests.yaml
+++ b/changelogs/fragments/aws_ec2_inventory_integration_tests.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - inventory_aws_ec2 - fix no_log indentation so AWS temporary credentials aren't displayed in tests

--- a/test/integration/targets/inventory_aws_ec2/playbooks/setup.yml
+++ b/test/integration/targets/inventory_aws_ec2/playbooks/setup.yml
@@ -5,7 +5,7 @@
       aws_secret_key: '{{ aws_secret_key }}'
       security_token: '{{ security_token }}'
       region: '{{ aws_region }}'
-    no_log: yes
+  no_log: yes
 
 - name: get image ID to create an instance
   ec2_ami_facts:

--- a/test/integration/targets/inventory_aws_ec2/playbooks/tear_down.yml
+++ b/test/integration/targets/inventory_aws_ec2/playbooks/tear_down.yml
@@ -5,7 +5,7 @@
       aws_secret_key: '{{ aws_secret_key }}'
       security_token: '{{ security_token }}'
       region: '{{ aws_region }}'
-    no_log: yes
+  no_log: yes
 
 - name: remove setup security group
   ec2_group:


### PR DESCRIPTION
Fix displaying Ansible AWS temporary security credentials in shippable

(cherry picked from commit 6cacbcba665af685608253d16275d3bcf33dfa79)

##### SUMMARY
Backport #53073

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory_aws_ec2 integration test
