### PR TITLE
become: Add missing documentation for pfexec, dzdo and machinectl

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -554,7 +554,12 @@ def process_plugins(module_map, templates, outputname, output_dir, ansible_versi
 
         display.v('about to template %s' % module)
         display.vvvvv(pp.pformat(doc))
-        text = templates['plugin'].render(doc)
+        try:
+            text = templates['plugin'].render(doc)
+        except Exception as e:
+            display.warning(msg="Could not parse %s due to %s" % (module, e))
+            continue
+
         if LooseVersion(jinja2.__version__) < LooseVersion('2.10'):
             # jinja2 < 2.10's indent filter indents blank lines.  Cleanup
             text = re.sub(' +\n', '\n', text)

--- a/lib/ansible/plugins/become/pfexec.py
+++ b/lib/ansible/plugins/become/pfexec.py
@@ -15,7 +15,7 @@ DOCUMENTATION = """
         become_user:
             description:
                 - User you 'become' to execute the task
-                - This plugin ignores this settingas pfexec uses it's own ``exec_attr`` to figure this out,
+                - This plugin ignores this setting as pfexec uses it's own ``exec_attr`` to figure this out,
                   but it is supplied here for Ansible to make decisions needed for the task execution, like file permissions.
             default: root
             ini:
@@ -80,6 +80,7 @@ DOCUMENTATION = """
             vars:
               - name: ansible_pfexec_wrap_execution
             env:
+              - name: ANSIBLE_PFEXEC_WRAP_EXECUTION
     note:
       - This plugin ignores ``become_user`` as pfexec uses it's own ``exec_attr`` to figure this out.
 """


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docs/bin/plugin_formatter.py
lib/ansible/plugins/become/pfexec.py