### PR TITLE
Remove 'network-interface' for tag_specifications

### DIFF
--- a/changelogs/fragments/53398-fix-ec2_launch_template-tags.yaml
+++ b/changelogs/fragments/53398-fix-ec2_launch_template-tags.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_launch_template - Only 'volume' and 'instance' are valid resource types for tag specifications.

--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -382,7 +382,7 @@ def params_to_launch_data(module, template_params):
                     in template_params['tags'].items()
                 ]
             }
-            for r_type in ('instance', 'network-interface', 'volume')
+            for r_type in ('instance', 'volume')
         ]
         del template_params['tags']
     if module.params.get('iam_instance_profile'):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove 'network-interface' for tag_specifications
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_launch_template.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As noted in https://github.com/aws/aws-cli/issues/2865, tag 'network-interface' is not valid for launch template. It is not possible to use aws ec2 run-instances without this modification.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
