### PR TITLE
nxos_igmp_snooping: more group-timeout fixes

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
@@ -181,11 +181,12 @@ def config_igmp_snooping(delta, existing, default=False):
 
     commands = []
     command = None
+    gt_command = None
     for key, value in delta.items():
         if value:
             if default and key == 'group_timeout':
                 if existing.get(key):
-                    command = 'no ' + CMDS.get(key).format(existing.get(key))
+                    gt_command = 'no ' + CMDS.get(key).format(existing.get(key))
             elif value == 'default' and key == 'group_timeout':
                 if existing.get(key):
                     command = 'no ' + CMDS.get(key).format(existing.get(key))
@@ -198,6 +199,9 @@ def config_igmp_snooping(delta, existing, default=False):
             commands.append(command)
         command = None
 
+    if gt_command:
+        # ensure that group-timeout command is configured last
+        commands.append(gt_command)
     return commands
 
 

--- a/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
@@ -3,18 +3,23 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- meta: end_host
+  # show ip igmp snooping | json does not work on some platforms
+  when: platform is search('N6K')
+
 - set_fact: gt_run="false"
-- set_fact: gt_run="true"
-  when: not (platform is match("N5K")) and not (platform is match("N35"))
+- block:
+  - set_fact: gt_run="true"
+  - set_fact: group_timeout="never"
+  - set_fact: def_group_timeout="default"
+  when: platform is not search('N35|N5K|N6K')
 
-- set_fact: group_timeout="never"
-  when: not (platform is match("N5K")) and not (platform is match("N35"))
-
-- set_fact: def_group_timeout="default"
-  when: not (platform is match("N5K")) and not (platform is match("N35"))
+- name: Setup
+  nxos_igmp_snooping: &default
+    provider: "{{ connection }}"
+    state: default
 
 - block:
-
   - name: Configure igmp snooping with non-default values
     nxos_igmp_snooping: &non-default
       snooping: false
@@ -90,9 +95,7 @@
     when: gt_run or (imagetag and (imagetag is version_compare('D1', 'ne')))
 
   - name: Configure igmp snooping with default values
-    nxos_igmp_snooping: &default
-      provider: "{{ connection }}"
-      state: default
+    nxos_igmp_snooping: *default
     register: result
 
   - assert: *true


### PR DESCRIPTION
##### SUMMARY
* Fixed another problem where `group-timeout` was processed before `ip igmp snooping` was enabled

* `sanity` playbook:
  * N6K: `show ip igmp snooping | json` succeeds on the device but doesn't return any data in body; added a skip to the sanity playbook to keep it out of CI
  * Added a setup task to do initial cleanup on the device

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_igmp_snooping`