### PR TITLE
win_psexec: make the tests more stable (#53716) - 2.6

### DIFF
--- a/test/integration/targets/win_psexec/aliases
+++ b/test/integration/targets/win_psexec/aliases
@@ -1,2 +1,1 @@
 shippable/windows/group3
-unstable

--- a/test/integration/targets/win_psexec/tasks/main.yml
+++ b/test/integration/targets/win_psexec/tasks/main.yml
@@ -41,12 +41,10 @@
     system: yes
     nobanner: true
   register: whoami_as_system
-
-- name: Test whoami as SYSTEM
-  assert:
-    that:
-    - whoami_as_system.rc == 0
-    - whoami_as_system.stdout == 'nt authority\system'
+  # Seems to be a bug with PsExec where the stdout can be empty, just retry the task to make this test a bit more stable
+  until: whoami_as_system.rc == 0 and whoami_as_system.stdout == 'nt authority\system'
+  retries: 3
+  delay: 2
 
 # FIXME: Behaviour is not consistent on all Windows systems
 #- name: Run whoami as ELEVATED


### PR DESCRIPTION
(cherry picked from commit 33939f7fe8bb214cf87260fafb2f6be683ce5fea)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/53716

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psexec