### PR TITLE
get_url: return no change in check mode when checksum matches

### DIFF
--- a/changelogs/fragments/53070-get_url-check_mode.yml
+++ b/changelogs/fragments/53070-get_url-check_mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - get_url - return no change in check mode when checksum matches

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -522,12 +522,6 @@ def main():
     checksum_src = None
     checksum_dest = None
 
-    # If the remote URL exists, we're done with check mode
-    if module.check_mode:
-        os.remove(tmpsrc)
-        res_args = dict(url=url, dest=dest, src=tmpsrc, changed=True, msg=info.get('msg', ''))
-        module.exit_json(**res_args)
-
     # raise an error if there is no tmpsrc file
     if not os.path.exists(tmpsrc):
         os.remove(tmpsrc)
@@ -554,6 +548,16 @@ def main():
         if not os.access(os.path.dirname(dest), os.W_OK):
             os.remove(tmpsrc)
             module.fail_json(msg="Destination %s is not writable" % (os.path.dirname(dest)))
+
+    if module.check_mode:
+        if os.path.exists(tmpsrc):
+            os.remove(tmpsrc)
+        changed = (checksum_dest is None or
+                   checksum_src != checksum_dest)
+        res_args = dict(url=url, changed=changed, dest=dest, src=tmpsrc,
+                        checksum_dest=checksum_dest, checksum_src=checksum_src,
+                        msg=info.get('msg', ''))
+        module.exit_json(**res_args)
 
     backup_file = None
     if checksum_src != checksum_dest:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -268,6 +268,19 @@
     that:
       - result is not changed
 
+- name: test checksum match in check mode
+  get_url:
+    url: 'https://{{ httpbin_host }}/get'
+    dest: '{{ output_dir }}/test'
+    checksum: 'sha256:7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.'
+  check_mode: True
+  register: result
+
+- name: Assert that check mode was green
+  assert:
+    that:
+      - result is not changed
+
 # https://github.com/ansible/ansible/issues/27617
 
 - name: set role facts


### PR DESCRIPTION
##### SUMMARY

backport of #53070 

In check_mode, `get_url` does not compare the checksum with the destination file, so it produces spurious `changed` results which turn out to be green when check_mode is False.

This change moves the check_mode logic a little bit later in get_url so that the destination file checksum is available for comparison with the source file checksum.

##### ISSUE TYPE

* Bugfix Pull Request

##### COMPONENT NAME

get_url
