### PR TITLE
docker_swarm_service: Documentation fixes

### DIFF
--- a/changelogs/fragments/53479-docker_swarm_service-documentation-fixes.yaml
+++ b/changelogs/fragments/53479-docker_swarm_service-documentation-fixes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - Validate choices for option ``mode``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -306,9 +306,13 @@ options:
   mode:
     description:
       - Service replication mode.
+      - Service will be removed and recreated when changed.
       - Corresponds to the C(--mode) option of C(docker service create).
     type: str
     default: replicated
+    choices:
+        - replicated
+        - global
   mounts:
     description:
       - List of dictionaries describing the service mounts.
@@ -461,7 +465,6 @@ options:
       mode:
         description:
           - What publish mode to use.
-          - Service will be removed and recreated when changed.
           - Requires API version >= 1.32.
         type: str
         choices:
@@ -2146,7 +2149,11 @@ def main():
         hosts=dict(type='dict'),
         labels=dict(type='dict'),
         container_labels=dict(type='dict'),
-        mode=dict(type='str', default='replicated'),
+        mode=dict(
+            type='str',
+            default='replicated',
+            choices=('replicated', 'global')
+        ),
         replicas=dict(type='int', default=-1),
         endpoint_mode=dict(type='str', choices=['vip', 'dnsrr']),
         stop_grace_period=dict(type='str'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1099,6 +1099,7 @@ class DockerService(DockerBaseClass):
             'replicas': self.replicas,
             'endpoint_mode': self.endpoint_mode,
             'restart_policy': self.restart_policy,
+            'secrets': self.secrets,
             'stop_grace_period': self.stop_grace_period,
             'stop_signal': self.stop_signal,
             'limit_cpu': self.limit_cpu,
@@ -1114,6 +1115,7 @@ class DockerService(DockerBaseClass):
             'update_monitor': self.update_monitor,
             'update_max_failure_ratio': self.update_max_failure_ratio,
             'update_order': self.update_order,
+            'user': self.user,
             'working_dir': self.working_dir,
         }
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -21,6 +21,33 @@ description:
   - Manages docker services via a swarm manager node.
 version_added: "2.7"
 options:
+  name:
+    description:
+      - Service name.
+      - Corresponds to the C(--name) option of C(docker service create).
+    type: str
+    required: yes
+  image:
+    description:
+      - Service image path and tag.
+      - Corresponds to the C(IMAGE) parameter of C(docker service create).
+    type: str
+    required: yes
+  resolve_image:
+    description:
+      - If the current image digest should be resolved from registry and updated if changed.
+    type: bool
+    default: yes
+    version_added: 2.8
+  state:
+    description:
+      - Service state.
+    type: str
+    required: yes
+    default: present
+    choices:
+      - present
+      - absent
   args:
     description:
       - List arguments to be passed to the container.
@@ -33,112 +60,29 @@ options:
       - Corresponds to the C(COMMAND) parameter of C(docker service create).
     type: raw
     version_added: 2.8
-  configs:
+  placement:
     description:
-      - List of dictionaries describing the service configs.
-      - Corresponds to the C(--config) option of C(docker service create).
-      - Requires API version >= 1.30.
-    type: list
+      - Configures service placement preferences and constraints.
     suboptions:
-      config_id:
+      constraints:
         description:
-          - Config's ID.
-        type: str
-        required: yes
-      config_name:
+          - List of the service constraints.
+          - Corresponds to the C(--constraint) option of C(docker service create).
+        type: list
+      preferences:
         description:
-          - Config's name as defined at its creation.
-        type: str
-        required: yes
-      filename:
-        description:
-          - Name of the file containing the config. Defaults to the I(config_name) if not specified.
-        type: str
-        required: yes
-      uid:
-        description:
-          - UID of the config file's owner.
-        type: int
-        default: 0
-      gid:
-        description:
-          - GID of the config file's group.
-        type: int
-        default: 0
-      mode:
-        description:
-          - File access mode inside the container.
-        type: str
-        default: "0o444"
+          - List of the placement preferences as key value pairs.
+          - Corresponds to the C(--placement-pref) option of C(docker service create).
+          - Requires API version >= 1.27.
+        type: list
+    type: dict
+    version_added: "2.8"
   constraints:
     description:
       - List of the service constraints.
       - Corresponds to the C(--constraint) option of C(docker service create).
       - Deprecated in 2.8, will be removed in 2.12. Use parameter C(placement.constraints) instead.
     type: list
-  container_labels:
-    description:
-      - Dictionary of key value pairs.
-      - Corresponds to the C(--container-label) option of C(docker service create).
-    type: dict
-  dns:
-    description:
-      - List of custom DNS servers.
-      - Corresponds to the C(--dns) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-  dns_search:
-    description:
-      - List of custom DNS search domains.
-      - Corresponds to the C(--dns-search) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-  dns_options:
-    description:
-      - List of custom DNS options.
-      - Corresponds to the C(--dns-option) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-  endpoint_mode:
-    description:
-      - Service endpoint mode.
-      - Corresponds to the C(--endpoint-mode) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: str
-    choices:
-      - vip
-      - dnsrr
-  env:
-    description:
-      - List or dictionary of the service environment variables.
-      - If passed a list each items need to be in the format of C(KEY=VALUE).
-      - If passed a dictionary values which might be parsed as numbers,
-        booleans or other types by the YAML parser must be quoted (e.g. C("true"))
-        in order to avoid data loss.
-      - Corresponds to the C(--env) option of C(docker service create).
-    type: raw
-  env_files:
-    description:
-      - List of paths to files, present on the target, containing environment variables C(FOO=BAR).
-      - The order of the list is significant in determining the value assigned to a
-        variable that shows up more than once.
-      - If variable also present in I(env), then I(env) value will override.
-    type: list
-    version_added: "2.8"
-  force_update:
-    description:
-      - Force update even if no changes require it.
-      - Corresponds to the C(--force) option of C(docker service update).
-      - Requires API version >= 1.25.
-    type: bool
-    default: no
-  groups:
-    description:
-      - List of additional group names and/or IDs that the container process will run as.
-      - Corresponds to the C(--group) option of C(docker service update).
-      - Requires API version >= 1.25.
-    type: list
-    version_added: "2.8"
   healthcheck:
     description:
       - Configure a check that is run to determine whether or not containers for this service are "healthy".
