### PR TITLE
win_reboot - Fix rc validation when using psrp and add extra docs

### DIFF
--- a/changelogs/fragments/win_reboot-psrp.yaml
+++ b/changelogs/fragments/win_reboot-psrp.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_reboot - Fix reboot command validation failure when running under the psrp connection plugin

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -65,6 +65,10 @@ notes:
 - If a shutdown was already scheduled on the system, C(win_reboot) will abort the scheduled shutdown and enforce its own shutdown.
 - Beware that when C(win_reboot) returns, the Windows system may not have settled yet and some base services could be in limbo.
   This can result in unexpected behavior. Check the examples for ways to mitigate this.
+- The connection user must have the L(SeRemoteShutdownPrivilege,
+  https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/force-shutdown-from-a-remote-system)
+  privilege to be able to use this module. This is granted to Administrators by default but may have been removed on
+  some Windows hosts.
 seealso:
 - module: reboot
 author:

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -65,9 +65,9 @@ notes:
 - If a shutdown was already scheduled on the system, C(win_reboot) will abort the scheduled shutdown and enforce its own shutdown.
 - Beware that when C(win_reboot) returns, the Windows system may not have settled yet and some base services could be in limbo.
   This can result in unexpected behavior. Check the examples for ways to mitigate this.
-- The connection user must have the L(SeRemoteShutdownPrivilege,
-  https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/force-shutdown-from-a-remote-system)
-  privilege to be able to use this module. This is granted to Administrators by default but may have been removed on
+- The connection user must have the C(SeRemoteShutdownPrivilege) privilege enabled, see
+  U(https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/force-shutdown-from-a-remote-system)
+  for more information.
   some Windows hosts.
 seealso:
 - module: reboot

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -26,7 +26,8 @@ class ActionModule(RebootActionModule, ActionBase):
         'reboot_timeout', 'reboot_timeout_sec', 'shutdown_timeout', 'shutdown_timeout_sec', 'test_command',
     ))
 
-    DEFAULT_BOOT_TIME_COMMAND = "(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime"
+    DEFAULT_BOOT_TIME_COMMAND = "(Get-CimInstance -ClassName Win32_OperatingSystem -Property LastBootUpTime)" \
+                                ".LastBootUpTime.ToFileTimeUtc()"
     DEFAULT_CONNECT_TIMEOUT = 5
     DEFAULT_PRE_REBOOT_DELAY = 2
     DEFAULT_SUDOABLE = False
@@ -49,7 +50,7 @@ class ActionModule(RebootActionModule, ActionBase):
     def perform_reboot(self, task_vars, distribution):
         shutdown_command = self.get_shutdown_command(task_vars, distribution)
         shutdown_command_args = self.get_shutdown_command_args(distribution)
-        reboot_command = '{0} {1}'.format(shutdown_command, shutdown_command_args)
+        reboot_command = self._connection._shell._encode_script('{0} {1}'.format(shutdown_command, shutdown_command_args))
 
         display.vvv("{action}: rebooting server...".format(action=self._task.action))
         display.debug("{action}: distribution: {dist}".format(action=self._task.action, dist=distribution))
@@ -66,7 +67,8 @@ class ActionModule(RebootActionModule, ActionBase):
             display.warning('A scheduled reboot was pre-empted by Ansible.')
 
             # Try to abort (this may fail if it was already aborted)
-            result1 = self._low_level_execute_command('shutdown /a', sudoable=self.DEFAULT_SUDOABLE)
+            result1 = self._low_level_execute_command(self._connection._shell._encode_script('shutdown /a'),
+                                                      sudoable=self.DEFAULT_SUDOABLE)
 
             # Initiate reboot again
             result2 = self._low_level_execute_command(reboot_command, sudoable=self.DEFAULT_SUDOABLE)

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -26,8 +26,7 @@ class ActionModule(RebootActionModule, ActionBase):
         'reboot_timeout', 'reboot_timeout_sec', 'shutdown_timeout', 'shutdown_timeout_sec', 'test_command',
     ))
 
-    DEFAULT_BOOT_TIME_COMMAND = "(Get-CimInstance -ClassName Win32_OperatingSystem -Property LastBootUpTime)" \
-                                ".LastBootUpTime.ToFileTimeUtc()"
+    DEFAULT_BOOT_TIME_COMMAND = "(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime"
     DEFAULT_CONNECT_TIMEOUT = 5
     DEFAULT_PRE_REBOOT_DELAY = 2
     DEFAULT_SUDOABLE = False


### PR DESCRIPTION
##### SUMMARY
When the `shutdown.exe` command fails and we are running through psrp the return code is not passed back to Ansible due to the nature of psrp. We need to enclose the command with `self._connection._shell._encode_script` which returns the rc from the last run command so that win_reboot can validate the result properly.

This PR also adds some docs around the required privilege `SeRemoteShutdownPrivilege` ~~and optimises the last boot time command to be quicker and use non deprecated commands.~~ Edit: looks like we can't change that yet due to changes in the permissions required.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reboot