### PR TITLE
Added support for infoblox member object

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -31,6 +31,7 @@ from functools import partial
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import env_fallback
 
 try:
     from infoblox_client.connector import Connector
@@ -54,20 +55,26 @@ NIOS_MX_RECORD = 'record:mx'
 NIOS_SRV_RECORD = 'record:srv'
 NIOS_NAPTR_RECORD = 'record:naptr'
 NIOS_TXT_RECORD = 'record:txt'
+NIOS_NSGROUP = 'nsgroup'
+NIOS_IPV4_FIXED_ADDRESS = 'fixedaddress'
+NIOS_IPV6_FIXED_ADDRESS = 'ipv6fixedaddress'
+NIOS_NEXT_AVAILABLE_IP = 'func:nextavailableip'
+NIOS_IPV4_NETWORK_CONTAINER = 'networkcontainer'
+NIOS_IPV6_NETWORK_CONTAINER = 'ipv6networkcontainer'
 NIOS_MEMBER = 'member'
 
 NIOS_PROVIDER_SPEC = {
-    'host': dict(),
-    'username': dict(),
-    'password': dict(no_log=True),
-    'ssl_verify': dict(type='bool', default=False),
+    'host': dict(fallback=(env_fallback, ['INFOBLOX_HOST'])),
+    'username': dict(fallback=(env_fallback, ['INFOBLOX_USERNAME'])),
+    'password': dict(fallback=(env_fallback, ['INFOBLOX_PASSWORD']), no_log=True),
+    'ssl_verify': dict(type='bool', default=False, fallback=(env_fallback, ['INFOBLOX_SSL_VERIFY'])),
     'silent_ssl_warnings': dict(type='bool', default=True),
-    'http_request_timeout': dict(type='int', default=10),
+    'http_request_timeout': dict(type='int', default=10, fallback=(env_fallback, ['INFOBLOX_HTTP_REQUEST_TIMEOUT'])),
     'http_pool_connections': dict(type='int', default=10),
     'http_pool_maxsize': dict(type='int', default=10),
-    'max_retries': dict(type='int', default=3),
-    'wapi_version': dict(default='2.1'),
-    'max_results': dict(type='int', default=1000),
+    'max_retries': dict(type='int', default=3, fallback=(env_fallback, ['INFOBLOX_MAX_RETRIES'])),
+    'wapi_version': dict(default='2.1', fallback=(env_fallback, ['INFOBLOX_WAP_VERSION'])),
+    'max_results': dict(type='int', default=1000, fallback=(env_fallback, ['INFOBLOX_MAX_RETRIES']))
 }
 
 
@@ -129,6 +136,7 @@ def flatten_extattrs(value):
     '''
     return dict([(k, v['value']) for k, v in iteritems(value)])
 
+
 def member_normalize(member_spec):
     ''' Transforms the member module arguments into a valid WAPI struct
     This function will transform the arguments into a structure that
@@ -141,15 +149,16 @@ def member_normalize(member_spec):
     The remainder of the value validation is performed by WAPI
     '''
     for key in member_spec.keys():
-        if isinstance (member_spec[key],dict):
-            member_spec[key]=member_normalize(member_spec[key])
-        elif isinstance(member_spec[key],list):
+        if isinstance(member_spec[key], dict):
+            member_spec[key] = member_normalize(member_spec[key])
+        elif isinstance(member_spec[key], list):
             for x in member_spec[key]:
-                if isinstance (x,dict):
-                    x=member_normalize(x)
+                if isinstance(x, dict):
+                    x = member_normalize(x)
         elif member_spec[key] is None:
             del member_spec[key]
     return member_spec
+
 
 class WapiBase(object):
     ''' Base class for implementing Infoblox WAPI API '''
@@ -224,6 +233,7 @@ class WapiModule(WapiBase):
         :args ib_spec: the specification for the WAPI object as a dict
         :returns: a results dict
         '''
+
         update = new_name = None
         state = self.module.params['state']
         if state not in ('present', 'absent'):
@@ -236,15 +246,6 @@ class WapiModule(WapiBase):
         # get object reference
         ib_obj_ref, update, new_name = self.get_object_ref(self.module, ib_obj_type, obj_filter, ib_spec)
 
-        if ib_obj_ref:
-            current_object = ib_obj_ref[0]
-            if 'extattrs' in current_object:
-                current_object['extattrs'] = flatten_extattrs(current_object['extattrs'])
-            ref = current_object.pop('_ref')
-        else:
-            current_object = obj_filter
-            ref = None
-
         proposed_object = {}
         for key, value in iteritems(ib_spec):
             if self.module.params[key] is not None:
@@ -252,8 +253,25 @@ class WapiModule(WapiBase):
                     proposed_object[key] = value['transform'](self.module)
                 else:
                     proposed_object[key] = self.module.params[key]
+
+        if ib_obj_ref:
+            if len(ib_obj_ref) > 1:
+                for each in ib_obj_ref:
+                    if ('ipv4addr' in each) and ('ipv4addr' in proposed_object)\
+                            and each['ipv4addr'] == proposed_object['ipv4addr']:
+                        current_object = each
+            else:
+                current_object = ib_obj_ref[0]
+            if 'extattrs' in current_object:
+                current_object['extattrs'] = flatten_extattrs(current_object['extattrs'])
+            ref = current_object.pop('_ref')
+        else:
+            current_object = obj_filter
+            ref = None
+
+        # checks if the object type is member to normalize the attributes being passed
         if (ib_obj_type == NIOS_MEMBER):
-             proposed_object= member_normalize(proposed_object)
+            proposed_object = member_normalize(proposed_object)
 
         # checks if the name's field has been updated
         if update and new_name:
@@ -263,6 +281,10 @@ class WapiModule(WapiBase):
         modified = not self.compare_objects(current_object, proposed_object)
         if 'extattrs' in proposed_object:
             proposed_object['extattrs'] = normalize_extattrs(proposed_object['extattrs'])
