### PR TITLE
Minor change to mongodb_replicaset module

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -376,11 +376,13 @@ def main():
     try:
         client['admin'].command('listDatabases', 1.0)  # if this throws an error we need to authenticate
     except Exception as excep:
-        if "not authorized on" not in str(excep) and "command listDatabases requires authentication" not in str(excep):
+        if "not authorized on" in str(excep) or "command listDatabases requires authentication" in str(excep):
+            if login_user is not None and login_password is not None:
+                client.admin.authenticate(login_user, login_password, source=login_database)
+            else:
+                raise excep
+        else:
             raise excep
-        if login_user is None or login_password is None:
-            raise excep
-        client.admin.authenticate(login_user, login_password, source=login_database)
 
     if len(replica_set) == 0:
         module.fail_json(msg="Parameter 'replica_set' must not be an empty string")


### PR DESCRIPTION
##### SUMMARY

Minor change to flow of exception handling when authentication is enabled. Original logic here was a bit quirky. This is now the same as the mongodb_shard module.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

mongodb_replicaset

##### ADDITIONAL INFORMATION

Changed from...

```
try:
        client['admin'].command('listDatabases', 1.0)  # if this throws an error we need to authenticate
    except Exception as excep:
        if "not authorized on" not in str(excep) and "command listDatabases requires authentication" not in str(excep):
            raise excep
        if login_user is None or login_password is None:
            raise excep
        client.admin.authenticate(login_user, login_password, source=login_database)
```

to...

```
    try:
        client['admin'].command('listDatabases', 1.0)  # if this throws an error we need to authenticate
    except Exception as excep:
        if "not authorized on" in str(excep) or "command listDatabases requires authentication" in str(excep):
            if login_user is not None and login_password is not None:
                client.admin.authenticate(login_user, login_password, source=login_database)
            else:
                raise excep
        else:
            raise excep
```
