### PR TITLE
Strip whitespace when reading limit file

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -608,7 +608,7 @@ class InventoryManager(object):
             for x in subset_patterns:
                 if x.startswith("@"):
                     fd = open(x[1:])
-                    results.extend(fd.read().split("\n"))
+                    results.extend([l.strip() for l in fd.read().split("\n")])
                     fd.close()
                 else:
                     results.append(x)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove whitespace when reading entries from a file provided to the `--limit` parameter, so that accidental whitespace typos don't lead to non-matches.

Fixes #17088
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/inventory/manager.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

inventory:
```
hostA
hostB
hostC
```

limit file:
```
hostA
hostB 
```

before:
```
$ ansible -i inventory --limit @limit.txt all -m ping
 [WARNING]: Could not match supplied host pattern, ignoring: hostB

hostA | SUCCESS => {
    "changed": false, 
    "ping": "pong"
}
```

after:
```
$ ansible -i inventory --limit @limit.txt all -m ping

hostA | SUCCESS => {
    "changed": false, 
    "ping": "pong"
}

hostB | SUCCESS => {
    "changed": false, 
    "ping": "pong"
}
```