### PR TITLE
Template value of debugger and then check for validity

### DIFF
--- a/changelogs/fragments/53587-allow_templated_debugger_value.yaml
+++ b/changelogs/fragments/53587-allow_templated_debugger_value.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Allow debugger to take a templated value: https://github.com/ansible/ansible/pull/53587

--- a/changelogs/fragments/53587-allow_templated_debugger_value.yaml
+++ b/changelogs/fragments/53587-allow_templated_debugger_value.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-    - Allow debugger to take a templated value: https://github.com/ansible/ansible/pull/53587
+    - Allow debugger to take a templated value (https://github.com/ansible/ansible/pull/53587)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -259,7 +259,11 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
     def get_variable_manager(self):
         return self._variable_manager
 
-    def _validate_debugger(self, attr, name, value):
+    def _post_validate_debugger(self, attr, value, templar):
+        if templar.is_template(value):
+            value = templar.template(value, fail_on_undefined=True)
+        else:
+            value = value
         valid_values = frozenset(('always', 'on_failed', 'on_unreachable', 'on_skipped', 'never'))
         if value and isinstance(value, string_types) and value not in valid_values:
             raise AnsibleParserError("'%s' is not a valid value for debugger. Must be one of %s" % (value, ', '.join(valid_values)), obj=self.get_ds())

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -260,10 +260,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
         return self._variable_manager
 
     def _post_validate_debugger(self, attr, value, templar):
-        if templar.is_template(value):
-            value = templar.template(value, fail_on_undefined=True)
-        else:
-            value = value
+        value = templar.template(value)
         valid_values = frozenset(('always', 'on_failed', 'on_unreachable', 'on_skipped', 'never'))
         if value and isinstance(value, string_types) and value not in valid_values:
             raise AnsibleParserError("'%s' is not a valid value for debugger. Must be one of %s" % (value, ', '.join(valid_values)), obj=self.get_ds())


### PR DESCRIPTION
##### SUMMARY
Allow debugger to accept a templated value

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py

##### ADDITIONAL INFORMATION
Allow a variable to be defined to specify what behaviour to expect from debugger, so that debugging statements may be kept in the code base 
before:
```
fatal: [localhost]: FAILED! => {"msg": "'{{ thing_debugger }}' is not a valid value for debugger. Must be one of always, on_unreachable, never, on_skipped, on_failed"}
```
after, when thing_debugger is set to always:
```
[localhost] TASK: Gathering Facts (debug)>
```