### PR TITLE
add another automatic group by tag name (which can easily set when...

### DIFF
--- a/lib/ansible/plugins/inventory/vultr.py
+++ b/lib/ansible/plugins/inventory/vultr.py
@@ -137,7 +137,7 @@ class InventoryModule(BaseInventoryPlugin):
         hostname_preference = self.get_option('hostname')
         for server in _retrieve_servers(api_key):
             server = Vultr.normalize_result(server, SCHEMA)
-            for group in ['region', 'os']:
+            for group in ['region', 'os', 'tag']:
                 self.inventory.add_group(group=server[group])
                 self.inventory.add_host(group=server[group], host=server['name'])
 


### PR DESCRIPTION
…creating Vultr instances via Ansible)

##### SUMMARY
Since the Vultr plugin seems not to support features like `keyed_groups` or `group` like the `aws_ec2` plugin it would be great to have some option to group individually. 

With this feature you can group servers dynamically and individually. E.g. you want to group a region-wide cluster, I give all those servers the tag name `tag: k8s-cluster` on creation or on updating. Then, I can access those easily with `hosts: k8s-cluster`

##### ISSUE TYPE
- Bug

##### COMPONENT NAME
vultr plugin

*Edit: I changed the type to bug, see below for more info; **tl;dr without the tag field, this plugin is a nice toy but not useful for production***