### PR TITLE
Add new Cloudstack module cs_image_store

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -97,13 +97,10 @@ class AnsibleCloudstackImageStore(AnsibleCloudStack):
     def __init__(self, module):
         super(AnsibleCloudstackImageStore, self).__init__(module)
         self.returns = {
-            'id': 'id',
-            'name': 'name',
             'protocol': 'protocol',
             'providername': 'provider_name',
             'scope': 'scope',
-            'url': 'url',
-            'zone': 'zone'
+            'url': 'url'
 
         }
         self.image_store = None

--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -164,7 +164,9 @@ class AnsibleCloudstackImageStore(AnsibleCloudStack):
             # Cloudstack API expects 'provider' but returns 'providername'
             args['providername'] = args.pop('provider')
             if self.has_changed(args, image_store):
-                self.fail_json(msg='Image Store cannot be updated. Please delete it first.')
+                self.absent_image_store()
+                self.image_store = None
+                self.image_store = self.present_image_store()
 
         return self.image_store
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # Copyright: (c) 2019, Patryk Cichy @PatTheSilent
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -26,7 +23,7 @@ description:
 options:
     url:
         description:
-            - The URL for the Image Store. 
+            - The URL for the Image Store.
         required: true
     name:
         description:
@@ -39,6 +36,8 @@ options:
     state:
         description:
             - Stage of the Image Store
+        choices: ['present', 'absent']
+        default: present
     provider:
         description:
             - The image store provider name. Required when creating a new Image Store
@@ -61,26 +60,36 @@ RETURN = '''
 id:
     description: the ID of the image store
     type: str
+    returned: success
 name:
     description: the name of the image store
     type: str
+    returned: success
 protocol:
     description: the protocol of the image store
     type: str
+    returned: success
 provider_name:
     description: the provider name of the image store
     type: str
+    returned: success
 scope:
     description: the scope of the image store
     type: str
+    returned: success
 url:
     description: the url of the image store
     type: str
+    returned: success
 zone:
     description: the Zone name of the image store
     type: str
+    returned: success
 
 '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
 
 
 class AnsibleCloudstackImageStore(AnsibleCloudStack):

--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -18,7 +18,7 @@ short_description: Manages CloudStack Image Stores.
 version_added: "2.8"
 
 description:
-  - "Deploy, remove, recreate CloudStack Image Stores."
+  - Deploy, remove, recreate CloudStack Image Stores.
 
 options:
   url:
@@ -39,7 +39,7 @@ options:
   state:
     description:
       - Stage of the Image Store
-    choices: ['present', 'absent']
+    choices: [present, absent]
     default: present
     type: str
   provider:
@@ -48,7 +48,7 @@ options:
     type: str
   force_recreate:
     description:
-      - Set to C(True) if you're changing an existing Image Store.
+      - Set to C(yes) if you're changing an existing Image Store.
       - This will force the recreation of the Image Store.
       - Recreation might fail if there are snapshots present on the Image Store. Delete them before running the recreation.
     type: bool
@@ -65,7 +65,24 @@ EXAMPLES = '''
   cs_image_store:
     zone: zone-01
     name: nfs-01
+    provider: NFS
     url: nfs://192.168.21.16/exports/secondary
+
+# Change the NFS share URL and force a Image Store recreation
+- name: Change the NFS url
+  cs_image_store:
+    zone: zone-01
+    name: nfs-01
+    provider: NFS
+    force_recreate: yes
+    url: nfs://192.168.21.10/shares/secondary
+
+- name: delete the image store
+  cs_image_store:
+    name: nfs-01
+    zone: zone-01
+    state: absent
+
 '''
 
 RETURN = '''
@@ -119,7 +136,6 @@ class AnsibleCloudstackImageStore(AnsibleCloudStack):
             'providername': 'provider_name',
             'scope': 'scope',
             'url': 'url'
