### PR TITLE
[stable-2.7] Python 2: accept both long and int for type=int (module options) (#53289)

### DIFF
--- a/changelogs/fragments/53289-module-option-int-long.yml
+++ b/changelogs/fragments/53289-module-option-int-long.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "If large integers are passed as options to modules under Python 2, module argument
+   parsing will reject them as they are of type ``long`` and not of type ``int``."

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1952,7 +1952,7 @@ class AnsibleModule(object):
         raise TypeError('%s cannot be converted to a bool' % type(value))
 
     def _check_type_int(self, value):
-        if isinstance(value, int):
+        if isinstance(value, integer_types):
             return value
 
         if isinstance(value, string_types):


### PR DESCRIPTION
##### SUMMARY

Backport of #53289 for Ansible 2.7

(cherry picked from commit 07fcb60d5587a57d6b910f3e2694f23d46e500fa)

Co-authored-by: Felix Fontein <felix@fontein.de>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/module_utils/basic.py`