### PR TITLE
ovirt_vnic_profile: Fix issue in resetting the network filter

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vnic_profile.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vnic_profile.py
@@ -169,7 +169,7 @@ class EntityVnicPorfileModule(BaseModule):
 
     def __get_network_filter_id(self):
         nf_service = self._connection.system_service().network_filters_service()
-        return get_id_by_name(nf_service, self.param('network_filter'))
+        return get_id_by_name(nf_service, self.param('network_filter')) if self.param('network_filter') else None
 
     def build_entity(self):
         return otypes.VnicProfile(
@@ -191,7 +191,7 @@ class EntityVnicPorfileModule(BaseModule):
             qos=otypes.Qos(id=self.__get_qos_id())
             if self.param('qos') else None,
             network_filter=otypes.NetworkFilter(id=self.__get_network_filter_id())
-            if self.param('network_filter') else None
+            if self.param('network_filter') is not None else None
         )
 
     def update_check(self, entity):
@@ -209,7 +209,7 @@ class EntityVnicPorfileModule(BaseModule):
             equal(self.param('migratable'), getattr(entity, 'migratable', None)) and
             equal(self.param('pass_through'), entity.pass_through.mode.name) and
             equal(self.param('description'), entity.description) and
-            equal(self.param('network_filter'), entity.network_filter.name) and
+            equal(self.param('network_filter'), getattr(entity.network_filter, 'name', None)) and
             equal(self.param('qos'), entity.qos.name) and
             equal(self.param('port_mirroring'), getattr(entity, 'port_mirroring', None))
         )


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, there is no way to reset the network profile of vNIC profiles to "No Network Filter". To reset the vNIC profile, we have to pass an None value to "types.NetworkFilter". The patch allows to reset it by
passing empty string ('') to "network_filter".

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_vnic_profile
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Fixes https://github.com/ansible/ansible/issues/52824
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
