### PR TITLE
grafana_plugin: Add check condition when plugin version is 'latest'

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_plugin.py
+++ b/lib/ansible/modules/monitoring/grafana_plugin.py
@@ -135,6 +135,7 @@ def get_grafana_plugin_version(module, params):
                 return plugin_version
     return None
 
+
 def get_grafana_plugin_version_latest(module, params):
     '''
     Fetch the latest version available from grafana-cli.
@@ -150,6 +151,7 @@ def get_grafana_plugin_version_latest(module, params):
     if stdout_lines[0]:
         return stdout_lines[0].rstrip()
     return None
+
 
 def grafana_plugin(module, params):
     '''


### PR DESCRIPTION
##### SUMMARY

`grafana_plugin` module was updating continuously plugins when the `version` was set to `latest`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
This is a small change for monitoring/grafana module

##### ADDITIONAL INFORMATION

While using the `grafana_plugin`  module for some testing I noticed that continuous run of playbooks using it were executed on each run.
The status of the tasks would be changed on each run, making it not optimal.

Example of test that was showing the behavior:
```yaml
- name: Install grafana zabbix plugin
  grafana_plugin:
    name: alexanderzobnin-zabbix-app
    version: latest
    state: present
  notify: restart grafana
```

Result before:
```
TASK [grafana : Install grafana zabbix plugin] ***********************************************************************
changed: [XX.YY.ZZ.ABC]
```

Result after
```
TASK [grafana : Install grafana zabbix plugin] ***********************************************************************
ok: [XX.YY.ZZ.ABC]
```