### PR TITLE
win_chocolatey: Fix error when choco.exe not found

### DIFF
--- a/changelogs/fragments/win_chocolatey-check-install-path.yaml
+++ b/changelogs/fragments/win_chocolatey-check-install-path.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_chocolatey - Improve error checking when finding the path of a newly installed Chocolatey app

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -284,23 +284,21 @@ Function Install-Chocolatey {
         # locate the newly installed choco.exe
         $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
         if ($null -eq $choco_app) {
-            $choco_path = $env:ChocolateyInstall
-            if ($null -ne $choco_path) {
-                $choco_path = "$choco_path\bin\choco.exe"
-            } else {
-                $choco_path = "$env:SYSTEMDRIVE\ProgramData\Chocolatey\bin\choco.exe"
+            $choco_dir = $env:ChocolateyInstall
+            if ($null -eq $choco_path) {
+                $choco_dir = "$env:SYSTEMDRIVE\ProgramData\Chocolatey"
             }
-
-            $choco_app = Get-Command -Name $choco_path -CommandType Application -ErrorAction SilentlyContinue
+            $choco_app = Get-Command -Name "$choco_dir\bin\choco.exe" -CommandType Application -ErrorAction SilentlyContinue
         }
     }
+
     if ($module.CheckMode -and $null -eq $choco_app) {
         $module.Result.skipped = $true
         $module.Result.msg = "Skipped check mode run on win_chocolatey as choco.exe cannot be found on the system"
         $module.ExitJson()
     }
 
-    if (-not (Test-Path -Path $choco_app.Path)) {
+    if ($null -eq $choco_app -or -not (Test-Path -LiteralPath $choco_app.Path)) {
         $module.FailJson("Failed to find choco.exe, make sure it is added to the PATH or the env var 'ChocolateyInstall' is set")
     }
 
@@ -321,6 +319,7 @@ Function Install-Chocolatey {
         }
         $module.Warn("Chocolatey was older than v0.10.5 so it was upgraded during this task run.")
         Update-ChocolateyPackage -choco_path $choco_app.Path -packages @("chocolatey") `
+
             -proxy_url $proxy_url -proxy_username $proxy_username `
             -proxy_password $proxy_password -source $source `
             -source_username $source_username -source_password $source_password

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -285,7 +285,7 @@ Function Install-Chocolatey {
         $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
         if ($null -eq $choco_app) {
             $choco_dir = $env:ChocolateyInstall
-            if ($null -eq $choco_path) {
+            if ($null -eq $choco_dir) {
                 $choco_dir = "$env:SYSTEMDRIVE\ProgramData\Chocolatey"
             }
             $choco_app = Get-Command -Name "$choco_dir\bin\choco.exe" -CommandType Application -ErrorAction SilentlyContinue

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -4981,7 +4981,6 @@ lib/ansible/modules/windows/setup.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_acl_inheritance.ps1 pslint:PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_audit_rule.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_certificate_store.ps1 validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/windows/win_chocolatey.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_chocolatey_config.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_chocolatey_facts.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_chocolatey_source.ps1 pslint:PSCustomUseLiteralPath


### PR DESCRIPTION
##### SUMMARY
This fixes an issue where Get-Command would return $null, but we access the Path property anyway and PowerShell accepts it as if everything is possible. Sigh.

This relates to #47821 but does not fix it. We still do not know why the newly installed choco.exe was not found. (Possibly because it was not correctly installed, it was removed or it requires a reboot ?)

At least we now get a proper error indication.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey