### PR TITLE
 Don't raise AnsibleConnectionFailure if the ssh process has already died.

### DIFF
--- a/changelogs/fragments/ssh-check-returncode-before-exception.yaml
+++ b/changelogs/fragments/ssh-check-returncode-before-exception.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+- ssh - Check the return code of the ssh process before raising AnsibleConnectionFailure, as the error message
+  for the ssh process will likely contain more useful information. This will improve the missing interpreter messaging
+  when using modules such as setup which have a larger payload to transfer when combined with pipelining.
+  (https://github.com/ansible/ansible/issues/53487)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -975,8 +975,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
             # try to figure out if we are missing interpreter
             if self._used_interpreter is not None:
-                match = '%s: No such file or directory' % self._used_interpreter.lstrip('!#')
-                if match in data['module_stderr'] or match in data['module_stdout']:
+                match = re.compile('%s: (?:No such file or directory|not found)' % self._used_interpreter.lstrip('!#'))
+                if match.search(data['module_stderr']) or match.search(data['module_stdout']):
                     data['msg'] = "The module failed to execute correctly, you probably need to set the interpreter."
 
             # always append hint

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -663,7 +663,7 @@ class Connection(ConnectionBase):
 
         return b_command
 
-    def _send_initial_data(self, fh, in_data):
+    def _send_initial_data(self, fh, in_data, ssh_process):
         '''
         Writes initial data to the stdin filehandle of the subprocess and closes
         it. (The handle must be closed; otherwise, for example, "sftp -b -" will
@@ -676,7 +676,15 @@ class Connection(ConnectionBase):
             fh.write(to_bytes(in_data))
             fh.close()
         except (OSError, IOError):
-            raise AnsibleConnectionFailure('SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached over ssh' % self.host)
+            # The ssh connection may have already terminated at this point, with a more useful error
+            # Only raise AnsibleConnectionFailure if the ssh process is still alive
+            time.sleep(0.001)
+            ssh_process.poll()
+            if getattr(ssh_process, 'returncode', None) is None:
+                raise AnsibleConnectionFailure(
+                    'SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached '
+                    'over ssh' % self.host
+                )
 
         display.debug('Sent initial data (%d bytes)' % len(in_data))
 
@@ -853,7 +861,7 @@ class Connection(ConnectionBase):
         # If we can send initial data without waiting for anything, we do so
         # before we start polling
         if states[state] == 'ready_to_send' and in_data:
-            self._send_initial_data(stdin, in_data)
+            self._send_initial_data(stdin, in_data, p)
             state += 1
 
         try:
@@ -967,7 +975,7 @@ class Connection(ConnectionBase):
 
                 if states[state] == 'ready_to_send':
                     if in_data:
-                        self._send_initial_data(stdin, in_data)
+                        self._send_initial_data(stdin, in_data, p)
                     state += 1
 
                 # Now we're awaiting_exit: has the child process exited? If it has,


### PR DESCRIPTION
##### SUMMARY
 Don't raise AnsibleConnectionFailure if the ssh process has already died. Fixes #53487 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/plugins/connection/ssh.py
lib/ansible/plugins/action/__init__.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```