### PR TITLE
Pluribus Networks network cli terminal and cliconf plugins

### DIFF
--- a/lib/ansible/module_utils/network/netvisor/netvisor.py
+++ b/lib/ansible/module_utils/network/netvisor/netvisor.py
@@ -1,0 +1,59 @@
+# Copyright: (c) 2018, Pluribus Networks
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+from ansible.module_utils._text import to_text
+from ansible.module_utils.network.common.utils import to_list, ComplexList
+from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.module_utils.connection import exec_command
+
+
+def get_connection(module):
+    if hasattr(module, '_nvos_connection'):
+        return module._nvos_connection
+
+    capabilities = get_capabilities(module)
+    network_api = capabilities.get('network_api')
+    if network_api == 'cliconf':
+        module._nvos_connection = Connection(module._socket_path)
+    else:
+        module.fail_json(msg='Invalid connection type %s' % network_api)
+
+    return module._nvos_connection
+
+
+def get_capabilities(module):
+    if hasattr(module, '_nvos_capabilities'):
+        return module._nvos_capabilities
+    try:
+        capabilities = Connection(module._socket_path).get_capabilities()
+    except ConnectionError as exc:
+        module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+    module._nvos_capabilities = json.loads(capabilities)
+    return module._nvos_capabilities
+
+
+def to_commands(module, commands):
+    spec = {
+        'command': dict(key=True),
+        'prompt': dict(),
+        'answer': dict()
+    }
+    transform = ComplexList(spec, module)
+    return transform(commands)
+
+
+def run_commands(module, commands, check_rc=True):
+    commands = to_commands(module, to_list(commands))
+    for cmd in commands:
+        cmd = module.jsonify(cmd)
+        rc, out, err = exec_command(module, cmd)
+        if check_rc and rc != 0:
+            module.fail_json(msg=to_text(err, errors='surrogate_or_strict'), rc=rc)
+        responses = (to_text(out, errors='surrogate_or_strict'))
+
+    return rc, out, err

--- a/lib/ansible/module_utils/network/netvisor/pn_nvos.py
+++ b/lib/ansible/module_utils/network/netvisor/pn_nvos.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-import shlex
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def pn_cli(module, switch=None, username=None, password=None, switch_local=None):
@@ -16,7 +16,7 @@ def pn_cli(module, switch=None, username=None, password=None, switch_local=None)
     :return: The cli string for further processing.
     """
 
-    cli = '/usr/bin/cli --quiet -e --no-login-prompt '
+    cli = ''
 
     if username and password:
         cli += '--user "%s":"%s" ' % (username, password)
@@ -48,25 +48,19 @@ def run_cli(module, cli, state_map):
     state = module.params['state']
     command = state_map[state]
 
-    cmd = shlex.split(cli)
-    result, out, err = module.run_command(cmd)
-
-    remove_cmd = '/usr/bin/cli --quiet -e --no-login-prompt'
+    result, out, err = run_commands(module, cli)
 
     results = dict(
-        command=' '.join(cmd).replace(remove_cmd, ''),
-        msg="%s operation completed" % command,
+        command=cli,
+        msg="%s operation completed" % cli,
         changed=True
     )
     # Response in JSON format
     if result != 0:
         module.exit_json(
-            command=' '.join(cmd).replace(remove_cmd, ''),
-            stderr=err.strip(),
-            msg="%s operation failed" % command,
+            command=cli,
+            msg="%s operation failed" % cli,
             changed=False
         )
 
-    if out:
-        results['stdout'] = out.strip()
     module.exit_json(**results)

--- a/lib/ansible/modules/network/netvisor/pn_access_list.py
+++ b/lib/ansible/modules/network/netvisor/pn_access_list.py
@@ -85,38 +85,29 @@ changed:
   type: bool
 """
 
-import shlex
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
     """
     This method checks for idempotency using the access-list-show command.
-    If a list with given name exists, return ACC_LIST_EXISTS
-    as True else False.
+    If a list with given name exists, return True else False.
     :param module: The Ansible module to fetch input parameters
     :param cli: The CLI string
-    :return Global Booleans: ACC_LIST_EXISTS
     """
     list_name = module.params['pn_name']
 
-    show = cli + \
-        ' access-list-show format name no-show-headers'
-    show = shlex.split(show)
-    out = module.run_command(show)[1]
+    cli += ' access-list-show format name no-show-headers'
+    out = run_commands(module, cli)
 
-    out = out.split()
-    # Global flags
-    global ACC_LIST_EXISTS
-
-    ACC_LIST_EXISTS = True if list_name in out else False
+    return True if list_name in out else False
 
 
 def main():
     """ This section is for arguments parsing """
 
