### PR TITLE
win_reboot - fix broken tests after recent commit

### DIFF
--- a/test/integration/targets/win_reboot/tasks/main.yml
+++ b/test/integration/targets/win_reboot/tasks/main.yml
@@ -78,7 +78,7 @@
         ansible_password: '{{standard_pass}}'
         ansible_winrm_transport: ntlm
       register: fail_shutdown
-      failed_when: "fail_shutdown.msg != 'Reboot command failed, error was:  Access is denied.(5)'"
+      failed_when: "'Reboot command failed, error was:  Access is denied.(5)' not in fail_shutdown.msg"
 
   always:
     - name: set the original SDDL to the WinRM listener


### PR DESCRIPTION
##### SUMMARY
One of the win_reboot tests was testing the full string returned by the module. The change in https://github.com/ansible/ansible/pull/53711 meant that the stderr value changed slightly on newer PowerShell versions. This PR fixes the test to make it a bit more lenient but still test the failure scenario.

A bug in the test classification meant that the original tests only ran on 2012 R2 and not 2016+ where this issue occurs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reboot