### PR TITLE
Constructed keyed inventory groups: Allow groups with hyphen

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1445,7 +1445,7 @@ TRANSFORM_INVALID_GROUP_CHARS:
   description:
     - Make ansible transform invalid characters in group names supplied by inventory sources.
     - If 'false' it will allow for the group name but warn about the issue.
-    - When 'true' it will replace any invalid charachters with '_' (underscore).
+    - When 'true' it will replace any invalid characters with '_' (underscore).
   env: [{name: ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS}]
   ini:
   - {key: force_valid_group_names, section: defaults}

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -416,7 +416,7 @@ class Constructable(object):
 
                         for bare_name in new_raw_group_names:
                             if keyed.get('unsafe', False):
-                                gname = bare_name
+                                gname = '%s%s%s' % (prefix, sep, bare_name)
                             else:
                                 gname = to_safe_group_name('%s%s%s' % (prefix, sep, bare_name))
 

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -378,7 +378,7 @@ class Constructable(object):
                     continue
 
                 if result:
-                    # ensure group exists, use sanatized name
+                    # ensure group exists, use santanized name
                     group_name = self.inventory.add_group(group_name)
                     # add host to group
                     self.inventory.add_child(group_name, host)
@@ -415,7 +415,11 @@ class Constructable(object):
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
 
                         for bare_name in new_raw_group_names:
-                            gname = to_safe_group_name('%s%s%s' % (prefix, sep, bare_name))
+                            if keyed.get('unsafe', False):
+                                gname = bare_name
+                            else:
+                                gname = to_safe_group_name('%s%s%s' % (prefix, sep, bare_name))
+
                             self.inventory.add_group(gname)
                             self.inventory.add_child(gname, host)
 

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -129,6 +129,9 @@ keyed_groups:
   # create a group per region e.g. aws_region_us_east_2
   - key: placement.region
     prefix: aws_region
+  # create a group when name contains hyphens
+  - key: tags['Name']
+    unsafe: True
 # set individual variables with compose
 compose:
   # use the private IP address to connect to the host

--- a/test/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
+++ b/test/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
@@ -44,6 +44,10 @@
           set_fact:
             sg_group_name: "security_groups_{{ sg_id | replace('-', '_') }}"
 
+        - name: register the keyed and unsafe sg group name
+          set_fact:
+            unsafe_sg_group_name: "unsafe_security_groups_{{ sg_id }}"
+
         - name: register one of the keyed tag groups name
           set_fact:
             tag_group_name: "tag_Name_{{ resource_prefix | replace('-', '_') }}"
@@ -58,6 +62,7 @@
               - "groups.arch_x86_64 | length == 1"
               - "groups.tag_with_name_key | length == 1"
               - vars.hostvars[groups.aws_ec2.0]['test_compose_var_sum'] == 'value1value2'
+              - "groups[unsafe_sg_group_name] | length == 1"
 
       always:
 

--- a/test/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml
+++ b/test/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml
@@ -14,6 +14,9 @@ keyed_groups:
     prefix: 'tag'
   - prefix: 'arch'
     key: "architecture"
+  - key: 'unsafe_security_groups|json_query("[].group_id")'
+    prefix: 'security_groups'
+    unsafe: true
 compose:
   test_compose_var_sum: tags.tag1 + tags.tag2
 groups:

--- a/test/units/plugins/inventory/test_constructed.py
+++ b/test/units/plugins/inventory/test_constructed.py
@@ -51,6 +51,29 @@ def test_group_by_value_only(inventory_module):
     assert group.hosts == [host]
 
 
+def test_keyed_group_with_hyphen(inventory_module):
+    inventory_module.inventory.add_host('sample-host')
+    inventory_module.inventory.set_variable('sample-host', 'region', 'us-east')
+    host = inventory_module.inventory.get_host('sample-host')
+    keyed_groups = [
+        {
+            'key': 'region',
+            'unsafe': False
+        },
+        {
+            'key': 'region',
+            'unsafe': True
+        }
+    ]
+    inventory_module._add_host_to_keyed_groups(
+        keyed_groups, host.vars, host.name, strict=False
+    )
+    for group_name in ('_us_east', '_us-east'):
+        assert group_name in inventory_module.inventory.groups
+        group = inventory_module.inventory.groups[group_name]
+        assert group.hosts == [host]
+
+
 def test_keyed_group_separator(inventory_module):
     inventory_module.inventory.add_host('farm')
     inventory_module.inventory.set_variable('farm', 'farmer', 'mcdonald')


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
Fixes #40581

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/config/base.yml
lib/ansible/plugins/inventory/__init__.py
lib/ansible/plugins/inventory/aws_ec2.py
test/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
test/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml