### PR TITLE
More kubevirt_* modules in k8s mod defaults group

### DIFF
--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -604,5 +604,15 @@ groupings:
   - k8s
   k8s_scale:
   - k8s
+  kubevirt_cdi_upload:
+  - k8s
+  kubevirt_preset:
+  - k8s
+  kubevirt_pvc:
+  - k8s
+  kubevirt_rs:
+  - k8s
+  kubevirt_template:
+  - k8s
   kubevirt_vm:
   - k8s


### PR DESCRIPTION
##### SUMMARY
More `kubevirt_*` got added recently and they should be in the `k8s` group.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
kubevirt_*
