### PR TITLE
Prefer ansible_facts namespace in examples

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -86,7 +86,7 @@ For more fine grained skipping, use conditionals in integration test playbooks, 
 
 .. code-block:: yaml
 
-   when: ansible_distribution in ('Ubuntu')
+   when: ansible_facts['distribution'] in ('Ubuntu')
 
 
 Miscellaneous

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -14,7 +14,7 @@ How can I set the PATH or any other environment variable for a task or entire pl
 Setting environment variables can be done with the `environment` keyword. It can be used at the task or other levels in the play::
 
     environment:
-      PATH: "{{ ansible_env.PATH }}:/thingy/bin"
+      PATH: "{{ ansible_facts['env']['PATH'] }}:/thingy/bin"
       SOME: value
 
 .. note:: starting in 2.0.1 the setup task from gather_facts also inherits the environment directive from the play, you might need to use the `|default` filter to avoid errors if setting this at play level.
@@ -352,7 +352,7 @@ Then you can use the facts inside your template, like this:
 .. code-block:: jinja
 
     {% for host in groups['db_servers'] %}
-       {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+       {{ hostvars[host]['ansible_facts']['eth0']['ipv4']['address'] }}
     {% endfor %}
 
 .. _programatic_access_to_a_variable:
@@ -397,16 +397,16 @@ Anyway, here's the trick:
 
 .. code-block:: jinja
 
-    {{ hostvars[groups['webservers'][0]]['ansible_eth0']['ipv4']['address'] }}
+    {{ hostvars[groups['webservers'][0]]['ansible_facts']['eth0']['ipv4']['address'] }}
 
 Notice how we're pulling out the hostname of the first machine of the webservers group.  If you are doing this in a template, you
 could use the Jinja2 '#set' directive to simplify this, or in a playbook, you could also use set_fact::
 
-    - set_fact: headnode={{ groups[['webservers'][0]] }}
+    - set_fact:
+        headnode: "{{ groups[['webservers'][0]] }}"
 
-    - debug: msg={{ hostvars[headnode].ansible_eth0.ipv4.address }}
-
-Notice how we interchanged the bracket syntax for dots -- that can be done anywhere.
+    - debug:
+        msg: "{{ hostvars[headnode]['ansible_facts']['eth0']['ipv4']['address'] }}"
 
 .. _file_recursion:
 
@@ -433,7 +433,7 @@ For environment variables on the TARGET machines, they are available via facts i
 
 .. code-block:: jinja
 
-   {{ ansible_env.SOME_VARIABLE }}
+   {{ ansible_facts['env']['SOME_VARIABLE'] }}
 
 If you need to set environment variables for TASK execution, see :ref:`playbooks_environment` in the :ref:`Advanced Playbooks <playbooks_special_topics>` section.
 There are several ways to set environment variables on your target machines. You can use the :ref:`template <template_module>`, :ref:`replace <replace_module>`, or :ref:`lineinfile <lineinfile_module>` modules to introduce environment variables into files.

--- a/docs/docsite/rst/reference_appendices/glossary.rst
+++ b/docs/docsite/rst/reference_appendices/glossary.rst
@@ -245,7 +245,7 @@ when a term comes up on the mailing list.
     Local Action
         A local_action directive in a :term:`playbook <playbooks>` targeting
         remote machines means that the given step will actually occur on the
-        local machine, but that the variable ``{{ ansible_hostname }}`` can be
+        local machine, but that the variable ``{{ ansible_facts['hostname'] }}`` can be
         passed in to reference the remote hostname being referred to in that
         step.  This can be used to trigger, for example, an rsync operation.
 

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -230,7 +230,7 @@ The directive `delegate_facts` may be set to `True` to assign the task's gathere
           loop: "{{groups['dbservers']}}"
 
 The above will gather facts for the machines in the dbservers group and assign the facts to those machines and not to app_servers.
-This way you can lookup `hostvars['dbhost1']['ansible_default_ipv4']['address']` even though dbservers were not part of the play, or left out by using `--limit`.
+This way you can lookup `hostvars['dbhost1']['ansible_facts']['default_ipv4']['address']` even though dbservers were not part of the play, or left out by using `--limit`.
 
 
 .. _run_once:

--- a/docs/docsite/rst/user_guide/playbooks_environment.rst
+++ b/docs/docsite/rst/user_guide/playbooks_environment.rst
@@ -85,7 +85,7 @@ Some language-specific version managers (such as rbenv and nvm) require environm
 
       environment:
         NVM_DIR: /var/local/nvm
-        PATH: /var/local/nvm/versions/node/v4.2.1/bin:{{ ansible_env.PATH }}
+        PATH: /var/local/nvm/versions/node/v4.2.1/bin:{{ ansible_facts['env']['PATH'] }}
 
       tasks:
       - name: check for package.json
@@ -117,7 +117,7 @@ You might also want to simply specify the environment for a single task::
       environment:
         CONFIGURE_OPTS: '--disable-install-doc'
         RBENV_ROOT: '{{ rbenv_root }}'
-        PATH: '{{ rbenv_root }}/bin:{{ rbenv_root }}/shims:{{ rbenv_plugins }}/ruby-build/bin:{{ ansible_env.PATH }}'
+        PATH: '{{ rbenv_root }}/bin:{{ rbenv_root }}/shims:{{ rbenv_plugins }}/ruby-build/bin:{{ ansible_facts['env']['PATH'] }}'
 
 .. note::
    ``environment:`` does not affect Ansible itself, ONLY the context of the specific task action and this does not include Ansible's own configuration settings.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1214,7 +1214,7 @@ doesn't know it is a boolean value::
 To make use of one attribute from each item in a list of complex variables, use the "map" filter (see the `Jinja2 map() docs`_ for more)::
 
     # get a comma-separated list of the mount points (e.g. "/,/mnt/stuff") on a host
-    {{ ansible_mounts | map(attribute='mount') | join(',') }}
+    {{ ansible_facts['mounts'] | map(attribute='mount') | join(',') }}
 
 To get date object from string use the `to_datetime` filter, (new in version in 2.2)::
 
@@ -1239,7 +1239,7 @@ To format a date using a string (like with the shell date command), use the "str
     {{ '%H:%M:%S' | strftime }}
 
     # Use ansible_date_time.epoch fact
-    {{ '%Y-%m-%d %H:%M:%S' | strftime(ansible_date_time.epoch) }}
+    {{ '%Y-%m-%d %H:%M:%S' | strftime(ansible_facts['date_time']['epoch']) }}
 
     # Use arbitrary epoch value
     {{ '%Y-%m-%d' | strftime(0) }}          # => 1970-01-01

--- a/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule_member.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule_member.py
@@ -94,7 +94,7 @@ EXAMPLES = '''
     - name: Remove from load balancer
       cs_loadbalancer_rule_member:
         name: balance_http
-        vm: "{{ ansible_hostname }}"
+        vm: "{{ ansible_facts['hostname'] }}"
         state: absent
       delegate_to: localhost
   tasks:
@@ -103,7 +103,7 @@ EXAMPLES = '''
     - name: Add to load balancer
       cs_loadbalancer_rule_member:
         name: balance_http
-        vm: "{{ ansible_hostname }}"
+        vm: "{{ ansible_facts['hostname'] }}"
         state: present
       delegate_to: localhost
 '''

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -204,7 +204,7 @@ EXAMPLES = '''
 
 - name: Create a template from a stopped virtual machine's volume
   cs_template:
-    name: Debian 9 (64-bit) 20GB ({{ ansible_date_time.date }})
+    name: "Debian 9 (64-bit) 20GB ({{ ansible_facts['date_time']['date'] }})"
     vm: debian-9-base-vm
     os_type: Debian GNU/Linux 9 (64-bit)
     zone: tokio-ix
@@ -216,7 +216,7 @@ EXAMPLES = '''
 - name: Create a template from a stopped virtual machine's volume
   cs_template:
     name: Debian 9 (64-bit)
-    display_text: Debian 9 (64-bit) 20GB ({{ ansible_date_time.date }})
+    display_text: "Debian 9 (64-bit) 20GB ({{ ansible_facts['date_time']['date'] }})"
     template_find_option: display_text
     vm: debian-9-base-vm
     os_type: Debian GNU/Linux 9 (64-bit)

--- a/lib/ansible/modules/cloud/univention/udm_share.py
+++ b/lib/ansible/modules/cloud/univention/udm_share.py
@@ -41,7 +41,7 @@ options:
         required: false
         description:
             - Host FQDN (server which provides the share), e.g. C({{
-              ansible_fqdn }}). Required if C(state=present).
+              ansible_facts['fqdn'] }}). Required if C(state=present).
     path:
         required: false
         description:

--- a/lib/ansible/modules/database/influxdb/influxdb_write.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_write.py
@@ -45,14 +45,14 @@ EXAMPLES = r'''
           tags:
             host: server01
             region: us-west
-          time: "{{ ansible_date_time.iso8601 }}"
+          time: "{{ ansible_facts['date_time']['iso8601'] }}"
           fields:
             value: 2000
         - measurement: connections
           tags:
             host: server02
             region: us-east
-          time: "{{ ansible_date_time.iso8601 }}"
+          time: "{{ ansible_facts['date_time']['iso8601'] }}"
           fields:
             value: 3000
 '''

--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -130,8 +130,8 @@ EXAMPLES = r'''
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     insertafter: "<body>"
     block: |
-      <h1>Welcome to {{ ansible_hostname }}</h1>
-      <p>Last updated on {{ ansible_date_time.iso8601 }}</p>
+      <h1>Welcome to {{ ansible_facts['hostname'] }}</h1>
+      <p>Last updated on {{ ansible_facts['date_time']['iso8601'] }}</p>
 
 - name: Remove HTML as well as surrounding markers
   blockinfile:

--- a/lib/ansible/modules/inventory/group_by.py
+++ b/lib/ansible/modules/inventory/group_by.py
@@ -43,15 +43,15 @@ author:
 EXAMPLES = r'''
 # Create groups based on the machine architecture
 - group_by:
-    key: machine_{{ ansible_machine }}
+    key: machine_{{ ansible_facts['machine'] }}
 
 # Create groups like 'virt_kvm_host'
 - group_by:
-    key: virt_{{ ansible_virtualization_type }}_{{ ansible_virtualization_role }}
+    key: virt_{{ ansible_facts['virtualization_type'] }}_{{ ansible_facts['virtualization_role'] }}
 
 # Create nested groups
 - group_by:
-    key: el{{ ansible_distribution_major_version }}-{{ ansible_architecture }}
+    key: el{{ ansible_facts['distribution_major_version'] }}_{{ ansible_facts['architecture'] }}
     parents:
-      - el{{ ansible_distribution_major_version }}
+      - el{{ ansible_facts['distribution_major_version'] }}
 '''

--- a/lib/ansible/modules/monitoring/bigpanda.py
+++ b/lib/ansible/modules/monitoring/bigpanda.py
@@ -91,8 +91,8 @@ EXAMPLES = '''
 - bigpanda:
     component: myapp
     version: '1.3'
-    token: '{{ bigpanda_token }}'
-    hosts: '{{ ansible_hostname }}'
+    token: "{{ bigpanda_token }}"
+    hosts: "{{ ansible_facts['hostname'] }}"
     state: started
   delegate_to: localhost
   register: deployment

--- a/lib/ansible/modules/monitoring/datadog_event.py
+++ b/lib/ansible/modules/monitoring/datadog_event.py
@@ -53,7 +53,7 @@ options:
         choices: [normal, low]
     host:
         description: ["Host name to associate with the event."]
-        default: "{{ ansible_hostname }}"
+        default: "{{ ansible_facts['hostname'] }}"
         version_added: "2.4"
     tags:
         description: ["Comma separated list of tags to apply to the event."]

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -105,8 +105,8 @@ EXAMPLES = '''
     url_username: "ansible"
     url_password: "a_secret"
     state: present
-    name: "{{ ansible_fqdn }}"
-    ip: "{{ ansible_default_ipv4.address }}"
+    name: "{{ ansible_facts['fqdn'] }}"
+    ip: "{{ ansible_facts['default_ipv4']['address'] }}"
   delegate_to: 127.0.0.1
 '''
 

--- a/lib/ansible/modules/monitoring/sensu_client.py
+++ b/lib/ansible/modules/monitoring/sensu_client.py
@@ -95,8 +95,8 @@ EXAMPLES = '''
 # With customization
 - name: Configure Sensu client
   sensu_client:
-    name: "{{ ansible_fqdn }}"
-    address: "{{ ansible_default_ipv4['address'] }}"
+    name: "{{ ansible_facts['fqdn'] }}"
+    address: "{{ ansible_facts['default_ipv4']['address'] }}"
     subscriptions:
       - default
       - webserver

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -66,7 +66,7 @@ EXAMPLES = '''
 - name: Silence server1.example.dev
   sensu_silence:
     subscription: client:server1.example.dev
-    creator: "{{ ansible_user_id }}"
+    creator: "{{ ansible_facts['user_id'] }}"
     reason: Performing maintenance
 
 # Silence specific check for a client
@@ -74,7 +74,7 @@ EXAMPLES = '''
   sensu_silence:
     subscription: client:server1.example.dev
     check: CPU_Usage
-    creator: "{{ ansible_user_id }}"
+    creator: "{{ ansible_facts['user_id'] }}"
     reason: Investigation alert issue
 
 # Silence multiple clients from a dict
@@ -86,9 +86,9 @@ EXAMPLES = '''
 
 - name: Silence several clients from a dict
   sensu_silence:
-    subscription: "client:{{ item.key }}"
-    reason: "{{ item.value.reason }}"
-    creator: "{{ ansible_user_id }}"
+    subscription: "client:{{ item['key'] }}"
+    reason: "{{ item['value']['reason'] }}"
+    creator: "{{ ansible_facts['user_id'] }}"
   with_dict: "{{ silence }}"
 '''
 

--- a/lib/ansible/modules/network/bigswitch/bigmon_policy.py
+++ b/lib/ansible/modules/network/bigswitch/bigmon_policy.py
@@ -48,7 +48,7 @@ options:
   start_time:
     description:
      - Date the policy becomes active
-    default: ansible_date_time.iso8601
+    default: ansible_facts['date_time']['iso8601']
   delivery_packet_count:
     description:
      - Run policy until delivery_packet_count packets are delivered.

--- a/lib/ansible/modules/network/f5/bigip_pool_member.py
+++ b/lib/ansible/modules/network/f5/bigip_pool_member.py
@@ -213,7 +213,7 @@ EXAMPLES = '''
   bigip_pool_member:
     pool: my-pool
     partition: Common
-    host: "{{ ansible_default_ipv4['address'] }}"
+    host: "{{ ansible_facts['default_ipv4']['address'] }}"
     port: 80
     description: web server
     connection_limit: 100
@@ -229,7 +229,7 @@ EXAMPLES = '''
   bigip_pool_member:
     pool: my-pool
     partition: Common
-    host: "{{ ansible_default_ipv4['address'] }}"
+    host: "{{ ansible_facts['default_ipv4']['address'] }}"
     port: 80
     ratio: 1
     description: nginx server
@@ -244,7 +244,7 @@ EXAMPLES = '''
     state: absent
     pool: my-pool
     partition: Common
-    host: "{{ ansible_default_ipv4['address'] }}"
+    host: "{{ ansible_facts['default_ipv4']['address'] }}"
     port: 80
     provider:
       server: lb.mydomain.com
@@ -257,7 +257,7 @@ EXAMPLES = '''
     state: forced_offline
     pool: my-pool
     partition: Common
-    host: "{{ ansible_default_ipv4['address'] }}"
+    host: "{{ ansible_facts['default_ipv4']['address'] }}"
     port: 80
     provider:
       server: lb.mydomain.com

--- a/lib/ansible/modules/notification/irc.py
+++ b/lib/ansible/modules/notification/irc.py
@@ -106,7 +106,7 @@ EXAMPLES = '''
     port: 6669
     server: irc.example.net
     channel: #t1
-    msg: 'All finished at {{ ansible_date_time.iso8601 }}'
+    msg: "All finished at {{ ansible_facts['date_time']['iso8601'] }}"
     color: red
     nick: ansibleIRC
 
@@ -118,7 +118,7 @@ EXAMPLES = '''
     nick_to:
       - nick1
       - nick2
-    msg: 'All finished at {{ ansible_date_time.iso8601 }}'
+    msg: "All finished at {{ ansible_facts['date_time']['iso8601'] }}"
     color: red
     nick: ansibleIRC
 '''

--- a/lib/ansible/modules/notification/logentries_msg.py
+++ b/lib/ansible/modules/notification/logentries_msg.py
@@ -46,7 +46,7 @@ RETURN = '''# '''
 EXAMPLES = '''
 - logentries_msg:
     token=00000000-0000-0000-0000-000000000000
-    msg="{{ ansible_hostname }}"
+    msg="{{ ansible_facts['hostname'] }}"
 '''
 
 import socket

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -137,7 +137,7 @@ options:
 EXAMPLES = r'''
 - name: Example playbook sending mail to root
   mail:
-    subject: System {{ ansible_hostname }} has been successfully provisioned.
+    subject: System {{ ansible_facts['hostname'] }} has been successfully provisioned.
   delegate_to: localhost
 
 - name: Sending an e-mail using Gmail SMTP servers
@@ -148,7 +148,7 @@ EXAMPLES = r'''
     password: mysecret
     to: John Smith <john.smith@example.com>
     subject: Ansible-report
-    body: System {{ ansible_hostname }} has been successfully provisioned.
+    body: System {{ ansible_facts['hostname'] }} has been successfully provisioned.
   delegate_to: localhost
 
 - name: Send e-mail to a bunch of users, attaching files
@@ -177,7 +177,7 @@ EXAMPLES = r'''
     port: 25
     to: John Smith <john.smith@example.com>
     subject: Ansible-report
-    body: System {{ ansible_hostname }} has been successfully provisioned.
+    body: System {{ ansible_facts['hostname'] }} has been successfully provisioned.
 
 - name: Sending an e-mail using Legacy SSL to the remote machine
   mail:
@@ -185,7 +185,7 @@ EXAMPLES = r'''
     port: 25
     to: John Smith <john.smith@example.com>
     subject: Ansible-report
-    body: System {{ ansible_hostname }} has been successfully provisioned.
+    body: System {{ ansible_facts['hostname'] }} has been successfully provisioned.
     secure: always
 
 - name: Sending an e-mail using StartTLS to the remote machine
@@ -194,7 +194,7 @@ EXAMPLES = r'''
     port: 25
     to: John Smith <john.smith@example.com>
     subject: Ansible-report
-    body: System {{ ansible_hostname }} has been successfully provisioned.
+    body: System {{ ansible_facts['hostname'] }} has been successfully provisioned.
     secure: starttls
 '''
 

--- a/lib/ansible/modules/notification/mqtt.py
+++ b/lib/ansible/modules/notification/mqtt.py
@@ -99,8 +99,8 @@ author: "Jan-Piet Mens (@jpmens)"
 
 EXAMPLES = '''
 - mqtt:
-    topic: 'service/ansible/{{ ansible_hostname }}'
-    payload: 'Hello at {{ ansible_date_time.iso8601 }}'
+    topic: "service/ansible/{{ ansible_facts['hostname'] }}"
+    payload: "Hello at {{ ansible_facts['date_time']['iso8601'] }}"
     qos: 0
     retain: False
     client_id: ans001

--- a/lib/ansible/modules/source_control/git_config.py
+++ b/lib/ansible/modules/source_control/git_config.py
@@ -108,7 +108,7 @@ EXAMPLES = '''
     name: user.email
     repo: /etc
     scope: local
-    value: 'root@{{ ansible_fqdn }}'
+    value: "root@{{ ansible_facts['fqdn'] }}"
 
 # Read individual values from git config
 - git_config:

--- a/lib/ansible/modules/system/crypttab.py
+++ b/lib/ansible/modules/system/crypttab.py
@@ -70,10 +70,10 @@ EXAMPLES = r'''
 
 - name: Add the 'discard' option to any existing options for all devices
   crypttab:
-    name: '{{ item.device }}'
+    name: "{{ item['device'] }}"
     state: opts_present
     opts: discard
-  loop: '{{ ansible_mounts }}'
+  loop: "{{ ansible_facts['mounts'] }}"
   when: "'/dev/mapper/luks-' in {{ item.device }}"
 '''
 

--- a/lib/ansible/modules/utilities/helper/meta.py
+++ b/lib/ansible/modules/utilities/helper/meta.py
@@ -96,6 +96,6 @@ EXAMPLES = r'''
 - name: End the play for hosts that run CentOS 6
   meta: end_host
   when:
-  - ansible_distribution == 'CentOS'
-  - ansible_distribution_major_version == '6'
+  - ansible_facts['distribution'] == 'CentOS'
+  - ansible_facts['distribution_major_version'] == '6'
 '''

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -55,7 +55,7 @@ author:
 '''
 
 EXAMPLES = r'''
-- assert: { that: "ansible_os_family != 'RedHat'" }
+- assert: { that: "ansible_facts['os_family'] != 'RedHat'" }
 
 - assert:
     that:

--- a/lib/ansible/modules/utilities/logic/debug.py
+++ b/lib/ansible/modules/utilities/logic/debug.py
@@ -57,8 +57,8 @@ EXAMPLES = r'''
     msg: System {{ inventory_hostname }} has uuid {{ ansible_product_uuid }}
 
 - debug:
-    msg: System {{ inventory_hostname }} has gateway {{ ansible_default_ipv4.gateway }}
-  when: ansible_default_ipv4.gateway is defined
+    msg: "System {{ inventory_hostname }} has gateway {{ ansible_facts['default_ipv4']['gateway'] }}"
+  when: ansible_facts['default_ipv4']['gateway'] is defined
 
 # Example that prints return information from the previous task
 - shell: /usr/bin/uptime

--- a/lib/ansible/modules/utilities/logic/include_vars.py
+++ b/lib/ansible/modules/utilities/logic/include_vars.py
@@ -103,8 +103,8 @@ EXAMPLES = r'''
   include_vars: "{{ lookup('first_found', possible_files) }}"
   vars:
     possible_files:
-      - "{{ ansible_distribution }}.yaml"
-      - "{{ ansible_os_family }}.yaml"
+      - "{{ ansible_facts['distribution'] }}.yaml"
+      - "{{ ansible_facts['os_family'] }}.yaml"
       - default.yaml
 
 - name: Bare include (free-form)

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -73,7 +73,7 @@ EXAMPLES = """
     dest: "/etc/foo.conf"
   vars:
     findme:
-      - "{{ ansible_virtualization_type }}_foo.conf"
+      - "{{ ansible_facts['virtualization_type'] }}_foo.conf"
       - "default_foo.conf"
 
 - name: read vars from first file found, use 'vars/' relative subdir
@@ -81,8 +81,8 @@ EXAMPLES = """
   vars:
     params:
       files:
-        - '{{ansible_os_distribution}}.yml'
-        - '{{ansible_os_family}}.yml'
+        - "{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - 'vars'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We should prefer the use of `ansible_facts` in the examples. Also remove one mention of dot vs. array notation in `faq.rst` since it has it's own explanation a few lines down.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

