### PR TITLE
meraki_mx_l3_firewall - Create syslog in integration tests

### DIFF
--- a/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -110,6 +110,20 @@
       that:
         - create_one_idempotent.changed == False
 
+  - name: Create syslog in network
+    meraki_syslog:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: present
+      servers:
+        - host: 192.0.2.10
+          port: 514
+          roles:
+            - Appliance event log
+            - Flows
+    delegate_to: localhost
+
   - name: Enable syslog for default rule
     meraki_mx_l3_firewall:
       auth_key: '{{ auth_key }}'


### PR DESCRIPTION
##### SUMMARY
Some of the integration tests in the MX l3 module require creation of a syslog server. This PR adds a task to create a syslog server on the network, purely for testing.

Fixes #48861

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_mx_l3_firewall
