### PR TITLE
Add toggle to 3 inventory plugins to enable / disable group name modifications

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -149,6 +149,7 @@ class BaseInventoryPlugin(AnsiblePlugin):
     """ Parses an Inventory Source"""
 
     TYPE = 'generator'
+    _sanatize_group_name = staticmethod(to_safe_group_name)
 
     def __init__(self):
 
@@ -369,7 +370,7 @@ class Constructable(object):
             self.templar.set_available_variables(variables)
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = to_safe_group_name(group_name)
+                group_name = self._sanatize_group_name(group_name)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:
@@ -415,12 +416,12 @@ class Constructable(object):
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
 
                         for bare_name in new_raw_group_names:
-                            gname = to_safe_group_name('%s%s%s' % (prefix, sep, bare_name))
+                            gname = self._sanatize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             self.inventory.add_group(gname)
                             self.inventory.add_child(gname, host)
 
                             if raw_parent_name:
-                                parent_name = to_safe_group_name(raw_parent_name)
+                                parent_name = self._sanatize_group_name(raw_parent_name)
                                 self.inventory.add_group(parent_name)
                                 self.inventory.add_child(parent_name, gname)
 

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -149,7 +149,7 @@ class BaseInventoryPlugin(AnsiblePlugin):
     """ Parses an Inventory Source"""
 
     TYPE = 'generator'
-    _sanatize_group_name = staticmethod(to_safe_group_name)
+    _sanitize_group_name = staticmethod(to_safe_group_name)
 
     def __init__(self):
 
@@ -370,7 +370,7 @@ class Constructable(object):
             self.templar.set_available_variables(variables)
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = self._sanatize_group_name(group_name)
+                group_name = self._sanitize_group_name(group_name)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:
@@ -379,7 +379,7 @@ class Constructable(object):
                     continue
 
                 if result:
-                    # ensure group exists, use sanatized name
+                    # ensure group exists, use sanitized name
                     group_name = self.inventory.add_group(group_name)
                     # add host to group
                     self.inventory.add_child(group_name, host)
@@ -416,12 +416,12 @@ class Constructable(object):
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
 
                         for bare_name in new_raw_group_names:
-                            gname = self._sanatize_group_name('%s%s%s' % (prefix, sep, bare_name))
+                            gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             self.inventory.add_group(gname)
                             self.inventory.add_child(gname, host)
 
                             if raw_parent_name:
-                                parent_name = self._sanatize_group_name(raw_parent_name)
+                                parent_name = self._sanitize_group_name(raw_parent_name)
                                 self.inventory.add_group(parent_name)
                                 self.inventory.add_child(parent_name, gname)
 

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -69,6 +69,18 @@ DOCUMENTATION = '''
               False in the inventory config file which will allow 403 errors to be gracefully skipped.
           type: bool
           default: True
+        transform_invalid_group_chars:
+          description:
+            - By default this plugin is using a general group name sanitization to create safe and usable group names for use in Ansible.
+              You can turn this off by giving this a valud of "False".
+              Various deprecated behaviors can be obtained by turning this off and using custom regex_replace jinja2 filters.
+            - For this to work you should also turn off the global TRANSFORM_INVALID_GROUP_CHARS setting,
+              otherwise the core engine will just use the standard sanitization on top.
+            - This is not the default as such names break certain functionality as not all characters are valid Python identifiers
+              which group names end up being used as.
+          type: bool
+          default: True
+          version_added: "2.8"
 '''
 
 EXAMPLES = '''
@@ -521,6 +533,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).parse(inventory, loader, path)
 
         config_data = self._read_config_data(path)
+
+        if not self.get_option('transform_invalid_group_chars'):
+            self._sanitize_group_name = lambda name: name
+
         self._set_credentials()
 
         # get user specifications

--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -60,6 +60,18 @@ DOCUMENTATION = r'''
                 C(exclude_host_filters) to exclude powered-off and not-fully-provisioned hosts. Set this to a different
                 value or empty list if you need to include hosts in these states.
             default: ['powerstate != "running"', 'provisioning_state != "succeeded"']
+        transform_invalid_group_chars:
+          description:
+            - By default this plugin is using a general group name sanitization to create safe and usable group names for use in Ansible.
+              You can turn this off by giving this a valud of "False".
+              Various deprecated behaviors can be obtained by turning this off and using custom regex_replace jinja2 filters.
+            - For this to work you should also turn off the global TRANSFORM_INVALID_GROUP_CHARS setting,
+              otherwise the core engine will just use the standard sanitization on top.
+            - This is not the default as such names break certain functionality as not all characters are valid Python identifiers
+              which group names end up being used as.
+          type: bool
+          default: True
+          version_added: "2.8"
 '''
 
 EXAMPLES = '''
@@ -227,6 +239,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         super(InventoryModule, self).parse(inventory, loader, path)
 
         self._read_config_data(path)
+
+        if not self.get_option('transform_invalid_group_chars'):
+            self._sanitize_group_name = lambda name: name
+
         self._batch_fetch = self.get_option('batch_fetch')
 
         self._filters = self.get_option('exclude_host_filters') + self.get_option('default_host_filters')

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -51,6 +51,18 @@ DOCUMENTATION = '''
         vars_prefix:
             description: prefix to apply to host variables, does not include facts nor params
             default: ''
+        transform_invalid_group_chars:
+          description:
+            - By default this plugin is using a general group name sanitization to create safe and usable group names for use in Ansible.
+              You can turn this off by giving this a valud of "False".
+              Various deprecated behaviors can be obtained by turning this off and using custom regex_replace jinja2 filters.
+            - For this to work you should also turn off the global TRANSFORM_INVALID_GROUP_CHARS setting,
+              otherwise the core engine will just use the standard sanitization on top.
+            - This is not the default as such names break certain functionality as not all characters are valid Python identifiers
+              which group names end up being used as.
+          type: bool
+          default: True
+          version_added: "2.8"
 '''
 
 EXAMPLES = '''
@@ -324,6 +336,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         config_data = {}
         config_data = self._read_config_data(path)
+
+        if not self.get_option('transform_invalid_group_chars'):
+            self._sanitize_group_name = lambda name: name
 
         # get user specifications
         if 'zones' in config_data:


### PR DESCRIPTION
##### SUMMARY
This intends to replace https://github.com/ansible/ansible/pull/53458

A toggle is added, so that users can turn it off, and have the inventory plugin not modify group names from the keyed groups entries.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
inventory plugin ec2
inventory plugin gcp_compute
inventory plugin azure_rm

##### ADDITIONAL INFORMATION
I have tested all these on the CLI with accounts for each of the sources, and confirmed the un-sanitized group names with this set to false, and that group names are sanitized with it set to true. Set to false, I get the warning messages. With the default, no warning messages. This is the intended behavior.
