### PR TITLE
zabbix_*: zabbix-api dep clarification + removed unnecessary ZabbixAPIExtends class

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
@@ -27,7 +27,7 @@ author:
     - "Harrison Gu (@harrisongu)"
 requirements:
     - "python >= 2.6"
-    - zabbix-api
+    - "zabbix-api >= 0.5.3"
 options:
     state:
         description:
@@ -80,7 +80,7 @@ import atexit
 import traceback
 
 try:
-    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
+    from zabbix_api import ZabbixAPI
     from zabbix_api import Already_Exists
 
     HAS_ZABBIX_API = True

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
@@ -33,7 +33,7 @@ author:
     - "Michael Miko (@RedWhiteMiko)"
 requirements:
     - "python >= 2.6"
-    - zabbix-api
+    - "zabbix-api >= 0.5.3"
 options:
     hostgroup_name:
         description:
@@ -63,19 +63,7 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 try:
-    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
-
-    # Extend the ZabbixAPI
-    # Since the zabbix-api python module too old (version 1.0, no higher version so far),
-    # it does not support the 'hostinterface' api calls,
-    # so we have to inherit the ZabbixAPI class to add 'hostinterface' support.
-    class ZabbixAPIExtends(ZabbixAPI):
-        hostinterface = None
-
-        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
-            self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
-
+    from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
     ZBX_IMP_ERR = traceback.format_exc()
@@ -126,8 +114,8 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
-                               validate_certs=validate_certs)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
         atexit.register(zbx.logout)
     except Exception as e:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -281,19 +281,7 @@ import copy
 import traceback
 
 try:
-    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
-
-    # Extend the ZabbixAPI
-    # Since the zabbix-api python module too old (version 1.0, no higher version so far),
-    # it does not support the 'hostinterface' api calls,
-    # so we have to inherit the ZabbixAPI class to add 'hostinterface' support.
-    class ZabbixAPIExtends(ZabbixAPI):
-        hostinterface = None
-
-        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
-            self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
-
+    from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
     ZBX_IMP_ERR = traceback.format_exc()
@@ -751,8 +739,8 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
-                               validate_certs=validate_certs)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
@@ -34,7 +34,7 @@ author:
     - "Michael Miko (@RedWhiteMiko)"
 requirements:
     - "python >= 2.6"
-    - zabbix-api
+    - "zabbix-api >= 0.5.3"
 options:
     host_name:
         description:
@@ -102,19 +102,7 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 try:
-    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
-
-    # Extend the ZabbixAPI
-    # Since the zabbix-api python module too old (version 1.0, no higher version so far),
-    # it does not support the 'hostinterface' api calls,
-    # so we have to inherit the ZabbixAPI class to add 'hostinterface' support.
-    class ZabbixAPIExtends(ZabbixAPI):
-        hostinterface = None
-
-        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
-            self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
-
+    from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
     ZBX_IMP_ERR = traceback.format_exc()
@@ -216,8 +204,8 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
-                               validate_certs=validate_certs)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
         atexit.register(zbx.logout)
     except Exception as e:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -25,7 +25,7 @@ author:
     - Dean Hailin Song (!UNKNOWN)
 requirements:
     - "python >= 2.6"
-    - zabbix-api
+    - "zabbix-api >= 0.5.3"
 options:
     host_name:
         description:
@@ -76,14 +76,7 @@ import atexit
 import traceback
 
 try:
-    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
-
-    # Extend the ZabbixAPI
-    # Since the zabbix-api python module too old (version 1.0, no higher version so far).
-    class ZabbixAPIExtends(ZabbixAPI):
-        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
-
+    from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
     ZBX_IMP_ERR = traceback.format_exc()
@@ -198,8 +191,8 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
-                               validate_certs=validate_certs)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
         atexit.register(zbx.logout)
     except Exception as e:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
@@ -23,7 +23,7 @@ version_added: "1.8"
 author: "Alexander Bulimov (@abulimov)"
 requirements:
     - "python >= 2.6"
-    - zabbix-api
+    - "zabbix-api >= 0.5.3"
 options:
     state:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
@@ -38,7 +38,7 @@ description:
         C(zbx_trigger_draw_style) contains indicator draw style. Possible values are the same as for C(zbx_draw_style)."
 requirements:
     - "python >= 2.6"
-    - zabbix-api
+    - "zabbix-api >= 0.5.3"
     - pydotplus
     - webcolors
     - Pillow
@@ -197,7 +197,7 @@ except ImportError:
     HAS_WEBCOLORS = False
 
 try:
-    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
+    from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
     ZBX_IMP_ERR = traceback.format_exc()

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -26,7 +26,7 @@ author:
     - "Harrison Gu (@harrisongu)"
 requirements:
     - "python >= 2.6"
-    - zabbix-api
+    - "zabbix-api >= 0.5.3"
 options:
     screens:
         description:
@@ -158,19 +158,9 @@ import atexit
 import traceback
 
 try:
-    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
+    from zabbix_api import ZabbixAPI
     from zabbix_api import ZabbixAPIException
     from zabbix_api import Already_Exists
-
-    # Extend the ZabbixAPI
-    # Since the zabbix-api python module too old (version 1.0, and there's no higher version so far), it doesn't support the 'screenitem' api call,
-    # we have to inherit the ZabbixAPI class to add 'screenitem' support.
-    class ZabbixAPIExtends(ZabbixAPI):
-        screenitem = None
-
-        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
-            self.screenitem = ZabbixAPISubClass(self, dict({"prefix": "screenitem"}, **kwargs))
 
     HAS_ZABBIX_API = True
 except ImportError:
@@ -391,8 +381,8 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
-                               validate_certs=validate_certs)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
         atexit.register(zbx.logout)
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY

Unified zabbix_* modules under single `zabbix-api` dependency and removed thus unnecessary extend of `ZabbixAPI` class.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_group
zabbix_group_facts
zabbix_host
zabbix_host_facts
zabbix_hostmacro
zabbix_maintenance
zabbix_map
zabbix_screen

##### ADDITIONAL INFORMATION
Zabbix modules are using `ZabbixAPI` class from `zabbix-api` python module by extending it and adding support for missing API calls. This was probably first introduced upon `zabbix_host` module creation sometimes around ~2014:

```python
class ZabbixAPIExtends(ZabbixAPI):
    hostinterface = None

    def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
        ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
        self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
```

By that time, `zabbix-api` did support only a few explicit API calls, but situation had changed at the end of 2015 where explicit API calls were replaced by universal [call method in this commit](https://github.com/gescheit/scripts/commit/6d6413e0d4471b07ec1bf6c4ed5526d25a2ea6e2#diff-9df2c15e1f682802fecaf4cadb1efb20).

This PR builds on this knowledge by first unifying all zabbix modules under specific python module dependency `zabbix-api >= 0.5.3` and then removing unnecessary extending via `ZabbixAPIExtends` class.

Tested against all currently supported Zabbix server releases (3.0, 3.4, 4.0).