### PR TITLE
Warn user to send a password if the privatekey is password protected

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -76,7 +76,7 @@ options:
 
     privatekey_passphrase:
         description:
-            - The passphrase for the I(privatekey_path).
+            - The passphrase for the I(privatekey_path). This may be required if the privatekey is password protected.
         type: str
 
     selfsigned_version:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -76,7 +76,8 @@ options:
 
     privatekey_passphrase:
         description:
-            - The passphrase for the I(privatekey_path). This may be required if the privatekey is password protected.
+            - The passphrase for the I(privatekey_path). 
+            - This is required if the privatekey is password protected.
         type: str
 
     selfsigned_version:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -76,7 +76,7 @@ options:
 
     privatekey_passphrase:
         description:
-            - The passphrase for the I(privatekey_path). 
+            - The passphrase for the I(privatekey_path).
             - This is required if the privatekey is password protected.
         type: str
 

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -77,7 +77,7 @@ options:
     privatekey_passphrase:
         description:
             - The passphrase for the I(privatekey_path).
-            - This is required if the privatekey is password protected.
+            - This is required if the private key is password protected.
         type: str
 
     selfsigned_version:

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -45,7 +45,8 @@ options:
         required: true
     privatekey_passphrase:
         description:
-            - The passphrase for the privatekey.
+            - The passphrase for the privatekey(privatekey_path).
+            - This is required if the privatekey is password protected.
         type: str
     version:
         description:

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -45,7 +45,7 @@ options:
         required: true
     privatekey_passphrase:
         description:
-            - The passphrase for the privatekey(privatekey_path).
+            - The passphrase for the privatekey.
             - This is required if the privatekey is password protected.
         type: str
     version:

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -40,13 +40,13 @@ options:
         default: sha256
     privatekey_path:
         description:
-            - The path to the privatekey to use when signing the certificate signing request.
+            - The path to the private key to use when signing the certificate signing request.
         type: path
         required: true
     privatekey_passphrase:
         description:
-            - The passphrase for the privatekey.
-            - This is required if the privatekey is password protected.
+            - The passphrase for the private key.
+            - This is required if the private key is password protected.
         type: str
     version:
         description:

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -56,7 +56,7 @@ options:
         required: true
     privatekey_passphrase:
         description:
-            - The passphrase for the privatekey.
+            - The passphrase for the private key.
         type: str
         version_added: "2.4"
 extends_documentation_fragment:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a warning to the openssl_certificate documentation to send a passphrase if the private key specified is password protected. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssl_certificate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When generating a self-signed certificate with either a user-supplied private key or Ansible generated private key that is passphrase protected; the following issue occurs.
 
If the user doesn't pass `privatekey_passphrase` with `privatekey_path` the Ansible run hangs with no output warning or error. This was tested on both Debian and Freebsd instances.
<!--- Paste verbatim command output below, e.g. before and after your change -->