### PR TITLE
docker_swarm_service: rename return variable to swarm_service

### DIFF
--- a/changelogs/fragments/53229-docker_swarm_service-return-value.yml
+++ b/changelogs/fragments/53229-docker_swarm_service-return-value.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- "docker_swarm_service - the return value was documented as ``ansible_swarm_service``, but the
+   module actually returned ``ansible_docker_service``. Documentation and code have been updated
+   so that the variable is now called ``swarm_service``."

--- a/changelogs/fragments/53229-docker_swarm_service-return-value.yml
+++ b/changelogs/fragments/53229-docker_swarm_service-return-value.yml
@@ -1,4 +1,5 @@
 bugfixes:
 - "docker_swarm_service - the return value was documented as ``ansible_swarm_service``, but the
    module actually returned ``ansible_docker_service``. Documentation and code have been updated
-   so that the variable is now called ``swarm_service``."
+   so that the variable is now called ``swarm_service``. In Ansible 2.7.x, the old name
+   ``ansible_docker_service`` can still be used to access the result."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -492,13 +492,16 @@ notes:
 '''
 
 RETURN = '''
-ansible_swarm_service:
+swarm_service:
   returned: always
   type: dict
   description:
   - Dictionary of variables representing the current state of the service.
     Matches the module parameters format.
   - Note that facts are not part of registered vars but accessible directly.
+  - Note that before Ansible 2.7.9, the return variable was documented as C(ansible_swarm_service),
+    while the module actually returned a variable called C(ansible_docker_service). The variable
+    was renamed to C(swarm_service) in both code and documentation for Ansible 2.7.9 and Ansible 2.8.0.
   sample: '{
     "args": [
       "sleep",
@@ -1852,7 +1855,7 @@ def main():
         changed=changed,
         rebuilt=rebuilt,
         changes=changes,
-        ansible_docker_service=facts,
+        swarm_service=facts,
     )
     if client.module._diff:
         before, after = dsm.diff_tracker.get_before_after()

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -502,6 +502,7 @@ swarm_service:
   - Note that before Ansible 2.7.9, the return variable was documented as C(ansible_swarm_service),
     while the module actually returned a variable called C(ansible_docker_service). The variable
     was renamed to C(swarm_service) in both code and documentation for Ansible 2.7.9 and Ansible 2.8.0.
+    In Ansible 2.7.x, the old name C(ansible_docker_service) can still be used.
   sample: '{
     "args": [
       "sleep",

--- a/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
@@ -50,7 +50,7 @@
 - name: assert service args are correct
   assert:
     that:
-      - output.ansible_docker_service.args == ['sleep', '1800']
+      - output.swarm_service.args == ['sleep', '1800']
 
 - name: set service mode to global
   register: output
@@ -88,7 +88,7 @@
 
 - name: fake image key as it is not predictable
   set_fact:
-    ansible_docker_service_output: "{{ output.ansible_docker_service|combine({'image': 'busybox'}) }}"
+    ansible_docker_service_output: "{{ output.swarm_service|combine({'image': 'busybox'}) }}"
 
 - name: assert service matches expectations
   assert:


### PR DESCRIPTION
##### SUMMARY
As discussed in #51939, renaming the return variable to `swarm_service`.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_swarm_service
