### PR TITLE
openssl_privatekey: add backup option

### DIFF
--- a/changelogs/fragments/53593-openssl_privatekey-backup.yml
+++ b/changelogs/fragments/53593-openssl_privatekey-backup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "openssl_privatekey - add ``backup`` option."

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -230,7 +230,7 @@ class OpenSSLObject(object):
 
         pass
 
-    def remove(self):
+    def remove(self, module):
         """Remove the resource from the filesystem."""
 
         try:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1220,7 +1220,7 @@ def main():
             module.exit_json(**result)
 
         try:
-            certificate.remove()
+            certificate.remove(module)
         except CertificateError as exc:
             module.fail_json(msg=to_native(exc))
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -1044,7 +1044,7 @@ def main():
             module.exit_json(**result)
 
         try:
-            csr.remove()
+            csr.remove(module)
         except (CertificateSigningRequestError, crypto_utils.OpenSSLObjectError) as exc:
             module.fail_json(msg=to_native(exc))
 

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -241,7 +241,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
         self.pkcs12 = crypto.PKCS12()
 
         try:
-            self.remove()
+            self.remove(module)
         except PkcsError as exc:
             module.fail_json(msg=to_native(exc))
 
@@ -274,14 +274,14 @@ class Pkcs(crypto_utils.OpenSSLObject):
                                                      self.iter_size, self.maciter_size))
             os.close(pkcs12_file)
         except (IOError, OSError) as exc:
-            self.remove()
+            self.remove(module)
             raise PkcsError(exc)
 
     def parse(self, module):
         """Read PKCS#12 file."""
 
         try:
