### PR TITLE
WIP - test out get_url in Shippable

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -337,6 +337,7 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 # ==============================================================
 # url handling
+# comment for testing
 
 
 def url_filename(url):


### PR DESCRIPTION
get_url seems to be failing on Ubuntu 14.04, cannot replicate locally so trying out a few things