### PR TITLE
win_chocolatey: Fix up validate_certs default value

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -35,7 +35,7 @@ $spec = @{
         source_password = @{ type = "str"; no_log = $true }
         state = @{ type = "str"; default = "present"; choices = "absent", "downgrade", "latest", "present", "reinstalled" }
         timeout = @{ type = "int"; default = 2700; aliases = "execution_timeout" }
-        validate_certs = @{ type = "bool"; default = $false }
+        validate_certs = @{ type = "bool"; default = $true }
         version = @{ type = "str" }
     }
     supports_check_mode = $true


### PR DESCRIPTION
##### SUMMARY
The `validate_certs` option was incorrectly set with a default of `$false` when it should be `$true`. This is only an issue in devel as it was a problem with the recent rewrite to use Ansible.Basic.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey