### PR TITLE
Add documentation for win_copy as become user needing temp dir set

### DIFF
--- a/lib/ansible/modules/windows/win_copy.py
+++ b/lib/ansible/modules/windows/win_copy.py
@@ -154,6 +154,17 @@ EXAMPLES = r'''
   win_copy:
     content: abc123
     dest: C:\Temp\foo.txt
+
+- name: Copy a single file as another user
+  win_copy:
+    src: NuGet.config
+    dest: '%AppData%\NuGet\NuGet.config'
+  vars:
+    ansible_become_user: user
+    ansible_become_password: pass
+    # The tmp dir must be set when using win_copy as another user
+    # This ensures the become user will have permissions for the operation
+    ansible_remote_tmp: '%temp%'
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
Documentation for #48577 explaining setting the temp dir on win_copy as a become user.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This provides documentation as suggested in #48577 for using the win_copy module as a become user that does not have admin privs.