-
         }
         self.image_store = None
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+# Copyright: (c) 2019, Patryk Cichy @PatTheSilent
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: cs_image_store
+
+short_description: Manages CloudStack Image Stores.
+
+version_added: "2.8"
+
+description:
+    - ""
+
+options:
+    url:
+        description:
+            - The URL for the Image Store. 
+        required: true
+    name:
+        description:
+            - The ID of the Image Store. Required when deleting a Image Store.
+        required: true
+    zone:
+        description:
+            - The Zone name for the Image Store.
+        required: true
+    state:
+        description:
+            - Stage of the Image Store
+    provider:
+        description:
+            - The image store provider name. Required when creating a new Image Store
+
+extends_documentation_fragment: cloudstack
+
+author:
+    - Patryk Cichy (@PatTheSilent)
+'''
+
+EXAMPLES = '''
+- name: Add a Image Store (NFS)
+  cs_image_store:
+    zone: zone-01
+    name: nfs-01
+    url: nfs://192.168.21.16/exports/secondary
+'''
+
+RETURN = '''
+id:
+    description: the ID of the image store
+    type: str
+name:
+    description: the name of the image store
+    type: str
+protocol:
+    description: the protocol of the image store
+    type: str
+provider_name:
+    description: the provider name of the image store
+    type: str
+scope:
+    description: the scope of the image store
+    type: str
+url:
+    description: the url of the image store
+    type: str
+zone:
+    description: the Zone name of the image store
+    type: str
+
+'''
+
+
+class AnsibleCloudstackImageStore(AnsibleCloudStack):
+
+    def __init__(self, module):
+        super(AnsibleCloudstackImageStore, self).__init__(module)
+        self.returns = {
+            'id': 'id',
+            'name': 'name',
+            'protocol': 'protocol',
+            'providername': 'provider_name',
+            'scope': 'scope',
+            'url': 'url',
+            'zone': 'zone'
+
+        }
+        self.image_store = None
+
+    def get_storage_providers(self, storage_type="image"):
+        args = {
+            'type': storage_type
+        }
+        storage_provides = self.query_api('listStorageProviders', **args)
+        return [provider.get('name') for provider in storage_provides.get('dataStoreProvider')]
+
+    def get_image_store(self):
+        image_store = self.module.params.get('name')
+        args = {
+            'name': self.module.params.get('name'),
+            'zoneid': self.get_zone(key='id')
+        }
+
+        image_stores = self.query_api('listImageStores', **args)
+        if image_stores:
+            for img_s in image_stores.get('imagestore'):
+                if image_store.lower() in [img_s['name'].lower(), img_s['id']]:
+                    self.image_store = img_s
+                    break
+
+        return self.image_store
+
+    def present_image_store(self):
+        provider_list = self.get_storage_providers()
+        image_store = self.get_image_store()
+
+        if self.module.params.get('provider') not in provider_list:
+            self.module.fail_json(
+                msg='Provider %s is not in the provider list (%s). Please specify a correct provider' % (
+                    self.module.params.get('provider'), provider_list))
+
+        if not self.module.check_mode:
+            args = {
+                'name': self.module.params.get('name'),
+                'url': self.module.params.get('url'),
+                'zoneid': self.get_zone(key='id'),
+                'provider': self.module.params.get('provider')
+            }
+            if not image_store:
+                self.result['changed'] = True
+                self.query_api('addImageStore', **args)
+            else:
+                if self.has_changed(args, image_store):
+                    self.fail_json(msg='Image Store cannot be updated. Please delete it first.')
+
+        return image_store
+
+    def absent_image_store(self):
+        image_store = self.get_image_store()
+        if image_store:
+            self.result['changed'] = True
+            if not self.module.check_mode:
+                args = {
+                    'id': image_store.get('id')
+                }
+                self.query_api('deleteImageStore', **args)
+        return image_store
+
+
+def main():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(dict(
+        url=dict(),
+        name=dict(required=True),
+        zone=dict(required=True),
+        provider=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=cs_required_together(),
+        required_if=[
+            ('state', 'present', ['url', 'provider']),
+        ],
+        supports_check_mode=True
+    )
+
+    acis_do = AnsibleCloudstackImageStore(module)
+
+    state = module.params.get('state')
+    if state == "absent":
+        image_store = acis_do.absent_image_store()
+    else:
+        image_store = acis_do.present_image_store()
+
+    result = acis_do.get_result(image_store)
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -5,7 +5,7 @@
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['stableinterface'],
+    'status': ['preview'],
     'supported_by': 'community'
 }
 
@@ -18,7 +18,7 @@ short_description: Manages CloudStack Image Stores.
 version_added: "2.8"
 
 description:
-    - ""
+    - "Deploy, remove, recreate CloudStack Image Stores."
 
 options:
     url:

--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -18,34 +18,39 @@ short_description: Manages CloudStack Image Stores.
 version_added: "2.8"
 
 description:
-    - "Deploy, remove, recreate CloudStack Image Stores."
+  - "Deploy, remove, recreate CloudStack Image Stores."
 
 options:
-    url:
-        description:
-            - The URL for the Image Store.
-        required: true
-    name:
-        description:
-            - The ID of the Image Store. Required when deleting a Image Store.
-        required: true
-    zone:
-        description:
-            - The Zone name for the Image Store.
-        required: true
-    state:
-        description:
-            - Stage of the Image Store
-        choices: ['present', 'absent']
-        default: present
-    provider:
-        description:
-            - The image store provider name. Required when creating a new Image Store
+  url:
+    description:
+      - The URL for the Image Store.
+      - Required when I(state=present).
+    type: str
+  name:
+    description:
+      - The ID of the Image Store. Required when deleting a Image Store.
+    required: true
+    type: str
+  zone:
+    description:
+      - The Zone name for the Image Store.
+    required: true
+    type: str
+  state:
+    description:
+      - Stage of the Image Store
+    choices: ['present', 'absent']
+    default: present
+    type: str
+  provider:
+    description:
+      - The image store provider name. Required when creating a new Image Store
+    type: str
 
 extends_documentation_fragment: cloudstack
 
 author:
-    - Patryk Cichy (@PatTheSilent)
+  - Patryk Cichy (@PatTheSilent)
 '''
 
 EXAMPLES = '''
@@ -58,34 +63,40 @@ EXAMPLES = '''
 
 RETURN = '''
 id:
-    description: the ID of the image store
-    type: str
-    returned: success
+  description: the ID of the image store
+  type: str
+  returned: success
+  sample: feb11a84-a093-45eb-b84d-7f680313c40b
 name:
-    description: the name of the image store
-    type: str
-    returned: success
+  description: the name of the image store
+  type: str
+  returned: success
+  sample: nfs-01
 protocol:
-    description: the protocol of the image store
-    type: str
-    returned: success
+  description: the protocol of the image store
+  type: str
+  returned: success
+  sample: nfs
 provider_name:
-    description: the provider name of the image store
-    type: str
-    returned: success
+  description: the provider name of the image store
+  type: str
+  returned: success
+  sample: NFS
 scope:
-    description: the scope of the image store
-    type: str
-    returned: success
+  description: the scope of the image store
+  type: str
+  returned: success
+  sample: ZONE
 url:
-    description: the url of the image store
-    type: str
-    returned: success
+  description: the url of the image store
+  type: str
+  sample: nfs://192.168.21.16/exports/secondary
+  returned: success
 zone:
-    description: the Zone name of the image store
-    type: str
-    returned: success
-
+  description: the Zone name of the image store
+  type: str
+  returned: success
+  sample: zone-01
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_image_store.py
@@ -67,6 +67,7 @@ EXAMPLES = '''
     name: nfs-01
     provider: NFS
     url: nfs://192.168.21.16/exports/secondary
