### PR TITLE
plugin_formatter: Check if docs are present for given plugin

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -321,6 +321,10 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         if module_categories:
             primary_category = module_categories[0]
 
+        if not doc:
+            display.error("*** ERROR: DOCUMENTATION section missing for %s. ***" % module_path)
+            continue
+
         if 'options' in doc and doc['options'] is None:
             display.error("*** ERROR: DOCUMENTATION.options must be a dictionary/hash when used. ***")
             pos = getattr(doc, "ansible_pos", None)


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docs/bin/plugin_formatter.py

##### ADDITIONAL INFORMATION
Before:

```
$ PYTHONPATH=../../lib ../bin/plugin_formatter.py -t rst --plugin-type cliconf --template-dir=../templates --module-dir=../../lib/ansible/plugins/cliconf -o rst
Evaluating cliconf files...
Traceback (most recent call last):
  File "../bin/plugin_formatter.py", line 779, in <module>
    main()
  File "../bin/plugin_formatter.py", line 734, in main
    plugin_info, categories = get_plugin_info(options.module_dir, limit_to=options.limit_to, verbose=(options.verbosity > 0))
  File "../bin/plugin_formatter.py", line 324, in get_plugin_info
    if 'options' in doc and doc['options'] is None:
TypeError: argument of type 'NoneType' is not iterable

```

After 

```
$ PYTHONPATH=../../lib ../bin/plugin_formatter.py -t rst --plugin-type cliconf --template-dir=../templates --module-dir=../../lib/ansible/plugins/cliconf -o rst
Evaluating cliconf files...
 [ERROR]: *** ERROR: DOCUMENTATION section missing for ../../lib/ansible/plugins/cliconf/netvisor.py. ***
```