### PR TITLE
Fix checksum file parsing in get_url

### DIFF
--- a/changelogs/fragments/get_url-checksum.yaml
+++ b/changelogs/fragments/get_url-checksum.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- get_url - Fix issue with checksum validation when using a file to ensure we skip lines in the file that
+  do not contain exactly 2 parts. Also restrict exception handling to the minimum number of
+  necessary lines (https://github.com/ansible/ansible/issues/48790)

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -487,33 +487,38 @@ def main():
     if checksum:
         try:
             algorithm, checksum = checksum.split(':', 1)
-            if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
-                checksum_url = checksum
-                # download checksum file to checksum_tmpsrc
-                checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
-                with open(checksum_tmpsrc) as f:
-                    lines = [line.rstrip('\n') for line in f]
-                os.remove(checksum_tmpsrc)
-                lines = dict(s.split(None, 1) for s in lines)
-                filename = url_filename(url)
-
-                # Look through each line in the checksum file for a hash corresponding to
-                # the filename in the url, returning the first hash that is found.
-                for cksum in (s for (s, f) in lines.items() if f.strip('./') == filename):
-                    checksum = cksum
-                    break
-                else:
-                    checksum = None
-
-                if checksum is None:
-                    module.fail_json(msg="Unable to find a checksum for file '%s' in '%s'" % (filename, checksum_url))
-            # Remove any non-alphanumeric characters, including the infamous
-            # Unicode zero-width space
-            checksum = re.sub(r'\W+', '', checksum).lower()
-            # Ensure the checksum portion is a hexdigest
-            int(checksum, 16)
         except ValueError:
             module.fail_json(msg="The checksum parameter has to be in format <algorithm>:<checksum>", **result)
+
+        if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
+            checksum_url = checksum
+            # download checksum file to checksum_tmpsrc
+            checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
+            with open(checksum_tmpsrc) as f:
+                lines = [line.rstrip('\n') for line in f]
+            os.remove(checksum_tmpsrc)
+            checksum_map = {}
+            for line in lines:
+                parts = line.split(None, 1)
+                if len(parts) == 2:
+                    checksum_map[parts[0]] = parts[1]
+            filename = url_filename(url)
+
+            # Look through each line in the checksum file for a hash corresponding to
+            # the filename in the url, returning the first hash that is found.
+            for cksum in (s for (s, f) in checksum_map.items() if f.strip('./') == filename):
+                checksum = cksum
+                break
+            else:
+                checksum = None
+
+            if checksum is None:
+                module.fail_json(msg="Unable to find a checksum for file '%s' in '%s'" % (filename, checksum_url))
+        # Remove any non-alphanumeric characters, including the infamous
+        # Unicode zero-width space
+        checksum = re.sub(r'\W+', '', checksum).lower()
+        # Ensure the checksum portion is a hexdigest
+        int(checksum, 16)
 
     if not dest_is_dir and os.path.exists(dest):
         checksum_mismatch = False

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -522,7 +522,6 @@ def main():
             int(checksum, 16)
         except ValueError:
             module.fail_json(msg='The checksum format is invalid', **result)
-        
 
     if not dest_is_dir and os.path.exists(dest):
         checksum_mismatch = False

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -518,7 +518,11 @@ def main():
         # Unicode zero-width space
         checksum = re.sub(r'\W+', '', checksum).lower()
         # Ensure the checksum portion is a hexdigest
-        int(checksum, 16)
+        try:
+            int(checksum, 16)
+        except ValueError:
+            module.fail_json(msg='The checksum format is invalid', **result)
+        
 
     if not dest_is_dir and os.path.exists(dest):
         checksum_mismatch = False


### PR DESCRIPTION
##### SUMMARY
Fix checksum file parsing in get_url. Fixes #48790

Due to over zealous exception catching, we were obscuring the real error.  The real error was the result of assuming that every line in a checksum file could be split into exactly 2 parts.

This PR:
1. ensures that the split results in 2 parts before trying to add to the dict.
1. Wraps the minimal number of lines to detect the specific exception the code is concerned with
1. Uses a new variable `checksum_map` instead of re-using a variable `lines` that was converted from a list to a dict

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/basic/get_url.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```