### PR TITLE
nxos_pim_rp_address: N7K sanity test fix when removing rp w/pfx-list

### DIFF
--- a/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -4,13 +4,16 @@
   when: ansible_connection == "local"
 
 - block:
-  # N3L does not support bidir
+  # platforms do not support bidir
   - set_fact: bidir_true="true"
   - set_fact: bidir_false="false"
-  # N3L can only remove rpa, cannot remove rpa+prefixlist or rpa+routemap
+  when: platform is not search('N3L')
+
+- block:
+  # platforms can only remove rpa, cannot remove rpa+prefixlist or rpa+routemap
   - set_fact: pim_prefix_list="pim_prefix_list"
   - set_fact: pim_route_map="pim_route_map"
-  when: platform is not match("N3L")
+  when: platform is not search('N3L|N7K')
 
 - block:
   - name: "Disable feature PIM"


### PR DESCRIPTION
##### SUMMARY
Sanity test fix.
The N7K is another platform that raises an error when trying to remove `ip pim rp-address` w/prefix-list specified. These prefix-lists are now omitted when testing removal with N7K. The `rp-address` config statement can still be removed when the prefix-list is not specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_pim_rp_address`

##### ADDITIONAL INFORMATION
```
n7k(config)# no ip pim rp-address 10.1.1.2 prefix-list pim_prefix_list
No policy was configured for 10.1.1.2
n7k(config)# no ip pim rp-address 10.1.1.2
n7k(config)#
```
