### PR TITLE
[2.7] apply node_id parameter to swarm node removal

### DIFF
--- a/changelogs/fragments/53503-docker_swarm_fix_node_id.yml
+++ b/changelogs/fragments/53503-docker_swarm_fix_node_id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_swarm - Fixed node_id parameter not working for node removal (https://github.com/ansible/ansible/issues/53501)


### PR DESCRIPTION
##### SUMMARY
Backport of #53503 to stable-2.7: fixes docker node removal (which probably never worked).

Also sped up the node-down test in case it fails (no final `sleep(5)`).

CC @jwitko

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
