### PR TITLE
Remove `skip/rhel8.0` from osx_defaults test.

### DIFF
--- a/test/integration/targets/osx_defaults/aliases
+++ b/test/integration/targets/osx_defaults/aliases
@@ -2,4 +2,3 @@ shippable/posix/group1
 skip/freebsd
 skip/rhel
 skip/docker
-skip/rhel8.0


### PR DESCRIPTION
##### SUMMARY

Remove `skip/rhel8.0` from osx_defaults test.

The test already has `skip/rhel` which is enough.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

osx_defaults integration test
