### PR TITLE
Make "absent" runnable with specifying NVR in DNF module.

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1100,7 +1100,7 @@ class DnfModule(YumDnf):
                         installed_pkg = installed.filter(name=candidate_pkg['name']).run()
                     else:
                         candidate_pkg = self._packagename_dict(pkg_spec)
-                        installed_pkg = installed.filter(nevra_strict=pkg_spec).run()
+                        installed_pkg = installed.filter(nevra=pkg_spec).run()
                     if installed_pkg:
                         installed_pkg = installed_pkg[0]
                         evr_cmp = self._compare_evr(

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1094,22 +1094,20 @@ class DnfModule(YumDnf):
 
                 installed = self.base.sack.query().installed()
                 for pkg_spec in pkg_specs:
-                # pkg_spec = '%{name}'
-                installed_pkg = list(map(str, installed.filter(name=pkg_spec).run()))
-                if installed_pkg:
-                    candidate_pkg = self._packagename_dict(installed_pkg[0])
-                else:
-                    # pkg_spec = '%{name}-%{version}-%{release}.%{arch}'
-                    candidate_pkg = self._packagename_dict(pkg_spec)
-                installed_pkg = installed.filter(name=candidate_pkg['name']).run()
-                if installed_pkg:
-                    installed_pkg = installed_pkg[0]
-                    evr_cmp = self._compare_evr(
-                        installed_pkg.epoch, installed_pkg.version, installed_pkg.release,
-                        candidate_pkg['epoch'], candidate_pkg['version'], candidate_pkg['release'],
-                    )
-                    if evr_cmp == 0:
-                        self.base.remove(pkg_spec)
+                    installed_pkg = list(map(str, installed.filter(name=pkg_spec).run()))
+                    if installed_pkg:
+                        candidate_pkg = self._packagename_dict(installed_pkg[0])
+                    else:
+                        candidate_pkg = self._packagename_dict(pkg_spec)
+                    installed_pkg = installed.filter(name=candidate_pkg['name']).run()
+                    if installed_pkg:
+                        installed_pkg = installed_pkg[0]
+                        evr_cmp = self._compare_evr(
+                            installed_pkg.epoch, installed_pkg.version, installed_pkg.release,
+                            candidate_pkg['epoch'], candidate_pkg['version'], candidate_pkg['release'],
+                        )
+                        if evr_cmp == 0:
+                            self.base.remove(pkg_spec)
 
                 # Like the dnf CLI we want to allow recursive removal of dependent
                 # packages

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1094,8 +1094,22 @@ class DnfModule(YumDnf):
 
                 installed = self.base.sack.query().installed()
                 for pkg_spec in pkg_specs:
-                    if ("*" in pkg_spec) or installed.filter(name=pkg_spec):
-                        self.base.remove(pkg_spec)
+                #pkg_spec = '%{name}'
+                installed_pkg = list(map(str, installed.filter(name=pkg_spec).run()))
+                if installed_pkg:
+                    candidate_pkg = self._packagename_dict(installed_pkg[0])
+                else:
+                    #pkg_spec = '%{name}-%{version}-%{release}.%{arch}'
+                    candidate_pkg = self._packagename_dict(pkg_spec)
+                installed_pkg = installed.filter(name=candidate_pkg['name']).run()
+                if installed_pkg:
+                    installed_pkg = installed_pkg[0]
+                    evr_cmp = self._compare_evr(
+                        installed_pkg.epoch, installed_pkg.version, installed_pkg.release,
+                        candidate_pkg['epoch'], candidate_pkg['version'], candidate_pkg['release'],
+                    )
+                    if evr_cmp == 0:
+                            self.base.remove(pkg_spec)
 
                 # Like the dnf CLI we want to allow recursive removal of dependent
                 # packages

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1094,12 +1094,12 @@ class DnfModule(YumDnf):
 
                 installed = self.base.sack.query().installed()
                 for pkg_spec in pkg_specs:
-                #pkg_spec = '%{name}'
+                # pkg_spec = '%{name}'
                 installed_pkg = list(map(str, installed.filter(name=pkg_spec).run()))
                 if installed_pkg:
                     candidate_pkg = self._packagename_dict(installed_pkg[0])
                 else:
-                    #pkg_spec = '%{name}-%{version}-%{release}.%{arch}'
+                    # pkg_spec = '%{name}-%{version}-%{release}.%{arch}'
                     candidate_pkg = self._packagename_dict(pkg_spec)
                 installed_pkg = installed.filter(name=candidate_pkg['name']).run()
                 if installed_pkg:
@@ -1109,7 +1109,7 @@ class DnfModule(YumDnf):
                         candidate_pkg['epoch'], candidate_pkg['version'], candidate_pkg['release'],
                     )
                     if evr_cmp == 0:
-                            self.base.remove(pkg_spec)
+                        self.base.remove(pkg_spec)
 
                 # Like the dnf CLI we want to allow recursive removal of dependent
                 # packages

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1097,9 +1097,10 @@ class DnfModule(YumDnf):
                     installed_pkg = list(map(str, installed.filter(name=pkg_spec).run()))
                     if installed_pkg:
                         candidate_pkg = self._packagename_dict(installed_pkg[0])
+                        installed_pkg = installed.filter(name=candidate_pkg['name']).run()
                     else:
                         candidate_pkg = self._packagename_dict(pkg_spec)
-                    installed_pkg = installed.filter(name=candidate_pkg['name']).run()
+                        installed_pkg = installed.filter(nevra_strict=pkg_spec).run()
                     if installed_pkg:
                         installed_pkg = installed_pkg[0]
                         evr_cmp = self._compare_evr(


### PR DESCRIPTION
##### SUMMARY
"present" seems to honor NVR but "absent" doesn't.
This behavior prevent for us to remove packages specifying certain version if there, for example kernel version or any specific insecure version of packages.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/dnf.py

##### ADDITIONAL INFORMATION
Quick reproducible steps:

1) Install sipcalc-1.1.6-14.fc29.x86_64.

2) Try to remove (absent) sipcalc-1.1.6-14.fc29.x86_64.

Before patching:
  ansible localhost -m dnf -a "name=sipcalc state=absent" will remove package with specified name.
  ansible localhost -m dnf -a "name=sipcalc-1.1.6-14.fc29.x86_64 state=absent" didn't remove anything.

After patching:
  ansible localhost -m dnf -a "name=sipcalc state=absent" will remove package with specified name.
  ansible localhost -m dnf -a "name=sipcalc-1.1.6-14.fc29.x86_64 state=absent" will remove package with NVR.
