### PR TITLE
Update inventory.rst

### DIFF
--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -41,18 +41,18 @@ The only requirement for using an inventory plugin after it is enabled is to pro
 Ansible will try to use the list of enabled inventory plugins, in order, against each inventory source provided.
 Once an inventory plugin succeeds at parsing a source, any remaining inventory plugins will be skipped for that source.
 
-To start using an inventory plugin with a YAML configuration source, create a file with the accepted filename schema for the plugin in question, then add ``plugin: plugin_name``. Each plugin documents any naming restrictions. For example, the aws_ec2 inventory plugin:
+To start using an inventory plugin with a YAML configuration source, create a file with the accepted filename schema for the plugin in question, then add ``plugin: plugin_name``. Each plugin documents any naming restrictions. For example, the aws_ec2 inventory plugin has to end with ``aws_ec2.(yml|yaml)``
 
 .. code-block:: yaml
 
     # demo.aws_ec2.yml
     plugin: aws_ec2
 
-Or for the openstack plugin:
+Or for the openstack plugin the file has to be called ``clouds.yml`` or ``openstack.(yml|yaml)``:
 
 .. code-block:: yaml
 
-    # clouds.yml
+    # clouds.yml or openstack.(yml|yaml)
     plugin: openstack
 
 The ``auto`` inventory plugin is enabled by default and works by using the ``plugin`` field to indicate the plugin that should attempt to parse it. You can configure the whitelist/precedence of inventory plugins used to parse source using the `ansible.cfg` ['inventory'] ``enable_plugins`` list. After enabling the plugin and providing any required options you can view the populated inventory with ``ansible-inventory -i demo.aws_ec2.yml --graph``:


### PR DESCRIPTION
I spent almost an hour trying to use the aws_ec2 plugin. I mainly refered to the docs for the [Inventory Plugins](https://docs.ansible.com/ansible/latest/plugins/inventory.html#inventory-plugins). Then I found the some more docs in the plugin itself (https://docs.ansible.com/ansible/latest/plugins/inventory/aws_ec2.html). 

Only then I found out that you have to name the inventory-file `*.aws_ec2.yml` else it won't get parsed.

So this PR tries to make this more clear in the inventory-plugins docs-page.

+label: docsite_pr

##### SUMMARY
Add explicit examples how to name file for inventory plugins to make it more obvious.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
inventory plugin

