### PR TITLE
Option parsing: warn if both an option and its alias are specified for a module

### DIFF
--- a/changelogs/fragments/53698-alias-collision-warning.yaml
+++ b/changelogs/fragments/53698-alias-collision-warning.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Ansible will now warn if two aliases of the same option are used for Python modules.

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -112,9 +112,13 @@ def list_deprecations(argument_spec, params):
     return deprecations
 
 
-def handle_aliases(argument_spec, params):
+def handle_aliases(argument_spec, params, alias_warnings=None):
     """Return a two item tuple. The first is a dictionary of aliases, the second is
-    a list of legal inputs."""
+    a list of legal inputs.
+
+    If a list is provided to the alias_warnings parameter, it will be filled with tuples
+    (option, alias) in every case where both an option and its alias are specified.
+    """
 
     legal_inputs = ['_ansible_%s' % k for k in PASS_VARS]
     aliases_results = {}  # alias:canon
@@ -135,6 +139,8 @@ def handle_aliases(argument_spec, params):
             legal_inputs.append(alias)
             aliases_results[alias] = k
             if alias in params:
+                if k in params and alias_warnings is not None:
+                    alias_warnings.append((k, alias))
                 params[k] = params[alias]
 
     return aliases_results, legal_inputs

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -233,6 +233,14 @@ class TestComplexArgSpecs:
         assert isinstance(am.params['foo'], str)
         assert am.params['foo'] == 'hello'
 
+    @pytest.mark.parametrize('stdin', [{'foo': 'hello1', 'dup': 'hello2'}], indirect=['stdin'])
+    def test_complex_duplicate_warning(self, stdin, complex_argspec):
+        """Test that the complex argspec issues a warning if we specify an option both with its canonical name and its alias"""
+        am = basic.AnsibleModule(**complex_argspec)
+        assert isinstance(am.params['foo'], str)
+        assert 'Both option foo and its alias dup are set.' in am._warnings
+        assert am.params['foo'] == 'hello2'
+
     @pytest.mark.parametrize('stdin', [{'foo': 'hello', 'bam': 'test'}], indirect=['stdin'])
     def test_complex_type_fallback(self, mocker, stdin, complex_argspec):
         """Test that the complex argspec works if we get a required parameter via fallback"""


### PR DESCRIPTION
##### SUMMARY
Currently, if both an option and its alias are provided in module options, the value of the alias overwrites the value of the option. (If multiple aliases of that option are specified, the last one appearing in the `aliases` list wins.)

I think there should be a warning if that happens. This PR implements such a warning:

Example:
```
 - argtest:
      l: 1,2,3
      lalias: 1,2,3,4
      x:
        y: 1
        yy: 2
```
with `argument_spec=dict(l=dict(type='list', elements='int', aliases=['lalias']), x=dict(type='dict', options=dict(y=dict(type='str', aliases=['yy']))))` results in
```
 [WARNING]: Both option l and its alias lalias are set.
 [WARNING]: Both option x.y and its alias x.yy are set.
```

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
lib/ansible/module_utils/common/parameters.py
