### PR TITLE
[2.7] docs: SAN prefixes are required for openssl_csr

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -108,7 +108,7 @@ options:
         description:
             - SAN extension to attach to the certificate signing request
             - This can either be a 'comma separated string' or a YAML list.
-            - Values should be prefixed by their options. (i.e., C(email), C(URI), C(DNS), C(RID), C(IP), C(dirName),
+            - Values must be prefixed by their options. (i.e., C(email), C(URI), C(DNS), C(RID), C(IP), C(dirName),
               C(otherName) and the ones specific to your CA)
             - More at U(https://tools.ietf.org/html/rfc5280#section-4.2.1.6)
     subject_alt_name_critical:


### PR DESCRIPTION
##### SUMMARY
Backport of #53144 to stable-2.7: improves docs on SANs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
openssl_csr
