### PR TITLE
openssl_csr: improve invalid SAN error messages

### DIFF
--- a/changelogs/fragments/53201-openssl_csr-improve-invalid-san.yml
+++ b/changelogs/fragments/53201-openssl_csr-improve-invalid-san.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_csr - improve error messages for invalid SANs."

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -489,7 +489,14 @@ class CertificateSigningRequestPyOpenSSL(CertificateSigningRequestBase):
         extensions = []
         if self.subjectAltName:
             altnames = ', '.join(self.subjectAltName)
-            extensions.append(crypto.X509Extension(b"subjectAltName", self.subjectAltName_critical, altnames.encode('ascii')))
+            try:
+                extensions.append(crypto.X509Extension(b"subjectAltName", self.subjectAltName_critical, altnames.encode('ascii')))
+            except OpenSSL.crypto.Error as e:
+                raise CertificateSigningRequestError(
+                    'Error while parsing Subject Alternative Names {0} (check for missing type prefix, such as "DNS:"!): {1}'.format(
+                        ', '.join(["{0}".format(san) for san in self.subjectAltName]), str(e)
+                    )
+                )
 
         if self.keyUsage:
             usages = ', '.join(self.keyUsage)

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -158,6 +158,15 @@
     commonName: www.ansible.com
     select_crypto_backend: '{{ select_crypto_backend }}'
 
+- name: Generate CSR with invalid SAN
+  openssl_csr:
+    path: '{{ output_dir }}/csrinvsan.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    subject_alt_name: invalid-san.example.com
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: generate_csr_invalid_san
+  ignore_errors: yes
+
 - name: Generate CSR with OCSP Must Staple
   openssl_csr:
     path: '{{ output_dir }}/csr_ocsp.csr'

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -54,6 +54,12 @@
       - csr_oldapi_cn.stdout.split('=')[-1] == 'www.ansible.com'
       - csr_oldapi_modulus.stdout == privatekey_modulus.stdout
 
+- name: Validate invalid SAN
+  assert:
+    that:
+      - generate_csr_invalid_san is failed
+      - "'Subject Alternative Name' in generate_csr_invalid_san.msg"
+
 - name: Validate OCSP Must Staple CSR (test - everything)
   shell: "openssl req -noout -in {{ output_dir }}/csr_ocsp.csr -text"
   register: csr_ocsp


### PR DESCRIPTION
##### SUMMARY
When an invalid subject alternative name is specified (like prefix type is forgotten, such as `DNS:`), this PR will improve the error message. Fixes #53141.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_csr
