### PR TITLE
docker_container: show warnings, fix/improve tests

### DIFF
--- a/changelogs/fragments/53440-docker_container-warnings.yml
+++ b/changelogs/fragments/53440-docker_container-warnings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - now returns warnings from docker daemon on container creation and updating."

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -23,6 +23,7 @@ from distutils.version import LooseVersion
 
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE, BOOLEANS_FALSE
 
@@ -659,6 +660,20 @@ class AnsibleDockerClient(Client):
         new_tag = self.find_image(name, tag)
 
         return new_tag, old_tag == new_tag
+
+    def report_warnings(self, result, warnings_key=None):
+        '''
+        Checks result of client operation for warnings, and if present, outputs them.
+        '''
+        if warnings_key is None:
+            warnings_key = ['Warnings']
+        for key in warnings_key:
+            if not isinstance(result, Mapping):
+                return
+            result = result.get(key)
+        if isinstance(result, Sequence):
+            for warning in result:
+                self.module.warn('Docker warning: {0}'.format(warning))
 
 
 def compare_dict_allow_more_present(av, bv):

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2480,6 +2480,9 @@ class ContainerManager(DockerBaseClass):
         if not self.check_mode:
             try:
                 new_container = self.client.create_container(image, **create_parameters)
+                if new_container and new_container.get('Warnings'):
+                    for warning in new_container.get('Warnings'):
+                        self.client.module.warn(warning)
             except Exception as exc:
                 self.fail("Error creating container: %s" % str(exc))
             return self._get_container(new_container['Id'])
@@ -2572,7 +2575,10 @@ class ContainerManager(DockerBaseClass):
             self.results['changed'] = True
             if not self.check_mode and callable(getattr(self.client, 'update_container')):
                 try:
-                    self.client.update_container(container_id, **update_parameters)
+                    result = self.client.update_container(container_id, **update_parameters)
+                    if result and result.get('Warnings'):
+                        for warning in result.get('Warnings'):
+                            self.client.module.warn(warning)
                 except Exception as exc:
                     self.fail("Error updating container %s: %s" % (container_id, str(exc)))
         return self._get_container(container_id)

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2482,7 +2482,7 @@ class ContainerManager(DockerBaseClass):
                 new_container = self.client.create_container(image, **create_parameters)
                 if new_container and new_container.get('Warnings'):
                     for warning in new_container.get('Warnings'):
-                        self.client.module.warn(warning)
+                        self.client.module.warn('Docker warning: {0}'.format(warning))
             except Exception as exc:
                 self.fail("Error creating container: %s" % str(exc))
             return self._get_container(new_container['Id'])
@@ -2578,7 +2578,7 @@ class ContainerManager(DockerBaseClass):
                     result = self.client.update_container(container_id, **update_parameters)
                     if result and result.get('Warnings'):
                         for warning in result.get('Warnings'):
-                            self.client.module.warn(warning)
+                            self.client.module.warn('Docker warning: {0}'.format(warning))
                 except Exception as exc:
                     self.fail("Error updating container %s: %s" % (container_id, str(exc)))
         return self._get_container(container_id)

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2480,9 +2480,7 @@ class ContainerManager(DockerBaseClass):
         if not self.check_mode:
             try:
                 new_container = self.client.create_container(image, **create_parameters)
-                if new_container and new_container.get('Warnings'):
-                    for warning in new_container.get('Warnings'):
-                        self.client.module.warn('Docker warning: {0}'.format(warning))
+                self.client.report_warnings(new_container)
             except Exception as exc:
                 self.fail("Error creating container: %s" % str(exc))
             return self._get_container(new_container['Id'])
@@ -2576,9 +2574,7 @@ class ContainerManager(DockerBaseClass):
             if not self.check_mode and callable(getattr(self.client, 'update_container')):
                 try:
                     result = self.client.update_container(container_id, **update_parameters)
-                    if result and result.get('Warnings'):
-                        for warning in result.get('Warnings'):
-                            self.client.module.warn('Docker warning: {0}'.format(warning))
+                    self.client.report_warnings(result)
                 except Exception as exc:
                     self.fail("Error updating container %s: %s" % (container_id, str(exc)))
         return self._get_container(container_id)

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -121,8 +121,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1010
-    - 1011
+    - "1010"
+    - "1011"
   register: set_1
 
 - name: set (change, ignore)
@@ -132,9 +132,9 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1010
-    - 1011
-    - 1012
+    - "1010"
+    - "1011"
+    - "1012"
     force_kill: yes
     comparisons:
       groups: ignore
@@ -147,9 +147,9 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1010
-    - 1011
-    - 1012
+    - "1010"
+    - "1011"
+    - "1012"
     force_kill: yes
     comparisons:
       groups: allow_more_present
@@ -162,8 +162,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1010
-    - 1012
+    - "1010"
+    - "1012"
     force_kill: yes
     comparisons:
       groups: allow_more_present
@@ -176,8 +176,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1010
-    - 1012
+    - "1010"
+    - "1012"
     force_kill: yes
     comparisons:
       groups: strict

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -8,11 +8,13 @@
 
 - name: Pull images
   docker_image:
-    name: "{{ item }}"
+    name: "{{ image }}"
     pull: true
   loop:
     - "hello-world:latest"
     - "alpine:3.8"
+  loop_control:
+    loop_var: image
 
 - name: Get image ID of hello-world and alpine images
   docker_image_facts:

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -101,7 +101,7 @@
 - assert:
     that:
     - blkio_weight_1 is changed
-    - blkio_weight_2 is not changed
+    - blkio_weight_2 is not changed or 'Your kernel does not support Block I/O weight or the cgroup is not mounted. Weight discarded.' in blkio_weight_2.warnings
     - blkio_weight_3 is changed
 
 ####################################################################

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -356,7 +356,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_cpus: 0
+    cpuset_cpus: "0"
     state: started
   register: cpuset_cpus_1
 
@@ -365,7 +365,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_cpus: 0
+    cpuset_cpus: "0"
     state: started
   register: cpuset_cpus_2
 
@@ -374,7 +374,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_cpus: 1
+    cpuset_cpus: "1"
     state: started
     force_kill: yes
   # This will fail if the system the test is run on doesn't have
@@ -404,7 +404,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_mems: 0
+    cpuset_mems: "0"
     state: started
   register: cpuset_mems_1
 
@@ -413,7 +413,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_mems: 0
+    cpuset_mems: "0"
     state: started
   register: cpuset_mems_2
 
@@ -422,7 +422,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_mems: 1
+    cpuset_mems: "1"
     state: started
     force_kill: yes
   # This will fail if the system the test is run on doesn't have
@@ -1355,8 +1355,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 1234
-    - 5678
+    - "1234"
+    - "5678"
   register: exposed_ports_1
 
 - name: exposed_ports (idempotency)
@@ -1366,8 +1366,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 5678
-    - 1234
+    - "5678"
+    - "1234"
   register: exposed_ports_2
 
 - name: exposed_ports (less ports)
@@ -1377,7 +1377,7 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 1234
+    - "1234"
   register: exposed_ports_3
 
 - name: exposed_ports (more ports)
@@ -1387,8 +1387,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 1234
-    - 1235
+    - "1234"
+    - "1235"
     force_kill: yes
   register: exposed_ports_4
 
@@ -1423,8 +1423,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1234
-    - 5678
+    - "1234"
+    - "5678"
   register: groups_1
 
 - name: groups (idempotency)
@@ -1434,8 +1434,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 5678
-    - 1234
+    - "5678"
+    - "1234"
   register: groups_2
 
 - name: groups (less groups)
@@ -1445,7 +1445,7 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1234
+    - "1234"
   register: groups_3
 
 - name: groups (more groups)
@@ -1455,8 +1455,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1234
-    - 2345
+    - "1234"
+    - "2345"
     force_kill: yes
   register: groups_4
 
@@ -3413,7 +3413,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    stop_signal: 30
+    stop_signal: "30"
     state: started
   register: stop_signal_1
 
@@ -3422,7 +3422,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    stop_signal: 30
+    stop_signal: "30"
     state: started
   register: stop_signal_2
 
@@ -3431,7 +3431,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    stop_signal: 9
+    stop_signal: "9"
     state: started
     force_kill: yes
   register: stop_signal_3

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -101,7 +101,7 @@
 - assert:
     that:
     - blkio_weight_1 is changed
-    - blkio_weight_2 is not changed or 'Your kernel does not support Block I/O weight or the cgroup is not mounted. Weight discarded.' in blkio_weight_2.warnings
+    - "blkio_weight_2 is not changed or 'Docker warning: Your kernel does not support Block I/O weight or the cgroup is not mounted. Weight discarded.' in blkio_weight_2.warnings"
     - blkio_weight_3 is changed
 
 ####################################################################

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1115,7 +1115,7 @@
     state: started
   register: entrypoint_2
 
-- name: entrypoint (change order idempotency)
+- name: entrypoint (change order, should not be idempotent)
   docker_container:
     image: alpine:3.8
     entrypoint:
@@ -1125,6 +1125,7 @@
     - "-v"
     name: "{{ cname }}"
     state: started
+    force_kill: yes
   register: entrypoint_3
 
 - name: entrypoint (less parameters)

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -14,8 +14,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
     - all
     force_kill: yes
@@ -28,8 +28,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
     - all
     force_kill: yes
@@ -42,11 +42,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     force_kill: yes
   register: published_ports_3
 
@@ -57,11 +57,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     force_kill: yes
   register: published_ports_4
 
@@ -72,8 +72,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
     - all
     force_kill: yes
@@ -105,11 +105,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 5000-5040
+    - "8080"
+    - "5000-5040"
     published_ports:
-    - 8080:8080
-    - 5000-5040:5000-5040
+    - "8080:8080"
+    - "5000-5040:5000-5040"
     force_kill: yes
   register: published_ports_1
 
@@ -120,11 +120,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 5000-5040
+    - "8080"
+    - "5000-5040"
     published_ports:
-    - 8080:8080
-    - 5000-5040:5000-5040
+    - "8080:8080"
+    - "5000-5040:5000-5040"
     force_kill: yes
   register: published_ports_2
 
@@ -135,11 +135,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 5000-5040
+    - "8080"
+    - "5000-5040"
     published_ports:
-    - 8080:8080
-    - 5010-5050:5010-5050
+    - "8080:8080"
+    - "5010-5050:5010-5050"
     force_kill: yes
   register: published_ports_3
 
@@ -189,7 +189,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 127.0.0.1:8080:8080
+    - "127.0.0.1:8080:8080"
     force_kill: yes
   register: published_ports_3
 
@@ -200,7 +200,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - localhost:8080:8080
+    - "localhost:8080:8080"
     force_kill: yes
   register: published_ports_4
   ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
I noticed that the `docker_container` tests don't work anymore on my machine, more specifically, the `blkio_weight` idempotency broke. I found out that container creation and updating actually returns warnings (which contained a warning that this isn't supported with my kernel), so I added a mechanism to return these warnings, and updated the tests to accept that warning too.

I also fixes some warnings appearing with the tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
