### PR TITLE
improve docker_* test speed

### DIFF
--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -128,10 +128,11 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
             node_id = self.get_swarm_node_id()
 
         for retry in range(0, repeat_check):
+            if retry > 0:
+                sleep(5)
             node_info = self.get_node_inspect(node_id=node_id)
             if node_info['Status']['State'] == 'down':
                 return True
-            sleep(5)
         return False
 
     def get_node_inspect(self, node_id=None, skip_missing=False):

--- a/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
@@ -16,6 +16,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: json-file
@@ -25,6 +26,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: json-file
@@ -34,6 +36,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
   register: logging_driver_2b
@@ -42,6 +45,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: syslog
@@ -68,6 +72,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: json-file
@@ -80,6 +85,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: json-file
@@ -92,6 +98,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
     log_driver_options:
@@ -103,6 +110,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: json-file
@@ -116,6 +124,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: json-file
@@ -126,6 +135,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
       driver: json-file

--- a/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
@@ -29,6 +29,7 @@
         name: test_service
         endpoint_mode: dnsrr
         image: busybox
+        resolve_image: no
         args:
           - sleep
           - "3600"
@@ -43,6 +44,7 @@
       docker_swarm_service:
         name: test_service
         image: busybox
+        resolve_image: no
         args:
           - sleep
           - "1800"
@@ -57,6 +59,7 @@
       docker_swarm_service:
         name: test_service
         image: busybox
+        resolve_image: no
         endpoint_mode: vip
         mode: global
         args:
@@ -73,6 +76,7 @@
       docker_swarm_service:
         name: test_service
         image: busybox
+        resolve_image: no
         mode: global
         args:
           - sleep

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -75,6 +75,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     args:
       - sleep
       - "3600"
@@ -84,6 +85,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     args:
       - sleep
       - "3600"
@@ -93,6 +95,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     args:
       - sleep
       - "3400"
@@ -102,6 +105,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     args: []
   register: args_4
 
@@ -109,6 +113,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     args: []
   register: args_5
 
@@ -134,6 +139,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
       - config_id: "{{ config_result_1.config_id|default('') }}"
@@ -146,6 +152,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
       - config_id: "{{ config_result_1.config_id|default('') }}"
@@ -158,6 +165,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
       - config_id: "{{ config_result_1.config_id|default('') }}"
@@ -173,6 +181,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
   register: configs_4
@@ -182,6 +191,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
   register: configs_5
@@ -216,6 +226,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_1
 
@@ -223,6 +234,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_2
 
@@ -230,6 +242,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -c "sleep 10m"'
   register: command_3
 
@@ -237,6 +250,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command:
       - "/bin/sh"
       - "-c"
@@ -247,6 +261,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: []
   register: command_5
 
@@ -254,6 +269,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: []
   register: command_6
 
@@ -261,6 +277,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: yes
   register: command_7
   ignore_errors: yes
@@ -269,6 +286,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command:
       - "/bin/sh"
       - yes
@@ -300,6 +318,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
       test_1: "1"
@@ -310,6 +329,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
       test_1: "1"
@@ -320,6 +340,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
       test_1: "1"
@@ -330,6 +351,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
   register: container_labels_4
@@ -338,6 +360,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
   register: container_labels_5
@@ -364,6 +387,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
       - 1.1.1.1
@@ -375,6 +399,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
       - 1.1.1.1
@@ -386,6 +411,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
       - 8.8.8.8
@@ -397,6 +423,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
       - 8.8.8.8
@@ -408,6 +435,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
   register: dns_5
@@ -417,6 +445,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
   register: dns_6
@@ -451,6 +480,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
       - "timeout:10"
@@ -462,6 +492,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
       - "timeout:10"
@@ -473,6 +504,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
       - "timeout:10"
@@ -484,6 +516,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
   register: dns_options_4
@@ -493,6 +526,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
   register: dns_options_5
@@ -526,6 +560,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
       - example.com
@@ -537,6 +572,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
       - example.com
@@ -548,6 +584,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
       - example.org
@@ -559,6 +596,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
       - ansible.com
@@ -570,6 +608,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
   register: dns_search_5
@@ -579,6 +618,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
   register: dns_search_6
@@ -613,6 +653,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
   register: endpoint_mode_1
@@ -622,6 +663,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
   register: endpoint_mode_2
@@ -631,6 +673,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "vip"
   register: endpoint_mode_3
@@ -662,6 +705,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
       - "TEST1=val1"
@@ -672,6 +716,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
       TEST1: val1
@@ -682,6 +727,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
       - "TEST1=val1"
@@ -692,6 +738,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
   register: env_4
@@ -700,6 +747,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
   register: env_5
@@ -708,6 +756,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env:
       TEST1: true
   register: env_6
@@ -717,6 +766,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env:
       - "TEST1=val3"
       - "TEST2"
@@ -747,6 +797,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
   register: env_file_1
@@ -755,6 +806,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
   register: env_file_2
@@ -763,6 +815,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
       - "{{ role_path }}/files/env-file-2"
