### PR TITLE
Refactor of win_xml (2nd attempt) to add support for processing multiple nodes and counting nodes matched by xpath

### DIFF
--- a/changelogs/fragments/win_xml_refactor.yaml
+++ b/changelogs/fragments/win_xml_refactor.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - win_xml - Behaviour change, module now processes all nodes specified by xpath, not just first encountered.
+  - win_xml - Behaviour change, fragment no longer required when processing element type nodes and state=absent.
+  - win_xml - Some output messages worded differently now the module uses a generic method to save changes.
+  - win_xml - Added 'count' module parameter which will return number of nodes matched by xpath if set to yes/true

--- a/lib/ansible/modules/windows/win_xml.ps1
+++ b/lib/ansible/modules/windows/win_xml.ps1
@@ -80,6 +80,22 @@ function Compare-XmlDocs($actual, $expected) {
     }
 }
 
+
+function Save-ChangedXml($xmlorig, $result, $message, $check_mode, $backup) {
+    $result.changed = $true
+    if (-Not $check_mode) {
+        if ($backup) {
+            $result.backup_file = Backup-File -path $dest -WhatIf:$check_mode
+            # Ensure backward compatibility (deprecate in future)
+            $result.backup = $result.backup_file
+        }
+        $xmlorig.Save($dest)
+        $result.msg = $message
+    } else {
+        $result.msg += " check mode"
+    }
+}
+
 $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
@@ -87,12 +103,13 @@ $debug_level = Get-AnsibleParam -obj $params -name "_ansible_verbosity" -type "i
 $debug = $debug_level -gt 2
 
 $dest = Get-AnsibleParam $params "path" -type "path" -FailIfEmpty $true -aliases "dest", "file"
-$fragment = Get-AnsibleParam $params "fragment" -type "str" -FailIfEmpty $true -aliases "xmlstring"
+$fragment = Get-AnsibleParam $params "fragment" -type "str" -aliases "xmlstring"
 $xpath = Get-AnsibleParam $params "xpath" -type "str" -FailIfEmpty $true
-$backup = Get-AnsibleParam $params "backup" -type "bool" -default $false
+$backup = Get-AnsibleParam $params "backup" -type "bool" -Default $false
 $type = Get-AnsibleParam $params "type" -type "str" -Default "element" -ValidateSet "element", "attribute", "text"
 $attribute = Get-AnsibleParam $params "attribute" -type "str" -FailIfEmpty ($type -eq "attribute")
 $state = Get-AnsibleParam $params "state" -type "str" -Default "present"
