### PR TITLE
 Allocate an explicit stdin in async_wrapper

### DIFF
--- a/changelogs/fragments/async-wrapper-stdin.yaml
+++ b/changelogs/fragments/async-wrapper-stdin.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- async_wrapper - Allocate an explicit stdin (https://github.com/ansible/ansible/issues/50758)

--- a/lib/ansible/modules/utilities/logic/async_wrapper.py
+++ b/lib/ansible/modules/utilities/logic/async_wrapper.py
@@ -148,7 +148,8 @@ def _run_module(wrapped_cmd, jid, job_path):
         interpreter = _get_interpreter(cmd[0])
         if interpreter:
             cmd = interpreter + cmd
-        script = subprocess.Popen(cmd, shell=False, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        script = subprocess.Popen(cmd, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE)
 
         (outdata, stderr) = script.communicate()
         if PY3:

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -280,3 +280,9 @@
     file:
       path: '{{ custom_async_tmp }}'
       state: absent
+
+- name: Test that async has stdin
+  command: >
+    {{ ansible_python_interpreter|default('/usr/bin/python') }} -c 'import os; os.fdopen(os.dup(0), "r")'
+  async: 1
+  poll: 1


### PR DESCRIPTION
##### SUMMARY
Allocate an explicit stdin in `async_wrapper`

Prior to https://github.com/ansible/ansible/commit/52449cc01a71778ef94ea0237eed0284f5d75582 `async_wrapper` inherited `stdin` from the `Popen` call to execute a module.

In the mentioned commit, we moved away from `Popen` to effectively calling `imp.load_module`, which does not allocate `stdin`.

Instead of adjusting AnsiballZ so that `async_wrapper` can inherit `stdin`, have `async_wrapper` allocate a `stdin` when it calls `Popen`.

Fixes #50758 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/utilities/logic/async_wrapper.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```