### PR TITLE
openstack inventory: allow filename without extension

### DIFF
--- a/changelogs/fragments/inventory-openstack-filename.yml
+++ b/changelogs/fragments/inventory-openstack-filename.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- openstack inventory plugin - accept inventory files with names ending in
+  'openstack' or 'cloud' when the ``---`` yaml doc-start indicator is used.

--- a/lib/ansible/plugins/inventory/auto.py
+++ b/lib/ansible/plugins/inventory/auto.py
@@ -32,7 +32,7 @@ class InventoryModule(BaseInventoryPlugin):
     NAME = 'auto'
 
     def verify_file(self, path):
-        if not path.endswith('.yml') and not path.endswith('.yaml'):
+        if not path.endswith('.yml') and not path.endswith('.yaml') and not self.verify_yaml_header(path):
             return False
         return super(InventoryModule, self).verify_file(path)
 

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -23,6 +23,8 @@ DOCUMENTATION = '''
     description:
         - Get inventory hosts from OpenStack clouds
         - Uses openstack.(yml|yaml) YAML configuration file to configure the inventory plugin
+        - If the plugin configuration file starts with ``---`` (the yaml document
+          start indicator,) the ``.(yml|yaml)`` extension may be omitted. (Version 2.8)
         - Uses standard clouds.yaml YAML configuration file to configure cloud credentials
     options:
         plugin:
@@ -326,6 +328,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if super(InventoryModule, self).verify_file(path):
             for fn in ('openstack', 'clouds'):
+                if path.endswith(fn) and self.verify_yaml_header(path):
+                    return True
                 for suffix in ('yaml', 'yml'):
                     maybe = '{fn}.{suffix}'.format(fn=fn, suffix=suffix)
                     if path.endswith(maybe):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
currently the openstack inventory plugin requires inventory files to end in {openstack,cloud}.{yml,yaml}.  This change makes files ending in {openstack,cloud} w/o an extension also acceptable as long as the file starts with `---`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openstack
inventory_plugins

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
