### PR TITLE
Don't run integration tests for OS'es older than Windows 2016

### DIFF
--- a/test/integration/targets/win_dsc/aliases
+++ b/test/integration/targets/win_dsc/aliases
@@ -1,1 +1,5 @@
 shippable/windows/group4
+skip/windows/2008
+skip/windows/2008-R2
+skip/windows/2012
+skip/windows/2012-R2

--- a/test/integration/targets/win_firewall/aliases
+++ b/test/integration/targets/win_firewall/aliases
@@ -1,1 +1,5 @@
 shippable/windows/group2
+skip/windows/2008
+skip/windows/2008-R2
+skip/windows/2012
+skip/windows/2012-R2


### PR DESCRIPTION
##### SUMMARY
The pull request disables running of integration test on Windows Server 2008, 2008R2, 2012, 2012 R2 due that PowerShell >= 5.0 is required to run tests.

It's a backport of the PR #53057.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_dsc
win_firewall

##### ADDITIONAL INFORMATION
It's a backport of the PR #53057.