### PR TITLE
Update AIX fileset if newer, optionally install prereqs, add emgr and aix_dumpdevice modules

### DIFF
--- a/lib/ansible/modules/packaging/os/emgr.py
+++ b/lib/ansible/modules/packaging/os/emgr.py
@@ -1,0 +1,183 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+author: Vasiliy Gokoyev (@k3it)
+module: emgr
+short_description: Installs or removes AIX IFIX packages
+description:
+  - Manage AIX emergency fixes (ifix).  check_mode is supported
+version_added: "2.7"
+options:
+  package:
+    description:
+      - full path to location of the ifix .Z package. Required for state 'present'
+  label:
+    description:
+      - IFIX label as reported by /usr/sbin/emgr -l.  Required for state 'absent'
+  state:
+    description:
+      - State of the IFIX
+    choices: ["present", "absent"]
+    default: "present"
+''' 
+
+EXAMPLES = '''
+- name: Install xorgs ifix /foo/bar/xorg_fix3/IJ11544s0a.181127.epkg.Z
+  emgr:
+    package: /foo/bar/xorg_fix3/IJ11544s0a.181127.epkg.Z
+    state: present
+
+- name: Remove ifix with label IJ11544s0a
+  emgr:
+    label: IJ11544s0a
+    state: absent
+'''
+
+RETURN = '''
+changed:
+  description: Return changed for the IFIX state as true or false.
+  returned: always
+  type: boolean
+  version_added: 2.7
+msg:
+  description: Return message regarding the action.
+  returned: always
+  type: string
+  version_added: 2.7
+'''
+
+from ansible.module_utils.basic import *
+
+import os, subprocess, re
+
+def main():
+	
+	fields = {
+		"label" : {"required": False, "type": 'str'},
+		"package" : {"required": False, "type": 'str'},
+		"state" : {
+			"default": "present",
+			"choices": ['present', 'absent'],
+			"type": 'str'
+		},
+	}
+
+	module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+
+	label = module.params['label']
+	package = module.params['package']
+	state = module.params['state']
+
+	if state == 'present':
+
+		if package is None:
+			module.fail_json(msg="package path/filename is required to install ifix")
+		
+		label = _get_ifix_label(package)
+
+		if label is None:
+			module.fail_json(msg = ("Invalid package file or unable to get ifix label from %s" % package))
+	
+		if _ifix_installed(label):
+			changed = False
+			msg = ("Ifix already installed: %s" % label)
+		else:
+			if not module.check_mode and _install_ifix_pkg(package):
+				changed = True
+				msg = ("IFIX package with label {0} has been installed".format(label))
+			elif module.check_mode:
+				changed = True
+				msg = ("IFIX package with label {0} would be installed".format(label))
+			else:
+				module.fail_json(msg = ("Failed to install ifix from %s" % package))
+
+	elif state == 'absent':
+		
+
+		if label is None:
+			module.fail_json(msg = "Ifix label is required to uninstall ifix")
+				
+		if _ifix_installed(label):
+			if not module.check_mode and _remove_ifix_pkg(label):
+				changed = True
+				msg = ("IFIX package with label {0} has been removed".format(label))
+			elif module.check_mode:
+				changed = True
+				msg = ("IFIX package with label {0} would be removed".format(label))
+			else:
+				module.fail_json(msg = ("Failed to uninstall ifix %s" % label))
+		else:
+			changed = False
+			msg = ("Ifix is not installed: %s" % label)
+
+
+	else:
+		changed = False
+        	msg = "Unexpected state."
+        	module.fail_json(msg=msg)
+
+    	module.exit_json(changed=changed, msg=msg)
+
+
+def _get_ifix_label(package):
+	# gets ifix label from the ifix package file (.Z)
+	command = ["emgr"]
+	command.extend(["-d",  "-e", package])
+	result = subprocess.Popen(command, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+	output = result.communicate()[0]
+	labels = re.findall("LABEL:\s+(\w+)",output)
+	returncode = result.returncode
+	if returncode is 0 and len(labels) > 0:
+		return labels[0]
+	else:
+		return None
+
+def _ifix_installed(label):
+	# checks if an ifix with given label is installed on the system
+	command = ["emgr"]
+	command.extend(["-c", "-L", label])
+	result = subprocess.Popen(command)
+	output = result.communicate()[0]
+	returncode = result.returncode
+	if returncode is 0:
+		return True
+	else:
+		return False
+
+def _install_ifix_pkg(package):
+	# installs ifix given package file
+	command = ["emgr"]
+	command.extend(["-e", package])
+	result = subprocess.Popen(command)
+	output = result.communicate()[0]
+	returncode = result.returncode
+	if returncode is 0:
+		return True
+	else:
+		return False
+
+def _remove_ifix_pkg(label):
+	command = ["emgr"]
+	command.extend(["-r", "-L", label])
+	result = subprocess.Popen(command)
+	output = result.communicate()[0]
+	returncode = result.returncode
+	if returncode is 0:
+		return True
+	else:
+		return False
+	
+
+if __name__ == '__main__':
+	main()

--- a/lib/ansible/modules/packaging/os/installp.py
+++ b/lib/ansible/modules/packaging/os/installp.py
@@ -1,53 +1,66 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2017, Kairo Araujo <kairo@kairo.eti.br>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# (c) 2017, Kairo Araujo
+# Written by Kairo Araujo <kairo@kairo.eti.br>
+#
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
+from distutils.version import LooseVersion
+
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = r'''
+DOCUMENTATION = '''
 ---
 module: installp
-author:
-- Kairo Araujo (@kairoaraujo)
-short_description: Manage packages on AIX
+author: Kairo Araujo (@kairoaraujo)
+short_description: Installing packages for AIX
 description:
-  - Manage packages using 'installp' on AIX
-version_added: '2.8'
+  - Manage packages for AIX using 'installp'.
+version_added: "2.5"
 options:
   accept_license:
     description:
-    - Whether to accept the license for the package(s).
-    type: bool
+      - Accept license for package.
+    choices: [ 'yes', 'no' ]
+    required: false
+    default: no
+  install_prereqs:
+    description:
+      - Install pre-requisite software automatically
+    choices: ['yes', 'no' ]
+    required: false
     default: no
   name:
     description:
-    - One or more packages to install or remove.
-    - Use C(all) to install all packages available on informed C(repository_path).
-    type: list
+      - Name of package to install/remove. To operate on several packages
+        this can accept a comma separated.
+      - C(all) is also allowed with state install. It will install all packages
+        available on informed C(repository_path).
     required: true
-    aliases: [ pkg ]
   repository_path:
     description:
-    - Path with AIX packages (required to install).
-    type: path
+      - Path with AIX packages (required to install).
+    required: no
   state:
     description:
-    - Whether the package needs to be present on or absent from the system.
-    type: str
-    choices: [ absent, present ]
+      - State of the package.
+    choices: [present, absent]
+    required: false
     default: present
 notes:
-- If the package is already installed, even the package/fileset is new, the module will not install it.
+  - If the package is already installed, and the package/fileset is new,
+    the module will update to the newer version.
 '''
 
