### PR TITLE
WIP: cloudscale_server: fix missing param use_private_network

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -377,20 +377,11 @@ class AnsibleCloudscaleServer(AnsibleCloudscaleBase):
         self._result['changed'] = True
         required_params = ('name', 'ssh_keys', 'image', 'flavor')
         self._module.fail_on_missing_params(required_params)
-        params = self._module.params
-        data = {
-            'name': params['name'],
-            'image': params['image'],
-            'flavor': params['flavor'],
-            'volume_size_gb': params['volume_size_gb'],
-            'bulk_volume_size_gb': params['bulk_volume_size_gb'],
-            'ssh_keys': params['ssh_keys'],
-            'use_public_network': params['use_public_network'],
-            'use_private_network': params['use_private_network'],
-            'use_ipv6': params['use_ipv6'],
-            'anti_affinity_with': params['anti_affinity_with'],
-            'user_data': params['user_data'],
-        }
+
+        data = deepcopy(self._module.params)
+        for i in ('uuid', 'state', 'force'):
+            del data[i]
+
         self._result['diff']['before'] = self._init_server_container()
         self._result['diff']['after'] = deepcopy(data)
         if not self._module.check_mode:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -386,6 +386,7 @@ class AnsibleCloudscaleServer(AnsibleCloudscaleBase):
             'bulk_volume_size_gb': params['bulk_volume_size_gb'],
             'ssh_keys': params['ssh_keys'],
             'use_public_network': params['use_public_network'],
+            'use_private_network': params['use_private_network'],
             'use_ipv6': params['use_ipv6'],
             'anti_affinity_with': params['anti_affinity_with'],
             'user_data': params['user_data'],


### PR DESCRIPTION
##### SUMMARY
in the refactoring in #52683 the param `use_private_network` was left out. This fixes it. No need for backport.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
