### PR TITLE
Fix for "AttributeError: 'module' object has no attribute 'cursors'" (#49191)

### DIFF
--- a/changelogs/fragments/49191-module_utils_mysql-unexpected-keyword-argument-cursorclass.yml
+++ b/changelogs/fragments/49191-module_utils_mysql-unexpected-keyword-argument-cursorclass.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql - MySQLdb doesn't import the cursors module for its own purposes so it has to be imported in MySQL module utilities before it can be used in dependent modules like the proxysql module family.

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -34,7 +34,8 @@ try:
     _mysql_cursor_param = 'cursor'
 except ImportError:
     try:
-        import MySQLdb as mysql_driver, MySQLdb.cursors
+        import MySQLdb as mysql_driver
+        import MySQLdb.cursors
         _mysql_cursor_param = 'cursorclass'
     except ImportError:
         mysql_driver = None

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -34,7 +34,7 @@ try:
     _mysql_cursor_param = 'cursor'
 except ImportError:
     try:
-        import MySQLdb as mysql_driver
+        import MySQLdb as mysql_driver, MySQLdb.cursors
         _mysql_cursor_param = 'cursorclass'
     except ImportError:
         mysql_driver = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #49191.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
MySQLdb doesn't import the cursors module for its own purposes so it has to be imported in MySQL module utilities before it can be used in dependent modules like the proxysql module family.
