### PR TITLE
Mark ec2_vpc_vgw as disabled to avoid hitting the resource limit (#53…

### DIFF
--- a/test/integration/targets/ec2_vpc_vgw/aliases
+++ b/test/integration/targets/ec2_vpc_vgw/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 shippable/aws/group2
+disabled


### PR DESCRIPTION
…082)

* Mark ec2_vpc_vgw as disabled to avoid hitting the resource limit (#53082)

(cherry picked from commit c4d0c58c5a07a9e0d9c07dc3935d585d3b4df74d)

##### SUMMARY
backport #53082

Disabling these for the time being because AWS appears to be significantly slower than usual. The tests are passing for me, albeit irregularly. When the tests fail the cleanup often fails, and this results in hitting the account limit on virtual private gateways (which is currently 5) until the terminator can clean up the stray resources.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_vgw
