### PR TITLE
Fix node_id parameter for node removal

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -273,6 +273,7 @@ class TaskParameters(DockerBaseClass):
         self.election_tick = None
         self.dispatcher_heartbeat_period = None
         self.node_cert_expiry = None
+        self.node_id = None
         self.name = None
         self.labels = None
         self.log_driver = None
@@ -512,7 +513,7 @@ class SwarmManager(DockerBaseClass):
             self.client.fail("This node is not a manager.")
 
         try:
-            status_down = self.client.check_if_swarm_node_is_down(repeat_check=5)
+            status_down = self.client.check_if_swarm_node_is_down(node_id=self.parameters.node_id, repeat_check=5)
         except APIError:
             return
 


### PR DESCRIPTION
##### SUMMARY
The module currently does not define a default `None` for `node_id` in the Spec section.  It also does not apply it during the node removal phase causing the removal to get attempted on the swarm manager that is receiving the API request instead of the swarm node specified by the `node_id` parameter.  This is met with an error since the manager receiving the request is likely not demoted and if it was it could not service the API request.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm

##### ADDITIONAL INFORMATION
This fixes https://github.com/ansible/ansible/issues/53501
More full details are in the issue on how to reproduce, system details, etc.  But I think this one is pretty straight forward.