### PR TITLE
Fix for receiving vm names of disconnected nodes

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -604,7 +604,7 @@ def get_nextvmid(module, proxmox):
 
 
 def get_vmid(proxmox, name):
-    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm['name'] == name]
+    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm.get('name', '') == name]
 
 
 def get_vm(proxmox, vmid):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In environments were are disconnected nodes within the cluster, vms can still be present but not have a `name` field within the API.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#46633
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
As there is no `name` field of vms of disconnected proxmox nodes, the ansible script will fail due to a KeyError. This fix just provides an default (empty string) value if there is no such name field within the API.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Output of a VM of a disconnected node:
{u'status': u'unknown', u'type': u'qemu', u'vmid': 104, u'id': u'qemu/104', u'node': u'prx-node01'}

Output of a VM of a connected node:
{u'status': u'running', u'node': u'prx03-test', u'uptime': 6765768, u'name': u'VM 105', u'maxcpu': 4, u'diskread': 398603672, u'mem': 498401280, u'vmid': 105, u'netin': 238735348261, u'id': u'qemu/105', u'diskwrite': 1248907264,
u'template': 0, u'netout': 10991935, u'disk': 0, u'type': u'qemu', u'cpu': 0.0106896209386423, u'maxdisk': 10737418240, u'maxmem': 8589934592}
```