-EXAMPLES = r'''
+EXAMPLES = '''
 - name: Install package foo
   installp:
     name: foo
@@ -62,11 +75,12 @@ EXAMPLES = r'''
     package_license: yes
     state: present
 
-- name: Install bos.sysmgt.nim.master only
+- name: Install bos.sysmgt.nim.master and its pre-requisite filesets
   installp:
     name: bos.sysmgt.nim.master
     repository_path: /repository/AIX71/installp/base
     package_license: yes
+    install_prereqs: yes
     state: present
 
 - name: Install bos.sysmgt.nim.master and bos.sysmgt.nim.spot
@@ -82,12 +96,17 @@ EXAMPLES = r'''
     state: absent
 '''
 
-RETURN = r''' # '''
-
-import os
-import re
+RETURN = '''
+changed:
+    description: Return changed for installp actions as true or false.
+    returned: always
+    type: boolean
+    version_added: 2.5
+'''
 
 from ansible.module_utils.basic import AnsibleModule
+import os
+import re
 
 
 def _check_new_pkg(module, package, repository_path):
@@ -102,7 +121,8 @@ def _check_new_pkg(module, package, repository_path):
 
     if os.path.isdir(repository_path):
         installp_cmd = module.get_bin_path('installp', True)
-        rc, package_result, err = module.run_command("%s -l -MR -d %s" % (installp_cmd, repository_path))
+        rc, package_result, err = module.run_command(
+            "%s -l -MR -d %s" % (installp_cmd, repository_path))
         if rc != 0:
             module.fail_json(msg="Failed to run installp.", rc=rc, err=err)
 
@@ -112,21 +132,25 @@ def _check_new_pkg(module, package, repository_path):
 
         else:
             pkg_info = {}
+            found_pkg = False
+
             for line in package_result.splitlines():
                 if re.findall(package, line):
                     pkg_name = line.split()[0].strip()
                     pkg_version = line.split()[1].strip()
                     pkg_info[pkg_name] = pkg_version
 
