### PR TITLE
Clarify json behavior with return_content key

### DIFF
--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -70,8 +70,8 @@ options:
     description:
       - Whether or not to return the body of the response as a "content" key in
         the dictionary result.
-      - If the reported Content-type is "application/json", then the JSON is
-        additionally loaded into a key called C(json) in the dictionary results.
+      - Independently of this option, if the reported Content-type is "application/json", then the JSON is
+        always loaded into a key called C(json) in the dictionary results.
     type: bool
     default: no
   force_basic_auth:


### PR DESCRIPTION



##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The docs were not clear enough about what would happen if a JSON response is read.

The actual behavior is that the `json` key is always present in such cases, regardless of this parameter, so by changing a few words, we make the docs clearer to the reader.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
uri
