### PR TITLE
Make zypper work with python3 - 2.6

### DIFF
--- a/changelogs/fragments/zypper-python3.yaml
+++ b/changelogs/fragments/zypper-python3.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- zypper - Fix Python 3 compatibility issues

--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -488,7 +488,7 @@ def main():
     update_cache = module.params['update_cache']
 
     # remove empty strings from package list
-    name = filter(None, name)
+    name = list(filter(None, name))
 
     # Refresh repositories
     if update_cache and not module.check_mode:


### PR DESCRIPTION
(cherry picked from commit 24e94ec3c624fafb23c30ac6da0673769c63c5a8)

##### SUMMARY
Fix Python 3 compat issue with the zypper module in stable-2.6

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper