### PR TITLE
Fixes #51324 azure_rm_publicipaddress not idempotent

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
@@ -237,7 +237,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
             if self.state == 'present':
                 results = pip_to_dict(pip)
                 domain_lable = results['dns_settings'].get('domain_name_label')
-                if self.domain_name != None and ((self.domain_name or domain_lable) and self.domain_name != domain_lable):
+                if self.domain_name is not None and ((self.domain_name or domain_lable) and self.domain_name != domain_lable):
                     self.log('CHANGED: domain_name_label')
                     changed = True
                     results['dns_settings']['domain_name_label'] = self.domain_name

--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
@@ -236,7 +236,8 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
             self.log("PIP {0} exists".format(self.name))
             if self.state == 'present':
                 results = pip_to_dict(pip)
-                if self.domain_name != results['dns_settings'].get('domain_name_label'):
+                domain_lable = results['dns_settings'].get('domain_name_label')
+                if self.domain_name != None and ((self.domain_name or domain_lable) and self.domain_name != domain_lable):
                     self.log('CHANGED: domain_name_label')
                     changed = True
                     results['dns_settings']['domain_name_label'] = self.domain_name


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #51324 azure_rm_publicipaddress not idempotent

First row is the possible value for self.domain_name, first column is the possible value for response.

|      | None | Empty |     ValA     |
|:----:|:----:|-------|:------------:|
| **None** |   X  |   X   |       V      |
| **ValB** |   X  |   V   | ValA != ValB |

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_publicipaddress
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
