### PR TITLE
[docker_image] fix the changed state for tagging and pushing

### DIFF
--- a/changelogs/fragments/53451-docker_image-fix-changed-tag-push.yml
+++ b/changelogs/fragments/53451-docker_image-fix-changed-tag-push.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_image - set ``changed`` to ``false`` when using ``force: yes`` to tag or push an image that ends up being identical to one already present on the Docker host or Docker registry."

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -468,11 +468,15 @@ class ImageManager(DockerBaseClass):
             if not self.check_mode:
                 status = None
                 try:
+                    changed = False
                     for line in self.client.push(repository, tag=tag, stream=True, decode=True):
                         self.log(line, pretty_print=True)
                         if line.get('errorDetail'):
                             raise Exception(line['errorDetail']['message'])
                         status = line.get('status')
+                        if status == 'Pushing':
+                            changed = True
+                    self.results['changed'] = changed
                 except Exception as exc:
                     if re.search('unauthorized', str(exc)):
                         if re.search('authentication required', str(exc)):
@@ -524,6 +528,9 @@ class ImageManager(DockerBaseClass):
                 except Exception as exc:
                     self.fail("Error: failed to tag image - %s" % str(exc))
                 self.results['image'] = self.client.find_image(name=repo, tag=repo_tag)
+                if image and image['Id'] == self.results['image']['Id']:
+                    self.results['changed'] = False
+
                 if push:
                     self.push_image(repo, repo_tag)
 

--- a/test/integration/targets/docker_image/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_image/tasks/tests/basic.yml
@@ -38,6 +38,41 @@
     - present_1 is changed
     - present_2 is not changed
 
+- name: Make sure tag is not there
+  docker_image:
+    name: "hello-world:alias"
+    state: absent
+
+- name: Tag image with alias
+  docker_image:
+    name: "hello-world:latest"
+    repository: "hello-world:alias"
+  register: tag_1
+
+- name: Tag image with alias (idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    repository: "hello-world:alias"
+  register: tag_2
+
+- name: Tag image with alias (force, still idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    repository: "hello-world:alias"
+    force: yes
+  register: tag_3
+
+- assert:
+    that:
+    - tag_1 is changed
+    - tag_2 is not changed
+    - tag_3 is not changed
+
+- name: Cleanup alias tag
+  docker_image:
+    name: "hello-world:alias"
+    state: absent
+
 ####################################################################
 ## interact with test registry #####################################
 ####################################################################
@@ -61,10 +96,19 @@
     push: yes
   register: push_2
 
+- name: Push image to test registry (force, still idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    repository: "{{ registry_address }}/test/hello-world"
+    push: yes
+    force: yes
+  register: push_3
+
 - assert:
     that:
     - push_1 is changed
     - push_2 is not changed
+    - push_3 is not changed
 
 - name: Get facts of local image
   docker_image_facts:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A followup PR for https://github.com/ansible/ansible/pull/33754.

Set `changed=false` in case a force tag results in the same image ID, similarly for a force push.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_image

<!--- ##### ADDITIONAL INFORMATION -->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
