### PR TITLE
Add non_unique parameter for group module

### DIFF
--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -53,6 +53,12 @@ options:
         type: bool
         default: no
         version_added: "2.6"
+    non_unique:
+        description:
+            - This option allows to change the group ID to a non-unique value. Requires C(gid).
+        type: bool
+        default: no
+        version_added: "2.8"
 seealso:
 - module: user
 - module: win_group
@@ -99,6 +105,7 @@ class Group(object):
         self.gid = module.params['gid']
         self.system = module.params['system']
         self.local = module.params['local']
+        self.non_unique = module.params['non_unique']
 
     def execute_command(self, cmd):
         return self.module.run_command(cmd)
@@ -121,6 +128,8 @@ class Group(object):
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
                 cmd.append(str(kwargs[key]))
+                if self.non_unique:
+                    cmd.append('-o')
             elif key == 'system' and kwargs[key] is True:
                 cmd.append('-r')
         cmd.append(self.name)
@@ -138,6 +147,8 @@ class Group(object):
                 if kwargs[key] is not None and info[2] != int(kwargs[key]):
                     cmd.append('-g')
                     cmd.append(str(kwargs[key]))
+                    if self.non_unique:
+                        cmd.append('-o')
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -183,6 +194,8 @@ class SunOS(Group):
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
                 cmd.append(str(kwargs[key]))
+                if self.non_unique:
+                    cmd.append('-o')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -257,6 +270,8 @@ class FreeBsdGroup(Group):
         if self.gid is not None:
             cmd.append('-g')
             cmd.append(str(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
@@ -266,6 +281,8 @@ class FreeBsdGroup(Group):
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
             cmd.append(str(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         # modify the group if cmd will do anything
         if cmd_len != len(cmd):
             if self.module.check_mode:
@@ -377,6 +394,8 @@ class OpenBsdGroup(Group):
         if self.gid is not None:
             cmd.append('-g')
             cmd.append(str(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -386,6 +405,8 @@ class OpenBsdGroup(Group):
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
             cmd.append(str(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -419,6 +440,8 @@ class NetBsdGroup(Group):
         if self.gid is not None:
             cmd.append('-g')
             cmd.append(str(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -428,6 +451,8 @@ class NetBsdGroup(Group):
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
             cmd.append(str(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -445,9 +470,13 @@ def main():
             name=dict(type='str', required=True),
             gid=dict(type='int'),
             system=dict(type='bool', default=False),
-            local=dict(type='bool', default=False)
+            local=dict(type='bool', default=False),
+            non_unique=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
+        required_if=[
+            ['non_unique', True, ['gid']],
+        ],
     )
 
     group = Group(module)

--- a/test/integration/targets/group/tasks/main.yml
+++ b/test/integration/targets/group/tasks/main.yml
@@ -23,6 +23,7 @@
   loop:
   - ansibullgroup
   - ansibullgroup2
+  - ansibullgroup3
 
 - block:
   - name: run tests
@@ -36,3 +37,4 @@
     loop:
     - ansibullgroup
     - ansibullgroup2
+    - ansibullgroup3

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -129,6 +129,22 @@
       - not create_group_gid_again is changed
       - create_group_gid_again.gid | int == gid.stdout_lines[0] | int
 
+- block:
+    - name: create a group with a non-unique gid
+      group:
+        name: ansibullgroup3
+        gid: '{{ gid.stdout_lines[0] }}'
+        non_unique: true
+        state: present
+      register: create_group_gid_non_unique
+
+    - name: assert create group with a non unique gid
+      assert:
+          that:
+          - create_group_gid_non_unique is changed
+          - create_group_gid_non_unique.gid | int == gid.stdout_lines[0] | int
+  when: ansible_facts.system != 'Darwin'
+
 ##
 ## group remove
 ##


### PR DESCRIPTION
Add non_unique parameter for group module
closes #30233

##### SUMMARY
- Implements  #30233
- Add non_unique parameter for group module, which is normally option -o or --non-unique to most POSIX systems. This options is available to create and modify groups. Read more:
    - linux groupadd: https://linux.die.net/man/8/groupadd
    - linux groupmod: https://linux.die.net/man/8/groupmod
    - freebsd pw: https://www.freebsd.org/cgi/man.cgi?pw(8)
    - sunos groupadd: https://www.unix.com/man-page/sunos/1M/groupadd/
    - sunos groupmod: https://www.unix.com/man-page/sunos/1M/groupmod/
    - openbsd groupadd: https://man.openbsd.org/groupadd.8
    - openbsd groupmod: https://man.openbsd.org/groupmod.8
    - netbsd groupadd: http://netbsd.gw.com/cgi-bin/man-cgi?groupadd+8.i386+NetBSD-8.0
    - netbsd groupmod: http://netbsd.gw.com/cgi-bin/man-cgi?groupmod+8.i386+NetBSD-8.0

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- group

##### ADDITIONAL INFORMATION
- I used module user as reference. I could not find HPUX on group module that exists on user module
- I could not find tests for non_unique parameter on user module
- The option non_unique is not available for darwin/macOs systems

