### PR TITLE
Properly quote the username to support usernames with spaces

### DIFF
--- a/changelogs/fragments/ssh-quote-user.yaml
+++ b/changelogs/fragments/ssh-quote-user.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ssh - Properly quote the username to allow usernames containing spaces (https://github.com/ansible/ansible/issues/49968)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -612,7 +612,7 @@ class Connection(ConnectionBase):
         if user:
             self._add_args(
                 b_command,
-                (b"-o", b"User=" + to_bytes(self._play_context.remote_user, errors='surrogate_or_strict')),
+                (b"-o", b'User="%s"' % to_bytes(self._play_context.remote_user, errors='surrogate_or_strict')),
                 u"ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set"
             )
 


### PR DESCRIPTION
##### SUMMARY
Properly quote the username to support usernames with spaces

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/ssh.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```