### PR TITLE
fix pkg name nevra parsing regex in dnf

### DIFF
--- a/changelogs/fragments/dnf-packagename-parse.yaml
+++ b/changelogs/fragments/dnf-packagename-parse.yaml
@@ -1,4 +1,4 @@
 ---
-- bugfixes:
+bugfixes:
   - 'dnf - fix package parsing to handle git snapshot nevra'
   - 'dnf - enable package name specification for absent'

--- a/changelogs/fragments/dnf-packagename-parse.yaml
+++ b/changelogs/fragments/dnf-packagename-parse.yaml
@@ -1,0 +1,4 @@
+---
+- bugfixes:
+  - 'dnf - fix package parsing to handle git snapshot nevra'
+  - 'dnf - enable package name specification for absent'

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -383,7 +383,7 @@ class DnfModule(YumDnf):
         ]
 
         rpm_arch_re = re.compile(r'(.*)\.(.*)')
-        rpm_nevr_re = re.compile(r'(\S+)-(?:(\d*):)?(.*)-(~?\w+[\w.]*)')
+        rpm_nevr_re = re.compile(r'(\S+)-(?:(\d*):)?(.*)-(~?\w+[\w.+]*)')
         try:
             arch = None
             rpm_arch_match = rpm_arch_re.match(packagename)


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR https://github.com/ansible/ansible/pull/53206 exposed a previously unknown bug in the regex that parses package names. This is the fix for that and adds a changelog fragment for both.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf

