### PR TITLE
nxos_vxlan_vtep: sanity.yaml test needs cast for httpapi tcam check

### DIFF
--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -31,7 +31,7 @@
   - block:
     - set_fact: global_suppress_arp="true"
     - set_fact: def_global_suppress_arp="false"
-    when: tcam_state.stdout[0] != 0
+    when: "tcam_state.stdout[0]|int > 0"
 
   when:  platform is search('N9K') and (major_version is version('9.2', 'ge'))
 


### PR DESCRIPTION
##### SUMMARY
This check was working for `network_cli` (returns value as int) but
failing for `httpapi` (returns value as str). Casting to `int` fixes the problem.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_vxlan_vtep`
