### PR TITLE
[stable-2.7] Fix checksum file parsing in get_url (#53685)

### DIFF
--- a/changelogs/fragments/get_url-checksum.yaml
+++ b/changelogs/fragments/get_url-checksum.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- get_url - Fix issue with checksum validation when using a file to ensure we skip lines in the file that
+  do not contain exactly 2 parts. Also restrict exception handling to the minimum number of
+  necessary lines (https://github.com/ansible/ansible/issues/48790)

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -443,33 +443,41 @@ def main():
     if checksum:
         try:
             algorithm, checksum = checksum.split(':', 1)
-            if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
-                checksum_url = checksum
-                # download checksum file to checksum_tmpsrc
-                checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
-                with open(checksum_tmpsrc) as f:
-                    lines = [line.rstrip('\n') for line in f]
-                os.remove(checksum_tmpsrc)
-                lines = dict(s.split(None, 1) for s in lines)
-                filename = url_filename(url)
-
-                # Look through each line in the checksum file for a hash corresponding to
-                # the filename in the url, returning the first hash that is found.
-                for cksum in (s for (s, f) in lines.items() if f.strip('./') == filename):
-                    checksum = cksum
-                    break
-                else:
-                    checksum = None
-
-                if checksum is None:
-                    module.fail_json("Unable to find a checksum for file '%s' in '%s'" % (filename, checksum_url))
-            # Remove any non-alphanumeric characters, including the infamous
-            # Unicode zero-width space
-            checksum = re.sub(r'\W+', '', checksum).lower()
-            # Ensure the checksum portion is a hexdigest
-            int(checksum, 16)
         except ValueError:
             module.fail_json(msg="The checksum parameter has to be in format <algorithm>:<checksum>")
+
+        if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
+            checksum_url = checksum
+            # download checksum file to checksum_tmpsrc
+            checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
+            with open(checksum_tmpsrc) as f:
+                lines = [line.rstrip('\n') for line in f]
+            os.remove(checksum_tmpsrc)
+            checksum_map = {}
+            for line in lines:
+                parts = line.split(None, 1)
+                if len(parts) == 2:
+                    checksum_map[parts[0]] = parts[1]
+            filename = url_filename(url)
+
+            # Look through each line in the checksum file for a hash corresponding to
+            # the filename in the url, returning the first hash that is found.
+            for cksum in (s for (s, f) in checksum_map.items() if f.strip('./') == filename):
+                checksum = cksum
+                break
+            else:
+                checksum = None
+
+            if checksum is None:
+                module.fail_json(msg="Unable to find a checksum for file '%s' in '%s'" % (filename, checksum_url))
+        # Remove any non-alphanumeric characters, including the infamous
+        # Unicode zero-width space
+        checksum = re.sub(r'\W+', '', checksum).lower()
+        # Ensure the checksum portion is a hexdigest
+        try:
+            int(checksum, 16)
+        except ValueError:
+            module.fail_json(msg='The checksum format is invalid', **result)
 
     if not dest_is_dir and os.path.exists(dest):
         checksum_mismatch = False

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -477,7 +477,7 @@ def main():
         try:
             int(checksum, 16)
         except ValueError:
-            module.fail_json(msg='The checksum format is invalid', **result)
+            module.fail_json(msg='The checksum format is invalid')
 
     if not dest_is_dir and os.path.exists(dest):
         checksum_mismatch = False


### PR DESCRIPTION
* Fix checksum file parsing. Fixes #48790

* guard invalid int conversion

Co-Authored-By: sivel <matt@sivel.net>

* Remove extra newline.
(cherry picked from commit 77217fdd24c399d02b01d0b504d587c27077bb1b)

Co-authored-by: Matt Martz <matt@sivel.net>