### PR TITLE
enable ec2_vpc_vgw tests

### DIFF
--- a/test/integration/targets/ec2_vpc_vgw/aliases
+++ b/test/integration/targets/ec2_vpc_vgw/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 shippable/aws/group2
-disabled


### PR DESCRIPTION
##### SUMMARY
It seems like AWS has fixed the issue with timeouts while attaching vgws
The CI account limit for virtual private gateways has also been increased

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_vgw