@@ -772,6 +825,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
       - "{{ role_path }}/files/env-file-1"
@@ -781,6 +835,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
       - "{{ role_path }}/files/env-file-1"
@@ -790,6 +845,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env_files: []
   register: env_file_6
 
@@ -797,6 +853,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     env_files: []
   register: env_file_7
 
@@ -824,6 +881,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
       - sleep
@@ -836,6 +894,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
       - sleep
@@ -869,6 +928,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
       - 1234
@@ -880,6 +940,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
       - 1234
@@ -891,6 +952,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
       - 1234
@@ -901,6 +963,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
   register: groups_4
@@ -910,6 +973,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
   register: groups_5
@@ -943,6 +1007,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test:
@@ -959,6 +1024,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test:
@@ -975,6 +1041,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test:
@@ -991,6 +1058,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test:
@@ -1002,6 +1070,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test:
@@ -1013,6 +1082,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test: "sleep 1"
@@ -1023,6 +1093,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test: "sleep 1"
@@ -1033,6 +1104,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
   register: healthcheck_8
@@ -1042,6 +1114,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
   register: healthcheck_9
@@ -1079,6 +1152,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
   register: hostname_1
@@ -1088,6 +1162,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
   register: hostname_2
@@ -1097,6 +1172,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.org
   register: hostname_3
@@ -1128,6 +1204,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
       example.com: 1.2.3.4
@@ -1139,6 +1216,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
       example.com: 1.2.3.4
@@ -1150,6 +1228,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
       example.com: 1.2.3.4
@@ -1183,6 +1262,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_1
 
@@ -1190,6 +1270,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_2
 
@@ -1219,6 +1300,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
       test_1: "1"
@@ -1229,6 +1311,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
       test_1: "1"
@@ -1239,6 +1322,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
       test_1: "1"
@@ -1250,6 +1334,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
   register: labels_4
@@ -1258,6 +1343,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
   register: labels_5
@@ -1284,6 +1370,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
     replicas: 1
@@ -1293,6 +1380,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
     replicas: 1
@@ -1302,6 +1390,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "global"
     replicas: 1
@@ -1327,6 +1416,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
       - source: "{{ volume_name_1 }}"
@@ -1338,6 +1428,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
       - source: "{{ volume_name_1 }}"
@@ -1349,6 +1440,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
       - source: "{{ volume_name_1 }}"
@@ -1363,6 +1455,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
   register: mounts_4
@@ -1371,6 +1464,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
   register: mounts_5
@@ -1397,6 +1491,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
       - "{{ network_name_1 }}"
@@ -1406,6 +1501,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
       - "{{ network_name_1 }}"
@@ -1415,6 +1511,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
       - "{{ network_name_1 }}"
@@ -1425,6 +1522,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
       - "{{ network_name_1 }}"
@@ -1435,6 +1533,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
       - "{{ network_name_2 }}"
@@ -1444,6 +1543,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
       - "{{ network_name_2 }}"
@@ -1453,6 +1553,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
   register: networks_7
@@ -1461,6 +1562,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
   register: networks_8
@@ -1502,6 +1604,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
   register: stop_grace_period_1
@@ -1510,6 +1613,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
   register: stop_grace_period_2
@@ -1518,6 +1622,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 1m30s
   register: stop_grace_period_3
@@ -1542,6 +1647,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
   register: stop_signal_1
@@ -1551,6 +1657,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
   register: stop_signal_2
@@ -1560,6 +1667,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "9"
   register: stop_signal_3
@@ -1591,6 +1699,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
       - protocol: tcp
@@ -1606,6 +1715,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
       - protocol: udp
@@ -1620,6 +1730,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
       - protocol: tcp
@@ -1635,6 +1746,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
       - protocol: tcp
@@ -1652,6 +1764,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
       - protocol: udp
@@ -1669,6 +1782,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
   register: publish_6
@@ -1678,6 +1792,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
   register: publish_7
@@ -1713,6 +1828,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
   register: replicas_1
@@ -1721,6 +1837,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
   register: replicas_2
@@ -1729,6 +1846,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 3
   register: replicas_3
@@ -1800,6 +1918,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
       - secret_id: "{{ secret_result_1.secret_id|default('') }}"
@@ -1812,6 +1931,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
       - secret_id: "{{ secret_result_1.secret_id|default('') }}"
@@ -1824,6 +1944,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
       - secret_id: "{{ secret_result_1.secret_id|default('') }}"
@@ -1839,6 +1960,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
   register: secrets_4
@@ -1848,6 +1970,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
   register: secrets_5
@@ -1882,6 +2005,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     tty: yes
   register: tty_1
@@ -1891,6 +2015,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     tty: yes
   register: tty_2
@@ -1900,6 +2025,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     tty: no
   register: tty_3
@@ -1931,6 +2057,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     user: "operator"
   register: user_1
@@ -1939,6 +2066,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     user: "operator"
   register: user_2
