### PR TITLE
meraki - Unchanged requests now return the original data

### DIFF
--- a/changelogs/fragments/53576-meraki-unchanged-returns.yml
+++ b/changelogs/fragments/53576-meraki-unchanged-returns.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "meraki_* - Meraki modules now return data when no changes are made."

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -354,7 +354,6 @@ def create_admin(meraki, org_id, name, email):
         if not meraki.params['networks']:
             payload['networks'] = []
         if meraki.is_update_required(is_admin_existing, payload) is True:
-            # meraki.fail_json(msg='Update is required!!!', original=is_admin_existing, proposed=payload)
             path = meraki.construct_path('update', function='admin', org_id=org_id) + is_admin_existing['id']
             r = meraki.request(path,
                                method='PUT',
@@ -364,7 +363,7 @@ def create_admin(meraki, org_id, name, email):
                 meraki.result['changed'] = True
                 return r
         else:
-            # meraki.fail_json(msg='No update is required!!!')
+            meraki.result['data'] = is_admin_existing
             return -1
 
 

--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -247,6 +247,8 @@ def main():
                 meraki.fail_json(msg='Unable to bind configuration template to network')
             meraki.result['changed'] = True
             meraki.result['data'] = template_bind
+        else:
+            meraki.result['data'] = {}
     elif meraki.params['state'] == 'absent':
         if not meraki.params['net_name'] and not meraki.params['net_id']:
             meraki.result['data'] = delete_template(meraki,
@@ -266,6 +268,8 @@ def main():
                     meraki.fail_json(msg='Unable to unbind configuration template from network')
                 meraki.result['changed'] = True
                 meraki.result['data'] = config_unbind
+            else:
+                meraki.result['data'] = {}
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/network/meraki/meraki_content_filtering.py
+++ b/lib/ansible/modules/network/meraki/meraki_content_filtering.py
@@ -210,6 +210,8 @@ def main():
             response = meraki.request(path, method='PUT', payload=json.dumps(payload))
             meraki.result['data'] = response
             meraki.result['changed'] = True
+        else:
+            meraki.result['data'] = current
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -378,6 +378,8 @@ def main():
                     updated_device.append(meraki.request(path, method='PUT', payload=json.dumps(payload)))
                     meraki.result['data'] = updated_device
                     meraki.result['changed'] = True
+                else:
+                    meraki.result['data'] = device_data
         else:
             if net_id is None:
                 device_list = get_org_devices(meraki, org_id)

--- a/lib/ansible/modules/network/meraki/meraki_mr_l3_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mr_l3_firewall.py
@@ -278,6 +278,8 @@ def main():
             if meraki.status == 200:
                 meraki.result['data'] = response
                 meraki.result['changed'] = True
+        else:
+            meraki.result['data'] = rules
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/network/meraki/meraki_mr_l3_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mr_l3_firewall.py
@@ -20,6 +20,7 @@ short_description: Manage MR access point layer 3 firewalls in the Meraki cloud
 version_added: "2.7"
 description:
 - Allows for creation, management, and visibility into layer 3 firewalls implemented on Meraki MR access points.
+- Module is not idempotent as of current release.
 options:
     state:
         description:

--- a/lib/ansible/modules/network/meraki/meraki_mx_l3_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mx_l3_firewall.py
@@ -303,7 +303,6 @@ def main():
         update = False
         if meraki.params['syslog_default_rule'] is not None:
             payload['syslogDefaultRule'] = meraki.params['syslog_default_rule']
-            # meraki.fail_json(msg='Payload', payload=payload)
         try:
             if len(rules) - 1 != len(payload['rules']):  # Quick and simple check to avoid more processing
                 update = True
@@ -311,14 +310,14 @@ def main():
                 if rules[len(rules) - 1]['syslogEnabled'] != meraki.params['syslog_default_rule']:
                     update = True
             if update is False:
+                default_rule = rules[len(rules) - 1].copy()
                 del rules[len(rules) - 1]  # Remove default rule for comparison
                 for r in range(len(rules) - 1):
                     if meraki.is_update_required(rules[r], payload['rules'][r]) is True:
                         update = True
+                rules.append(default_rule)
         except KeyError:
             pass
-            # if meraki.params['syslog_default_rule']:
-            #     meraki.fail_json(msg='Compare', original=rules, proposed=payload)
         if update is True:
             response = meraki.request(path, method='PUT', payload=json.dumps(payload))
             if meraki.status == 200:

--- a/lib/ansible/modules/network/meraki/meraki_mx_l3_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mx_l3_firewall.py
@@ -324,6 +324,8 @@ def main():
             if meraki.status == 200:
                 meraki.result['data'] = response
                 meraki.result['changed'] = True
+        else:
+            meraki.result['data'] = rules
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -316,7 +316,6 @@ def main():
                 if meraki.status == 200:
                     meraki.result['data'] = r
                     meraki.result['changed'] = True
-
             else:  # Update existing network
                 net = meraki.get_net(meraki.params['org_name'], meraki.params['net_name'], data=nets)
                 if meraki.params['enable_vlans'] is not None:
@@ -344,6 +343,8 @@ def main():
                     if meraki.status == 200:
                         meraki.result['data'] = r
                         meraki.result['changed'] = True
+                else:
+                    meraki.result['data'] = net
     elif meraki.params['state'] == 'absent':
         if is_net_valid(meraki, meraki.params['net_name'], nets) is True:
             net_id = meraki.get_net_id(net_name=meraki.params['net_name'],

--- a/lib/ansible/modules/network/meraki/meraki_organization.py
+++ b/lib/ansible/modules/network/meraki/meraki_organization.py
@@ -207,12 +207,8 @@ def main():
             payload = {'name': meraki.params['org_name'],
                        'id': meraki.params['org_id'],
                        }
-            if meraki.is_update_required(
-                get_org(
-                    meraki,
-                    meraki.params['org_id'],
-                    orgs),
-                    payload):
+            original = get_org(meraki, meraki.params['org_id'], orgs)
+            if meraki.is_update_required(original, payload):
                 response = meraki.request(meraki.construct_path('update',
                                                                 org_id=meraki.params['org_id']
                                                                 ),
@@ -222,6 +218,9 @@ def main():
                     meraki.fail_json(msg='Organization update failed')
                 meraki.result['data'] = response
                 meraki.result['changed'] = True
+            else:
+                meraki.result['data'] = original
+
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results
     meraki.exit_json(**meraki.result)

--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -209,7 +209,8 @@ def set_snmp(meraki, org_id):
         if meraki.status == 200:
             meraki.result['changed'] = True
             return r
-    return -1
+    else:
+        return snmp
 
 
 def main():

--- a/lib/ansible/modules/network/meraki/meraki_ssid.py
+++ b/lib/ansible/modules/network/meraki/meraki_ssid.py
@@ -519,6 +519,8 @@ def main():
             result = meraki.request(path, 'PUT', payload=json.dumps(payload))
             meraki.result['data'] = result
             meraki.result['changed'] = True
+        else:
+            meraki.result['data'] = original
     elif meraki.params['state'] == 'absent':
         ssids = get_ssids(meraki, net_id)
         ssid_id = meraki.params['number']

--- a/lib/ansible/modules/network/meraki/meraki_static_route.py
+++ b/lib/ansible/modules/network/meraki/meraki_static_route.py
@@ -363,6 +363,8 @@ def main():
                 path = meraki.construct_path('update', net_id=net_id, custom={'route_id': meraki.params['route_id']})
                 meraki.result['data'] = meraki.request(path, method="PUT", payload=json.dumps(payload))
                 meraki.result['changed'] = True
+            else:
+                meraki.result['data'] = existing_route
         else:
             if module.check_mode:
                 meraki.result['data'] = payload

--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -384,6 +384,8 @@ def main():
             response = meraki.request(path, method='PUT', payload=json.dumps(payload))
             meraki.result['data'] = response
             meraki.result['changed'] = True
+        else:
+            meraki.result['data'] = original
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/network/meraki/meraki_syslog.py
+++ b/lib/ansible/modules/network/meraki/meraki_syslog.py
@@ -278,6 +278,8 @@ def main():
             if meraki.status == 200:
                 meraki.result['data'] = r
                 meraki.result['changed'] = True
+        else:
+            meraki.result['data'] = original
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -397,6 +397,8 @@ def main():
                 response = meraki.request(path, method='PUT', payload=json.dumps(payload))
                 meraki.result['changed'] = True
                 meraki.result['data'] = response
+            else:
+                meraki.result['data'] = original
     elif meraki.params['state'] == 'absent':
         if is_vlan_valid(meraki, net_id, meraki.params['vlan_id']):
             path = meraki.construct_path('delete', net_id=net_id) + str(meraki.params['vlan_id'])

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -174,6 +174,7 @@
   - assert:
       that:
         - update_network_idempotent.changed == false
+        - update_network_idempotent.data is defined
 
   - name: Create administrator with invalid network
     meraki_admin:

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -142,7 +142,8 @@
 
   - assert:
       that:
-        bind_id_idempotent.changed == False
+        - bind_id_idempotent.changed == False
+        - bind_id_idempotent.data is defined
 
   - name: Unbind a template to a network via id
     meraki_config_template:

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -4,39 +4,39 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
-  # - name: Test an API key is provided
-  #   fail:
-  #     msg: Please define an API key
-  #   when: auth_key is not defined
+  - name: Test an API key is provided
+    fail:
+      msg: Please define an API key
+    when: auth_key is not defined
     
-  # - name: Use an invalid domain
-  #   meraki_config_template:
-  #     auth_key: '{{ auth_key }}'
-  #     host: marrrraki.com
-  #     state: query
-  #     org_name: DevTestOrg
-  #     output_level: debug
-  #   delegate_to: localhost
-  #   register: invalid_domain
-  #   ignore_errors: yes
+  - name: Use an invalid domain
+    meraki_config_template:
+      auth_key: '{{ auth_key }}'
+      host: marrrraki.com
+      state: query
+      org_name: DevTestOrg
+      output_level: debug
+    delegate_to: localhost
+    register: invalid_domain
+    ignore_errors: yes
 
-  # - name: Connection assertions
-  #   assert:
-  #     that:
-  #       - '"Failed to connect to" in invalid_domain.msg'
+  - name: Connection assertions
+    assert:
+      that:
+        - '"Failed to connect to" in invalid_domain.msg'
 
   - name: Query all configuration templates
     meraki_config_template:
       auth_key: '{{auth_key}}'
       state: query
-      org_name: DevTestOrg
+      org_name: '{{test_org_name}}'
     register: get_all
 
   - name: Delete non-existant configuration template
     meraki_config_template:
       auth_key: '{{auth_key}}'
       state: absent
-      org_name: DevTestOrg
+      org_name: '{{test_org_name}}'
       config_template: FakeConfigTemplate
     register: deleted
     ignore_errors: yes

--- a/test/integration/targets/meraki_content_filtering/tasks/main.yml
+++ b/test/integration/targets/meraki_content_filtering/tasks/main.yml
@@ -58,6 +58,7 @@
   - assert:
       that:
         - single_allowed_idempotent.changed == False
+        - single_allowed_idempotent.data is defined
 
   - name: Set single blocked URL pattern
     meraki_content_filtering:

--- a/test/integration/targets/meraki_content_filtering/tasks/main.yml
+++ b/test/integration/targets/meraki_content_filtering/tasks/main.yml
@@ -4,26 +4,37 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
-  # - name: Test an API key is provided
-  #   fail:
-  #     msg: Please define an API key
-  #   when: auth_key is not defined
+  - name: Test an API key is provided
+    fail:
+      msg: Please define an API key
+    when: auth_key is not defined
     
-  # - name: Use an invalid domain
-  #   meraki_config_template:
-  #     auth_key: '{{ auth_key }}'
-  #     host: marrrraki.com
-  #     state: query
-  #     org_name: DevTestOrg
-  #     output_level: debug
-  #   delegate_to: localhost
-  #   register: invalid_domain
-  #   ignore_errors: yes
+  - name: Use an invalid domain
+    meraki_config_template:
+      auth_key: '{{ auth_key }}'
+      host: marrrraki.com
+      state: query
+      org_name: DevTestOrg
+      output_level: debug
+    delegate_to: localhost
+    register: invalid_domain
+    ignore_errors: yes
 
-  # - name: Connection assertions
-  #   assert:
-  #     that:
-  #       - '"Failed to connect to" in invalid_domain.msg'
+  - name: Connection assertions
+    assert:
+      that:
+        - '"Failed to connect to" in invalid_domain.msg'
+
+  - name: Create network with type switch
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      type: appliance
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_appliance
 
   - name: Set single allowed URL pattern
     meraki_content_filtering:

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -183,6 +183,7 @@
       tags: recently-added
       state: present
       move_map_marker: True
+      note: Test device notes
     delegate_to: localhost
     register: update_device_idempotent
 

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -192,6 +192,7 @@
   - assert:
       that:
         - update_device_idempotent.changed == False
+        - update_device_idempotent.data is defined
 
   always:
   - name: Remove a device from a network

--- a/test/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
@@ -41,6 +41,7 @@
       that:
         - create_one.data.0.comment == 'Integration test rule'
         - create_one.data.1.policy == 'deny'
+        - create_one.data is defined
 
   - name: Enable local LAN access
     meraki_mr_l3_firewall:

--- a/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -4,37 +4,37 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
-  # - name: Test an API key is provided
-  #   fail:
-  #     msg: Please define an API key
-  #   when: auth_key is not defined
+  - name: Test an API key is provided
+    fail:
+      msg: Please define an API key
+    when: auth_key is not defined
     
-  # - name: Use an invalid domain
-  #   meraki_organization:
-  #     auth_key: '{{ auth_key }}'
-  #     host: marrrraki.com
-  #     state: present
-  #     org_name: IntTestOrg
-  #     output_level: debug
-  #   delegate_to: localhost
-  #   register: invalid_domain
-  #   ignore_errors: yes
+  - name: Use an invalid domain
+    meraki_organization:
+      auth_key: '{{ auth_key }}'
+      host: marrrraki.com
+      state: present
+      org_name: IntTestOrg
+      output_level: debug
+    delegate_to: localhost
+    register: invalid_domain
+    ignore_errors: yes
     
-  # - name: Disable HTTP
-  #   meraki_organization:
-  #     auth_key: '{{ auth_key }}'
-  #     use_https: false
-  #     state: query
-  #     output_level: debug
-  #   delegate_to: localhost
-  #   register: http
-  #   ignore_errors: yes
+  - name: Disable HTTP
+    meraki_organization:
+      auth_key: '{{ auth_key }}'
+      use_https: false
+      state: query
+      output_level: debug
+    delegate_to: localhost
+    register: http
+    ignore_errors: yes
 
-  # - name: Connection assertions
-  #   assert:
-  #     that:
-  #       - '"Failed to connect to" in invalid_domain.msg'
-  #       - '"http" in http.url'
+  - name: Connection assertions
+    assert:
+      that:
+        - '"Failed to connect to" in invalid_domain.msg'
+        - '"http" in http.url'
 
   - name: Create network
     meraki_network:

--- a/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -54,9 +54,6 @@
     delegate_to: localhost
     register: query
 
-  - debug:
-      msg: '{{query}}'
-
   - assert:
       that:
         - query.data|length == 1
@@ -78,6 +75,9 @@
     delegate_to: localhost
     register: create_one
 
+  - debug:
+      var: create_one
+
   - assert:
       that:
         - create_one.data|length == 2
@@ -85,6 +85,7 @@
         - create_one.data.0.protocol == 'tcp'
         - create_one.data.0.policy == 'deny'
         - create_one.changed == True
+        - create_one.data is defined
 
   - name: Check for idempotency
     meraki_mx_l3_firewall:
@@ -146,6 +147,10 @@
   - debug:
       msg: '{{default_syslog}}'
 
+  - assert:
+      that:
+        - default_syslog.data is defined
+
   - name: Query firewall rules
     meraki_mx_l3_firewall:
       auth_key: '{{ auth_key }}'
@@ -184,6 +189,10 @@
   - debug:
       msg: '{{disable_syslog}}'
 
+  - assert:
+      that:
+        - disable_syslog.data is defined
+
   - name: Query firewall rules
     meraki_mx_l3_firewall:
       auth_key: '{{ auth_key }}'
@@ -211,3 +220,11 @@
       rules: []
     delegate_to: localhost
     register: delete_all
+
+  - name: Delete network
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: absent
+    delegate_to: localhost

--- a/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -109,6 +109,7 @@
   - assert:
       that:
         - create_one_idempotent.changed == False
+        - create_one_idempotent.data is defined
 
   - name: Create syslog in network
     meraki_syslog:

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -67,9 +67,6 @@
     delegate_to: localhost
     register: enable_vlan
 
-  - debug:
-      msg: '{{ enable_vlan }}'
-
   - assert:
       that:
         - enable_vlan.data.enabled == True
@@ -84,9 +81,13 @@
     delegate_to: localhost
     register: enable_vlan_idempotent
 
+  - debug:
+      var: enable_vlan_idempotent
+
   - assert:
       that:
         - enable_vlan_idempotent is not changed
+        - enable_vlan_idempotent.data is defined
   
   - name: Disable VLAN support on appliance network
     meraki_network:
@@ -97,9 +98,6 @@
       enable_vlans: no
     delegate_to: localhost
     register: disable_vlan
-
-  - debug:
-      msg: '{{ disable_vlan }}'
 
   - assert:
       that:
@@ -118,6 +116,7 @@
   - assert:
       that:
         - disable_vlan_idempotent is not changed
+        - disable_vlan_idempotent.data is defined
 
   - name: Create network with type wireless
     meraki_network:
@@ -140,6 +139,10 @@
       timezone: America/Chicago
     delegate_to: localhost
     register: create_net_wireless_idempotent
+
+  - assert:
+      that:
+        - create_net_wireless_idempotent.data is defined
 
   - name: Create network with type combined and disable my.meraki.com
     meraki_network:
@@ -176,9 +179,6 @@
       tags: first_tag
     delegate_to: localhost
     register: create_net_tag
-
-  - debug:
-      msg: '{{create_net_tag}}'
     
   - name: Create network with two tags
     meraki_network:
@@ -193,9 +193,6 @@
         - second_tag
     delegate_to: localhost
     register: create_net_tags
-
-  - debug:
-      msg: '{{create_net_tags}}'
 
   - name: Modify network
     meraki_network:
@@ -226,6 +223,10 @@
         - third_tag
     delegate_to: localhost
     register: create_net_modified_idempotent
+
+  - assert:
+      that:
+        - create_net_modified_idempotent.data is defined
 
   - name: Present assertions
     assert:

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -241,11 +241,13 @@
         - '"IntTestNetworkSwitchOrgID" in create_net_switch_org_id.data.name'
         - '"IntTestNetworkWireless" in create_net_wireless.data.name'
         - create_net_wireless_idempotent.changed == False
+        - create_net_wireless_idempotent.data is defined
         - '"first_tag" in create_net_tag.data.tags'
         - '"second_tag" in create_net_tags.data.tags'
         - '"third_tag" in create_net_modified.data.tags'
         - create_net_modified.changed == True
         - create_net_modified_idempotent.changed == False
+        - create_net_modified_idempotent.data is defined
 
   - name: Query all networks
     meraki_network:

--- a/test/integration/targets/meraki_organization/tasks/main.yml
+++ b/test/integration/targets/meraki_organization/tasks/main.yml
@@ -91,6 +91,7 @@
       - modify_org.changed == True
       - 'modify_org.data.name == "IntTestOrgRenamed"'
       - modify_org_idempotent.changed == False
+      - modify_org_idempotent.data is defined
 
 - name: List all organizations
   meraki_organization:

--- a/test/integration/targets/meraki_snmp/tasks/main.yml
+++ b/test/integration/targets/meraki_snmp/tasks/main.yml
@@ -118,6 +118,7 @@
 - assert:
     that:
       - snmp_idempotent.changed == False
+      - snmp_idempotent.data is defined
 
 - name: Add peer IPs
   meraki_snmp:

--- a/test/integration/targets/meraki_ssid/tasks/main.yml
+++ b/test/integration/targets/meraki_ssid/tasks/main.yml
@@ -94,6 +94,7 @@
   - assert:
       that:
         - enable_name_ssid_idempotent.changed == False
+        - enable_name_ssid_idempotent.data is defined
 
   - name: Query one SSIDs
     meraki_ssid:

--- a/test/integration/targets/meraki_static_route/tasks/main.yml
+++ b/test/integration/targets/meraki_static_route/tasks/main.yml
@@ -106,6 +106,7 @@
   - assert:
       that:
         - update_idempotent.changed == False
+        - update_idempotent.data is defined
 
   - name: Update static route with fixed IP assignment and reservation
     meraki_static_route:

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -3,21 +3,21 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test an API key is provided
-  fail:
-    msg: Please define an API key
-  when: auth_key is not defined
+# - name: Test an API key is provided
+#   fail:
+#     msg: Please define an API key
+#   when: auth_key is not defined
   
-- name: Use an invalid domain
-  meraki_switchport:
-    auth_key: '{{ auth_key }}'
-    host: marrrraki.com
-    state: query
-    serial: Q2HP-2C6E-GTLD
-    org_name: IntTestOrg
-  delegate_to: localhost
-  register: invaliddomain
-  ignore_errors: yes
+# - name: Use an invalid domain
+#   meraki_switchport:
+#     auth_key: '{{ auth_key }}'
+#     host: marrrraki.com
+#     state: query
+#     serial: Q2HP-2C6E-GTLD
+#     org_name: IntTestOrg
+#   delegate_to: localhost
+#   register: invaliddomain
+#   ignore_errors: yes
   
 - name: Disable HTTP
   meraki_switchport:
@@ -218,6 +218,7 @@
 - assert:
     that:
       - update_port_access_idempotent.changed == False
+      - update_port_access_idempotent.data is defined
 
 - name: Configure trunk port
   meraki_switchport:
@@ -321,3 +322,4 @@
 - assert:
     that:
       - update_trunk_idempotent.changed == False
+      - update_trunk_idempotent.data is defined

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -3,21 +3,21 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-# - name: Test an API key is provided
-#   fail:
-#     msg: Please define an API key
-#   when: auth_key is not defined
+- name: Test an API key is provided
+  fail:
+    msg: Please define an API key
+  when: auth_key is not defined
   
-# - name: Use an invalid domain
-#   meraki_switchport:
-#     auth_key: '{{ auth_key }}'
-#     host: marrrraki.com
-#     state: query
-#     serial: Q2HP-2C6E-GTLD
-#     org_name: IntTestOrg
-#   delegate_to: localhost
-#   register: invaliddomain
-#   ignore_errors: yes
+- name: Use an invalid domain
+  meraki_switchport:
+    auth_key: '{{ auth_key }}'
+    host: marrrraki.com
+    state: query
+    serial: Q2HP-2C6E-GTLD
+    org_name: IntTestOrg
+  delegate_to: localhost
+  register: invaliddomain
+  ignore_errors: yes
   
 - name: Disable HTTP
   meraki_switchport:

--- a/test/integration/targets/meraki_syslog/tasks/main.yml
+++ b/test/integration/targets/meraki_syslog/tasks/main.yml
@@ -102,6 +102,7 @@
   - assert:
       that:
         - create_server_idempotency.changed == False
+        - create_server_idempotency.data is defined
 
   - name: Set multiple syslog servers  # Broken
     meraki_syslog:

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -165,6 +165,7 @@
   - assert:
       that:
         - update_vlan_idempotent.changed == False
+        - update_vlan_idempotent.data is defined
 
   - name: Add IP assignments and reserved IP ranges
     meraki_vlan:
@@ -262,6 +263,7 @@
   - assert:
       that:
         - update_vlan_idempotent.changed == False
+        - update_vlan_idempotent.data is defined
 
   - name: Update VLAN with list of DNS entries
     meraki_vlan:


### PR DESCRIPTION
##### SUMMARY
Fixes #53575

Unchanged data now returns the existing information so it's idempotent to the end user.

###### Modules Tested Via Integration Tests
- [x] meraki_admin
- [x] meraki_config_template
- [x] meraki_content_filtering
- [ ] meraki_device
- [ ] meraki_mr_l3_firewall
- [x] meraki_mx_l3_firewall
- [x] meraki_network
- [x] meraki_organization
- [x] meraki_snmp
- [x] meraki_ssid
- [x] meraki_static_route
- [x] meraki_switchport
- [x] meraki_syslog
- [x] meraki_vlan

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki
