### PR TITLE
min_size does not default to current value when new instance not needed

### DIFF
--- a/changelogs/fragments/53669-ec2_asg_fix_race_condition.yml
+++ b/changelogs/fragments/53669-ec2_asg_fix_race_condition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_asg - Fix scenario where min_size can end up passing None type to boto

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -1488,6 +1488,8 @@ def terminate_batch(connection, replace_instances, initial_instances, leftovers=
     if num_new_inst_needed == 0:
         decrement_capacity = True
         if as_group['MinSize'] != min_size:
+            if min_size is None:
+                min_size = as_group['MinSize']
             updated_params = dict(AutoScalingGroupName=as_group['AutoScalingGroupName'], MinSize=min_size)
             update_asg(connection, **updated_params)
             module.debug("Updating minimum size back to original of %s" % min_size)


### PR DESCRIPTION
##### SUMMARY
In the event that a auto-scaling group has scaled ahead of the `replace_instances:` call and therefore there is no need to create a new instance when replacing an old one, the module will make a reference to `min_size` where it is undefined.

This PR will set that value to the existing value should the type equal `None` before passing to Boto, thus avoiding the error.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_asg

##### ADDITIONAL INFORMATION
**Error**
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Invalid type for parameter MinSize, value: None, type: <type 'NoneType'>, valid types: <type 'int'>, <type 'long'>
fatal: [localhost]: FAILED! => 
{
  "changed": false,
  "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 113, in <module>
  File \"<stdin>\", line 105, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module
  File \"/tmp/ansible_ec2_asg_payload_NaYwru/__main__.py\", line 1672, in <module>
  File \"/tmp/ansible_ec2_asg_payload_NaYwru/__main__.py\", line 1665, in main
  File \"/tmp/ansible_ec2_asg_payload_NaYwru/__main__.py\", line 1318, in replace
  File \"/tmp/ansible_ec2_asg_payload_NaYwru/__main__.py\", line 1492, in terminate_batch
  File \"/tmp/ansible_ec2_asg_payload_NaYwru/ansible_ec2_asg_payload.zip/ansible/module_utils/cloud.py\", line 153, in retry_func\nbotocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter MinSize, value: None, type: <type 'NoneType'>, valid types: <type 'int'>, <type 'long'>",
  "module_stdout": "",
  "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
  "rc": 1
}
```

**Task**:
```
- name: Cycle | Apply launch config and cycle instance.
  ec2_asg:
    region: "{{ region }}"
    name: "{{ cycle_asg_name }}"
    launch_config_name: "{{ lc_latest.launch_configuration_name }}"
    replace_instances: "{{ [item.key] }}"
    wait_for_instances: no
    wait_timeout: 2000
  register: ec2_cycle_register
```