### PR TITLE
Fix failure of cloudscale_floating_ip without server

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -176,7 +176,8 @@ class AnsibleCloudscaleFloatingIP(AnsibleCloudscaleBase):
 
         # Replace the server with just the UUID, the href to the server is useless and just makes
         # things more complicated
-        resp['server'] = resp['server']['uuid']
+        if resp['server'] is not None:
+            resp['server'] = resp['server']['uuid']
 
         return resp
 

--- a/test/integration/targets/cloudscale_floating_ip/tasks/main.yml
+++ b/test/integration/targets/cloudscale_floating_ip/tasks/main.yml
@@ -22,6 +22,8 @@
         - { 'ip_version': 6, 'reverse_ptr': '{{ cloudscale_resource_prefix }}-6.example.com' }
         - { 'ip_version': 6, 'prefix_length': 56 }
 
+    - import_tasks: unassigned.yml
+
   always:
     - import_role:
         name: cloudscale_common

--- a/test/integration/targets/cloudscale_floating_ip/tasks/unassigned.yml
+++ b/test/integration/targets/cloudscale_floating_ip/tasks/unassigned.yml
@@ -1,0 +1,25 @@
+---
+- name: Assign Floating IP to server test01
+  cloudscale_floating_ip:
+    ip_version: 6
+    server: '{{ test01.uuid }}'
+    reverse_ptr: '{{ cloudscale_resource_prefix }}-unassigned.example.com'
+  register: floating_ip
+
+# The only way to have an unassigned floating IP is to delete the server
+# where the floating IP is currently assigned.
+- name: Delete server test01
+  cloudscale_server:
+    uuid: '{{ test01.uuid }}'
+    state: 'absent'
+
+- name: Do not fail if floating IP is unassigned
+  cloudscale_floating_ip:
+    ip: '{{ floating_ip.ip }}'
+  register: floating_ip_not_fail
+- name: Verify do not fail if floating IP is unassigned
+  assert:
+    that:
+      - floating_ip_not_fail is successful
+      - floating_ip_not_fail is not changed
+      - floating_ip_not_fail.server == None


### PR DESCRIPTION
##### SUMMARY

The cloudscale_floating_ip module failed if no server was assigned to
the floating IP. This also adds a test to avoid a regression.

The only way to have a floating IP without a server assigned is to
delete the server where the floating IP is currently assigned. Under
normal circumstances it's not possible to have an unassigned floating
IP.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudscale_floating_ip