+$count = Get-AnsibleParam $params "count" -type "bool" -Default $false
 
 $result = @{
     changed = $false
@@ -117,121 +134,110 @@ $localname = $xmlorig.DocumentElement.LocalName
 
 $namespaceMgr.AddNamespace($xmlorig.$localname.SchemaInfo.Prefix, $namespace)
 
+$nodeList = $xmlorig.SelectNodes($xpath, $namespaceMgr)
+$nodeListCount = $nodeList.get_Count()
+if ($count) {
+    $result.count = $nodeListCount
+    if (-not $fragment) {
+       Exit-Json $result
+    }
+}
+## Exit early if xpath did not match any nodes
+if ($nodeListCount -eq 0) {
+    $result.msg = "The supplied xpath did not match any nodes.  If this is unexpected, check your xpath is valid for the xml file at supplied path."
+    Exit-Json $result
+} 
+
+$changed = $false
+$result.msg = "not changed"
+
 if ($type -eq "element") {
-    $xmlchild = $null
-    Try {
-        $xmlchild = [xml]$fragment
-    } Catch {
-        Fail-Json $result "Failed to parse fragment as XML: $($_.Exception.Message)"
-    }
-
-    $child = $xmlorig.CreateElement($xmlchild.get_DocumentElement().get_Name(), $xmlorig.get_DocumentElement().get_NamespaceURI())
-    Copy-Xml -dest $child -src $xmlchild.DocumentElement -xmlorig $xmlorig
-
-    $node = $xmlorig.SelectSingleNode($xpath, $namespaceMgr)
-    if ($node.get_NodeType() -eq "Document") {
-        $node = $node.get_DocumentElement()
-    }
-    $elements = $node.get_ChildNodes()
-    [bool]$present = $false
-    [bool]$changed = $false
-    if ($elements.get_Count()) {
-        if ($debug) {
-            $err = @()
-            $result.err = {$err}.Invoke()
-        }
-        foreach ($element in $elements) {
-            try {
-                Compare-XmlDocs $child $element
-                $present = $true
-                break
-            } catch {
+    if ($state -eq "absent") {
+        foreach ($node in $nodeList) {
+            # there are some nodes that match xpath, delete without comparing them to fragment
+            if (-Not $check_mode) {
+                $removedNode = $node.get_ParentNode().RemoveChild($node)
+                $changed = $true
                 if ($debug) {
-                    $result.err.Add($_.Exception.ToString())
+                    $result.removed += $result.removed + $removedNode.get_OuterXml()
                 }
             }
         }
-        if (!$present -and ($state -eq "present")) {
-            [void]$node.AppendChild($child)
-            $result.msg = "xml added"
-            $changed = $true
-        } elseif ($present -and ($state -eq "absent")) {
-            [void]$node.RemoveChild($element)
-            $result.msg = "xml removed"
-            $changed = $true
+    } else { # state -eq 'present'
+        $xmlchild = $null
+        Try {
+            $xmlchild = [xml]$fragment
+        } Catch {
+            Fail-Json $result "Failed to parse fragment as XML: $($_.Exception.Message)"
         }
-    } else {
-        if ($state -eq "present") {
-            [void]$node.AppendChild($child)
-            $result.msg = "xml added"
-            $changed = $true
-        }
-    }
 
-    if ($changed) {
-        if ($backup) {
-            $result.backup_file = Backup-File -path $dest -WhatIf:$check_mode
-            # Ensure backward compatibility (deprecate in future)
-            $result.backup = $result.backup_file
+        $child = $xmlorig.CreateElement($xmlchild.get_DocumentElement().get_Name(), $xmlorig.get_DocumentElement().get_NamespaceURI())
+        Copy-Xml -dest $child -src $xmlchild.DocumentElement -xmlorig $xmlorig
+
+        foreach ($node in $nodeList) {
+            if ($node.get_NodeType() -eq "Document") {
+                $node = $node.get_DocumentElement()
+            }
+            $elements = $node.get_ChildNodes()
+            [bool]$present = $false
+            [bool]$changed = $false
+            if ($elements.get_Count()) {
+                if ($debug) {
+                    $err = @()
+                    $result.err = {$err}.Invoke()
+                }
+                foreach ($element in $elements) {
+                    try {
+                        Compare-XmlDocs $child $element
+                        $present = $true
+                        break
+                    } catch {
+                        if ($debug) {
+                            $result.err.Add($_.Exception.ToString())
+                        }
+                    }
+                }
+                if (-Not $present -and ($state -eq "present")) {
+                    [void]$node.AppendChild($child)
+                    $result.msg = $result.msg + "xml added "
+                    $changed = $true
+                }
+            }
         }
-        if (-not $check_mode) {
-            $xmlorig.Save($dest)
-        }
-        $result.changed = $true
-    } else {
-        $result.msg = "not changed"
     }
 } elseif ($type -eq "text") {
-    $node = $xmlorig.SelectSingleNode($xpath, $namespaceMgr)
-    [bool]$add = ($node.get_InnerText() -ne $fragment)
-    if ($add) {
-        if ($backup) {
-            $result.backup_file = Backup-File -path $dest -WhatIf:$check_mode
-            # Ensure backward compatibility (deprecate in future)
-            $result.backup = $result.backup_file
+    foreach ($node in $nodeList) {
+        if ($node.get_InnerText() -ne $fragment) {
+            $node.set_InnerText($fragment)
+            $changed = $true
         }
-        $node.set_InnerText($fragment)
-        if (-not $check_mode) {
-            $xmlorig.Save($dest)
-        }
-        $result.changed = $true
-        $result.msg = "text changed"
-    } else {
-        $result.msg = "not changed"
     }
 } elseif ($type -eq "attribute") {
-    $node = $xmlorig.SelectSingleNode($xpath, $namespaceMgr)
-    [bool]$add = !$node.HasAttribute($attribute) -Or ($node.$attribute -ne $fragment)
-    if ($add -And ($state -eq "present")) {
-        if ($backup) {
-            $result.backup_file = Backup-File -path $dest -WhatIf:$check_mode
-            # Ensure backward compatibility (deprecate in future)
-            $result.backup = $result.backup_file
+    foreach ($node in $nodeList) {
+        [bool]$add = !$node.HasAttribute($attribute) -Or ($node.$attribute -ne $fragment)
+        if ($add -And ($state -eq "present")) {
+            if (!$node.HasAttribute($attribute)) {
+                $node.SetAttributeNode($attribute, $xmlorig.get_DocumentElement().get_NamespaceURI())
+            }
+            $node.SetAttribute($attribute, $fragment)
+            $changed = $true
+        } elseif (!$add -And ($state -eq "absent")) {
+            $node.RemoveAttribute($attribute)
+            $changed = $true
+        } else {
+            Add-Warning $result "Unexpected state when processing attribute $($attribute), add was $add, state was $state"
         }
-        if (!$node.HasAttribute($attribute)) {
-            $node.SetAttributeNode($attribute, $xmlorig.get_DocumentElement().get_NamespaceURI())
-        }
-        $node.SetAttribute($attribute, $fragment)
-        if (-not $check_mode) {
-            $xmlorig.Save($dest)
-        }
-        $result.changed = $true
-        $result.msg = "text changed"
-    } elseif (!$add -And ($state -eq "absent")) {
-        if ($backup) {
-            $result.backup_file = Backup-File -path $dest -WhatIf:$check_mode
-            # Ensure backward compatibility (deprecate in future)
-            $result.backup = $result.backup_file
-        }
-        $node.RemoveAttribute($attribute)
-        if (-not $check_mode) {
-            $xmlorig.Save($dest)
-        }
-        $result.changed = $true
-        $result.msg = "text changed"
-    } else {
-        $result.msg = "not changed"
     }
+}
+
+
+if ($changed) {
+    if ($state -eq "absent") {
+        $summary = "$type removed"
+    } else {
+        $summary = "$type changed"
+    }
+    Save-ChangedXml $xmlorig $result $summary $check_mode $backup
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_xml.ps1
+++ b/lib/ansible/modules/windows/win_xml.ps1
@@ -146,7 +146,7 @@ if ($count) {
 if ($nodeListCount -eq 0) {
     $result.msg = "The supplied xpath did not match any nodes.  If this is unexpected, check your xpath is valid for the xml file at supplied path."
     Exit-Json $result
-} 
+}
 
 $changed = $false
 $result.msg = "not changed"
@@ -182,7 +182,7 @@ if ($type -eq "element") {
             [bool]$present = $false
             [bool]$changed = $false
             $element_count = $elements.get_Count()
-            $nstatus = "node: " + $node.get_Value() + " element: " + $elements.get_OuterXml() + " Element count is $element_count" 
+            $nstatus = "node: " + $node.get_Value() + " element: " + $elements.get_OuterXml() + " Element count is $element_count"
             Add-Warning $result $nstatus
             if ($elements.get_Count()) {
                 if ($debug) {

--- a/lib/ansible/modules/windows/win_xml.ps1
+++ b/lib/ansible/modules/windows/win_xml.ps1
@@ -259,7 +259,7 @@ if ($changed) {
     } else {
         $summary = "$type changed"
     }
-    Save-ChangedXml $xmlorig $result $summary $check_mode $backup
+    Save-ChangedXml -xmlorig $xmlorig -result $result -summary $summary -check_mode $check_mode -backup $backup
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_xml.ps1
+++ b/lib/ansible/modules/windows/win_xml.ps1
@@ -259,7 +259,7 @@ if ($changed) {
     } else {
         $summary = "$type changed"
     }
-    Save-ChangedXml -xmlorig $xmlorig -result $result -summary $summary -check_mode $check_mode -backup $backup
+    Save-ChangedXml -xmlorig $xmlorig -result $result -message $summary -check_mode $check_mode -backup $backup
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_xml.py
+++ b/lib/ansible/modules/windows/win_xml.py
@@ -17,7 +17,8 @@ module: win_xml
 version_added: "2.7"
 short_description: Manages XML file content on Windows hosts
 description:
-    - Manages XML file contents, using xpath to select which xml nodes need to be managed, fragments formatted as strings to modify existing XML on remote Windows servers.
+    - Manages XML file contents, using xpath to select which xml nodes need to be managed.
+    - XML fragments, formatted as strings, are used to modify existing XML on remote Windows servers.
     - For non-Windows targets, use the M(xml) module instead.
 options:
     attribute:

--- a/lib/ansible/modules/windows/win_xml.py
+++ b/lib/ansible/modules/windows/win_xml.py
@@ -73,8 +73,8 @@ options:
 author:
     - Richard Levenberg (@richardcs)
     - Jon Hawkesworth (@jhawkesworth)
-notes: 
-    - Only supports operating on xml elements, attributes and text. 
+notes:
+    - Only supports operating on xml elements, attributes and text.
     - Namespace, processing-instruction, command and document node types cannot be modified with this module.
 seealso:
     - module: xml

--- a/lib/ansible/modules/windows/win_xml.py
+++ b/lib/ansible/modules/windows/win_xml.py
@@ -31,7 +31,7 @@ options:
         - When set to C(yes), return the number of nodes matched by I(xpath).
         type: bool
         default: false
-        version_added: 2.8
+        version_added: 2.9
     backup:
         description:
         - Determine whether a backup should be created.
@@ -41,7 +41,7 @@ options:
         default: no
     fragment:
         description:
-        - The string representation of the XML fragment expected at xpath.  Since ansible 2.8 not required when I(state=absent), or when I(count=yes).
+        - The string representation of the XML fragment expected at xpath.  Since ansible 2.9 not required when I(state=absent), or when I(count=yes).
         type: str
         required: false
         aliases: [ xmlstring ]
@@ -57,7 +57,7 @@ options:
         type: str
         default: present
         choices: [ present, absent ]
-        version_added: 2.8
+        version_added: 2.9
     type:
         description:
         - The type of XML node you are working with.

--- a/lib/ansible/modules/windows/win_xml.py
+++ b/lib/ansible/modules/windows/win_xml.py
@@ -17,8 +17,8 @@ module: win_xml
 version_added: "2.7"
 short_description: Manages XML file content on Windows hosts
 description:
-    - Manages XML file contents, using xpath to select which xml nodes need to be managed.
-    - XML fragments, formatted as strings, are used to modify existing XML on remote Windows servers.
+    - Manages XML nodes, attributes and text, using xpath to select which xml nodes need to be managed.
+    - XML fragments, formatted as strings, are used to specify the desired state of a part or parts of XML files on remote Windows servers.
     - For non-Windows targets, use the M(xml) module instead.
 options:
     attribute:
@@ -28,7 +28,7 @@ options:
         type: str
     count:
         description:
-        - When set to C(yes), return the number of nodes matched by C(xpath).
+        - When set to C(yes), return the number of nodes matched by I(xpath).
         type: bool
         default: false
         version_added: 2.8
@@ -41,7 +41,7 @@ options:
         default: no
     fragment:
         description:
-        - The string representation of the XML fragment expected at xpath.  Since ansible 2.8 not required when state is absent, or when C(count=yes).
+        - The string representation of the XML fragment expected at xpath.  Since ansible 2.8 not required when I(state=absent), or when I(count=yes).
         type: str
         required: false
         aliases: [ xmlstring ]
@@ -53,7 +53,7 @@ options:
         aliases: [ dest, file ]
     state:
         description:
-        - Set or remove the nodes (or attributes) matched by C(xpath).
+        - Set or remove the nodes (or attributes) matched by I(xpath).
         type: str
         default: present
         choices: [ present, absent ]
@@ -73,6 +73,13 @@ options:
 author:
     - Richard Levenberg (@richardcs)
     - Jon Hawkesworth (@jhawkesworth)
+notes: Only supports operating on xml elements, attributes and text. Namespace, processing-instruction, command and document node types cannot be modified with this module.
+seealso:
+    - module: xml
+      description: XML manipulation for Posix hosts.
+    - name: w3shools XPath tutorial
+      description: A useful tutorial on XPath
+      link: https://www.w3schools.com/xml/xpath_intro.asp
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_xml.py
+++ b/lib/ansible/modules/windows/win_xml.py
@@ -73,7 +73,9 @@ options:
 author:
     - Richard Levenberg (@richardcs)
     - Jon Hawkesworth (@jhawkesworth)
-notes: Only supports operating on xml elements, attributes and text. Namespace, processing-instruction, command and document node types cannot be modified with this module.
+notes: 
+    - Only supports operating on xml elements, attributes and text. 
+    - Namespace, processing-instruction, command and document node types cannot be modified with this module.
 seealso:
     - module: xml
       description: XML manipulation for Posix hosts.

--- a/test/integration/targets/win_xml/files/books.xml
+++ b/test/integration/targets/win_xml/files/books.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<books>
+  <works lang="en">
+    <title lang="en" isbn13="123412341234X">A Great Book</title>
+    <title lang="en" isbn13="1234109823400">Best Book Ever</title>
+    <title lang="en" isbn13="123412121234X">Worst Book Ever</title>
+    <title lang="en" isbn13="423412341234X">Another Book</title>
+    <title lang="en" isbn13="523412341234X">Worst Book Ever Two</title>
+  </works>
+</books>

--- a/test/integration/targets/win_xml/tasks/main.yml
+++ b/test/integration/targets/win_xml/tasks/main.yml
@@ -203,5 +203,3 @@
       - logger_level_error_node_count_again.count == 0
       - logger_level_error_node_count_again.changed == false
       - logger_level_error_node_count_again.msg == 'The supplied xpath did not match any nodes.  If this is unexpected, check your xpath is valid for the xml file at supplied path.'
-
-

--- a/test/integration/targets/win_xml/tasks/main.yml
+++ b/test/integration/targets/win_xml/tasks/main.yml
@@ -153,16 +153,13 @@
     count: yes
   register: logger_node_count
 
-- name: show node count
-  debug:
-    var: logger_node_count
-
 - name: verify node count
   assert:
     that:
       - logger_node_count.count == 5
 
-- name: count logger level error nodes and change to debug
+# multiple attribute change
+- name: ensure //logger/level value attributes are set to debug
   win_xml:
     path: "{{ win_output_dir }}\\log4j.xml"
     xpath: '//logger/level[@value="error"]'
@@ -170,20 +167,16 @@
     attribute: value
     fragment: debug
     count: yes
-  register: logger_level_error_node_count
+  register: logger_level_value_attrs
  
-- name: show logger_level_error_node_count result
-  debug:
-    var: logger_level_error_node_count
-
-- name: verify logger level error node count
+- name: verify //logger/level value attributes
   assert:
     that:
-      - logger_level_error_node_count.count == 4
-      - logger_level_error_node_count.changed == true
-      - logger_level_error_node_count.msg == 'attribute changed'
+      - logger_level_value_attrs.count == 4
+      - logger_level_value_attrs.changed == true
+      - logger_level_value_attrs.msg == 'attribute changed'
 
-- name: redo count logger level error nodes and change to debug
+- name: ensure //logger/level value attributes are set to debug (idempotency)
   win_xml:
     path: "{{ win_output_dir }}\\log4j.xml"
     xpath: '//logger/level[@value="error"]'
@@ -191,15 +184,124 @@
     attribute: value
     fragment: debug
     count: yes
-  register: logger_level_error_node_count_again
+  register: logger_level_value_attrs_again
  
-- name: show logger_level_error_node_count_again result
-  debug:
-    var: logger_level_error_node_count_again
-
-- name: verify logger level error node count again (idempotency)
+- name: verify //logger/level value attributes again (idempotency)
   assert:
     that:
-      - logger_level_error_node_count_again.count == 0
-      - logger_level_error_node_count_again.changed == false
-      - logger_level_error_node_count_again.msg == 'The supplied xpath did not match any nodes.  If this is unexpected, check your xpath is valid for the xml file at supplied path.'
+      - logger_level_value_attrs_again.count == 0
+      - logger_level_value_attrs_again.changed == false
+      - logger_level_value_attrs_again.msg == 'The supplied xpath did not match any nodes.  If this is unexpected, check your xpath is valid for the xml file at supplied path.'
+
+# multiple text nodes
+- name: ensure test books.xml is present
+  win_copy:
+    src: books.xml
+    dest: '{{ win_output_dir }}\books.xml'
+
+- name: demonstrate multi text replace by replacing all title text elements
+  win_xml:
+    path: '{{ win_output_dir }}\books.xml'
+    xpath: //works/title
+    type: text
+    fragment: _TITLE_TEXT_REMOVED_BY_WIN_XML_MODULE_
+    count: yes
+  register: multi_text
+
+- name: verify multi text change
+  assert:
+    that:
+      - multi_text.changed == true
+      - multi_text.count == 5
+      - multi_text.msg == 'text changed'
+
+- name: demonstrate multi text replace by replacing all title text elements again (idempotency)
+  win_xml:
+    path: '{{ win_output_dir }}\books.xml'
+    xpath: //works/title
+    type: text
+    fragment: _TITLE_TEXT_REMOVED_BY_WIN_XML_MODULE_
+    count: yes
+  register: multi_text_again
+
+- name: verify multi text again change (idempotency)
+  assert:
+    that:
+      - multi_text_again.changed == false
+      - multi_text_again.count == 5
+      - multi_text_again.msg == 'not changed'
+
+# multiple element 
+
+#- name: ensure a fresh test books.xml is present
+#  win_copy:
+#    src: books.xml
+#    dest: '{{ win_output_dir }}\books.xml'
+
+- name: demonstrate multi element should append new information element from fragment
+  win_xml:
+    path: '{{ win_output_dir }}\books.xml'
+    xpath: //works/title
+    type: element
+    fragment: <information>This element added by ansible</information>
+    count: yes
+  register: multi_element
+
+- name: verify multi element
+  assert:
+    that:
+      - multi_element.changed == true
+      - multi_element.count == 5
+      - multi_element.msg == 'element changed'
+
+- name: demonstrate multi element unchanged (idempotency)
+  win_xml:
+    path: '{{ win_output_dir }}\books.xml'
+    xpath: //works/title
+    type: element
+    fragment: <information>This element added by ansible</information>
+    count: yes
+  register: multi_element_again
+
+- name: verify multi element again (idempotency)
+  assert:
+    that:
+      - multi_element_again.changed == false
+      - multi_element_again.count == 5
+      - multi_element_again.msg == 'not changed'
+
+# multiple attributes on differing parent nodes
+
+- name: ensure all attribute lang=nl
+  win_xml:
+    path: '{{ win_output_dir }}\books.xml'
+    xpath: //@lang
+    type: attribute
+    attribute: lang
+    fragment: nl
+    count: yes
+  register: multi_attr
+
+- name: verify multi attribute
+  assert:
+    that:
+      - multi_attr.changed == true
+      - multi_attr.count == 6
+      - multi_attr.msg == 'attribute changed'
+
+- name: ensure all attribute lang=nl (idempotency)
+  win_xml:
+    path: '{{ win_output_dir }}\books.xml'
+    xpath: //@lang
+    type: attribute
+    attribute: lang
+    fragment: nl
+    count: yes
+  register: multi_attr_again
+
+- name: verify multi attribute (idempotency)
+  assert:
+    that:
+      - multi_attr_again.changed == false
+      - multi_attr_again.count == 6
+      - multi_attr_again.msg == 'not changed'

--- a/test/integration/targets/win_xml/tasks/main.yml
+++ b/test/integration/targets/win_xml/tasks/main.yml
@@ -142,3 +142,66 @@
   assert:
     that:
       - sha1_checksum.stat.checksum == 'de86f79b409383447cf4cf112b20af8ffffcfdbf'
+
+# features added ansible 2.8
+# count
+
+- name: count logger nodes in log4j.xml
+  win_xml:
+    path: "{{ win_output_dir }}\\log4j.xml"
+    xpath: //logger
+    count: yes
+  register: logger_node_count
+
+- name: show node count
+  debug:
+    var: logger_node_count
+
+- name: verify node count
+  assert:
+    that:
+      - logger_node_count.count == 5
+
+- name: count logger level error nodes and change to debug
+  win_xml:
+    path: "{{ win_output_dir }}\\log4j.xml"
+    xpath: '//logger/level[@value="error"]'
+    type: attribute
+    attribute: value
+    fragment: debug
+    count: yes
+  register: logger_level_error_node_count
+ 
+- name: show logger_level_error_node_count result
+  debug:
+    var: logger_level_error_node_count
+
+- name: verify logger level error node count
+  assert:
+    that:
+      - logger_level_error_node_count.count == 4
+      - logger_level_error_node_count.changed == true
+      - logger_level_error_node_count.msg == 'attribute changed'
+
+- name: redo count logger level error nodes and change to debug
+  win_xml:
+    path: "{{ win_output_dir }}\\log4j.xml"
+    xpath: '//logger/level[@value="error"]'
+    type: attribute
+    attribute: value
+    fragment: debug
+    count: yes
+  register: logger_level_error_node_count_again
+ 
+- name: show logger_level_error_node_count_again result
+  debug:
+    var: logger_level_error_node_count_again
+
+- name: verify logger level error node count again (idempotency)
+  assert:
+    that:
+      - logger_level_error_node_count_again.count == 0
+      - logger_level_error_node_count_again.changed == false
+      - logger_level_error_node_count_again.msg == 'The supplied xpath did not match any nodes.  If this is unexpected, check your xpath is valid for the xml file at supplied path.'
+
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds multi-node manipulation, the ability to delete nodes only having matched on the supplied xpath (rather than also the exact expected content at the matched xpath) and add a count capability to win_xml.

The purpose of these changes is to increase the flexibility and utilty of this module, and hopefully make it easier to understand.

I have removed the use of SelectSingleNode so multiple matched elements can be processed in a single run. Now the module works with a list of xml nodes. This should allow using xpaths that match many times inside a single document, for example if you wanted to change lang=en attribute to lang=fr the intention is this should be achievable now.

Also, when type=element or type=attribute and state=absent the module no longer requires exact node match of both the xpath AND the supplied fragment in order to delete nodes. With this modification, only the xpath needs to match. This greatly increases the flexibility of the module as you can use this to remove entire node trees without having to know their exact existing content in advance. This change came from a use case where I wanted to ensure certain nodes did not exist in an nlog.config xml file which allows us to ensure debug output is not written to disk in production environments.

I created a new Save-ChangedXml function to separate the xml manipulation from the point where changes are commited to disk.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Does not fix any bugs but 'scratches an itch' for some features I needed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_xml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Adds a few new tests.
~~TODO: add tests to demonstrate multi node element and text processing, and multi node delete.~~
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
to test, pull the PR contents (perhaps as described here: http://blog.rolpdog.com/2018/08/testing-and-modifying-github-prs.html) and run
source hacking/env-setup
bin/ansible-test windows-integration win_xml -vvv
```
