### PR TITLE
nxos_user: fails to remove usernames with embedded '\'

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -360,6 +360,7 @@ def main():
         have_users = [x['name'] for x in have]
         for item in set(have_users).difference(want_users):
             if item != 'admin':
+                item = item.replace("\\", "\\\\")
                 commands.append('no username %s' % item)
 
     result['commands'] = commands


### PR DESCRIPTION
##### SUMMARY
When `purge: yes` is set in a playbook, `nxos_user` should remove all non-admin users. Any usernames that have embedded `\` chars are not being removed because the `\` needs to be escaped.

Example: `username ucs-DOMAIN\x password 0 foo`

Found by `common/sanity` test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_user`