+  delegate_to: localhost
 
 # Change the NFS share URL and force a Image Store recreation
 - name: Change the NFS url
@@ -76,12 +77,14 @@ EXAMPLES = '''
     provider: NFS
     force_recreate: yes
     url: nfs://192.168.21.10/shares/secondary
+  delegate_to: localhost
 
 - name: delete the image store
   cs_image_store:
     name: nfs-01
     zone: zone-01
     state: absent
+  delegate_to: localhost
 
 '''
 

--- a/test/integration/targets/cs_image_store/aliases
+++ b/test/integration/targets/cs_image_store/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_image_store/meta/main.yml
+++ b/test/integration/targets/cs_image_store/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/test/integration/targets/cs_image_store/tasks/main.yml
+++ b/test/integration/targets/cs_image_store/tasks/main.yml
@@ -35,6 +35,20 @@
       - ss is failed
       - "ss.msg == 'state is present but all of the following are missing: url, provider'"
 
+- name: setup image store in check mode
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    url: "nfs://nfs-mount.domain/share/images/"
+    provider: "NFS"
+    state: present
+  check_mode: true
+  register: ss
+- name: verify setup image store in check mode
+  assert:
+    that:
+      - ss is successful
+      - ss is changed
 
 - name: setup image store
   cs_image_store:
