### PR TITLE
Backport/2.7/51853

### DIFF
--- a/changelogs/fragments/51853-fix-truncated-macro-contexts.yml
+++ b/changelogs/fragments/51853-fix-truncated-macro-contexts.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "zabbix_hostmacro: fixes truncation of macro contexts that contain colons
+   (see https://github.com/ansible/ansible/pull/51853)"

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -186,7 +186,7 @@ def main():
     force = module.params['force']
 
     if ':' in macro_name:
-        macro_name = ':'.join([macro_name.split(':')[0].upper(), macro_name.split(':')[1]])
+        macro_name = ':'.join([macro_name.split(':')[0].upper(), ':'.join(macro_name.split(':')[1:])])
     else:
         macro_name = macro_name.upper()
 


### PR DESCRIPTION
##### SUMMARY

Fix Zabbix macro context truncation when context has colons

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Zabbix module: lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py

##### ADDITIONAL INFORMATION

```
# Examples of current behavior:
>>> macro_name = 'C_DRIVE_THRESHOLD: "C:"' 
>>> ':'.join([macro_name.split(':')[0].upper(), macro_name.split(':')[1]])
'C_DRIVE_THRESHOLD: "C'
#(see how it cuts the end)

# Propose change:
>>> macro_name = 'C_DRIVE_THRESHOLD: "C:"' 
>>> ':'.join([macro_name.split(':')[0].upper(), ':'.join(macro_name.split(':')[1:])])
'C_DRIVE_THRESHOLD: "C:"'

# it is backwards compatible:
>>> macro_name = 'FREE_DISK_PERCENT_THRESHOLD: "/boot"' 
>>> ':'.join([macro_name.split(':')[0].upper(), ':'.join(macro_name.split(':')[1:])])
'FREE_DISK_PERCENT_THRESHOLD: "/boot"'
```
It works in python2.7 and python3.6