### PR TITLE
docs: refresh testing_integration.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -115,7 +115,7 @@ Define Windows inventory::
 
 Run the Windows tests executed by our CI system::
 
-    ansible-test windows-integration -v windows/ci/
+    ansible-test windows-integration -v shippable/
 
 Tests in Docker containers
 ==========================

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -33,7 +33,7 @@ more information about supported credentials, refer to ``credentials.template``.
 Prerequisites
 =============
 
-The tests will assume things like hg, svn, and git are installed and in path.  Some tests
+The tests will assume things like hg, svn, and git are installed, and in path.  Some tests
 (such as those for Amazon Web Services) need separate definitions, which will be covered
 later in this document.
 
@@ -55,15 +55,19 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 Run as follows for all POSIX platform tests executed by our CI system::
 
-    test/runner/ansible-test integration --docker fedora25 -v posix/ci/
+    test/runner/ansible-test integration --docker fedora29 -v shippable/posix/
 
-You can select specific tests as well, such as for individual modules::
+You can target a specific tests as well, such as for individual modules::
 
     test/runner/ansible-test integration -v ping
 
-By installing ``argcomplete`` you can obtain a full list by doing::
+Use the following command to list all the available targets::
 
-    test/runner/ansible-test integration <tab><tab>
+    test/runner/ansible-test integration --list-targets
+
+.. note:: Bash users
+
+   If you use ``Bash`` with ``argcomplete``, obtain a full list by doing: ``test/runner/ansible-test integration <tab><tab>``
 
 Destructive Tests
 =================
@@ -71,7 +75,7 @@ Destructive Tests
 These tests are allowed to install and remove some trivial packages.  You will likely want to devote these
 to a virtual environment, such as Docker.  They won't reformat your filesystem::
 
-    test/runner/ansible-test integration --docker fedora25 -v destructive/
+    test/runner/ansible-test integration --docker fedora29 -v destructive/
 
 Windows Tests
 =============
@@ -113,7 +117,7 @@ Running Integration Tests
 
 To run all CI integration test targets for POSIX platforms in a Ubuntu 16.04 container::
 
-    test/runner/ansible-test integration -v posix/ci/ --docker
+    test/runner/ansible-test integration --docker -v shippable/
 
 You can also run specific tests or select a different Linux distribution.
 For example, to run tests for the ``ping`` module on a Ubuntu 14.04 container::

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -28,7 +28,7 @@ Configuration
 ansible-test command
 --------------------
 
-The example below assumes ``test/runner`` is in your ``$PATH``. An easy way to achieve that
+The example below assumes ``bin/`` is in your ``$PATH``. An easy way to achieve that
 is to initialize your environment with the ``env-setup`` command::
 
     source hacking/env-setup
@@ -36,7 +36,7 @@ is to initialize your environment with the ``env-setup`` command::
 
 You can also call ``ansible-test`` with the full path::
 
-    test/runner/ansible-test --help
+    bin/ansible-test --help
 
 integration_config.yml
 ----------------------

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -33,7 +33,7 @@ more information about supported credentials, refer to ``credentials.template``.
 Prerequisites
 =============
 
-The tests will assume things like hg, svn, and git are installed, and in path.  Some tests
+Some tests assume things like hg, svn, and git are installed, and in path.  Some tests
 (such as those for Amazon Web Services) need separate definitions, which will be covered
 later in this document.
 
@@ -55,7 +55,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 Run as follows for all POSIX platform tests executed by our CI system::
 
-    test/runner/ansible-test integration --docker fedora29 -v shippable/posix/
+    ansible-test integration --docker fedora29 -v shippable/
 
 You can target a specific tests as well, such as for individual modules::
 
@@ -117,7 +117,7 @@ Running Integration Tests
 
 To run all CI integration test targets for POSIX platforms in a Ubuntu 16.04 container::
 
-    test/runner/ansible-test integration --docker -v shippable/
+    test/runner/ansible-test integration --docker ubuntu1604 -v shippable/
 
 You can also run specific tests or select a different Linux distribution.
 For example, to run tests for the ``ping`` module on a Ubuntu 14.04 container::

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -84,7 +84,7 @@ Use the following command to list all the available targets::
 
 .. note:: Bash users
 
