### PR TITLE
[2.7] fix ec2 regression when assigning a private IP without a public IP 

### DIFF
--- a/changelogs/fragments/ec2_fix_assigning_private_without_public_ip.yml
+++ b/changelogs/fragments/ec2_fix_assigning_private_without_public_ip.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ec2 - if the private_ip has been provided for the new network interface it shouldn't also be added to top level
+    parameters for run_instances()

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1111,7 +1111,7 @@ def create_instances(module, ec2, vpc, override_count=None):
 
             # check to see if we're using spot pricing first before starting instances
             if not spot_price:
-                if assign_public_ip and private_ip:
+                if assign_public_ip is not None and private_ip:
                     params.update(
                         dict(
                             min_count=count_remaining,


### PR DESCRIPTION
##### SUMMARY
If the private_ip has been provided for the new network interface it shouldn't also be added to top level parameters for run_instances

changelog

(cherry picked from commit d16ec175fcc17f29e081f4fab4d8b9fc5842ebae)

Backport #52579

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py
