### PR TITLE
Fixes #52713: Do not delete hosts in zabbix_host_facts

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
@@ -137,7 +137,6 @@ class Host(object):
         listed_hostnames = []
         for zabbix_host in hosts:
             if zabbix_host['name'] in listed_hostnames:
-                self._zapi.host.delete([zabbix_host['hostid']])
                 continue
             unique_hosts.append(zabbix_host)
             listed_hostnames.append(zabbix_host['name'])


### PR DESCRIPTION
##### SUMMARY
Do not delete hosts in zabbix_host_facts
Fixes #52713

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host_facts

##### ADDITIONAL INFORMATION