### PR TITLE
Haproxy: add support for track in wait_until_status

### DIFF
--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -353,8 +353,9 @@ class HAProxy(object):
             state = self.get_state_for(pxname, svname)
 
             # We can assume there will only be 1 element in state because both svname and pxname are always set when we get here
-            if state[0]['status'] == status:
-                if not self._drain or (state[0]['scur'] == '0' and state == 'MAINT'):
+            # When using track we get a status like this: MAINT (via pxname/svname) so we need to do substring matching
+            if status in state[0]['status']:
+                if not self._drain or (state[0]['scur'] == '0' and 'MAINT' in state):
                     return True
             else:
                 time.sleep(self.wait_interval)


### PR DESCRIPTION
When haproxy is configured to track the status of a server using a
server in another backend it will not report all status as expected.
Using substring matching will solve this.

The CSV will output the server status in the following way:
MAINT: MAINT (via pxname/svname)
UP: UP
DOWN: DOWN

Haproxy doc on trach: https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-track

##### SUMMARY
Fixes #53676

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/net_tools/haproxy.py

##### ADDITIONAL INFORMATION
Configure haproxy to track the server status using a different backend and try to put the server in maintenance mode using ansible.


Haproxy:
```
backend backendA
    option httpchk
    server server01 1.2.3.4:80 check
    server server02 1.2.3.5:80 check

backend backendB
    server server01 1.2.3.4:80 track backendA/server01
    server server02 1.2.3.5:80 track backendA/server02
```
Playbook:
```
- name: disable backend in haproxy
  delegate_to: haproxy
  haproxy:
    state: disable
    host: server01
    socket: /var/run/haproxy/admin.sock
    wait: yes
```