-    global state_map
     state_map = dict(
         present='access-list-create',
         absent='access-list-delete',
@@ -148,7 +139,7 @@ def main():
     # Building the CLI command string
     cli = pn_cli(module, cliswitch)
 
-    check_cli(module, cli)
+    ACC_LIST_EXISTS = check_cli(module, cli)
     cli += ' %s name %s ' % (command, list_name)
 
     if command == 'access-list-delete':

--- a/lib/ansible/modules/network/netvisor/pn_admin_service.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_service.py
@@ -135,7 +135,6 @@ from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, booleanArgs, r
 def main():
     """ This section is for arguments parsing """
 
-    global state_map
     state_map = dict(
         update='admin-service-modify'
     )

--- a/lib/ansible/modules/network/netvisor/pn_admin_syslog.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_syslog.py
@@ -73,7 +73,7 @@ options:
 EXAMPLES = """
 - name: admin-syslog functionality
   pn_admin_syslog:
-    pn_cliswitch: sw01
+    pn_cliswitch: "sw01"
     state: "absent"
     pn_name: "foo"
     pn_scope: "local"
@@ -116,6 +116,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -129,7 +130,7 @@ def check_cli(module, cli):
     name = module.params['pn_name']
 
     cli += ' admin-syslog-show format name no-show-headers'
-    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 

--- a/lib/ansible/modules/network/netvisor/pn_connection_stats_settings.py
+++ b/lib/ansible/modules/network/netvisor/pn_connection_stats_settings.py
@@ -140,8 +140,7 @@ stdout:
   returned: always
   type: list
 stderr:
-  description: set of error responses from the connection-stats-settings
-               command.
+  description: set of error responses from the connection-stats-settings command.
   returned: on error
   type: list
 changed:

--- a/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
+++ b/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
@@ -88,6 +88,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -100,7 +101,7 @@ def check_cli(module, cli):
     user_name = module.params['pn_name']
 
     cli += ' dhcp-filter-show format name no-show-headers'
-    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 

--- a/lib/ansible/modules/network/netvisor/pn_dscp_map.py
+++ b/lib/ansible/modules/network/netvisor/pn_dscp_map.py
@@ -80,6 +80,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -92,17 +93,16 @@ def check_cli(module, cli):
     name = module.params['pn_name']
 
     cli += ' dscp-map-show name %s format name no-show-headers' % name
-    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 
-    return True if name in out else False
+    return True if name in out[-1] else False
 
 
 def main():
     """ This section is for arguments parsing """
 
-    global state_map
     state_map = dict(
         present='dscp-map-create',
         absent='dscp-map-delete'

--- a/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
+++ b/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
@@ -52,7 +52,7 @@ options:
 EXAMPLES = """
 - name: dscp map pri map modify
   pn_dscp_map_pri_map:
-    pn_cliswitch: "sw01"
+    pn_cliswitch: 'sw01'
     state: 'update'
     pn_name: 'foo'
     pn_pri: '0'
@@ -60,7 +60,7 @@ EXAMPLES = """
 
 - name: dscp map pri map modify
   pn_dscp_map_pri_map:
-    pn_cliswitch: "sw01"
+    pn_cliswitch: 'sw01'
     state: 'update'
     pn_name: 'foo'
     pn_pri: '1'
@@ -88,6 +88,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -100,11 +101,11 @@ def check_cli(module, cli):
     name = module.params['pn_name']
 
     cli += ' dscp-map-show name %s format name no-show-headers' % name
-    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 
-    return True if name in out else False
+    return True if name in out[-1] else False
 
 
 def main():

--- a/lib/ansible/modules/network/netvisor/pn_port_config.py
+++ b/lib/ansible/modules/network/netvisor/pn_port_config.py
@@ -208,6 +208,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli, booleanArgs
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -220,11 +221,11 @@ def check_cli(module, cli):
     name = module.params['pn_dscp_map']
 
     cli += ' dscp-map-show name %s format name no-show-headers' % name
-    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 
-    return True if name in out else False
+    return True if name in out[-1] else False
 
 
 def main():

--- a/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
+++ b/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
@@ -74,6 +74,7 @@ EXAMPLES = """
     state: "update"
     pn_port: "all"
     pn_cos: "0"
+    pn_weight: "priority"
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
+++ b/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
@@ -88,6 +88,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -101,10 +102,10 @@ def check_cli(module, cli):
     network = module.params['pn_network']
     show = cli
 
-    cli += ' prefix-list-show name %s format name no-show-headers' % name
-    rc, out, err = module.run_command(cli, use_unsafe_shell=True)
+    cli += ' prefix-list-show format name no-show-headers'
+    out = run_commands(module, cli)[1]
 
-    if not out:
+    if name not in out.split()[-1]:
         module.fail_json(
             failed=True,
             msg='Prefix list with name %s does not exists' % name
@@ -112,7 +113,7 @@ def check_cli(module, cli):
 
     cli = show
     cli += ' prefix-list-network-show name %s format network no-show-headers' % name
-    out = module.run_command(cli, use_unsafe_shell=True)[1]
+    rc, out, err = run_commands(module, cli)
 
     if out:
         out = out.split()[1]

--- a/lib/ansible/modules/network/netvisor/pn_role.py
+++ b/lib/ansible/modules/network/netvisor/pn_role.py
@@ -118,6 +118,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli, booleanArgs
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -130,7 +131,7 @@ def check_cli(module, cli):
     role_name = module.params['pn_name']
 
     cli += ' role-show format name no-show-headers'
-    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 

--- a/lib/ansible/modules/network/netvisor/pn_snmp_community.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_community.py
@@ -87,6 +87,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -99,7 +100,7 @@ def check_cli(module, cli):
     comm_str = module.params['pn_community_string']
 
     cli += ' snmp-community-show format community-string no-show-headers'
-    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 

--- a/lib/ansible/modules/network/netvisor/pn_snmp_trap_sink.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_trap_sink.py
@@ -93,6 +93,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -107,14 +108,14 @@ def check_cli(module, cli):
 
     show = cli
     cli += ' snmp-community-show format community-string no-show-headers'
-    rc, out, err = module.run_command(cli, use_unsafe_shell=True)
+    rc, out, err = run_commands(module, cli)
 
     out = out.split()
 
     if community in out:
         cli = show
         cli += ' snmp-trap-sink-show community %s format type,dest-host no-show-headers' % community
-        rc, out, err = module.run_command(cli, use_unsafe_shell=True)
+        rc, out, err = run_commands(module, cli)
 
         out = out.split()
 

--- a/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
@@ -57,20 +57,23 @@ options:
 """
 
 EXAMPLES = """
-- name: snmp vacm functionality
+- name: create snmp vacm
   pn_snmp_vacm:
+    pn_cliswitch: "sw01"
     state: "present"
     pn_user_name: "foo"
     pn_user_type: "rouser"
 
-- name: snmp vacm functionality
+- name: update snmp vacm
   pn_snmp_vacm:
+    pn_cliswitch: "sw01"
     state: "update"
     pn_user_name: "foo"
     pn_user_type: "rwuser"
 
-- name: snmp vacm functionality
+- name: delete snmp vacm
   pn_snmp_vacm:
+    pn_cliswitch: "sw01"
     state: "absent"
     pn_user_name: "foo"
 """
@@ -97,6 +100,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli, booleanArgs
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -110,7 +114,7 @@ def check_cli(module, cli):
     show = cli
 
     cli += ' snmp-user-show user-name %s format user-name no-show-headers' % user_name
-    rc, out, err = module.run_command(cli, use_unsafe_shell=True)
+    rc, out, err = run_commands(module, cli)
     if out:
         pass
     else:
@@ -118,7 +122,7 @@ def check_cli(module, cli):
 
     cli = show
     cli += ' snmp-vacm-show format user-name no-show-headers'
-    out = module.run_command(cli, use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 

--- a/lib/ansible/modules/network/netvisor/pn_user.py
+++ b/lib/ansible/modules/network/netvisor/pn_user.py
@@ -96,6 +96,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -108,7 +109,7 @@ def check_cli(module, cli):
     name = module.params['pn_name']
 
     cli += ' user-show format name no-show-headers'
-    out = module.run_command(cli, use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
 
     out = out.split()
 

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_bgp_network.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_bgp_network.py
@@ -53,7 +53,7 @@ options:
 EXAMPLES = """
 - name:  Add network to bgp
   pn_vrouter_bgp_network:
-    pn_cliswitch: "{{ inventory_hostname }}"
+    pn_cliswitch: "sw01"
     state: "present"
     pn_vrouter_name: "foo-vrouter"
     pn_network: '10.10.10.10'
@@ -61,7 +61,7 @@ EXAMPLES = """
 
 - name:  Remove network from bgp
   pn_vrouter_bgp_network:
-    pn_cliswitch: "{{ inventory_hostname }}"
+    pn_cliswitch: "sw01"
     state: "absent"
     pn_vrouter_name: "foo-vrouter"
     pn_network: '10.10.10.10'
@@ -89,6 +89,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -103,14 +104,14 @@ def check_cli(module, cli):
 
     show = cli
     cli += ' vrouter-show name %s format name no-show-headers' % name
-    rc, out, err = module.run_command(cli, use_unsafe_shell=True)
+    rc, out, err = run_commands(module, cli)
     VROUTER_EXISTS = '' if out else None
 
     cli = show
     cli += ' vrouter-bgp-network-show vrouter-name %s network %s format network no-show-headers' % (name, network)
-    out = module.run_command(cli, use_unsafe_shell=True)[1]
-
-    NETWORK_EXISTS = True if network in out else False
+    out = run_commands(module, cli)[1]
+    out = out.split()
+    NETWORK_EXISTS = True if network in out[-1] else False
 
     return NETWORK_EXISTS, VROUTER_EXISTS
 

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
@@ -88,6 +88,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -109,7 +110,7 @@ def check_cli(module, cli):
 
     # Check for vRouter
     check_vrouter = cli + ' vrouter-show format name no-show-headers '
-    out = module.run_command(check_vrouter, use_unsafe_shell=True)[1]
+    out = run_commands(module, check_vrouter)[1]
     out = out.split()
 
     VROUTER_EXISTS = True if vrouter_name in out else False
@@ -117,7 +118,7 @@ def check_cli(module, cli):
     if nic_str:
         # Check for nic
         show = cli + ' vrouter-ospf6-show vrouter-name %s format nic no-show-headers' % vrouter_name
-        out = module.run_command(show, use_unsafe_shell=True)[1]
+        out = run_commands(module, show)[1]
 
         NIC_EXISTS = True if nic_str in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_pim_config.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_pim_config.py
@@ -84,6 +84,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
 
 
 def check_cli(module, cli):
@@ -96,16 +97,18 @@ def check_cli(module, cli):
     name = module.params['pn_vrouter_name']
 
     show = cli
-    cli += 'vrouter-show name %s format name no-show-headers ' % name
-    out = module.run_command(cli, use_unsafe_shell=True)
-    if out:
+    cli += ' vrouter-show name %s format name no-show-headers ' % name
+    out = run_commands(module, cli)[1]
+    out = out.split()
+    if out[-1] == name:
         pass
     else:
         return False
 
     cli = show
     cli += ' vrouter-show name %s format proto-multi no-show-headers' % name
-    out = module.run_command(cli, use_unsafe_shell=True)[1]
+    out = run_commands(module, cli)[1]
+    out = out.split()
 
     return True if 'none' not in out else False
 

--- a/lib/ansible/plugins/cliconf/netvisor.py
+++ b/lib/ansible/plugins/cliconf/netvisor.py
@@ -1,0 +1,56 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from ansible.plugins.cliconf import CliconfBase
+
+
+class Cliconf(CliconfBase):
+
+    def get(self, command=None, prompt=None, answer=None, sendonly=False, output=None, check_all=False):
+        if not command:
+            raise ValueError('must provide value of command to execute')
+        if output:
+            raise ValueError("'output' value %s is not supported for get" % output)
+
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
+
+    def get_option_values(self):
+        return {
+            'format': ['text'],
+            'diff_match': ['line', 'strict', 'exact', 'none'],
+            'diff_replace': ['line', 'block'],
+            'output': []
+        }
+
+    def get_capabilities(self):
+        result = dict()
+        result['rpc'] = self.get_base_rpc()
+        result['network_api'] = 'cliconf'
+        result['device_info'] = self.get_device_info()
+        result.update(self.get_option_values())
+        return json.dumps(result)
+
+    def get_device_info(self):
+        device_info = {}
+        device_info['network_os'] = 'netvisor'
+
+        return device_info

--- a/lib/ansible/plugins/cliconf/netvisor.py
+++ b/lib/ansible/plugins/cliconf/netvisor.py
@@ -19,6 +19,16 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+DOCUMENTATION = """
+---
+cliconf: netvisor
+short_description: Use netvisor cliconf to run command on Pluribus netvisor platform
+description:
+  - This netvisor plugin provides low level abstraction apis for
+    sending and receiving CLI commands from Pluribus netvisor devices.
+version_added: 2.8
+"""
+
 import json
 from ansible.plugins.cliconf import CliconfBase
 

--- a/lib/ansible/plugins/terminal/netvisor.py
+++ b/lib/ansible/plugins/terminal/netvisor.py
@@ -1,0 +1,39 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import re
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_text, to_bytes
+from ansible.plugins.terminal import TerminalBase
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_stdout_re = [
+        re.compile(br">.*[\r\n]?(.*)")
+
+    ]
+
+    terminal_stderr_re = [
+        re.compile(br"% ?Error: (?!\bdoes not exist\b)(?!\balready exists\b)")
+    ]

--- a/test/units/modules/network/netvisor/test_pn_access_list_ip.py
+++ b/test/units/modules/network/netvisor/test_pn_access_list_ip.py
@@ -50,12 +50,12 @@ class TestAccessListIpModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_ip': '172.16.3.1', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 access-list-ip-add name foo  ip 172.16.3.1'
+        expected_cmd = ' switch sw01 access-list-ip-add name foo  ip 172.16.3.1'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_access_list_ip_remove(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_ip': '172.16.3.1', 'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 access-list-ip-remove name foo  ip 172.16.3.1'
+        expected_cmd = ' switch sw01 access-list-ip-remove name foo  ip 172.16.3.1'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_admin_service.py
+++ b/test/units/modules/network/netvisor/test_pn_admin_service.py
@@ -38,19 +38,19 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn__if': 'mgmt',
                          'pn_web': 'False', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-service-modify  if mgmt no-web '
+        expected_cmd = ' switch sw01 admin-service-modify  if mgmt no-web '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_admin_service_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn__if': 'mgmt',
                          'pn_snmp': 'True', 'pn_net_api': 'True', 'pn_ssh': 'True', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-service-modify  if mgmt snmp  ssh  net-api '
+        expected_cmd = ' switch sw01 admin-service-modify  if mgmt snmp  ssh  net-api '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_admin_service_modify_t3(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn__if': 'data',
                          'pn_web_port': '8080', 'pn_net_api': 'True', 'pn_web_log': 'True', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-service-modify  if data web-port 8080 net-api  web-log '
+        expected_cmd = ' switch sw01 admin-service-modify  if data web-port 8080 net-api  web-log '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_admin_session_timeout.py
+++ b/test/units/modules/network/netvisor/test_pn_admin_session_timeout.py
@@ -38,19 +38,19 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_timeout': '61s',
                          'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-session-timeout-modify  timeout 61s'
+        expected_cmd = ' switch sw01 admin-session-timeout-modify  timeout 61s'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_admin_session_timeout_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_timeout': '1d',
                          'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-session-timeout-modify  timeout 1d'
+        expected_cmd = ' switch sw01 admin-session-timeout-modify  timeout 1d'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_admin_session_timeout_modify_t3(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_timeout': '10d20m3h15s',
                          'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-session-timeout-modify  timeout 10d20m3h15s'
+        expected_cmd = ' switch sw01 admin-session-timeout-modify  timeout 10d20m3h15s'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_admin_syslog.py
+++ b/test/units/modules/network/netvisor/test_pn_admin_syslog.py
@@ -57,7 +57,7 @@ class TestAdminSyslogModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_scope': 'local', 'pn_host': '166.68.224.46', 'pn_message_format': 'structured', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-syslog-create name foo  scope local host 166.68.224.46 '
+        expected_cmd = ' switch sw01 admin-syslog-create name foo  scope local host 166.68.224.46 '
         expected_cmd += 'transport udp message-format structured'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -65,12 +65,12 @@ class TestAdminSyslogModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-syslog-delete name foo '
+        expected_cmd = ' switch sw01 admin-syslog-delete name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_admin_syslog_update(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'state': 'update'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-syslog-modify name foo  transport udp'
+        expected_cmd = ' switch sw01 admin-syslog-modify name foo  transport udp'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_connection_stats_settings.py
+++ b/test/units/modules/network/netvisor/test_pn_connection_stats_settings.py
@@ -38,21 +38,21 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_enable': False,
                          'pn_fabric_connection_max_memory': '1000', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify  disable  fabric-connection-max-memory 1000'
+        expected_cmd = ' switch sw01 connection-stats-settings-modify  disable  fabric-connection-max-memory 1000'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_connection_stats_settings_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_enable': True,
                          'pn_connection_stats_log_enable': False, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify  enable  connection-stats-log-disable '
+        expected_cmd = ' switch sw01 connection-stats-settings-modify  enable  connection-stats-log-disable '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_connection_stats_settings_modify_t3(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_client_server_stats_max_memory': '60M',
                          'pn_client_server_stats_log_disk_space': '40M', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify  client-server-stats-max-memory '
+        expected_cmd = ' switch sw01 connection-stats-settings-modify  client-server-stats-max-memory '
         expected_cmd += '60M client-server-stats-log-disk-space 40M'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -60,6 +60,6 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_connection_stats_max_memory': '45M',
                          'pn_fabric_connection_backup_enable': False, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify '
+        expected_cmd = ' switch sw01 connection-stats-settings-modify '
         expected_cmd += ' fabric-connection-backup-disable  connection-stats-max-memory 45M'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_cpu_class.py
+++ b/test/units/modules/network/netvisor/test_pn_cpu_class.py
@@ -52,19 +52,19 @@ class TestCpuClassModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'icmp',
                          'pn_scope': 'local', 'pn_rate_limit': '1000', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 cpu-class-create name icmp  scope local  rate-limit 1000 '
+        expected_cmd = ' switch sw01 cpu-class-create name icmp  scope local  rate-limit 1000 '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_cpu_class_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'icmp',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 cpu-class-delete name icmp '
+        expected_cmd = ' switch sw01 cpu-class-delete name icmp '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_cpu_class_update(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'icmp',
                          'pn_rate_limit': '2000', 'state': 'update'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 cpu-class-modify name icmp  rate-limit 2000 '
+        expected_cmd = ' switch sw01 cpu-class-modify name icmp  rate-limit 2000 '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_cpu_mgmt_class.py
+++ b/test/units/modules/network/netvisor/test_pn_cpu_mgmt_class.py
@@ -38,12 +38,12 @@ class TestCpuMgmtClassModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'icmp',
                          'pn_rate_limit': '10000', 'pn_burst_size': '14000', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 cpu-mgmt-class-modify name icmp  burst-size 14000 rate-limit 10000'
+        expected_cmd = ' switch sw01 cpu-mgmt-class-modify name icmp  burst-size 14000 rate-limit 10000'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_cpu_mgmt_class_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'ssh',
                          'pn_rate_limit': '10000', 'pn_burst_size': '100000', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 cpu-mgmt-class-modify name ssh  burst-size 100000 rate-limit 10000'
+        expected_cmd = ' switch sw01 cpu-mgmt-class-modify name ssh  burst-size 100000 rate-limit 10000'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_dhcp_filter.py
+++ b/test/units/modules/network/netvisor/test_pn_dhcp_filter.py
@@ -57,19 +57,19 @@ class TestDhcpFilterModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_trusted_ports': '1', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dhcp-filter-create name foo  trusted-ports 1'
+        expected_cmd = ' switch sw01 dhcp-filter-create name foo  trusted-ports 1'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_dhcp_filter_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dhcp-filter-delete name foo '
+        expected_cmd = ' switch sw01 dhcp-filter-delete name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_dhcp_filter_update(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_trusted_ports': '2', 'state': 'update'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dhcp-filter-modify name foo  trusted-ports 2'
+        expected_cmd = ' switch sw01 dhcp-filter-modify name foo  trusted-ports 2'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_dscp_map.py
+++ b/test/units/modules/network/netvisor/test_pn_dscp_map.py
@@ -50,12 +50,12 @@ class TestDscpMapModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_scope': 'local', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-create name foo  scope local'
+        expected_cmd = ' switch sw01 dscp-map-create name foo  scope local'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_dscp_map_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-delete name foo '
+        expected_cmd = ' switch sw01 dscp-map-delete name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
+++ b/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
@@ -44,19 +44,19 @@ class TestCpuClassModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_pri': '0', 'pn_dsmap': '40', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 0 name foo dsmap 40'
+        expected_cmd = ' switch sw01 dscp-map-pri-map-modify  pri 0 name foo dsmap 40'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_dscp_map_pri_map_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_pri': '1', 'pn_dsmap': '8,10,12,14', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 1 name foo dsmap 8,10,12,14'
+        expected_cmd = ' switch sw01 dscp-map-pri-map-modify  pri 1 name foo dsmap 8,10,12,14'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_dscp_map_pri_map_t3(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_pri': '2', 'pn_dsmap': '25', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 2 name foo dsmap 25'
+        expected_cmd = ' switch sw01 dscp-map-pri-map-modify  pri 2 name foo dsmap 25'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
+++ b/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
@@ -46,12 +46,12 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_scope': 'local',
                          'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  scope local'
+        expected_cmd = ' switch sw01 igmp-snooping-modify  scope local'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_igmp_snooping_modify_t3(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vxlan': False,
                          'pn_enable_vlans': '1-399', 'pn_igmpv3_vlans': '1-399', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  no-vxlan  igmpv3-vlans 1-399 enable-vlans 1-399'
+        expected_cmd = ' switch sw01 igmp-snooping-modify  no-vxlan  igmpv3-vlans 1-399 enable-vlans 1-399'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
+++ b/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
@@ -38,7 +38,7 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vxlan': True,
                          'pn_enable_vlans': '1-399,401-4092', 'pn_no_snoop_linklocal_vlans': 'none', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  vxlan  enable-vlans '
+        expected_cmd = ' switch sw01 igmp-snooping-modify  vxlan  enable-vlans '
         expected_cmd += '1-399,401-4092 no-snoop-linklocal-vlans none'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 

--- a/test/units/modules/network/netvisor/test_pn_port_config.py
+++ b/test/units/modules/network/netvisor/test_pn_port_config.py
@@ -38,26 +38,26 @@ class TestPortConfigModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': '1,2',
                          'pn_speed': '10g', 'pn_jumbo': True, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-config-modify  speed 10g port 1,2 jumbo '
+        expected_cmd = ' switch sw01 port-config-modify  speed 10g port 1,2 jumbo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_pn_port_config_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': 'all',
                          'pn_host_enable': True, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-config-modify  port all host-enable '
+        expected_cmd = ' switch sw01 port-config-modify  port all host-enable '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_pn_port_config_modify_t3(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': '5',
                          'pn_crc_check_enable': True, 'pn_vxlan_termination': False, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-config-modify  port 5 crc-check-enable  no-vxlan-termination '
+        expected_cmd = ' switch sw01 port-config-modify  port 5 crc-check-enable  no-vxlan-termination '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_pn_port_config_modify_t4(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': '10,11,12',
                          'pn_pause': False, 'pn_enable': True, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-config-modify  port 10,11,12 no-pause  enable '
+        expected_cmd = ' switch sw01 port-config-modify  port 10,11,12 no-pause  enable '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_port_cos_bw.py
+++ b/test/units/modules/network/netvisor/test_pn_port_cos_bw.py
@@ -38,12 +38,12 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': '1',
                          'pn_cos': '0', 'pn_min_bw_guarantee': '60', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-bw-modify  cos 0 port 1 min-bw-guarantee 60'
+        expected_cmd = ' switch sw01 port-cos-bw-modify  cos 0 port 1 min-bw-guarantee 60'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_pn_port_cos_bw_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': 'all',
                          'pn_cos': '1', 'pn_weight': 'priority', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-bw-modify  cos 1 port all weight priority'
+        expected_cmd = ' switch sw01 port-cos-bw-modify  cos 1 port all weight priority'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_port_cos_rate_setting.py
+++ b/test/units/modules/network/netvisor/test_pn_port_cos_rate_setting.py
@@ -38,7 +38,7 @@ class TestPortCosRateSettingModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': 'control-port',
                          'pn_cos1_rate': '4000', 'pn_cos2_rate': '4000', 'pn_cos3_rate': '4000', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-rate-setting-modify  cos1-rate 4000 cos2-rate 4000 '
+        expected_cmd = ' switch sw01 port-cos-rate-setting-modify  cos1-rate 4000 cos2-rate 4000 '
         expected_cmd += 'cos3-rate 4000 port control-port'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -46,6 +46,6 @@ class TestPortCosRateSettingModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': 'data-port',
                          'pn_cos1_rate': '2000', 'pn_cos5_rate': '3000', 'pn_cos2_rate': '4000', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-rate-setting-modify  cos1-rate 2000 cos5-rate 3000 '
+        expected_cmd = ' switch sw01 port-cos-rate-setting-modify  cos1-rate 2000 cos5-rate 3000 '
         expected_cmd += 'cos2-rate 4000 port data-port'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_prefix_list_network.py
+++ b/test/units/modules/network/netvisor/test_pn_prefix_list_network.py
@@ -51,12 +51,12 @@ class TestPrefixListNetworkModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_network': '172.16.3.1', 'pn_netmask': '24', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 prefix-list-network-add  name foo network 172.16.3.1 netmask 24'
+        expected_cmd = ' switch sw01 prefix-list-network-add  name foo network 172.16.3.1 netmask 24'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_prefix_list_network_remove(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_network': '172.16.3.1', 'pn_netmask': '24', 'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 prefix-list-network-remove  name foo network 172.16.3.1 netmask 24'
+        expected_cmd = ' switch sw01 prefix-list-network-remove  name foo network 172.16.3.1 netmask 24'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_role.py
+++ b/test/units/modules/network/netvisor/test_pn_role.py
@@ -58,19 +58,19 @@ class TestRoleModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_scope': 'local', 'pn_access': 'read-only', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 role-create name foo  scope local access read-only'
+        expected_cmd = ' switch sw01 role-create name foo  scope local access read-only'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_role_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 role-delete name foo '
+        expected_cmd = ' switch sw01 role-delete name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_role_update(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_access': 'read-write', 'pn_sudo': True, 'pn_shell': True, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 role-modify name foo  access read-write shell  sudo '
+        expected_cmd = ' switch sw01 role-modify name foo  access read-write shell  sudo '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_snmp_community.py
+++ b/test/units/modules/network/netvisor/test_pn_snmp_community.py
@@ -58,19 +58,19 @@ class TestSnmpCommunityModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_community_string': 'foo',
                          'pn_community_type': 'read-write', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-community-create community-string foo  community-type read-write'
+        expected_cmd = ' switch sw01 snmp-community-create community-string foo  community-type read-write'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_snmp_community_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_community_string': 'foo',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-community-delete community-string foo '
+        expected_cmd = ' switch sw01 snmp-community-delete community-string foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_snmp_community_update(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_community_string': 'foo',
                          'pn_community_type': 'read-only', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-community-modify community-string foo  community-type read-only'
+        expected_cmd = ' switch sw01 snmp-community-modify community-string foo  community-type read-only'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_snmp_trap_sink.py
+++ b/test/units/modules/network/netvisor/test_pn_snmp_trap_sink.py
@@ -51,7 +51,7 @@ class TestSnmpTrapSinkModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_community': 'foo',
                          'pn_dest_host': '192.168.67.8', 'pn_type': 'TRAP_TYPE_V2_INFORM', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-trap-sink-create  type TRAP_TYPE_V2_INFORM dest-host 192.168.67.8 '
+        expected_cmd = ' switch sw01 snmp-trap-sink-create  type TRAP_TYPE_V2_INFORM dest-host 192.168.67.8 '
         expected_cmd += 'community foo dest-port 162'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -59,5 +59,5 @@ class TestSnmpTrapSinkModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_community': 'foo',
                          'pn_dest_host': '192.168.67.8', 'pn_type': 'TRAP_TYPE_V2_INFORM', 'state': 'absent'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-trap-sink-delete  community foo dest-host 192.168.67.8 dest-port 162'
+        expected_cmd = ' switch sw01 snmp-trap-sink-delete  community foo dest-host 192.168.67.8 dest-port 162'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_snmp_vacm.py
+++ b/test/units/modules/network/netvisor/test_pn_snmp_vacm.py
@@ -58,19 +58,19 @@ class TestSnmpVacmModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
                          'pn_user_type': 'rouser', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-create user-name foo  user-type rouser'
+        expected_cmd = ' switch sw01 snmp-vacm-create user-name foo  user-type rouser'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_snmp_vacm_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-delete user-name foo '
+        expected_cmd = ' switch sw01 snmp-vacm-delete user-name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_snmp_vacm_modify(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_user_name': 'foo',
                          'pn_user_type': 'rwuser', 'state': 'absent'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 snmp-vacm-delete user-name foo '
+        expected_cmd = ' switch sw01 snmp-vacm-delete user-name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_stp.py
+++ b/test/units/modules/network/netvisor/test_pn_stp.py
@@ -38,7 +38,7 @@ class TestStpModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_hello_time': '3',
                          'pn_stp_mode': 'rstp', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 stp-modify  hello-time 3 root-guard-wait-time 20 mst-max-hops 20 max-age 20 '
+        expected_cmd = ' switch sw01 stp-modify  hello-time 3 root-guard-wait-time 20 mst-max-hops 20 max-age 20 '
         expected_cmd += 'stp-mode rstp forwarding-delay 15 bridge-priority 32768'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -46,6 +46,6 @@ class TestStpModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_root_guard_wait_time': '50',
                          'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 stp-modify  hello-time 2 root-guard-wait-time 50 mst-max-hops 20 '
+        expected_cmd = ' switch sw01 stp-modify  hello-time 2 root-guard-wait-time 50 mst-max-hops 20 '
         expected_cmd += 'max-age 20 forwarding-delay 15 bridge-priority 32768'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_stp_port.py
+++ b/test/units/modules/network/netvisor/test_pn_stp_port.py
@@ -38,12 +38,12 @@ class TestStpPortModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': '1',
                          'pn_filter': True, 'pn_priority': '144', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 stp-port-modify  priority 144 cost 2000 port 1 filter '
+        expected_cmd = ' switch sw01 stp-port-modify  priority 144 cost 2000 port 1 filter '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_stp_port_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': '1,2',
                          'pn_cost': '200', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 stp-port-modify  priority 128 cost 200 port 1,2'
+        expected_cmd = ' switch sw01 stp-port-modify  priority 128 cost 200 port 1,2'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_switch_setup.py
+++ b/test/units/modules/network/netvisor/test_pn_switch_setup.py
@@ -38,7 +38,7 @@ class TestSwitchSetupModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_timezone': 'America/New_York',
                          'pn_in_band_ip': '20.20.1.1', 'pn_in_band_netmask': '24', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 switch-setup-modify  timezone America/New_York '
+        expected_cmd = ' switch sw01 switch-setup-modify  timezone America/New_York '
         expected_cmd += 'in-band-netmask 24 in-band-ip 20.20.1.1'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -46,7 +46,7 @@ class TestSwitchSetupModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_in_band_ip6': '2001:0db8:85a3::8a2e:0370:7334',
                          'pn_in_band_netmask_ip6': '127', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 switch-setup-modify  in-band-ip6 2001:0db8:85a3::8a2e:0370:7334 '
+        expected_cmd = ' switch sw01 switch-setup-modify  in-band-ip6 2001:0db8:85a3::8a2e:0370:7334 '
         expected_cmd += 'in-band-netmask-ip6 127'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -54,12 +54,12 @@ class TestSwitchSetupModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_date': '2019-01-11',
                          'pn_loopback_ip': '10.10.10.1', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 switch-setup-modify  date 2019-01-11 loopback-ip 10.10.10.1'
+        expected_cmd = ' switch sw01 switch-setup-modify  date 2019-01-11 loopback-ip 10.10.10.1'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_pn_switch_setup_modify_t4(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_dns_ip': '172.16.5.5',
                          'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 switch-setup-modify  dns-ip 172.16.5.5'
+        expected_cmd = ' switch sw01 switch-setup-modify  dns-ip 172.16.5.5'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_user.py
+++ b/test/units/modules/network/netvisor/test_pn_user.py
@@ -58,19 +58,19 @@ class TestUserModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_scope': 'local', 'pn_password': 'test123', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 user-create name foo  scope local password test123'
+        expected_cmd = ' switch sw01 user-create name foo  scope local password test123'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_user_delete(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 user-delete name foo '
+        expected_cmd = ' switch sw01 user-delete name foo '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_user_modify(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_password': 'test1234', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 user-modify name foo  password test1234'
+        expected_cmd = ' switch sw01 user-modify name foo  password test1234'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_vflow_table_profile.py
+++ b/test/units/modules/network/netvisor/test_pn_vflow_table_profile.py
@@ -38,12 +38,12 @@ class TestVflowTableProfileModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_profile': 'ipv6',
                          'pn_hw_tbl': 'switch-main', 'pn_enable': True, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vflow-table-profile-modify  profile ipv6 hw-tbl switch-main enable '
+        expected_cmd = ' switch sw01 vflow-table-profile-modify  profile ipv6 hw-tbl switch-main enable '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_vflow_table_profile_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_profile': 'qos',
                          'pn_hw_tbl': 'switch-main', 'pn_enable': False, 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vflow-table-profile-modify  profile qos hw-tbl switch-main disable '
+        expected_cmd = ' switch sw01 vflow-table-profile-modify  profile qos hw-tbl switch-main disable '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_vrouter_bgp_network.py
+++ b/test/units/modules/network/netvisor/test_pn_vrouter_bgp_network.py
@@ -51,7 +51,7 @@ class TestVrouterBGPNetworkModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
                          'pn_network': '10.10.10.10', 'pn_netmask': '31', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-bgp-network-add vrouter-name foo-vrouter  netmask 31 '
+        expected_cmd = ' switch sw01 vrouter-bgp-network-add vrouter-name foo-vrouter  netmask 31 '
         expected_cmd += 'network 10.10.10.10'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -59,5 +59,5 @@ class TestVrouterBGPNetworkModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
                          'pn_network': '10.10.10.10', 'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-bgp-network-remove vrouter-name foo-vrouter  network 10.10.10.10'
+        expected_cmd = ' switch sw01 vrouter-bgp-network-remove vrouter-name foo-vrouter  network 10.10.10.10'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_vrouter_interface_ip.py
+++ b/test/units/modules/network/netvisor/test_pn_vrouter_interface_ip.py
@@ -51,7 +51,7 @@ class TestVrouterInterfaceIpModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
                          'pn_ip': '2620:0:1651:1::30', 'pn_netmask': '127', 'pn_nic': 'eth0.4092', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-interface-ip-add vrouter-name foo-vrouter  nic eth0.4092 '
+        expected_cmd = ' switch sw01 vrouter-interface-ip-add vrouter-name foo-vrouter  nic eth0.4092 '
         expected_cmd += 'ip 2620:0:1651:1::30  netmask 127'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -59,6 +59,6 @@ class TestVrouterInterfaceIpModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
                          'pn_ip': '2620:0:1651:1::30', 'pn_nic': 'eth0.4092', 'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-interface-ip-remove vrouter-name foo-vrouter  nic eth0.4092  '
+        expected_cmd = ' switch sw01 vrouter-interface-ip-remove vrouter-name foo-vrouter  nic eth0.4092  '
         expected_cmd += 'ip 2620:0:1651:1::30 '
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_vrouter_ospf6.py
+++ b/test/units/modules/network/netvisor/test_pn_vrouter_ospf6.py
@@ -51,12 +51,12 @@ class TestVrouterOSPF6Module(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
                          'pn_nic': 'eth0.4092', 'pn_ospf6_area': '0.0.0.0', 'state': 'present'})
         result = self.execute_module(changed=True, state='present')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-ospf6-add vrouter-name foo-vrouter  nic eth0.4092 ospf6-area 0.0.0.0 '
+        expected_cmd = ' switch sw01 vrouter-ospf6-add vrouter-name foo-vrouter  nic eth0.4092 ospf6-area 0.0.0.0 '
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_vrouter_ospf6_remove(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
                          'pn_nic': 'eth0.4092', 'state': 'absent'})
         result = self.execute_module(changed=True, state='absent')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-ospf6-remove vrouter-name foo-vrouter  nic eth0.4092'
+        expected_cmd = ' switch sw01 vrouter-ospf6-remove vrouter-name foo-vrouter  nic eth0.4092'
         self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_vrouter_pim_config.py
+++ b/test/units/modules/network/netvisor/test_pn_vrouter_pim_config.py
@@ -44,7 +44,7 @@ class TestVrouterPimConfigModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_query_interval': '10',
                          'pn_querier_timeout': '30', 'pn_vrouter_name': 'foo-vrouter', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-pim-config-modify vrouter-name foo-vrouter  '
+        expected_cmd = ' switch sw01 vrouter-pim-config-modify vrouter-name foo-vrouter  '
         expected_cmd += 'querier-timeout 30 query-interval 10'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
@@ -52,6 +52,6 @@ class TestVrouterPimConfigModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_query_interval': '30',
                          'pn_hello_interval': '120', 'pn_vrouter_name': 'foo-vrouter', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 vrouter-pim-config-modify vrouter-name foo-vrouter  '
+        expected_cmd = ' switch sw01 vrouter-pim-config-modify vrouter-name foo-vrouter  '
         expected_cmd += 'hello-interval 120 query-interval 30'
         self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Terminal and cliconf plugins for connection: network_cli for Pluribus Networks switches.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
network cli plugins.
##### ADDITIONAL INFORMATION
ansible-playbook 2.7.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
Using /etc/ansible/ansible.cfg as config file


```