-            self.remove()
+            self.remove(module)
             with open(self.src, 'rb') as pkcs12_fh:
                 pkcs12_content = pkcs12_fh.read()
             p12 = crypto.load_pkcs12(pkcs12_content,
@@ -298,7 +298,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
             os.close(pkcs12_file)
 
         except IOError as exc:
-            self.remove()
+            self.remove(module)
             raise PkcsError(exc)
 
 
@@ -378,7 +378,7 @@ def main():
 
         if os.path.exists(module.params['path']):
             try:
-                pkcs12.remove()
+                pkcs12.remove(module)
                 changed = True
             except PkcsError as exc:
                 module.fail_json(msg=to_native(exc))

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -119,7 +119,7 @@ options:
     backup:
         description:
             - Create a backup file including a timestamp so you can get
-              the original private key back if you somehow clobbered it incorrectly.
+              the original private key back if you overwrote it with a new one by accident.
         type: bool
         default: no
         version_added: "2.8"

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -292,7 +292,7 @@ class PrivateKeyBase(crypto_utils.OpenSSLObject):
 
         if not self.check(module, perms_required=False) or self.force:
             if self.backup:
-                self.backup_file = self.module.backup_local(self.path)
+                self.backup_file = module.backup_local(self.path)
             privatekey_data = self._generate_private_key_data()
             try:
                 privatekey_file = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
@@ -320,10 +320,10 @@ class PrivateKeyBase(crypto_utils.OpenSSLObject):
         if module.set_fs_attributes_if_different(file_args, False):
             self.changed = True
 
-    def remove(self):
+    def remove(self, module):
         if self.backup:
-            self.backup_file = self.module.backup_local(self.path)
-        super(PrivateKeyBase, self).remove()
+            self.backup_file = module.backup_local(self.path)
+        super(PrivateKeyBase, self).remove(module)
 
     @abc.abstractmethod
     def _check_passphrase(self):
@@ -686,7 +686,7 @@ def main():
             module.exit_json(**result)
 
         try:
-            private_key.remove()
+            private_key.remove(module)
         except PrivateKeyError as exc:
             module.fail_json(msg=to_native(exc))
 

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -118,7 +118,7 @@ options:
         version_added: "2.8"
     backup:
         description:
-            - Create a backup file including the timestamp information so you can get
+            - Create a backup file including a timestamp so you can get
               the original private key back if you somehow clobbered it incorrectly.
         type: bool
         default: no

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -26,7 +26,7 @@ description:
     - "Please note that the module regenerates private keys if they don't match
       the module's options. In particular, if you provide another passphrase
       (or specify none), change the keysize, etc., the private key will be
-      regenerated. If you are concerned of this overwriting your private key,
+      regenerated. If you are concerned that this could overwrite your private key,
       please consider using the I(backup) option."
     - The module can use the cryptography Python library, or the pyOpenSSL Python
       library. By default, it tries to detect which one is available. This can be

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -27,7 +27,7 @@ description:
       the module's options. In particular, if you provide another passphrase
       (or specify none), change the keysize, etc., the private key will be
       regenerated. If you are concerned that this could overwrite your private key,
-      please consider using the I(backup) option."
+      consider using the I(backup) option."
     - The module can use the cryptography Python library, or the pyOpenSSL Python
       library. By default, it tries to detect which one is available. This can be
       overridden with the I(select_crypto_backend) option."

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -205,7 +205,7 @@ class PublicKey(crypto_utils.OpenSSLObject):
             except (IOError, OSError) as exc:
                 raise PublicKeyError(exc)
             except AttributeError as exc:
-                self.remove()
+                self.remove(module)
                 raise PublicKeyError('You need to have PyOpenSSL>=16.0.0 to generate public keys')
 
         self.fingerprint = crypto_utils.get_fingerprint(
@@ -315,7 +315,7 @@ def main():
             module.exit_json(**result)
 
         try:
-            public_key.remove()
+            public_key.remove(module)
         except PublicKeyError as exc:
             module.fail_json(msg=to_native(exc))
 

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -149,6 +149,7 @@
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
+    backup: yes
   register: passphrase_1
 
 - name: Generate privatekey with passphrase (idempotent)
@@ -157,18 +158,21 @@
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
+    backup: yes
   register: passphrase_2
 
 - name: Regenerate privatekey without passphrase
   openssl_privatekey:
     path: '{{ output_dir }}/privatekeypw.pem'
     select_crypto_backend: '{{ select_crypto_backend }}'
+    backup: yes
   register: passphrase_3
 
 - name: Regenerate privatekey without passphrase (idempotent)
   openssl_privatekey:
     path: '{{ output_dir }}/privatekeypw.pem'
     select_crypto_backend: '{{ select_crypto_backend }}'
+    backup: yes
   register: passphrase_4
 
 - name: Regenerate privatekey with passphrase
@@ -177,4 +181,25 @@
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
+    backup: yes
   register: passphrase_5
+
+- name: Remove module
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekeypw.pem'
+    passphrase: hunter2
+    cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    select_crypto_backend: '{{ select_crypto_backend }}'
+    backup: yes
+    state: absent
+  register: remove_1
+
+- name: Remove module (idempotent)
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekeypw.pem'
+    passphrase: hunter2
+    cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    select_crypto_backend: '{{ select_crypto_backend }}'
+    backup: yes
+    state: absent
+  register: remove_2

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -113,3 +113,16 @@
       - passphrase_3 is changed
       - passphrase_4 is not changed
       - passphrase_5 is changed
+      - passphrase_1.backup_file is undefined
+      - passphrase_2.backup_file is undefined
+      - passphrase_3.backup_file is not none
+      - passphrase_4.backup_file is undefined
+      - passphrase_5.backup_file is not none
+
+- name: Validate remove
+  assert:
+    that:
+      - remove_1 is changed
+      - remove_2 is not changed
+      - remove_1.backup_file is not none
+      - remove_2.backup_file is undefined


### PR DESCRIPTION
##### SUMMARY
Adds a `backup` option (similarly to the `copy` or `template` modules) and mention it as an option for paranoid/careless users. (Default is `off`.)

Fixes #32038.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_privatekey
