### PR TITLE
[WIP] crypto modules: invalid file handling

### DIFF
--- a/test/integration/targets/openssh_cert/tasks/main.yml
+++ b/test/integration/targets/openssh_cert/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: openssh_cert integration tests
   when: not (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "6")
   block:
@@ -388,6 +389,48 @@
       #valid_from: "2001-01-21"
       #valid_to: "2019-01-21"
     check_mode: yes
+
+  - name: Create broken key
+    copy:
+      dest: "{{ item }}"
+      content: ""
+      mode: "0700"
+    loop:
+      - "{{ output_dir }}/id_key_broken"
+      - "{{ output_dir }}/id_key_broken.pub"
+  - name: Cannot load broken key
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key_broken'
+      public_key: '{{ output_dir }}/id_key_broken.pub'
+      path: '{{ output_dir }}/id_cert_broken'
+      valid_from: always
+      valid_to: forever
+    ignore_errors: yes
+    register: output
+  - name: Verify that broken key won't be loaded
+    assert:
+      that:
+        - output is failed
+
+  - name: Create broken cert
+    copy:
+      dest: "{{ output_dir }}/id_cert_broken"
+      content: ""
+  - name: Regenerate broken cert
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_broken'
+      valid_from: always
+      valid_to: forever
+    register: output
+  - name: Verify that broken cert will be regenerated
+    assert:
+      that:
+        - output is changed
+
   - name: Remove keypair (check mode)
     openssh_keypair:
       path: '{{ output_dir }}/id_key'

--- a/test/integration/targets/openssh_keypair/tasks/main.yml
+++ b/test/integration/targets/openssh_keypair/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Generate privatekey1 - standard
   connection: local
   openssh_keypair:
@@ -26,5 +27,19 @@
   openssh_keypair:
     path: '{{ output_dir }}/privatekey5'
   register: publickey_gen
+
+- name: Create broken key
+  copy:
+    dest: "{{ item }}"
+    content: ""
+    mode: "0700"
+  loop:
+    - "{{ output_dir }}/privatekeybroken"
+    - "{{ output_dir }}/privatekeybroken.pub"
+- name: Regenerate broken key
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekeybroken'
+    type: rsa
+  register: output_broken
 
 - import_tasks: ../tests/validate.yml

--- a/test/integration/targets/openssh_keypair/tests/validate.yml
+++ b/test/integration/targets/openssh_keypair/tests/validate.yml
@@ -1,3 +1,4 @@
+---
 - name: Validate privatekey1 (test - RSA key with size 4096 bits)
   shell: "ssh-keygen -lf {{ output_dir }}/privatekey1 | grep -o -E '^[0-9]+'"
   register: privatekey1
@@ -43,3 +44,8 @@
   assert:
     that:
       - "publickey_gen.public_key == lookup('file', output_dir ~ '/privatekey5.pub').strip('\n')"
+
+- name: Verify that broken key will be regenerated
+  assert:
+    that:
+      - output_broken is changed


### PR DESCRIPTION
##### SUMMARY
In the wake of #36738, I wanted to find out what happens if the various `crypto_*` modules are presented with invalid input (for idempotency checking).

Current findings:
 - openssh_cert returns an error, though somewhat convoluted:
```fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/ssh-keygen -s output-6dabffd3/id_key_broken -I '' -P '' /tmp/tmpmtua18gy/id_key_broken.pub", "msg": "Load key \"output-6dabffd3/id_key_broken\": invalid format", "rc": 255, "stderr": "Load key \"output-6dabffd3/id_key_broken\": invalid format\r\n", "stderr_lines": ["Load key \"output-6dabffd3/id_key_broken\": invalid format"], "stdout": "", "stdout_lines": []}```
 - openssh_keypair returns a not very helpful error:
```fatal: [localhost]: FAILED! => {"changed": false, "msg": "list index out of range"}```
 - openssl_certificate crashes:
```fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "/home/felix/.ansible/tmp/ansible-tmp-1551612045.0003505-89376799709255/AnsiballZ_openssl_certificate.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\nTraceback (most recent call last):\n  File \"/home/felix/.ansible/tmp/ansible-tmp-1551612045.0003505-89376799709255/AnsiballZ_openssl_certificate.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/home/felix/.ansible/tmp/ansible-tmp-1551612045.0003505-89376799709255/AnsiballZ_openssl_certificate.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/felix/.ansible/tmp/ansible-tmp-1551612045.0003505-89376799709255/AnsiballZ_openssl_certificate.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.7/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.7/imp.py\", line 169, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 630, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_openssl_certificate_payload_o44_kf7z/__main__.py\", line 1173, in <module>\n  File \"/tmp/ansible_openssl_certificate_payload_o44_kf7z/__main__.py\", line 1152, in main\n  File \"/tmp/ansible_openssl_certificate_payload_o44_kf7z/__main__.py\", line 608, in generate\n  File \"/tmp/ansible_openssl_certificate_payload_o44_kf7z/__main__.py\", line 564, in check\n  File \"/tmp/ansible_openssl_certificate_payload_o44_kf7z/ansible_openssl_certificate_payload.zip/ansible/module_utils/crypto.py\", line 105, in load_certificate\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/crypto.py\", line 1825, in load_certificate\n    _raise_current_error()\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/_util.py\", line 54, in exception_from_error_queue\n    raise exception_type(errors)\nOpenSSL.crypto.Error: [('PEM routines', 'PEM_read_bio', 'no start line')]\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}```
 - openssl_csr crashes: ```fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "/home/felix/.ansible/tmp/ansible-tmp-1551612113.785685-202158316249600/AnsiballZ_openssl_csr.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\nTraceback (most recent call last):\n  File \"/home/felix/.ansible/tmp/ansible-tmp-1551612113.785685-202158316249600/AnsiballZ_openssl_csr.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/home/felix/.ansible/tmp/ansible-tmp-1551612113.785685-202158316249600/AnsiballZ_openssl_csr.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/felix/.ansible/tmp/ansible-tmp-1551612113.785685-202158316249600/AnsiballZ_openssl_csr.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.7/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.7/imp.py\", line 169, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 630, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_openssl_csr_payload_v9bfv_c1/__main__.py\", line 1039, in <module>\n  File \"/tmp/ansible_openssl_csr_payload_v9bfv_c1/__main__.py\", line 1017, in main\n  File \"/tmp/ansible_openssl_csr_payload_v9bfv_c1/__main__.py\", line 421, in generate\n  File \"/tmp/ansible_openssl_csr_payload_v9bfv_c1/__main__.py\", line 454, in check\n  File \"/tmp/ansible_openssl_csr_payload_v9bfv_c1/__main__.py\", line 598, in _check_csr\n  File \"/tmp/ansible_openssl_csr_payload_v9bfv_c1/ansible_openssl_csr_payload.zip/ansible/module_utils/crypto.py\", line 116, in load_certificate_request\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/crypto.py\", line 2854, in load_certificate_request\n    _openssl_assert(req != _ffi.NULL)\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/_util.py\", line 67, in openssl_assert\n    exception_from_error_queue(error)\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/_util.py\", line 54, in exception_from_error_queue\n    raise exception_type(errors)\nOpenSSL.crypto.Error: [('PEM routines', 'PEM_read_bio', 'no start line')]\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}```
 - openssl_dhparam simply recreates the DH params
 - openssl_pkcs12 simply recreates the PKCS#12 file (not surprising considering #53221)
 - openssl_privatekey simply recreates the private key

Let's continue the discussion on what to do in #36738.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssh_cert
openssh_keypair
openssl_certificate
openssl_csr
openssl_dhparam
openssl_pkcs12
openssl_privatekey
openssl_publickey
