### PR TITLE
doc: preseve block-quote structure

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -70,7 +70,7 @@ be written.  Online reports are available but only cover the ``devel`` branch (s
 Add the ``--coverage`` option to any test command to collect code coverage data.  If you
 aren't using the ``--tox`` or ``--docker`` options which create an isolated python
 environment then you may have to use the ``--requirements`` option to ensure that the
-correct version of the coverage module is installed
+correct version of the coverage module is installed::
 
    ansible-test units --coverage apt
    ansible-test integration --coverage aws_lambda --tox --requirements


### PR DESCRIPTION
Without the `::`, the indentation of the example block is lost.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

dev_guide