### PR TITLE
Set the atime, mtime using a floating point number (timestamp).

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -81,7 +81,7 @@ options:
   modification_time:
     description:
     - This parameter indicates the time the file's modification time should be set to.
-    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, 
+    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format,
       C(float) when using C(raw) time format, or C(now).
     - Default is None meaning that C(preserve) is the default for C(state=[file,directory,link,hard]) and C(now) is default for C(state=touch).
     type: str
@@ -96,7 +96,7 @@ options:
   access_time:
     description:
     - This parameter indicates the time the file's access time should be set to.
-    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, 
+    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format,
       C(float) when using C(raw) time format, or C(now).
     - Default is C(None) meaning that C(preserve) is the default for C(state=[file,directory,link,hard]) and C(now) is default for C(state=touch).
     type: str

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -81,7 +81,8 @@ options:
   modification_time:
     description:
     - This parameter indicates the time the file's modification time should be set to.
-    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, C(float) when using C(raw) time format, or C(now).
+    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, 
+      C(float) when using C(raw) time format, or C(now).
     - Default is None meaning that C(preserve) is the default for C(state=[file,directory,link,hard]) and C(now) is default for C(state=touch).
     type: str
     version_added: "2.7"
@@ -95,7 +96,8 @@ options:
   access_time:
     description:
     - This parameter indicates the time the file's access time should be set to.
-    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, C(float) when using C(raw) time format, or C(now).
+    - Should be C(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, 
+      C(float) when using C(raw) time format, or C(now).
     - Default is C(None) meaning that C(preserve) is the default for C(state=[file,directory,link,hard]) and C(now) is default for C(state=touch).
     type: str
     version_added: '2.7'


### PR DESCRIPTION
##### SUMMARY
Currently, the `stat` module returns atime and mtime using a floating point number. Allowing the `file`  module to set the time using a floating point number seems reasonable in this case.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
file

##### ADDITIONAL INFORMATION
Example code of the task, which the new functionality can use:
```
- stat:
    path: /some_file
  register: stat_some_file

- file:
    path: /other_file
    modification_time: "{{ stat_some_file.stat.mtime }}"
    modification_time_format: "raw"
```
