### PR TITLE
Update aws_secret.py lookup added_version

### DIFF
--- a/lib/ansible/plugins/lookup/aws_secret.py
+++ b/lib/ansible/plugins/lookup/aws_secret.py
@@ -8,7 +8,7 @@ DOCUMENTATION = r"""
 lookup: aws_secret
 author:
   - Aaron Smith <ajsmith10381@gmail.com>
-version_added: "2.7"
+version_added: "2.8"
 requirements:
   - boto3
   - botocore>=1.10.0


### PR DESCRIPTION
Update the version_added variable that should be 2.8

##### SUMMARY
The aws_secret plugin has a wrong version in `added_version` variable. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/lookup/aws_secret.py`
