### PR TITLE
[2.7] docker_swarm_service: don't crash when publish isn't specified

### DIFF
--- a/changelogs/fragments/53262-docker_swarm_service-test_parameter_versions.yml
+++ b/changelogs/fragments/53262-docker_swarm_service-test_parameter_versions.yml
@@ -1,2 +1,3 @@
 bugfixes:
 - "docker_swarm_service - don't crash when ``publish`` is not specified."
+- "docker_swarm_service - do basic validation of ``publish`` option if specified (must be list of dicts)."

--- a/changelogs/fragments/53262-docker_swarm_service-test_parameter_versions.yml
+++ b/changelogs/fragments/53262-docker_swarm_service-test_parameter_versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - don't crash when ``publish`` is not specified."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -477,6 +477,7 @@ from ansible.module_utils.docker_common import docker_version
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text
 
+from ansible.module_utils.common._collections_compat import Mapping
 
 try:
     from distutils.version import LooseVersion
@@ -1054,7 +1055,7 @@ class DockerServiceManager():
                          % (pv['param'], pv['min_version'])))
 
         for publish_def in params['publish'] or []:
-            if not isinstance(publish_def, dict):
+            if not isinstance(publish_def, Mapping):
                 self.client.module.fail_json(msg='The publish option must be provided with a list of dicts!')
             if 'mode' in publish_def.keys():
                 if LooseVersion(self.client.version()['ApiVersion']) < LooseVersion('1.25'):

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1053,7 +1053,7 @@ class DockerServiceManager():
                     msg=('%s parameter supported only with api_version>=%s'
                          % (pv['param'], pv['min_version'])))
 
-        for publish_def in self.client.module.params.get('publish', []):
+        for publish_def in params['publish'] or []:
             if 'mode' in publish_def.keys():
                 if LooseVersion(self.client.version()['ApiVersion']) < LooseVersion('1.25'):
                     self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1054,6 +1054,8 @@ class DockerServiceManager():
                          % (pv['param'], pv['min_version'])))
 
         for publish_def in params['publish'] or []:
+            if not isinstance(publish_def, dict):
+                self.client.module.fail_json(msg='The publish option must be provided with a list of dicts!')
             if 'mode' in publish_def.keys():
                 if LooseVersion(self.client.version()['ApiVersion']) < LooseVersion('1.25'):
                     self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')


### PR DESCRIPTION
##### SUMMARY
This PR is not a backport, but tries to fix something which no longer applies to `devel`. @hannseman @dariko @jwitko I would appreciate if you could review this!

Fixes part of #53223.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service
