### PR TITLE
Fix maven_artifact.py when your maven is behind a cloudflare

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -297,7 +297,7 @@ class MavenDownloader:
         self.base = base
         self.local = local
         self.headers = headers
-        self.user_agent = "Maven Artifact Downloader/1.0"
+        self.user_agent = "Ansible {0} maven_artifact".format(self.module.ansible_version)
         self.latest_version_found = None
         self.metadata_file_name = "maven-metadata-local.xml" if local else "maven-metadata.xml"
 
@@ -380,7 +380,7 @@ class MavenDownloader:
         # Hack to add parameters in the way that fetch_url expects
         self.module.params['url_username'] = self.module.params.get('username', '')
         self.module.params['url_password'] = self.module.params.get('password', '')
-        self.module.params['http_agent'] = self.module.params.get('user_agent', None)
+        self.module.params['http_agent'] = self.user_agent
 
         response, info = fetch_url(self.module, url_to_use, timeout=req_timeout, headers=self.headers)
         if info['status'] == 200:


### PR DESCRIPTION
Cloudflare has a feature that checks Browser Integrity Check, when the user agent is not present, it can fail on BIC.

Since we are defining the default value of variable "self.module.params['http_agent']" to None, this will cause that User-Agent header will not be added, because of the conditional if present on module_utils/urls.py [1]

[1] https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/urls.py#L1135-L1136

This fix will ensure that the "self.module.params['http_agent']" will be defined if user_agent is passed through the module

URLs:
https://support.cloudflare.com/hc/en-us/articles/200171806-Error-1010-The-owner-of-this-website-has-banned-your-access-based-on-your-browser-s-signature
https://support.cloudflare.com/hc/en-us/articles/200170086-What-does-the-Browser-Integrity-Check-do-

##### SUMMARY
This change allows downloading artifacts from a maven installation that's behind Cloudflare.

When User-Agent is not present and try to download from a Cloudflare server that has Browser Integrity Check enabled, it fails.

##### ISSUE TYPE
BugFix

##### COMPONENT NAME
maven_artifact.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
