### PR TITLE
Do not error in case of empty list/dict constructed group

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -429,7 +429,9 @@ class Constructable(object):
                                 self.inventory.add_child(parent_name, gname)
 
                     else:
-                        if strict:
-                            raise AnsibleParserError("No key or key resulted empty, invalid entry")
+                        # exclude case of empty list and dictionary, because these are valid constructions
+                        # simply no groups need to be constructed, but are still falsy
+                        if strict and key not in ([], {}):
+                            raise AnsibleParserError("No key or key resulted empty for %s in host %s, invalid entry" % (keyed.get('key'), host))
                 else:
                     raise AnsibleParserError("Invalid keyed group entry, it must be a dictionary: %s " % keyed)

--- a/test/units/plugins/inventory/test_constructed.py
+++ b/test/units/plugins/inventory/test_constructed.py
@@ -24,7 +24,7 @@ from ansible.inventory.data import InventoryData
 from ansible.template import Templar
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def inventory_module():
     r = InventoryModule()
     r.inventory = InventoryData()
@@ -60,13 +60,11 @@ def test_keyed_group_separator(inventory_module):
         {
             'prefix': 'farmer',
             'separator': '_old_',
-            'key': 'farmer',
-            'unsafe': True
+            'key': 'farmer'
         },
         {
             'separator': 'mmmmmmmmmm',
-            'key': 'barn',
-            'unsafe': True
+            'key': 'barn'
         }
     ]
     inventory_module._add_host_to_keyed_groups(
@@ -76,6 +74,22 @@ def test_keyed_group_separator(inventory_module):
         assert group_name in inventory_module.inventory.groups
         group = inventory_module.inventory.groups[group_name]
         assert group.hosts == [host]
+
+
+def test_keyed_group_empty_construction(inventory_module):
+    inventory_module.inventory.add_host('farm')
+    inventory_module.inventory.set_variable('farm', 'barn', {})
+    host = inventory_module.inventory.get_host('farm')
+    keyed_groups = [
+        {
+            'separator': 'mmmmmmmmmm',
+            'key': 'barn'
+        }
+    ]
+    inventory_module._add_host_to_keyed_groups(
+        keyed_groups, host.vars, host.name, strict=True
+    )
+    assert host.groups == []
 
 
 def test_keyed_parent_groups(inventory_module):


### PR DESCRIPTION
##### SUMMARY
I had a case where a constructed (keyed_group) was templating from a certain hostvar, and it produced an empty list. It produced an error that didn't make any sense. This adds content to the error message and makes this use case work successfully.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
constructed inventory plugin

##### ADDITIONAL INFORMATION
The error that my case produced, using `devel`, was:

```paste below
 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/ansible-inventory-file-examples/private/ec2/aws_ec2.yaml with auto plugin: No key or key resulted empty, invalid
entry

  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/manager.py", line 272, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/aws_ec2.py", line 590, in parse
    self._populate(results, hostnames)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/aws_ec2.py", line 490, in _populate
    self._add_hosts(hosts=groups[group], group=group, hostnames=hostnames)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/aws_ec2.py", line 525, in _add_hosts
    self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname, strict=strict)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/__init__.py", line 432, in _add_host_to_keyed_groups
    raise AnsibleParserError("No key or key resulted empty, invalid entry")
```

In this case I was using `tags.keys()`, where the host variables had `"tags": {}`. It is going to be a problem if this case cannot be allowed to proceed.

Note: I only encountered this because I set `strict: True`, this allows users to be more vigilant, and I think it's a good idea to use this setting. However, it loses its utility if it fails the parsing process on cases it shouldn't.

Ping @bcoca @s-hertel 