### PR TITLE
remove checksum from get_url

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -85,8 +85,7 @@ options:
       - 'If a checksum is passed to this parameter, the digest of the
         destination file will be calculated after it is downloaded to ensure
         its integrity and verify that the transfer completed successfully.
-        Format: <algorithm>:<checksum|url>, e.g. checksum="sha256:D98291AC[...]B6DC7B97",
-        checksum="sha256:http://example.com/path/sha256sum.txt"'
+        Format: <algorithm>:<checksum>, e.g. checksum="sha256:D98291AC[...]B6DC7B97"'
       - If you worry about portability, only the sha1 algorithm is available
         on all platforms and python versions.
       - The third party hashlib library can be installed for access to additional algorithms.
@@ -209,12 +208,6 @@ EXAMPLES = r'''
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf
     checksum: md5:66dffb5228a211e61d6d7ef4a86f5758
-
-- name: Download file with checksum url (sha256)
-  get_url:
-    url: http://example.com/path/file.conf
-    dest: /etc/foo.conf
-    checksum: sha256:http://example.com/path/sha256sum.txt
 
 - name: Download file from a file path
   get_url:


### PR DESCRIPTION
As per this comment https://github.com/ansible/ansible/issues/48790#issuecomment-440432038 it seems ansible won't provide this feature to checksum files using an url 

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Tried to use this feature in a small example and it's not working 
```
---
- hosts: localhost
  tasks:
  - name: Download file
    get_url: 
      url: "http://localhost/file" 
      checksum: "sha256:http://localhost/sha256sum.txt"
      dest: "/home/hgarcia/file"
```

Ansible throws the following error
```
TASK [Download file] *******************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "The checksum parameter has to be in format <algorithm>:<checksum>"}           
        to retry, use: --limit @/home/user/example.retry
```

I tried using `ansible` version `2.6.4`
```
➜  ~  ansible-playbook --version
ansible-playbook 2.6.4
  config file = None
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.13 (default, Sep 26 2018, 18:42:22) [GCC 6.3.0 20170516]
```

It has been mentioned in this comment that such feature won't be provided 
https://github.com/ansible/ansible/issues/48790#issuecomment-440432038

We need to update the documentation

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`get_url`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
