### PR TITLE
docker_swarm: removing nodes requires docker >= 2.4.0

### DIFF
--- a/changelogs/fragments/53129-docker_swarm-older-docker-py.yaml
+++ b/changelogs/fragments/53129-docker_swarm-older-docker-py.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- "docker_swarm - now supports docker-py 1.10.0 and newer, instead only docker 2.6.0 and newer."
+- "docker_swarm - now supports docker-py 1.10.0 and newer for most operations, instead only docker 2.6.0 and newer."

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -52,6 +52,7 @@ options:
       - Set to C(join), to join an existing cluster.
       - Set to C(absent), to leave an existing cluster.
       - Set to C(remove), to remove an absent node from the cluster.
+        Note that removing requires docker-py >= 2.4.0.
       - Set to C(inspect) to display swarm informations.
     type: str
     required: yes
@@ -530,6 +531,10 @@ class SwarmManager(DockerBaseClass):
         self.results['changed'] = True
 
 
+def _detect_remove_operation(client):
+    return client.module.params['state'] == 'remove'
+
+
 def main():
     argument_spec = dict(
         advertise_addr=dict(type='str'),
@@ -569,6 +574,11 @@ def main():
         ca_force_rotate=dict(docker_py_version='2.6.0', docker_api_version='1.30'),
         autolock_managers=dict(docker_py_version='2.6.0'),
         log_driver=dict(docker_py_version='2.6.0'),
+        remove_operation=dict(
+            docker_py_version='2.4.0',
+            detect_usage=_detect_remove_operation,
+            usage_msg='remove swarm nodes'
+        ),
     )
 
     client = AnsibleDockerSwarmClient(


### PR DESCRIPTION
##### SUMMARY
Because it calls `client.inspect_node` to detect whether the node is down or not. For the same reason, we had to bump the minimal docker-py requirements for `docker_node` also to 2.4.0. See [here](https://github.com/ansible/ansible/pull/53129#issuecomment-468569940) for details.

This updates #53129.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
