### PR TITLE
docker_swarm: support older docker-py versions

### DIFF
--- a/changelogs/fragments/53129-docker_swarm-older-docker-py.yaml
+++ b/changelogs/fragments/53129-docker_swarm-older-docker-py.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm - now supports docker-py 1.10.0 and newer, instead only docker 2.6.0 and newer."

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -76,7 +76,7 @@ extends_documentation_fragment:
   - docker
   - docker.docker_py_1_documentation
 requirements:
-  - "docker-py >= 1.10.0"
+  - "docker-py >= 2.4.0"
   - Docker API >= 1.25
 author:
   - Piotr Wojciechowski (@WojciechowskiPiotr)
@@ -273,7 +273,7 @@ def main():
     client = AnsibleDockerSwarmClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        min_docker_version='1.10.0',
+        min_docker_version='2.4.0',
         min_docker_api_version='1.25',
     )
 

--- a/lib/ansible/modules/cloud/docker/docker_node_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_facts.py
@@ -48,7 +48,7 @@ author:
   - Piotr Wojciechowski (@wojciechowskipiotr)
 
 requirements:
-  - "docker-py >= 1.10.0"
+  - "docker-py >= 2.4.0"
   - "Docker API >= 1.24"
 '''
 
@@ -130,7 +130,7 @@ def main():
     client = AnsibleDockerSwarmClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        min_docker_version='1.10.0',
+        min_docker_version='2.4.0',
         min_docker_api_version='1.24',
     )
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -464,10 +464,11 @@ class SwarmManager(DockerBaseClass):
                 self.results['actions'].append("No modification")
                 self.results['changed'] = False
                 return
-            self.parameters.update_parameters(self.client)
+            update_parameters = TaskParameters.from_ansible_params(self.client)
+            update_parameters.update_parameters(self.client)
             if not self.check_mode:
                 self.client.update_swarm(
-                    version=version, swarm_spec=self.parameters.spec,
+                    version=version, swarm_spec=update_parameters.spec,
                     rotate_worker_token=self.parameters.rotate_worker_token,
                     rotate_manager_token=self.parameters.rotate_manager_token)
         except APIError as exc:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1702,14 +1702,16 @@ class DockerServiceManager(object):
 
 
 def _detect_publish_mode_usage(client):
-    for publish_def in client.module.params['publish']:
+    for publish_def in client.module.params['publish'] or []:
         if publish_def.get('mode'):
             return True
     return False
 
 
 def _detect_healthcheck_start_period(client):
-    return client.module.params['healthcheck']['start_period'] is not None
+    if client.module.params['healthcheck']:
+        return client.module.params['healthcheck']['start_period'] is not None
+    return False
 
 
 def main():

--- a/test/integration/targets/docker_host_facts/tasks/main.yml
+++ b/test/integration/targets/docker_host_facts/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: test_host_facts.yml
   when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.21', '>=')
 
-- fail: msg="Too old docker / docker-py version to run docker_swarm_facts tests!"
+- fail: msg="Too old docker / docker-py version to run docker_host_facts tests!"
   when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.21', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_node/aliases
+++ b/test/integration/targets/docker_node/aliases
@@ -3,3 +3,9 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system. On VMs, we restart docker daemon
+             # after finishing the tests to minimize potential effects
+             # on other tests.
+needs/root

--- a/test/integration/targets/docker_node/tasks/main.yml
+++ b/test/integration/targets/docker_node/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: test_node.yml
-  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')
+  when: docker_py_version is version('2.4.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_node tests!"
-  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.4.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_node/tasks/main.yml
+++ b/test/integration/targets/docker_node/tasks/main.yml
@@ -1,4 +1,30 @@
-- include_tasks: test_node.yml
+---
+# Run the tests
+- block:
+  - include_tasks: test_node.yml
+
+  always:
+  - name: Cleanup (trying)
+    docker_swarm:
+      state: absent
+      force: true
+    diff: no
+    ignore_errors: yes
+
+  - name: Restart docker daemon
+    service:
+      name: docker
+      state: restarted
+    become: yes
+  - name: Wait for docker daemon to be fully restarted
+    command: docker ps
+
+  - name: Cleanup
+    docker_swarm:
+      state: absent
+      force: true
+    diff: no
+
   when: docker_py_version is version('2.4.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_node tests!"

--- a/test/integration/targets/docker_node/tasks/main.yml
+++ b/test/integration/targets/docker_node/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: test_node.yml
-  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.24', '>=')
+  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')
 
-- fail: msg="Too old docker / docker-py version to run docker_swarm_facts tests!"
-  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.24', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+- fail: msg="Too old docker / docker-py version to run docker_node tests!"
+  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_node_facts/tasks/main.yml
+++ b/test/integration/targets/docker_node_facts/tasks/main.yml
@@ -1,6 +1,6 @@
 - include_tasks: test_node_facts.yml
   # Maximum of 1.24 (docker API version for docker_node_facts) and 1.25 (docker API version for docker_swarm) is 1.25
-  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')
+  when: docker_py_version is version('2.4.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_node_facts tests!"
-  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.4.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_node_facts/tasks/main.yml
+++ b/test/integration/targets/docker_node_facts/tasks/main.yml
@@ -1,5 +1,6 @@
 - include_tasks: test_node_facts.yml
-  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.24', '>=')
+  # Maximum of 1.24 (docker API version for docker_node_facts) and 1.25 (docker API version for docker_swarm) is 1.25
+  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')
 
-- fail: msg="Too old docker / docker-py version to run docker_swarm_facts tests!"
-  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.24', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+- fail: msg="Too old docker / docker-py version to run docker_node_facts tests!"
+  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_secret/tasks/main.yml
+++ b/test/integration/targets/docker_secret/tasks/main.yml
@@ -1,6 +1,5 @@
 - include_tasks: test_secrets.yml
-  # Maximum of 2.1.0 (docker-py version for docker_secrets) and 2.6.0 (docker-py version for docker_swarm) is 2.6.0
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')
+  when: docker_py_version is version('2.1.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_secrets tests!"
-  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.1.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -27,7 +27,7 @@
       force: true
     diff: no
 
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')
+  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_swarm tests!"
-  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/basic.yml
@@ -64,7 +64,7 @@
 - name: Create a Swarm cluster (force re-create)
   docker_swarm:
     state: present
-    advertise_addr: "{{ansible_default_ipv4.address}}"
+    advertise_addr: "{{ansible_default_ipv4.address | default('127.0.0.1')}}"
     force: yes
   diff: yes
   register: output_5
@@ -72,7 +72,7 @@
 - name: Create a Swarm cluster (force re-create, check mode)
   docker_swarm:
     state: present
-    advertise_addr: "{{ansible_default_ipv4.address}}"
+    advertise_addr: "{{ansible_default_ipv4.address | default('127.0.0.1')}}"
     force: yes
   check_mode: yes
   diff: yes

--- a/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
@@ -50,6 +50,7 @@
     check_mode: yes
     diff: yes
     register: output_1
+    ignore_errors: yes
 
   - name: signing_ca_cert and signing_ca_key
     docker_swarm:
@@ -60,6 +61,7 @@
       timeout: 120
     diff: yes
     register: output_2
+    ignore_errors: yes
 
   - name: Private key
     debug: msg="{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.key') }}"
@@ -67,6 +69,7 @@
     debug: msg="{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.pem') }}"
   - docker_swarm_facts:
     register: output
+    ignore_errors: yes
   - debug: var=output
 
   # Idempotence for CA cert and key don't work yet! FIXME
@@ -79,6 +82,7 @@
   #    timeout: 120
   #  diff: yes
   #  register: output_3
+  #  ignore_errors: yes
 
   #- name: signing_ca_cert and signing_ca_key (idempotent, check mode)
   #  docker_swarm:
@@ -89,6 +93,7 @@
   #  check_mode: yes
   #  diff: yes
   #  register: output_4
+  #  ignore_errors: yes
 
   - name: signing_ca_cert and signing_ca_key (change, check mode)
     docker_swarm:
@@ -99,6 +104,7 @@
     check_mode: yes
     diff: yes
     register: output_5
+    ignore_errors: yes
 
   - name: signing_ca_cert and signing_ca_key (change)
     docker_swarm:
@@ -108,6 +114,7 @@
       timeout: 120
     diff: yes
     register: output_6
+    ignore_errors: yes
 
   - name: assert signing_ca_cert and signing_ca_key
     assert:
@@ -136,6 +143,12 @@
          - 'output_6.actions[0] == "Swarm cluster updated"'
          - 'output_6.diff.before is defined'
          - 'output_6.diff.after is defined'
+    when: docker_py_version is version('2.6.0', '>=')
+  - assert:
+      that:
+      - output_1 is failed
+      - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+    when: docker_py_version is version('2.6.0', '<')
 
   # https://github.com/ansible/ansible/issues/34054: openssl_certificate unusable on RHEL 7
   when: pyopenssl_version.stdout is version('0.15', '>=')

--- a/test/integration/targets/docker_swarm/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options.yml
@@ -17,6 +17,7 @@
   check_mode: yes
   diff: yes
   register: output_1
+  ignore_errors: yes
 
 - name: autolock_managers
   docker_swarm:
@@ -24,6 +25,7 @@
     autolock_managers: yes
   diff: yes
   register: output_2
+  ignore_errors: yes
 
 - name: autolock_managers (idempotent)
   docker_swarm:
@@ -31,6 +33,7 @@
     autolock_managers: yes
   diff: yes
   register: output_3
+  ignore_errors: yes
 
 - name: autolock_managers (idempotent, check mode)
   docker_swarm:
@@ -39,6 +42,7 @@
   check_mode: yes
   diff: yes
   register: output_4
+  ignore_errors: yes
 
 - name: autolock_managers (change, check mode)
   docker_swarm:
@@ -47,6 +51,7 @@
   check_mode: yes
   diff: yes
   register: output_5
+  ignore_errors: yes
 
 - name: autolock_managers (change)
   docker_swarm:
@@ -54,8 +59,9 @@
     autolock_managers: no
   diff: yes
   register: output_6
+  ignore_errors: yes
 
-- name: assert changed when remove a swarm cluster
+- name: assert autolock_managers changes
   assert:
     that:
        - 'output_1 is changed'
@@ -82,6 +88,12 @@
        - 'output_6.actions[0] == "Swarm cluster updated"'
        - 'output_6.diff.before is defined'
        - 'output_6.diff.after is defined'
+  when: docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - output_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+  when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## ca_force_rotate #################################################
@@ -94,6 +106,7 @@
   check_mode: yes
   diff: yes
   register: output_1
+  ignore_errors: yes
 
 - name: ca_force_rotate
   docker_swarm:
@@ -101,6 +114,7 @@
     ca_force_rotate: 1
   diff: yes
   register: output_2
+  ignore_errors: yes
 
 - name: ca_force_rotate (idempotent)
   docker_swarm:
@@ -108,6 +122,7 @@
     ca_force_rotate: 1
   diff: yes
   register: output_3
+  ignore_errors: yes
 
 - name: ca_force_rotate (idempotent, check mode)
   docker_swarm:
@@ -116,6 +131,7 @@
   check_mode: yes
   diff: yes
   register: output_4
+  ignore_errors: yes
 
 - name: ca_force_rotate (change, check mode)
   docker_swarm:
@@ -124,6 +140,7 @@
   check_mode: yes
   diff: yes
   register: output_5
+  ignore_errors: yes
 
 - name: ca_force_rotate (change)
   docker_swarm:
@@ -131,8 +148,9 @@
     ca_force_rotate: 0
   diff: yes
   register: output_6
+  ignore_errors: yes
 
-- name: assert changed when remove a swarm cluster
+- name: assert ca_force_rotate changes
   assert:
     that:
        - 'output_1 is changed'
@@ -159,6 +177,12 @@
        - 'output_6.actions[0] == "Swarm cluster updated"'
        - 'output_6.diff.before is defined'
        - 'output_6.diff.after is defined'
+  when: docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - output_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+  when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## dispatcher_heartbeat_period #####################################
@@ -209,7 +233,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert dispatcher_heartbeat_period changes
   assert:
     that:
        - 'output_1 is changed'
@@ -286,7 +310,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert election_tick changes
   assert:
     that:
        - 'output_1 is changed'
@@ -363,7 +387,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert heartbeat_tick changes
   assert:
     that:
        - 'output_1 is changed'
@@ -439,7 +463,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert keep_old_snapshots changes
   assert:
     that:
        - 'output_1 is changed'
@@ -479,6 +503,7 @@
   check_mode: yes
   diff: yes
   register: output_1
+  ignore_errors: yes
 
 - name: labels
   docker_swarm:
@@ -488,6 +513,7 @@
       b: v2
   diff: yes
   register: output_2
+  ignore_errors: yes
 
 - name: labels (idempotent)
   docker_swarm:
@@ -497,6 +523,7 @@
       b: v2
   diff: yes
   register: output_3
+  ignore_errors: yes
 
 - name: labels (idempotent, check mode)
   docker_swarm:
@@ -507,6 +534,7 @@
   check_mode: yes
   diff: yes
   register: output_4
+  ignore_errors: yes
 
 - name: labels (change, check mode)
   docker_swarm:
@@ -517,6 +545,7 @@
   check_mode: yes
   diff: yes
   register: output_5
+  ignore_errors: yes
 
 - name: labels (change)
   docker_swarm:
@@ -526,8 +555,43 @@
       c: v3
   diff: yes
   register: output_6
+  ignore_errors: yes
 
-- name: assert changed when remove a swarm cluster
+- name: labels (empty, check mode)
+  docker_swarm:
+    state: present
+    labels: {}
+  check_mode: yes
+  diff: yes
+  register: output_7
+  ignore_errors: yes
+
+- name: labels (empty)
+  docker_swarm:
+    state: present
+    labels: {}
+  diff: yes
+  register: output_8
+  ignore_errors: yes
+
+- name: labels (empty, idempotent, check mode)
+  docker_swarm:
+    state: present
+    labels: {}
+  check_mode: yes
+  diff: yes
+  register: output_9
+  ignore_errors: yes
+
+- name: labels (empty, idempotent)
+  docker_swarm:
+    state: present
+    labels: {}
+  diff: yes
+  register: output_10
+  ignore_errors: yes
+
+- name: assert labels changes
   assert:
     that:
        - 'output_1 is changed'
@@ -554,6 +618,28 @@
        - 'output_6.actions[0] == "Swarm cluster updated"'
        - 'output_6.diff.before is defined'
        - 'output_6.diff.after is defined'
+       - 'output_7 is changed'
+       - 'output_7.actions[0] == "Swarm cluster updated"'
+       - 'output_7.diff.before is defined'
+       - 'output_7.diff.after is defined'
+       - 'output_8 is changed'
+       - 'output_8.actions[0] == "Swarm cluster updated"'
+       - 'output_8.diff.before is defined'
+       - 'output_8.diff.after is defined'
+       - 'output_9 is not changed'
+       - 'output_9.actions[0] == "No modification"'
+       - 'output_9.diff.before is defined'
+       - 'output_9.diff.after is defined'
+       - 'output_10 is not changed'
+       - 'output_10.actions[0] == "No modification"'
+       - 'output_10.diff.before is defined'
+       - 'output_10.diff.after is defined'
+  when: docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - output_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+  when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## log_entries_for_slow_followers ##################################
@@ -603,7 +689,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert log_entries_for_slow_followers changes
   assert:
     that:
        - 'output_1 is changed'
@@ -660,7 +746,7 @@
   register: output_3
   ignore_errors: yes
 
-- name: assert changed when remove a swarm cluster
+- name: assert name changes
   assert:
     that:
        - 'output_1 is not changed'
@@ -721,7 +807,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert node_cert_expiry changes
   assert:
     that:
        - 'output_1 is changed'
@@ -782,7 +868,7 @@
   diff: yes
   register: output_4
 
-- name: assert changed when remove a swarm cluster
+- name: assert rotate_manager_token changes
   assert:
     that:
        - 'output_1 is changed'
@@ -835,7 +921,7 @@
   diff: yes
   register: output_4
 
-- name: assert changed when remove a swarm cluster
+- name: assert rotate_worker_token changes
   assert:
     that:
        - 'output_1 is changed'
@@ -903,7 +989,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert snapshot_interval changes
   assert:
     that:
        - 'output_1 is changed'
@@ -979,7 +1065,7 @@
   diff: yes
   register: output_6
 
-- name: assert changed when remove a swarm cluster
+- name: assert task_history_retention_limit changes
   assert:
     that:
        - 'output_1 is changed'

--- a/test/integration/targets/docker_swarm/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options.yml
@@ -557,13 +557,38 @@
   register: output_6
   ignore_errors: yes
 
+- name: labels (not specifying, check mode)
+  docker_swarm:
+    state: present
+  check_mode: yes
+  diff: yes
+  register: output_7
+  ignore_errors: yes
+
+- name: labels (not specifying)
+  docker_swarm:
+    state: present
+  diff: yes
+  register: output_8
+  ignore_errors: yes
+
+- name: labels (idempotency, check that labels are still there)
+  docker_swarm:
+    state: present
+    labels:
+      a: v1
+      c: v3
+  diff: yes
+  register: output_9
+  ignore_errors: yes
+
 - name: labels (empty, check mode)
   docker_swarm:
     state: present
     labels: {}
   check_mode: yes
   diff: yes
-  register: output_7
+  register: output_10
   ignore_errors: yes
 
 - name: labels (empty)
@@ -571,7 +596,7 @@
     state: present
     labels: {}
   diff: yes
-  register: output_8
+  register: output_11
   ignore_errors: yes
 
 - name: labels (empty, idempotent, check mode)
@@ -580,7 +605,7 @@
     labels: {}
   check_mode: yes
   diff: yes
-  register: output_9
+  register: output_12
   ignore_errors: yes
 
 - name: labels (empty, idempotent)
@@ -588,7 +613,7 @@
     state: present
     labels: {}
   diff: yes
-  register: output_10
+  register: output_13
   ignore_errors: yes
 
 - name: assert labels changes
@@ -618,22 +643,34 @@
        - 'output_6.actions[0] == "Swarm cluster updated"'
        - 'output_6.diff.before is defined'
        - 'output_6.diff.after is defined'
-       - 'output_7 is changed'
-       - 'output_7.actions[0] == "Swarm cluster updated"'
+       - 'output_7 is not changed'
+       - 'output_7.actions[0] == "No modification"'
        - 'output_7.diff.before is defined'
        - 'output_7.diff.after is defined'
-       - 'output_8 is changed'
-       - 'output_8.actions[0] == "Swarm cluster updated"'
+       - 'output_8 is not changed'
+       - 'output_8.actions[0] == "No modification"'
        - 'output_8.diff.before is defined'
        - 'output_8.diff.after is defined'
        - 'output_9 is not changed'
        - 'output_9.actions[0] == "No modification"'
        - 'output_9.diff.before is defined'
        - 'output_9.diff.after is defined'
-       - 'output_10 is not changed'
-       - 'output_10.actions[0] == "No modification"'
+       - 'output_10 is changed'
+       - 'output_10.actions[0] == "Swarm cluster updated"'
        - 'output_10.diff.before is defined'
        - 'output_10.diff.after is defined'
+       - 'output_11 is changed'
+       - 'output_11.actions[0] == "Swarm cluster updated"'
+       - 'output_11.diff.before is defined'
+       - 'output_11.diff.after is defined'
+       - 'output_12 is not changed'
+       - 'output_12.actions[0] == "No modification"'
+       - 'output_12.diff.before is defined'
+       - 'output_12.diff.after is defined'
+       - 'output_13 is not changed'
+       - 'output_13.actions[0] == "No modification"'
+       - 'output_13.diff.before is defined'
+       - 'output_13.diff.after is defined'
   when: docker_py_version is version('2.6.0', '>=')
 - assert:
     that:

--- a/test/integration/targets/docker_swarm_facts/tasks/main.yml
+++ b/test/integration/targets/docker_swarm_facts/tasks/main.yml
@@ -1,5 +1,6 @@
 - include_tasks: test_swarm_facts.yml
-  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.24', '>=')
+  # Maximum of 1.24 (docker API version for docker_swarm_facts) and 1.25 (docker API version for docker_swarm) is 1.25
+  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_swarm_facts tests!"
-  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.24', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm_service/tasks/main.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/main.yml
@@ -68,7 +68,8 @@
         state: absent
         force: yes
       ignore_errors: yes
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.24', '>=')
+  # Maximum of 1.24 (docker API version for docker_swarm_service) and 1.25 (docker API version for docker_swarm) is 1.25
+  when: docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_swarm_service tests!"
-  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.24', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)


### PR DESCRIPTION
##### SUMMARY
This adds support to `docker_swarm` for docker-py from version 1.10.0 on. I mainly want this so we can run the integration tests of other docker_* modules which require a swarm cluster to run with older docker-py versions as well. Currently, all these tests fail for docker < 2.6.0 because they call `docker_swarm` first.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
