### PR TITLE
[stable-2.7] Allow dict2items to work with hostvars (#53538).

### DIFF
--- a/changelogs/fragments/dict2items-mapping.yaml
+++ b/changelogs/fragments/dict2items-mapping.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- dict2items - Allow dict2items to work with hostvars

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -34,7 +34,7 @@ import time
 import uuid
 import yaml
 
-from collections import MutableMapping
+from collections import Mapping, MutableMapping
 import datetime
 from functools import partial
 from random import Random, SystemRandom, shuffle, random
@@ -498,7 +498,7 @@ def dict_to_list_of_dict_key_value_elements(mydict):
     ''' takes a dictionary and transforms it into a list of dictionaries,
         with each having a 'key' and 'value' keys that correspond to the keys and values of the original '''
 
-    if not isinstance(mydict, MutableMapping):
+    if not isinstance(mydict, Mapping):
         raise AnsibleFilterError("dict2items requires a dictionary, got %s instead." % type(mydict))
 
     ret = []

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -237,3 +237,10 @@
     that:
             - "'00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
             - "'00:00:00' | random_mac != '00:00:00' | random_mac"
+
+- name: Ensure dict2items works with hostvars
+  debug:
+    msg: "{{ item.key }}"
+  loop: "{{ hostvars|dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"


### PR DESCRIPTION
(cherry picked from commit 414440e3237186bf6eb2f3cb1d1fbb1ebb4186e5)

Co-authored-by: Matt Martz <matt@sivel.net>