### PR TITLE
docker_swarm_service: Extend mount options

### DIFF
--- a/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
+++ b/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
@@ -1,2 +1,3 @@
 bugfixes:
   - "docker_swarm_service - Extended ``mounts`` options. It now also accepts ``labels``, ``propagation``, ``no_copy``, ``driver_config``, ``tmpfs_size``, ``tmpfs_mode``."
+  - "docker_swarm_service - The module return value for ``mounts`` previously returned a key named ``readonly``. It's now known as ``read_only``."

--- a/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
+++ b/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
@@ -1,3 +1,2 @@
 minor_changes:
   - "docker_swarm_service - Extended ``mounts`` options. It now also accepts ``labels``, ``propagation``, ``no_copy``, ``driver_config``, ``tmpfs_size``, ``tmpfs_mode``."
-  - "docker_swarm_service - The module return value for ``mounts`` previously returned a key named ``readonly``. It's now known as ``read_only``."

--- a/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
+++ b/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
@@ -1,4 +1,3 @@
-bugfixes:
-  - "docker_swarm_service - Extended ``mounts`` options. It now also accepts ``labels``, ``propagation``, ``no_copy``, ``driver_config``, ``tmpfs_size``, ``tmpfs_mode``."
 minor_changes:
+  - "docker_swarm_service - Extended ``mounts`` options. It now also accepts ``labels``, ``propagation``, ``no_copy``, ``driver_config``, ``tmpfs_size``, ``tmpfs_mode``."
   - "docker_swarm_service - The module return value for ``mounts`` previously returned a key named ``readonly``. It's now known as ``read_only``."

--- a/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
+++ b/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
@@ -1,3 +1,4 @@
 bugfixes:
   - "docker_swarm_service - Extended ``mounts`` options. It now also accepts ``labels``, ``propagation``, ``no_copy``, ``driver_config``, ``tmpfs_size``, ``tmpfs_mode``."
+minor_changes:
   - "docker_swarm_service - The module return value for ``mounts`` previously returned a key named ``readonly``. It's now known as ``read_only``."

--- a/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
+++ b/changelogs/fragments/53559-docker_swarm_service-mounts-options.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - Extended ``mounts`` options. It now also accepts ``labels``, ``propagation``, ``no_copy``, ``driver_config``, ``tmpfs_size``, ``tmpfs_mode``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -299,6 +299,59 @@ options:
         description:
           - Whether the mount should be read-only.
         type: bool
