### PR TITLE
nxos_igmp_snooping: group-timeout fails when igmp snooping disabled

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
@@ -222,8 +222,7 @@ def igmp_snooping_gt_dependency(command, existing, module):
     # group-timeout will fail if igmp snooping is disabled
     gt = [i for i in command if i.startswith('ip igmp snooping group-timeout')]
     if gt:
-        if 'no ip igmp snooping' in command or \
-            (existing['snooping'] is False and 'ip igmp snooping' not in command):
+        if 'no ip igmp snooping' in command or (existing['snooping'] is False and 'ip igmp snooping' not in command):
             msg = "group-timeout cannot be enabled or changed when ip igmp snooping is disabled"
             module.fail_json(msg=msg)
         else:

--- a/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
@@ -217,19 +217,20 @@ def get_igmp_snooping_defaults():
 
     return default
 
+
 def igmp_snooping_gt_dependency(command, existing, module):
     # group-timeout will fail if igmp snooping is disabled
     gt = [i for i in command if i.startswith('ip igmp snooping group-timeout')]
     if gt:
-        invalid1 = 'no ip igmp snooping' in command
-        invalid2 = existing['snooping'] == False and not 'ip igmp snooping' in command
-        if invalid1 or invalid2:
+        if 'no ip igmp snooping' in command or \
+            (existing['snooping'] is False and 'ip igmp snooping' not in command):
             msg = "group-timeout cannot be enabled or changed when ip igmp snooping is disabled"
             module.fail_json(msg=msg)
         else:
             # ensure that group-timeout command is configured last
             command.remove(gt[0])
             command.append(gt[0])
+
 
 def main():
     argument_spec = dict(

--- a/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
@@ -273,7 +273,8 @@ def main():
         if delta:
             command = config_igmp_snooping(delta, existing)
             if command:
-                igmp_snooping_gt_dependency(command, existing, module)
+                if group_timeout:
+                    igmp_snooping_gt_dependency(command, existing, module)
                 commands.append(command)
     elif state == 'default':
         proposed = get_igmp_snooping_defaults()

--- a/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
@@ -18,7 +18,7 @@
   - name: Configure igmp snooping with non-default values
     nxos_igmp_snooping: &non-default
       snooping: false
-      group_timeout: "{{group_timeout|default(omit)}}"
+      # group_timeout: n/a when snooping:false
       link_local_grp_supp: false
       report_supp: false
       v3_report_supp: true
@@ -38,6 +38,42 @@
         that:
           - "result.changed == false"
     when: (imagetag and (imagetag is version_compare('D1', 'ne')))
+
+  - block:
+    - name: Negative Test config group-timeout when igmp snooping disabled
+      nxos_igmp_snooping:
+        snooping: false
+        group_timeout: "{{group_timeout|default(omit)}}"
+        provider: "{{ connection }}"
+        state: present
+      ignore_errors: yes
+      register: result
+
+    - assert:
+        that:
+          - "result.failed == true"
+          - "result.msg == 'group-timeout cannot be enabled or changed when ip igmp snooping is disabled'"
+    when: gt_run
+
+  - block:
+    - name: Configure group-timeout non-default
+      nxos_igmp_snooping: &non-defgt
+        snooping: true
+        group_timeout: "{{group_timeout|default(omit)}}"
+        provider: "{{ connection }}"
+        state: present
+      register: result
+
+    - assert: *true
+    when: gt_run
+
+  - block:
+    - name: "Check Idempotence"
+      nxos_igmp_snooping: *non-defgt
+      register: result
+
+    - assert: *false
+    when: gt_run
 
   - name: Configure igmp snooping with default group timeout
     nxos_igmp_snooping: &defgt

--- a/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
@@ -53,9 +53,7 @@
         that:
           - "result.failed == true"
           - "result.msg == 'group-timeout cannot be enabled or changed when ip igmp snooping is disabled'"
-    when: gt_run
 
-  - block:
     - name: Configure group-timeout non-default
       nxos_igmp_snooping: &non-defgt
         snooping: true
@@ -65,9 +63,7 @@
       register: result
 
     - assert: *true
-    when: gt_run
 
-  - block:
     - name: "Check Idempotence"
       nxos_igmp_snooping: *non-defgt
       register: result


### PR DESCRIPTION
##### SUMMARY
`group-timeout` config will be rejected by the device if `ip igmp snooping` is disabled.

  * Raise a failure for this condition

  * Reorder the command list so that `group-timeout` is always last

  * Updated sanity test. Passes on N9k/N7k. One sanity failure still seen on N6k, to be fixed later.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_igmp_snooping`