-                    return True, pkg_info
+                    found_pkg = True
 
-        return False, None
+        return found_pkg, pkg_info
+
 
     else:
-        module.fail_json(msg="Repository path %s is not valid." % repository_path)
+        module.fail_json(
+            msg="Repository path %s is not valid." % repository_path)
 
 
-def _check_installed_pkg(module, package, repository_path):
+def _check_installed_pkg(module, package, repository_path, min_version='0.0'):
     """
     Check the package on AIX.
     It verifies if the package is installed and informations
@@ -134,12 +158,14 @@ def _check_installed_pkg(module, package, repository_path):
     :param module: Ansible module parameters spec.
     :param package: Package/fileset name.
     :param repository_path: Repository package path.
+    :param min_version: Package version check 
     :return: Bool, package data.
     """
 
     lslpp_cmd = module.get_bin_path('lslpp', True)
-    rc, lslpp_result, err = module.run_command("%s -lcq %s*" % (lslpp_cmd, package))
 
+    rc, lslpp_result, err = module.run_command(
+        "%s -lcq %s*" % (lslpp_cmd, package))
     if rc == 1:
         package_state = ' '.join(err.split()[-2:])
         if package_state == 'not installed.':
@@ -147,16 +173,23 @@ def _check_installed_pkg(module, package, repository_path):
         else:
             module.fail_json(msg="Failed to run lslpp.", rc=rc, err=err)
 
-    if rc != 0:
+    elif rc != 0:
         module.fail_json(msg="Failed to run lslpp.", rc=rc, err=err)
 
-    pkg_data = {}
-    full_pkg_data = lslpp_result.splitlines()
-    for line in full_pkg_data:
-        pkg_name, fileset, level = line.split(':')[0:3]
-        pkg_data[pkg_name] = fileset, level
+    else:
+        pkg_data = {}
+        full_pkg_data = lslpp_result.splitlines()
+        for line in full_pkg_data:
+            pkg_name = line.split(':')[0]
+            fileset = line.split(':')[1]
+            level = line.split(':')[2]
+            pkg_data[pkg_name] = fileset, level
 
-    return True, pkg_data
+            # check if a higher version is available on the install media
+            if LooseVersion(level) < LooseVersion(min_version):
+                return False, None
+
+        return True, pkg_data
 
 
 def remove(module, installp_cmd, packages):
@@ -165,17 +198,20 @@ def remove(module, installp_cmd, packages):
     removed_pkgs = []
     not_found_pkg = []
     for package in packages:
-        pkg_check, dummy = _check_installed_pkg(module, package, repository_path)
+        pkg_check, _ = _check_installed_pkg(module, package, repository_path)
 
         if pkg_check:
             if not module.check_mode:
-                rc, remove_out, err = module.run_command("%s -u %s" % (installp_cmd, package))
+                rc, remove_out, err = module.run_command(
+                    "%s -u %s" % (installp_cmd, package))
                 if rc != 0:
-                    module.fail_json(msg="Failed to run installp.", rc=rc, err=err)
-            remove_count += 1
-            removed_pkgs.append(package)
+                    module.fail_json(
+                        msg="Failed to run installp.", rc=rc, err=err)
+                else:
+                    remove_count += 1
+                    removed_pkgs.append(package)
 
-        else:
+        if not pkg_check:
             not_found_pkg.append(package)
 
     if remove_count > 0:
@@ -183,16 +219,22 @@ def remove(module, installp_cmd, packages):
             not_found_pkg.insert(0, "Package(s) not found: ")
 
         changed = True
-        msg = "Packages removed: %s. %s " % (' '.join(removed_pkgs), ' '.join(not_found_pkg))
+        msg = "Packages removed: %s. %s " % (
+            ' '.join(removed_pkgs), ' '.join(not_found_pkg))
 
     else:
         changed = False
-        msg = ("No packages removed, all packages not found: %s" % ' '.join(not_found_pkg))
+        msg = (
+            "No packages removed, all packages not found: %s" %
+            ' '.join(not_found_pkg))
+
+    if module.check_mode:
+        changed = True
 
     return changed, msg
 
 
-def install(module, installp_cmd, packages, repository_path, accept_license):
+def install(module, installp_cmd, packages, repository_path, accept_license, install_prereqs):
     installed_pkgs = []
     not_found_pkgs = []
     already_installed_pkgs = {}
@@ -202,13 +244,22 @@ def install(module, installp_cmd, packages, repository_path, accept_license):
         False: '',
     }
 
+    install_prereqs_param = {
+        True: '-g',
+        False: '',
+    }
+
     # Validate if package exists on repository path.
     for package in packages:
-        pkg_check, pkg_data = _check_new_pkg(module, package, repository_path)
+        pkg_check, pkg_data = _check_new_pkg(
+            module, package, repository_path)
 
         # If package exists on repository path, check if package is installed.
         if pkg_check:
-            pkg_check_current, pkg_info = _check_installed_pkg(module, package, repository_path)
+            min_version = pkg_data[package]
+
+            pkg_check_current, pkg_info = _check_installed_pkg(
+                module, package, repository_path, min_version)
 
             # If package is already installed.
             if pkg_check_current:
@@ -226,35 +277,54 @@ def install(module, installp_cmd, packages, repository_path, accept_license):
 
             else:
                 if not module.check_mode:
-                    rc, out, err = module.run_command("%s -a %s -X -d %s %s" % (installp_cmd, accept_license_param[accept_license], repository_path, package))
-                    if rc != 0:
-                        module.fail_json(msg="Failed to run installp", rc=rc, err=err)
-                installed_pkgs.append(package)
+                    rc, install_out, err = module.run_command(
+                        "%s -a %s %s -X -d %s %s" % (
+                            installp_cmd, accept_license_param[accept_license], install_prereqs_param[install_prereqs],
+                            repository_path, package))
 
-        else:
+                    if rc != 0:
+                        module.fail_json(
+                            msg="Failed to run installp", rc=rc, err=err)
+                    else:
+                        installed_pkgs.append(package)
+
+        if not pkg_check:
             not_found_pkgs.append(package)
 
     if len(installed_pkgs) > 0:
-        installed_msg = (" Installed: %s." % ' '.join(installed_pkgs))
+        installed_msg = (
+            " Installed: %s." % ' '.join(installed_pkgs))
     else:
         installed_msg = ''
 
     if len(not_found_pkgs) > 0:
         not_found_msg = (" Not found: %s." % ' '.join(not_found_pkgs))
+
     else:
         not_found_msg = ''
 
     if len(already_installed_pkgs) > 0:
-        already_installed_msg = (" Already installed: %s." % already_installed_pkgs)
+        already_installed_msg = (
+            " Already installed: %s." % already_installed_pkgs)
+
     else:
         already_installed_msg = ''
 
     if len(installed_pkgs) > 0:
         changed = True
-        msg = ("%s%s%s" % (installed_msg, not_found_msg, already_installed_msg))
+        msg = (
+            "%s%s%s" % (installed_msg, not_found_msg, already_installed_msg))
     else:
         changed = False
-        msg = ("No packages installed.%s%s%s" % (installed_msg, not_found_msg, already_installed_msg))
+        msg = (
+            "No packages installed.%s%s%s" % (
+                installed_msg, not_found_msg, already_installed_msg))
+
+    if module.check_mode:
+        changed = True
+        msg = (
+            "%s%s" % (
+                not_found_msg, already_installed_msg))
 
     return changed, msg
 
@@ -262,32 +332,39 @@ def install(module, installp_cmd, packages, repository_path, accept_license):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(type='list', required=True, aliases=['pkg']),
-            repository_path=dict(type='path'),
-            accept_license=dict(type='bool', default=False),
-            state=dict(type='str', default='present', choices=['absent', 'present']),
-        ),
-        supports_check_mode=True,
+            name=dict(aliases=['pkg'], type='list'),
+            repository_path=dict(type='str', default=None),
+            accept_license=dict(type='bool', default='no'),
+            install_prereqs=dict(type='bool', default='no'),
+            state=dict(default='present', choices=['present', 'absent']),
+        ), supports_check_mode=True,
     )
 
-    name = module.params['name']
-    repository_path = module.params['repository_path']
-    accept_license = module.params['accept_license']
-    state = module.params['state']
+    installp_params = module.params
 
     installp_cmd = module.get_bin_path('installp', True)
 
+    name = installp_params['name']
+    repository_path = installp_params['repository_path']
+    accept_license = installp_params['accept_license']
+    install_prereqs = installp_params['install_prereqs']
+    state = installp_params['state']
+
     if state == 'present':
         if repository_path is None:
-            module.fail_json(msg="repository_path is required to install package")
+            module.fail_json(msg="repository_path is required to install "
+                                 "package")
 
-        changed, msg = install(module, installp_cmd, name, repository_path, accept_license)
+        changed, msg = install(
+            module, installp_cmd, name, repository_path, accept_license, install_prereqs)
 
     elif state == 'absent':
         changed, msg = remove(module, installp_cmd, name)
 
     else:
-        module.fail_json(changed=False, msg="Unexpected state.")
+        changed = False
+        msg = "Unexpected state."
+        module.fail_json(msg=msg)
 
     module.exit_json(changed=changed, msg=msg)
 

--- a/lib/ansible/modules/system/aix_dumpdevice.py
+++ b/lib/ansible/modules/system/aix_dumpdevice.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+author: Vasiliy Gokoyev (@k3it)
+module: aix_dumpdevice
+short_description: Checks and expands AIX dump device
+description:
+  - Set the largest dump device to equal or greater than the estimated dump size.  check_mode is supported
+version_added: "2.7"
+options:
+  ratio:
+    description:
+      - If the largest dump device is too small set dump device to at least ratio x estimated dump size.
+    required: false
+    default: 1.0
+''' 
+
+EXAMPLES = '''
+- name: Expand the largerst AIX dump device to at least 1.1 x estimated dump size
+  aix_dumpdevice:
+    ratio: 1.1
+'''
+
+RETURN = '''
+changed:
+  description: Return true if the dump device was expanded
+  returned: always
+  type: boolean
+  version_added: 2.7
+msg:
+  description: Return message regarding the state of the dump device.
+  returned: always
+  type: string
+  version_added: 2.7
+'''
+
+from ansible.module_utils.basic import *
+
+import subprocess 
+
+import datetime, math
+import os, glob, re
+
+def main():
+	
+	fields = {
+		"ratio" : {"required": False, "type": 'float', "default": 1.0},
+	}
+
+	module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+
+	timestamp = str(datetime.datetime.now())
+	ratio = module.params['ratio']
+
+	check, dumplv, dump_shortage = _check_dump_dev(ratio)
+
+	msg = ("Dump device {0} shortage {1} MB".format(dumplv, dump_shortage))
+
+	if dump_shortage < 0:
+		module.fail_json(msg = ("Failed to execute /usr/lib/ras/dumpcheck -p or dump dev is not set"))
+
+    	if module.check_mode:
+		changed = check
+        	module.exit_json(changed=changed, msg=msg)
+
+	if dump_shortage > 0:
+		result, msg = _increase_dump_size(dumplv,dump_shortage)
+
+	else:
+		msg=''
+		result = False
+
+
+        module.exit_json(changed=result, msg=msg)
+
+def _increase_dump_size(dumplv, dump_shortage):
+	# find the partion size
+	command = ["lslv"]
+	command.extend([dumplv])
+	result = subprocess.Popen(command, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+	output = result.communicate()[0]
+
+        returncode = result.returncode
+        if returncode is not 0:
+                return False
+
+	pp_size = int(re.findall('PP SIZE:.+?(\d+)', output)[0])
+	lvs = math.ceil(dump_shortage/pp_size) 
+
+	# extend the lv
+	command = ["extendlv"]
+	command.extend([dumplv, str(lvs)])
+	result = subprocess.Popen(command, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+	output = result.communicate()[0]
+
+        returncode = result.returncode
+        if returncode is 0:
+		msg = ("Extended {0} by {1} MB".format(dumplv, lvs*pp_size))
+		return True, msg
+	else:
+		msg = ("Failed while running {0}".format(command))
+		return False, msg
+
+
+def _check_dump_dev(ratio):
+	# checks dumpdev and returns estimate
+	command = ["/usr/lib/ras/dumpcheck"]
+	command.extend(["-p"])
+	result = subprocess.Popen(command, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+	output = result.communicate()[0]
+	
+	check = False
+	dumplv = None
+	dump_size_shortage = 0
+
+
+	if output.find("too small.") > 0:
+		dumpinfo = output.splitlines()
+		dumplv = dumpinfo[3].strip()
+		dump_size_mb = int(dumpinfo[5].strip())/1024
+		dump_estimate_mb = int(dumpinfo[7].strip())*ratio/1024
+		dump_size_shortage = dump_estimate_mb - dump_size_mb
+		check = True
+
+	returncode = result.returncode
+	if returncode is 0:
+		return check, dumplv, dump_size_shortage
+	else:
+		return check, dumplv, -1
+
+	
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AIX installp module:
  - update filesets if a newer version is available on install media
  - add option to install fileset prerequisites
  - pull request based on the code in https://github.com/kairoaraujo/ansible-aix-support repository
    as discussed w/ @gforster and @kairoaraujo 

add AIX emgr module:
  - manage AIX emergency fix (IFIX) .Z packages
    
add AIX aix_dumpdevice module:
  - expand AIX dump device to fit estimated dump size

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
installp
emgr
aix_dumpdevice

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
