### PR TITLE
Remove cursor parameter since it's the default and breaks.

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -257,7 +257,7 @@ def main():
     login_user = module.params["login_user"]
 
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 'mysql_driver.cursors.DictCursor',
+        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 
                                connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -257,7 +257,7 @@ def main():
     login_user = module.params["login_user"]
 
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 
+        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None,
                                connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):


### PR DESCRIPTION
##### SUMMARY
mysql_replication module gave an error. It sets the same cursorclass as in the `module_utils/mysql.py` and removing this redundant parameter fixes the error.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_replication

##### ADDITIONAL INFORMATION
mysql_replication module didn't work for me. It gave me the following error using this task:

```yaml
- name: test
  mysql_replication:
    mode: getmaster
```
```
The full traceback is:
  File "/tmp/ansible_mysql_replication_payload_88feug8a/__main__.py", line 245, in main
    connect_timeout=connect_timeout)
  File "/tmp/ansible_mysql_replication_payload_88feug8a/ansible_mysql_replication_payload.zip/ansible/module_utils/mysql.py", line 78, in mysql_connect
    return db_connection.cursor(cursorclass=mysql_driver.cursors.DictCursor)

fatal: [db01]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "config_file": "/root/.my.cnf",
            "connect_timeout": 30,
            "login_host": "localhost",
            "login_password": null,
            "login_port": 3306,
            "login_unix_socket": null,
            "login_user": null,
            "master_auto_position": false,
            "master_connect_retry": null,
            "master_host": null,
            "master_log_file": null,
            "master_log_pos": null,
            "master_password": null,
            "master_port": null,
            "master_ssl": false,
            "master_ssl_ca": null,
            "master_ssl_capath": null,
            "master_ssl_cert": null,
            "master_ssl_cipher": null,
            "master_ssl_key": null,
            "master_user": null,
            "mode": "getmaster",
            "relay_log_file": null,
            "relay_log_pos": null,
            "ssl_ca": null,
            "ssl_cert": null,
            "ssl_key": null
        }
    },
    "msg": "unable to find /root/.my.cnf. Exception message: cursor() got an unexpected keyword argument 'cursorclass'"
}
```
