### PR TITLE
Add example on how to mount ISO9660

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -142,6 +142,13 @@ EXAMPLES = r'''
     opts: bind
     state: mounted
     fstype: none
+    
+- name: Mount an ISO9660
+  mount:
+    path: /mnt/foo
+    src: /foo/file.iso
+    opts: ro,loop=
+    state: mounted
 '''
 
 


### PR DESCRIPTION
##### SUMMARY

Adding an example on how to mount ISO9660. On CentOs seems neccesary passing "loop=" as opts argument. I was unable to find examples for this particular use. 

Also in the process of mounting a loop device on  CentOS release 6.9 Ansible miserably fails mounting the loop device:

`"msg": "Error mounting /mnt/xentools: mount: /tmp/xentools7-4.iso is not a block device (maybe try -o loop'?)\n"`

Whit other distros (Ubuntu and Debian) I hadn't this problem, no need to add "loop=" as opts for ansible mount module.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

mount

##### ADDITIONAL INFORMATION

Reproduction of the problem: I created a playbook:

```
- name: Mount iso de xen tools
  mount:
    path: /mnt/xentools
    src: /tmp/xentools7-4.iso
    opts: ro
    fstype: iso9660
    state: mounted
```
Executed it on 150 servers (Ubuntu and CentOs) mainly. On Ubuntu and Debian servers it worked. But with CentOs 6.9 failed:

`"msg": "Error mounting /mnt/xentools: mount: /tmp/xentools7-4.iso is not a block device (maybe try -o loop'?)\n"`

Adding the parameter "loop=" fixes that behaviour:

```
- name: Mount iso de xen tools
  mount:
    path: /mnt/xentools
    src: /tmp/xentools7-4.iso
    opts: ro,loop=
    fstype: iso9660
    state: mounted
```