### PR TITLE
ovirt_network: Fix update_check for cluster network role

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -241,18 +241,18 @@ class ClusterNetworksModule(BaseModule):
         return (
             equal(self._cluster_network.get('required'), entity.required) and
             equal(self._cluster_network.get('display'), entity.display) and
-            equal(
-                sorted([
-                    usage
-                    for usage in ['display', 'gluster', 'migration']
-                    if self._cluster_network.get(usage, False)
-                ]),
-                sorted([
+            all(
+                x in [
                     str(usage)
                     for usage in getattr(entity, 'usages', [])
                     # VM + MANAGEMENT is part of root network
                     if usage != otypes.NetworkUsage.VM and usage != otypes.NetworkUsage.MANAGEMENT
-                ]),
+                ]
+                for x in [
+                    usage
+                    for usage in ['display', 'gluster', 'migration']
+                    if self._cluster_network.get(usage, False)
+                ]
             )
         )
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently if we didn't specify the "role" in the task which is already
available for the network, the update_check will return FALSE. The
patch fixes the same and update_check will only return FALSE if there
is any additonal role specified for the network that are not currently
available for the network.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_network
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Fixes bug https://bugzilla.redhat.com/show_bug.cgi?id=1673225