@@ -185,53 +129,80 @@ options:
       - Requires API version >= 1.25.
     type: dict
     version_added: "2.8"
-  image:
+  tty:
     description:
-      - Service image path and tag.
-      - Corresponds to the C(IMAGE) parameter of C(docker service create).
-    type: str
-    required: yes
+      - Allocate a pseudo-TTY.
+      - Corresponds to the C(--tty) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: bool
+  dns:
+    description:
+      - List of custom DNS servers.
+      - Corresponds to the C(--dns) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+  dns_search:
+    description:
+      - List of custom DNS search domains.
+      - Corresponds to the C(--dns-search) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+  dns_options:
+    description:
+      - List of custom DNS options.
+      - Corresponds to the C(--dns-option) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+  force_update:
+    description:
+      - Force update even if no changes require it.
+      - Corresponds to the C(--force) option of C(docker service update).
+      - Requires API version >= 1.25.
+    type: bool
+    default: no
+  groups:
+    description:
+      - List of additional group names and/or IDs that the container process will run as.
+      - Corresponds to the C(--group) option of C(docker service update).
+      - Requires API version >= 1.25.
+    type: list
+    version_added: "2.8"
   labels:
     description:
       - Dictionary of key value pairs.
       - Corresponds to the C(--label) option of C(docker service create).
     type: dict
-  limits:
+  container_labels:
     description:
-      - Configures service resource limits.
-    suboptions:
-      cpus:
-        description:
-          - Service CPU limit. C(0) equals no limit.
-          - Corresponds to the C(--limit-cpu) option of C(docker service create).
-        type: float
-      memory:
-        description:
-          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
-            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-            C(T) (tebibyte), or C(P) (pebibyte)."
-          - C(0) equals no reservation.
-          - Omitting the unit defaults to bytes.
-          - Corresponds to the C(--reserve-memory) option of C(docker service create).
-        type: str
+      - Dictionary of key value pairs.
+      - Corresponds to the C(--container-label) option of C(docker service create).
     type: dict
-    version_added: "2.8"
-  limit_cpu:
+  endpoint_mode:
     description:
-      - Service CPU limit. C(0) equals no limit.
-      - Corresponds to the C(--limit-cpu) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.cpus) instead.
-    type: float
-  limit_memory:
-    description:
-      - "Service memory limit (format: C(<number>[<unit>])). Number is a positive integer.
-        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-        C(T) (tebibyte), or C(P) (pebibyte)."
-      - C(0) equals no limit.
-      - Omitting the unit defaults to bytes.
-      - Corresponds to the C(--limit-memory) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.memory) instead.
+      - Service endpoint mode.
+      - Corresponds to the C(--endpoint-mode) option of C(docker service create).
+      - Requires API version >= 1.25.
     type: str
+    choices:
+      - vip
+      - dnsrr
+  env:
+    description:
+      - List or dictionary of the service environment variables.
+      - If passed a list each items need to be in the format of C(KEY=VALUE).
+      - If passed a dictionary values which might be parsed as numbers,
+        booleans or other types by the YAML parser must be quoted (e.g. C("true"))
+        in order to avoid data loss.
+      - Corresponds to the C(--env) option of C(docker service create).
+    type: raw
+  env_files:
+    description:
+      - List of paths to files, present on the target, containing environment variables C(FOO=BAR).
+      - The order of the list is significant in determining the value assigned to a
+        variable that shows up more than once.
+      - If variable also present in I(env), then I(env) value will override.
+    type: list
+    version_added: "2.8"
   logging:
     description:
       - "Logging configuration for the service."
@@ -260,6 +231,78 @@ options:
       - Corresponds to the C(--log-opt) option of C(docker service create).
       - Deprecated in 2.8, will be removed in 2.12. Use parameter C(logging.options) instead.
     type: dict
