### PR TITLE
iptables: Add support for gateway parameter

### DIFF
--- a/changelogs/fragments/53170-iptables-support_gateway.yml
+++ b/changelogs/fragments/53170-iptables-support_gateway.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added support for gateway parameter in iptables module (https://github.com/ansible/ansible/issues/53170).


### PR DESCRIPTION
##### SUMMARY
When user specifies the JUMP value to 'tee', gateway is required.
This fix adds new parameter 'gateway' to support this functionality.

Fixes: #53170

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

changelogs/fragments/53170-iptables-support_gateway.yml
lib/ansible/modules/system/iptables.py
test/units/modules/system/test_iptables.py