### PR TITLE
docker_swarm_service: Add read_only option

### DIFF
--- a/changelogs/fragments/53482-docker_swarm_service-read_only_option.yaml
+++ b/changelogs/fragments/53482-docker_swarm_service-read_only_option.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - Added support for ``read_only`` parameter."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -475,6 +475,7 @@ options:
       - Mount the containers root filesystem as read only.
       - Corresponds to the C(--read-only) option of C(docker service create).
     type: bool
+    version_added: "2.8"
   replicas:
     description:
       - Number of containers instantiated in the service. Valid only if I(mode) is C(replicated).

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1821,6 +1821,58 @@
   when: docker_api_version is version('1.25', '<') or docker_py_version is version('3.0.0', '<')
 
 ###################################################################
+## read_only ######################################################
+###################################################################
+
+- name: read_only
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    read_only: true
+  register: read_only_1
+  ignore_errors: yes
+
+- name: read_only (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    read_only: true
+  register: read_only_2
+  ignore_errors: yes
+
+- name: read_only (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    read_only: false
+  register: read_only_3
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - read_only_1 is changed
+      - read_only_2 is not changed
+      - read_only_3 is changed
+  when: docker_api_version is version('1.28', '>=') and docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - read_only_1 is failed
+    - "'Minimum version required' in read_only_1.msg"
+  when: docker_api_version is version('1.28', '<') or docker_py_version is version('2.6.0', '<')
+
+###################################################################
 ## replicas #######################################################
 ###################################################################
 

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -33,6 +33,7 @@ service_expected_output:
   publish:
     - {mode: null, protocol: tcp, published_port: 60001, target_port: 60001}
     - {mode: null, protocol: udp, published_port: 60001, target_port: 60001}
+  read_only: null
   replicas: null
   reserve_cpu: null
   reserve_memory: null


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add `read_only` option.

https://docs.docker.com/engine/reference/commandline/service_create/#options

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service