### PR TITLE
docker_swarm_service: Set minimum docker-py version to 2.0.2

### DIFF
--- a/changelogs/fragments/53295-docker_swarm_service-docker-py-versions.yaml
+++ b/changelogs/fragments/53295-docker_swarm_service-docker-py-versions.yaml
@@ -1,3 +1,4 @@
 bugfixes:
 - "docker_swarm_service - Raise minimum required docker-py version for module to 2.0.2."
+- "docker_swarm_service - Raise minimum required docker-py version for ``secrets`` to 2.4.0."
 - "docker_swarm_service - Validate minimum docker-py version of 2.4.0 for option ``constraints``."

--- a/changelogs/fragments/53295-docker_swarm_service-docker-py-versions.yaml
+++ b/changelogs/fragments/53295-docker_swarm_service-docker-py-versions.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_swarm_service - Raise minimum required docker-py version for module to 2.0.2."
+- "docker_swarm_service - Validate minimum docker-py version of 2.4.0 for option ``constraints``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2206,7 +2206,7 @@ def main():
         dns_search=dict(docker_py_version='2.6.0', docker_api_version='1.25'),
         endpoint_mode=dict(docker_py_version='3.0.0', docker_api_version='1.25'),
         force_update=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
-        healthcheck=dict(docker_py_version='2.0.0', docker_api_version='1.25'),
+        healthcheck=dict(docker_py_version='2.6.0', docker_api_version='1.25'),
         hostname=dict(docker_py_version='2.2.0', docker_api_version='1.25'),
         hosts=dict(docker_py_version='2.6.0', docker_api_version='1.25'),
         groups=dict(docker_py_version='2.6.0', docker_api_version='1.25'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -658,7 +658,7 @@ extends_documentation_fragment:
   - docker
   - docker.docker_py_2_documentation
 requirements:
-  - "docker >= 2.0"
+  - "docker >= 2.0.2"
   - "Docker API >= 1.24"
 notes:
   - "Images will only resolve to the latest digest when using Docker API >= 1.30 and docker-py >= 3.2.0.
@@ -2269,7 +2269,7 @@ def main():
         argument_spec=argument_spec,
         required_if=required_if,
         supports_check_mode=True,
-        min_docker_version='2.0.0',
+        min_docker_version='2.0.2',
         min_docker_api_version='1.24',
         option_minimal_versions=option_minimal_versions,
     )

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2200,6 +2200,7 @@ def main():
     )
 
     option_minimal_versions = dict(
+        constraints=dict(docker_py_version='2.4.0'),
         dns=dict(docker_py_version='2.6.0', docker_api_version='1.25'),
         dns_options=dict(docker_py_version='2.6.0', docker_api_version='1.25'),
         dns_search=dict(docker_py_version='2.6.0', docker_api_version='1.25'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2216,7 +2216,7 @@ def main():
         hosts=dict(docker_py_version='2.6.0', docker_api_version='1.25'),
         groups=dict(docker_py_version='2.6.0', docker_api_version='1.25'),
         tty=dict(docker_py_version='2.4.0', docker_api_version='1.25'),
-        secrets=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
+        secrets=dict(docker_py_version='2.4.0', docker_api_version='1.25'),
         configs=dict(docker_py_version='2.6.0', docker_api_version='1.30'),
         update_max_failure_ratio=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
         update_monitor=dict(docker_py_version='2.1.0', docker_api_version='1.25'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2263,6 +2263,13 @@ def main():
             ) is not None,
             usage_msg='set placement.preferences'
         ),
+        placement_config_constraints=dict(
+            docker_py_version='2.4.0',
+            detect_usage=lambda c: (c.module.params['placement'] or {}).get(
+                'constraints'
+            ) is not None,
+            usage_msg='set placement.constraints'
+        ),
     )
 
     required_if = [

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1943,7 +1943,10 @@ class DockerServiceManager(object):
 
     def can_update_networks(self):
         # Before Docker API 1.29 adding/removing networks was not supported
-        return self.client.docker_api_version >= LooseVersion('1.29')
+        return (
+            self.client.docker_api_version >= LooseVersion('1.29') and
+            self.client.docker_py_version >= LooseVersion('2.7')
+        )
 
     def run(self):
         self.diff_tracker = DifferenceTracker()

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1784,7 +1784,12 @@ class DockerServiceManager(object):
 
         hosts = task_template_data['ContainerSpec'].get('Hosts')
         if hosts:
-            hosts = [host.split(' ', 1) for host in hosts]
+            hosts = [
+                list(reversed(host.split(":", 1)))
+                if ":" in host
+                else host.split(" ", 1)
+                for host in hosts
+            ]
             ds.hosts = dict((hostname, ip) for ip, hostname in hosts)
         ds.tty = task_template_data['ContainerSpec'].get('TTY')
 

--- a/test/integration/targets/docker_swarm_service/tasks/main.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/main.yml
@@ -69,7 +69,7 @@
         force: yes
       ignore_errors: yes
   # Maximum of 1.24 (docker API version for docker_swarm_service) and 1.25 (docker API version for docker_swarm) is 1.25
-  when: docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.25', '>=')
+  when: docker_py_version is version('2.0.2', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_swarm_service tests!"
-  when: not(docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.0.2', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
@@ -1,108 +1,109 @@
 ---
+- block:
+    - name: Create a swarm service without name
+      register: output
+      docker_swarm_service:
+        state: present
+      ignore_errors: yes
 
-- name: Create a swarm service without name
-  register: output
-  docker_swarm_service:
-    state: present
-  ignore_errors: yes
+    - name: assert failure when name not set
+      assert:
+        that:
+          - output is failed
+          - 'output.msg == "missing required arguments: name"'
 
-- name: assert failure when name not set
-  assert:
-    that:
-      - output is failed
-      - 'output.msg == "missing required arguments: name"'
+    - name: Remove an non-existing service
+      register: output
+      docker_swarm_service:
+        state: absent
+        name: non_existing_service
 
-- name: Remove an non-existing service
-  register: output
-  docker_swarm_service:
-    state: absent
-    name: non_existing_service
+    - name: assert output not changed when deleting non-existing service
+      assert:
+        that:
+          - output is not changed
 
-- name: assert output not changed when deleting non-existing service
-  assert:
-    that:
-      - output is not changed
+    - name: create sample service
+      register: output
+      docker_swarm_service:
+        name: test_service
+        endpoint_mode: dnsrr
+        image: busybox
+        args:
+          - sleep
+          - "3600"
 
-- name: create sample service
-  register: output
-  docker_swarm_service:
-    name: test_service
-    endpoint_mode: dnsrr
-    image: busybox
-    args:
-      - sleep
-      - "3600"
+    - name: assert sample service is created
+      assert:
+        that:
+          - output is changed
 
-- name: assert sample service is created
-  assert:
-    that:
-      - output is changed
+    - name: change service args
+      register: output
+      docker_swarm_service:
+        name: test_service
+        image: busybox
+        args:
+          - sleep
+          - "1800"
 
-- name: change service args
-  register: output
-  docker_swarm_service:
-    name: test_service
-    image: busybox
-    args:
-      - sleep
-      - "1800"
+    - name: assert service args are correct
+      assert:
+        that:
+          - output.swarm_service.args == ['sleep', '1800']
 
-- name: assert service args are correct
-  assert:
-    that:
-      - output.swarm_service.args == ['sleep', '1800']
+    - name: set service mode to global
+      register: output
+      docker_swarm_service:
+        name: test_service
+        image: busybox
+        endpoint_mode: vip
+        mode: global
+        args:
+          - sleep
+          - "1800"
 
-- name: set service mode to global
-  register: output
-  docker_swarm_service:
-    name: test_service
-    image: busybox
-    endpoint_mode: vip
-    mode: global
-    args:
-      - sleep
-      - "1800"
+    - name: assert service mode changed caused service rebuild
+      assert:
+        that:
+          - output.rebuilt
 
-- name: assert service mode changed caused service rebuild
-  assert:
-    that:
-      - output.rebuilt
+    - name: add published ports to service
+      register: output
+      docker_swarm_service:
+        name: test_service
+        image: busybox
+        mode: global
+        args:
+          - sleep
+          - "1800"
+        endpoint_mode: vip
+        publish:
+          - protocol: tcp
+            published_port: 60001
+            target_port: 60001
+          - protocol: udp
+            published_port: 60001
+            target_port: 60001
 
-- name: add published ports to service
-  register: output
-  docker_swarm_service:
-    name: test_service
-    image: busybox
-    mode: global
-    args:
-      - sleep
-      - "1800"
-    endpoint_mode: vip
-    publish:
-      - protocol: tcp
-        published_port: 60001
-        target_port: 60001
-      - protocol: udp
-        published_port: 60001
-        target_port: 60001
+    - name: fake image key as it is not predictable
+      set_fact:
+        ansible_docker_service_output: "{{ output.swarm_service|combine({'image': 'busybox'}) }}"
 
-- name: fake image key as it is not predictable
-  set_fact:
-    ansible_docker_service_output: "{{ output.swarm_service|combine({'image': 'busybox'}) }}"
+    - name: assert service matches expectations
+      assert:
+        that:
+          - ansible_docker_service_output == service_expected_output
 
-- name: assert service matches expectations
-  assert:
-    that:
-      - ansible_docker_service_output == service_expected_output
+    - name: delete sample service
+      register: output
+      docker_swarm_service:
+        name: test_service
+        state: absent
 
-- name: delete sample service
-  register: output
-  docker_swarm_service:
-    name: test_service
-    state: absent
-
-- name: assert service deletion returns changed
-  assert:
-    that:
-      - output is success
-      - output is changed
+    - name: assert service deletion returns changed
+      assert:
+        that:
+          - output is success
+          - output is changed
+  when: docker_api_version is version('1.24', '>=') and docker_py_version is version('3.0.0', '>=')

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1498,29 +1498,29 @@
 ## stop_grace_period ###############################################
 ####################################################################
 
-- name: stop_signal
+- name: stop_grace_period
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
-  register: stop_signal_1
+  register: stop_grace_period_1
 
-- name: stop_signal (idempotency)
+- name: stop_grace_period (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
-  register: stop_signal_2
+  register: stop_grace_period_2
 
-- name: stop_signal (change)
+- name: stop_grace_period (change)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 1m30s
-  register: stop_signal_3
+  register: stop_grace_period_3
 
 - name: cleanup
   docker_swarm_service:
@@ -1530,9 +1530,9 @@
 
 - assert:
     that:
-    - stop_signal_1 is changed
-    - stop_signal_2 is not changed
-    - stop_signal_3 is changed
+    - stop_grace_period_1 is changed
+    - stop_grace_period_2 is not changed
+    - stop_grace_period_3 is changed
 
 ####################################################################
 ## stop_signal #####################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1543,7 +1543,7 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
-    stop_signal: 30
+    stop_signal: "30"
   register: stop_signal_1
   ignore_errors: yes
 
@@ -1552,7 +1552,7 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
-    stop_signal: 30
+    stop_signal: "30"
   register: stop_signal_2
   ignore_errors: yes
 
@@ -1561,7 +1561,7 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
-    stop_signal: 9
+    stop_signal: "9"
   register: stop_signal_3
   ignore_errors: yes
 

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -25,24 +25,28 @@
     data: "hello"
     state: present
   register: "config_result_1"
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - docker_config:
     name: "{{ config_name_2 }}"
     data: "test"
     state: present
   register: "config_result_2"
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - docker_secret:
     name: "{{ secret_name_1 }}"
     data: "secret1"
     state: "present"
   register: "secret_result_1"
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
 
 - docker_secret:
     name: "{{ secret_name_2 }}"
     data: "secret2"
     state: "present"
   register: "secret_result_2"
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
 
 - docker_network:
     name: "{{ network_name }}"
@@ -132,10 +136,11 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
-      - config_id: "{{ config_result_1.config_id }}"
+      - config_id: "{{ config_result_1.config_id|default('') }}"
         config_name: "{{ config_name_1 }}"
         filename: "/tmp/{{ config_name_1 }}.txt"
   register: configs_1
+  ignore_errors: yes
 
 - name: configs (idempotency)
   docker_swarm_service:
@@ -143,10 +148,11 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
-      - config_id: "{{ config_result_1.config_id }}"
+      - config_id: "{{ config_result_1.config_id|default('') }}"
         config_name: "{{ config_name_1 }}"
         filename: "/tmp/{{ config_name_1 }}.txt"
   register: configs_2
+  ignore_errors: yes
 
 - name: configs (add)
   docker_swarm_service:
@@ -154,13 +160,14 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
-      - config_id: "{{ config_result_1.config_id }}"
+      - config_id: "{{ config_result_1.config_id|default('') }}"
         config_name: "{{ config_name_1 }}"
         filename: "/tmp/{{ config_name_1 }}.txt"
-      - config_id: "{{ config_result_2.config_id }}"
+      - config_id: "{{ config_result_2.config_id|default('') }}"
         config_name: "{{ config_name_2 }}"
         filename: "/tmp/{{ config_name_2 }}.txt"
   register: configs_3
+  ignore_errors: yes
 
 - name: configs (empty)
   docker_swarm_service:
@@ -169,6 +176,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
   register: configs_4
+  ignore_errors: yes
 
 - name: configs (empty idempotency)
   docker_swarm_service:
@@ -177,6 +185,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
   register: configs_5
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -191,13 +200,13 @@
     - configs_3 is changed
     - configs_4 is changed
     - configs_5 is not changed
-  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.5.0', '>=')
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - assert:
     that:
     - configs_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.30') in configs_1.msg"
-  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.5.0', '<')
+    - "'Minimum version required' in configs_1.msg"
+  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## command #########################################################
@@ -360,6 +369,7 @@
       - 1.1.1.1
       - 8.8.8.8
   register: dns_1
+  ignore_errors: yes
 
 - name: dns (idempotency)
   docker_swarm_service:
@@ -370,6 +380,7 @@
       - 1.1.1.1
       - 8.8.8.8
   register: dns_2
+  ignore_errors: yes
 
 - name: dns_servers (changed order)
   docker_swarm_service:
@@ -380,6 +391,7 @@
       - 8.8.8.8
       - 1.1.1.1
   register: dns_3
+  ignore_errors: yes
 
 - name: dns_servers (changed elements)
   docker_swarm_service:
@@ -390,6 +402,7 @@
       - 8.8.8.8
       - 9.9.9.9
   register: dns_4
+  ignore_errors: yes
 
 - name: dns_servers (empty)
   docker_swarm_service:
@@ -398,6 +411,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
   register: dns_5
+  ignore_errors: yes
 
 - name: dns_servers (empty idempotency)
   docker_swarm_service:
@@ -406,6 +420,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
   register: dns_6
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -425,7 +440,7 @@
 - assert:
     that:
     - dns_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in dns_1.msg"
+    - "'Minimum version required' in dns_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -500,7 +515,7 @@
 - assert:
     that:
     - dns_options_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in dns_options_1.msg"
+    - "'Minimum version required' in dns_options_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -516,6 +531,7 @@
       - example.com
       - example.org
   register: dns_search_1
+  ignore_errors: yes
 
 - name: dns_search (idempotency)
   docker_swarm_service:
@@ -526,6 +542,7 @@
       - example.com
       - example.org
   register: dns_search_2
+  ignore_errors: yes
 
 - name: dns_search (different order)
   docker_swarm_service:
@@ -536,6 +553,7 @@
       - example.org
       - example.com
   register: dns_search_3
+  ignore_errors: yes
 
 - name: dns_search (changed elements)
   docker_swarm_service:
@@ -546,6 +564,7 @@
       - ansible.com
       - example.com
   register: dns_search_4
+  ignore_errors: yes
 
 - name: dns_search (empty)
   docker_swarm_service:
@@ -554,6 +573,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
   register: dns_search_5
+  ignore_errors: yes
 
 - name: dns_search (empty idempotency)
   docker_swarm_service:
@@ -562,6 +582,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
   register: dns_search_6
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -581,7 +602,7 @@
 - assert:
     that:
     - dns_search_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in dns_search_1.msg"
+    - "'Minimum version required' in dns_search_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -595,6 +616,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
   register: endpoint_mode_1
+  ignore_errors: yes
 
 - name: endpoint_mode (idempotency)
   docker_swarm_service:
@@ -603,6 +625,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
   register: endpoint_mode_2
+  ignore_errors: yes
 
 - name: endpoint_mode (changes)
   docker_swarm_service:
@@ -611,6 +634,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "vip"
   register: endpoint_mode_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -627,7 +651,7 @@
 - assert:
     that:
     - endpoint_mode_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in endpoint_mode_1.msg"
+    - "'Minimum version required' in endpoint_mode_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('3.0.0', '<')
 
 ####################################################################
@@ -806,6 +830,7 @@
       - "3600"
     force_update: yes
   register: force_update_1
+  ignore_errors: yes
 
 - name: force_update (idempotency)
   docker_swarm_service:
@@ -817,6 +842,7 @@
       - "3600"
     force_update: yes
   register: force_update_2
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -832,7 +858,7 @@
 - assert:
     that:
     - force_update_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in force_update_1.msg"
+    - "'Minimum version required' in force_update_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.1.0', '<')
 
 ####################################################################
@@ -848,6 +874,7 @@
       - 1234
       - 5678
   register: groups_1
+  ignore_errors: yes
 
 - name: groups (idempotency)
   docker_swarm_service:
@@ -858,6 +885,7 @@
       - 1234
       - 5678
   register: groups_2
+  ignore_errors: yes
 
 - name: groups (change)
   docker_swarm_service:
@@ -867,6 +895,7 @@
     groups:
       - 1234
   register: groups_3
+  ignore_errors: yes
 
 - name: groups (empty)
   docker_swarm_service:
@@ -875,6 +904,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
   register: groups_4
+  ignore_errors: yes
 
 - name: groups (empty idempotency)
   docker_swarm_service:
@@ -883,6 +913,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
   register: groups_5
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -901,7 +932,7 @@
 - assert:
     that:
     - groups_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in groups_1.msg"
+    - "'Minimum version required' in groups_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -922,6 +953,7 @@
       interval: 0h0m2s3ms4us
       retries: 2
   register: healthcheck_1
+  ignore_errors: yes
 
 - name: healthcheck (idempotency)
   docker_swarm_service:
@@ -937,6 +969,7 @@
       interval: 0h0m2s3ms4us
       retries: 2
   register: healthcheck_2
+  ignore_errors: yes
 
 - name: healthcheck (changed)
   docker_swarm_service:
@@ -952,6 +985,7 @@
       interval: 0h1m2s3ms4us
       retries: 3
   register: healthcheck_3
+  ignore_errors: yes
 
 - name: healthcheck (disabled)
   docker_swarm_service:
@@ -962,6 +996,7 @@
       test:
         - NONE
   register: healthcheck_4
+  ignore_errors: yes
 
 - name: healthcheck (disabled, idempotency)
   docker_swarm_service:
@@ -972,6 +1007,7 @@
       test:
       - NONE
   register: healthcheck_5
+  ignore_errors: yes
 
 - name: healthcheck (string in healthcheck test, changed)
   docker_swarm_service:
@@ -981,6 +1017,7 @@
     healthcheck:
       test: "sleep 1"
   register: healthcheck_6
+  ignore_errors: yes
 
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_swarm_service:
@@ -990,6 +1027,7 @@
     healthcheck:
       test: "sleep 1"
   register: healthcheck_7
+  ignore_errors: yes
 
 - name: healthcheck (empty)
   docker_swarm_service:
@@ -998,6 +1036,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
   register: healthcheck_8
+  ignore_errors: yes
 
 - name: healthcheck (empty idempotency)
   docker_swarm_service:
@@ -1006,6 +1045,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
   register: healthcheck_9
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -1024,12 +1064,12 @@
     - healthcheck_7 is not changed
     - healthcheck_8 is changed
     - healthcheck_9 is not changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.6.0', '>=')
 - assert:
     that:
     - healthcheck_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in healthcheck_1.msg"
-  when: docker_api_version is version('1.25', '<')
+    - "'Minimum version required' in healthcheck_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ###################################################################
 ## hostname #######################################################
@@ -1042,6 +1082,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
   register: hostname_1
+  ignore_errors: yes
 
 - name: hostname (idempotency)
   docker_swarm_service:
@@ -1050,6 +1091,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
   register: hostname_2
+  ignore_errors: yes
 
 - name: hostname (change)
   docker_swarm_service:
@@ -1058,6 +1100,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.org
   register: hostname_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -1074,7 +1117,7 @@
 - assert:
     that:
     - hostname_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in hostname_1.msg"
+    - "'Minimum version required' in hostname_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.2.0', '<')
 
 ###################################################################
@@ -1440,13 +1483,13 @@
     that:
     - networks_3.rebuilt == false
     - networks_5.rebuilt == false
-  when: docker_api_version is version('1.29', '>=')
+  when: docker_api_version is version('1.29', '>=') and docker_py_version is version('2.7.0', '>=')
 
 - assert:
     that:
     - networks_3.rebuilt == true
     - networks_5.rebuilt == true
-  when: docker_api_version is version('1.29', '<')
+  when: docker_api_version is version('1.29', '<') or docker_py_version is version('2.7.0', '<')
 
 ####################################################################
 ## stop_grace_period ###############################################
@@ -1499,6 +1542,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: 30
   register: stop_signal_1
+  ignore_errors: yes
 
 - name: stop_signal (idempotency)
   docker_swarm_service:
@@ -1507,6 +1551,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: 30
   register: stop_signal_2
+  ignore_errors: yes
 
 - name: stop_signal (change)
   docker_swarm_service:
@@ -1515,6 +1560,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: 9
   register: stop_signal_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -1531,7 +1577,7 @@
 - assert:
     that:
     - stop_signal_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.28') in stop_signal_1.msg"
+    - "'Minimum version required' in stop_signal_1.msg"
   when: docker_api_version is version('1.28', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -1551,6 +1597,7 @@
         published_port: 60002
         target_port: 60002
   register: publish_1
+  ignore_errors: yes
 
 - name: publish (idempotency)
   docker_swarm_service:
@@ -1564,6 +1611,7 @@
       - published_port: 60001
         target_port: 60001
   register: publish_2
+  ignore_errors: yes
 
 - name: publish (change)
   docker_swarm_service:
@@ -1578,6 +1626,7 @@
         published_port: 60001
         target_port: 60001
   register: publish_3
+  ignore_errors: yes
 
 - name: publish (mode)
   docker_swarm_service:
@@ -1594,6 +1643,7 @@
         target_port: 60001
         mode: host
   register: publish_4
+  ignore_errors: yes
 
 - name: publish (mode idempotency)
   docker_swarm_service:
@@ -1610,6 +1660,7 @@
         target_port: 60003
         mode: host
   register: publish_5
+  ignore_errors: yes
 
 - name: publish (empty)
   docker_swarm_service:
@@ -1618,6 +1669,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
   register: publish_6
+  ignore_errors: yes
 
 - name: publish (empty idempotency)
   docker_swarm_service:
@@ -1626,6 +1678,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
   register: publish_7
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -1646,7 +1699,7 @@
 - assert:
     that:
     - publish_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in publish_1.msg"
+    - "'Minimum version required' in publish_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('3.0.0', '<')
 
 ###################################################################
@@ -1728,6 +1781,13 @@
       - resolve_image_1 is changed
       - resolve_image_2 is not changed
       - resolve_image_3 is changed
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('3.2.0', '>=')
+- assert:
+    that:
+      - resolve_image_1 is changed
+      - resolve_image_2 is not changed
+      - resolve_image_3 is not changed
+  when: docker_api_version is version('1.30', '<') or docker_py_version is version('3.2.0', '<')
 
 ####################################################################
 ## secrets #########################################################
@@ -1739,10 +1799,11 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
-      - secret_id: "{{ secret_result_1.secret_id }}"
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
         secret_name: "{{ secret_name_1 }}"
         filename: "/run/secrets/{{ secret_name_1 }}.txt"
   register: secrets_1
+  ignore_errors: yes
 
 - name: secrets (idempotency)
   docker_swarm_service:
@@ -1750,10 +1811,11 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
-      - secret_id: "{{ secret_result_1.secret_id }}"
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
         secret_name: "{{ secret_name_1 }}"
         filename: "/run/secrets/{{ secret_name_1 }}.txt"
   register: secrets_2
+  ignore_errors: yes
 
 - name: secrets (add)
   docker_swarm_service:
@@ -1761,13 +1823,14 @@
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
-      - secret_id: "{{ secret_result_1.secret_id }}"
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
         secret_name: "{{ secret_name_1 }}"
         filename: "/run/secrets/{{ secret_name_1 }}.txt"
-      - secret_id: "{{ secret_result_2.secret_id }}"
+      - secret_id: "{{ secret_result_2.secret_id|default('') }}"
         secret_name: "{{ secret_name_2 }}"
         filename: "/run/secrets/{{ secret_name_2 }}.txt"
   register: secrets_3
+  ignore_errors: yes
 
 - name: secrets (empty)
   docker_swarm_service:
@@ -1776,6 +1839,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
   register: secrets_4
+  ignore_errors: yes
 
 - name: secrets (empty idempotency)
   docker_swarm_service:
@@ -1784,6 +1848,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
   register: secrets_5
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -1802,8 +1867,9 @@
 - assert:
     that:
     - secrets_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in secrets_1.msg"
+    - "'Minimum version required' in secrets_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.1.0', '<')
+
 
 ###################################################################
 # tty #############################################################
@@ -1816,6 +1882,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     tty: yes
   register: tty_1
+  ignore_errors: yes
 
 - name: tty (idempotency)
   docker_swarm_service:
@@ -1824,6 +1891,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     tty: yes
   register: tty_2
+  ignore_errors: yes
 
 - name: tty (change)
   docker_swarm_service:
@@ -1832,6 +1900,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     tty: no
   register: tty_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -1848,7 +1917,7 @@
 - assert:
     that:
     - tty_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in tty_1.msg"
+    - "'Minimum version required' in tty_1.msg"
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
 
 ###################################################################
@@ -1956,7 +2025,7 @@
   ignore_errors: yes
 
 - name: Delete configs
-  docker_network:
+  docker_config:
     name: "{{ config_name }}"
     state: absent
     force: yes
@@ -1966,9 +2035,10 @@
   loop_control:
     loop_var: config_name
   ignore_errors: yes
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - name: Delete secrets
-  docker_network:
+  docker_secret:
     name: "{{ secret_name }}"
     state: absent
     force: yes
@@ -1978,3 +2048,4 @@
   loop_control:
     loop_var: secret_name
   ignore_errors: yes
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1866,12 +1866,12 @@
       - secrets_3 is changed
       - secrets_4 is changed
       - secrets_5 is not changed
-  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
 - assert:
     that:
     - secrets_1 is failed
     - "'Minimum version required' in secrets_1.msg"
-  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.1.0', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
 
 
 ###################################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1133,6 +1133,7 @@
       example.com: 1.2.3.4
       example.org: 4.3.2.1
   register: hosts_1
+  ignore_errors: yes
 
 - name: hosts (idempotency)
   docker_swarm_service:
@@ -1143,6 +1144,7 @@
       example.com: 1.2.3.4
       example.org: 4.3.2.1
   register: hosts_2
+  ignore_errors: yes
 
 - name: hosts (change)
   docker_swarm_service:
@@ -1152,6 +1154,7 @@
     hosts:
       example.com: 1.2.3.4
   register: hosts_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -1164,12 +1167,12 @@
       - hosts_1 is changed
       - hosts_2 is not changed
       - hosts_3 is changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.6.0', '>=')
 - assert:
     that:
     - hosts_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in hosts_1.msg"
-  when: docker_api_version is version('1.25', '<')
+    - "'Minimum version required' in hosts_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 
 ###################################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -191,12 +191,13 @@
     - configs_3 is changed
     - configs_4 is changed
     - configs_5 is not changed
-  when: docker_api_version is version('1.30', '>=')
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.5.0', '>=')
+
 - assert:
     that:
     - configs_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.30') in configs_1.msg"
-  when: docker_api_version is version('1.30', '<')
+  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.5.0', '<')
 
 ####################################################################
 ## command #########################################################
@@ -420,12 +421,12 @@
       - dns_4 is changed
       - dns_5 is changed
       - dns_6 is not changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.6.0', '>=')
 - assert:
     that:
     - dns_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in dns_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## dns_options #####################################################
@@ -495,12 +496,12 @@
       - dns_options_3 is changed
       - dns_options_4 is changed
       - dns_options_5 is not changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.6.0', '>=')
 - assert:
     that:
     - dns_options_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in dns_options_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## dns_search ######################################################
@@ -576,12 +577,12 @@
       - dns_search_4 is changed
       - dns_search_5 is changed
       - dns_search_6 is not changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.6.0', '>=')
 - assert:
     that:
     - dns_search_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in dns_search_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## endpoint_mode ###################################################
@@ -622,6 +623,12 @@
       - endpoint_mode_1 is changed
       - endpoint_mode_2 is not changed
       - endpoint_mode_3 is changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('3.0.0', '>=')
+- assert:
+    that:
+    - endpoint_mode_1 is failed
+    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in endpoint_mode_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('3.0.0', '<')
 
 ####################################################################
 ## env #############################################################
@@ -821,12 +828,12 @@
     that:
       - force_update_1 is changed
       - force_update_2 is changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
 - assert:
     that:
     - force_update_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in force_update_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.1.0', '<')
 
 ####################################################################
 ## groups ##########################################################
@@ -890,6 +897,12 @@
     - groups_3 is changed
     - groups_4 is changed
     - groups_5 is not changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - groups_1 is failed
+    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in groups_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## healthcheck #####################################################
@@ -1011,12 +1024,12 @@
     - healthcheck_7 is not changed
     - healthcheck_8 is changed
     - healthcheck_9 is not changed
-  when: docker_py_version is version('2.4.0', '>=')
+  when: docker_api_version is version('1.25', '>=')
 - assert:
     that:
     - healthcheck_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.4.0') in healthcheck_1.msg"
-  when: docker_py_version is version('2.4.0', '<')
+    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in healthcheck_1.msg"
+  when: docker_api_version is version('1.25', '<')
 
 ###################################################################
 ## hostname #######################################################
@@ -1057,12 +1070,12 @@
       - hostname_1 is changed
       - hostname_2 is not changed
       - hostname_3 is changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.2.0', '>=')
 - assert:
     that:
     - hostname_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in hostname_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.2.0', '<')
 
 ###################################################################
 ## hosts ##########################################################
@@ -1514,6 +1527,12 @@
     - stop_signal_1 is changed
     - stop_signal_2 is not changed
     - stop_signal_3 is changed
+  when: docker_api_version is version('1.28', '>=') and docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - stop_signal_1 is failed
+    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.28') in stop_signal_1.msg"
+  when: docker_api_version is version('1.28', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## publish #########################################################
@@ -1623,12 +1642,12 @@
       - publish_5 is not changed
       - publish_6 is changed
       - publish_7 is not changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('3.0.0', '>=')
 - assert:
     that:
     - publish_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in publish_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('3.0.0', '<')
 
 ###################################################################
 ## replicas #######################################################
@@ -1779,12 +1798,12 @@
       - secrets_3 is changed
       - secrets_4 is changed
       - secrets_5 is not changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
 - assert:
     that:
     - secrets_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in secrets_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.1.0', '<')
 
 ###################################################################
 # tty #############################################################
@@ -1825,12 +1844,12 @@
       - tty_1 is changed
       - tty_2 is not changed
       - tty_3 is changed
-  when: docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
 - assert:
     that:
     - tty_1 is failed
     - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.25') in tty_1.msg"
-  when: docker_api_version is version('1.25', '<')
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
 
 ###################################################################
 ## user ###########################################################

--- a/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
@@ -22,6 +22,7 @@
       preferences:
         - spread: "node.labels.test"
   register: placement_preferences_1
+  ignore_errors: yes
 
 - name: placement.preferences (idempotency)
   docker_swarm_service:
@@ -32,6 +33,7 @@
       preferences:
         - spread: "node.labels.test"
   register: placement_preferences_2
+  ignore_errors: yes
 
 - name: placement.preferences (change)
   docker_swarm_service:
@@ -42,6 +44,7 @@
       preferences:
         - spread: "node.labels.test2"
   register: placement_preferences_3
+  ignore_errors: yes
 
 - name: placement.preferences (empty)
   docker_swarm_service:
@@ -51,6 +54,7 @@
     placement:
       preferences: []
   register: placement_preferences_4
+  ignore_errors: yes
 
 - name: placement.preferences (empty idempotency)
   docker_swarm_service:
@@ -60,6 +64,7 @@
     placement:
       preferences: []
   register: placement_preferences_5
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -74,6 +79,12 @@
       - placement_preferences_3 is changed
       - placement_preferences_4 is changed
       - placement_preferences_5 is not changed
+  when: docker_api_version is version('1.27', '>=') and docker_py_version is version('2.4.0', '>=')
+- assert:
+    that:
+    - placement_preferences_1 is failed
+    - "'Minimum version required' in placement_preferences_1.msg"
+  when: docker_api_version is version('1.27', '<') or docker_py_version is version('2.4.0', '<')
 
 ####################################################################
 ## placement.constraints #####################################################
@@ -88,6 +99,7 @@
       constraints:
         - "node.role == manager"
   register: constraints_1
+  ignore_errors: yes
 
 - name: placement.constraints (idempotency)
   docker_swarm_service:
@@ -98,6 +110,7 @@
       constraints:
         - "node.role == manager"
   register: constraints_2
+  ignore_errors: yes
 
 - name: constraints (idempotency, old name)
   docker_swarm_service:
@@ -107,6 +120,7 @@
     constraints:
       - "node.role == manager"
   register: constraints_2b
+  ignore_errors: yes
 
 - name: placement.constraints (change)
   docker_swarm_service:
@@ -117,6 +131,7 @@
       constraints:
         - "node.role == worker"
   register: constraints_3
+  ignore_errors: yes
 
 - name: placement.constraints (empty)
   docker_swarm_service:
@@ -126,6 +141,7 @@
     placement:
       constraints: []
   register: constraints_4
+  ignore_errors: yes
 
 - name: placement.constraints (empty idempotency)
   docker_swarm_service:
@@ -135,6 +151,7 @@
     placement:
       constraints: []
   register: constraints_5
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -150,3 +167,9 @@
       - constraints_3 is changed
       - constraints_4 is changed
       - constraints_5 is not changed
+  when: docker_api_version is version('1.27', '>=') and docker_py_version is version('2.4.0', '>=')
+- assert:
+    that:
+    - constraints_1 is failed
+    - "'Minimum version required' in constraints_1.msg"
+  when: docker_api_version is version('1.27', '<') or docker_py_version is version('2.4.0', '<')

--- a/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
@@ -87,7 +87,7 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
-    limit_memory: 67108864
+    limit_memory: "67108864"
   register: limit_memory_2b
 
 - name: limits.memory (change)
@@ -189,7 +189,7 @@
     name: "{{ service_name }}"
     image: alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
-    reserve_memory: 67108864
+    reserve_memory: "67108864"
   register: reserve_memory_2b
 
 - name: reservations.memory (change)

--- a/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
@@ -124,6 +124,7 @@
     update_config:
       max_failure_ratio: 0.25
   register: update_max_failure_ratio_1
+  ignore_errors: yes
 
 - name: update_config.max_failure_ratio (idempotency)
   docker_swarm_service:
@@ -133,6 +134,7 @@
     update_config:
       max_failure_ratio: 0.25
   register: update_max_failure_ratio_2
+  ignore_errors: yes
 
 - name: update_max_failure_ratio (idempotency, old name)
   docker_swarm_service:
@@ -141,6 +143,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     update_max_failure_ratio: 0.25
   register: update_max_failure_ratio_2b
+  ignore_errors: yes
 
 - name: update_config.max_failure_ratio (change)
   docker_swarm_service:
@@ -150,6 +153,7 @@
     update_config:
       max_failure_ratio: 0.50
   register: update_max_failure_ratio_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -163,6 +167,12 @@
       - update_max_failure_ratio_2 is not changed
       - update_max_failure_ratio_2b is not changed
       - update_max_failure_ratio_3 is changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
+- assert:
+    that:
+    - update_max_failure_ratio_1 is failed
+    - "'Minimum version required' in update_max_failure_ratio_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.1.0', '<')
 
 ###################################################################
 # update_config.monitor ###########################################
@@ -176,6 +186,7 @@
     update_config:
       monitor: 10s
   register: update_monitor_1
+  ignore_errors: yes
 
 - name: update_config.monitor (idempotency)
   docker_swarm_service:
@@ -185,6 +196,7 @@
     update_config:
       monitor: 10s
   register: update_monitor_2
+  ignore_errors: yes
 
 - name: update_monitor (idempotency, old name)
   docker_swarm_service:
@@ -193,6 +205,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     update_monitor: 10s
   register: update_monitor_2b
+  ignore_errors: yes
 
 - name: update_config.monitor (change)
   docker_swarm_service:
@@ -202,6 +215,7 @@
     update_config:
       monitor: 60s
   register: update_monitor_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -215,6 +229,12 @@
       - update_monitor_2 is not changed
       - update_monitor_2b is not changed
       - update_monitor_3 is changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
+- assert:
+    that:
+    - update_monitor_1 is failed
+    - "'Minimum version required' in update_monitor_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.1.0', '<')
 
 ###################################################################
 # update_config.order #############################################
@@ -228,6 +248,7 @@
     update_config:
       order: "start-first"
   register: update_order_1
+  ignore_errors: yes
 
 - name: update_config.order (idempotency)
   docker_swarm_service:
@@ -237,6 +258,7 @@
     update_config:
       order: "start-first"
   register: update_order_2
+  ignore_errors: yes
 
 - name: update_order (idempotency, old name)
   docker_swarm_service:
@@ -245,6 +267,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     update_order: "start-first"
   register: update_order_2b
+  ignore_errors: yes
 
 - name: update_config.order (change)
   docker_swarm_service:
@@ -254,6 +277,7 @@
     update_config:
       order: "stop-first"
   register: update_order_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_swarm_service:
@@ -267,12 +291,12 @@
       - update_order_2 is not changed
       - update_order_2b is not changed
       - update_order_3 is changed
-  when: docker_api_version is version('1.29', '>=')
+  when: docker_api_version is version('1.29', '>=') and docker_py_version is version('2.7.0', '>=')
 - assert:
     that:
-    - secrets_1 is failed
-    - "('version is ' ~ docker_api_version ~'. Minimum version required is 1.29') in update_order_1.msg"
-  when: docker_api_version is version('1.29', '<')
+    - update_order_1 is failed
+    - "'Minimum version required' in update_order_1.msg"
+  when: docker_api_version is version('1.29', '<') or docker_py_version is version('2.7.0', '<')
 
 ###################################################################
 ## update_config.parallelism ######################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Try and set minimum docker-py version to 2.0.2 as discussed in https://github.com/ansible/ansible/issues/53193. This PR also checks both `docker_api_version` and `docker_py_version` for each test case.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service