### PR TITLE
apt_repository should update only the new repository

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -543,7 +543,8 @@ def main():
             sourceslist.save()
             if update_cache:
                 cache = apt.Cache()
-                cache.update()
+                if module.params['state'] == 'present':
+                    cache.update(sources_list='/etc/apt/sources.list.d/' + module.params['filename'] + '.list')
         except OSError as err:
             module.fail_json(msg=to_native(err))
 

--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -166,6 +166,7 @@ class SourcesList(object):
     def __init__(self, module):
         self.module = module
         self.files = {}  # group sources by file
+        self.repofile = None
         # Repositories that we're adding -- used to implement mode param
         self.new_repos = set()
         self.default_file = self._apt_cfg_file('Dir::Etc::sourcelist')
@@ -187,9 +188,10 @@ class SourcesList(object):
 
     def _expand_path(self, filename):
         if '/' in filename:
-            return filename
+            self.repofile = filename
         else:
-            return os.path.abspath(os.path.join(self._apt_cfg_dir('Dir::Etc::sourceparts'), filename))
+            self.repofile = os.path.abspath(os.path.join(self._apt_cfg_dir('Dir::Etc::sourceparts'), filename))
+        return self.repofile
 
     def _suggest_filename(self, line):
         def _cleanup_filename(s):
@@ -544,7 +546,7 @@ def main():
             if update_cache:
                 cache = apt.Cache()
                 if module.params['state'] == 'present':
-                    cache.update(sources_list='/etc/apt/sources.list.d/' + module.params['filename'] + '.list')
+                    cache.update(sources_list=sourceslist.repofile)
         except OSError as err:
             module.fail_json(msg=to_native(err))
 


### PR DESCRIPTION
when adding new repository to apt (with `apt_repository` module), and set `update_cache` to `true`, the apt update should update just the new repo added instead all repos

822a7e1 

##### SUMMARY
this will create a slight performance gain since apt cache update would not need to update all repository sources, especially while adding multiple sources.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
apt_repository module

##### ADDITIONAL INFORMATION
the question "apt-get update only for a specific repository" has been [answered](https://askubuntu.com/a/197532/497082) on askubuntu.com with following code sniplet:
```bash
update-repo() {
    for source in "$@"; do
        sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/${source}" \
        -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"    
    done
}
```

this is the same behaviour that `python-apt` bindings are using to update the cache in [`cache.update()`](https://salsa.debian.org/apt-team/python-apt/blob/745ce7abfdc5a91cdcdc6440652cde3143040c8a/apt/cache.py#L525) function, however due to the following [line](https://salsa.debian.org/apt-team/python-apt/blob/745ce7abfdc5a91cdcdc6440652cde3143040c8a/apt/cache.py#L546) with `os.path.abspath` 
```python
                apt_pkg.config.set("Dir::Etc::sourcelist",
                                   os.path.abspath(sources_list))
```
we need to provide the absolute path of the new repo file.

Therefore please review the code if there is a better way to add the absolute path and filename within ansible.

Additionally while removing a repository we don't need to update the apt sources cache again, apt seems to be intelligent enough to handle this properly.
