### PR TITLE
nxos_user: auth.yaml test: stronger test password needed

### DIFF
--- a/test/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/common/auth.yaml
@@ -6,13 +6,13 @@
       role: network-operator
       provider: "{{ connection }}"
       state: present
-      configured_password: pass123
+      configured_password: pasS!123
 
   - name: test login
     expect:
       command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
       responses:
-        (?i)password: "pass123"
+        (?i)password: "pasS!123"
 
   - name: test login with invalid password (should fail)
     expect:


### PR DESCRIPTION
##### SUMMARY
`nxos_user/tests/common/auth.yaml:11` fails because the simple password added in an earlier step was rejected by the device.

Basic passwords are rejected by the nxos device unless `no password strength-check`
is configured. This change just makes the password meet the minimum strength checks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_user`

##### ADDITIONAL INFORMATION
 NXOS: version 9.2(2)
 cisco Nexus9000 9000v Chassis