### PR TITLE
Use unicode string for auto interpreter warnings

### DIFF
--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -109,55 +109,56 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
         if not version_map:
             raise NotImplementedError('unsupported Linux distribution: {0}'.format(distro))
 
-        platform_interpreter = _version_fuzzy_match(version, version_map)
+        platform_interpreter = to_text(_version_fuzzy_match(version, version_map), encoding='utf-8',
+                                       errors='surrogate_or_strict')
 
         # provide a transition period for hosts that were using /usr/bin/python previously (but shouldn't have been)
         if is_auto_legacy:
-            if platform_interpreter != '/usr/bin/python' and '/usr/bin/python' in found_interpreters:
+            if platform_interpreter != u'/usr/bin/python' and u'/usr/bin/python' in found_interpreters:
                 # FIXME: support comments in sivel's deprecation scanner so we can get reminded on this
                 if not is_silent:
                     action._discovery_deprecation_warnings.append(dict(
-                        msg="Distribution {0} {1} on host {2} should use {3}, but is using "
-                            "/usr/bin/python for backward compatibility with prior Ansible releases. "
-                            "A future Ansible release will default to using the discovered platform "
-                            "python for this host. See {4} for more information"
+                        msg=u"Distribution {0} {1} on host {2} should use {3}, but is using "
+                            u"/usr/bin/python for backward compatibility with prior Ansible releases. "
+                            u"A future Ansible release will default to using the discovered platform "
+                            u"python for this host. See {4} for more information"
                             .format(distro, version, host, platform_interpreter,
                                     get_versioned_doclink('reference_appendices/interpreter_discovery.html')),
                         version='2.12'))
-                return '/usr/bin/python'
+                return u'/usr/bin/python'
 
         if platform_interpreter not in found_interpreters:
             if platform_interpreter not in bootstrap_python_list:
                 # sanity check to make sure we looked for it
                 if not is_silent:
                     action._discovery_warnings \
