### PR TITLE
Try to get correct buffer size to avoid races

### DIFF
--- a/changelogs/fragments/avoid_race.yml
+++ b/changelogs/fragments/avoid_race.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Attempt to avoid race condition based on incorrect buffer size assumptions

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2916,7 +2916,7 @@ class AnsibleModule(object):
             try:
                 # not as exact as above, but should be good enough for most platforms that fail the previous call
                 buffer_size = select.PIPE_BUF
-             except Exception:
+            except Exception:
                 buffer_size = 9000  # use sane default JIC
 
         return buffer_size

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2912,11 +2912,11 @@ class AnsibleModule(object):
         try:
             # 1032 == FZ_GETPIPE_SZ
             buffer_size = fcntl.fcntl(fd, 1032)
-         except Exception:
+        except Exception:
             try:
                 # not as exact as above, but should be good enough for most platforms that fail the previous call
                 buffer_size = select.PIPE_BUF
-            except Exception:
+             except Exception:
                 buffer_size = 9000  # use sane default JIC
 
         return buffer_size

--- a/test/units/module_utils/basic/test_run_command.py
+++ b/test/units/module_utils/basic/test_run_command.py
@@ -83,6 +83,7 @@ def rc_am(mocker, am, mock_os, mock_subprocess):
     am.fail_json = mocker.MagicMock(side_effect=SystemExit)
     am._os = mock_os
     am._subprocess = mock_subprocess
+    am.get_buffer_size = mocker.MagicMock(return_value=900)
     yield am
 
 


### PR DESCRIPTION
Avoid subtle race condition by trying to use accurate buffer size instead of guessing.

  fixes #51393


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/basic
