### PR TITLE
Update the Ansible Tower team

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1416,7 +1416,7 @@ macros:
   team_rhn: alikins barnabycourt FlossWare vritant
   team_scaleway: sieben Spredzy abarbare Anthony25 pilou-
   team_solaris: bcoca dagwieers fishman jpdasma jasperla mator scathatheworm troy2914 xen0l
-  team_tower: ghjm jlaska matburt wwitzel3 simfarm ryanpetrello rooftopcellist AlanCoding
+  team_tower: ghjm matburt wwitzel3 ryanpetrello rooftopcellist AlanCoding jladdjr kdelee
   team_ucs: dsoper2 johnamcdonough SDBrett vallard vvb
   team_vmware: Akasurde dav1x warthog9 ckotte Tomorrow9
   team_virt: joshainglis karmab


### PR DESCRIPTION
##### SUMMARY
This updates the list of maintainers for tower modules for the comings and goings of the team

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ADDITIONAL INFORMATION
@simfarm is no longer in the same role, and @jlaska has also changed roles and hasn't been active in Ansible core tower modules to my recollection (in addition to having his name on many many other projects which have been handed off).

@jladdjr may be starting work on some CLI / SDK options for AWX & Tower soon

@kdelee has been active in maintaining issues related to AWX & Tower inventory