### PR TITLE
Fix an incorrect function call in a documentation example.

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -185,7 +185,7 @@ To facilitate this there are a few of helper functions used in the example below
             for colo in mydata:
                 for server in mydata[colo]['servers']:
                     self.inventory.add_host(server['name'])
-                    self.inventory.set_variable('ansible_host', server['external_ip'])
+                    self.inventory.set_variable(server['name'], 'ansible_host', server['external_ip'])
 
 The specifics will vary depending on API and structure returned. But one thing to keep in mind, if the inventory source or any other issue crops up you should ``raise AnsibleParserError`` to let Ansible know that the source was invalid or the process failed.
 


### PR DESCRIPTION
##### SUMMARY
The `set_variable` function takes the name of the inventory object that the variable is being set on as a mandatory positional argument. See the definition [here](https://github.com/ansible/ansible/blob/4817dcd0fce5cd639e5baf8794bb99e302031739/lib/ansible/inventory/data.py#L235).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docs