### PR TITLE
[2.7] docker_swarm_service: rename return variable to swarm_service

### DIFF
--- a/changelogs/fragments/53229-docker_swarm_service-return-value.yml
+++ b/changelogs/fragments/53229-docker_swarm_service-return-value.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- "docker_swarm_service - the return value was documented as ``ansible_swarm_service``, but the
+   module actually returned ``ansible_docker_service``. Documentation and code have been updated
+   so that the variable is now called ``swarm_service``. In Ansible 2.7.x, the old name
+   ``ansible_docker_service`` can still be used to access the result."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1203,6 +1203,7 @@ def main():
         rebuilt=rebuilt,
         changes=changes,
         swarm_service=facts,
+        ansible_docker_service=facts  # kept for backwards-compatibility, will be removed in Ansible 2.8
     )
 
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -299,13 +299,17 @@ requirements:
 '''
 
 RETURN = '''
-ansible_swarm_service:
+swarm_service:
   returned: always
   type: dict
   description:
   - Dictionary of variables representing the current state of the service.
     Matches the module parameters format.
   - Note that facts are not part of registered vars but accessible directly.
+  - Note that before Ansible 2.7.9, the return variable was documented as C(ansible_swarm_service),
+    while the module actually returned a variable called C(ansible_docker_service). The variable
+    was renamed to C(swarm_service) in both code and documentation for Ansible 2.7.9 and Ansible 2.8.0.
+    In Ansible 2.7.x, the old name C(ansible_docker_service) can still be used.
   sample: '{
     "args": [
       "sleep",
@@ -1193,7 +1197,13 @@ def main():
     dsm = DockerServiceManager(client)
     msg, changed, rebuilt, changes, facts = dsm.run()
 
-    client.module.exit_json(msg=msg, changed=changed, rebuilt=rebuilt, changes=changes, ansible_docker_service=facts)
+    client.module.exit_json(
+        msg=msg,
+        changed=changed,
+        rebuilt=rebuilt,
+        changes=changes,
+        swarm_service=facts,
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Backport of #53229 to stable-2.7: fixes discrepancy between code (return variable is called `ansible_docker_service`) and docs (return variable is called `ansible_swarm_service`), and at the same time renaming it to `swarm_service` to better fit to the other docker_* modules. As discussed with @abadger, will keep returning the old name in Ansible 2.7.

This should be merged for 2.7.9; if not, both this PR and devel have to be adjusted since the documentation inside the PR (and #53229) mentions that this change happens in that Ansible version.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_swarm_service
