### PR TITLE
Remove logged chap secret

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_iscsi_target.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_iscsi_target.py
@@ -157,7 +157,7 @@ class IscsiTarget(object):
 
         if not self.url.endswith('/'):
             self.url += '/'
-        self._logger.info(self.chap_secret)
+
         if self.chap_secret is not None:
             if len(self.chap_secret) < 12 or len(self.chap_secret) > 16:
                 self.module.fail_json(msg="The provided CHAP secret is not valid, it must be between 12 and 16"
@@ -234,8 +234,6 @@ class IscsiTarget(object):
         elif target['chap']:
             update = True
             body.update(dict(enableChapAuthentication=False))
-
-        self._logger.info(pformat(body))
 
         if update and not self.check_mode:
             try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removed a couple of logging statements that included a chap secret in the netapp_e_iscsi_target module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_iscsi_target

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/swartzn/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/ansible-dev/lib/ansible
  executable location = /home/swartzn/ansible-dev/bin/ansible
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
```
