### PR TITLE
httpapi/nxos_facts: raise ConnectionError is missing `code`

### DIFF
--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -165,7 +165,7 @@ def handle_response(response):
     if response['ins_api'].get('outputs'):
         for output in to_list(response['ins_api']['outputs']['output']):
             if output['code'] != '200':
-                raise ConnectionError('%s: %s' % (output['input'], output['msg']))
+                raise ConnectionError('%s: %s' % (output['input'], output['msg']), code=output['code'])
             elif 'body' in output:
                 result = output['body']
                 if isinstance(result, dict):


### PR DESCRIPTION
##### SUMMARY

* `nxos_facts` crashes with certain nxos images; e.g. `7.0(3)I7(3)` as a result of this call:
  ```
        data = self.run('show lldp neighbors', output='json')
  ```
  ...which returns `ERROR: No neighbour information` when the device has no neighbors.

* This response causes httpapi's `handle_reponse()` to raise a ConnectionError, which is caught by `utils/jsonrpc.py` which is expecting `code` in the exception data:

  ```
             except ConnectionError as exc:
                 display.vvv(traceback.format_exc())
                 error = self.error(code=exc.code, message=to_text(exc))
                                    ^^^^^^^^^^^^^
  ```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/httpapi/nxos.py`
`modules/network/nxos/nxos_facts.py`

##### ADDITIONAL INFORMATION
Found by: `nxos_facts/tests/common/not_hardware.yaml:7`. 
The `nxos_facts` tests are now 100% pass rate on `7.0(3)I7(3)` with this commit.