+  reservations:
+    description:
+      - Configures service resource reservations.
+    suboptions:
+      cpus:
+        description:
+          - Service CPU reservation. C(0) equals no reservation.
+          - Corresponds to the C(--reserve-cpu) option of C(docker service create).
+        type: float
+      memory:
+        description:
+          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
+            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+            C(T) (tebibyte), or C(P) (pebibyte)."
+          - C(0) equals no reservation.
+          - Omitting the unit defaults to bytes.
+          - Corresponds to the C(--reserve-memory) option of C(docker service create).
+        type: str
+    type: dict
+    version_added: "2.8"
+  limits:
+    description:
+      - Configures service resource limits.
+    suboptions:
+      cpus:
+        description:
+          - Service CPU limit. C(0) equals no limit.
+          - Corresponds to the C(--limit-cpu) option of C(docker service create).
+        type: float
+      memory:
+        description:
+          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
+            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+            C(T) (tebibyte), or C(P) (pebibyte)."
+          - C(0) equals no reservation.
+          - Omitting the unit defaults to bytes.
+          - Corresponds to the C(--reserve-memory) option of C(docker service create).
+        type: str
+    type: dict
+    version_added: "2.8"
+  limit_cpu:
+    description:
+      - Service CPU limit. C(0) equals no limit.
+      - Corresponds to the C(--limit-cpu) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.cpus) instead.
+    type: float
+  reserve_cpu:
+    description:
+      - Service CPU reservation. C(0) equals no reservation.
+      - Corresponds to the C(--reserve-cpu) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.cpus) instead.
+    type: float
+  limit_memory:
+    description:
+      - "Service memory limit (format: C(<number>[<unit>])). Number is a positive integer.
+        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+        C(T) (tebibyte), or C(P) (pebibyte)."
+      - C(0) equals no limit.
+      - Omitting the unit defaults to bytes.
+      - Corresponds to the C(--limit-memory) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.memory) instead.
+    type: str
+  reserve_memory:
+    description:
+      - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
+        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+        C(T) (tebibyte), or C(P) (pebibyte)."
+      - C(0) equals no reservation.
+      - Omitting the unit defaults to bytes.
+      - Corresponds to the C(--reserve-memory) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.memory) instead.
+    type: str
   mode:
     description:
       - Service replication mode.
@@ -268,8 +311,8 @@ options:
     type: str
     default: replicated
     choices:
-      - replicated
-      - global
+        - replicated
+        - global
   mounts:
     description:
       - List of dictionaries describing the service mounts.
@@ -300,12 +343,79 @@ options:
           - Whether the mount should be read-only.
         type: bool
         default: no
-  name:
+  secrets:
     description:
-      - Service name.
-      - Corresponds to the C(--name) option of C(docker service create).
-    type: str
-    required: yes
+      - List of dictionaries describing the service secrets.
+      - Corresponds to the C(--secret) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+    suboptions:
+      secret_id:
+        description:
+          - Secret's ID.
+        type: str
+        required: yes
+      secret_name:
+        description:
+          - Secret's name as defined at its creation.
+        type: str
+        required: yes
+      filename:
+        description:
+          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified.
+        type: str
+      uid:
+        description:
+          - UID of the secret file's owner.
+        type: int
+        default: 0
+      gid:
+        description:
+          - GID of the secret file's group.
+        type: int
+        default: 0
+      mode:
+        description:
+          - File access mode inside the container.
+        type: int
+        default: 0o444
+  configs:
+    description:
+      - List of dictionaries describing the service configs.
+      - Corresponds to the C(--config) option of C(docker service create).
+      - Requires API version >= 1.30.
+    type: list
+    suboptions:
+      config_id:
+        description:
+          - Config's ID.
+        type: str
+        required: yes
+      config_name:
+        description:
+          - Config's name as defined at its creation.
+        type: str
+        required: yes
+      filename:
+        description:
+          - Name of the file containing the config. Defaults to the I(config_name) if not specified.
+        type: str
+        required: yes
+      uid:
+        description:
+          - UID of the config file's owner.
+        type: int
+        default: 0
+      gid:
+        description:
+          - GID of the config file's group.
+        type: int
+        default: 0
+      mode:
+        description:
+          - File access mode inside the container.
+        type: str
+        default: "0o444"
   networks:
     description:
       - List of the service networks names.
@@ -313,22 +423,19 @@ options:
         If changes are made the service will then be removed and recreated.
       - Corresponds to the C(--network) option of C(docker service create).
     type: list
-  placement:
+  stop_grace_period:
     description:
-      - Configures service placement preferences and constraints.
-    suboptions:
-      constraints:
-        description:
-          - List of the service constraints.
-          - Corresponds to the C(--constraint) option of C(docker service create).
-        type: list
-      preferences:
-        description:
-          - List of the placement preferences as key value pairs.
-          - Corresponds to the C(--placement-pref) option of C(docker service create).
-          - Requires API version >= 1.27.
-        type: list
-    type: dict
+      - Time to wait before force killing a container.
+      - "Accepts a duration as a string in a format that look like:
+        C(5h34m56s), C(1m30s) etc. The supported units are C(us), C(ms), C(s), C(m) and C(h)."
+      - Corresponds to the C(--stop-grace-period) option of C(docker service create).
+    type: str
+    version_added: "2.8"
+  stop_signal:
+    description:
+      - Override default signal used to stop the container.
+      - Corresponds to the C(--stop-signal) option of C(docker service create).
+    type: str
     version_added: "2.8"
   publish:
     description:
@@ -371,48 +478,6 @@ options:
       - Corresponds to the C(--replicas) option of C(docker service create).
     type: int
     default: -1