@@ -1947,6 +2075,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     user: "root"
   register: user_3
@@ -1971,6 +2100,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     working_dir: /tmp
   register: working_dir_1
 
@@ -1978,6 +2108,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     working_dir: /tmp
   register: working_dir_2
 
@@ -1985,6 +2116,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     working_dir: /
   register: working_dir_3
 

--- a/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
@@ -17,6 +17,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       preferences:
@@ -28,6 +29,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       preferences:
@@ -39,6 +41,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       preferences:
@@ -50,6 +53,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       preferences: []
@@ -60,6 +64,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       preferences: []
@@ -94,6 +99,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       constraints:
@@ -105,6 +111,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       constraints:
@@ -116,6 +123,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     constraints:
       - "node.role == manager"
@@ -126,6 +134,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       constraints:
@@ -137,6 +146,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       constraints: []
@@ -147,6 +157,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
       constraints: []

--- a/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
@@ -16,6 +16,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
       cpus: 1
@@ -25,6 +26,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
       cpus: 1
@@ -34,6 +36,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_cpu: 1
   register: limit_cpu_2b
@@ -42,6 +45,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
       cpus: 2
@@ -68,6 +72,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
       memory: 64M
@@ -77,6 +82,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
       memory: 64M
@@ -86,6 +92,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: "67108864"
   register: limit_memory_2b
@@ -94,6 +101,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: 32M
   register: limit_memory_3
@@ -119,6 +127,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
       cpus: 1
@@ -128,6 +137,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
       cpus: 1
@@ -137,6 +147,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_cpu: 1
   register: reserve_cpu_2b
@@ -145,6 +156,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
       cpus: 2
@@ -171,6 +183,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
       memory: 64M
@@ -180,6 +193,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 64M
   register: reserve_memory_2
@@ -188,6 +202,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: "67108864"
   register: reserve_memory_2b
@@ -196,6 +211,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 32M
   register: reserve_memory_3

--- a/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
@@ -16,6 +16,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       condition: "on-failure"
@@ -25,6 +26,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       condition: "on-failure"
@@ -34,6 +36,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy: "on-failure"
   register: restart_policy_2b
@@ -42,6 +45,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       condition: "any"
@@ -68,6 +72,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       max_attempts: 1
@@ -77,6 +82,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       max_attempts: 1
@@ -86,6 +92,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_attempts: 1
   register: restart_policy_attempts_2b
@@ -94,6 +101,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       max_attempts: 2
@@ -120,6 +128,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       delay: 5s
@@ -129,6 +138,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       delay: 5s
@@ -138,6 +148,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_delay: 5000000000
   register: restart_policy_delay_2b
@@ -146,6 +157,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       delay: 10s
@@ -172,6 +184,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       window: 10s
@@ -181,6 +194,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       window: 10s
@@ -190,6 +204,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_window: 10000000000
   register: restart_policy_window_2b
@@ -198,6 +213,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
       window: 20s

--- a/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
@@ -16,6 +16,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       delay: 5s
@@ -25,6 +26,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       delay: 5s
@@ -34,6 +36,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_delay: 5000000000
   register: update_delay_2b
@@ -42,6 +45,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       delay: 12s
@@ -68,6 +72,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       failure_action: "pause"
@@ -77,6 +82,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       failure_action: "pause"
@@ -86,6 +92,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_failure_action: "pause"
   register: update_failure_action_2b
@@ -94,6 +101,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       failure_action: "continue"
@@ -120,6 +128,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       max_failure_ratio: 0.25
@@ -130,6 +139,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       max_failure_ratio: 0.25
@@ -140,6 +150,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_max_failure_ratio: 0.25
   register: update_max_failure_ratio_2b
@@ -149,6 +160,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       max_failure_ratio: 0.50
@@ -182,6 +194,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       monitor: 10s
@@ -192,6 +205,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       monitor: 10s
@@ -202,6 +216,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_monitor: 10s
   register: update_monitor_2b
@@ -211,6 +226,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       monitor: 60s
@@ -244,6 +260,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       order: "start-first"
@@ -254,6 +271,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       order: "start-first"
@@ -264,6 +282,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_order: "start-first"
   register: update_order_2b
@@ -273,6 +292,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       order: "stop-first"
@@ -306,6 +326,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       parallelism: 2
@@ -315,6 +336,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       parallelism: 2
@@ -324,6 +346,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_parallelism: 2
   register: update_parallelism_2b
@@ -332,6 +355,7 @@
   docker_swarm_service:
     name: "{{ service_name }}"
     image: alpine:3.8
+    resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
       parallelism: 1


### PR DESCRIPTION
##### SUMMARY
Trying to speed up docker_* tests. The longest are (taken from a CI run on RHEL7):
 - docker_container: ~8 minutes
 - docker_node: ~7 minutes
 - docker_swarm_service: ~5 minutes
 - docker_network: ~3.5 minutes

First try: using `resolve_image: no` for `docker_swarm_service`, which should stop registry lookups for the image (with a new enough docker daemon).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service