-                        .append("Platform interpreter {0} on host {1} is missing from bootstrap list"
+                        .append(u"Platform interpreter {0} on host {1} is missing from bootstrap list"
                                 .format(platform_interpreter, host))
 
             if not is_silent:
                 action._discovery_warnings \
-                    .append("Distribution {0} {1} on host {2} should use {3}, but is using {4}, since the "
-                            "discovered platform python interpreter was not present. See {5} "
-                            "for more information."
+                    .append(u"Distribution {0} {1} on host {2} should use {3}, but is using {4}, since the "
+                            u"discovered platform python interpreter was not present. See {5} "
+                            u"for more information."
                             .format(distro, version, host, platform_interpreter, found_interpreters[0],
                                     get_versioned_doclink('reference_appendices/interpreter_discovery.html')))
             return found_interpreters[0]
 
         return platform_interpreter
     except NotImplementedError as ex:
-        display.vvv(msg='Python interpreter discovery fallback ({0})'.format(to_text(ex)), host=host)
+        display.vvv(msg=u'Python interpreter discovery fallback ({0})'.format(to_text(ex)), host=host)
     except Exception as ex:
         if not is_silent:
-            display.warning(msg='Unhandled error in Python interpreter discovery for host {0}: {1}'.format(host, to_text(ex)))
-            display.debug(msg='Interpreter discovery traceback:\n{0}'.format(to_text(format_exc())), host=host)
+            display.warning(msg=u'Unhandled error in Python interpreter discovery for host {0}: {1}'.format(host, to_text(ex)))
+            display.debug(msg=u'Interpreter discovery traceback:\n{0}'.format(to_text(format_exc())), host=host)
             if res and res.get('stderr'):
-                display.vvv(msg='Interpreter discovery remote stderr:\n{0}'.format(to_text(res.get('stderr'))), host=host)
+                display.vvv(msg=u'Interpreter discovery remote stderr:\n{0}'.format(to_text(res.get('stderr'))), host=host)
 
     if not is_silent:
         action._discovery_warnings \
-            .append("Platform {0} on host {1} is using the discovered Python interpreter at {2}, but future installation of "
-                    "another Python interpreter could change this. See {3} "
-                    "for more information."
+            .append(u"Platform {0} on host {1} is using the discovered Python interpreter at {2}, but future installation of "
+                    u"another Python interpreter could change this. See {3} "
+                    u"for more information."
                     .format(platform_type, host, found_interpreters[0],
                             get_versioned_doclink('reference_appendices/interpreter_discovery.html')))
     return found_interpreters[0]

--- a/test/units/executor/test_interpreter_discovery.py
+++ b/test/units/executor/test_interpreter_discovery.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# (c) 2019, Jordan Borean <jborean@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat.mock import MagicMock
+
+from ansible.executor.interpreter_discovery import discover_interpreter
+
+mock_ubuntu_platform_res = \
+    ur'{"osrelease_content": "NAME=\"Ubuntu\"\nVERSION=\"16.04.5 LTS (Xenial Xerus)\"\nID=ubuntu\nID_LIKE=debian\n' \
+    ur'PRETTY_NAME=\"Ubuntu 16.04.5 LTS\"\nVERSION_ID=\"16.04\"\nHOME_URL=\"http://www.ubuntu.com/\"\n' \
+    ur'SUPPORT_URL=\"http://help.ubuntu.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/ubunut/\"\n' \
+    ur'VERSION_CODENAME=xenial\nUBUNTU_CODENAME=xenial\n", "platform_dist_result": ["Ubuntu", "16.04", "xenial"]}'
+
+
+def test_discovery_interpreter_linux_auto_legacy():
+    res1 = u'PLATFORM\nLinux\nFOUND\n/usr/bin/python\n/usr/bin/python3.5\n/usr/bin/python3\nENDFOUND'
+
+    mock_action = MagicMock()
+    mock_action._low_level_execute_command.side_effect = [{'stdout': res1}, {'stdout': mock_ubuntu_platform_res}]
+
+    actual = discover_interpreter(mock_action, 'python', 'auto_legacy', {'inventory_hostname': u'host-fóöbär'})
+
+    assert actual == u'/usr/bin/python'
+    assert len(mock_action.method_calls) == 3
+    assert mock_action.method_calls[2][0] == '_discovery_deprecation_warnings.append'
+    assert u'Distribution Ubuntu 16.04 on host host-fóöbär should use /usr/bin/python3, but is using /usr/bin/python' \
+           u' for backward compatibility' in mock_action.method_calls[2][1][0]['msg']
+    assert mock_action.method_calls[2][1][0]['version'] == '2.12'
+
+
+def test_discovery_interpreter_linux_auto_legacy_silent():
+    res1 = u'PLATFORM\nLinux\nFOUND\n/usr/bin/python\n/usr/bin/python3.5\n/usr/bin/python3\nENDFOUND'
+
+    mock_action = MagicMock()
+    mock_action._low_level_execute_command.side_effect = [{'stdout': res1}, {'stdout': mock_ubuntu_platform_res}]
+
+    actual = discover_interpreter(mock_action, 'python', 'auto_legacy_silent', {'inventory_hostname': u'host-fóöbär'})
+
+    assert actual == u'/usr/bin/python'
+    assert len(mock_action.method_calls) == 2
+
+
+def test_discovery_interpreter_linux_auto():
+    res1 = u'PLATFORM\nLinux\nFOUND\n/usr/bin/python\n/usr/bin/python3.5\n/usr/bin/python3\nENDFOUND'
+
+    mock_action = MagicMock()
+    mock_action._low_level_execute_command.side_effect = [{'stdout': res1}, {'stdout': mock_ubuntu_platform_res}]
+
+    actual = discover_interpreter(mock_action, 'python', 'auto', {'inventory_hostname': u'host-fóöbär'})
+
+    assert actual == u'/usr/bin/python3'
+    assert len(mock_action.method_calls) == 2
+
+
+def test_discovery_interpreter_non_linux():
+    mock_action = MagicMock()
+    mock_action._low_level_execute_command.return_value = \
+        {'stdout': u'PLATFORM\nDarwin\nFOUND\n/usr/bin/python\nENDFOUND'}
+
+    actual = discover_interpreter(mock_action, 'python', 'auto_legacy', {'inventory_hostname': u'host-fóöbär'})
+
+    assert actual == u'/usr/bin/python'
+    assert len(mock_action.method_calls) == 2
+    assert mock_action.method_calls[1][0] == '_discovery_warnings.append'
+    assert u'Platform darwin on host host-fóöbär is using the discovered Python interpreter at /usr/bin/python, ' \
+           u'but future installation of another Python interpreter could change this' \
+           in mock_action.method_calls[1][1][0]
+
+
+def test_no_interpreters_found():
+    mock_action = MagicMock()
+    mock_action._low_level_execute_command.return_value = {'stdout': u'PLATFORM\nWindows\nFOUND\nENDFOUND'}
+
+    actual = discover_interpreter(mock_action, 'python', 'auto_legacy', {'inventory_hostname': u'host-fóöbär'})
+
+    assert actual == u'/usr/bin/python'
+    assert len(mock_action.method_calls) == 2
+    assert mock_action.method_calls[1][0] == '_discovery_warnings.append'
+    assert u'No python interpreters found for host host-fóöbär (tried' \
+           in mock_action.method_calls[1][1][0]

--- a/test/units/executor/test_interpreter_discovery.py
+++ b/test/units/executor/test_interpreter_discovery.py
@@ -9,12 +9,14 @@ __metaclass__ = type
 from units.compat.mock import MagicMock
 
 from ansible.executor.interpreter_discovery import discover_interpreter
+from ansible.module_utils._text import to_text
 
-mock_ubuntu_platform_res = \
-    ur'{"osrelease_content": "NAME=\"Ubuntu\"\nVERSION=\"16.04.5 LTS (Xenial Xerus)\"\nID=ubuntu\nID_LIKE=debian\n' \
-    ur'PRETTY_NAME=\"Ubuntu 16.04.5 LTS\"\nVERSION_ID=\"16.04\"\nHOME_URL=\"http://www.ubuntu.com/\"\n' \
-    ur'SUPPORT_URL=\"http://help.ubuntu.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/ubunut/\"\n' \
-    ur'VERSION_CODENAME=xenial\nUBUNTU_CODENAME=xenial\n", "platform_dist_result": ["Ubuntu", "16.04", "xenial"]}'
+mock_ubuntu_platform_res = to_text(
+    r'{"osrelease_content": "NAME=\"Ubuntu\"\nVERSION=\"16.04.5 LTS (Xenial Xerus)\"\nID=ubuntu\nID_LIKE=debian\n'
+    r'PRETTY_NAME=\"Ubuntu 16.04.5 LTS\"\nVERSION_ID=\"16.04\"\nHOME_URL=\"http://www.ubuntu.com/\"\n'
+    r'SUPPORT_URL=\"http://help.ubuntu.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/ubuntu/\"\n'
+    r'VERSION_CODENAME=xenial\nUBUNTU_CODENAME=xenial\n", "platform_dist_result": ["Ubuntu", "16.04", "xenial"]}'
+)
 
 
 def test_discovery_interpreter_linux_auto_legacy():


### PR DESCRIPTION
##### SUMMARY
Currently when running on Python 2 and the inventory_hostname contains non-ascii chars it will fail with something like;

```
The full traceback is:                                                                           
Traceback (most recent call last):                                                                      
  File "/Users/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 144, in run                                                                              
    res = self._execute()                                                                                                                                                                                      
  File "/Users/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 645, in _execute                                                                                             
    result = self._handler.run(task_vars=variables)                                                                                     
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/normal.py", line 46, in run               
    result = merge_hash(result, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))                  
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/__init__.py", line 794, in _execute_module
    (module_style, shebang, module_data, module_path) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/__init__.py", line 209, in _configure_module                                                                                                       
    task_vars=task_vars)                                                                                
  File "/Users/jborean/dev/ansible/lib/ansible/executor/interpreter_discovery.py", line 163, in discover_interpreter                                                                                            
    .format("", host, "", docs))                                                                                                                                          
UnicodeEncodeError: 'ascii' codec can't encode characters in position 6-7: ordinal not in range(128)  
```

This is because the warning is combining native strings and text strings where the latter contains non-ascii chars. On Python 2 these are automatically converted to a native/byte string using ascii encoding and fails. The PR ensures all warnings are text strings and also makes sure the returned interpreter is uniform as a text string.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
interpreter_discovery