### PR TITLE
aws_ec2 - update instances with additional host vars

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -69,6 +69,7 @@ DOCUMENTATION = '''
               may be persistent and instances may have associated events.
           type: bool
           default: False
+          version_added: '2.8'
         strict_permissions:
           description: By default if a 403 (Forbidden) is encountered this plugin will fail. You can set strict_permissions to
               False in the inventory config file which will allow 403 errors to be gracefully skipped.

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -64,6 +64,11 @@ DOCUMENTATION = '''
               U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options)
           type: dict
           default: {}
+        include_extra_api_calls:
+          description: Add two additional API calls for every instance to include 'persistent' and 'events' host variables. Spot instances
+              may be persistent and instances may have associated events.
+          type: bool
+          default: False
         strict_permissions:
           description: By default if a 403 (Forbidden) is encountered this plugin will fail. You can set strict_permissions to
               False in the inventory config file which will allow 403 errors to be gracefully skipped.
@@ -382,7 +387,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     new_instances = r['Instances']
                     for instance in new_instances:
                         instance.update(self._get_reservation_details(r))
-                        instance.update(self._get_event_set_and_persistence(connection, instance['InstanceId'], instance.get('SpotInstanceRequestId')))
+                        if self.get_option('include_extra_api_calls'):
+                            instance.update(self._get_event_set_and_persistence(connection, instance['InstanceId'], instance.get('SpotInstanceRequestId')))
                     instances.extend(new_instances)
             except botocore.exceptions.ClientError as e:
                 if e.response['ResponseMetadata']['HTTPStatusCode'] == 403 and not strict_permissions:
@@ -408,16 +414,22 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         try:
             kwargs = {'InstanceIds': [instance_id]}
             host_vars['Events'] = connection.describe_instance_status(**kwargs)['InstanceStatuses'][0].get('Events', '')
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-            pass
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            if not self.get_option('strict_permissions'):
+                pass
+            else:
+                raise AnsibleError("Failed to describe instance status: %s" % to_native(e))
         if spot_instance:
             try:
                 kwargs = {'SpotInstanceRequestIds': [spot_instance]}
                 host_vars['Persistent'] = bool(
                     connection.describe_spot_instance_requests(**kwargs)['SpotInstanceRequests'][0].get('Type') == 'persistent'
                 )
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-                pass
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                if not self.get_option('strict_permissions'):
+                    pass
+                else:
+                    raise AnsibleError("Failed to describe spot instance requests: %s" % to_native(e))
         return host_vars
 
     def _get_tag_hostname(self, preference, instance):


### PR DESCRIPTION
##### SUMMARY
For #52358

Some of the host vars returned by boto's get_all_instances are not returned now. This allows these host vars to be created again:
```
ec2_eventsSet
ec2_persistent
ec2_requester_id
```
The others listed in #52358 don't appear to be accessible anymore. previous_state and previous_state_code are returned by starting/stopping instances, but not by read-only API calls such as made by the inventory plugin.
```
ec2__in_monitoring_element
ec2_item
ec2_previous_state
ec2_previous_state_code
```

~I've made it forgiving as it requires additional IAM permissions and people who have been using the plugin would probably be frustrated by sudden permission errors for host vars they may not care about. Maybe I should reference `strict_permissions` instead of making it forgiving by default; thoughts?~

Added a toggle for the new API calls as they could influence performance otherwise. I also made those calls adhere to the `strict_permissions` option.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/aws_ec2.py
