### PR TITLE
win_psexec - deprecate the extra_opts module options

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -316,6 +316,8 @@ Noteworthy module changes
 
 * The ``ipa_user`` module originally always sent ``password`` to FreeIPA regardless of whether the password changed. Now the module only sends ``password`` if ``update_password`` is set to ``always``, which is the default.
 
+* The ``win_psexec`` has deprecated the undocumented ``extra_opts`` module option. This will be removed in Ansible 2.10.
+
 Plugins
 =======
 

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -27,7 +27,7 @@ $spec = @{
         session = @{ type='int' }
         priority = @{ type='str'; choices=@( 'background', 'low', 'belownormal', 'abovenormal', 'high', 'realtime' ) }
         timeout = @{ type='int' }
-        extra_opts = @{ type='list' }
+        extra_opts = @{ type='list'; removed_in_version = '2.10' }
     }
 }
 

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -32,6 +32,8 @@ options:
   extra_opts:
     description:
     - Specify additional options to add onto the PsExec invocation.
+    - This module was undocumented in older releases and will be removed in
+      Ansible 2.10.
     type: list
   hostnames:
     description:


### PR DESCRIPTION
##### SUMMARY
The `extra_options` module option for `win_psexec` has been undocumented but recently was added in https://github.com/ansible/ansible/pull/53615 to satisfy module doc validation. This option was never meant to be used but cannot be removed straight away as that could break user's playbooks. Instead the PR will run it on a shorter deprecation cycle and remove it in Ansible 2.10 after warning users that it will be removed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_psexec