### PR TITLE
nxos_ospf_vrf: sanity.yaml test: fix timer_throttle_lsa_hold

### DIFF
--- a/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
@@ -3,6 +3,13 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- name: "Setup: disable feature OSPF for initial cleanup"
+  nxos_feature:
+    feature: ospf
+    provider: "{{ connection }}"
+    state: disabled
+  ignore_errors: yes
+
 - name: "Enable feature OSPF"
   nxos_feature:
     feature: ospf
@@ -44,6 +51,7 @@
       ospf: 2
       auto_cost: 5000
       timer_throttle_spf_hold: 1100
+      timer_throttle_lsa_hold: 2220
       timer_throttle_lsa_max: 2222
       default_metric: 1000
       log_adjacency: log


### PR DESCRIPTION
##### SUMMARY
* The test was setting `lsa max` value to 2222 but the default `lsa hold` value is 5000.

* `hold` must be less than `max` or else the device raises a clierror, so I just added a lower non-default `hold` value to satisfy the cli.

* Also added an initial cleanup for the test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_ospf_vrf`

