### PR TITLE
Adds SKU to properties returned by get_system_inventory

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -966,7 +966,7 @@ class RedfishUtils(object):
         # Get these entries, but does not fail if not found
         properties = ['Status', 'HostName', 'PowerState', 'Model', 'Manufacturer',
                       'PartNumber', 'SystemType', 'AssetTag', 'ServiceTag',
-                      'SerialNumber', 'BiosVersion', 'MemorySummary',
+                      'SerialNumber', 'SKU', 'BiosVersion', 'MemorySummary',
                       'ProcessorSummary', 'TrustedModules']
 
         response = self.get_request(self.root_uri + self.systems_uri)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #53461

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Just add SKU property to data returned by get_system_inventory in order to be able to get serial number/service tags of DELL servers

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
