### PR TITLE
cs_iso: fix missing param "is_public"

### DIFF
--- a/changelogs/fragments/53738-cs_iso-missing_is_public.yml
+++ b/changelogs/fragments/53738-cs_iso-missing_is_public.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cs_iso - Add the 'is_public' param into argument_spec to allow the registering of public iso.

--- a/lib/ansible/modules/cloud/cloudstack/cs_iso.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_iso.py
@@ -418,6 +418,7 @@ def main():
         is_ready=dict(type='bool', default=False),
         bootable=dict(type='bool'),
         is_featured=dict(type='bool'),
+        is_public=dict(type='bool'),
         is_dynamically_scalable=dict(type='bool'),
         state=dict(choices=['present', 'absent'], default='present'),
         poll_async=dict(type='bool', default=True),

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -98,7 +98,6 @@ lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py E335
 lib/ansible/modules/cloud/centurylink/clc_server_snapshot.py E335
 lib/ansible/modules/cloud/cloudstack/cs_cluster.py E326
 lib/ansible/modules/cloud/cloudstack/cs_host.py E326
-lib/ansible/modules/cloud/cloudstack/cs_iso.py E323
 lib/ansible/modules/cloud/cloudstack/cs_network.py E324
 lib/ansible/modules/cloud/cloudstack/cs_network_offering.py E322
 lib/ansible/modules/cloud/cloudstack/cs_network_offering.py E326


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the `is_public` param into `argument_spec` to allow the registering of public iso.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #53738 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudstack/cs_iso.py
