### PR TITLE
[2.7] docker_container: don't die when kernel memory accounting is not supported by runc build

### DIFF
--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1495,6 +1495,7 @@
     kernel_memory: 8M
     state: started
   register: kernel_memory_1
+  ignore_errors: yes
 
 - name: kernel_memory (idempotency)
   docker_container:
@@ -1504,6 +1505,7 @@
     kernel_memory: 8M
     state: started
   register: kernel_memory_2
+  ignore_errors: yes
 
 - name: kernel_memory (change)
   docker_container:
@@ -1514,18 +1516,21 @@
     state: started
     stop_timeout: 1
   register: kernel_memory_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
     stop_timeout: 1
+  ignore_errors: yes
 
 - assert:
     that:
     - kernel_memory_1 is changed
     - kernel_memory_2 is not changed
     - kernel_memory_3 is changed
+  when: kernel_memory_1 is not failed or 'kernel memory accounting disabled in this runc build' not in kernel_memory_1.msg
 
 ####################################################################
 ## kill_signal #####################################################


### PR DESCRIPTION
##### SUMMARY
Backport of #53163: fixes problem with `docker_container` CI tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
