### PR TITLE
Altered to use roles slug to get rid of unwanted space in the roles name

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -326,7 +326,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def refresh_device_roles_lookup(self):
         url = urljoin(self.api_endpoint, "/api/dcim/device-roles/?limit=0")
         device_roles = self.get_resource_list(api_url=url)
-        self.device_roles_lookup = dict((device_role["id"], device_role["name"]) for device_role in device_roles)
+        self.device_roles_lookup = dict((device_role["id"], device_role["slug"]) for device_role in device_roles)
 
     def refresh_device_types_lookup(self):
         url = urljoin(self.api_endpoint, "/api/dcim/device-types/?limit=0")


### PR DESCRIPTION
##### SUMMARY
Altered to use roles slug to get rid of unwanted space in the roles name.
Fixed #53380 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Roles slug instead of roles name

##### ADDITIONAL INFORMATION
Please check #53380 for additional information
