### PR TITLE
Make "absent" runnable with specifying NVR in DNF module.

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -420,8 +420,22 @@ def ensure(module, base, state, names, autoremove):
 
             installed = base.sack.query().installed()
             for pkg_spec in pkg_specs:
-                if installed.filter(name=pkg_spec):
-                    base.remove(pkg_spec)
+                #pkg_spec = '%{name}'
+                installed_pkg = list(map(str, installed.filter(name=pkg_spec).run()))
+                if installed_pkg:
+                    candidate_pkg = self._packagename_dict(installed_pkg[0])
+                else:
+                    #pkg_spec = '%{name}-%{version}-%{release}.%{arch}'
+                    candidate_pkg = self._packagename_dict(pkg_spec)
+                installed_pkg = installed.filter(name=candidate_pkg['name']).run()
+                if installed_pkg:
+                    installed_pkg = installed_pkg[0]
+                    evr_cmp = self._compare_evr(
+                        installed_pkg.epoch, installed_pkg.version, installed_pkg.release,
+                        candidate_pkg['epoch'], candidate_pkg['version'], candidate_pkg['release'],
+                    )
+                    if evr_cmp == 0:
+                            self.base.remove(pkg_spec)
 
             # Like the dnf CLI we want to allow recursive removal of dependent
             # packages


### PR DESCRIPTION
##### SUMMARY
"present" seems to honor NVR but "absent" doesn't.
This behavior prevent for us to remove packages specifying certain version if there, for example kernel version or any specific insecure version of packages.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/dnf.py

##### ADDITIONAL INFORMATION
Quick reproducible steps:

1) Install sipcalc-1.1.6-14.fc29.x86_64.

2) Try to remove (absent) sipcalc-1.1.6-14.fc29.x86_64.

Before patching:
  ansible localhost -m dnf -a "name=sipcalc state=absent" will remove package with specified name.
  ansible localhost -m dnf -a "name=sipcalc-1.1.6-14.fc29.x86_64 state=absent" didn't remove anything.

After patching:
  ansible localhost -m dnf -a "name=sipcalc state=absent" will remove package with specified name.
  ansible localhost -m dnf -a "name=sipcalc-1.1.6-14.fc29.x86_64 state=absent" will remove package with NVR.
