### PR TITLE
Modified puppet module to include bool for using no-use_srv_records flag

### DIFF
--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -86,6 +86,7 @@ options:
     description:
       - Toggles no-use_srv_records flag
     type: bool
+    version_added: "2.8"
   summarize:
     description:
       - Whether to print a transaction summary.

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -82,6 +82,11 @@ options:
       - It has no effect with a puppetmaster.
     type: str
     version_added: "2.1"
+  no_use_srv_records:
+    description:
+      - Toggles no-use_srv_records flag
+    type: bool
+    version_added: ""
   summarize:
     description:
       - Whether to print a transaction summary.
@@ -192,6 +197,7 @@ def main():
             summarize=dict(type='bool', default=False),
             debug=dict(type='bool', default=False),
             verbose=dict(type='bool', default=False),
+            no_use_srv_records=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
         mutually_exclusive=[
@@ -260,6 +266,8 @@ def main():
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
             cmd += " --noop"
+        if p['no_use_srv_records']:
+            cmd += " --no-use_srv_records"
         elif 'noop' in p:
             if p['noop']:
                 cmd += " --noop"

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -86,7 +86,6 @@ options:
     description:
       - Toggles no-use_srv_records flag
     type: bool
-    version_added: ""
   summarize:
     description:
       - Whether to print a transaction summary.

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -86,7 +86,7 @@ options:
     description:
       - Toggles use_srv_records flag
     type: bool
-    version_added: "2.8"
+    version_added: "2.9"
   summarize:
     description:
       - Whether to print a transaction summary.

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -82,9 +82,9 @@ options:
       - It has no effect with a puppetmaster.
     type: str
     version_added: "2.1"
-  no_use_srv_records:
+  use_srv_records:
     description:
-      - Toggles no-use_srv_records flag
+      - Toggles use_srv_records flag
     type: bool
     version_added: "2.8"
   summarize:
@@ -197,7 +197,7 @@ def main():
             summarize=dict(type='bool', default=False),
             debug=dict(type='bool', default=False),
             verbose=dict(type='bool', default=False),
-            no_use_srv_records=dict(type='bool', default=False),
+            use_srv_records=dict(type='bool'),
         ),
         supports_check_mode=True,
         mutually_exclusive=[
@@ -266,8 +266,11 @@ def main():
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
             cmd += " --noop"
-        if p['no_use_srv_records']:
-            cmd += " --no-use_srv_records"
+        if p['use_srv_records']:
+            if not ['use_srv_records']:
+                cmd += " --no-use_srv_records"
+            else:
+                cmd += " --use_srv_records"
         elif 'noop' in p:
             if p['noop']:
                 cmd += " --noop"

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -266,7 +266,7 @@ def main():
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
             cmd += " --noop"
-        if p['use_srv_records']:
+        if p['use_srv_records'] is not None:
             if not ['use_srv_records']:
                 cmd += " --no-use_srv_records"
             else:


### PR DESCRIPTION
##### SUMMARY
This change adds an option to toggle the --no-use_srv_records flag in a puppet agent run command with the puppet module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Puppet module no-use_srv_records flag

##### ADDITIONAL INFORMATION