@@ -43,12 +57,12 @@
     url: "nfs://nfs-mount.domain/share/images/"
     provider: "NFS"
     state: present
-  ignore_errors: true
   register: ss
 - name: verify setup image store
   assert:
     that:
       - ss is successful
+      - ss is changed
 
 - name: setup image store idempotence
   cs_image_store:
@@ -57,11 +71,11 @@
     url: "nfs://nfs-mount.domain/share/images/"
     provider: "NFS"
     state: present
-  ignore_errors: true
   register: ss
 - name: verify setup image store idempotence
   assert:
     that:
+      - ss is successful
       - ss is not changed
 
 - name: delete the image store
@@ -69,19 +83,18 @@
     name: "storage_pool_adv"
     zone: "{{ cs_common_zone_adv }}"
     state: absent
-  ignore_errors: true
   register: ss
 - name: verify results for delete the image store
   assert:
     that:
       - ss is successful
+      - ss is changed
 
 - name: delete the image store idempotence
   cs_image_store:
     name: "storage_pool_adv"
     zone: "{{ cs_common_zone_adv }}"
     state: absent
-  ignore_errors: true
   register: ss
 - name: verify delete the image store idempotence
   assert:

--- a/test/integration/targets/cs_image_store/tasks/main.yml
+++ b/test/integration/targets/cs_image_store/tasks/main.yml
@@ -78,6 +78,21 @@
       - ss is successful
       - ss is not changed
 
+- name: recreate image store
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    url: "nfs://nfs-mount.domain/share2/images/"
+    provider: "NFS"
+    state: present
+  register: ss
+- name: verify setup image store idempotence
+  assert:
+    that:
+      - ss is successful
+      - ss is changed
+      - "ss.url == 'nfs://nfs-mount.domain/share2/images/'"
+
 - name: delete the image store
   cs_image_store:
     name: "storage_pool_adv"

--- a/test/integration/targets/cs_image_store/tasks/main.yml
+++ b/test/integration/targets/cs_image_store/tasks/main.yml
@@ -78,12 +78,28 @@
       - ss is successful
       - ss is not changed
 
+- name: image store not recreated
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    url: "nfs://nfs-mount.domain/share2/images/"
+    provider: "NFS"
+    state: present
+  register: ss
+- name: verify image store not recreated
+  assert:
+    that:
+      - ss is successful
+      - ss is not changed
+      - "ss.url == 'nfs://nfs-mount.domain/share/images/'"
+
 - name: recreate image store
   cs_image_store:
     name: "storage_pool_adv"
     zone: "{{ cs_common_zone_adv }}"
     url: "nfs://nfs-mount.domain/share2/images/"
     provider: "NFS"
+    force_recreate: yes
     state: present
   register: ss
 - name: verify setup image store idempotence

--- a/test/integration/targets/cs_image_store/tasks/main.yml
+++ b/test/integration/targets/cs_image_store/tasks/main.yml
@@ -63,6 +63,10 @@
     that:
       - ss is successful
       - ss is changed
+      - "ss.url == 'nfs://nfs-mount.domain/share/images/'"
+      - "ss.provider_name == 'NFS'"
+      - "ss.zone == cs_common_zone_adv"
+      - "ss.protocol == 'nfs'"
 
 - name: setup image store idempotence
   cs_image_store:
