### PR TITLE
Fix integration tests with custom inventory.

### DIFF
--- a/test/integration/targets/any_errors_fatal/inventory
+++ b/test/integration/targets/any_errors_fatal/inventory
@@ -1,3 +1,6 @@
 [local]
 testhost ansible_connection=local host_var_role_name=role3
 testhost2 ansible_connection=local host_var_role_name=role2
+
+[local:vars]
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/callback_default/inventory
+++ b/test/integration/targets/callback_default/inventory
@@ -1,5 +1,5 @@
 [local]
-testhost ansible_connection=local
+testhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
 
 [nonexistent]
-testhost5 ansible_host=169.254.199.200
+testhost5 ansible_host=169.254.199.200  # no connection is ever established with this host

--- a/test/integration/targets/connection_chroot/test_connection.inventory
+++ b/test/integration/targets/connection_chroot/test_connection.inventory
@@ -4,3 +4,4 @@ chroot-no-pipelining ansible_ssh_pipelining=false
 [chroot:vars]
 ansible_host=/
 ansible_connection=chroot
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/connection_local/test_connection.inventory
+++ b/test/integration/targets/connection_local/test_connection.inventory
@@ -4,3 +4,4 @@ local-no-pipelining ansible_ssh_pipelining=false
 [local:vars]
 ansible_host=localhost
 ansible_connection=local
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/connection_paramiko_ssh/test_connection.inventory
+++ b/test/integration/targets/connection_paramiko_ssh/test_connection.inventory
@@ -4,3 +4,4 @@ paramiko_ssh-no-pipelining ansible_ssh_pipelining=false
 [paramiko_ssh:vars]
 ansible_host=localhost
 ansible_connection=paramiko_ssh
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/connection_ssh/test_connection.inventory
+++ b/test/integration/targets/connection_ssh/test_connection.inventory
@@ -4,3 +4,4 @@ ssh-no-pipelining ansible_ssh_pipelining=false
 [ssh:vars]
 ansible_host=localhost
 ansible_connection=ssh
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/delegate_to/inventory
+++ b/test/integration/targets/delegate_to/inventory
@@ -3,3 +3,6 @@ testhost ansible_connection=local
 testhost2 ansible_connection=local
 testhost3 ansible_ssh_host=127.0.0.3
 testhost4 ansible_ssh_host=127.0.0.4
+
+[local:vars]
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/delegate_to/test_delegate_to_loop_randomness.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to_loop_randomness.yml
@@ -8,6 +8,7 @@
         name: "foo{{item}}"
         groups: foo
         ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       loop: "{{ range(10)|list }}"
 
     # We expect all of the next 3 runs to succeeed

--- a/test/integration/targets/gathering_facts/inventory
+++ b/test/integration/targets/gathering_facts/inventory
@@ -1,2 +1,2 @@
 [local]
-facthost[0:25] ansible_connection=local
+facthost[0:25] ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/hosts_field/inventory.hosts_field
+++ b/test/integration/targets/hosts_field/inventory.hosts_field
@@ -1,1 +1,1 @@
-42 ansible_host=127.0.0.42 ansible_connection=local
+42 ansible_host=127.0.0.42 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/include_import/inventory
+++ b/test/integration/targets/include_import/inventory
@@ -1,3 +1,6 @@
 [local]
 testhost ansible_connection=local host_var_role_name=role3
 testhost2 ansible_connection=local host_var_role_name=role2
+
+[local:vars]
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/set_fact/inventory
+++ b/test/integration/targets/set_fact/inventory
@@ -1,3 +1,3 @@
 [testgroup]
-testhost ansible_connection=local
-localhost
+testhost ansible_connection=local  # no connection is actually established with this host
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/var_blending/inventory
+++ b/test/integration/targets/var_blending/inventory
@@ -1,6 +1,6 @@
 [local]
-testhost ansible_connection=local
-testhost2 ansible_connection=local
+testhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+testhost2 ansible_connection=local  # connections are never made to this host, only host vars are accessed
 
 # the following inline declarations are accompanied
 # by (preferred) group_vars/ and host_vars/ variables

--- a/test/integration/targets/var_precedence/inventory
+++ b/test/integration/targets/var_precedence/inventory
@@ -1,12 +1,12 @@
 [local]
-testhost ansible_connection=local
+testhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
 
 [all:vars]
 extra_var_override=FROM_INVENTORY
 inven_var=inventory_var
 
 [inven_overridehosts]
-invenoverride ansible_connection=local
+invenoverride ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
 
 [inven_overridehosts:vars]
 foo=foo


### PR DESCRIPTION
##### SUMMARY

Fix integration tests with custom inventory.

All inventory hosts to which a connection is actually established should declare ansible_python_interpreter to avoid interpreter auto-discovery, as that may select the wrong interpreter.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