-  reservations:
-    description:
-      - Configures service resource reservations.
-    suboptions:
-      cpus:
-        description:
-          - Service CPU reservation. C(0) equals no reservation.
-          - Corresponds to the C(--reserve-cpu) option of C(docker service create).
-        type: float
-      memory:
-        description:
-          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
-            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-            C(T) (tebibyte), or C(P) (pebibyte)."
-          - C(0) equals no reservation.
-          - Omitting the unit defaults to bytes.
-          - Corresponds to the C(--reserve-memory) option of C(docker service create).
-        type: str
-    type: dict
-    version_added: "2.8"
-  reserve_cpu:
-    description:
-      - Service CPU reservation. C(0) equals no reservation.
-      - Corresponds to the C(--reserve-cpu) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.cpus) instead.
-    type: float
-  reserve_memory:
-    description:
-      - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
-        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-        C(T) (tebibyte), or C(P) (pebibyte)."
-      - C(0) equals no reservation.
-      - Omitting the unit defaults to bytes.
-      - Corresponds to the C(--reserve-memory) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.memory) instead.
-    type: str
-  resolve_image:
-    description:
-      - If the current image digest should be resolved from registry and updated if changed.
-    type: bool
-    default: yes
-    version_added: 2.8
   restart_config:
     description:
       - Configures if and how to restart containers when they exit.
@@ -479,71 +544,6 @@ options:
       - Corresponds to the C(--restart-window) option of C(docker service create).
       - Deprecated in 2.8, will be removed in 2.12. Use parameter C(restart_config.window) instead.
     type: raw
-  secrets:
-    description:
-      - List of dictionaries describing the service secrets.
-      - Corresponds to the C(--secret) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-    suboptions:
-      secret_id:
-        description:
-          - Secret's ID.
-        type: str
-        required: yes
-      secret_name:
-        description:
-          - Secret's name as defined at its creation.
-        type: str
-        required: yes
-      filename:
-        description:
-          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified.
-        type: str
-      uid:
-        description:
-          - UID of the secret file's owner.
-        type: int
-        default: 0
-      gid:
-        description:
-          - GID of the secret file's group.
-        type: int
-        default: 0
-      mode:
-        description:
-          - File access mode inside the container.
-        type: int
-        default: 0o444
-  state:
-    description:
-      - Service state.
-    type: str
-    required: yes
-    default: present
-    choices:
-      - present
-      - absent
-  stop_grace_period:
-    description:
-      - Time to wait before force killing a container.
-      - "Accepts a duration as a string in a format that look like:
-        C(5h34m56s), C(1m30s) etc. The supported units are C(us), C(ms), C(s), C(m) and C(h)."
-      - Corresponds to the C(--stop-grace-period) option of C(docker service create).
-    type: str
-    version_added: "2.8"
-  stop_signal:
-    description:
-      - Override default signal used to stop the container.
-      - Corresponds to the C(--stop-signal) option of C(docker service create).
-    type: str
-    version_added: "2.8"
-  tty:
-    description:
-      - Allocate a pseudo-TTY.
-      - Corresponds to the C(--tty) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: bool
   update_config:
     description:
       - Configures how the service should be updated. Useful for configuring rolling updates.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -673,13 +673,13 @@ swarm_service:
   returned: always
   type: dict
   description:
