### PR TITLE
To fix bug on switch port issue of L3 interfaces.

### DIFF
--- a/lib/ansible/modules/network/cnos/cnos_l3_interface.py
+++ b/lib/ansible/modules/network/cnos/cnos_l3_interface.py
@@ -41,7 +41,7 @@ notes:
 options:
   name:
     description:
-      - Name of the Layer-3 interface to be configured eg. GigabitEthernet0/2
+      - Name of the Layer-3 interface to be configured eg. Ethernet1/2
   ipv4:
     description:
       - IPv4 address to be set for the Layer-3 interface mentioned in I(name)
@@ -161,7 +161,7 @@ EXAMPLES = """
   cnos_l3_interface:
     aggregate:
       - { name: Ethernet1/33, ipv4: 10.241.107.1/24 }
-      - { name: GigabitEthernet1/33, ipv4: 10.241.107.1/24,
+      - { name: Ethernet1/33, ipv4: 10.241.107.1/24,
           ipv6: "fd5d:12c9:2201:1::1/64" }
 
 - name: Remove IP addresses on aggregate
@@ -192,6 +192,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cnos.cnos import get_config, load_config
 from ansible.module_utils.network.cnos.cnos import cnos_argument_spec
+from ansible.module_utils.network.cnos.cnos import run_commands
 from ansible.module_utils.network.common.config import NetworkConfig
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.common.utils import is_netmask, is_masklen
@@ -254,6 +255,35 @@ def search_obj_in_list(name, lst):
             return o
 
     return None
+
+
+def get_interface_type(interface):
+    intf_type = 'unknown'
+    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE'):
+        intf_type = 'ethernet'
+    elif interface.upper().startswith('VL'):
+        intf_type = 'svi'
+    elif interface.upper().startswith('LO'):
+        intf_type = 'loopback'
+    elif interface.upper()[:2] in ('MG', 'MA'):
+        intf_type = 'management'
+    elif interface.upper().startswith('PO'):
+        intf_type = 'portchannel'
+    elif interface.upper().startswith('NV'):
+        intf_type = 'nve'
+
+    return intf_type
+
+
+def is_switchport(name, module):
+    intf_type = get_interface_type(name)
+
+    if intf_type in ('ethernet', 'portchannel'):
+        config = run_commands(module,
+                              ['show interface {0} switchport'.format(name)])[0]
+        match = re.search(r'Switchport              : enabled', config)
+        return bool(match)
+    return False
 
 
 def map_obj_to_commands(updates, module):
@@ -395,6 +425,14 @@ def main():
     result = {'changed': False}
 
     want = map_params_to_obj(module)
+    for w in want:
+        name = w['name']
+        name = name.lower()
+        if is_switchport(name, module):
+            module.fail_json(msg='Ensure interface is configured to be a L3'
+                             '\nport first before using this module. You can use'
+                             '\nthe cnos_interface module for this.')
+
     have = map_config_to_obj(module)
 
     commands = map_obj_to_commands((want, have), module)

--- a/lib/ansible/modules/network/cnos/cnos_l3_interface.py
+++ b/lib/ansible/modules/network/cnos/cnos_l3_interface.py
@@ -161,14 +161,14 @@ EXAMPLES = """
   cnos_l3_interface:
     aggregate:
       - { name: Ethernet1/33, ipv4: 10.241.107.1/24 }
-      - { name: Ethernet1/33, ipv4: 10.241.107.1/24,
+      - { name: Ethernet1/44, ipv4: 10.240.106.1/24,
           ipv6: "fd5d:12c9:2201:1::1/64" }
 
 - name: Remove IP addresses on aggregate
   cnos_l3_interface:
     aggregate:
       - { name: Ethernet1/33, ipv4: 10.241.107.1/24 }
-      - { name: Ethernet1/3``3, ipv4: 10.241.107.1/24,
+      - { name: Ethernet1/44, ipv4: 10.240.106.1/24,
           ipv6: "fd5d:12c9:2201:1::1/64" }
     state: absent
 """

--- a/test/integration/targets/cnos_l3_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/cnos_l3_interface/tests/cli/basic.yaml
@@ -19,6 +19,8 @@
   cnos_config:
     lines:
       - no shutdown
+      - no switchport
+      - no logging monitor
     parents:
       - "interface {{ item }}"
     provider: "{{ cli }}"

--- a/test/units/modules/network/cnos/test_cnos_l3_interface.py
+++ b/test/units/modules/network/cnos/test_cnos_l3_interface.py
@@ -39,9 +39,13 @@ class TestCnosL3InterfaceModule(TestCnosModule):
         self._patch_load_config = patch(
             'ansible.modules.network.cnos.cnos_l3_interface.load_config'
         )
+        self._patch_is_switchport = patch(
+            'ansible.modules.network.cnos.cnos_l3_interface.is_switchport'
+        )
 
         self._get_config = self._patch_get_config.start()
         self._load_config = self._patch_load_config.start()
+        self._is_switchport = self._patch_is_switchport.start()
 
     def tearDown(self):
         super(TestCnosL3InterfaceModule, self).tearDown()
@@ -52,6 +56,7 @@ class TestCnosL3InterfaceModule(TestCnosModule):
         config_file = 'l3_interface_config.cfg'
         self._get_config.return_value = load_fixture(config_file)
         self._load_config.return_value = None
+        self._is_switchport.return_value = False
 
     def test_cnos_l3_interface_ipv4_address(self, *args, **kwargs):
         set_module_args(dict(


### PR DESCRIPTION
##### SUMMARY
Fixing a bug on cnos_l3_interface module to check if port is configured as switchport 

##### ISSUE TYPE
- Bug Fix Pull Request 

##### COMPONENT NAME

  lib/ansible/modules/network/cnos/cnos_l3_interface.py
  test/integration/targets/cnos_l3_interface/tests/cli/basic.yaml

##### ANSIBLE VERSION
ansible 2.8.0.dev0 (devel e2b9c36080) last updated 2018/10/12 13:58:41 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/sheru/ansible/lib/ansible
  executable location = /home/ansible/sheru/ansible/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
Unit Test and Integration tests are also added which are succesfully tested with CNOS G8272 with image version 10.9.1