### PR TITLE
remove some instances of `state: installed` from examples

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_environment.rst
+++ b/docs/docsite/rst/user_guide/playbooks_environment.rst
@@ -16,7 +16,10 @@ Ansible makes it easy for you to configure the remote execution environment by u
 
       tasks:
 
-        - apt: name=cobbler state=installed
+        - name: Install cobbler
+          package:
+            name: cobbler
+            state: present
           environment:
             http_proxy: http://proxy.example.com:8080
 
@@ -32,7 +35,10 @@ The environment can also be stored in a variable, and accessed like so::
 
       tasks:
 
-        - apt: name=cobbler state=installed
+        - name: Install cobbler
+          package:
+            name: cobbler
+            state: present
           environment: "{{proxy_env}}"
 
 You can also use it at a play level::

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -371,7 +371,7 @@ EXAMPLES = r'''
         - nm-connection-editor
         - libsemanage-python
         - policycoreutils-python
-      state: installed
+      state: present
 
 ##### Working with all cloud nodes - Teaming
   - name: Try nmcli add team - conn_name only & ip4 gw4

--- a/lib/ansible/modules/packaging/os/swdepot.py
+++ b/lib/ansible/modules/packaging/os/swdepot.py
@@ -46,7 +46,7 @@ options:
 EXAMPLES = '''
 - swdepot:
     name: unzip-6.0
-    state: installed
+    state: present
     depot: 'repository:/path'
 
 - swdepot:

--- a/lib/ansible/modules/utilities/logic/async_status.py
+++ b/lib/ansible/modules/utilities/logic/async_status.py
@@ -48,7 +48,7 @@ EXAMPLES = r'''
 - name: Asynchronous yum task
   yum:
     name: docker-io
-    state: installed
+    state: present
   async: 1000
   poll: 0
   register: yum_sleeper


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes the examples in multiple modules so they use `state: present`
instead of `state: installed`.

fix Partially  #47869
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli_module
swdepot_module
async_status_module

