### PR TITLE
Add public key return to openssh_keypair

### DIFF
--- a/test/integration/targets/openssh_keypair/tasks/main.yml
+++ b/test/integration/targets/openssh_keypair/tasks/main.yml
@@ -22,4 +22,9 @@
     state: absent
     path: '{{ output_dir }}/privatekey4'
 
+- name: Generate privatekey5 - standard
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey5'
+  register: publickey_gen
+
 - import_tasks: ../tests/validate.yml

--- a/test/integration/targets/openssh_keypair/tests/validate.yml
+++ b/test/integration/targets/openssh_keypair/tests/validate.yml
@@ -37,3 +37,9 @@
   assert:
     that:
       - privatekey4.stat.exists == False
+
+
+- name: Validate privatekey5 (assert - Public key module output equal to the public key on host)
+  assert:
+    that:
+      - "publickey_gen.public_key == lookup('file', output_dir ~ '/privatekey5.pub').strip('\n')"


### PR DESCRIPTION
##### SUMMARY
The openssh_keypair module will return a public key output on the
private key creation.

Fixes: #52663

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssh_keypair