### PR TITLE
[2.7] use composed vars in constructed groups (#53152)

### DIFF
--- a/changelogs/fragments/53152-create-groups-using-composed-variables.yaml
+++ b/changelogs/fragments/53152-create-groups-using-composed-variables.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - inventory plugins - Fix creating groups from composed variables by getting the latest host variables

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -33,6 +33,7 @@ from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import string_types
 from ansible.template import Templar
+from ansible.utils.vars import combine_vars
 
 try:
     from __main__ import display
@@ -294,6 +295,7 @@ class Constructable(object):
         ''' helper to create complex groups for plugins based on jinja2 conditionals, hosts that meet the conditional are added to group'''
         # process each 'group entry'
         if groups and isinstance(groups, dict):
+            variables = combine_vars(variables, self.inventory.get_host(host).get_vars())
             self.templar.set_available_variables(variables)
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
@@ -317,6 +319,7 @@ class Constructable(object):
             for keyed in keys:
                 if keyed and isinstance(keyed, dict):
 
+                    variables = combine_vars(variables, self.inventory.get_host(host).get_vars())
                     try:
                         key = self._compose(keyed.get('key'), variables)
                     except Exception as e:


### PR DESCRIPTION
* changelog

* combine provided variables and host vars inside of constructing groups to take into account composed variables

let composed variables "win"

* fix whitespace

* Allow user to control hash behavior

(cherry picked from commit 4172d68dc3f07c61b8b0ea96b5de2cc0c7413948)

##### SUMMARY
Backport #53152

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugins
