### PR TITLE
Creates base Sophos XG module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -310,6 +310,11 @@ files:
   $modules/network/panos/: ivanbojer jtschichold shinmog
   $modules/network/protocol/: $team_networking
   $modules/network/routeros/: heuels
+  $modules/network/sfos/:
+    maintainers: rdelcampog
+    keywords:
+      - sophos
+      - xg
   $modules/network/routing/: $team_networking
   $modules/network/slxos/: $team_extreme
   $modules/network/sros/: privateip
@@ -778,6 +783,8 @@ files:
       - cloud
   $module_utils/utm_utils.py:
     maintainers: $team_e_spirit
+  $module_utils/sfos_utils.py:
+    maintainers: rdelcampog
   $module_utils/vmware: *vmware
   $module_utils/vultr.py: *vultr
   $module_utils/xenserver.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -314,6 +314,7 @@ files:
     maintainers: rdelcampog
     keywords:
       - sophos
+      - sfos
       - xg
   $modules/network/routing/: $team_networking
   $modules/network/slxos/: $team_extreme

--- a/lib/ansible/module_utils/sfos_utils.py
+++ b/lib/ansible/module_utils/sfos_utils.py
@@ -39,7 +39,6 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import fetch_url
-from ansible.errors import AnsibleError, AnsibleConnectionFailure
 
 try:
     import xmltodict

--- a/lib/ansible/module_utils/sfos_utils.py
+++ b/lib/ansible/module_utils/sfos_utils.py
@@ -38,6 +38,7 @@ import six.moves.urllib.parse as urllib
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import fetch_url
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
 
