### PR TITLE
Fixed win_file crash with hidden files (#52584) - 2.6

### DIFF
--- a/changelogs/fragments/win_file-hidden.yaml
+++ b/changelogs/fragments/win_file-hidden.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_file - Fix issue when managing hidden files and directories - https://github.com/ansible/ansible/issues/42466

--- a/lib/ansible/modules/windows/win_file.ps1
+++ b/lib/ansible/modules/windows/win_file.ps1
@@ -106,7 +106,7 @@ if ($state -eq "touch") {
 }
 
 if (Test-Path -LiteralPath $path) {
-    $fileinfo = Get-Item -LiteralPath $path
+    $fileinfo = Get-Item -LiteralPath $path -Force
     if ($state -eq "absent") {
         Remove-File -file $fileinfo -checkmode $check_mode
         $result.changed = $true

--- a/test/integration/targets/win_file/tasks/main.yml
+++ b/test/integration/targets/win_file/tasks/main.yml
@@ -568,6 +568,27 @@
        - file_result.changed
        - "stat_result.stat.exists == False"
 
+# Need to use shell to create the file as win_file doesn't support setting attributes
+- name: create hidden file
+  win_shell: $file = New-Item -Path "{{ win_output_dir }}\hidden.txt" -ItemType File; $file.Attributes = "Hidden"
+
+- name: delete hidden file
+  win_file:
+    path: '{{ win_output_dir }}\hidden.txt'
+    state: absent
+  register: delete_hidden
+
+- name: get result of delete hidden file
+  win_stat:
+    path: '{{ win_output_dir }}\hidden.txt'
+  register: delete_hidden_actual
+
+- name: assert delete hidden file
+  assert:
+    that:
+    - delete_hidden is changed
+    - not delete_hidden_actual.stat.exists
+
 - name: create folder to point set symbolic link for
   win_file:
     path: "{{win_output_dir}}/link-test/link-target"


### PR DESCRIPTION
(cherry picked from commit 3bc474bf99ad2109262366809bd735deef1312ee)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/52584

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_file