### PR TITLE
acme_account: improve account deactivation idempotency

### DIFF
--- a/test/integration/targets/acme_account/tests/validate.yml
+++ b/test/integration/targets/acme_account/tests/validate.yml
@@ -111,6 +111,9 @@
   assert:
     that:
       - account_deactivate_idempotent is not changed
+      # The next condition should be true for all conforming ACME servers.
+      # In case it is not true, it could be both an error in acme_account
+      # and in the ACME server.
       - account_deactivate_idempotent.account_uri is none
 
 - name: Validate that the account is gone (new account key)

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -44,7 +44,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.4.1'
+            self.image = 'quay.io/ansible/acme-test-container:1.4.2'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Improves idempotency for account deactivation. Needed for idempotency to still work with letsencrypt/pebble#180, which isn't implemented in Boulder yet (ticket: letsencrypt/boulder#3971).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_account
