### PR TITLE
Fixes typo of dicionaries to dictionaries

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -364,7 +364,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_instances_by_region(self, regions, filters, strict_permissions):
         '''
            :param regions: a list of regions in which to describe instances
-           :param filters: a list of boto3 filter dicionaries
+           :param filters: a list of boto3 filter dictionaries
            :param strict_permissions: a boolean determining whether to fail or ignore 403 error codes
            :return A list of instance dictionaries
         '''

--- a/lib/ansible/plugins/inventory/aws_rds.py
+++ b/lib/ansible/plugins/inventory/aws_rds.py
@@ -166,8 +166,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_all_hosts(self, regions, instance_filters, cluster_filters, strict, statuses, gather_clusters=False):
         '''
            :param regions: a list of regions in which to describe hosts
-           :param instance_filters: a list of boto3 filter dicionaries
-           :param cluster_filters: a list of boto3 filter dicionaries
+           :param instance_filters: a list of boto3 filter dictionaries
+           :param cluster_filters: a list of boto3 filter dictionaries
            :param strict: a boolean determining whether to fail or ignore 403 error codes
            :param statuses: a list of statuses that the returned hosts should match
            :return A list of host dictionaries


### PR DESCRIPTION
Fixes typo of `dicionaries` to `dictionaries`

cc @Akasurde 