### PR TITLE
Clarify that do until loops are unsupported on include tasks (#49581)

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -22,7 +22,8 @@ short_description: Load and execute a role
 description:
   - Loads and executes a role as a task dynamically. This frees roles from the `roles:` directive and allows them to be
     treated more as tasks.
-  - Unlike M(import_role), most keywords, including loops and conditionals, apply to this statement.
+  - Unlike M(import_role), most keywords, including loop, with_items, and conditionals, apply to this statement.
+  - The do until loop is not supported on M(include_role).
   - This module is also supported for Windows targets.
 version_added: "2.2"
 options:

--- a/lib/ansible/modules/utilities/logic/include_tasks.py
+++ b/lib/ansible/modules/utilities/logic/include_tasks.py
@@ -26,7 +26,8 @@ options:
   file:
     description:
       - The name of the imported file is specified directly without any other option.
-      - Unlike M(import_tasks), most keywords, including loops and conditionals, apply to this statement.
+      - Unlike M(import_tasks), most keywords, including loop, with_items, and conditionals, apply to this statement.
+      - The do until loop is not supported on M(include_tasks).
     version_added: '2.7'
   apply:
     description:


### PR DESCRIPTION
(cherry picked from commit 0d7e95b4dbb73f3e08f0c3fa19c4678b10c57fab)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backport for #49581
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
