### PR TITLE
[stable-2.7] Don't raise AnsibleConnectionFailure if the ssh process has already died. (#53534)

### DIFF
--- a/changelogs/fragments/ssh-check-returncode-before-exception.yaml
+++ b/changelogs/fragments/ssh-check-returncode-before-exception.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+- ssh - Check the return code of the ssh process before raising AnsibleConnectionFailure, as the error message
+  for the ssh process will likely contain more useful information. This will improve the missing interpreter messaging
+  when using modules such as setup which have a larger payload to transfer when combined with pipelining.
+  (https://github.com/ansible/ansible/issues/53487)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -899,8 +899,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
             # try to figure out if we are missing interpreter
             if self._used_interpreter is not None:
-                match = '%s: No such file or directory' % self._used_interpreter.lstrip('!#')
-                if match in data['module_stderr'] or match in data['module_stdout']:
+                match = re.compile('%s: (?:No such file or directory|not found)' % self._used_interpreter.lstrip('!#'))
+                if match.search(data['module_stderr']) or match.search(data['module_stdout']):
                     data['msg'] = "The module failed to execute correctly, you probably need to set the interpreter."
 
             # always append hint


### PR DESCRIPTION
* Don't raise AnsibleConnectionFailure if the ssh_process has already died. Fixes #53487

* Better support for file not found messages

* Add changelog fragment
(cherry picked from commit e9f9bca)


Co-authored-by: Matt Martz <matt@sivel.net>