### PR TITLE
Fix typo in CLI help text

### DIFF
--- a/lib/ansible/cli/arguments/optparse_helpers.py
+++ b/lib/ansible/cli/arguments/optparse_helpers.py
@@ -214,7 +214,7 @@ def add_async_options(parser):
 def add_basedir_options(parser):
     """Add options for commands which can set a playbook basedir"""
     parser.add_option('--playbook-dir', default=None, dest='basedir', action='store',
-                      help="Since this tool does not use playbooks, use this as a subsitute playbook directory."
+                      help="Since this tool does not use playbooks, use this as a substitute playbook directory."
                            "This sets the relative path for many features including roles/ group_vars/ etc.")
 
 


### PR DESCRIPTION
##### SUMMARY
The word "substitute" was misspelled in the --playbook-dir option.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible CLI

##### ADDITIONAL INFORMATION
Before:
```
$ ansible -h
...
  --playbook-dir=BASEDIR
                        Since this tool does not use playbooks, use this as a
                        subsitute playbook directory.This sets the relative
                        path for many features including roles/ group_vars/
                        etc.
...
```
After:
```
$ ansible -h
...
  --playbook-dir=BASEDIR
                        Since this tool does not use playbooks, use this as a
                        substitute playbook directory.This sets the relative
                        path for many features including roles/ group_vars/
                        etc.
...
```