### PR TITLE
fix azure_postgresql modules class name

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlconfiguration.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlconfiguration.py
@@ -90,7 +90,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMConfigurations(AzureRMModuleBase):
+class AzureRMPostgreSqlConfigurations(AzureRMModuleBase):
 
     def __init__(self):
         self.module_arg_spec = dict(
@@ -125,9 +125,9 @@ class AzureRMConfigurations(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMConfigurations, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                                    supports_check_mode=True,
-                                                    supports_tags=False)
+        super(AzureRMPostgreSqlConfigurations, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                              supports_check_mode=True,
+                                                              supports_tags=False)
 
     def exec_module(self, **kwargs):
 
@@ -234,7 +234,7 @@ class AzureRMConfigurations(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMConfigurations()
+    AzureRMPostgreSqlConfigurations()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase.py
@@ -109,7 +109,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMDatabases(AzureRMModuleBase):
+class AzureRMPostgreSqlDatabases(AzureRMModuleBase):
     """Configuration class for an Azure RM PostgreSQL Database resource"""
 
     def __init__(self):
@@ -154,9 +154,9 @@ class AzureRMDatabases(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMDatabases, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                               supports_check_mode=True,
-                                               supports_tags=False)
+        super(AzureRMPostgreSqlDatabases, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                         supports_check_mode=True,
+                                                         supports_tags=False)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -300,7 +300,7 @@ class AzureRMDatabases(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMDatabases()
+    AzureRMPostgreSqlDatabases()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase_facts.py
@@ -111,7 +111,7 @@ except ImportError:
     pass
 
 
-class AzureRMDatabasesFacts(AzureRMModuleBase):
+class AzureRMPostgreSqlDatabasesFacts(AzureRMModuleBase):
     def __init__(self):
         # define user inputs into argument
         self.module_arg_spec = dict(
@@ -134,7 +134,7 @@ class AzureRMDatabasesFacts(AzureRMModuleBase):
         self.resource_group = None
         self.server_name = None
         self.name = None
-        super(AzureRMDatabasesFacts, self).__init__(self.module_arg_spec, supports_tags=False)
+        super(AzureRMPostgreSqlDatabasesFacts, self).__init__(self.module_arg_spec, supports_tags=False)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:
@@ -194,7 +194,7 @@ class AzureRMDatabasesFacts(AzureRMModuleBase):
 
 
 def main():
-    AzureRMDatabasesFacts()
+    AzureRMPostgreSqlDatabasesFacts()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlfirewallrule.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlfirewallrule.py
@@ -93,7 +93,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMFirewallRules(AzureRMModuleBase):
+class AzureRMPostgreSqlFirewallRules(AzureRMModuleBase):
     """Configuration class for an Azure RM PostgreSQL firewall rule resource"""
 
     def __init__(self):
@@ -133,9 +133,9 @@ class AzureRMFirewallRules(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMFirewallRules, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                                   supports_check_mode=True,
-                                                   supports_tags=False)
+        super(AzureRMPostgreSqlFirewallRules, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                             supports_check_mode=True,
+                                                             supports_tags=False)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -268,7 +268,7 @@ class AzureRMFirewallRules(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMFirewallRules()
+    AzureRMPostgreSqlFirewallRules()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -148,7 +148,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMServers(AzureRMModuleBase):
+class AzureRMPostgreSqlServers(AzureRMModuleBase):
     """Configuration class for an Azure RM PostgreSQL Server resource"""
 
     def __init__(self):
@@ -205,9 +205,9 @@ class AzureRMServers(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMServers, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                             supports_check_mode=True,
-                                             supports_tags=True)
+        super(AzureRMPostgreSqlServers, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                       supports_check_mode=True,
+                                                       supports_tags=True)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -373,7 +373,7 @@ class AzureRMServers(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMServers()
+    AzureRMPostgreSqlServers()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver_facts.py
@@ -160,7 +160,7 @@ except ImportError:
     pass
 
 
-class AzureRMServersFacts(AzureRMModuleBase):
+class AzureRMPostgreSqlServersFacts(AzureRMModuleBase):
     def __init__(self):
         # define user inputs into argument
         self.module_arg_spec = dict(
@@ -182,7 +182,7 @@ class AzureRMServersFacts(AzureRMModuleBase):
         self.resource_group = None
         self.name = None
         self.tags = None
-        super(AzureRMServersFacts, self).__init__(self.module_arg_spec, supports_tags=False)
+        super(AzureRMPostgreSqlServersFacts, self).__init__(self.module_arg_spec, supports_tags=False)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:
@@ -247,7 +247,7 @@ class AzureRMServersFacts(AzureRMModuleBase):
 
 
 def main():
-    AzureRMServersFacts()
+    AzureRMPostgreSqlServersFacts()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
azure_rm_postgresqlxxx modules now  use general class name, maybe duplicate with other class, fix it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
