### PR TITLE
docker_*: enable RHEL8 tests

### DIFF
--- a/test/integration/targets/docker_config/aliases
+++ b/test/integration/targets/docker_config/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.

--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_container_facts/aliases
+++ b/test/integration/targets/docker_container_facts/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_host_facts/aliases
+++ b/test/integration/targets/docker_host_facts/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_image/aliases
+++ b/test/integration/targets/docker_image/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_image_facts/aliases
+++ b/test/integration/targets/docker_image_facts/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_network/aliases
+++ b/test/integration/targets/docker_network/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_network_facts/aliases
+++ b/test/integration/targets/docker_network_facts/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_node/aliases
+++ b/test/integration/targets/docker_node/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system. On VMs, we restart docker daemon

--- a/test/integration/targets/docker_node_facts/aliases
+++ b/test/integration/targets/docker_node_facts/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.

--- a/test/integration/targets/docker_prune/aliases
+++ b/test/integration/targets/docker_prune/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_secret/aliases
+++ b/test/integration/targets/docker_secret/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.

--- a/test/integration/targets/docker_stack/aliases
+++ b/test/integration/targets/docker_stack/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.

--- a/test/integration/targets/docker_swarm/aliases
+++ b/test/integration/targets/docker_swarm/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system. On VMs, we restart docker daemon

--- a/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
@@ -44,8 +44,8 @@
     docker_swarm:
       advertise_addr: "{{ansible_default_ipv4.address | default('127.0.0.1')}}"
       state: present
-      signing_ca_cert: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.pem') }}"
-      signing_ca_key: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.key') }}"
+      signing_ca_cert: "{{ lookup('file', output_dir ~ '/ansible_key1.pem') }}"
+      signing_ca_key: "{{ lookup('file', output_dir ~ '/ansible_key1.key') }}"
       timeout: 120
     check_mode: yes
     diff: yes
@@ -56,17 +56,17 @@
     docker_swarm:
       advertise_addr: "{{ansible_default_ipv4.address | default('127.0.0.1')}}"
       state: present
-      signing_ca_cert: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.pem') }}"
-      signing_ca_key: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.key') }}"
+      signing_ca_cert: "{{ lookup('file', output_dir ~ '/ansible_key1.pem') }}"
+      signing_ca_key: "{{ lookup('file', output_dir ~ '/ansible_key1.key') }}"
       timeout: 120
     diff: yes
     register: output_2
     ignore_errors: yes
 
   - name: Private key
-    debug: msg="{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.key') }}"
+    debug: msg="{{ lookup('file', output_dir ~ '/ansible_key1.key') }}"
   - name: Cert
-    debug: msg="{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.pem') }}"
+    debug: msg="{{ lookup('file', output_dir ~ '/ansible_key1.pem') }}"
   - docker_swarm_facts:
     register: output
     ignore_errors: yes
@@ -77,8 +77,8 @@
   #- name: signing_ca_cert and signing_ca_key (idempotent)
   #  docker_swarm:
   #    state: present
-  #    signing_ca_cert: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.pem') }}"
-  #    signing_ca_key: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.key') }}"
+  #    signing_ca_cert: "{{ lookup('file', output_dir ~ '/ansible_key1.pem') }}"
+  #    signing_ca_key: "{{ lookup('file', output_dir ~ '/ansible_key1.key') }}"
   #    timeout: 120
   #  diff: yes
   #  register: output_3
@@ -87,8 +87,8 @@
   #- name: signing_ca_cert and signing_ca_key (idempotent, check mode)
   #  docker_swarm:
   #    state: present
-  #    signing_ca_cert: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.pem') }}"
-  #    signing_ca_key: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key1.key') }}"
+  #    signing_ca_cert: "{{ lookup('file', output_dir ~ '/ansible_key1.pem') }}"
+  #    signing_ca_key: "{{ lookup('file', output_dir ~ '/ansible_key1.key') }}"
   #    timeout: 120
   #  check_mode: yes
   #  diff: yes
