### PR TITLE
apply node_id parameter to swarm node removal

### DIFF
--- a/changelogs/fragments/53503-docker_swarm_fix_node_id.yml
+++ b/changelogs/fragments/53503-docker_swarm_fix_node_id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_swarm - Fixed node_id parameter not working for node removal (https://github.com/ansible/ansible/issues/53501)

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -395,6 +395,7 @@ class SwarmManager(DockerBaseClass):
 
         self.state = client.module.params['state']
         self.force = client.module.params['force']
+        self.node_id = client.module.params['node_id']
 
         self.differences = DifferenceTracker()
         self.parameters = TaskParameters.from_ansible_params(client)
@@ -512,7 +513,7 @@ class SwarmManager(DockerBaseClass):
             self.client.fail("This node is not a manager.")
 
         try:
-            status_down = self.client.check_if_swarm_node_is_down(repeat_check=5)
+            status_down = self.client.check_if_swarm_node_is_down(node_id=self.node_id, repeat_check=5)
         except APIError:
             return
 
@@ -521,7 +522,7 @@ class SwarmManager(DockerBaseClass):
 
         if not self.check_mode:
             try:
-                self.client.remove_node(node_id=self.parameters.node_id, force=self.force)
+                self.client.remove_node(node_id=self.node_id, force=self.force)
             except APIError as exc:
                 self.client.fail("Can not remove the node from the Swarm Cluster: %s" % to_native(exc))
         self.results['actions'].append("Node is removed from swarm cluster.")


### PR DESCRIPTION
##### SUMMARY
The module currently does not define a default `None` for `node_id` in the Spec section.  It also does not apply it during the node removal phase causing the removal to get attempted on the swarm manager that is receiving the API request instead of the swarm node specified by the `node_id` parameter.  This is met with an error since the manager receiving the request is likely not demoted and if it was it could not service the API request.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm

##### ADDITIONAL INFORMATION
This fixes https://github.com/ansible/ansible/issues/53501
More full details are in the issue on how to reproduce, system details, etc.  But I think this one is pretty straight forward.