### PR TITLE
openssl_certificate, fixed has_expired to check the cert expiration date

### DIFF
--- a/changelogs/fragments/openssl_certificate_fix_has_expired.yml
+++ b/changelogs/fragments/openssl_certificate_fix_has_expired.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openssl_certificate - has_expired correctly checks if the certificate is expired or not

--- a/changelogs/fragments/openssl_certificate_fix_has_expired.yml
+++ b/changelogs/fragments/openssl_certificate_fix_has_expired.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - openssl_certificate - has_expired correctly checks if the certificate is expired or not
+  - openssl_certificate - ``has_expired`` correctly checks if the certificate is expired or not

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -230,7 +230,7 @@ options:
     has_expired:
         description:
             - Checks if the certificate is expired/not expired at the time the module is executed. This only applies to
-              the C(assertonly) provider
+              the C(assertonly) provider.
         type: bool
         default: no
 
@@ -831,6 +831,10 @@ class AssertOnlyCertificate(Certificate):
                     )
 
         def _validate_has_expired():
+            # The following 3 lines are the same as the PyOpenSSL code.
+            # Older version of PyOpenSSL have a buggy implementation,
+            # to avoid issues with those we added the code from a more recent release here.
+
             time_string = to_native(self.cert.get_notAfter())
             not_after = datetime.datetime.strptime(time_string, "%Y%m%d%H%M%SZ")
             cert_expired = not_after < datetime.datetime.utcnow()

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -836,10 +836,9 @@ class AssertOnlyCertificate(Certificate):
             cert_expired = not_after < datetime.datetime.utcnow()
 
             if self.has_expired != cert_expired:
-                if cert_expired:
-                    self.message.append(
-                        'Certificate expiration check failed (certificate expiration is %s, expected %s)' % (cert_expired, self.has_expired)
-                    )
+                self.message.append(
+                    'Certificate expiration check failed (certificate expiration is %s, expected %s)' % (cert_expired, self.has_expired)
+                )
 
         def _validate_version():
             if self.version:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -835,16 +835,10 @@ class AssertOnlyCertificate(Certificate):
             not_after = datetime.datetime.strptime(time_string, "%Y%m%d%H%M%SZ")
             cert_expired = not_after < datetime.datetime.utcnow()
 
-            if self.has_expired is False:
+            if self.has_expired != cert_expired:
                 if cert_expired:
                     self.message.append(
-                        'Certificate expiration check failed (certificate expiration is %s, expected %s)' % (self.cert.has_expired(), self.has_expired)
-                    )
-            else:
-                if not cert_expired:
-                    self.message.append(
-                        'Certificate expiration check failed (certificate expiration is to %s, expected %s)' %
-                        (self.cert.has_expired(), self.has_expired)
+                        'Certificate expiration check failed (certificate expiration is %s, expected %s)' % (cert_expired, self.has_expired)
                     )
 
         def _validate_version():

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -831,7 +831,7 @@ class AssertOnlyCertificate(Certificate):
                     )
 
         def _validate_has_expired():
-            # The following 3 lines are the same as the PyOpenSSL code.
+            # The following 3 lines are the same as the current PyOpenSSL code for cert.has_expired().
             # Older version of PyOpenSSL have a buggy implementation,
             # to avoid issues with those we added the code from a more recent release here.
 

--- a/test/integration/targets/openssl_certificate/tasks/expired.yml
+++ b/test/integration/targets/openssl_certificate/tasks/expired.yml
@@ -1,0 +1,45 @@
+---
+- name: Generate privatekey
+  openssl_privatekey:
+    path: '{{ output_dir }}/has_expired_privatekey.pem'
+
+- name: Generate CSR
+  openssl_csr:
+    path: '{{ output_dir }}/has_expired_csr.csr'
+    privatekey_path: '{{ output_dir }}/has_expired_privatekey.pem'
+    subject:
+      commonName: www.example.com
+
+- name: Generate selfsigned certificate
+  openssl_certificate:
+    path: '{{ output_dir }}/has_expired_cert.pem'
+    csr_path: '{{ output_dir }}/has_expired_csr.csr'
+    privatekey_path: '{{ output_dir }}/has_expired_privatekey.pem'
+    provider: selfsigned
+    selfsigned_digest: sha256
+    selfsigned_not_after: "-1s"
+
+- name: "Check task fails because cert is expired (has_expired: false)"
+  openssl_certificate:
+    provider: assertonly
+    path: "{{ output_dir }}/has_expired_cert.pem"
+    has_expired: false
+  ignore_errors: true
+  register: expired_cert_check
+
+- name: Ensure previous task failed
+  assert:
+    that: expired_cert_check is failed
+
+- name: "Check expired cert check is ignored (has_expired: true)"
+  openssl_certificate:
+    provider: assertonly
+    path: "{{ output_dir }}/has_expired_cert.pem"
+    has_expired: true
+  register: expired_cert_skip
+
+- name: Ensure previous task was OK
+  assert:
+    that: expired_cert_skip is success
+
+

--- a/test/integration/targets/openssl_certificate/tasks/expired.yml
+++ b/test/integration/targets/openssl_certificate/tasks/expired.yml
@@ -37,9 +37,3 @@
     path: "{{ output_dir }}/has_expired_cert.pem"
     has_expired: true
   register: expired_cert_skip
-
-- name: Ensure previous task was OK
-  assert:
-    that: expired_cert_skip is success
-
-

--- a/test/integration/targets/openssl_certificate/tasks/expired.yml
+++ b/test/integration/targets/openssl_certificate/tasks/expired.yml
@@ -10,7 +10,7 @@
     subject:
       commonName: www.example.com
 
-- name: Generate selfsigned certificate
+- name: Generate expired selfsigned certificate
   openssl_certificate:
     path: '{{ output_dir }}/has_expired_cert.pem'
     csr_path: '{{ output_dir }}/has_expired_csr.csr'

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - block:
 
+    - import_tasks: expired.yml
+
     - import_tasks: selfsigned.yml
 
     - import_tasks: ownca.yml


### PR DESCRIPTION
##### SUMMARY
`has_expired` was not actually checking the certificate expiration, and had an issue with older versions of the `pyOpenSSL` package which was incorrectly verifying the expiry date. 
Also adds tests for this case

Fixes #51267

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate

##### ADDITIONAL INFORMATION
N/A