@@ -77,6 +81,11 @@
     that:
       - ss is successful
       - ss is not changed
+      - "ss.url == 'nfs://nfs-mount.domain/share/images/'"
+      - "ss.provider_name == 'NFS'"
+      - "ss.zone == cs_common_zone_adv"
+      - "ss.protocol == 'nfs'"
+      - "ss.name == 'storage_pool_adv'"
 
 - name: image store not recreated
   cs_image_store:
@@ -92,6 +101,8 @@
       - ss is successful
       - ss is not changed
       - "ss.url == 'nfs://nfs-mount.domain/share/images/'"
+      - "ss.name == 'storage_pool_adv'"
+      - "ss.zone == cs_common_zone_adv"
 
 - name: recreate image store
   cs_image_store:
@@ -108,6 +119,8 @@
       - ss is successful
       - ss is changed
       - "ss.url == 'nfs://nfs-mount.domain/share2/images/'"
+      - "ss.name == 'storage_pool_adv'"
+      - "ss.zone == cs_common_zone_adv"
 
 - name: delete the image store
   cs_image_store:
@@ -120,6 +133,8 @@
     that:
       - ss is successful
       - ss is changed
+      - "ss.name == 'storage_pool_adv'"
+      - "ss.zone == cs_common_zone_adv"
 
 - name: delete the image store idempotence
   cs_image_store:
@@ -132,3 +147,5 @@
     that:
       - ss is successful
       - ss is not changed
+      - ss.name is undefined
+      - "ss.zone == cs_common_zone_adv"

--- a/test/integration/targets/cs_image_store/tasks/main.yml
+++ b/test/integration/targets/cs_image_store/tasks/main.yml
@@ -18,7 +18,9 @@
   assert:
     that:
       - ss is failed
-      - "ss.msg == 'missing required arguments: zone, name'"
+      - "'name' in ss.msg"
+      - "'zone' in ss.msg"
+      - "'missing required arguments: ' in ss.msg"
 
 - name: setup image store with wrong parameters
   cs_image_store:

--- a/test/integration/targets/cs_image_store/tasks/main.yml
+++ b/test/integration/targets/cs_image_store/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+- name: setup image store is absent
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: sp
+- name: verify setup image store is absent
+  assert:
+    that:
+      - sp is successful
+
+- name: test fail if missing params
+  cs_image_store:
+  register: ss
+  ignore_errors: true
+- name: verify test fail if missing params
+  assert:
+    that:
+      - ss is failed
+      - "ss.msg == 'missing required arguments: zone, name'"
+
+- name: setup image store with wrong parameters
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    state: present
+  ignore_errors: true
+  register: ss
+- name: verify setup image store with wrong parameters
+  assert:
+    that:
+      - ss is failed
+      - "ss.msg == 'state is present but all of the following are missing: url, provider'"
+
+
+- name: setup image store
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    url: "nfs://nfs-mount.domain/share/images/"
+    provider: "NFS"
+    state: present
+  ignore_errors: true
+  register: ss
+- name: verify setup image store
+  assert:
+    that:
+      - ss is successful
+
+- name: setup image store idempotence
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    url: "nfs://nfs-mount.domain/share/images/"
+    provider: "NFS"
+    state: present
+  ignore_errors: true
+  register: ss
+- name: verify setup image store idempotence
+  assert:
+    that:
+      - ss is not changed
+
+- name: delete the image store
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  ignore_errors: true
+  register: ss
+- name: verify results for delete the image store
+  assert:
+    that:
+      - ss is successful
+
+- name: delete the image store idempotence
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  ignore_errors: true
+  register: ss
+- name: verify delete the image store idempotence
+  assert:
+    that:
+      - ss is successful
+      - ss is not changed


### PR DESCRIPTION
##### SUMMARY
Add a new Cloudstack module `cs_image_store`.
##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
cs_image_store

##### ADDITIONAL INFORMATION
 The module is capable of adding or removing Cloudstack Image Stores. Updating is not supported as the Cloudstack API doesn't support it.