@@ -98,8 +98,8 @@
   - name: signing_ca_cert and signing_ca_key (change, check mode)
     docker_swarm:
       state: present
-      signing_ca_cert: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key2.pem') }}"
-      signing_ca_key: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key2.key') }}"
+      signing_ca_cert: "{{ lookup('file', output_dir ~ '/ansible_key2.pem') }}"
+      signing_ca_key: "{{ lookup('file', output_dir ~ '/ansible_key2.key') }}"
       timeout: 120
     check_mode: yes
     diff: yes
@@ -109,8 +109,8 @@
   - name: signing_ca_cert and signing_ca_key (change)
     docker_swarm:
       state: present
-      signing_ca_cert: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key2.pem') }}"
-      signing_ca_key: "{{ lookup('file', role_path ~ '/' ~ output_dir ~ '/ansible_key2.key') }}"
+      signing_ca_cert: "{{ lookup('file', output_dir ~ '/ansible_key2.pem') }}"
+      signing_ca_key: "{{ lookup('file', output_dir ~ '/ansible_key2.key') }}"
       timeout: 120
     diff: yes
     register: output_6

--- a/test/integration/targets/docker_swarm_facts/aliases
+++ b/test/integration/targets/docker_swarm_facts/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.

--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -2,7 +2,6 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.

--- a/test/integration/targets/docker_volume/aliases
+++ b/test/integration/targets/docker_volume/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/docker_volume_facts/aliases
+++ b/test/integration/targets/docker_volume_facts/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-skip/rhel8.0

--- a/test/integration/targets/setup_docker/tasks/RHEL8.yml
+++ b/test/integration/targets/setup_docker/tasks/RHEL8.yml
@@ -1,0 +1,25 @@
+# The RHEL extras repository must be enabled to provide the container-selinux package.
+# See: https://docs.docker.com/engine/installation/linux/docker-ee/rhel/#install-using-the-repository
+
+- name: Install Docker pre-reqs
+  dnf:
+    name:
+    - dnf-utils
+    - device-mapper-persistent-data
+    - lvm2
+    - libseccomp
+    state: present
+
+- name: Set-up repository
+  command: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+
+- name: Install docker
+  dnf:
+    name: docker-ce
+    state: present
+
+- name: Make sure the docker daemon is running (failure expected inside docker container)
+  service:
+    name: docker
+    state: started
+  ignore_errors: "{{ ansible_virtualization_type == 'docker' }}"

--- a/test/integration/targets/setup_docker/tasks/main.yml
+++ b/test/integration/targets/setup_docker/tasks/main.yml
@@ -2,13 +2,16 @@
     is_rhel: "{{ ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora' }}"
     is_rhel6: "{{ is_rhel and ansible_distribution_major_version == '6' }}"
     is_rhel7: "{{ is_rhel and ansible_distribution_major_version == '7' }}"
+    is_rhel8: "{{ is_rhel and ansible_distribution_major_version == '8' }}"
   block:
     - include_tasks: "{{ lookup('first_found', params) }}"
       vars:
         params:
           - '{{ ansible_distribution }}.yml'
           - '{{ ansible_os_family }}.yml'
-      when: not is_rhel6
+      when: not is_rhel6 and not is_rhel8
+    - include_tasks: RHEL8.yml
+      when: is_rhel8
 
     - name: Install Python requirements
       vars:


### PR DESCRIPTION
##### SUMMARY
Experiment to support RHEL8 CI for docker_* integration tests.

Fixes #48842.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_config
docker_container
docker_container_facts
docker_host_facts
docker_image
docker_image_facts
docker_network
docker_network_facts
docker_node
docker_node_facts
docker_prune
docker_secret
docker_stack
docker_swarm
docker_swarm_facts
docker_swarm_service
docker_volume
docker_volume_facts
test/integration/targets/setup_docker