+
+        # Checks if nios_next_ip param is passed in ipv4addrs/ipv4addr args
+        proposed_object = self.check_if_nios_next_ip_exists(proposed_object)
+
         if state == 'present':
             if ref is None:
                 if not self.module.check_mode:
@@ -273,6 +295,11 @@ class WapiModule(WapiBase):
 
                 if (ib_obj_type in (NIOS_HOST_RECORD, NIOS_NETWORK_VIEW, NIOS_DNS_VIEW)):
                     proposed_object = self.on_update(proposed_object, ib_spec)
+                    res = self.update_object(ref, proposed_object)
+                if (ib_obj_type in (NIOS_A_RECORD, NIOS_AAAA_RECORD)):
+                    # popping 'view' key as update of 'view' is not supported with respect to a:record/aaaa:record
+                    proposed_object = self.on_update(proposed_object, ib_spec)
+                    del proposed_object['view']
                     res = self.update_object(ref, proposed_object)
                 elif 'network_view' in proposed_object:
                     proposed_object.pop('network_view')
@@ -305,6 +332,23 @@ class WapiModule(WapiBase):
 
             if obj_host_name == ref_host_name and current_ip_addr != proposed_ip_addr:
                 self.create_object(ib_obj_type, proposed_object)
+
+    def check_if_nios_next_ip_exists(self, proposed_object):
+        ''' Check if nios_next_ip argument is passed in ipaddr while creating
+            host record, if yes then format proposed object ipv4addrs and pass
+            func:nextavailableip and ipaddr range to create hostrecord with next
+             available ip in one call to avoid any race condition '''
+
+        if 'ipv4addrs' in proposed_object:
+            if 'nios_next_ip' in proposed_object['ipv4addrs'][0]['ipv4addr']:
+                ip_range = self.module._check_type_dict(proposed_object['ipv4addrs'][0]['ipv4addr'])['nios_next_ip']
+                proposed_object['ipv4addrs'][0]['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
+        elif 'ipv4addr' in proposed_object:
+            if 'nios_next_ip' in proposed_object['ipv4addr']:
+                ip_range = self.module._check_type_dict(proposed_object['ipv4addr'])['nios_next_ip']
+                proposed_object['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
+
+        return proposed_object
 
     def issubset(self, item, objects):
         ''' Checks if item is a subset of objects
@@ -361,6 +405,8 @@ class WapiModule(WapiBase):
             if old_name and new_name:
                 if (ib_obj_type == NIOS_HOST_RECORD):
                     test_obj_filter = dict([('name', old_name), ('view', obj_filter['view'])])
+                elif (ib_obj_type in (NIOS_AAAA_RECORD, NIOS_A_RECORD)):
+                    test_obj_filter = obj_filter
                 else:
                     test_obj_filter = dict([('name', old_name)])
                 # get the object reference
@@ -378,13 +424,15 @@ class WapiModule(WapiBase):
                     test_obj_filter = dict([('name', name)])
                 else:
                     test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
+            elif (ib_obj_type == NIOS_IPV4_FIXED_ADDRESS or ib_obj_type == NIOS_IPV6_FIXED_ADDRESS and 'mac' in obj_filter):
+                test_obj_filter = dict([['mac', obj_filter['mac']]])
             elif (ib_obj_type == NIOS_A_RECORD):
                 # resolves issue where a_record with uppercase name was returning null and was failing
                 test_obj_filter = obj_filter
                 test_obj_filter['name'] = test_obj_filter['name'].lower()
             # check if test_obj_filter is empty copy passed obj_filter
             else:
-                test_obj_filter = dict([('name', name)])
+                test_obj_filter = obj_filter
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=ib_spec.keys())
         elif (ib_obj_type == NIOS_ZONE):
             # del key 'restart_if_needed' as nios_zone get_object fails with the key present
@@ -412,4 +460,3 @@ class WapiModule(WapiBase):
             update = ib_spec[key].get('update', True)
             if not update:
                 keys.add(key)
-        return dict([(k, v) for k, v in iteritems(proposed_object) if k not in keys])

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -460,3 +460,4 @@ class WapiModule(WapiBase):
             update = ib_spec[key].get('update', True)
             if not update:
                 keys.add(key)
+        return dict([(k, v) for k, v in iteritems(proposed_object) if k not in keys])

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -83,7 +83,7 @@ options:
     suboptions:
       enabled:
         description:
-          - If set to True, then it has its own IP settings. 
+          - If set to True, then it has its own IP settings.
         type: bool
       network_setting:
         description:

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -282,9 +282,7 @@ options:
               - Hardware type.
       licenses:
         description:
-          - An array of license types the pre-provisioned member should have
-          in order to join the Grid, or the licenses that must be allocated
-          to the member when it joins the Grid.
+          - An array of license types 
   state:
     description:
       - Configures the intended state of the instance of the object on

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -1,0 +1,486 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+DOCUMENTATION = '''
+---
+module: nios_member
+version_added: "2.9"
+author: "Krishna Vasudevan"
+short_description: Configure Infoblox NIOS members
+description:
+  - Adds and/or removes Infoblox NIOS servers.  This module manages NIOS C(member) objects using the Infoblox WAPI interface over REST.
+requirements:
+  - infoblox-client
+extends_documentation_fragment: nios
+options:
+  host_name:
+    description:
+      - Specifies the host name of the member to either add or remove from
+        the NIOS instance.
+    required: true
+    aliases:
+      - name
+  vip_setting:
+    description:
+      - Configures the network settings for the grid member.
+    required: true
+    suboptions:
+      address:
+        description:
+          - The IPv4 Address of the Grid Member
+      subnet_mask:
+        description:
+          - The subnet mask for the Grid Member
+      gateway:
+        description:
+          - The default gateway for the Grid Member
+  ipv6_setting:
+    description:
+      - Configures the IPv6 settings for the grid member.
+    required: true
+    suboptions:
+      virtual_ip:
+        description:
+          - The IPv6 Address of the Grid Member
+      cidr_prefix:
+        description:
+          - The IPv6 CIDR prefix for the Grid Member
+      gateway:
+        description:
+          - The gateway address for the Grid Member
+  config_addr_type:
+    description:
+      - Address configuration type (IPV4/IPV6/BOTH)
+    default: IPV4
+  comment:
+    description:
+      - A descriptive comment of the Grid member.
+  extattrs:
+    description:
+      - Extensible attributes associated with the object.
+  enable_ha:
+    description:
+      - If set to True, the member has two physical nodes (HA pair).
+    type: bool
+  router_id:
+    description:
+      - Virtual router identifier. Provide this ID if "ha_enabled" is set to "true". This is a unique VRID number (from 1 to 255) for the local subnet.
+  lan2_enabled:
+    description:
+      - When set to "true", the LAN2 port is enabled as an independent port or as a port for failover purposes.
+    type: bool
+  lan2_port_setting:
+    description:
+      - Settings for the Grid member LAN2 port if 'lan2_enabled' is set to "true".
+    suboptions:
+      enabled:
+        description:
+          - If set to True, then it has its own IP settings. Otherwise, port redundancy mechanism is used, in which the LAN1 and LAN2 ports share the same IP settings for failover purposes.
+        type: bool
+      network_setting:
+        description:
+          - If the 'enable' field is set to True, this defines IPv4 network settings for LAN2.
+        suboptions:
+          address:
+            description:
+              - The IPv4 Address of LAN2
+          subnet_mask:
+            description:
+              - The subnet mask of LAN2
+          gateway:
+            description:
+              - The default gateway of LAN2
+      v6_network_setting:
+        description:
+          - If the 'enable' field is set to True, this defines IPv6 network settings for LAN2.
+        suboptions:
+          virtual_ip:
+            description:
+              - The IPv6 Address of LAN2
+          cidr_prefix:
+            description:
+              - The IPv6 CIDR prefix of LAN2
+          gateway:
+            description:
+              - The gateway address of LAN2
+  platform:
+    description:
+      - Configures the Hardware Platform.
+    default: INFOBLOX
+  node_info:
+    description:
+      - Configures the node information list with detailed status report on the operations of the Grid Member.
+    suboptions:
+      lan2_physical_setting:
+        description:
+          - Physical port settings for the LAN2 interface.
+        suboptions:
+          auto_port_setting_enabled:
+            description:
+              - Enable or disalbe the auto port setting.
+            type: bool
+          duplex:
+            description:
+              - The port duplex; if speed is 1000, duplex must be FULL.
+          speed:
+            description:
+              - The port speed; if speed is 1000, duplex is FULL.
+      lan_ha_port_setting:
+        description:
+          - LAN/HA port settings for the node.
+        suboptions:
+          ha_ip_address:
+            description:
+              - HA IP address.
+          ha_port_setting:
+            description:
+              - Physical port settings for the HA interface.
+            suboptions:
+              auto_port_setting_enabled:
+                description:
+                  - Enable or disalbe the auto port setting.
+                type: bool
+              duplex:
+                description:
+                  - The port duplex; if speed is 1000, duplex must be FULL.
+              speed:
+                description:
+                  - The port speed; if speed is 1000, duplex is FULL.
+          lan_port_setting:
+            description:
+              - Physical port settings for the LAN interface.
+            suboptions:
+              auto_port_setting_enabled:
+                description:
+                  - Enable or disalbe the auto port setting.
+                type: bool
+              duplex:
+                description:
+                  - The port duplex; if speed is 1000, duplex must be FULL.
+              speed:
+                description:
+                  - The port speed; if speed is 1000, duplex is FULL.
+          mgmt_ipv6addr:
+            description:
+              - Public IPv6 address for the LAN1 interface.
+          mgmt_lan:
+            description:
+              - Public IPv4 address for the LAN1 interface.
+      mgmt_network_setting:
+        description:
+          - Network settings for the MGMT port of the node.
+        suboptions:
+          address:
+            description:
+              - The IPv4 Address of MGMT
+          subnet_mask:
+            description:
+              - The subnet mask of MGMT
+          gateway:
+            description:
+              - The default gateway of MGMT
+      v6_mgmt_network_setting:
+        description:
+          - The network settings for the IPv6 MGMT port of the node.
+        suboptions:
+          virtual_ip:
+            description:
+              - The IPv6 Address of MGMT
+          cidr_prefix:
+            description:
+              - The IPv6 CIDR prefix of MGMT
+          gateway:
+            description:
+              - The gateway address of MGMT
+  mgmt_port_setting:
+    description:
+      - Settings for the member MGMT port.
+    suboptions:
+      enabled:
+        description:
+          - Determines if MGMT port settings should be enabled.
+        type: bool
+      security_access_enabled:
+        description:
+          - Determines if security access on the MGMT port is enabled or not.
+        type: bool
+      vpn_enabled:
+        description:
+          - Determines if VPN on the MGMT port is enabled or not.
+        type: bool
+  upgrade_group:
+    description:
+      - The name of the upgrade group to which this Grid member belongs.
+    default: Default
+  use_syslog_proxy_setting:
+    description:
+      - Use flag for: external_syslog_server_enable , syslog_servers, syslog_proxy_setting, syslog_size
+    type: bool
+  external_syslog_server_enable:
+    description:
+      - Determines if external syslog servers should be enabled
+    type:bool
+  syslog_servers:
+    description:
+      - The list of external syslog servers.
+    suboptions:
+      address:
+        description:
+          - The server address.
+      category_list:
+        description:
+          - The list of all syslog logging categories.
+      connection_type:
+        description:
+          - The connection type for communicating with this server.(STCP/TCP?UDP)
+        default: UDP
+      local_interface:
+        description:
+          - The local interface through which the appliance sends syslog messages to the syslog server.(ANY/LAN/MGMT)
+        default: ANY
+      message_node_id:
+        description:
+          - Identify the node in the syslog message. (HOSTNAME/IP_HOSTNAME/LAN/MGMT)
+        default: LAN
+      message_source:
+        description:
+          - The source of syslog messages to be sent to the external syslog server. If set to 'INTERNAL', only messages the appliance generates will be sent to the syslog server.
+          If set to 'EXTERNAL', the appliance sends syslog messages that it receives from other devices, such as syslog servers and routers.
+          If set to 'ANY', the appliance sends both internal and external syslog messages.
+        default: ANY
+      only_category_list:
+        description:
+          - The list of selected syslog logging categories. The appliance forwards syslog messages that belong to the selected categories.
+        type: bool
+      port:
+        description:
+          - The port this server listens on.
+        default: 514
+      severity:
+        description:
+          - The severity filter. The appliance sends log messages of the specified severity and above to the external syslog server.
+        default: DEBUG
+  pre_provisioning:
+    description:
+      - Pre-provisioning information.
+    suboptions:
+      hardware_info:
+        description:
+          - An array of structures that describe the hardware being pre-provisioned.
+        suboptions:
+          hwmodel:
+            description:
+              - Hardware model - for IB-4010 are Rev1, Rev2; for IB-4030 are Rev1, Rev2; for PT-4000 is Rev2; for IB-VNIOS are IB-VM-100, IB-VM-810, IB-VM-820, IB-VM-RSP, IB-VM-1410, IB-VM-1420, IB-VM-2210, IB-VM-2220, IBVM-4010, CP-V800, CP-V1400, CP-V2200. Note that you cannot specify hwmodel for following hardware types: IB-FLEX, IB-V2215, IB-V1425, IB-V4025, IB-V4015, IB-V1415, IB-V815, IB-V825, IB-V2225.
+          hwtype
+            description:
+              - Hardware type.
+      licenses:
+        description:
+          - An array of license types the pre-provisioned member should have in order to join the Grid, or the licenses that must be allocated to the member when it joins the Grid using the token-based authentication.
+  state:
+    description:
+      - Configures the intended state of the instance of the object on
+        the NIOS server.  When this value is set to C(present), the object
+        is configured on the device and when this value is set to C(absent)
+        the value is removed (if necessary) from the device.
+    default: present
+    choices:
+      - present
+      - absent
+'''
+
+EXAMPLES = '''
+- name: add a member to the grid with IPv4 address
+  nios_member:
+    host_name: member01.localdomain
+    vip_setting:
+      address: 192.168.1.100
+      subnet_mask: 255.255.255.0
+      gateway: 192.168.1.1
+    config_addr_type: IPV4
+    platform: VNIOS
+    comment: "Created by Ansible"
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: add a HA member to the grid
+  nios_member:
+    host_name: memberha.localdomain
+    vip_setting:
+      address: 192.168.1.100
+      subnet_mask: 255.255.255.0
+      gateway: 192.168.1.1
+    config_addr_type: IPV4
+    platform: VNIOS
+    enable_ha: true
+    router_id: 150
+    node_info:
+      - lan_ha_port_setting:
+          ha_ip_address: 192.168.1.70
+          mgmt_lan: 192.168.1.80
+      - lan_ha_port_setting:
+          ha_ip_address: 192.168.1.71
+          mgmt_lan: 192.168.1.81
+    comment: "Created by Ansible"
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: update the member with pre-provisioning details specified
+  nios_member:
+    name: member01.localdomain
+    pre_provisioning:
+      hardware_info:
+        - hwmodel: IB-VM-820
+          hwtype: IB-VNIOS
+      licenses:
+        - dns
+        - dhcp
+        - enterprise
+        - vnios
+    comment: "Updated by Ansible"
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: remove the member
+  nios_member:
+    name: member01.localdomain
+    state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.net_tools.nios.api import WapiModule
+from ansible.module_utils.net_tools.nios.api import NIOS_MEMBER
+
+def main():
+    ''' Main entry point for module execution
+    '''
+    ipv4_spec = dict(
+        address=dict(),
+        subnet_mask=dict(),
+        gateway=dict(),
+    )
+
+    ipv6_spec = dict(
+        virtual_ip=dict(),
+        cidr_prefix=dict(type='int'),
+        gateway=dict(),
+    )
+
+    port_spec = dict(
+        auto_port_setting_enabled=dict(type='bool'),
+        duplex=dict(),
+        speed=dict(),
+    )
+
+    lan2_port_spec = dict(
+        enabled=dict(type='bool'),
+        network_setting=dict(type='dict', elements='dict', options=ipv4_spec),
+        v6_network_setting=dict(type='dict', elements='dict', options=ipv6_spec),
+    )
+
+    ha_port_spec = dict(
+        ha_ip_address=dict(),
+        ha_port_setting=dict(type='dict', elements='dict', options=port_spec),
+        lan_port_setting=dict(type='dict', elements='dict', options=port_spec),
+        mgmt_lan=dict(),
+        mgmt_ipv6addr=dict(),
+    )
+
+    node_spec = dict(
+        lan2_physical_setting=dict(type='dict', elements='dict', options=port_spec),
+        lan_ha_port_setting=dict(type='dict', elements='dict', options=ha_port_spec),
+        mgmt_network_setting=dict(type='dict', elements='dict', options=ipv4_spec),
+        v6_mgmt_network_setting=dict(type='dict', elements='dict', options=ipv6_spec),
+    )
+
+    mgmt_port_spec = dict(
+        enabled=dict(type='bool'),
+        security_access_enabled=dict(type='bool'),
+        vpn_enabled=dict(type='bool'),
+    )
+
+    syslog_spec = dict(
+        address=dict(),
+        category_list=dict(type='list'),
+        connection_type=dict(default='UDP'),
+        local_interface=dict(default='ANY'),
+        message_node_id=dict(default='LAN'),
+        message_source=dict(default='ANY'),
+        only_category_list=dict(type='bool'),
+        port=dict(type='int',default=514),
+        severity=dict(default='DEBUG'),
+    )
+
+    hw_spec = dict(
+        hwmodel=dict(),
+        hwtype=dict(),
+    )
+
+    pre_prov_spec = dict(
+        hardware_info=dict(type='list', elements='dict', options=hw_spec),
+        licenses=dict(type='list'),
+    )
+
+    ib_spec = dict(
+        host_name=dict(required=True, aliases=['name'], ib_req=True),
+        vip_setting=dict(type='dict', elements='dict', options=ipv4_spec),
+        ipv6_setting=dict(type='dict', elements='dict', options=ipv6_spec),
+        config_addr_type=dict(default='IPV4'),
+        comment=dict(),
+        enable_ha=dict(type='bool',default=False),
+        router_id=dict(type='int'),
+        lan2_enabled=dict(type='bool',default=False),
+        lan2_port_setting=dict(type='dict', elements='dict', options=lan2_port_spec),
+        platform=dict(default='INFOBLOX'),
+        node_info=dict(type='list', elements='dict', options=node_spec),
+        mgmt_port_setting=dict(type='dict', elements='dict', options=mgmt_port_spec),
+        upgrade_group=dict(default='Default'),
+        use_syslog_proxy_setting=dict(type='bool'),
+        external_syslog_server_enable=dict(type='bool'),
+        syslog_servers=dict(type='list', elements='dict', options=syslog_spec),
+        pre_provisioning=dict(type='dict', elements='dict', options=pre_prov_spec),
+        extattrs=dict(type='dict'),
+    )
+
+    argument_spec = dict(
+        provider=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    argument_spec.update(ib_spec)
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+    
+    wapi = WapiModule(module)
+    result = wapi.run(NIOS_MEMBER, ib_spec)
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -277,7 +277,7 @@ options:
           hwmodel:
             description:
               - Hardware model
-          hwtype
+          hwtype:
             description:
               - Hardware type.
       licenses:

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: nios_member
-version_added: "2.9"
+version_added: "2.8"
 author: "Krishna Vasudevan (@krisvasudevan)"
 short_description: Configure Infoblox NIOS members
 description:
@@ -282,7 +282,9 @@ options:
               - Hardware type.
       licenses:
         description:
-          - An array of license types the pre-provisioned member should have in order to join the Grid, or the licenses that must be allocated to the member when it joins the Grid.
+          - An array of license types the pre-provisioned member should have
+          in order to join the Grid, or the licenses that must be allocated
+          to the member when it joins the Grid.
   state:
     description:
       - Configures the intended state of the instance of the object on

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -283,6 +283,7 @@ options:
       licenses:
         description:
           - An array of license types the pre-provisioned member should have in order to join the Grid, or the licenses that must be allocated to the member when it joins the Grid.
+  state:
     description:
       - Configures the intended state of the instance of the object on
         the NIOS server.  When this value is set to C(present), the object

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 ---
 module: nios_member
 version_added: "2.9"
-author: "Krishna Vasudevan"
+author: "Krishna Vasudevan (@krisvasudevan)"
 short_description: Configure Infoblox NIOS members
 description:
   - Adds and/or removes Infoblox NIOS servers.  This module manages NIOS C(member) objects using the Infoblox WAPI interface over REST.
@@ -83,7 +83,7 @@ options:
     suboptions:
       enabled:
         description:
-          - If set to True, then it has its own IP settings. Otherwise, port redundancy mechanism is used, in which the LAN1 and LAN2 ports share the same IP settings for failover purposes.
+          - If set to True, then it has its own IP settings. 
         type: bool
       network_setting:
         description:
@@ -222,12 +222,12 @@ options:
     default: Default
   use_syslog_proxy_setting:
     description:
-      - Use flag for: external_syslog_server_enable , syslog_servers, syslog_proxy_setting, syslog_size
+      - Use flag for external_syslog_server_enable , syslog_servers, syslog_proxy_setting, syslog_size
     type: bool
   external_syslog_server_enable:
     description:
       - Determines if external syslog servers should be enabled
-    type:bool
+    type: bool
   syslog_servers:
     description:
       - The list of external syslog servers.
@@ -252,9 +252,7 @@ options:
         default: LAN
       message_source:
         description:
-          - The source of syslog messages to be sent to the external syslog server. If set to 'INTERNAL', only messages the appliance generates will be sent to the syslog server.
-          If set to 'EXTERNAL', the appliance sends syslog messages that it receives from other devices, such as syslog servers and routers.
-          If set to 'ANY', the appliance sends both internal and external syslog messages.
+          - The source of syslog messages to be sent to the external syslog server.
         default: ANY
       only_category_list:
         description:
@@ -278,14 +276,13 @@ options:
         suboptions:
           hwmodel:
             description:
-              - Hardware model - for IB-4010 are Rev1, Rev2; for IB-4030 are Rev1, Rev2; for PT-4000 is Rev2; for IB-VNIOS are IB-VM-100, IB-VM-810, IB-VM-820, IB-VM-RSP, IB-VM-1410, IB-VM-1420, IB-VM-2210, IB-VM-2220, IBVM-4010, CP-V800, CP-V1400, CP-V2200. Note that you cannot specify hwmodel for following hardware types: IB-FLEX, IB-V2215, IB-V1425, IB-V4025, IB-V4015, IB-V1415, IB-V815, IB-V825, IB-V2225.
+              - Hardware model
           hwtype
             description:
               - Hardware type.
       licenses:
         description:
-          - An array of license types the pre-provisioned member should have in order to join the Grid, or the licenses that must be allocated to the member when it joins the Grid using the token-based authentication.
-  state:
+          - An array of license types the pre-provisioned member should have in order to join the Grid, or the licenses that must be allocated to the member when it joins the Grid.
     description:
       - Configures the intended state of the instance of the object on
         the NIOS server.  When this value is set to C(present), the object
@@ -376,6 +373,7 @@ from ansible.module_utils.six import iteritems
 from ansible.module_utils.net_tools.nios.api import WapiModule
 from ansible.module_utils.net_tools.nios.api import NIOS_MEMBER
 
+
 def main():
     ''' Main entry point for module execution
     '''
@@ -432,7 +430,7 @@ def main():
         message_node_id=dict(default='LAN'),
         message_source=dict(default='ANY'),
         only_category_list=dict(type='bool'),
-        port=dict(type='int',default=514),
+        port=dict(type='int', default=514),
         severity=dict(default='DEBUG'),
     )
 
@@ -452,9 +450,9 @@ def main():
         ipv6_setting=dict(type='dict', elements='dict', options=ipv6_spec),
         config_addr_type=dict(default='IPV4'),
         comment=dict(),
-        enable_ha=dict(type='bool',default=False),
+        enable_ha=dict(type='bool', default=False),
         router_id=dict(type='int'),
-        lan2_enabled=dict(type='bool',default=False),
+        lan2_enabled=dict(type='bool', default=False),
         lan2_port_setting=dict(type='dict', elements='dict', options=lan2_port_spec),
         platform=dict(default='INFOBLOX'),
         node_info=dict(type='list', elements='dict', options=node_spec),
@@ -477,10 +475,11 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
-    
+
     wapi = WapiModule(module)
     result = wapi.run(NIOS_MEMBER, ib_spec)
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/nios/nios_member.py
+++ b/lib/ansible/modules/net_tools/nios/nios_member.py
@@ -282,7 +282,7 @@ options:
               - Hardware type.
       licenses:
         description:
-          - An array of license types 
+          - An array of license types.
   state:
     description:
       - Configures the intended state of the instance of the object on

--- a/test/units/modules/net_tools/nios/test_nios_member.py
+++ b/test/units/modules/net_tools/nios/test_nios_member.py
@@ -98,9 +98,9 @@ class TestNiosMemberModule(TestNiosModule):
                         "address": "192.168.1.100",
                         "dscp": 0,
                         "gateway": "192.168.1.1",
-                        "primary": true,
+                        "primary": True,
                         "subnet_mask": "255.255.255.0",
-                        "use_dscp": false
+                        "use_dscp": False
                     }
             }
         ]
