### PR TITLE
Implement display_ok_hosts and display_skipped_hosts for unixy

### DIFF
--- a/changelogs/fragments/53179-unixy-implement_display_ok_skipped_hosts.yaml
+++ b/changelogs/fragments/53179-unixy-implement_display_ok_skipped_hosts.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Implement config options for ``display_ok_hosts`` and ``display_skipped_hosts`` in unixy callback plugin

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -41,6 +41,7 @@ COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),)
 
+
 class CallbackModule(CallbackBase):
 
     '''

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -159,11 +159,11 @@ class CallbackModule(CallbackBase):
         if result_was_changed:
             msg = "done"
             display_color = C.COLOR_CHANGED
-        elif not self.display_ok_hosts:
-            return
-
-        task_result = self._process_result_output(result, msg)
-        self._display.display("  " + task_result, display_color)
+            task_result = self._process_result_output(result, msg)
+            self._display.display("  " + task_result, display_color)
+        elif self.display_ok_hosts:
+            task_result = self._process_result_output(result, msg)
+            self._display.display("  " + task_result, display_color)
 
     def v2_runner_item_on_skipped(self, result):
         self.v2_runner_on_skipped(result)

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -21,28 +21,14 @@ DOCUMENTATION = '''
 '''
 
 from os.path import basename
-
 from ansible import constants as C
 from ansible import context
 from ansible.module_utils._text import to_text
-from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
-
-# These values use ansible.constants for historical reasons, mostly to allow
-# unmodified derivative plugins to work. However, newer options added to the
-# plugin are not also added to ansible.constants, so authors of derivative
-# callback plugins will eventually need to add a reference to the common docs
-# fragment for the 'default' callback plugin
-
-# these are used to provide backwards compat with old plugins that subclass from default
-# but still don't use the new config system and/or fail to document the options
-COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
-                  ('display_ok_hosts', True),
-                  ('show_custom_stats', C.SHOW_CUSTOM_STATS),
-                  ('display_failed_stderr', False),)
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
 
-class CallbackModule(CallbackBase):
+class CallbackModule(CallbackModule_default):
 
     '''
     Design goals:
@@ -60,18 +46,6 @@ class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'unixy'
-
-    def set_options(self, task_keys=None, var_options=None, direct=None):
-
-        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
-
-        # for backwards compat with plugins subclassing default, fallback to constants
-        for option, constant in COMPAT_OPTIONS:
-            try:
-                value = self.get_option(option)
-            except (AttributeError, KeyError):
-                value = constant
-            setattr(self, option, value)
 
     def _run_is_verbose(self, result):
         return ((self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result)

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -28,6 +28,18 @@ from ansible.module_utils._text import to_text
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
 
+# These values use ansible.constants for historical reasons, mostly to allow
+# unmodified derivative plugins to work. However, newer options added to the
+# plugin are not also added to ansible.constants, so authors of derivative
+# callback plugins will eventually need to add a reference to the common docs
+# fragment for the 'default' callback plugin
+
+# these are used to provide backwards compat with old plugins that subclass from default
+# but still don't use the new config system and/or fail to document the options
+COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
+                  ('display_ok_hosts', True),
+                  ('show_custom_stats', C.SHOW_CUSTOM_STATS),
+                  ('display_failed_stderr', False),)
 
 class CallbackModule(CallbackBase):
 
@@ -47,6 +59,21 @@ class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'unixy'
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        # for backwards compat with plugins subclassing default, fallback to constants
+        for option, constant in COMPAT_OPTIONS:
+            try:
+                value = self.get_option(option)
+            except (AttributeError, KeyError):
+                value = constant
+            setattr(self, option, value)
+
+    def _run_is_verbose(self, result):
+        return ((self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result)
 
     def _get_task_display_name(self, task):
         self.task_display_name = None
@@ -106,12 +133,15 @@ class CallbackModule(CallbackBase):
         self._display.display(msg)
 
     def v2_runner_on_skipped(self, result, ignore_errors=False):
-        self._preprocess_result(result)
-        display_color = C.COLOR_SKIP
-        msg = "skipped"
+        if self.display_skipped_hosts:
+            self._preprocess_result(result)
+            display_color = C.COLOR_SKIP
+            msg = "skipped"
 
-        task_result = self._process_result_output(result, msg)
-        self._display.display("  " + task_result, display_color)
+            task_result = self._process_result_output(result, msg)
+            self._display.display("  " + task_result, display_color)
+        else:
+            return
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         self._preprocess_result(result)
@@ -128,6 +158,8 @@ class CallbackModule(CallbackBase):
         if result_was_changed:
             msg = "done"
             display_color = C.COLOR_CHANGED
+        elif not self.display_ok_hosts:
+            return
 
         task_result = self._process_result_output(result, msg)
         self._display.display("  " + task_result, display_color)


### PR DESCRIPTION
##### SUMMARY
Implements options `display_ok_hosts` and `display_skipped_hosts` like the default callback plugin.
Also implements `show_custom_stats` and `display_failed_stderr`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
unixy callback plugin

##### ADDITIONAL INFORMATION

```
# Default output
Executing playbook test.yml

- localhost on hosts: localhost -
Gathering Facts...
  localhost ok
command...
  localhost skipped | msg: skipped, running in check mode
  localhost skipped | msg: skipped, running in check mode
  localhost skipped | msg: skipped, running in check mode
  localhost skipped | msg: skipped, running in check mode
  localhost skipped
command...
  localhost skipped

- Play recap -
  localhost                  : ok=1    changed=0    unreachable=0    failed=0    rescued=0    ignored=0

# display_ok_hosts=false, display_skipped_hosts=false
Executing playbook test.yml

- localhost on hosts: localhost -
Gathering Facts...
command...
command...

- Play recap -
  localhost                  : ok=1    changed=0    unreachable=0    failed=0    rescued=0    ignored=0
ansible-playbook --diff test.yml --check  2.11s user 0.36s system 97% cpu 2.523 total
```
