### PR TITLE
Add a force_replace_host flag to win_domain_membership

### DIFF
--- a/changelogs/fragments/win_domain_membership-replace.yaml
+++ b/changelogs/fragments/win_domain_membership-replace.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_domain_membership - will now fail if an existing AD object for the host exists and ``allow_existing_computer_account=no`` - https://github.com/ansible/ansible/pull/53542

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -315,6 +315,10 @@ Noteworthy module changes
 * The ``win_dsc`` module will now validate the input options for a DSC resource. In previous versions invalid options
   would be ignored but are now not.
 
+* The ``win_domain_membership`` module will no longer automatically join a host in a domain that already has an account
+  with the same name. Set ``allow_existing_computer_account=yes`` to override this check and go back to the original
+  behaviour.
+
 Plugins
 =======
 

--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -47,7 +47,7 @@ Function Get-DomainMembershipMatch {
     }
     catch [System.Security.Authentication.AuthenticationException] {
         Write-DebugLog "Failed to get computer domain.  Attempting a different method."
-        Add-Type -AssemblyName System.DirectoryServices.AccountManagement            
+        Add-Type -AssemblyName System.DirectoryServices.AccountManagement
         $user_principal = [System.DirectoryServices.AccountManagement.UserPrincipal]::Current
         If ($user_principal.ContextType -eq "Machine") {
             $current_dns_domain = (Get-CimInstance -ClassName Win32_ComputerSystem -Property Domain).Domain
@@ -132,10 +132,10 @@ Function Join-Domain {
     $argstr = $add_args | Out-String
     Write-DebugLog "calling Add-Computer with args: $argstr"
     try {
-        if($hostname_in_domain -eq $null -or ($hostname_in_domain -ne $null -and $allow_existing_computer_account)) {
+        if($null -eq $hostname_in_domain -or ($null -ne $hostname_in_domain -and $allow_existing_computer_account)) {
             $add_result = Add-Computer @add_args
         } else {
-            Fail-Json -obj $result -message "failed to join domain: hostname already exists in AD and `$allow_existing_computer_account isn't set to true"
+            Fail-Json -obj $result -message "failed to join domain: hostname already exists in AD and allow_existing_computer_account=no"
         }
     } catch {
         Fail-Json -obj $result -message "failed to join domain: $($_.Exception.Message)"

--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -132,7 +132,7 @@ Function Join-Domain {
         if(Get-ADObject $new_hostname -eq $null -or (Get-ADObject $new_hostname -ne $null -and $force_replace_host)) {
             $add_result = Add-Computer @add_args
         } else {
-            Fail-Json -obj $result -message "failed to join domain: hostname already exists in AD and `force_replace_host` isn't `true`"
+            Fail-Json -obj $result -message "failed to join domain: hostname already exists in AD and `$force_replace_host isn't set to true"
         }
     } catch {
         Fail-Json -obj $result -message "failed to join domain: $($_.Exception.Message)"

--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -103,7 +103,7 @@ Function Join-Domain {
         [string] $domain_admin_user,
         [string] $domain_admin_password,
         [string] $domain_ou_path,
-        [bool]   $force_replace_host
+        [bool]   $allow_existing_computer_account
     )
 
     Write-DebugLog ("Creating credential for user {0}" -f $domain_admin_user)
@@ -132,10 +132,10 @@ Function Join-Domain {
     $argstr = $add_args | Out-String
     Write-DebugLog "calling Add-Computer with args: $argstr"
     try {
-        if($hostname_in_domain -eq $null -or ($hostname_in_domain -ne $null -and $force_replace_host)) {
+        if($hostname_in_domain -eq $null -or ($hostname_in_domain -ne $null -and $allow_existing_computer_account)) {
             $add_result = Add-Computer @add_args
         } else {
-            Fail-Json -obj $result -message "failed to join domain: hostname already exists in AD and `$force_replace_host isn't set to true"
+            Fail-Json -obj $result -message "failed to join domain: hostname already exists in AD and `$allow_existing_computer_account isn't set to true"
         }
     } catch {
         Fail-Json -obj $result -message "failed to join domain: $($_.Exception.Message)"
@@ -206,7 +206,7 @@ $workgroup_name = Get-AnsibleParam $params "workgroup_name"
 $domain_admin_user = Get-AnsibleParam $params "domain_admin_user" -failifempty $result
 $domain_admin_password = Get-AnsibleParam $params "domain_admin_password" -failifempty $result
 $domain_ou_path = Get-AnsibleParam $params "domain_ou_path"
-$force_replace_host = Get-AnsibleParam $params "force_replace_host" -type "bool" -default $false
+$allow_existing_computer_account = Get-AnsibleParam $params "allow_existing_computer_account" -type "bool" -default $false
 
 $log_path = Get-AnsibleParam $params "log_path"
 $_ansible_check_mode = Get-AnsibleParam $params "_ansible_check_mode" -default $false
@@ -248,7 +248,7 @@ Try {
                         dns_domain_name = $dns_domain_name
                         domain_admin_user = $domain_admin_user
                         domain_admin_password = $domain_admin_password
-                        force_replace_host = $force_replace_host
+                        allow_existing_computer_account = $allow_existing_computer_account
                     }
 
                     Write-DebugLog "not a domain member, joining..."

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -48,6 +48,13 @@ options:
     description:
       - When C(state) is C(workgroup), the name of the workgroup that the Windows host should be in.
     type: str
+  force_replace_host:
+    description:
+      - If a host with the same hostname is already in the AD, replace it.
+    type: bool
+    choices: [ true, false ]
+    default: false
+    version_added: "2.7"
 seealso:
 - module: win_domain
 - module: win_domain_controller

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -48,7 +48,7 @@ options:
     description:
       - When C(state) is C(workgroup), the name of the workgroup that the Windows host should be in.
     type: str
-  force_replace_host:
+  allow_existing_computer_account:
     description:
       - If a host with the same hostname is already in the AD, replace it.
     type: bool

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -54,7 +54,7 @@ options:
     type: bool
     choices: [ true, false ]
     default: false
-    version_added: "2.7"
+    version_added: "2.8"
 seealso:
 - module: win_domain
 - module: win_domain_controller

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -57,7 +57,6 @@ lib/ansible/modules/windows/win_domain_controller.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_domain_controller.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_domain_group.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_domain_membership.ps1 PSAvoidGlobalVars
-lib/ansible/modules/windows/win_domain_membership.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_domain_membership.ps1 PSAvoidUsingWMICmdlet
 lib/ansible/modules/windows/win_domain_membership.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_domain_membership.ps1 PSUseApprovedVerbs


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Currently, [`win_domain_membership`](https://docs.ansible.com/ansible/latest/modules/win_domain_membership_module.html) will join current computer to the given domain, **replacing** any machine with the same name that is already in the domain. If one is unaware of this [expected behaviour](https://social.technet.microsoft.com/Forums/Azure/en-US/6ca18455-a583-4a22-841b-0e6ba586ea7c/join-domain-overwrites-existing-computer-name?forum=winserverDS), this is a dangerous proposition.

Satisfies https://github.com/ansible/ansible/issues/53539

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`win_domain_membership`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->