### PR TITLE
[docker_image] do not pull an image in case the user disallowed it

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -364,13 +364,14 @@ class ImageManager(DockerBaseClass):
                 self.results['changed'] = True
                 if not self.check_mode:
                     self.results['image'] = self.load_image()
-            else:
+            elif self.pull:
                 # pull the image
                 self.results['actions'].append('Pulled image %s:%s' % (self.name, self.tag))
                 self.results['changed'] = True
                 if not self.check_mode:
                     self.results['image'], dummy = self.client.pull_image(self.name, tag=self.tag)
-            if not self.check_mode and image and image['Id'] == self.results['image']['Id']:
+
+            if not self.check_mode and image and self.results['image'] and image['Id'] == self.results['image']['Id']:
                 self.results['changed'] = False
 
         if self.archive_path:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `docker_image` module does not honor the users decision for `pull: no`. The module always pulls an image in case one or both of the following conditions are met:
- the image is not present
- the user specified `force: yes`

This renders this module useless when force tagging an existing image or force pushing a custom built images to a registry. Specifying `force: yes` pulls a different image from the docker registry and uses this image for the new tag or pushes it instead.
Without this fix one has to manually remove a previous local or repository tag before recreating the tag and pushing the image.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #44077

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_image

<!--- ##### ADDITIONAL INFORMATION -->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
