### PR TITLE
maven_artifact: fix #53713 - infinite recursion

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -192,7 +192,10 @@ def split_pre_existing_dir(dirname):
     head, tail = os.path.split(dirname)
     b_head = to_bytes(head, errors='surrogate_or_strict')
     if not os.path.exists(b_head):
-        (pre_existing_dir, new_directory_list) = split_pre_existing_dir(head)
+        if head == dirname:
+            return None, [head]
+        else:
+            (pre_existing_dir, new_directory_list) = split_pre_existing_dir(head)
     else:
         return head, [tail]
     new_directory_list.append(tail)
@@ -204,7 +207,11 @@ def adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list,
     Walk the new directories list and make sure that permissions are as we would expect
     '''
     if new_directory_list:
-        working_dir = os.path.join(pre_existing_dir, new_directory_list.pop(0))
+        first_sub_dir = new_directory_list.pop(0)
+        if not pre_existing_dir:
+            working_dir = first_sub_dir
+        else:
+            working_dir = os.path.join(pre_existing_dir, first_sub_dir)
         directory_args['path'] = working_dir
         changed = module.set_fs_attributes_if_different(directory_args, changed)
         changed = adjust_recursive_directory_permissions(working_dir, new_directory_list, module, directory_args, changed)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #53713 - infinite recursion in `maven_artifact` when the destination path is a single relative directory.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- maven_artifact

##### ADDITIONAL INFORMATION

This fixes the issue, however we have to consider if `maven_artifact` is supposed to crawl and create directories by itself.