### PR TITLE
win_chocolatey - add ability to pin a package

### DIFF
--- a/changelogs/fragments/win_chocolatey-pin.yaml
+++ b/changelogs/fragments/win_chocolatey-pin.yaml
@@ -1,0 +1,2 @@
+minor_features:
+- win_chocolatey - Added the ability to pin a package using the ``pinned`` option - https://github.com/ansible/ansible/issues/38526

--- a/changelogs/fragments/win_chocolatey-pin.yaml
+++ b/changelogs/fragments/win_chocolatey-pin.yaml
@@ -1,2 +1,2 @@
-minor_features:
+minor_changes:
 - win_chocolatey - Added the ability to pin a package using the ``pinned`` option - https://github.com/ansible/ansible/issues/38526

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -101,6 +101,17 @@ options:
     type: str
     version_added: '2.1'
     aliases: [ params ]
+  pinned:
+    description:
+    - Whether to pin the Chocolatey package or not.
+    - If omitted then no checks on package pins are done.
+    - Will pin/unpin the specific version if I(version) is set.
+    - Will pin the latest version of a package if C(yes), I(version) is not set
+      and and no pin already exists.
+    - Will unpin all versions of a package if C(no) and I(version) is not set.
+    - This is ignored when C(state=absent).
+    type: bool
+    version_added: '2.8'
   proxy_url:
     description:
     - Proxy URL used to install chocolatey and the package.
@@ -328,6 +339,19 @@ EXAMPLES = r'''
   become: yes
   become_user: Administrator
   become_method: runas
+
+- name: install and pin Notepad++ at 7.6.3
+  win_chocolatey:
+    name: notepadplusplus
+    version: 7.6.3
+    pinned: yes
+    state: present
+
+- name: remove all pins for Notepad++ on all versions
+  win_chocolatey:
+    name: notepadplusplus
+    pinned: no
+    state: present
 '''
 
 RETURN = r'''

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -474,6 +474,114 @@
     - allow_multiple is changed
     - allow_multiple_actual.stdout == "ansible|0.1.0\r\nansible|0.0.1\r\n"
 
+- name: pin 2 packages (check mode)
+  win_chocolatey:
+    name:
+    - '{{ test_choco_package1 }}'
+    - '{{ test_choco_package2 }}'
+    state: present
+    pinned: yes
+  register: pin_multiple_check
+  check_mode: True
+
+- name: get result of pin 2 packages (check mode)
+  win_command: choco.exe pin list --limit-output
+  register: pin_multiple_actual_check
+
+- name: assert pin 2 packages (check mode)
+  assert:
+    that:
+    - pin_multiple_check is changed
+    - pin_multiple_actual_check.stdout == ""
+
+- name: pin 2 packages
+  win_chocolatey:
+    name:
+    - '{{ test_choco_package1 }}'
+    - '{{ test_choco_package2 }}'
+    state: present
+    pinned: yes
+  register: pin_multiple
+
+- name: get result of pin 2 packages
+  win_command: choco.exe pin list --limit-output
+  register: pin_multiple_actual
+
+- name: assert pin 2 packages
+  assert:
+    that:
+    - pin_multiple is changed
+    - pin_multiple_actual.stdout_lines == ["ansible|0.1.0", "ansible-test|1.0.1-beta1"]
+
+- name: pin 2 packages (idempotent)
+  win_chocolatey:
+    name:
+    - '{{ test_choco_package1 }}'
+    - '{{ test_choco_package2 }}'
+    state: present
+    pinned: yes
+  register: pin_multiple_again
+
+- name: assert pin 2 packages (idempoent)
+  assert:
+    that:
+    - not pin_multiple_again is changed
+
+- name: pin specific older version
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: present
+    pinned: yes
+    version: '0.0.1'
+  register: pin_older
+
+- name: get result of pin specific older version
+  win_command: choco.exe pin list --limit-output
+  register: pin_older_actual
+
+- name: assert pin specific older version
+  assert:
+    that:
+    - pin_older is changed
+    - pin_older_actual.stdout_lines == ["ansible|0.1.0", "ansible|0.0.1", "ansible-test|1.0.1-beta1"]
+
+- name: unpin package at version
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: present
+    pinned: no
+    version: '0.1.0'
+  register: unpin_version
+
+- name: get result of unpin package at version
+  win_command: choco.exe pin list --limit-output
+  register: unpin_version_actual
+
+- name: assert unpin package at version
+  assert:
+    that:
+    - unpin_version is changed
+    - unpin_version_actual.stdout_lines == ["ansible|0.0.1", "ansible-test|1.0.1-beta1"]
+
+- name: unpin multiple packages without a version
+  win_chocolatey:
+    name:
+    - '{{ test_choco_package1 }}'
+    - '{{ test_choco_package2 }}'
+    state: present
+    pinned: no
+  register: unpin_multiple
+
+- name: get result of unpin multiple packages without a version
+  win_command: choco.exe pin list --limit-output
+  register: unpin_multiple_actual
+
+- name: assert unpin multiple packages without a version
+  assert:
+    that:
+    - unpin_multiple is changed
+    - unpin_multiple_actual.stdout == ""
+
 - name: uninstall specific version installed with allow_multiple
   win_chocolatey:
     name: '{{ test_choco_package1 }}'


### PR DESCRIPTION
##### SUMMARY
Add the ability to pin and unpin a Chocolatey package using the `pinned` option. This was originally planned to go into a separate module like https://github.com/ansible/ansible/pull/44766 but after playing around with the functionality it made more sense to include it in the base `win_chocolatey` module that already managed packages.

Fixes https://github.com/ansible/ansible/issues/38526

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_chocolatey