### PR TITLE
Improve CoreOS distribution parsing

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -70,7 +70,7 @@ class DistributionFiles:
         {'path': '/etc/lsb-release', 'name': 'Mandriva'},
         {'path': '/etc/sourcemage-release', 'name': 'SMGL'},
         {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
-        {'path': '/etc/coreos/update.conf', 'name': 'Coreos'},
+        {'path': '/etc/lsb-release', 'name': 'Coreos'},
         {'path': '/etc/os-release', 'name': 'NA'},
     )
 
@@ -385,19 +385,22 @@ class DistributionFiles:
 
     def parse_distribution_file_Coreos(self, name, data, path, collected_facts):
         coreos_facts = {}
-        # FIXME: pass in ro copy of facts for this kind of thing
-        distro = get_distribution()
 
-        if distro.lower() == 'coreos':
-            if not data:
-                # include fix from #15230, #15228
-                # TODO: verify this is ok for above bugs
-                return False, coreos_facts
-            release = re.search("^GROUP=(.*)", data)
-            if release:
-                coreos_facts['distribution_release'] = release.group(1).strip('"')
-        else:
-            return False, coreos_facts  # TODO: remove if tested without this
+        if 'CoreOS' not in data:
+            return False, coreos_facts
+
+        dist_id = re.search(r'DISTRIB_ID="(.*)"', data)
+        if dist_id:
+            coreos_facts['distribution'] = name
+
+        version = re.search(r'DISTRIB_RELEASE=(.*)', data)
+        if version:
+            coreos_facts['distribution_major_version'] = version.group(1).split('.')[0]
+            coreos_facts['distribution_version'] = version.group(1)
+
+        release = re.search(r'DISTRIB_CODENAME="(\w+)"', data)
+        if release:
+            coreos_facts['distribution_release'] = release.group(1).lower()
 
         return True, coreos_facts
 
@@ -451,7 +454,7 @@ class Distribution(object):
         {'path': '/etc/altlinux-release', 'name': 'Altlinux'},
         {'path': '/etc/sourcemage-release', 'name': 'SMGL'},
         {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
-        {'path': '/etc/coreos/update.conf', 'name': 'Coreos'},
+        {'path': '/etc/lsb-release', 'name': 'Coreos'},
         {'path': '/etc/os-release', 'name': 'NA'},
     )
 

--- a/test/units/module_utils/facts/system/distribution/distribution_data.py
+++ b/test/units/module_utils/facts/system/distribution/distribution_data.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DISTRIBUTION_FILE_DATA = {
+    'coreos': 'DISTRIB_ID="Container Linux by CoreOS"\nDISTRIB_RELEASE=1911.5.0\nDISTRIB_CODENAME="Rhyolite"\nDISTRIB_DESCRIPTION="Container Linux by CoreOS '
+              '1911.5.0 (Rhyolite)"',
+    'debian9': 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"\nNAME="Debian GNU/Linux"\nVERSION_ID="9"\nVERSION="9 (stretch)"\nID=debian\nHOME_URL="https://www.d'
+               'ebian.org/"\nSUPPORT_URL="https://www.debian.org/support"\nBUG_REPORT_URL="https://bugs.debian.org/"\n',
+    'clearlinux': 'NAME="Clear Linux OS"\nVERSION=1\nID=clear-linux-os\nID_LIKE=clear-linux-os\nVERSION_ID=28120\nPRETTY_NAME="Clear Linux OS"\nANSI_COLOR="1;'
+                  '35"\nHOME_URL="https://clearlinux.org"\nSUPPORT_URL="https://clearlinux.org"\nBUG_REPORT_URL="mailto:dev@lists.clearlinux.org"',
+    'linuxmint': 'NAME="Linux Mint"\nVERSION="19.1 (Tessa)"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME="Linux Mint 19.1"\nVERSION_ID="19.1"\nHOME_URL="h'
+                 'ttps://www.linuxmint.com/"\nSUPPORT_URL="https://forums.ubuntu.com/"\nBUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedo'
+                 'cs.io/en/latest/"\nPRIVACY_POLICY_URL="https://www.linuxmint.com/"\nVERSION_CODENAME=tessa\nUBUNTU_CODENAME=bionic',
+}

--- a/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_Coreos.py
+++ b/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_Coreos.py
@@ -20,29 +20,29 @@ def mock_module():
     return mock_module
 
 
-def test_parse_distribution_file_clear_linux():
+def test_parse_distribution_file_coreos():
     test_input = {
-        'name': 'ClearLinux',
-        'data': DISTRIBUTION_FILE_DATA['clearlinux'],
-        'path': '/usr/lib/os-release',
+        'name': 'Coreos',
+        'data': DISTRIBUTION_FILE_DATA['coreos'],
+        'path': '/etc/os-release',
         'collected_facts': None,
     }
 
     result = (
         True,
         {
-            'distribution': 'Clear Linux OS',
-            'distribution_major_version': '28120',
-            'distribution_release': 'clear-linux-os',
-            'distribution_version': '28120'
+            'distribution': 'Coreos',
+            'distribution_major_version': '1911',
+            'distribution_release': 'rhyolite',
+            'distribution_version': '1911.5.0'
         }
     )
 
     distribution = DistributionFiles(module=mock_module())
-    assert result == distribution.parse_distribution_file_ClearLinux(**test_input)
+    assert result == distribution.parse_distribution_file_Coreos(**test_input)
 
 
-def test_parse_distribution_file_clear_linux_no_match():
+def test_parse_distribution_file_coreos_no_match():
     # Test against data from other distributions that use same file path to
     # ensure we do not get an incorrect match.
 
@@ -50,8 +50,8 @@ def test_parse_distribution_file_clear_linux_no_match():
         {
             'case': {
                 'name': 'ClearLinux',
-                'data': DISTRIBUTION_FILE_DATA['coreos'],
-                'path': '/usr/lib/os-release',
+                'data': DISTRIBUTION_FILE_DATA['clearlinux'],
+                'path': '/etc/os-release',
                 'collected_facts': None,
             },
             'result': (False, {}),
@@ -60,16 +60,16 @@ def test_parse_distribution_file_clear_linux_no_match():
             'case': {
                 'name': 'ClearLinux',
                 'data': DISTRIBUTION_FILE_DATA['linuxmint'],
-                'path': '/usr/lib/os-release',
+                'path': '/etc/os-release',
                 'collected_facts': None,
             },
             'result': (False, {}),
         },
         {
             'case': {
-                'name': 'ClearLinux',
+                'name': 'Debian',
                 'data': DISTRIBUTION_FILE_DATA['debian9'],
-                'path': '/usr/lib/os-release',
+                'path': '/etc/os-release',
                 'collected_facts': None,
             },
             'result': (False, {}),
@@ -78,4 +78,4 @@ def test_parse_distribution_file_clear_linux_no_match():
 
     distribution = DistributionFiles(module=mock_module())
     for scenario in scenarios:
-        assert scenario['result'] == distribution.parse_distribution_file_ClearLinux(**scenario['case'])
+        assert scenario['result'] == distribution.parse_distribution_file_Coreos(**scenario['case'])


### PR DESCRIPTION
##### SUMMARY
- use `/etc/lsb-release` for CoreOS since it contains all the information we need and `/etc/coreos/update.conf` didn't have much at all
- add explicit check to ensure the system is CoreOS
- create fixtures of distribution data for easy reuse during tests
- update ClearLinux tests to use these fixtures
- add tests for CoreOS distribution parsing

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/facts/system/distribution.py`