### PR TITLE
MSO: Clarify the site-local modules in the index

### DIFF
--- a/lib/ansible/modules/network/aci/mso_schema_site_anp.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_anp.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_anp
-short_description: Manage site Application Network Profiles (ANPs) in schema template
+short_description: Manage site-local Application Network Profiles (ANPs) in schema template
 description:
-- Manage site ANPs in schema template on Cisco ACI Multi-Site.
+- Manage site-local ANPs in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_anp_epg.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_anp_epg.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_anp_epg
-short_description: Manage site Endpoint Groups (EPGs) in schema template
+short_description: Manage site-local Endpoint Groups (EPGs) in schema template
 description:
-- Manage site EPGs in schema template on Cisco ACI Multi-Site.
+- Manage site-local EPGs in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_staticleaf.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_staticleaf.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_anp_epg_staticleaf
-short_description: Manage site EPG static leafs in schema template
+short_description: Manage site-local EPG static leafs in schema template
 description:
-- Manage site EPG static leafs in schema template on Cisco ACI Multi-Site.
+- Manage site-local EPG static leafs in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_staticport.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_staticport.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_anp_epg_staticport
-short_description: Manage site EPG static ports in schema template
+short_description: Manage site-local EPG static ports in schema template
 description:
-- Manage site EPG static ports in schema template on Cisco ACI Multi-Site.
+- Manage site-local EPG static ports in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'
@@ -66,7 +66,7 @@ options:
     description:
     - The port encap VLAN id of the static port.
     type: int
-  immediacy:
+  deployment_immediacy:
     description:
     - The deployment immediacy of the static port.
     - C(immediate) means B(Deploy immediate).
@@ -110,7 +110,7 @@ EXAMPLES = r'''
     leaf: 101
     path: eth1/1
     vlan: 126
-    immediacy: immediate
+    deployment_immediacy: immediate
     state: present
   delegate_to: localhost
 
@@ -183,7 +183,7 @@ def main():
         leaf=dict(type='str'),  # This parameter is not required for querying all objects
         path=dict(type='str'),  # This parameter is not required for querying all objects
         vlan=dict(type='int'),  # This parameter is not required for querying all objects
-        immediacy=dict(type='str', choices=['immediate', 'lazy']),
+        deployment_immediacy=dict(type='str', choices=['immediate', 'lazy']),
         mode=dict(type='str', choices=['native', 'regular', 'untagged']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
@@ -207,7 +207,7 @@ def main():
     leaf = module.params['leaf']
     path = module.params['path']
     vlan = module.params['vlan']
-    immediacy = module.params['immediacy']
+    deployment_immediacy = module.params['deployment_immediacy']
     mode = module.params['mode']
     state = module.params['state']
 
@@ -266,7 +266,7 @@ def main():
             mso.fail_json(msg="Static port '{portpath}' not found".format(portpath=portpath))
         mso.exit_json()
 
-    ports_path = '/sites/{0}/anps/{1}/epgs/{2}/staticports'.format(site_template, anp_idx, epg_idx)
+    ports_path = '/sites/{0}/anps/{1}/epgs/{2}/staticPorts'.format(site_template, anp_idx, epg_idx)
     ops = []
 
     mso.previous = mso.existing
@@ -277,13 +277,13 @@ def main():
 
     elif state == 'present':
         if not mso.existing:
-            if immediacy is None:
-                immediacy = 'lazy'
+            if deployment_immediacy is None:
+                deployment_immediacy = 'lazy'
             if mode is None:
                 mode = 'untagged'
 
         payload = dict(
-            deploymentImmediacy=immediacy,
+            deploymentImmediacy=deployment_immediacy,
             mode=mode,
             path=portpath,
             portEncapVlan=vlan,

--- a/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_subnet.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_subnet.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_anp_epg_subnet
-short_description: Manage site EPG subnets in schema template
+short_description: Manage site-local EPG subnets in schema template
 description:
-- Manage site EPG subnets in schema template on Cisco ACI Multi-Site.
+- Manage site-local EPG subnets in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_bd.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_bd.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_bd
-short_description: Manage site Bridge Domains (BDs) in schema template
+short_description: Manage site-local Bridge Domains (BDs) in schema template
 description:
-- Manage site BDs in schema template on Cisco ACI Multi-Site.
+- Manage site-local BDs in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_bd_l3out.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_bd_l3out.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_bd_l3out
-short_description: Manage site BD l3out's in schema template
+short_description: Manage site-local BD l3out's in schema template
 description:
-- Manage site BDs l3out's in schema template on Cisco ACI Multi-Site.
+- Manage site-local BDs l3out's in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_bd_subnet.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_bd_subnet
-short_description: Manage site BD subnets in schema template
+short_description: Manage site-local BD subnets in schema template
 description:
-- Manage site BD subnets in schema template on Cisco ACI Multi-Site.
+- Manage site-local BD subnets in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_vrf.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_vrf.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_vrf
-short_description: Manage site VRFs in schema template
+short_description: Manage site-local VRFs in schema template
 description:
-- Manage site VRFs in schema template on Cisco ACI Multi-Site.
+- Manage site-local VRFs in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_vrf_region.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_vrf_region.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_vrf_region
-short_description: Manage site VRF regions in schema template
+short_description: Manage site-local VRF regions in schema template
 description:
-- Manage site VRF regions in schema template on Cisco ACI Multi-Site.
+- Manage site-local VRF regions in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_vrf_region_cidr.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_vrf_region_cidr.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_vrf_region_cidr
-short_description: Manage site VRF region CIDRs in schema template
+short_description: Manage site-local VRF region CIDRs in schema template
 description:
-- Manage site VRF region CIDRs in schema template on Cisco ACI Multi-Site.
+- Manage site-local VRF region CIDRs in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/mso_schema_site_vrf_region_cidr_subnet.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_vrf_region_cidr_subnet.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: mso_schema_site_vrf_region_cidr_subnet
-short_description: Manage site VRF regions in schema template
+short_description: Manage site-local VRF regions in schema template
 description:
-- Manage site VRF regions in schema template on Cisco ACI Multi-Site.
+- Manage site-local VRF regions in schema template on Cisco ACI Multi-Site.
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'


### PR DESCRIPTION
##### SUMMARY
This clarifies that these modules change the site-local properties of the template.

This PR also renames `immediacy` to `deployment_immediacy` since some modules also have `resolution_immediacy` so we cannot shorten it. This also matches the backend option better.


##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
MSO modules