### PR TITLE
nxos_vxlan_vtep: Add dependency checks

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
@@ -282,7 +282,7 @@ def gsa_tcam_check(module):
     This method checks the current TCAM allocation.
     Note that changing tcam_size requires a switch reboot to take effect.
     '''
-    cmds = [{'command': 'show hardware access-list tcam region', 'output': 'json' }]
+    cmds = [{'command': 'show hardware access-list tcam region', 'output': 'json'}]
     body = run_commands(module, cmds)
     if body:
         tcam_region = body[0]['TCAM_Region']['TABLE_Sizes']['ROW_Sizes']

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
@@ -114,6 +114,7 @@ import re
 
 from ansible.module_utils.network.nxos.nxos import get_config, load_config
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.network.nxos.nxos import run_commands
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.config import CustomNetworkConfig
 
@@ -275,6 +276,22 @@ def fix_commands(commands, module):
     return commands
 
 
+def gsa_tcam_check(module):
+    '''
+    global_suppress_arp is an N9k-only command that requires TCAM resources.
+    This method checks the current TCAM allocation.
+    Note that changing tcam_size requires a switch reboot to take effect.
+    '''
+    cmds = [{'command': 'show hardware access-list tcam region', 'output': 'json' }]
+    body = run_commands(module, cmds)
+    if body:
+        tcam_region = body[0]['TCAM_Region']['TABLE_Sizes']['ROW_Sizes']
+        if bool([i for i in tcam_region if i['type'].startswith('Ingress ARP-Ether ACL') and i['tcam_size'] == '0']):
+            msg = "'show hardware access-list tcam region' indicates 'ARP-Ether' tcam size is 0 (no allocated resources). " +\
+                  "'global_suppress_arp' will be rejected by device."
+            module.fail_json(msg=msg)
+
+
 def state_present(module, existing, proposed, candidate):
     commands = list()
     proposed_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, proposed)
@@ -371,6 +388,9 @@ def main():
                 proposed[key] = value
 
     candidate = CustomNetworkConfig(indent=3)
+
+    if proposed.get('global_suppress_arp'):
+        gsa_tcam_check(module)
     if state == 'present':
         if not existing:
             warnings.append("The proposed NVE interface did not exist. "

--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -3,33 +3,37 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
-- set_fact: global_ingress_replication_bgp="true"
-  when: platform is search('N9K$') and (major_version is version('9.2', 'ge'))
+- block:
+  # N9K(v9.2+) specific attrs
+  - set_fact: global_mcast_group_L2="225.1.1.2"
+  - set_fact: def_global_mcast_group_L2="default"
 
-- set_fact: def_global_ingress_replication_bgp="false"
-  when: platform is search('N9K$') and (major_version is version('9.2', 'ge'))
+  # Layer 3 Tenant Routed Multicast (TRM) dependency.
+  # global_mcast_group_l3 / global_ingress_replication_bgp have a dependency on TRM.
+  # TRM requires specific 92/93/95 chassis and -EX/-FX line cards.
+  - block:
+    - set_fact: global_mcast_group_L3="225.1.1.1"
+    - set_fact: def_global_mcast_group_L3="default"
+    - set_fact: global_ingress_replication_bgp="true"
+    - set_fact: def_global_ingress_replication_bgp="false"
+    when: false # Manually change this to true when correct h/w is present
 
-- set_fact: global_mcast_group_L3="225.1.1.1"
-  when: platform is search('N9K$') and (major_version is version('9.2', 'ge'))
+  - name: "TCAM resource check for global_suppress_arp"
+    # GSA requires tcam resources. Skip these attrs when arp-ether size is 0.
+    # Note: TCAM changes require a switch reload.
+    # Sample Input: "Ingress ARP-Ether ACL [arp-ether] size =  256"
+    nxos_command:
+      commands:
+        - command: show hardware access-list tcam region | incl arp-ether | sed 's/.*size = *//'
+          output: text
+    connection: network_cli
+    register: tcam_state
+  - block:
+    - set_fact: global_suppress_arp="true"
+    - set_fact: def_global_suppress_arp="false"
+    when: tcam_state.stdout[0] != 0
 
-- set_fact: def_global_mcast_group_L3="default"
-  when: platform is search('N9K$') and (major_version is version('9.2', 'ge'))
-
-- set_fact: global_mcast_group_L2="225.1.1.2"
-  when: platform is search('N9K') and (major_version is version('9.2', 'ge'))
-
-- set_fact: def_global_mcast_group_L2="default"
-  when: platform is search('N9K') and (major_version is version('9.2', 'ge'))
-
-- set_fact: global_suppress_arp="true"
-  when: platform is search('N9K') and (major_version is version('9.2', 'ge'))
-
-- set_fact: def_global_suppress_arp="false"
-  when: platform is search('N9K') and (major_version is version('9.2', 'ge'))
-
-# This parameter requires a switch reload.
-# The line below can be commented out if needed to verify the functionality.
-- set_fact: global_suppress_arp="false"
+  when:  platform is search('N9K') and (major_version is version('9.2', 'ge'))
 
 - block:
   - name: "Apply N7K specific setup config"
@@ -37,12 +41,21 @@
     when: platform is match('N7K')
 
   - name: "Enable feature nv overlay"
-    nxos_config: 
+    nxos_config:
       commands:
         - feature nv overlay
         - nv overlay evpn
       match: none
       provider: "{{ connection }}"
+
+  - block:
+    - name: "Enable feature ngmvpn"
+      nxos_config:
+        commands:
+          - feature ngmvpn
+        match: none
+        provider: "{{ connection }}"
+    when: global_mcast_group_L3 is defined
 
   - block:
     - name: configure vxlan_vtep
@@ -58,11 +71,11 @@
         shutdown: false
         provider: "{{ connection }}"
       register: result
-  
+
     - assert: &true
         that:
           - "result.changed == true"
-  
+
     - name: "Conf Idempotence"
       nxos_vxlan_vtep: *configure9
       register: result
@@ -84,9 +97,9 @@
         shutdown: true
         provider: "{{ connection }}"
       register: result
-  
+
     - assert: *true
-  
+
     - name: "reset Idempotence"
       nxos_vxlan_vtep: *def9
       register: result
@@ -100,9 +113,9 @@
         global_mcast_group_L2: "{{ global_mcast_group_L2|default(omit) }}"
         provider: "{{ connection }}"
       register: result
-  
+
     - assert: *true
-  
+
     - name: "Conf Idempotence"
       nxos_vxlan_vtep: *gml2
       register: result
@@ -116,9 +129,9 @@
         global_mcast_group_L2: "{{ def_global_mcast_group_L2|default(omit) }}"
         provider: "{{ connection }}"
       register: result
-  
+
     - assert: *true
-  
+
     - name: "reset Idempotence"
       nxos_vxlan_vtep: *rgml2
       register: result
@@ -137,11 +150,11 @@
         shutdown: false
         provider: "{{ connection }}"
       register: result
-  
+
     - assert:
         that:
           - "result.changed == true"
-  
+
     - name: "Conf Idempotence"
       nxos_vxlan_vtep: *configure7
       register: result
@@ -159,9 +172,9 @@
         shutdown: true
         provider: "{{ connection }}"
       register: result
-  
+
     - assert: *true
-  
+
     - name: "reset Idempotence"
       nxos_vxlan_vtep: *def7
       register: result
@@ -202,7 +215,7 @@
     when: platform is match('N7K')
 
   - name: "Disable nv overlay evpn"
-    nxos_config: 
+    nxos_config:
       commands:
         - no nv overlay evpn
       match: none
@@ -210,7 +223,7 @@
     ignore_errors: yes
 
   - name: "Disable feature nv overlay"
-    nxos_feature: 
+    nxos_feature:
       feature: nve
       provider: "{{ connection }}"
       state: disabled


### PR DESCRIPTION
##### SUMMARY
Some of the N9k-specific attrs are failing due to hardware/feature/resources.

 * `global_suppress_arp`
   - dependency on TCAM resources

 * `global_mcast_group_L3`
   - hardware dependency on specific chassis/linecards
   - feature dependency on `ngmvpn`

 * `global_ingress_replication_bgp`
   - hardware dependency on specific chassis/linecards

Tested on N9k with/without TCAM resources, various N9k chassis, N7k, N6k. All 100% Pass.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_vxlan_vtep`

