### PR TITLE
[rds_instance] don't hardcode license_model choices

### DIFF
--- a/changelogs/fragments/53409-rds_instance-remove-hardcoded-license-models.yaml
+++ b/changelogs/fragments/53409-rds_instance-remove-hardcoded-license-models.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - rds_instance - Don't hardcode the license models because there are accepted values undocumented by AWS.
+    Rely on the exception handling instead to provide a helpful error for invalid license models.

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -224,10 +224,8 @@ options:
     license_model:
         description:
           - The license model for the DB instance.
-        choices:
-          - license-included
-          - bring-your-own-license
-          - general-public-license
+          - Several options are license-included, bring-your-own-license, and general-public-license.
+          - This option can also be omitted to default to an accepted value.
         type: str
     master_user_password:
         description:
@@ -1090,7 +1088,7 @@ def main():
         force_failover=dict(type='bool'),
         iops=dict(type='int'),
         kms_key_id=dict(),
-        license_model=dict(choices=['license-included', 'bring-your-own-license', 'general-public-license']),
+        license_model=dict(),
         master_user_password=dict(aliases=['password'], no_log=True),
         master_username=dict(aliases=['username']),
         monitoring_interval=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY
License models are not restricted to those listed here https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html and there doesn't appear to be a good way to dynamically get the list of accepted licenses. The exception handling provides a helpful error if the wrong license is provided.

Fixes #53407

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rds_instance

