### PR TITLE
nxos_evpn_vni: exclude legacy N3k from sanity test

### DIFF
--- a/test/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
@@ -3,12 +3,15 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: nvoe_supported="{{ platform is not search('N3K|N3L|N35')}}"
+
 - name: "Setup"
   nxos_config: &remove_evpn
     lines: no nv overlay evpn
     match: none
     provider: "{{ connection }}"
   ignore_errors: yes
+  when: nvoe_supported
 
 - block:
   - name: "Enable feature BGP"
@@ -99,18 +102,21 @@
 
   - assert: *false
 
-  when: not (platform is search('N3K')) and not (platform is match('N35'))
+  when: nvoe_supported
+
 
   always:
-  - name: "Remove nv overlay evpn"
-    nxos_config: *remove_evpn
-    ignore_errors: yes
+  - block:
+    - name: "Remove nv overlay evpn"
+      nxos_config: *remove_evpn
+      ignore_errors: yes
 
-  - name: "Disable feature bgp"
-    nxos_feature:
-      feature: bgp
-      provider: "{{ connection }}"
-      state: disabled
-    ignore_errors: yes
+    - name: "Disable feature bgp"
+      nxos_feature:
+        feature: bgp
+        provider: "{{ connection }}"
+        state: disabled
+      ignore_errors: yes
+    when: nvoe_supported
 
 - debug: msg="END connection={{ ansible_connection }} nxos_evpn_vni sanity test"


### PR DESCRIPTION
##### SUMMARY
The test was only skipping N3K|N35, needs to also skip N3L (legacy n3048 chassis).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_evpn_vni`
