### PR TITLE
docker_swarm_service: Add hosts option

### DIFF
--- a/changelogs/fragments/53290-docker_swarm_service-add_hosts_option.yml
+++ b/changelogs/fragments/53290-docker_swarm_service-add_hosts_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_swarm_service - Added support for ``hosts`` parameter."

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1126,6 +1126,58 @@
   when: docker_api_version is version('1.25', '<')
 
 ###################################################################
+## hosts ##########################################################
+###################################################################
+
+- name: hosts
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    hosts:
+      example.com: 1.2.3.4
+      example.org: 4.3.2.1
+  register: hosts_1
+
+- name: hosts (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    hosts:
+      example.com: 1.2.3.4
+      example.org: 4.3.2.1
+  register: hosts_2
+
+- name: hosts (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    hosts:
+      example.com: 1.2.3.4
+  register: hosts_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - hosts_1 is changed
+      - hosts_2 is not changed
+      - hosts_3 is changed
+  when: docker_api_version is version('1.25', '>=')
+- assert:
+    that:
+    - hosts_1 is failed
+    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in hosts_1.msg"
+  when: docker_api_version is version('1.25', '<')
+
+
+###################################################################
 ## image ##########################################################
 ###################################################################
 

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -16,6 +16,7 @@ service_expected_output:
   healthcheck: null
   healthcheck_disabled: null
   hostname: null
+  hosts: null
   image: busybox
   labels: null
   limit_cpu: null


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Adds a `hosts`-option for setting extra entries in `/etc/hosts`

```yaml
docker_swarm_service:
  hosts:
    example.com: 1.2.3.4
    example.org: 4.3.2.1
```

There's a few different names for this option flying around. In docker compose it's called `extra_hosts` and in docker-py it's called `hosts` and in the ansible module `docker_compose` it's called `etc_hosts`. I choosed to stick with that docker-py is using as it maps against what the docker API is using.

Surprisingly the returned value from the docker-py was not a dict (not even a string in the format `host:ip` which is what the docker api expects). The returned value is in `/etc/hosts` format `ip hostname` so some conversion had to be made.

Fixes #53263

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