@@ -72,12 +73,12 @@ class SFOSModule(AnsibleModule):
                  mutually_exclusive=None, required_together=None, required_one_of=None, add_file_common_args=False,
                  supports_check_mode=False, required_if=None):
         default_specs = dict(
-            sfos_host=dict(type='str', required=True),
-            sfos_port=dict(type='int', default=4444),
-            sfos_username=dict(type='str', required=True, no_log=True),
-            sfos_password=dict(type='str', required=True, no_log=True),
-            sfos_protocol=dict(type='str', required=False, default="https", choices=["https", "http"]),
-            validate_certs=dict(type='bool', required=False, default=True),
+            sfos_host=dict(type='str', required=True, fallback=(env_fallback, ['SFOS_HOST'])),
+            sfos_port=dict(type='int', default=4444, fallback=(env_fallback, ['SFOS_PORT'])),
+            sfos_username=dict(type='str', required=True, no_log=True, fallback=(env_fallback, ['SFOS_USERNAME'])),
+            sfos_password=dict(type='str', required=True, no_log=True, fallback=(env_fallback, ['SFOS_PASSWORD'])),
+            sfos_protocol=dict(type='str', required=False, default="https", choices=["https", "http"], fallback=(env_fallback, ['SFOS_PROTOCOL'])),
+            validate_certs=dict(type='bool', required=False, default=True, fallback=(env_fallback, ['SFOS_VALIDATECERTS'])),
             state=dict(type='str', required=False, default='present', choices=['present', 'absent'])
         )
         super(SFOSModule, self).__init__(self._merge_specs(default_specs, argument_spec), bypass_checks, no_log,

--- a/lib/ansible/module_utils/sfos_utils.py
+++ b/lib/ansible/module_utils/sfos_utils.py
@@ -170,7 +170,7 @@ class SFOS:
         Method = ET.SubElement(Request, method, operation=operation)
         Endpoint = ET.SubElement(Method, self.endpoint)
 
-        if method is "Get":
+        if method == "Get":
             if self.info_only:
                 if self.module.params.get('name'):
                     Filter = ET.SubElement(Endpoint, "Filter")

--- a/lib/ansible/module_utils/sfos_utils.py
+++ b/lib/ansible/module_utils/sfos_utils.py
@@ -1,0 +1,331 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright: (c) 2019, Rubén del Campo Gómez <yo@rubendelcampo.es>
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import json
+import xml.etree.cElementTree as ET
+import six.moves.urllib.parse as urllib
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+from ansible.errors import AnsibleError, AnsibleConnectionFailure
+
+try:
+    import xmltodict
+    HAS_XMLTODICT = True
+except ImportError as e:
+    HAS_XMLTODICT = False
+    XMLTODICT_IMPORT_ERR = e
+
+
+class SFOSModuleConfigurationError(Exception):
+
+    def __init__(self, msg, **args):
+        super(SFOSModuleConfigurationError, self).__init__(self, msg)
+        self.msg = msg
+        self.module_fail_args = args
+
+    def do_fail(self, module):
+        module.fail_json(msg=self.msg, other=self.module_fail_args)
+
+
+class SFOSModule(AnsibleModule):
+    """
+    This is a helper class to construct any SFOS Module. This will automatically add the endpoint host, port, username,
+    password, protocol, validate_certs and state field to the module. If you want to implement your own sophos xg module
+    just initialize this SFOSModule class and define the Payload fields that are needed for your module.
+    See the other modules like sfos_iphost for example.
+    """
+
+    def __init__(self, argument_spec, bypass_checks=False, no_log=False, check_invalid_arguments=None,
+                 mutually_exclusive=None, required_together=None, required_one_of=None, add_file_common_args=False,
+                 supports_check_mode=False, required_if=None):
+        default_specs = dict(
+            sfos_host=dict(type='str', required=True),
+            sfos_port=dict(type='int', default=4444),
+            sfos_username=dict(type='str', required=True, no_log=True),
+            sfos_password=dict(type='str', required=True, no_log=True),
+            sfos_protocol=dict(type='str', required=False, default="https", choices=["https", "http"]),
+            validate_certs=dict(type='bool', required=False, default=True),
+            state=dict(type='str', required=False, default='present', choices=['present', 'absent'])
+        )
+        super(SFOSModule, self).__init__(self._merge_specs(default_specs, argument_spec), bypass_checks, no_log,
+                                         check_invalid_arguments, mutually_exclusive, required_together, required_one_of,
+                                         add_file_common_args, supports_check_mode, required_if)
+
+    def _merge_specs(self, default_specs, custom_specs):
+        result = default_specs.copy()
+        result.update(custom_specs)
+        return result
+
+
+class SFOS:
+
+    def __init__(self, module, endpoint, change_relevant_keys, bool_keys, argument_spec, info_only=False):
+        """
+        Initialize SFOS Class
+        :param module: The Ansible module
+        :param endpoint: The corresponding endpoint to the module
+        :param change_relevant_keys: The keys of the object to check for changes
+        :param info_only: When implementing an info module, set this to true. Will allow access to the info method only
+        """
+        self.info_only = info_only
+        self.module = module
+        self.argument_spec = argument_spec
+        self.endpoint = endpoint
+        self.bool_keys = bool_keys
+
+        if not HAS_XMLTODICT:
+            raise Exception("xmltodict is not installed: %s" % to_native(XMLTODICT_IMPORT_ERR))
+
+        self.request_url = module.params.get('sfos_protocol') + "://" + module.params.get('sfos_host') + ":" + to_native(
+            module.params.get('sfos_port')) + "/webconsole/APIController?reqxml="
+
+        """
+        The change_relevant_keys will be checked for changes to determine whether the object needs to be updated
+        """
+        self.change_relevant_keys = change_relevant_keys
+        self.module.params['sfos_username'] = module.params.get('sfos_username')
+        self.module.params['sfos_password'] = module.params.get('sfos_password')
+        if all(elem in self.change_relevant_keys for elem in module.params.keys()):
+            raise SFOSModuleConfigurationError(
+                "The keys " + to_native(
+                    self.change_relevant_keys) + " to check are not in the modules keys:\n" + to_native(
+                    module.params.keys()))
+
+    def execute(self):
+        try:
+            if not self.info_only:
+                if self.module.params.get('state') == 'present':
+                    self._add()
+                elif self.module.params.get('state') == 'absent':
+                    self._remove()
+            else:
+                self._info()
+        except Exception as e:
+            self.module.fail_json(msg=to_native(e))
+
+    def _info(self):
+        """
+        gathers facts for an object in Sophos XG
+        """
+        exists, result = self._lookup_entry(self.module, self.request_url)
+
+        if exists:
+            if type(result) == list:
+                for item in result:
+                    for k, v in list(item.items()):
+                        if not k.startswith('@'):
+                            item[k.lower()] = v  # copy lowercase result keys
+                        item.pop(k)  # remove the rest of keys, including xml attributes
+            else:
+                for k, v in list(result.items()):
+                    if not k.startswith('@'):
+                        result[k.lower()] = v  # copy lowercase result keys
+                    result.pop(k)  # remove the rest of keys, including xml attributes
+
+            self.module.exit_json(result=result, changed=False)
+        else:
+            self.module.exit_json(changed=False)
+
+    def _construct_xml_request(self, method, operation=""):
+        """
+        Construct XML request
+        :param method:
+        :param operation: Operation to perform, can be Get, Set or Remove
+        :return:
+        """
+        Request = ET.Element("Request")
+        Login = ET.SubElement(Request, "Login")
+        Method = ET.SubElement(Request, method, operation=operation)
+        Endpoint = ET.SubElement(Method, self.endpoint)
+
+        if method is "Get":
+            if self.info_only:
+                if self.module.params.get('name'):
+                    Filter = ET.SubElement(Endpoint, "Filter")
+                    ET.SubElement(Filter, "key", name="Name", criteria=self.module.params.get('criteria')).text = self.module.params.get('name')
+            else:
+                Filter = ET.SubElement(Endpoint, "Filter")
+                ET.SubElement(Filter, "key", name="Name", criteria="=").text = self.module.params.get('name')
+        else:
+            for k in list(self.argument_spec.keys()):
+                if self.module.params.get(k):
+                    if type(self.module.params.get(k)) == list:
+                        if "item" not in self.argument_spec[k]:
+                            ET.SubElement(Endpoint, k).text = str(','.join(map(str, self.module.params.get(k))))
+                        else:
+                            List = ET.SubElement(Endpoint, k)
+                            for item in list(self.module.params.get(k)):
+                                ET.SubElement(List, self.argument_spec[k]["item"]).text = str(item)
+                    else:
+                        ET.SubElement(Endpoint, k).text = str(self.module.params.get(k))
+
+        ET.SubElement(Login, "Username").text = self.module.params.get('sfos_username')
+        ET.SubElement(Login, "Password").text = self.module.params.get('sfos_password')
+
+        reqxml = urllib.quote(ET.tostring(Request).decode('utf-8'), safe="%/:=&?~#+!$,;'@()*[]<>")
+        return reqxml
+
+    def _construct_response(self, response):
+        """
+        Returns status code and text message from a request response
+        :param response: The API response received from the request
+        :return: The status code and text message
+        """
+        result = json.loads(json.dumps(xmltodict.parse(response.read())))
+        status = int(result['Response'][self.endpoint]['Status']['@code'])
+
+        if status >= 200:
+            msg = result['Response'][self.endpoint]['Status']['#text']
+
+        return status, msg
+
+    def _add(self):
+        """
+        Adds or updates a host object on sfos
+        """
+        is_changed = False
+        exists, results = self._lookup_entry(self.module, self.request_url)
+
+        if exists:
+            if self._is_object_changed(self.change_relevant_keys, self.module, results, self.bool_keys):
+                reqxml = self._construct_xml_request("Set")
+                is_changed = True
+        else:
+            reqxml = self._construct_xml_request("Set", "add")
+            is_changed = True
+
+        if is_changed:
+            response, _ = fetch_url(self.module, self.request_url + reqxml, method="GET")
+            status, msg = self._construct_response(response)
+            if status >= 500:
+                self.module.fail_json(msg=msg)
+
+        result = self._clean_result(self.module.params)
+        self.module.exit_json(result=result, changed=is_changed)
+
+    def _remove(self):
+        """
+        Removes an object from sfos
+        """
+        is_changed = False
+        exists, _ = self._lookup_entry(self.module, self.request_url)
+
+        if exists:
+            is_changed = True
+            reqxml = self._construct_xml_request("Remove")
+            response, _ = fetch_url(self.module, self.request_url + reqxml, method="GET")
+            status, msg = self._construct_response(response)
+            if status >= 500:
+                self.module.fail_json(msg=msg)
+
+        self.module.exit_json(changed=is_changed)
+
+    def _lookup_entry(self, module, request_url):
+        """
+        Lookup for existing entry in sfos
+        :param module:
+        :param request_url:
+        :return:
+        """
+        response, info = fetch_url(module, request_url + self._construct_xml_request("Get"), method="GET")
+
+        if info['status'] == -1:
+            self.module.fail_json(msg=info['msg'])
+
+        if response is not None:
+            res = json.loads(json.dumps(xmltodict.parse(response.read())))
+            exists = False
+            results = dict()
+
+            if self.endpoint in res['Response'].keys():
+                if type(res['Response'][self.endpoint]) == list or res['Response'][self.endpoint].get('Name'):
+                    exists = True
+                    results = res['Response'][self.endpoint]
+            else:
+                if res['Response']['Login']['status'] == "Authentication Failure":
+                    self.module.fail_json(msg="Authentication Failure")
+                else:
+                    if int(res['Response']['Status']['@code']) >= 200:
+                        msg = res['Response']['Status']['#text']
+                        self.module.fail_json(msg=msg)
+
+        return exists, results
+
+    def _clean_result(self, result):
+        """
+        Will clean the result from irrelevant fields
+        :param result: The result from the query
+        :return: The modified result
+        """
+        del result['sfos_host']
+        del result['sfos_username']
+        del result['sfos_password']
+        del result['sfos_port']
+        del result['validate_certs']
+        del result['sfos_protocol']
+        del result['state']
+        return result
+
+    def _is_object_changed(self, keys, module, result, matchs):
+        """
+        Check if my object is changed
+        :param keys: The keys that will determine if an object is changed
+        :param module: The module
+        :param result: The result from the query
+        :return: True or False if object has changed or not
+        """
+        result = {k.lower(): v for k, v in result.items()}
+        for key in keys:
+            # Format booleans returned as strings into correct boolean values
+            if key in matchs:
+                if result[key]:
+                    result[key] = matchs[key][str(result[key])]
+
+            if module.params.get(key) is None and self.argument_spec[key]["type"] == "list":
+                continue  # if key type is list and is not present, skip this check to not wipe current values
+            elif type(module.params.get(key)) != list:  # if key type is not list, compare string values
+                if str(module.params.get(key)) != str(result[key]):
+                    return True
+            else:
+                if key not in result.keys():  # if result list not exists, assume object has changed
+                    return True
+                elif type(result[key][self.argument_spec[key]["item"]]) == str:
+                    if module.params.get(key) != [result[key][self.argument_spec[key]["item"]]]:
+                        return True  # if the result list has only one item, type is string, so lets compare list with list
+                elif module.params.get(key) != result[key][self.argument_spec[key]["item"]]:
+                    return True
+
+        return False

--- a/lib/ansible/module_utils/sfos_utils.py
+++ b/lib/ansible/module_utils/sfos_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # This code is part of Ansible, but is an independent component.
@@ -34,7 +33,7 @@ __metaclass__ = type
 
 import json
 import xml.etree.cElementTree as ET
-import six.moves.urllib.parse as urllib
+import ansible.module_utils.six.moves.urllib.parse as urllib
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
@@ -229,7 +228,7 @@ class SFOS:
             is_changed = True
 
         if is_changed:
-            response, _ = fetch_url(self.module, self.request_url + reqxml, method="GET")
+            response, dummy = fetch_url(self.module, self.request_url + reqxml, method="GET")
             status, msg = self._construct_response(response)
             if status >= 500:
                 self.module.fail_json(msg=msg)
@@ -242,12 +241,12 @@ class SFOS:
         Removes an object from sfos
         """
         is_changed = False
-        exists, _ = self._lookup_entry(self.module, self.request_url)
+        exists, dummy = self._lookup_entry(self.module, self.request_url)
 
         if exists:
             is_changed = True
             reqxml = self._construct_xml_request("Remove")
-            response, _ = fetch_url(self.module, self.request_url + reqxml, method="GET")
+            response, dummy = fetch_url(self.module, self.request_url + reqxml, method="GET")
             status, msg = self._construct_response(response)
             if status >= 500:
                 self.module.fail_json(msg=msg)
@@ -308,7 +307,9 @@ class SFOS:
         :param result: The result from the query
         :return: True or False if object has changed or not
         """
-        result = {k.lower(): v for k, v in result.items()}
+        for k, v in list(result.items()):
+            result[k.lower()] = v
+
         for key in keys:
             # Format booleans returned as strings into correct boolean values
             if key in matchs:

--- a/lib/ansible/modules/network/sfos/sfos_iphost.py
+++ b/lib/ansible/modules/network/sfos/sfos_iphost.py
@@ -31,18 +31,21 @@ options:
   name:
     description:
       - Enter a descriptive name for the IP Host. Will be used to identify the entry.
-    type: string
+    type: str
     required: true
   ipfamily:
     description:
-      - IP Family to which the IP Host belongs: IPv4 or IPv6.
-    type: string
+      - IP Family to which the IP Host belongs - IPv4 or IPv6.
+    type: str
+    choices:
+      - IPv4
+      - IPv6
     required: false
     default: IPv4
   hosttype:
     description:
-      - Select the type of Host: IP, Network, IP Range or IP List. Required if state is 'present'.
-    type: string
+      - Select the type of Host - IP, Network, IP Range or IP List. Required if state is 'present'.
+    type: str
     choices:
       - IP
       - Network
@@ -51,22 +54,22 @@ options:
   ipaddress:
     description:
       - Specify IP Address. Required if the host type selected is 'IP' or 'Network'.
-    type: string
+    type: str
     required: false
   subnet:
     description:
       - Specify Subnet address. Required if the host type selected is 'Network'.
-    type: string
+    type: str
     required: false
   startipaddress:
     description:
       - Specify the starting IP address of the IP Range. Required if host type selected is 'IPRange'.
-    type: string
+    type: str
     required: false
   endipaddress:
     description:
       - Specify the end IP address of the IP Range. Required if host type selected is 'IPRange'.
-    type: string
+    type: str
     required: false
   listofipaddresses:
     description:
@@ -118,7 +121,7 @@ result:
       description: Descriptive name for the IP Host. Will be used to identify the entry.
       type: string
     ipfamily:
-      description: IP Family to which the IP Host belongs: IPv4 or IPv6.
+      description: IP Family to which the IP Host belongs - IPv4 or IPv6.
       type: string
     hosttype:
       description: The type of IP Host, can be IP, Network, IPRange or IPList.

--- a/lib/ansible/modules/network/sfos/sfos_iphost.py
+++ b/lib/ansible/modules/network/sfos/sfos_iphost.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Rubén del Campo Gómez <yo@rubendelcampo.es>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = """
+---
+module: sfos_iphost
+
+author:
+  - Rubén del Campo Gómez (@rdelcampog)
+
+short_description: create, update or destroy IP Host in Sophos XG
+
+description:
+  - Create, update or destroy a IP Host in Sophos XG.
+
+version_added: "2.8"
+
+options:
+  name:
+    description:
+      - Enter a descriptive name for the IP Host. Will be used to identify the entry.
+    type: string
+    required: true
+  ipfamily:
+    description:
+      - IP Family to which the IP Host belongs: IPv4 or IPv6.
+    type: string
+    required: false
+    default: IPv4
+  hosttype:
+    description:
+      - Select the type of Host: IP, Network, IP Range or IP List. Required if state is 'present'.
+    type: string
+    choices:
+      - IP
+      - Network
+      - IPRange
+      - IPList
+  ipaddress:
+    description:
+      - Specify IP Address. Required if the host type selected is 'IP' or 'Network'.
+    type: string
+    required: false
+  subnet:
+    description:
+      - Specify Subnet address. Required if the host type selected is 'Network'.
+    type: string
+    required: false
+  startipaddress:
+    description:
+      - Specify the starting IP address of the IP Range. Required if host type selected is 'IPRange'.
+    type: string
+    required: false
+  endipaddress:
+    description:
+      - Specify the end IP address of the IP Range. Required if host type selected is 'IPRange'.
+    type: string
+    required: false
+  listofipaddresses:
+    description:
+      - Specify the list of IP addresses. Required if host type selected is 'IPList'.
+    type: list
+    required: false
+  hostgrouplist:
+    description:
+      - List of host groups to which the Host belongs. If not present, values already set preserves. If set but empty, current values are deleted.
+    type: list
+    required: false
+
+extends_documentation_fragment:
+    - sfos
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication or endpoint details like username, password, host or port.
+
+- name: Create SophosXG IP Host list for GoogleDNS
+  sfos_iphost:
+    name: 'Google DNS Servers'
+    hosttype: 'IPList'
+    listofipaddresses:
+        - '8.8.8.8'
+        - '8.8.4.4'
+    state: present
+
+- name: Create SophosXG IP Host for localhost
+  sfos_iphost:
+    name: 'localhost'
+    hosttype: 'IP'
+    ipaddress: '127.0.0.1'
+    state: present
+
+- name: Remove SophosXG IP Host for GoogleDNS
+  sfos_iphost:
+    name: 'Google DNS Servers'
+    state: absent
+"""
+
+RETURN = """
+result:
+  description: The IP Host object that was created
+  returned: success
+  type: complex
+  contains:
+    name:
+      description: Descriptive name for the IP Host. Will be used to identify the entry.
+      type: string
+    ipfamily:
+      description: IP Family to which the IP Host belongs: IPv4 or IPv6.
+      type: string
+    hosttype:
+      description: The type of IP Host, can be IP, Network, IPRange or IPList.
+      type: string
+    ipaddress:
+      description: The IP Address for this IP Host, applicable if the host type selected is 'IP' or 'Network'.
+      type: string
+    subnet:
+      description: The subnet mask for this IP Host, applicable if the host type selected is 'Network'.
+      type: string
+    startipaddress:
+      description: The starting IP address of the IP Range, applicable if host type selected is 'IPRange'.
+      type: string
+    endipaddress:
+      description: The ending IP address of the IP Range, applicable if host type selected is 'IPRange'.
+      type: string
+    listofipaddresses:
+      description: The list of IP address of the IP Range, applicable if host type selected is 'IPList'.
+      type: list
+    hostgrouplist:
+      description: A list of host groups to which this IP Host belongs.
+      type: list
+"""
+
+from ansible.module_utils.sfos_utils import SFOS, SFOSModule
+from ansible.module_utils._text import to_native
+
+
+def main():
+    endpoint = "IPHost"
+    key_to_check_for_changes = ["name", "hostgrouplist"]
+
+    bool_keys = {}
+
+    argument_spec = dict(
+        name=dict(type='str', required=True),
+        ipfamily=dict(type='str', required=False, default="IPv4", choices=["IPv4", "IPv6"]),
+        hosttype=dict(type='str', required=False, choices=["IP", "Network", "IPRange", "IPList"]),
+        ipaddress=dict(type='str', required=False),
+        subnet=dict(type='str', required=False),
+        startipaddress=dict(type='str', required=False),
+        endipaddress=dict(type='str', required=False),
+        listofipaddresses=dict(type='list', required=False),
+        hostgrouplist=dict(type='list', required=False, item="HostGroup"),
+    )
+
+    required_if = [
+        ["state", "present", ["hosttype"]],
+        ["hosttype", "IP", ["ipaddress"]],
+        ["hosttype", "Network", ["ipaddress", "subnet"]],
+        ["hosttype", "IPRange", ["startipaddress", "endipaddress"]],
+        ["hosttype", "IPList", ["listofipaddresses"]],
+    ]
+
+    module = SFOSModule(argument_spec, required_if=required_if)
+    try:
+        SFOS(module, endpoint, key_to_check_for_changes, bool_keys, argument_spec).execute()
+    except Exception as e:
+        module.fail_json(msg=to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/doc_fragments/sfos.py
+++ b/lib/ansible/plugins/doc_fragments/sfos.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Rubén del Campo Gómez <yo@rubendelcampo.es>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = r'''
+options:
+    sfos_host:
+        description:
+          - The Sophos XG endpoint IP address or FQDN.
+        type: str
+        required: true
+    sfos_port:
+        description:
+          - Port you mention in above URL should be same as the port you have configured as Admin Console HTTPS Port from System > Administration > Settings.
+        type: int
+        default: 4444
+    sfos_protocol:
+        description:
+          - The protocol used to communicate with the API endpoint.
+        choices: [ http, https ]
+        type: str
+        default: https
+    sfos_username:
+        description:
+          - The username used to login and who has permission to send API requests. If not set then the value of the SFOS_USERNAME environment variable is used.
+        choices: [ http, https ]
+        type: str
+        required: true
+    sfos_password:
+        description:
+          - The password for the username used to login and who has permission to send API requests. If not set then the value of the SFOS_PASSWORD environment variable is used.
+        choices: [ http, https ]
+        type: str
+        required: true
+    validate_certs:
+        description:
+          - Whether the API interface's ssl certificate should be verified or not.
+        type: bool
+        default: yes
+    state:
+        description:
+          - The desired state of the object.
+          - C(present) will create or update an object
+          - C(absent) will delete an object if it was present
+        type: str
+        choices: [ absent, present ]
+        default: present
+notes:
+  - This module requires xmltodict python library.
+    Use 'pip install xmltodict' in order to get xmltodict.
+  - API access must be enabled in Sophos XG. See U(https://community.sophos.com/kb/en-us/132560)
+requirements:
+  - xmltodict
+'''

--- a/lib/ansible/plugins/doc_fragments/sfos.py
+++ b/lib/ansible/plugins/doc_fragments/sfos.py
@@ -9,17 +9,17 @@ class ModuleDocFragment(object):
 options:
     sfos_host:
         description:
-          - The Sophos XG endpoint IP address or FQDN.
+          - The Sophos XG endpoint IP address or FQDN. If not set then the value of the SFOS_HOST environment variable is used.
         type: str
         required: true
     sfos_port:
         description:
-          - Port you mention in above URL should be same as the port you have configured as Admin Console HTTPS Port from System > Administration > Settings.
+          - Port you mention in above URL should be same as the port you have configured as Admin Console HTTPS Port from System > Administration > Settings. If not set then the value of the SFOS_PORT environment variable is used.
         type: int
         default: 4444
     sfos_protocol:
         description:
-          - The protocol used to communicate with the API endpoint.
+          - The protocol used to communicate with the API endpoint. If not set then the value of the SFOS_PROTOCOL environment variable is used.
         choices: [ http, https ]
         type: str
         default: https
@@ -37,7 +37,7 @@ options:
         required: true
     validate_certs:
         description:
-          - Whether the API interface's ssl certificate should be verified or not.
+          - Whether the API interface's ssl certificate should be verified or not. If not set then the value of the SFOS_VALIDATECERTS environment variable is used.
         type: bool
         default: yes
     state:

--- a/lib/ansible/plugins/doc_fragments/sfos.py
+++ b/lib/ansible/plugins/doc_fragments/sfos.py
@@ -1,43 +1,47 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2019, Rubén del Campo Gómez <yo@rubendelcampo.es>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 
 class ModuleDocFragment(object):
     DOCUMENTATION = r'''
 options:
     sfos_host:
         description:
-          - The Sophos XG endpoint IP address or FQDN. If not set then the value of the SFOS_HOST environment variable is used.
+          - The Sophos XG endpoint IP address or FQDN.
+          - If not set then the value of the SFOS_HOST environment variable is used.
         type: str
         required: true
     sfos_port:
         description:
-          - Port you mention in above URL should be same as the port you have configured as Admin Console HTTPS Port from System > Administration > Settings. If not set then the value of the SFOS_PORT environment variable is used.
+          - The port you have configured as Admin Console HTTPS Port from System > Administration > Settings.
+          - If not set then the value of the SFOS_PORT environment variable is used.
         type: int
         default: 4444
     sfos_protocol:
         description:
-          - The protocol used to communicate with the API endpoint. If not set then the value of the SFOS_PROTOCOL environment variable is used.
+          - The protocol used to communicate with the API endpoint.
+          - If not set then the value of the SFOS_PROTOCOL environment variable is used.
         choices: [ http, https ]
         type: str
         default: https
     sfos_username:
         description:
-          - The username used to login and who has permission to send API requests. If not set then the value of the SFOS_USERNAME environment variable is used.
-        choices: [ http, https ]
+          - The username used to login and who has permission to send API requests.
+          - If not set then the value of the SFOS_USERNAME environment variable is used.
         type: str
         required: true
     sfos_password:
         description:
-          - The password for the username used to login and who has permission to send API requests. If not set then the value of the SFOS_PASSWORD environment variable is used.
-        choices: [ http, https ]
+          - The password for the username used to login and who has permission to send API requests.
+          - If not set then the value of the SFOS_PASSWORD environment variable is used.
         type: str
         required: true
     validate_certs:
         description:
-          - Whether the API interface's ssl certificate should be verified or not. If not set then the value of the SFOS_VALIDATECERTS environment variable is used.
+          - Whether the API interface's ssl certificate should be verified or not.
+          - If not set then the value of the SFOS_VALIDATECERTS environment variable is used.
         type: bool
         default: yes
     state:


### PR DESCRIPTION
##### SUMMARY
Implementation of SFOSModule Base Class that can easily be used to implement other endpoints to control Sophos XG NGFWs. Taking as base the @MatrixCrawler Sophos UTM module. Sophos XG API is based on XML request so XMLTODICT and a lot of checks and response checks have to be made.

I will try to add a module for each API endpoint described in Sophos XG API Docs (can be downloaded from [this KB](https://community.sophos.com/kb/en-us/132560)). A fully functional Sophos XG virtual appliance [can be downloaded for free](https://secure2.sophos.com/es-es/products/next-gen-firewall/free-trial.aspx) in order to test this module.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
- sfos_iphost

##### ADDITIONAL INFORMATION
Fully tested against SFOS v17.5.1.

##### ANSIBLE VERSION
```
ansible 2.7.6
  config file = None
  executable location = /usr/local/bin/ansible
  python version = 3.7.2 (default, Feb 12 2019, 08:15:36) [Clang 10.0.0 (clang-1000.11.45.5)]
```