### PR TITLE
Fix ec2_launch_template tagging

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -374,6 +374,10 @@ def existing_templates(module):
 
 def params_to_launch_data(module, template_params):
     if template_params.get('tags'):
+        r_types = ['instance', 'volume']
+        if template_params.get('network_interfaces'):
+            # don't say we want to tag the ENI if the user didn't ask for one explicitly
+            r_types.append('network-interface')
         template_params['tag_specifications'] = [
             {
                 'resource_type': r_type,
@@ -382,7 +386,7 @@ def params_to_launch_data(module, template_params):
                     in template_params['tags'].items()
                 ]
             }
-            for r_type in ('instance', 'network-interface', 'volume')
+            for r_type in r_types
         ]
         del template_params['tags']
     if module.params.get('iam_instance_profile'):

--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -320,9 +320,9 @@ import re
 from uuid import uuid4
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
+from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict, snake_dict_to_camel_dict
-from ansible.module_utils.ec2 import ansible_dict_to_boto3_tag_list, AWSRetry, boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
+from ansible.module_utils.ec2 import AWSRetry, boto3_tag_list_to_ansible_dict
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError, WaiterError
@@ -373,6 +373,11 @@ def existing_templates(module):
 
 
 def params_to_launch_data(module, template_params):
+    """
+    :param AnsibleAWSModule module: the current module
+    :param dict template_params: the "local" params specific to ``ec2_launch_template:``
+    :return: the boto3 compatible ``LaunchTemplateData`` structure
+    """
     if template_params.get('tags'):
         r_types = ['instance', 'volume']
         if template_params.get('network_interfaces'):


### PR DESCRIPTION
##### SUMMARY

If one does not provide `network_interfaces:` in `ec2_launch_template:`, then the module will still ask AWS to tag a resource of `network-interface` when launching the instance. However, that configuration is invalid, causing a 400 response from the AWS API

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`ec2_launch_template`

##### ADDITIONAL INFORMATION

1. specify a launch template without `network_interfaces:`
1. specify an `ec2_asg:` that references that launch template
1. observe the error below

```yaml
- ec2_launch_template:
    template_name: sample_lt
    # this is actually the default, but for clarity
    network_interfaces: ~
    tags:
        # or whatever
        Role: worker
    # and the rest

- ec2_asg:
    name: sample
    launch_template:
        launch_template_name: sample_lt
        version: '$Default'
```

```
    "msg": "Failed to update autoscaling group: An error occurred (ValidationError) when calling the UpdateAutoScalingGroup operation: You must use a valid fully-formed launch template. 'network-interface' is not a valid taggable resource type for this operation."
```
