### PR TITLE
cloudscale_server: fix missing param use_private_network

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -377,20 +377,11 @@ class AnsibleCloudscaleServer(AnsibleCloudscaleBase):
         self._result['changed'] = True
         required_params = ('name', 'ssh_keys', 'image', 'flavor')
         self._module.fail_on_missing_params(required_params)
-        params = self._module.params
-        data = {
-            'name': params['name'],
-            'image': params['image'],
-            'flavor': params['flavor'],
-            'volume_size_gb': params['volume_size_gb'],
-            'bulk_volume_size_gb': params['bulk_volume_size_gb'],
-            'ssh_keys': params['ssh_keys'],
-            'use_public_network': params['use_public_network'],
-            'use_private_network': params['use_private_network'],
-            'use_ipv6': params['use_ipv6'],
-            'anti_affinity_with': params['anti_affinity_with'],
-            'user_data': params['user_data'],
-        }
+
+        data = deepcopy(self._module.params)
+        for i in ('uuid', 'state', 'force', 'api_timeout', 'api_token'):
+            del data[i]
+
         self._result['diff']['before'] = self._init_server_container()
         self._result['diff']['after'] = deepcopy(data)
         if not self._module.check_mode:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -386,6 +386,7 @@ class AnsibleCloudscaleServer(AnsibleCloudscaleBase):
             'bulk_volume_size_gb': params['bulk_volume_size_gb'],
             'ssh_keys': params['ssh_keys'],
             'use_public_network': params['use_public_network'],
+            'use_private_network': params['use_private_network'],
             'use_ipv6': params['use_ipv6'],
             'anti_affinity_with': params['anti_affinity_with'],
             'user_data': params['user_data'],

--- a/test/integration/targets/cloudscale_server/tasks/main.yml
+++ b/test/integration/targets/cloudscale_server/tasks/main.yml
@@ -186,48 +186,65 @@
       - server.flavor.slug == '{{ cloudscale_test_flavor_2 }}'
       - server.name == '{{ cloudscale_resource_prefix }}-test-renamed'
 
-- name: Test create server stopped in check mode
+- name: Remember uuid of running server for anti affinity
+  set_fact:
+    running_server_uuid: '{{ server.uuid }}'
+
+- name: Test create server stopped in anti affinity and private network only in check mode
   cloudscale_server:
     name: '{{ cloudscale_resource_prefix }}-test-stopped'
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
+    anti_affinity_with: '{{ running_server_uuid }}'
+    use_public_network: no
+    use_private_network: yes
     state: stopped
   check_mode: yes
   register: server_stopped
-- name: Verify create server stopped
+- name: Verify create server stopped in anti affinity and private network only in check mode
   assert:
     that:
       - server_stopped is changed
       - server_stopped.state == 'absent'
 
-- name: Test create server stopped
+- name: Test create server stopped in anti affinity and private network only
   cloudscale_server:
     name: '{{ cloudscale_resource_prefix }}-test-stopped'
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
+    anti_affinity_with: '{{ running_server_uuid }}'
+    use_public_network: no
+    use_private_network: yes
     state: stopped
   register: server_stopped
-- name: Verify create server stopped
+- name: Verify create server stopped in anti affinity and private network only
   assert:
     that:
       - server_stopped is changed
       - server_stopped.state == 'stopped'
+      - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
+      - server_stopped.interfaces.0.type == 'private'
 
-- name: Test create server stopped idempotence
+- name: Test create server stopped in anti affinity and private network only idempotence
   cloudscale_server:
     name: '{{ cloudscale_resource_prefix }}-test-stopped'
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
+    anti_affinity_with: '{{ running_server_uuid }}'
+    use_public_network: no
+    use_private_network: yes
     state: stopped
   register: server_stopped
-- name: Verify create server stopped idempotence
+- name: Verify create server stopped in anti affinity and private network only idempotence
   assert:
     that:
       - server_stopped is not changed
       - server_stopped.state == 'stopped'
+      - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
+      - server_stopped.interfaces.0.type == 'private'
 
 - name: Test create server failure without required parameters
   cloudscale_server:


### PR DESCRIPTION
##### SUMMARY
in the refactoring in #52683 the param use_private_network was left out. This fixes it. adding tests for it. No need for backport.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudscale_server

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
