### PR TITLE
[2.7] docker_container: show warnings, fix/improve tests

### DIFF
--- a/changelogs/fragments/53440-docker_container-warnings.yml
+++ b/changelogs/fragments/53440-docker_container-warnings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - now returns warnings from docker daemon on container creation and updating."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -24,6 +24,7 @@ import copy
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE, BOOLEANS_FALSE
 
@@ -588,6 +589,20 @@ class AnsibleDockerClient(Client):
         new_tag = self.find_image(name, tag)
 
         return new_tag, old_tag == new_tag
+
+    def report_warnings(self, result, warnings_key=None):
+        '''
+        Checks result of client operation for warnings, and if present, outputs them.
+        '''
+        if warnings_key is None:
+            warnings_key = ['Warnings']
+        for key in warnings_key:
+            if not isinstance(result, Mapping):
+                return
+            result = result.get(key)
+        if isinstance(result, Sequence):
+            for warning in result:
+                self.module.warn('Docker warning: {0}'.format(warning))
 
 
 def compare_dict_allow_more_present(av, bv):

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2030,6 +2030,7 @@ class ContainerManager(DockerBaseClass):
         if not self.check_mode:
             try:
                 new_container = self.client.create_container(image, **create_parameters)
+                self.client.report_warnings(new_container)
             except Exception as exc:
                 self.fail("Error creating container: %s" % str(exc))
             return self._get_container(new_container['Id'])
@@ -2122,7 +2123,8 @@ class ContainerManager(DockerBaseClass):
             self.results['changed'] = True
             if not self.check_mode and callable(getattr(self.client, 'update_container')):
                 try:
-                    self.client.update_container(container_id, **update_parameters)
+                    result = self.client.update_container(container_id, **update_parameters)
+                    self.client.report_warnings(result)
                 except Exception as exc:
                     self.fail("Error updating container %s: %s" % (container_id, str(exc)))
         return self._get_container(container_id)

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -100,7 +100,7 @@
 - assert:
     that:
     - blkio_weight_1 is changed
-    - blkio_weight_2 is not changed
+    - "blkio_weight_2 is not changed or 'Docker warning: Your kernel does not support Block I/O weight or the cgroup is not mounted. Weight discarded.' in blkio_weight_2.warnings"
     - blkio_weight_3 is changed
 
 ####################################################################
@@ -350,7 +350,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_cpus: 0
+    cpuset_cpus: "0"
     state: started
   register: cpuset_cpus_1
 
@@ -359,7 +359,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_cpus: 0
+    cpuset_cpus: "0"
     state: started
   register: cpuset_cpus_2
 
@@ -368,7 +368,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_cpus: 1
+    cpuset_cpus: "1"
     state: started
     stop_timeout: 1
   # This will fail if the system the test is run on doesn't have
@@ -397,7 +397,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_mems: 0
+    cpuset_mems: "0"
     state: started
   register: cpuset_mems_1
 
@@ -406,7 +406,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_mems: 0
+    cpuset_mems: "0"
     state: started
   register: cpuset_mems_2
 
@@ -415,7 +415,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    cpuset_mems: 1
+    cpuset_mems: "1"
     state: started
     stop_timeout: 1
   # This will fail if the system the test is run on doesn't have
@@ -872,7 +872,7 @@
     state: started
   register: entrypoint_2
 
-- name: entrypoint (change order idempotency)
+- name: entrypoint (change order, should not be idempotent)
   docker_container:
     image: alpine:3.8
     entrypoint:
@@ -882,6 +882,7 @@
     - "-v"
     name: "{{ cname }}"
     state: started
+    force_kill: yes
   register: entrypoint_3
 
 - name: entrypoint (less parameters)
@@ -1108,8 +1109,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 1234
-    - 5678
+    - "1234"
+    - "5678"
   register: exposed_ports_1
 
 - name: exposed_ports (idempotency)
@@ -1119,8 +1120,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 5678
-    - 1234
+    - "5678"
+    - "1234"
   register: exposed_ports_2
 
 - name: exposed_ports (less ports)
@@ -1130,7 +1131,7 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 1234
+    - "1234"
   register: exposed_ports_3
 
 - name: exposed_ports (more ports)
@@ -1140,8 +1141,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 1234
-    - 1235
+    - "1234"
+    - "1235"
     stop_timeout: 1
   register: exposed_ports_4
 
@@ -1175,8 +1176,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1234
-    - 5678
+    - "1234"
+    - "5678"
   register: groups_1
 
 - name: groups (idempotency)
@@ -1186,8 +1187,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 5678
-    - 1234
+    - "5678"
+    - "1234"
   register: groups_2
 
 - name: groups (less groups)
@@ -1197,7 +1198,7 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1234
+    - "1234"
   register: groups_3
 
 - name: groups (more groups)
@@ -1207,8 +1208,8 @@
     name: "{{ cname }}"
     state: started
     groups:
-    - 1234
-    - 2345
+    - "1234"
+    - "2345"
     stop_timeout: 1
   register: groups_4
 
@@ -2897,7 +2898,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    stop_signal: 30
+    stop_signal: "30"
     state: started
   register: stop_signal_1
 
@@ -2906,7 +2907,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    stop_signal: 30
+    stop_signal: "30"
     state: started
   register: stop_signal_2
 
@@ -2915,7 +2916,7 @@
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
-    stop_signal: 9
+    stop_signal: "9"
     state: started
     stop_timeout: 1
   register: stop_signal_3

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -14,8 +14,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
     - all
     stop_timeout: 1
@@ -28,8 +28,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
     - all
     stop_timeout: 1
@@ -42,11 +42,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     stop_timeout: 1
   register: published_ports_3
 
@@ -57,11 +57,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     stop_timeout: 1
   register: published_ports_4
 
@@ -72,8 +72,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - 8080
-    - 8081
+    - "8080"
+    - "8081"
     published_ports:
     - all
     stop_timeout: 1


### PR DESCRIPTION
##### SUMMARY
Backport of #53440 to stable-2.7.

@abadger it adds a small feature, namely forwarding warnings from the docker daemon to Ansible, though that's necessary to prevent tests from breaking in the future. I would classify this feature more as a bugfix, since these warnings have simply been ignored so far (which is never a good idea with warnings IMO). Do you think this is OK for a backport?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
