### PR TITLE
docker swarm modules: only run integration tests on VMs

### DIFF
--- a/test/integration/targets/docker_config/aliases
+++ b/test/integration/targets/docker_config/aliases
@@ -3,3 +3,6 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system.

--- a/test/integration/targets/docker_node_facts/aliases
+++ b/test/integration/targets/docker_node_facts/aliases
@@ -3,3 +3,6 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system.

--- a/test/integration/targets/docker_secret/aliases
+++ b/test/integration/targets/docker_secret/aliases
@@ -3,3 +3,6 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system.

--- a/test/integration/targets/docker_stack/aliases
+++ b/test/integration/targets/docker_stack/aliases
@@ -3,3 +3,6 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system.

--- a/test/integration/targets/docker_swarm_facts/aliases
+++ b/test/integration/targets/docker_swarm_facts/aliases
@@ -3,3 +3,6 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system.

--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -3,3 +3,6 @@ skip/osx
 skip/freebsd
 destructive
 skip/rhel8.0
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system.


### PR DESCRIPTION
##### SUMMARY
This PR restricts all docker swarm related tests to proper VM based CI nodes. This hopefully improves stability, as putting the docker daemon in and out of swarm mode (and otherwise poking it) seems to destabilize it if you do it too often. This is dangerous if the whole CI system runs inside docker, so we restrict to proper VMs where the docker daemon is installed inside the VM by the setup_docker role.

Note that I didn't add docker daemon restarts to all affected tests, since that can also lead to further problems...

CC @mattclay

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_config
docker_node_facts
docker_secret
docker_stack
docker_swarm_facts
docker_swarm_service
