### PR TITLE
Show invalid coverage paths with verbosity > 1.

### DIFF
--- a/test/runner/lib/cover.py
+++ b/test/runner/lib/cover.py
@@ -139,6 +139,8 @@ def command_coverage_combine(args):
             arc_data[filename].update(arcs)
 
     output_files = []
+    invalid_path_count = 0
+    invalid_path_chars = 0
 
     for group in sorted(groups):
         arc_data = groups[group]
@@ -147,7 +149,12 @@ def command_coverage_combine(args):
 
         for filename in arc_data:
             if not os.path.isfile(filename):
-                display.warning('Invalid coverage path: %s' % filename)
+                invalid_path_count += 1
+                invalid_path_chars += len(filename)
+
+                if args.verbosity > 1:
+                    display.warning('Invalid coverage path: %s' % filename)
+
                 continue
 
             updated.add_arcs({filename: list(arc_data[filename])})
@@ -159,6 +166,9 @@ def command_coverage_combine(args):
             output_file = COVERAGE_FILE + group
             updated.write_file(output_file)
             output_files.append(output_file)
+
+    if invalid_path_count > 0:
+        display.warning('Ignored %d characters from %d invalid coverage path(s).' % (invalid_path_chars, invalid_path_count))
 
     return sorted(output_files)
 


### PR DESCRIPTION
##### SUMMARY

Show invalid coverage paths with verbosity > 1.

This will avoid excessively large line counts in Shippable console logs for test results due to invalid coverage paths, such as the ~244K lines found here: 

https://app.shippable.com/github/ansible/ansible/runs/112608/114/console

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test