### PR TITLE
[2.7] docker_swarm: removing nodes requires docker >= 2.4.0

### DIFF
--- a/changelogs/fragments/53129-docker_swarm-older-docker-py.yaml
+++ b/changelogs/fragments/53129-docker_swarm-older-docker-py.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- "docker_swarm - now supports docker-py 1.10.0 and newer, instead only docker 2.6.0 and newer."
+- "docker_swarm - now supports docker-py 1.10.0 and newer for most operations, instead only docker 2.6.0 and newer."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -442,7 +442,7 @@ class AnsibleDockerClient(Client):
             if not data['supported']:
                 # Test whether option is specified
                 if 'detect_usage' in data:
-                    used = data['detect_usage']()
+                    used = data['detect_usage'](self)
                 else:
                     used = self.module.params.get(option) is not None
                     if used and 'default' in self.module.argument_spec[option]:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2234,7 +2234,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
         self.comparisons = comparisons
 
     def __init__(self, **kwargs):
-        def detect_ipvX_address_usage():
+        def detect_ipvX_address_usage(client):
             '''
             Helper function to detect whether any specified network uses ipv4_address or ipv6_address
             '''

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -52,6 +52,7 @@ options:
       - Set to C(join), to join an existing cluster.
       - Set to C(absent), to leave an existing cluster.
       - Set to C(remove), to remove an absent node from the cluster.
+        Note that removing requires docker-py >= 2.4.0.
       - Set to C(inspect) to display swarm informations.
     type: str
     required: yes
@@ -551,6 +552,10 @@ class SwarmManager(DockerBaseClass):
         self.results['changed'] = True
 
 
+def _detect_remove_operation(client):
+    return client.module.params['state'] == 'remove'
+
+
 def main():
     argument_spec = dict(
         advertise_addr=dict(type='str'),
@@ -590,6 +595,11 @@ def main():
         ca_force_rotate=dict(docker_py_version='2.6.0', docker_api_version='1.30'),
         autolock_managers=dict(docker_py_version='2.6.0'),
         log_driver=dict(docker_py_version='2.6.0'),
+        remove_operation=dict(
+            docker_py_version='2.4.0',
+            detect_usage=_detect_remove_operation,
+            usage_msg='remove swarm nodes'
+        ),
     )
 
     client = AnsibleDockerClient(


### PR DESCRIPTION
##### SUMMARY
Backport of #53565 to stable-2.7. This is an update to the already merged backport #53272, which ensures that one feature which requires docker-py >= 2.4.0 (because of a docker-py bug) will fail with a proper error (instead of crashing because of docker-py).

(This is unfortunately one of the features which can't be tested in CI, since it needs a swarm cluster with at least two nodes...)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
