### PR TITLE
os_nova_host_aggregate - Fix aggregate delete with hosts

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
@@ -167,6 +167,9 @@ def main():
             if aggregate is None:
                 changed = False
             else:
+                if hosts:
+                    for h in hosts:
+                        cloud.remove_host_from_aggregate(aggregate.id, h)
                 cloud.delete_aggregate(aggregate.id)
                 changed = True
             module.exit_json(changed=changed)


### PR DESCRIPTION

##### SUMMARY
Aggregate delete task will fail in case it has hosts within the aggregate.
As by the OpenStack, the hosts should be removed from the aggregate
prior aggregate delete.

Add remove host in case provided.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_nova_host_aggregate