### PR TITLE
Module seboolean: added support for list syntax for name parameter

### DIFF
--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -324,17 +324,17 @@ def main():
     )
     changed = False
 
-    for pos, name in enumerate(names) :
+    for pos, name in enumerate(names):
         if hasattr(selinux, 'selinux_boolean_sub'):
             # selinux_boolean_sub allows sites to rename a boolean and alias the old name
             # Feature only available in selinux library since 2012.
             names[pos] = selinux.selinux_boolean_sub(name)
 
-    for name in names :
+    for name in names:
         if not has_boolean_value(module, name):
             module.fail_json(msg="SELinux boolean %s does not exist." % name)
 
-    for name in names :
+    for name in names:
         if persistent:
             changed = semanage_boolean_value(module, name, state)
         else:

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -295,6 +295,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             ignore_selinux_state=dict(type='bool', default=False),
+            # name=dict(type='str', required=True),
             name=dict(type='list', required=True),
             persistent=dict(type='bool', default=False),
             state=dict(type='bool', required=True),
@@ -345,10 +346,10 @@ def main():
                     changed = set_boolean_value(module, name, state)
                     if not changed:
                         module.fail_json(msg="Failed to set boolean %s to %s" % (name, state))
-                        try:
-                            selinux.security_commit_booleans()
-                        except Exception:
-                            module.fail_json(msg="Failed to commit pending boolean %s value" % name)
+                    try:
+                        selinux.security_commit_booleans()
+                    except Exception:
+                        module.fail_json(msg="Failed to commit pending boolean %s value" % name)
 
     result['changed'] = changed
 

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -318,7 +318,7 @@ def main():
     state = module.params['state']
 
     result = dict(
-        name=names,
+        name=names[0] if len(names) == 1 else names,
         persistent=persistent,
         state=state
     )


### PR DESCRIPTION
The new syntax allows the following (previously not possible):

```
- name: set all the above selinux booleans using list syntax
  seboolean:
    # old syntax (still available and working):
    #name: samba_share_nfs
    # new syntax:
    name: [samba_share_nfs, samba_export_all_ro, samba_export_all_rw]
    state: yes
    persistent: yes
```

Note: this commit does not break old syntax in my tests.

I agree to Ansible's Contributors License Agreement as stated in https://docs.ansible.com/ansible/latest/community/contributor_license_agreement.html  