-   If you use ``Bash`` with ``argcomplete``, obtain a full list by doing: ``test/runner/ansible-test integration <tab><tab>``
+   If you use ``bash`` with ``argcomplete``, obtain a full list by doing: ``test/runner/ansible-test integration <tab><tab>``
 
 Destructive Tests
 =================

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -43,8 +43,9 @@ integration_config.yml
 
 Making your own version of ``integration_config.yml`` can allow for setting some
 tunable parameters to help run the tests better in your environment.  Some
-tests (e.g. cloud) will only run when access credentials are provided.  For
-more information about supported credentials, refer to ``credentials.template``.
+tests (e.g. cloud) will only run when access credentials are provided.  For more
+information about supported credentials, refer to the various ``cloud-config-*.template``
+files in the ``test/integration/`` directory.
 
 Prerequisites
 =============

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -25,6 +25,22 @@ It provides tab completion in ``bash`` for the ``ansible-test`` test runner.
 Configuration
 =============
 
+ansible-test command
+--------------------
+
+The example below assumes ``test/runner`` is in your ``$PATH``. An easy way to achieve that
+is to initialize your environment with the ``env-setup`` command::
+
+    source hacking/env-setup
+    ansible-test --help
+
+You can also call ``ansible-test`` with the full path::
+
+    test/runner/ansible-test --help
+
+integration_config.yml
+----------------------
+
 Making your own version of ``integration_config.yml`` can allow for setting some
 tunable parameters to help run the tests better in your environment.  Some
 tests (e.g. cloud) will only run when access credentials are provided.  For
@@ -59,11 +75,11 @@ Run as follows for all POSIX platform tests executed by our CI system::
 
 You can target a specific tests as well, such as for individual modules::
 
-    test/runner/ansible-test integration -v ping
+    ansible-test integration -v ping
 
 Use the following command to list all the available targets::
 
-    test/runner/ansible-test integration --list-targets
+    ansible-test integration --list-targets
 
 .. note:: Bash users
 
@@ -75,7 +91,7 @@ Destructive Tests
 These tests are allowed to install and remove some trivial packages.  You will likely want to devote these
 to a virtual environment, such as Docker.  They won't reformat your filesystem::
 
-    test/runner/ansible-test integration --docker fedora29 -v destructive/
+    ansible-test integration --docker fedora29 -v destructive/
 
 Windows Tests
 =============
@@ -98,7 +114,7 @@ Define Windows inventory::
 
 Run the Windows tests executed by our CI system::
 
-    test/runner/ansible-test windows-integration -v windows/ci/
+    ansible-test windows-integration -v windows/ci/
 
 Tests in Docker containers
 ==========================
@@ -117,12 +133,12 @@ Running Integration Tests
 
 To run all CI integration test targets for POSIX platforms in a Ubuntu 16.04 container::
 
-    test/runner/ansible-test integration --docker ubuntu1604 -v shippable/
+    ansible-test integration --docker ubuntu1604 -v shippable/
 
 You can also run specific tests or select a different Linux distribution.
 For example, to run tests for the ``ping`` module on a Ubuntu 14.04 container::
 
-    test/runner/ansible-test integration -v ping --docker ubuntu1404
+    ansible-test integration -v ping --docker ubuntu1404
 
 Container Images
 ----------------

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -84,7 +84,7 @@ Use the following command to list all the available targets::
 
 .. note:: Bash users
 
-   If you use ``bash`` with ``argcomplete``, obtain a full list by doing: ``test/runner/ansible-test integration <tab><tab>``
+   If you use ``bash`` with ``argcomplete``, obtain a full list by doing: ``ansible-test integration <tab><tab>``
 
 Destructive Tests
 =================


### PR DESCRIPTION
Ensures the examples can be run:

- fedora25 is not available anymore, use fedora29 instead
- the posix/ci alias does not exist anymore, use shippable/posix/
  instead
- explain how to list the target without argcomplete

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

testing_integration.rst