### PR TITLE
[2.7] [docker_image] fix the changed state for tagging and pushing

### DIFF
--- a/changelogs/fragments/53451-docker_image-fix-changed-tag-push.yml
+++ b/changelogs/fragments/53451-docker_image-fix-changed-tag-push.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_image - set ``changed`` to ``false`` when using ``force: yes`` to tag or push an image that ends up being identical to one already present on the Docker host or Docker registry."

--- a/test/integration/targets/docker_image/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_image/tasks/tests/basic.yml
@@ -38,6 +38,41 @@
     - present_1 is changed
     - present_2 is not changed
 
+- name: Make sure tag is not there
+  docker_image:
+    name: "hello-world:alias"
+    state: absent
+
+- name: Tag image with alias
+  docker_image:
+    name: "hello-world:latest"
+    repository: "hello-world:alias"
+  register: tag_1
+
+- name: Tag image with alias (idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    repository: "hello-world:alias"
+  register: tag_2
+
+- name: Tag image with alias (force, still idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    repository: "hello-world:alias"
+    force: yes
+  register: tag_3
+
+- assert:
+    that:
+    - tag_1 is changed
+    - tag_2 is not changed
+    - tag_3 is not changed
+
+- name: Cleanup alias tag
+  docker_image:
+    name: "hello-world:alias"
+    state: absent
+
 ####################################################################
 ## interact with test registry #####################################
 ####################################################################
@@ -61,10 +96,19 @@
     push: yes
   register: push_2
 
+- name: Push image to test registry (force, still idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    repository: "{{ registry_address }}/test/hello-world"
+    push: yes
+    force: yes
+  register: push_3
+
 - assert:
     that:
     - push_1 is changed
     - push_2 is not changed
+    - push_3 is not changed
 
 - name: Get facts of local image
   docker_image_facts:


### PR DESCRIPTION
##### SUMMARY
Backport of #53451 to stable-2.7: don't have `changed == True` when the image is already at the destination.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_image
