### PR TITLE
Use GitHub Issue Templates to assign labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: 🐛 Bug report
 about: Create a report to help us improve
+labels: bug
 ---
 <!--- Verify first that your issue is not already reported on GitHub -->
 <!--- Also test if the latest release and devel branch are affected too -->

--- a/.github/ISSUE_TEMPLATE/documentation_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_report.md
@@ -1,6 +1,7 @@
 ---
 name: 📝 Documentation Report
 about: Ask us about docs
+labels: docs
 ---
 <!--- Verify first that your improvement is not already reported on GitHub -->
 <!--- Also test if the latest release and devel branch are affected too -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: ✨ Feature request
 about: Suggest an idea for this project
+labels: feature
 ---
 <!--- Verify first that your feature was not already discussed on GitHub -->
 <!--- Complete *all* sections as described, this form is processed automatically -->


### PR DESCRIPTION
##### SUMMARY
After chatting with GitHub today I found out about this cool feature.

We *will* keep the logic in the Bot to still add these labels.

##### ISSUE TYPE
- Bugfix Pull Request