-  - Dictionary of variables representing the current state of the service.
-    Matches the module parameters format.
-  - Note that facts are not part of registered vars but accessible directly.
-  - Note that before Ansible 2.7.9, the return variable was documented as C(ansible_swarm_service),
-    while the module actually returned a variable called C(ansible_docker_service). The variable
-    was renamed to C(swarm_service) in both code and documentation for Ansible 2.7.9 and Ansible 2.8.0.
-    In Ansible 2.7.x, the old name C(ansible_docker_service) can still be used.
+    - Dictionary of variables representing the current state of the service.
+      Matches the module parameters format.
+    - Note that facts are not part of registered vars but accessible directly.
+    - Note that before Ansible 2.7.9, the return variable was documented as C(ansible_swarm_service),
+      while the module actually returned a variable called C(ansible_docker_service). The variable
+      was renamed to C(swarm_service) in both code and documentation for Ansible 2.7.9 and Ansible 2.8.0.
+      In Ansible 2.7.x, the old name C(ansible_docker_service) can still be used.
   sample: '{
     "args": [
       "3600"
@@ -770,14 +770,13 @@ swarm_service:
 changes:
   returned: always
   description:
-  - List of changed service attributes if a service has been altered,
-    [] otherwise
+    - List of changed service attributes if a service has been altered, [] otherwise.
   type: list
   sample: ['container_labels', 'replicas']
 rebuilt:
   returned: always
   description:
-  - True if the service has been recreated (removed and created)
+    - True if the service has been recreated (removed and created)
   type: bool
   sample: True
 '''

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2205,8 +2205,8 @@ def main():
         publish=dict(type='list', elements='dict', options=dict(
             published_port=dict(type='int', required=True),
             target_port=dict(type='int', required=True),
-            protocol=dict(type='str', default='tcp', choices=('tcp', 'udp')),
-            mode=dict(type='str', choices=('ingress', 'host')),
+            protocol=dict(type='str', default='tcp', choices=['tcp', 'udp']),
+            mode=dict(type='str', choices=['ingress', 'host']),
         )),
         placement=dict(type='dict', options=dict(
             constraints=dict(type='list'),
@@ -2231,7 +2231,7 @@ def main():
         mode=dict(
             type='str',
             default='replicated',
-            choices=('replicated', 'global')
+            choices=['replicated', 'global']
         ),
         replicas=dict(type='int', default=-1),
         endpoint_mode=dict(type='str', choices=['vip', 'dnsrr']),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -682,47 +682,90 @@ swarm_service:
     In Ansible 2.7.x, the old name C(ansible_docker_service) can still be used.
   sample: '{
     "args": [
-      "sleep",
       "3600"
     ],
-    "constraints": [],
-    "container_labels": {},
-    "endpoint_mode": "vip",
-    "env": [
-      "ENVVAR1=envvar1"
+    "command": [
+      "sleep"
     ],
-    "force_update": False,
-    "image": "alpine",
-    "labels": {},
-    "limit_cpu": 0.0,
-    "limit_memory": 0,
-    "log_driver": "json-file",
-    "log_driver_options": {},
+    "configs": null,
+    "constraints": [
+      "node.role == manager",
+      "engine.labels.operatingsystem == ubuntu 14.04"
+    ],
+    "container_labels": null,
+    "dns": null,
+    "dns_options": null,
+    "dns_search": null,
+    "endpoint_mode": null,
+    "env": [
+       "ENVVAR1=envvar1",
+       "ENVVAR2=envvar2"
+    ],
+    "force_update": null,
+    "groups": null,
+    "healthcheck": {
+      "interval": 90000000000,
+      "retries": 3,
+      "start_period": 30000000000,
+      "test": [
+        "CMD",
+        "curl",
+        "--fail",
+        "http://nginx.host.com"
+      ],
+      "timeout": 10000000000
+    },
+    "healthcheck_disabled": false,
+    "hostname": null,
+    "hosts": null,
+    "image": "alpine:latest@sha256:b3dbf31b77fd99d9c08f780ce6f5282aba076d70a513a8be859d8d3a4d0c92b8",
+    "labels": {
+      "com.example.department": "Finance",
+      "com.example.description": "Accounting webapp"
+    },
+    "limit_cpu": 0.5,
+    "limit_memory": 52428800,
+    "log_driver": "fluentd",
+    "log_driver_options": {
+      "fluentd-address": "127.0.0.1:24224",
+      "fluentd-async-connect": "true",
+      "tag": "myservice"
+    },
     "mode": "replicated",
     "mounts": [
       {
+        "readonly": false,
         "source": "/tmp/",
         "target": "/remote_tmp/",
         "type": "bind"
       }
     ],
-    "secrets": [],
-    "configs": [],
-    "networks": [],
-    "publish": [],
+    "networks": null,
+    "placement_preferences": [
+      {
+        "spread": "node.labels.mylabel"
+      }
+    ],
+    "publish": null,
     "replicas": 1,
-    "reserve_cpu": 0.0,
-    "reserve_memory": 0,
-    "restart_policy": "any",
-    "restart_policy_attempts": 5,
-    "restart_policy_delay": 0,
-    "restart_policy_window": 30,
-    "update_delay": 10,
-    "update_parallelism": 1,
-    "update_failure_action": "continue",
-    "update_monitor": 5000000000
-    "update_max_failure_ratio": 0,
-    "update_order": "stop-first"
+    "reserve_cpu": 0.25,
+    "reserve_memory": 20971520,
+    "restart_policy": "on-failure",
+    "restart_policy_attempts": 3,
+    "restart_policy_delay": 5000000000,
+    "restart_policy_window": 120000000000,
+    "secrets": null,
+    "stop_grace_period": null,
+    "stop_signal": null,
+    "tty": null,
+    "update_delay": 10000000000,
+    "update_failure_action": null,
+    "update_max_failure_ratio": null,
+    "update_monitor": null,
+    "update_order": "stop-first",
+    "update_parallelism": 2,
+    "user": null,
+    "working_dir": null
   }'
 changes:
   returned: always

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -21,33 +21,6 @@ description:
   - Manages docker services via a swarm manager node.
 version_added: "2.7"
 options:
-  name:
-    description:
-      - Service name.
-      - Corresponds to the C(--name) option of C(docker service create).
-    type: str
-    required: yes
-  image:
-    description:
-      - Service image path and tag.
-      - Corresponds to the C(IMAGE) parameter of C(docker service create).
-    type: str
-    required: yes
-  resolve_image:
-    description:
-      - If the current image digest should be resolved from registry and updated if changed.
-    type: bool
-    default: yes
-    version_added: 2.8
-  state:
-    description:
-      - Service state.
-    type: str
-    required: yes
-    default: present
-    choices:
-      - present
-      - absent
   args:
     description:
       - List arguments to be passed to the container.
@@ -60,29 +33,112 @@ options:
       - Corresponds to the C(COMMAND) parameter of C(docker service create).
     type: raw
     version_added: 2.8
-  placement:
+  configs:
     description:
-      - Configures service placement preferences and constraints.
+      - List of dictionaries describing the service configs.
+      - Corresponds to the C(--config) option of C(docker service create).
+      - Requires API version >= 1.30.
+    type: list
     suboptions:
-      constraints:
+      config_id:
         description:
-          - List of the service constraints.
-          - Corresponds to the C(--constraint) option of C(docker service create).
-        type: list
-      preferences:
+          - Config's ID.
+        type: str
+        required: yes
+      config_name:
         description:
-          - List of the placement preferences as key value pairs.
-          - Corresponds to the C(--placement-pref) option of C(docker service create).
-          - Requires API version >= 1.27.
-        type: list
-    type: dict
-    version_added: "2.8"
+          - Config's name as defined at its creation.
+        type: str
+        required: yes
+      filename:
+        description:
+          - Name of the file containing the config. Defaults to the I(config_name) if not specified.
+        type: str
+        required: yes
+      uid:
+        description:
+          - UID of the config file's owner.
+        type: int
+        default: 0
+      gid:
+        description:
+          - GID of the config file's group.
+        type: int
+        default: 0
+      mode:
+        description:
+          - File access mode inside the container.
+        type: str
+        default: "0o444"
   constraints:
     description:
       - List of the service constraints.
       - Corresponds to the C(--constraint) option of C(docker service create).
       - Deprecated in 2.8, will be removed in 2.12. Use parameter C(placement.constraints) instead.
     type: list
+  container_labels:
+    description:
+      - Dictionary of key value pairs.
+      - Corresponds to the C(--container-label) option of C(docker service create).
+    type: dict
+  dns:
+    description:
+      - List of custom DNS servers.
+      - Corresponds to the C(--dns) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+  dns_search:
+    description:
+      - List of custom DNS search domains.
+      - Corresponds to the C(--dns-search) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+  dns_options:
+    description:
+      - List of custom DNS options.
+      - Corresponds to the C(--dns-option) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+  endpoint_mode:
+    description:
+      - Service endpoint mode.
+      - Corresponds to the C(--endpoint-mode) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: str
+    choices:
+      - vip
+      - dnsrr
+  env:
+    description:
+      - List or dictionary of the service environment variables.
+      - If passed a list each items need to be in the format of C(KEY=VALUE).
+      - If passed a dictionary values which might be parsed as numbers,
+        booleans or other types by the YAML parser must be quoted (e.g. C("true"))
+        in order to avoid data loss.
+      - Corresponds to the C(--env) option of C(docker service create).
+    type: raw
+  env_files:
+    description:
+      - List of paths to files, present on the target, containing environment variables C(FOO=BAR).
+      - The order of the list is significant in determining the value assigned to a
+        variable that shows up more than once.
+      - If variable also present in I(env), then I(env) value will override.
+    type: list
+    version_added: "2.8"
+  force_update:
+    description:
+      - Force update even if no changes require it.
+      - Corresponds to the C(--force) option of C(docker service update).
+      - Requires API version >= 1.25.
+    type: bool
+    default: no
+  groups:
+    description:
+      - List of additional group names and/or IDs that the container process will run as.
+      - Corresponds to the C(--group) option of C(docker service update).
+      - Requires API version >= 1.25.
+    type: list
+    version_added: "2.8"
   healthcheck:
     description:
       - Configure a check that is run to determine whether or not containers for this service are "healthy".
@@ -129,80 +185,53 @@ options:
       - Requires API version >= 1.25.
     type: dict
     version_added: "2.8"
-  tty:
+  image:
     description:
-      - Allocate a pseudo-TTY.
-      - Corresponds to the C(--tty) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: bool
-  dns:
-    description:
-      - List of custom DNS servers.
-      - Corresponds to the C(--dns) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-  dns_search:
-    description:
-      - List of custom DNS search domains.
-      - Corresponds to the C(--dns-search) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-  dns_options:
-    description:
-      - List of custom DNS options.
-      - Corresponds to the C(--dns-option) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-  force_update:
-    description:
-      - Force update even if no changes require it.
-      - Corresponds to the C(--force) option of C(docker service update).
-      - Requires API version >= 1.25.
-    type: bool
-    default: no
-  groups:
-    description:
-      - List of additional group names and/or IDs that the container process will run as.
-      - Corresponds to the C(--group) option of C(docker service update).
-      - Requires API version >= 1.25.
-    type: list
-    version_added: "2.8"
+      - Service image path and tag.
+      - Corresponds to the C(IMAGE) parameter of C(docker service create).
+    type: str
+    required: yes
   labels:
     description:
       - Dictionary of key value pairs.
       - Corresponds to the C(--label) option of C(docker service create).
     type: dict
-  container_labels:
+  limits:
     description:
-      - Dictionary of key value pairs.
-      - Corresponds to the C(--container-label) option of C(docker service create).
+      - Configures service resource limits.
+    suboptions:
+      cpus:
+        description:
+          - Service CPU limit. C(0) equals no limit.
+          - Corresponds to the C(--limit-cpu) option of C(docker service create).
+        type: float
+      memory:
+        description:
+          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
+            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+            C(T) (tebibyte), or C(P) (pebibyte)."
+          - C(0) equals no reservation.
+          - Omitting the unit defaults to bytes.
+          - Corresponds to the C(--reserve-memory) option of C(docker service create).
+        type: str
     type: dict
-  endpoint_mode:
-    description:
-      - Service endpoint mode.
-      - Corresponds to the C(--endpoint-mode) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: str
-    choices:
-      - vip
-      - dnsrr
-  env:
-    description:
-      - List or dictionary of the service environment variables.
-      - If passed a list each items need to be in the format of C(KEY=VALUE).
-      - If passed a dictionary values which might be parsed as numbers,
-        booleans or other types by the YAML parser must be quoted (e.g. C("true"))
-        in order to avoid data loss.
-      - Corresponds to the C(--env) option of C(docker service create).
-    type: raw
-  env_files:
-    description:
-      - List of paths to files, present on the target, containing environment variables C(FOO=BAR).
-      - The order of the list is significant in determining the value assigned to a
-        variable that shows up more than once.
-      - If variable also present in I(env), then I(env) value will override.
-    type: list
     version_added: "2.8"
+  limit_cpu:
+    description:
+      - Service CPU limit. C(0) equals no limit.
+      - Corresponds to the C(--limit-cpu) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.cpus) instead.
+    type: float
+  limit_memory:
+    description:
+      - "Service memory limit (format: C(<number>[<unit>])). Number is a positive integer.
+        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+        C(T) (tebibyte), or C(P) (pebibyte)."
+      - C(0) equals no limit.
+      - Omitting the unit defaults to bytes.
+      - Corresponds to the C(--limit-memory) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.memory) instead.
+    type: str
   logging:
     description:
       - "Logging configuration for the service."
@@ -231,78 +260,6 @@ options:
       - Corresponds to the C(--log-opt) option of C(docker service create).
       - Deprecated in 2.8, will be removed in 2.12. Use parameter C(logging.options) instead.
     type: dict
-  reservations:
-    description:
-      - Configures service resource reservations.
-    suboptions:
-      cpus:
-        description:
-          - Service CPU reservation. C(0) equals no reservation.
-          - Corresponds to the C(--reserve-cpu) option of C(docker service create).
-        type: float
-      memory:
-        description:
-          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
-            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-            C(T) (tebibyte), or C(P) (pebibyte)."
-          - C(0) equals no reservation.
-          - Omitting the unit defaults to bytes.
-          - Corresponds to the C(--reserve-memory) option of C(docker service create).
-        type: str
-    type: dict
-    version_added: "2.8"
-  limits:
-    description:
-      - Configures service resource limits.
-    suboptions:
-      cpus:
-        description:
-          - Service CPU limit. C(0) equals no limit.
-          - Corresponds to the C(--limit-cpu) option of C(docker service create).
-        type: float
-      memory:
-        description:
-          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
-            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-            C(T) (tebibyte), or C(P) (pebibyte)."
-          - C(0) equals no reservation.
-          - Omitting the unit defaults to bytes.
-          - Corresponds to the C(--reserve-memory) option of C(docker service create).
-        type: str
-    type: dict
-    version_added: "2.8"
-  limit_cpu:
-    description:
-      - Service CPU limit. C(0) equals no limit.
-      - Corresponds to the C(--limit-cpu) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.cpus) instead.
-    type: float
-  reserve_cpu:
-    description:
-      - Service CPU reservation. C(0) equals no reservation.
-      - Corresponds to the C(--reserve-cpu) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.cpus) instead.
-    type: float
-  limit_memory:
-    description:
-      - "Service memory limit (format: C(<number>[<unit>])). Number is a positive integer.
-        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-        C(T) (tebibyte), or C(P) (pebibyte)."
-      - C(0) equals no limit.
-      - Omitting the unit defaults to bytes.
-      - Corresponds to the C(--limit-memory) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(limits.memory) instead.
-    type: str
-  reserve_memory:
-    description:
-      - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
-        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-        C(T) (tebibyte), or C(P) (pebibyte)."
-      - C(0) equals no reservation.
-      - Omitting the unit defaults to bytes.
-      - Corresponds to the C(--reserve-memory) option of C(docker service create).
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.memory) instead.
-    type: str
   mode:
     description:
       - Service replication mode.
@@ -311,8 +268,8 @@ options:
     type: str
     default: replicated
     choices:
-        - replicated
-        - global
+      - replicated
+      - global
   mounts:
     description:
       - List of dictionaries describing the service mounts.
@@ -343,79 +300,12 @@ options:
           - Whether the mount should be read-only.
         type: bool
         default: no
-  secrets:
+  name:
     description:
-      - List of dictionaries describing the service secrets.
-      - Corresponds to the C(--secret) option of C(docker service create).
-      - Requires API version >= 1.25.
-    type: list
-    suboptions:
-      secret_id:
-        description:
-          - Secret's ID.
-        type: str
-        required: yes
-      secret_name:
-        description:
-          - Secret's name as defined at its creation.
-        type: str
-        required: yes
-      filename:
-        description:
-          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified.
-        type: str
-      uid:
-        description:
-          - UID of the secret file's owner.
-        type: int
-        default: 0
-      gid:
-        description:
-          - GID of the secret file's group.
-        type: int
-        default: 0
-      mode:
-        description:
-          - File access mode inside the container.
-        type: int
-        default: 0o444
-  configs:
-    description:
-      - List of dictionaries describing the service configs.
-      - Corresponds to the C(--config) option of C(docker service create).
-      - Requires API version >= 1.30.
-    type: list
-    suboptions:
-      config_id:
-        description:
-          - Config's ID.
-        type: str
-        required: yes
-      config_name:
-        description:
-          - Config's name as defined at its creation.
-        type: str
-        required: yes
-      filename:
-        description:
-          - Name of the file containing the config. Defaults to the I(config_name) if not specified.
-        type: str
-        required: yes
-      uid:
-        description:
-          - UID of the config file's owner.
-        type: int
-        default: 0
-      gid:
-        description:
-          - GID of the config file's group.
-        type: int
-        default: 0
-      mode:
-        description:
-          - File access mode inside the container.
-        type: str
-        default: "0o444"
+      - Service name.
+      - Corresponds to the C(--name) option of C(docker service create).
+    type: str
+    required: yes
   networks:
     description:
       - List of the service networks names.
@@ -423,19 +313,22 @@ options:
         If changes are made the service will then be removed and recreated.
       - Corresponds to the C(--network) option of C(docker service create).
     type: list
-  stop_grace_period:
+  placement:
     description:
-      - Time to wait before force killing a container.
-      - "Accepts a duration as a string in a format that look like:
-        C(5h34m56s), C(1m30s) etc. The supported units are C(us), C(ms), C(s), C(m) and C(h)."
-      - Corresponds to the C(--stop-grace-period) option of C(docker service create).
-    type: str
-    version_added: "2.8"
-  stop_signal:
-    description:
-      - Override default signal used to stop the container.
-      - Corresponds to the C(--stop-signal) option of C(docker service create).
-    type: str
+      - Configures service placement preferences and constraints.
+    suboptions:
+      constraints:
+        description:
+          - List of the service constraints.
+          - Corresponds to the C(--constraint) option of C(docker service create).
+        type: list
+      preferences:
+        description:
+          - List of the placement preferences as key value pairs.
+          - Corresponds to the C(--placement-pref) option of C(docker service create).
+          - Requires API version >= 1.27.
+        type: list
+    type: dict
     version_added: "2.8"
   publish:
     description:
@@ -478,6 +371,48 @@ options:
       - Corresponds to the C(--replicas) option of C(docker service create).
     type: int
     default: -1
+  reservations:
+    description:
+      - Configures service resource reservations.
+    suboptions:
+      cpus:
+        description:
+          - Service CPU reservation. C(0) equals no reservation.
+          - Corresponds to the C(--reserve-cpu) option of C(docker service create).
+        type: float
+      memory:
+        description:
+          - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
+            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+            C(T) (tebibyte), or C(P) (pebibyte)."
+          - C(0) equals no reservation.
+          - Omitting the unit defaults to bytes.
+          - Corresponds to the C(--reserve-memory) option of C(docker service create).
+        type: str
+    type: dict
+    version_added: "2.8"
+  reserve_cpu:
+    description:
+      - Service CPU reservation. C(0) equals no reservation.
+      - Corresponds to the C(--reserve-cpu) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.cpus) instead.
+    type: float
+  reserve_memory:
+    description:
+      - "Service memory reservation (format: C(<number>[<unit>])). Number is a positive integer.
+        Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+        C(T) (tebibyte), or C(P) (pebibyte)."
+      - C(0) equals no reservation.
+      - Omitting the unit defaults to bytes.
+      - Corresponds to the C(--reserve-memory) option of C(docker service create).
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter C(reservations.memory) instead.
+    type: str
+  resolve_image:
+    description:
+      - If the current image digest should be resolved from registry and updated if changed.
+    type: bool
+    default: yes
+    version_added: 2.8
   restart_config:
     description:
       - Configures if and how to restart containers when they exit.
@@ -544,6 +479,71 @@ options:
       - Corresponds to the C(--restart-window) option of C(docker service create).
       - Deprecated in 2.8, will be removed in 2.12. Use parameter C(restart_config.window) instead.
     type: raw
+  secrets:
+    description:
+      - List of dictionaries describing the service secrets.
+      - Corresponds to the C(--secret) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: list
+    suboptions:
+      secret_id:
+        description:
+          - Secret's ID.
+        type: str
+        required: yes
+      secret_name:
+        description:
+          - Secret's name as defined at its creation.
+        type: str
+        required: yes
+      filename:
+        description:
+          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified.
+        type: str
+      uid:
+        description:
+          - UID of the secret file's owner.
+        type: int
+        default: 0
+      gid:
+        description:
+          - GID of the secret file's group.
+        type: int
+        default: 0
+      mode:
+        description:
+          - File access mode inside the container.
+        type: int
+        default: 0o444
+  state:
+    description:
+      - Service state.
+    type: str
+    required: yes
+    default: present
+    choices:
+      - present
+      - absent
+  stop_grace_period:
+    description:
+      - Time to wait before force killing a container.
+      - "Accepts a duration as a string in a format that look like:
+        C(5h34m56s), C(1m30s) etc. The supported units are C(us), C(ms), C(s), C(m) and C(h)."
+      - Corresponds to the C(--stop-grace-period) option of C(docker service create).
+    type: str
+    version_added: "2.8"
+  stop_signal:
+    description:
+      - Override default signal used to stop the container.
+      - Corresponds to the C(--stop-signal) option of C(docker service create).
+    type: str
+    version_added: "2.8"
+  tty:
+    description:
+      - Allocate a pseudo-TTY.
+      - Corresponds to the C(--tty) option of C(docker service create).
+      - Requires API version >= 1.25.
+    type: bool
   update_config:
     description:
       - Configures how the service should be updated. Useful for configuring rolling updates.

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1106,7 +1106,7 @@
     image: alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
-    labels: {}
+    healthcheck: {}
   register: healthcheck_8
   ignore_errors: yes
 
@@ -1116,7 +1116,7 @@
     image: alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
-    labels: {}
+    healthcheck: {}
   register: healthcheck_9
   ignore_errors: yes
 

--- a/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
@@ -48,7 +48,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
-      cpus: 2
+      cpus: 0.5
   register: limit_cpu_3
 
 - name: cleanup
@@ -159,7 +159,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
-      cpus: 2
+      cpus: 0.5
   register: reserve_cpu_3
 
 - name: cleanup

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -26,6 +26,7 @@ service_expected_output:
   mode: global
   mounts: null
   networks: null
+  secrets: null
   stop_grace_period: null
   stop_signal: null
   placement_preferences: null
@@ -46,4 +47,5 @@ service_expected_output:
   update_monitor: null
   update_order: null
   update_parallelism: null
+  user: null
   working_dir: null


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes a number of issues:
* `mode` choices is now validated and documented. Documentation about recreation of service is now correctly under this option and not `publish.mode`
* Update and extend examples
* Some test fixes
* Update module return value sample with correct fields
* Add `secrets` and `users` to module return value

BTW @felixfontein I love these new fast tests!

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