@@ -139,9 +139,9 @@ class TestNiosMemberModule(TestNiosModule):
                         "address": "192.168.1.100",
                         "dscp": 0,
                         "gateway": "192.168.1.1",
-                        "primary": true,
+                        "primary": True,
                         "subnet_mask": "255.255.255.0",
-                        "use_dscp": false
+                        "use_dscp": False
                     }
             }
         ]

--- a/test/units/modules/net_tools/nios/test_nios_member.py
+++ b/test/units/modules/net_tools/nios/test_nios_member.py
@@ -57,7 +57,9 @@ class TestNiosMemberModule(TestNiosModule):
         return wapi
 
     def test_nios_member_create(self):
-        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': None, 'extattrs': None}
+        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 
+							  'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
+							  'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': None, 'extattrs': None}
 
         test_object = None
         test_spec = {
@@ -73,10 +75,14 @@ class TestNiosMemberModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS'})
+        wapi.create_object.assert_called_once_with('testobject', {'host_name': 'test_member', 
+		                                           'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
+												   'config_addr_type': 'IPV4', 'platform': 'VNIOS'})
 
-    def test_nios_member_update(self):
-        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
+	def test_nios_member_update(self):
+        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 
+		                      'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
+							  'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
 
         test_object = [{
 		"comment": "Created with Ansible",
@@ -85,7 +91,8 @@ class TestNiosMemberModule(TestNiosModule):
 		"host_name": "member01.ansible-dev.com",
 		"platform": "VNIOS",
 		"service_type_configuration": "ALL_V4",
-		"vip_setting": {
+		"vip_setting": 
+		{
 			"address": "192.168.1.100",
 			"dscp": 0,
 			"gateway": "192.168.1.1",
@@ -93,7 +100,7 @@ class TestNiosMemberModule(TestNiosModule):
 			"subnet_mask": "255.255.255.0",
 			"use_dscp": false
 		}
-	}]
+		}]
 
         test_spec = {
             "host_name": {"ib_req": True},
@@ -110,7 +117,9 @@ class TestNiosMemberModule(TestNiosModule):
         self.assertTrue(res['changed'])
 
     def test_nios_member_remove(self):
-        self.module.params = {'provider': None, 'state': 'absent', 'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
+        self.module.params = {'provider': None, 'state': 'absent', 'host_name': 'test_member', 
+		                      'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
+							  'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
 
         ref = "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com"
 
@@ -121,7 +130,8 @@ class TestNiosMemberModule(TestNiosModule):
 		"host_name": "member01.ansible-dev.com",
 		"platform": "VNIOS",
 		"service_type_configuration": "ALL_V4"
-		"vip_setting": {
+		"vip_setting": 
+		{
 			"address": "192.168.1.100",
 			"dscp": 0,
 			"gateway": "192.168.1.1",

--- a/test/units/modules/net_tools/nios/test_nios_member.py
+++ b/test/units/modules/net_tools/nios/test_nios_member.py
@@ -76,7 +76,8 @@ class TestNiosMemberModule(TestNiosModule):
 
         self.assertTrue(res['changed'])
         wapi.create_object.assert_called_once_with('testobject', {'host_name': 'test_member',
-                                                                  'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'},
+                                                                  'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0',
+                                                                                  'gateway': '192.168.1.1'},
                                                                   'config_addr_type': 'IPV4', 'platform': 'VNIOS'})
 
     def test_nios_member_update(self):

--- a/test/units/modules/net_tools/nios/test_nios_member.py
+++ b/test/units/modules/net_tools/nios/test_nios_member.py
@@ -1,0 +1,149 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible.module_utils.net_tools.nios import api
+from ansible.modules.net_tools.nios import nios_member
+from units.compat.mock import patch, MagicMock, Mock
+from .test_nios_module import TestNiosModule, load_fixture
+
+
+class TestNiosMemberModule(TestNiosModule):
+
+    module = nios_member
+
+    def setUp(self):
+        super(TestNiosMemberModule, self).setUp()
+        self.module = MagicMock(name='ansible.modules.net_tools.nios.nios_member.WapiModule')
+        self.module.check_mode = False
+        self.module.params = {'provider': None}
+        self.mock_wapi = patch('ansible.modules.net_tools.nios.nios_member.WapiModule')
+        self.exec_command = self.mock_wapi.start()
+        self.mock_wapi_run = patch('ansible.modules.net_tools.nios.nios_member.WapiModule.run')
+        self.mock_wapi_run.start()
+        self.load_config = self.mock_wapi_run.start()
+
+    def tearDown(self):
+        super(TestNiosMemberModule, self).tearDown()
+        self.mock_wapi.stop()
+        self.mock_wapi_run.stop()
+
+    def load_fixtures(self, commands=None):
+        self.exec_command.return_value = (0, load_fixture('nios_result.txt').strip(), None)
+        self.load_config.return_value = dict(diff=None, session='session')
+
+    def _get_wapi(self, test_object):
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(name='get_object', return_value=test_object)
+        wapi.create_object = Mock(name='create_object')
+        wapi.update_object = Mock(name='update_object')
+        wapi.delete_object = Mock(name='delete_object')
+        return wapi
+
+    def test_nios_member_create(self):
+        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': None, 'extattrs': None}
+
+        test_object = None
+        test_spec = {
+            "host_name": {"ib_req": True},
+            "vip_setting": {},
+            "config_addr_type": {},
+            "platform": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with('testobject', {'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS'})
+
+    def test_nios_member_update(self):
+        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
+
+        test_object = [
+            {
+				"comment": "Created with Ansible",
+                "_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
+				"config_addr_type": "IPV4",
+				"host_name": "member01.ansible-dev.com",
+				"platform": "VNIOS",
+				"service_type_configuration": "ALL_V4"
+				"vip_setting": {
+					"address": "192.168.1.100",
+					"dscp": 0,
+					"gateway": "192.168.1.1",
+					"primary": true,
+					"subnet_mask": "255.255.255.0",
+					"use_dscp": false
+				}
+			}
+        ]
+
+        test_spec = {
+            "host_name": {"ib_req": True},
+            "vip_setting": {},
+            "config_addr_type": {},
+            "platform": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+
+    def test_nios_member_remove(self):
+        self.module.params = {'provider': None, 'state': 'absent', 'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
+
+        ref = "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com"
+
+        test_object = [{
+            "comment": "Created with Ansible",
+			"_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
+			"config_addr_type": "IPV4",
+			"host_name": "member01.ansible-dev.com",
+			"platform": "VNIOS",
+			"service_type_configuration": "ALL_V4"
+			"vip_setting": {
+				"address": "192.168.1.100",
+				"dscp": 0,
+				"gateway": "192.168.1.1",
+				"primary": true,
+				"subnet_mask": "255.255.255.0",
+				"use_dscp": false
+			}
+        }]
+
+        test_spec = {
+            "host_name": {"ib_req": True},
+            "vip_setting": {},
+            "config_addr_type": {},
+            "platform": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)

--- a/test/units/modules/net_tools/nios/test_nios_member.py
+++ b/test/units/modules/net_tools/nios/test_nios_member.py
@@ -133,7 +133,7 @@ class TestNiosMemberModule(TestNiosModule):
                 "config_addr_type": "IPV4",
                 "host_name": "member01.ansible-dev.com",
                 "platform": "VNIOS",
-                "service_type_configuration": "ALL_V4"
+                "service_type_configuration": "ALL_V4",
                 "vip_setting":
                     {
                         "address": "192.168.1.100",

--- a/test/units/modules/net_tools/nios/test_nios_member.py
+++ b/test/units/modules/net_tools/nios/test_nios_member.py
@@ -57,9 +57,9 @@ class TestNiosMemberModule(TestNiosModule):
         return wapi
 
     def test_nios_member_create(self):
-        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 
-							  'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
-							  'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': None, 'extattrs': None}
+        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member',
+                              'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'},
+                              'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': None, 'extattrs': None}
 
         test_object = None
         test_spec = {
@@ -75,32 +75,34 @@ class TestNiosMemberModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'host_name': 'test_member', 
-		                                           'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
-												   'config_addr_type': 'IPV4', 'platform': 'VNIOS'})
+        wapi.create_object.assert_called_once_with('testobject', {'host_name': 'test_member',
+                                                                  'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'},
+                                                                  'config_addr_type': 'IPV4', 'platform': 'VNIOS'})
 
-	def test_nios_member_update(self):
-        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 
-		                      'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
-							  'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
+    def test_nios_member_update(self):
+        self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member',
+                              'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'},
+                              'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
 
-        test_object = [{
-		"comment": "Created with Ansible",
-		"_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
-		"config_addr_type": "IPV4",
-		"host_name": "member01.ansible-dev.com",
-		"platform": "VNIOS",
-		"service_type_configuration": "ALL_V4",
-		"vip_setting": 
-		{
-			"address": "192.168.1.100",
-			"dscp": 0,
-			"gateway": "192.168.1.1",
-			"primary": true,
-			"subnet_mask": "255.255.255.0",
-			"use_dscp": false
-		}
-		}]
+        test_object = [
+            {
+                "comment": "Created with Ansible",
+                "_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
+                "config_addr_type": "IPV4",
+                "host_name": "member01.ansible-dev.com",
+                "platform": "VNIOS",
+                "service_type_configuration": "ALL_V4",
+                "vip_setting":
+                    {
+                        "address": "192.168.1.100",
+                        "dscp": 0,
+                        "gateway": "192.168.1.1",
+                        "primary": true,
+                        "subnet_mask": "255.255.255.0",
+                        "use_dscp": false
+                    }
+            }
+        ]
 
         test_spec = {
             "host_name": {"ib_req": True},
@@ -117,29 +119,31 @@ class TestNiosMemberModule(TestNiosModule):
         self.assertTrue(res['changed'])
 
     def test_nios_member_remove(self):
-        self.module.params = {'provider': None, 'state': 'absent', 'host_name': 'test_member', 
-		                      'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 
-							  'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
+        self.module.params = {'provider': None, 'state': 'absent', 'host_name': 'test_member',
+                              'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'},
+                              'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
 
         ref = "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com"
 
-        test_object = [{
-		"comment": "Created with Ansible",
-		"_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
-		"config_addr_type": "IPV4",
-		"host_name": "member01.ansible-dev.com",
-		"platform": "VNIOS",
-		"service_type_configuration": "ALL_V4"
-		"vip_setting": 
-		{
-			"address": "192.168.1.100",
-			"dscp": 0,
-			"gateway": "192.168.1.1",
-			"primary": true,
-			"subnet_mask": "255.255.255.0",
-			"use_dscp": false
-		}
-        }]
+        test_object = [
+            {
+                "comment": "Created with Ansible",
+                "_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
+                "config_addr_type": "IPV4",
+                "host_name": "member01.ansible-dev.com",
+                "platform": "VNIOS",
+                "service_type_configuration": "ALL_V4"
+                "vip_setting":
+                    {
+                        "address": "192.168.1.100",
+                        "dscp": 0,
+                        "gateway": "192.168.1.1",
+                        "primary": true,
+                        "subnet_mask": "255.255.255.0",
+                        "use_dscp": false
+                    }
+            }
+        ]
 
         test_spec = {
             "host_name": {"ib_req": True},

--- a/test/units/modules/net_tools/nios/test_nios_member.py
+++ b/test/units/modules/net_tools/nios/test_nios_member.py
@@ -78,24 +78,22 @@ class TestNiosMemberModule(TestNiosModule):
     def test_nios_member_update(self):
         self.module.params = {'provider': None, 'state': 'present', 'host_name': 'test_member', 'vip_setting': {'address': '192.168.1.110', 'subnet_mask': '255.255.255.0', 'gateway': '192.168.1.1'}, 'config_addr_type': 'IPV4', 'platform': 'VNIOS', 'comment': 'updated comment', 'extattrs': None}
 
-        test_object = [
-            {
-				"comment": "Created with Ansible",
-                "_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
-				"config_addr_type": "IPV4",
-				"host_name": "member01.ansible-dev.com",
-				"platform": "VNIOS",
-				"service_type_configuration": "ALL_V4"
-				"vip_setting": {
-					"address": "192.168.1.100",
-					"dscp": 0,
-					"gateway": "192.168.1.1",
-					"primary": true,
-					"subnet_mask": "255.255.255.0",
-					"use_dscp": false
-				}
-			}
-        ]
+        test_object = [{
+		"comment": "Created with Ansible",
+		"_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
+		"config_addr_type": "IPV4",
+		"host_name": "member01.ansible-dev.com",
+		"platform": "VNIOS",
+		"service_type_configuration": "ALL_V4",
+		"vip_setting": {
+			"address": "192.168.1.100",
+			"dscp": 0,
+			"gateway": "192.168.1.1",
+			"primary": true,
+			"subnet_mask": "255.255.255.0",
+			"use_dscp": false
+		}
+	}]
 
         test_spec = {
             "host_name": {"ib_req": True},
@@ -117,20 +115,20 @@ class TestNiosMemberModule(TestNiosModule):
         ref = "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com"
 
         test_object = [{
-            "comment": "Created with Ansible",
-			"_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
-			"config_addr_type": "IPV4",
-			"host_name": "member01.ansible-dev.com",
-			"platform": "VNIOS",
-			"service_type_configuration": "ALL_V4"
-			"vip_setting": {
-				"address": "192.168.1.100",
-				"dscp": 0,
-				"gateway": "192.168.1.1",
-				"primary": true,
-				"subnet_mask": "255.255.255.0",
-				"use_dscp": false
-			}
+		"comment": "Created with Ansible",
+		"_ref": "member/b25lLnZpcnR1YWxfbm9kZSQ3:member01.ansible-dev.com",
+		"config_addr_type": "IPV4",
+		"host_name": "member01.ansible-dev.com",
+		"platform": "VNIOS",
+		"service_type_configuration": "ALL_V4"
+		"vip_setting": {
+			"address": "192.168.1.100",
+			"dscp": 0,
+			"gateway": "192.168.1.1",
+			"primary": true,
+			"subnet_mask": "255.255.255.0",
+			"use_dscp": false
+		}
         }]
 
         test_spec = {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support for member object. It supports adding and/or removes Infoblox NIOS servers.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios_member

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The module supports various parameters that enable adding a standalone/HA member. It also supports both IPv4 and IPv6.
Changes had to be made to api.py file in order to normalize the input parameters. The member_normalize function will remove any arguments that are set to None since WAPI will error on that condition.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
