### PR TITLE
Add option to use old name sanitization for azure_rm and gcp_compute inventory plugins

### DIFF
--- a/changelogs/fragments/allow_bad_things.yml
+++ b/changelogs/fragments/allow_bad_things.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Ebmed an overridable static santiization method into base inventory plugin class to allow individual plugins to override

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -149,6 +149,7 @@ class BaseInventoryPlugin(AnsiblePlugin):
     """ Parses an Inventory Source"""
 
     TYPE = 'generator'
+    _sanatize_group_name = staticmethod(to_safe_group_name)
 
     def __init__(self):
 
@@ -369,7 +370,7 @@ class Constructable(object):
             self.templar.set_available_variables(variables)
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = to_safe_group_name(group_name)
+                group_name = self._sanatize_group_name(group_name)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:
@@ -415,12 +416,12 @@ class Constructable(object):
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
 
                         for bare_name in new_raw_group_names:
-                            gname = to_safe_group_name('%s%s%s' % (prefix, sep, bare_name))
+                            gname = self._sanatize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             self.inventory.add_group(gname)
                             self.inventory.add_child(gname, host)
 
                             if raw_parent_name:
-                                parent_name = to_safe_group_name(raw_parent_name)
+                                parent_name = self._sanatize_group_name(raw_parent_name)
                                 self.inventory.add_group(parent_name)
                                 self.inventory.add_child(parent_name, gname)
 

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -149,7 +149,7 @@ class BaseInventoryPlugin(AnsiblePlugin):
     """ Parses an Inventory Source"""
 
     TYPE = 'generator'
-    _sanatize_group_name = staticmethod(to_safe_group_name)
+    _sanitize_group_name = staticmethod(to_safe_group_name)
 
     def __init__(self):
 
@@ -370,7 +370,7 @@ class Constructable(object):
             self.templar.set_available_variables(variables)
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = self._sanatize_group_name(group_name)
+                group_name = self._sanitize_group_name(group_name)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:
@@ -379,7 +379,7 @@ class Constructable(object):
                     continue
 
                 if result:
-                    # ensure group exists, use sanatized name
+                    # ensure group exists, use sanitized name
                     group_name = self.inventory.add_group(group_name)
                     # add host to group
                     self.inventory.add_child(group_name, host)
@@ -416,12 +416,12 @@ class Constructable(object):
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
 
                         for bare_name in new_raw_group_names:
-                            gname = self._sanatize_group_name('%s%s%s' % (prefix, sep, bare_name))
+                            gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             self.inventory.add_group(gname)
                             self.inventory.add_child(gname, host)
 
                             if raw_parent_name:
-                                parent_name = self._sanatize_group_name(raw_parent_name)
+                                parent_name = self._sanitize_group_name(raw_parent_name)
                                 self.inventory.add_group(parent_name)
                                 self.inventory.add_child(parent_name, gname)
 

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -73,8 +73,10 @@ DOCUMENTATION = '''
           description:
             - By default this plugin is using a general group name sanitization to create safe and usable group names for use in Ansible.
               This toggle allows those migration from the old ec2.py inventory script that want to continue using the old sanitization to do so.
-              For this to work you should also turn off the TRANSFORM_INVALID_GROUP_CHARS setting, otherwise the core engine will just use the standard sanitization on top.
-            - This is not the default as such names break certain functionality as not all characters are valid Python identifiers which group names end up being used as.
+              For this to work you should also turn off the TRANSFORM_INVALID_GROUP_CHARS setting,
+              otherwise the core engine will just use the standard sanitization on top.
+            - This is not the default as such names break certain functionality as not all characters are valid Python identifiers
+              which group names end up being used as.
           type: bool
           default: False
 '''
@@ -143,6 +145,7 @@ compose:
   # (note: this does not modify inventory_hostname, which is set via I(hostnames))
   ansible_host: private_ip_address
 '''
+import re
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native, to_text
@@ -531,7 +534,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         config_data = self._read_config_data(path)
 
-        if get_option('use_legacy_script_group_name_sanitization'):
+        if self.get_option('use_legacy_script_group_name_sanitization'):
             self._sanitize_group_name = self._legacy_script_compatible_group_sanitization
 
         self._set_credentials()

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -526,12 +526,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return False
 
     def parse(self, inventory, loader, path, cache=True):
+
         super(InventoryModule, self).parse(inventory, loader, path)
+
+        config_data = self._read_config_data(path)
 
         if get_option('use_legacy_script_group_name_sanitization'):
             self._sanitize_group_name = self._legacy_script_compatible_group_sanitization
 
-        config_data = self._read_config_data(path)
         self._set_credentials()
 
         # get user specifications

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -51,6 +51,17 @@ DOCUMENTATION = '''
         vars_prefix:
             description: prefix to apply to host variables, does not include facts nor params
             default: ''
+        use_legacy_script_group_name_sanitization:
+          description:
+            - By default this plugin is using a general group name sanitization to create safe and usable group names for use in Ansible.
+              This toggle allows those migration from the old gce.py inventory script that want to continue using no sanitization to do so.
+              For this to work you should also turn off the TRANSFORM_INVALID_GROUP_CHARS setting,
+              otherwise the core engine will just use the standard sanitization on top.
+            - This is not the default as such names break certain functionality as not all characters are valid Python identifiers
+              which group names end up being used as.
+          type: bool
+          default: False
+          version_added: "2.8"
 '''
 
 EXAMPLES = '''
@@ -324,6 +335,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         config_data = {}
         config_data = self._read_config_data(path)
+
+        if config_data.get('use_legacy_script_group_name_sanitization', False):
+            self._sanitize_group_name = lambda name: name
 
         # get user specifications
         if 'zones' in config_data:


### PR DESCRIPTION
##### SUMMARY
This implements an option to make the group name sanitization behave as it used to. Work had already began on doing this for ec2, but it is needed for azure and gcp.

It is also technically needed for tower, but I may leave that for another pull request.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm inventory plugin
gcp_compute inventory plugin

##### ADDITIONAL INFORMATION
I have done testing with `ansible-inventory` on the CLI with both of these

In general terms the commands look like

```
ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS=false ansible-inventory -i gcp_compute.yml --list --export
```

I have some specific groups that I'm looking to validate:

 - in the case of gcp, I need to see IP names with `.` in them
 - in the case of azure, I need to see groupings by resource groups or security groups with `-` in them