### PR TITLE
virt_net modify should fail

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt_net.py
+++ b/lib/ansible/modules/cloud/misc/virt_net.py
@@ -133,6 +133,7 @@ EXAMPLES = '''
 # Add a new host in the dhcp pool
 - virt_net:
     name: br_nat
+    command: modify
     xml: "<host mac='FC:C2:33:00:6c:3c' name='my_vm' ip='192.168.122.30'/>"
 '''
 

--- a/lib/ansible/modules/cloud/misc/virt_net.py
+++ b/lib/ansible/modules/cloud/misc/virt_net.py
@@ -273,8 +273,8 @@ class LibvirtConnection(object):
                         res = 0
                     if res == 0:
                         return True
-            #  command, section, parentIndex, xml, flags=0
-            self.module.fail_json(msg='updating this is not supported yet %s' % to_native(xml))
+        #  command, section, parentIndex, xml, flags=0
+        self.module.fail_json(msg='updating this is not supported yet %s' % to_native(xml))
 
     def destroy(self, entryid):
         if not self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY
The modify command should fail if any other xml but a host tag is used. The example should actually use the modify command.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
virt_net

##### STEPS TO REPRODUCE
Create xml with anything else but a host node on top level.

##### EXPECTED RESULTS
The module fails saying it cannot handle the xml.

##### ACTUAL RESULTS
The module passes.
