### PR TITLE
Validate botmeta teams

### DIFF
--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -72,7 +72,7 @@ def main():
 
     for macro in macros:
         if macro.startswith('team_'):
-            team_macros.append('$'+macro)
+            team_macros.append('$' + macro)
         else:
             path_macros.append(macro)
 
@@ -86,13 +86,12 @@ def main():
         #                      - fred
         if isinstance(botmeta.get('files', {}).get(file, ''), str):
             maintainers = botmeta.get('files', {}).get(file, '').split(' ')
-            validate_maintainers(maintainers, team_macros, path, file)
         elif botmeta.get('files', {}).get(file, '').get('maintainers', ''):
             if isinstance(botmeta.get('files', {}).get(file, '').get('maintainers', ''), str):
                 maintainers = botmeta.get('files', {}).get(file, '').get('maintainers', '').split(' ')
             if isinstance(botmeta.get('files', {}).get(file, '').get('maintainers', ''), list):
                 maintainers = botmeta.get('files', {}).get(file, '').get('maintainers', '')
-            validate_maintainers(maintainers, team_macros, path, file)
+        validate_maintainers(maintainers, team_macros, path, file)
 
         for macro in path_macros:
             file = file.replace('$' + macro, botmeta.get('macros', {}).get(macro, ''))
@@ -101,6 +100,7 @@ def main():
             # https://github.com/ansible/ansibullbot/pull/1023
             if not glob.glob('%s*' % file):
                 print("%s:%d:%d: Can't find '%s.*' in this branch" % (path, 0, 0, file))
+
 
 def validate_maintainers(maintainers, team_macros, path, file):
     """Ensure any mentioned `$team_` entries exist"""

--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -68,13 +68,26 @@ def main():
     # Find all path (none-team) macros so we can substitute them
     macros = botmeta.get('macros', {})
     path_macros = []
+    team_macros = []
+
     for macro in macros:
         if macro.startswith('team_'):
-            continue
-        path_macros.append(macro)
+            team_macros.append('$'+macro)
+        else:
+            path_macros.append(macro)
 
-    # Ensure all `files` correspond to a file
+    # Validate files
     for file in botmeta['files']:
+        try:
+            if botmeta.get('files', {}).get(file, '').get('maintainers', ''):
+                maintainers = botmeta.get('files', {}).get(file, '').get('maintainers', '').split(' ')
+                for m in maintainers:
+                    if m[0:5] == '$team':
+                        if m not in team_macros:
+                            print("%s:%d:%d: Entry '%s' references unknown team '%s'" % (path, 0, 0, file, m))
+
+        except AttributeError:
+            continue
         for macro in path_macros:
             file = file.replace('$' + macro, botmeta.get('macros', {}).get(macro, ''))
         if not os.path.exists(file):

--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -84,6 +84,7 @@ def main():
         # maintainer (list): maintainers:
         #                      - $team_foo
         #                      - fred
+        maintainers = []
         if isinstance(botmeta.get('files', {}).get(file, ''), str):
             maintainers = botmeta.get('files', {}).get(file, '').split(' ')
         elif botmeta.get('files', {}).get(file, '').get('maintainers', ''):


### PR DESCRIPTION
##### SUMMARY
I've seen twice recently undefined `$team_` entries (missing or typos). This causes Ansibulbot to get into a crash loop.

Ensure that any mentioned `$team_` maintainers listed under `files:` have been defined in `macros:`

```
ansible-test sanity --python 3.5 --test botmeta
Sanity check using botmeta
ERROR: Found 9 botmeta issue(s) which need to be resolved:
ERROR: .github/BOTMETA.yml:0:0: Entry '$module_utils/csharp' references unknown team '$team_windows_core'
ERROR: .github/BOTMETA.yml:0:0: Entry '$module_utils/powershell' references unknown team '$team_windows_core'
ERROR: .github/BOTMETA.yml:0:0: Entry '$modules/cloud/amazon/ec2.py' references unknown team '$team_ansibleAS'
ERROR: .github/BOTMETA.yml:0:0: Entry '$modules/windows/' references unknown team '$team_windows'
ERROR: .github/BOTMETA.yml:0:0: Entry '$plugins/action/win' references unknown team '$team_windows_core'
ERROR: .github/BOTMETA.yml:0:0: Entry '$plugins/connection/psrp.py' references unknown team '$team_windows_core'
ERROR: .github/BOTMETA.yml:0:0: Entry '$plugins/connection/winrm.py' references unknown team '$team_windows_core'
ERROR: .github/BOTMETA.yml:0:0: Entry '$plugins/shell/powershell.py' references unknown team '$team_windows_core'
ERROR: .github/BOTMETA.yml:0:0: Entry 'lib/ansible/executor/powershell' references unknown team '$team_windows_core'
ERROR: The 1 sanity test(s) listed below (out of 1) failed. See error output above for details.
botmeta
```

##### ISSUE TYPE
- Bugfix Pull Request
