### PR TITLE
vdo: document versions that have read cache options

### DIFF
--- a/lib/ansible/modules/system/vdo.py
+++ b/lib/ansible/modules/system/vdo.py
@@ -127,6 +127,7 @@ options:
               volumes will maintain their previously configured
               setting unless a different value is specified in the
               playbook.
+            - The read cache feature is available in VDO 6.1 and older.
         type: str
         choices: [ disabled, enabled ]
     readcachesize:
@@ -142,6 +143,7 @@ options:
               Existing volumes will maintain their previously
               configured setting unless a different value is specified
               in the playbook.
+            - The read cache feature is available in VDO 6.1 and older.
         type: str
     emulate512:
         description:


### PR DESCRIPTION
The "readcache" and "readcachesize" options, which correspond to
the same options in the "vdo create" and "vdo modify" commands,
have been removed in VDO version 6.2.  Document that the read
cache options are only in VDO 6.1 and older.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The read cache feature in VDO has been removed in VDO version 6.2. No code needs to be changed; instead, add documentation lines to the "readcache" and "readcachesize" options, stating that they are available in VDO versions 6.1 and older, allowing those versions to continue to use playbooks with those options.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vdo

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If playbooks for systems with VDO 6.2 and newer do not specify the "readcache" or "readcachesize" options, there should not be any errors. If either of these options are specified for VDO 6.2 and above, there will be an error from the "vdo" command stating "unrecognized arguments: --readCache..." and/or "unrecognized arguments: --readCache..."; these errors should be passed through by ansible, and visible to the user.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
