### PR TITLE
ios_logging: fix the error checking the existence of "host" destinations (IOS 12)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -291,6 +291,7 @@ def map_config_to_obj(module):
                 obj.append({
                     'dest': dest,
                     'name': match.group(1),
+                    'size': parse_size(line, dest),
                     'facility': parse_facility(line, dest),
                     'level': parse_level(line, dest)
                 })
@@ -301,6 +302,7 @@ def map_config_to_obj(module):
                     obj.append({
                         'dest': dest,
                         'name': match.group(1),
+                        'size': parse_size(line, dest),
                         'facility': parse_facility(line, dest),
                         'level': parse_level(line, dest)
                     })

--- a/test/units/modules/network/ios/fixtures/ios_logging_config_ios12.cfg
+++ b/test/units/modules/network/ios/fixtures/ios_logging_config_ios12.cfg
@@ -1,0 +1,6 @@
+!
+logging buffered 5000
+logging console informational
+logging facility local0
+logging 2.3.4.5
+!

--- a/test/units/modules/network/ios/test_ios_logging.py
+++ b/test/units/modules/network/ios/test_ios_logging.py
@@ -66,3 +66,72 @@ class TestIosLoggingModule(TestIosModule):
         set_module_args(dict(dest='buffered', size=6000))
         commands = ['logging buffered 6000']
         self.execute_module(changed=True, commands=commands)
+
+    def test_ios_logging_add_host(self):
+        set_module_args(dict(dest='host', name='192.168.1.1'))
+        commands = ['logging host 192.168.1.1']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ios_logging_host_idempotent(self):
+        set_module_args(dict(dest='host', name='2.3.4.5'))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_ios_logging_delete_non_exist_host(self):
+        set_module_args(dict(dest='host', name='192.168.1.1', state='absent'))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_ios_logging_delete_host(self):
+        set_module_args(dict(dest='host', name='2.3.4.5', state='absent'))
+        commands = ['no logging host 2.3.4.5']
+        self.execute_module(changed=True, commands=commands)
+
+class TestIosLoggingModuleIOS12(TestIosModule):
+
+    module = ios_logging
+
+    def setUp(self):
+        super(TestIosLoggingModuleIOS12, self).setUp()
+
+        self.mock_get_config = patch('ansible.modules.network.ios.ios_logging.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.ios.ios_logging.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_get_capabilities = patch('ansible.modules.network.ios.ios_logging.get_capabilities')
+        self.get_capabilities = self.mock_get_capabilities.start()
+        self.get_capabilities.return_value = {'device_info': {'network_os_version': '12.1(2)T'}}
+
+    def tearDown(self):
+        super(TestIosLoggingModuleIOS12, self).tearDown()
+
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_get_capabilities.stop()
+
+    def load_fixtures(self, commands=None):
+        self.get_config.return_value = load_fixture('ios_logging_config_ios12.cfg')
+        self.load_config.return_value = None
+
+    def test_ios_logging_add_host(self):
+        set_module_args(dict(dest='host', name='192.168.1.1'))
+        commands = ['logging 192.168.1.1']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ios_logging_host_idempotent(self):
+        set_module_args(dict(dest='host', name='2.3.4.5'))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_ios_logging_delete_non_exist_host(self):
+        set_module_args(dict(dest='host', name='192.168.1.1', state='absent'))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_ios_logging_delete_host(self):
+        set_module_args(dict(dest='host', name='2.3.4.5', state='absent'))
+        commands = ['no logging 2.3.4.5']
+        self.execute_module(changed=True, commands=commands)
+


### PR DESCRIPTION
##### SUMMARY
In the "have" list ([ios_logging.py:L412](https://github.com/ansible/ansible/blob/4d3a6123d5b84ed8cdaba4e945e6f1d55c35c4b4/lib/ansible/modules/network/ios/ios_logging.py#L412)) records of type "host" do not contain the key "size", although in the list "want" it is always there. Because of this, the module assumes that the "host" type destinations is not configured and does it again. This does not change the configuration on the device, but is redundant and the status of the task will always be "changed". This patch fixes it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ios_logging

##### ADDITIONAL INFORMATION
Condition: IOS 12
playbook to reproduce the problem:
```
---
- hosts: all
  gather_facts: no
  tasks:
  - name: configure syslog servers
    ios_logging:
     dest: host
     name: "192.168.1.1"

  - name: configure syslog servers (idempotent)
    register: result
    ios_logging:
     dest: host
     name: "192.168.1.1"

  - name: test
    assert:
     that:
     - "result.changed == false "
```
