### PR TITLE
Remove dependency to psycopg2 with dump/restore

### DIFF
--- a/changelogs/fragments/53323-no-psycopg2-for-dump-and-restore.yaml
+++ b/changelogs/fragments/53323-no-psycopg2-for-dump-and-restore.yaml
@@ -1,0 +1,8 @@
+bugfixes:
+    - 'dump' and 'restore' state only need pg_dump and pg_restore. These tools
+    don't use psycopg2 so this change tries to avoid the use of it in these
+    cases. Fixes https://github.com/ansible/ansible/issues/35906
+    - Replace the fix for https://github.com/ansible/ansible/issues/39412
+    made in https://github.com/ansible/ansible/pull/39483 when using a compression
+    program. This now uses a FIFO file to ensure failure detection of pg_dump.
+    The Windows compatibility is completely dropped in this case.

--- a/changelogs/fragments/53323-no-psycopg2-for-dump-and-restore.yaml
+++ b/changelogs/fragments/53323-no-psycopg2-for-dump-and-restore.yaml
@@ -1,8 +1,8 @@
 bugfixes:
-    - 'dump' and 'restore' state only need pg_dump and pg_restore. These tools
-    don't use psycopg2 so this change tries to avoid the use of it in these
-    cases. Fixes https://github.com/ansible/ansible/issues/35906
+    - States ``dump`` and ``restore`` only need pg_dump and pg_restore. These tools
+      don't use psycopg2 so this change tries to avoid the use of it in these
+      cases. Fixes https://github.com/ansible/ansible/issues/35906
     - Replace the fix for https://github.com/ansible/ansible/issues/39412
-    made in https://github.com/ansible/ansible/pull/39483 when using a compression
-    program. This now uses a FIFO file to ensure failure detection of pg_dump.
-    The Windows compatibility is completely dropped in this case.
+      made in https://github.com/ansible/ansible/pull/39483 when using a compression
+      program. This now uses a FIFO file to ensure failure detection of pg_dump.
+      The Windows compatibility is completely dropped in this case.

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -83,6 +83,8 @@ options:
     type: str
     default: postgres
     version_added: "2.5"
+notes:
+- State C(dump) and C(restore) don't require I(psycopg2) since version 2.7.9.
 author: "Ansible Core Team"
 extends_documentation_fragment:
 - postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -281,7 +281,7 @@ def db_dump(module, target, target_opts="",
         cmd += " {0} ".format(target_opts)
 
     if comp_prog_path:
-        # Use a fifo to be notfied of an error in pg_dump
+        # Use a fifo to be notified of an error in pg_dump
         # Using shell pipe has no way to return the code of the first command
         # in a portable way.
         fifo = os.path.join(module.tmpdir, 'pg_fifo')

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -84,7 +84,7 @@ options:
     default: postgres
     version_added: "2.5"
 notes:
-- State C(dump) and C(restore) don't require I(psycopg2) since version 2.7.9.
+- State C(dump) and C(restore) don't require I(psycopg2) since version 2.8.
 author: "Ansible Core Team"
 extends_documentation_fragment:
 - postgres


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
'dump' and 'restore' state only need pg_dump and pg_restore. These tools 
don't use psycopg2 so this change tries to avoid the use of it in these 
cases.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This obsoletes #35907 that fixes #35906.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The db_exists test was replaced with an error detection when piping to 
compression program, using a FIFO file. This effectively reverts #39483, 
that was a fix for #39412.
