### PR TITLE
Fix bug with keyed_group group name transformation

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -420,13 +420,13 @@ class Constructable(object):
 
                         for bare_name in new_raw_group_names:
                             gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
-                            self.inventory.add_group(gname)
-                            self.inventory.add_child(gname, host)
+                            result_gname = self.inventory.add_group(gname)
+                            self.inventory.add_child(result_gname, host)
 
                             if raw_parent_name:
                                 parent_name = self._sanitize_group_name(raw_parent_name)
                                 self.inventory.add_group(parent_name)
-                                self.inventory.add_child(parent_name, gname)
+                                self.inventory.add_child(parent_name, result_gname)
 
                     else:
                         if strict:


### PR DESCRIPTION
##### SUMMARY
If I used the setting to transform group names, it throws an error if keyed_groups are used, and those go over some groups with transformed characters

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugin constructible

##### ADDITIONAL INFORMATION
Reproduce with

```paste below
ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS=false ansible-inventory -i aws_ec2.yaml --list --export -vvv
```

Where you are using keyed groups like

```yaml
plugin: aws_ec2
keyed_groups:
  - prefix: ""
    separator: ""
    key: placement.availability_zone
    parent_group: zones
```

you get errors like

```
 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/ansible-inventory-file-examples/private/ec2/aws_ec2.yaml with auto plugin: us-east-2 is not a known group

  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/manager.py", line 272, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/aws_ec2.py", line 570, in parse
    self._populate(results, hostnames)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/aws_ec2.py", line 465, in _populate
    self._add_hosts(hosts=groups[group], group=group, hostnames=hostnames)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/aws_ec2.py", line 500, in _add_hosts
    self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname, strict=strict)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/__init__.py", line 424, in _add_host_to_keyed_groups
    self.inventory.add_child(gname, host)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/data.py", line 270, in add_child
    raise AnsibleError("%s is not a known group" % group)
```

This makes it work again with the setting on that.

ping @bcoca 