+      labels:
+        description:
+          - Volume labels to apply.
+        type: dict
+        version_added: "2.8"
+      propagation:
+        description:
+          - The propagation mode to use.
+          - Can only be used when I(mode) is C(bind).
+        type: str
+        choices:
+          - shared
+          - slave
+          - private
+          - rshared
+          - rslave
+          - rprivate
+        version_added: "2.8"
+      no_copy:
+        description:
+          - Disable copying of data from a container when a volume is created.
+          - Can only be used when I(mode) is C(volume).
+        type: bool
+        version_added: "2.8"
+      driver_config:
+        description:
+          - Volume driver configuration.
+          - Can only be used when I(mode) is C(volume).
+        suboptions:
+          name:
+            description:
+              - Name of the volume-driver plugin to use for the volume.
+            type: str
+          options:
+            description:
+              - Options as key-value pairs to pass to the driver for this volume.
+            type: dict
+        type: dict
+        version_added: "2.8"
+    tmpfs_size:
+      description:
+        - "Size of the tmpfs mount (format: C(<number>[<unit>])). Number is a positive integer.
+          Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+          C(T) (tebibyte), or C(P) (pebibyte)."
+        - Can only be used when I(mode) is C(tmpfs).
+      type: str
+      version_added: "2.8"
+    tmpfs_mode:
+      description:
+        - File mode of the tmpfs in octal.
+        - Can only be used when I(mode) is C(tmpfs).
+      type: int
+      version_added: "2.8"
   name:
     description:
       - Service name.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -792,7 +792,7 @@ swarm_service:
     "mode": "replicated",
     "mounts": [
       {
-        "read_only": false,
+        "readonly": false,
         "source": "/tmp/",
         "target": "/remote_tmp/",
         "type": "bind",
@@ -1464,7 +1464,7 @@ class DockerService(DockerBaseClass):
             s.mounts = []
             for param_m in ap['mounts']:
                 service_m = {}
-                service_m['read_only'] = param_m['readonly']
+                service_m['readonly'] = param_m['readonly']
                 service_m['type'] = param_m['type']
                 service_m['source'] = param_m['source']
                 service_m['target'] = param_m['target']
@@ -1665,23 +1665,23 @@ class DockerService(DockerBaseClass):
         if self.mounts is not None:
             mounts = []
             for mount_config in self.mounts:
-                mount_options = [
-                    'target',
-                    'source',
-                    'type',
-                    'read_only',
-                    'propagation',
-                    'labels',
-                    'no_copy',
-                    'driver_config',
-                    'tmpfs_size',
-                    'tmpfs_mode'
-                ]
+                mount_options = {
+                    'target': 'target',
+                    'source': 'source',
+                    'type': 'type',
+                    'readonly': 'read_only',
+                    'propagation': 'propagation',
+                    'labels': 'labels',
+                    'no_copy': 'no_copy',
+                    'driver_config': 'driver_config',
+                    'tmpfs_size': 'tmpfs_size',
+                    'tmpfs_mode': 'tmpfs_mode'
+                }
                 mount_args = {}
-                for option in mount_options:
+                for option, mount_arg in mount_options.items():
                     value = mount_config.get(option)
                     if value is not None:
-                        mount_args[option] = value
+                        mount_args[mount_arg] = value
 
                 mounts.append(types.Mount(**mount_args))
 
@@ -2057,7 +2057,7 @@ class DockerServiceManager(object):
                     'source': mount_data['Source'],
                     'type': mount_data['Type'],
                     'target': mount_data['Target'],
-                    'read_only': mount_data.get('ReadOnly'),
+                    'readonly': mount_data.get('ReadOnly'),
                     'propagation': bind_options.get('Propagation'),
                     'no_copy': volume_options.get('NoCopy'),
                     'labels': volume_options.get('Labels'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2274,9 +2274,9 @@ def _detect_mount_tmpfs_usage(client):
     for mount in client.module.params['mounts'] or []:
         if mount.get('type') == 'tmpfs':
             return True
-        if mount.get('tmpfs_size'):
+        if mount.get('tmpfs_size') is not None:
             return True
-        if mount.get('tmpfs_mode'):
+        if mount.get('tmpfs_mode') is not None:
             return True
     return False
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -299,7 +299,6 @@ options:
         description:
           - Whether the mount should be read-only.
         type: bool
-        default: no
   name:
     description:
       - Service name.
@@ -2005,7 +2004,7 @@ class DockerServiceManager(object):
                     'source': mount_data['Source'],
                     'type': mount_data['Type'],
                     'target': mount_data['Target'],
-                    'read_only': mount_data.get('ReadOnly', False),
+                    'read_only': mount_data.get('ReadOnly'),
                     'propagation': bind_options.get('Propagation'),
                     'no_copy': volume_options.get('NoCopy'),
                     'labels': volume_options.get('Labels'),
@@ -2242,7 +2241,7 @@ def main():
                 default='bind',
                 choices=['bind', 'volume', 'tmpfs'],
             ),
-            readonly=dict(type='bool', default=False),
+            readonly=dict(type='bool'),
             labels=dict(type='dict'),
             propagation=dict(
                 type='str',

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -338,20 +338,20 @@ options:
             type: dict
         type: dict
         version_added: "2.8"
-    tmpfs_size:
-      description:
-        - "Size of the tmpfs mount (format: C(<number>[<unit>])). Number is a positive integer.
-          Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
-          C(T) (tebibyte), or C(P) (pebibyte)."
-        - Can only be used when I(mode) is C(tmpfs).
-      type: str
-      version_added: "2.8"
-    tmpfs_mode:
-      description:
-        - File mode of the tmpfs in octal.
-        - Can only be used when I(mode) is C(tmpfs).
-      type: int
-      version_added: "2.8"
+      tmpfs_size:
+        description:
+          - "Size of the tmpfs mount (format: C(<number>[<unit>])). Number is a positive integer.
+            Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
+            C(T) (tebibyte), or C(P) (pebibyte)."
+          - Can only be used when I(mode) is C(tmpfs).
+        type: str
+        version_added: "2.8"
+      tmpfs_mode:
+        description:
+          - File mode of the tmpfs in octal.
+          - Can only be used when I(mode) is C(tmpfs).
+        type: int
+        version_added: "2.8"
   name:
     description:
       - Service name.

--- a/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
@@ -1,6 +1,6 @@
 - name: Registering service name
   set_fact:
-    service_name: "{{ name_prefix ~ '-logging' }}"
+    service_name: "{{ name_prefix ~ '-mounts' }}"
     volume_name_1: "{{ name_prefix ~ '-volume-1' }}"
     volume_name_2: "{{ name_prefix ~ '-volume-2' }}"
 

--- a/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
@@ -1,0 +1,525 @@
+- name: Registering service name
+  set_fact:
+    service_name: "{{ name_prefix ~ '-logging' }}"
+    volume_name_1: "{{ name_prefix ~ '-volume-1' }}"
+    volume_name_2: "{{ name_prefix ~ '-volume-2' }}"
+
+- name: Registering service name
+  set_fact:
+    service_names: "{{ service_names }} + [service_name]"
+    volume_names: "{{ volume_names }} + [volume_name_1, volume_name_2]"
+
+- docker_volume:
+    name: "{{ volume_name }}"
+    state: present
+  loop:
+    - "{{ volume_name_1 }}"
+    - "{{ volume_name_2 }}"
+  loop_control:
+    loop_var: volume_name
+
+####################################################################
+## mounts ##########################################################
+####################################################################
+
+- name: mounts
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+  register: mounts_1
+
+- name: mounts (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+  register: mounts_2
+
+- name: mounts (add)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+      - source: "/tmp/"
+        target: "/tmp/{{ volume_name_2 }}"
+        type: "bind"
+  register: mounts_3
+
+- name: mounts (empty)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts: []
+  register: mounts_4
+
+- name: mounts (empty idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts: []
+  register: mounts_5
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_1 is changed
+      - mounts_2 is not changed
+      - mounts_3 is changed
+      - mounts_4 is changed
+      - mounts_5 is not changed
+
+####################################################################
+## mounts.readonly #################################################
+####################################################################
+
+- name: mounts.readonly
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        readonly: true
+  register: mounts_readonly_1
+
+
+- name: mounts.readonly (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        readonly: true
+  register: mounts_readonly_2
+
+- name: mounts.readonly (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        readonly: false
+  register: mounts_readonly_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_readonly_1 is changed
+      - mounts_readonly_2 is not changed
+      - mounts_readonly_3 is changed
+
+####################################################################
+## mounts.propagation ##############################################
+####################################################################
+
+- name: mounts.propagation
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "/tmp"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "bind"
+        propagation: "slave"
+  register: mounts_propagation_1
+
+
+- name: mounts.propagation (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "/tmp"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "bind"
+        propagation: "slave"
+  register: mounts_propagation_2
+
+- name: mounts.propagation (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "/tmp"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "bind"
+        propagation: "rprivate"
+  register: mounts_propagation_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_propagation_1 is changed
+      - mounts_propagation_2 is not changed
+      - mounts_propagation_3 is changed
+
+####################################################################
+## mounts.labels ##################################################
+####################################################################
+
+- name: mounts.labels
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        labels:
+          mylabel: hello-world
+          my-other-label: hello-mars
+  register: mounts_labels_1
+
+
+- name: mounts.labels (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        labels:
+          mylabel: hello-world
+          my-other-label: hello-mars
+  register: mounts_labels_2
+
+- name: mounts.labels (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        labels:
+          mylabel: hello-world
+  register: mounts_labels_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_labels_1 is changed
+      - mounts_labels_2 is not changed
+      - mounts_labels_3 is changed
+
+####################################################################
+## mounts.no_copy ##################################################
+####################################################################
+
+- name: mounts.no_copy
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        no_copy: true
+  register: mounts_no_copy_1
+
+
+- name: mounts.no_copy (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        no_copy: true
+  register: mounts_no_copy_2
+
+- name: mounts.no_copy (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        no_copy: false
+  register: mounts_no_copy_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_no_copy_1 is changed
+      - mounts_no_copy_2 is not changed
+      - mounts_no_copy_3 is changed
+
+####################################################################
+## mounts.driver_config ############################################
+####################################################################
+
+- name: mounts.driver_config
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        driver_config:
+          name: "local"
+          options:
+            type: "nfs"
+  register: mounts_driver_config_1
+
+- name: mounts.driver_config
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        driver_config:
+          name: "local"
+          options:
+            type: "nfs"
+  register: mounts_driver_config_2
+
+- name: mounts.driver_config
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "volume"
+        driver_config:
+          name: "none"
+  register: mounts_driver_config_3
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_driver_config_1 is changed
+      - mounts_driver_config_2 is not changed
+      - mounts_driver_config_3 is changed
+
+####################################################################
+## mounts.tmpfs_size ###############################################
+####################################################################
+
+- name: mounts.tmpfs_size
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "tmpfs"
+        tmpfs_size: "50M"
+  register: mounts_tmpfs_size_1
+  ignore_errors: yes
+
+- name: mounts.tmpfs_size (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "tmpfs"
+        tmpfs_size: "50M"
+  register: mounts_tmpfs_size_2
+  ignore_errors: yes
+
+- name: mounts.tmpfs_size (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "tmpfs"
+        tmpfs_size: "25M"
+  register: mounts_tmpfs_size_3
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_tmpfs_size_1 is changed
+      - mounts_tmpfs_size_2 is not changed
+      - mounts_tmpfs_size_3 is changed
+  when: docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - mounts_tmpfs_size_1 is failed
+    - "'Minimum version required' in mounts_tmpfs_size_1.msg"
+  when: docker_py_version is version('2.6.0', '<')
+
+####################################################################
+## mounts.tmpfs_mode ###############################################
+####################################################################
+
+- name: mounts.tmpfs_mode
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "tmpfs"
+        tmpfs_mode: 0444
+  register: mounts_tmpfs_mode_1
+  ignore_errors: yes
+
+- name: mounts.tmpfs_mode (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "tmpfs"
+        tmpfs_mode: 0444
+  register: mounts_tmpfs_mode_2
+  ignore_errors: yes
+
+- name: mounts.tmpfs_mode (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - source: "{{ volume_name_1 }}"
+        target: "/tmp/{{ volume_name_1 }}"
+        type: "tmpfs"
+        tmpfs_mode: 0777
+  register: mounts_tmpfs_mode_3
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - mounts_tmpfs_mode_1 is changed
+      - mounts_tmpfs_mode_2 is not changed
+      - mounts_tmpfs_mode_3 is changed
+  when: docker_py_version is version('2.6.0', '>=')
+- assert:
+    that:
+    - mounts_tmpfs_size_1 is failed
+    - "'Minimum version required' in mounts_tmpfs_size_1.msg"
+  when: docker_py_version is version('2.6.0', '<')
+
+####################################################################
+####################################################################
+####################################################################
+
+- name: Delete volumes
+  docker_volume:
+    name: "{{ volume_name }}"
+    state: absent
+  loop:
+    - "{{ volume_name_1 }}"
+    - "{{ volume_name_2 }}"
+  loop_control:
+    loop_var: volume_name
+  ignore_errors: yes

--- a/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
@@ -334,9 +334,9 @@
         target: "/tmp/{{ volume_name_1 }}"
         type: "volume"
         driver_config:
-          name: "local"
+          name: "nfs"
           options:
-            type: "nfs"
+            addr: "127.0.0.1"
   register: mounts_driver_config_1
 
 - name: mounts.driver_config
@@ -350,9 +350,9 @@
         target: "/tmp/{{ volume_name_1 }}"
         type: "volume"
         driver_config:
-          name: "local"
+          name: "nfs"
           options:
-            type: "nfs"
+            addr: "127.0.0.1"
   register: mounts_driver_config_2
 
 - name: mounts.driver_config
@@ -366,7 +366,7 @@
         target: "/tmp/{{ volume_name_1 }}"
         type: "volume"
         driver_config:
-          name: "none"
+          name: "local"
   register: mounts_driver_config_3
 
 - name: cleanup

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -7,8 +7,6 @@
     network_name_2: "{{ name_prefix ~ '-network-2' }}"
     config_name_1: "{{ name_prefix ~ '-configs-1' }}"
     config_name_2: "{{ name_prefix ~ '-configs-2' }}"
-    volume_name_1: "{{ name_prefix ~ '-volume-1' }}"
-    volume_name_2: "{{ name_prefix ~ '-volume-2' }}"
     secret_name_1: "{{ name_prefix ~ '-secret-1' }}"
     secret_name_2: "{{ name_prefix ~ '-secret-2' }}"
 
@@ -17,7 +15,6 @@
     service_names: "{{ service_names }} + [service_name]"
     network_names: "{{ network_names }} + [network_name_1, network_name_2]"
     config_names: "{{ config_names }} + [config_name_1, config_name_2]"
-    volume_names: "{{ volume_names }} + [volume_name_1, volume_name_2]"
     secret_names: "{{ secret_names }} + [secret_name_1, secret_name_2]"
 
 - docker_config:
@@ -57,15 +54,6 @@
     - "{{ network_name_2 }}"
   loop_control:
     loop_var: network_name
-
-- docker_volume:
-    name: "{{ volume_name }}"
-    state: present
-  loop:
-    - "{{ volume_name_1 }}"
-    - "{{ volume_name_2 }}"
-  loop_control:
-    loop_var: volume_name
 
 ####################################################################
 ## args ############################################################
@@ -1407,81 +1395,6 @@
       - mode_1 is changed
       - mode_2 is not changed
       - mode_3 is changed
-
-####################################################################
-## mounts ##########################################################
-####################################################################
-
-- name: mounts
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    mounts:
-      - source: "{{ volume_name_1 }}"
-        target: "/tmp/{{ volume_name_1 }}"
-        type: "volume"
-  register: mounts_1
-
-- name: mounts (idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    mounts:
-      - source: "{{ volume_name_1 }}"
-        target: "/tmp/{{ volume_name_1 }}"
-        type: "volume"
-  register: mounts_2
-
-- name: mounts (add)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    mounts:
-      - source: "{{ volume_name_1 }}"
-        target: "/tmp/{{ volume_name_1 }}"
-        type: "volume"
-      - source: "{{ volume_name_2 }}"
-        target: "/tmp/{{ volume_name_2 }}"
-        type: "volume"
-  register: mounts_3
-
-- name: mounts (empty)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    mounts: []
-  register: mounts_4
-
-- name: mounts (empty idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    mounts: []
-  register: mounts_5
-
-- name: cleanup
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    state: absent
-  diff: no
-
-- assert:
-    that:
-      - mounts_1 is changed
-      - mounts_2 is not changed
-      - mounts_3 is changed
-      - mounts_4 is changed
-      - mounts_5 is not changed
 
 ####################################################################
 ## networks ########################################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This PR adds missing options for `mounts`.

* `labels`
* `propagation`
* `no_copy`
* `driver_config`
* `tmpfs_size`
* `tmpfs_mode`

Documentation can be found here: https://docs.docker.com/engine/reference/commandline/service_create/#add-bind-mounts-volumes-or-memory-filesystems

One option that is missing from this PR is `consistency`. The docker API accepts this parameter but does not return it on `docker service inspect`. I tried all thinkable combinations but never got it to "stick". Found an issue regarding this here https://github.com/moby/moby/issues/36548.

I've also removed the default value of `True` for `mounts.readonly`. This is already the default in docker-py. See: https://github.com/docker/docker-py/blob/master/docker/types/services.py#L214

Also changed usage of `DockerService.mounts.readonly` to `read_only` to be able to pass it directly to docker-py. 

The mount related integration tests have also been moved into its own file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service

