### PR TITLE
VMware: vcenter_license module support add ESXi license

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vcenter_license.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_license.py
@@ -41,6 +41,7 @@ options:
     description:
     - The hostname of the ESXi server to which the specified license will be assigned.
     - This parameter is optional.
+    version_added: '2.8'
 notes:
 - This module will also auto-assign the current vCenter to the license key
   if the product matches the license key, and vCenter us currently assigned
@@ -195,9 +196,8 @@ def main():
                     try:
                         lam.UpdateAssignedLicense(entity=esxi_host._moId, licenseKey=license)
                     except Exception as e:
-                        module.warn('Could not assign "%s" (%s) to ESXi host %s, due to %s.' % (license, key.name,
-                                                                                               esxi_host._moId,
-                                                                                               to_native(e)))
+                        module.warn('Could not assign "%s" (%s) to ESXi host %s, due to %s.'
+                                    % (license, key.name, esxi_host._moId, to_native(e)))
                     result['changed'] = True
                 else:
                     module.warn('License key "%s" edition "%s" is not suitable for ESXi server' % (license, key.editionKey))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51893 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vcenter_license
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add a new parameter "esxi_hostname" to specify the ESXi host to which the license key will be assigned.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Add ESXi license and assign to the ESXi host
  vcenter_license:
    hostname: '{{ vcenter_hostname }}'
    username: '{{ vcenter_username }}'
    password: '{{ vcenter_password }}'
    esxi_hostname: '{{ esxi_hostname }}'
    license: f600d-21ae3-5592b-249e0-dd502
    state: present
```
