### PR TITLE
Add IndicatorLED control commands to redfish_command module

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -385,6 +385,32 @@ class RedfishUtils(object):
             return response
         return {'ret': True}
 
+    def manage_indicator_led(self, command):
+        result = {}
+        key = 'IndicatorLED'
+
+        payloads = {'IndicatorLedOn': 'Lit', 'IndicatorLedOff': 'Off', "IndicatorLedBlink": 'Blinking'}
+
+        result = {}
+        for chassis_uri in self.chassis_uri_list:
+            response = self.get_request(self.root_uri + chassis_uri)
+            if response['ret'] is False:
+                return response
+            result['ret'] = True
+            data = response['data']
+            if key not in data:
+                return {'ret': False, 'msg': "Key %s not found" % key}
+
+            if command in payloads.keys():
+                payload = {'IndicatorLED': payloads[command]}
+                response = self.patch_request(self.root_uri + chassis_uri, payload, HEADERS)
+                if response['ret'] is False:
+                    return response
+            else:
+                return {'ret': False, 'msg': 'Invalid command'}
+
+        return result
+
     def manage_system_power(self, command):
         result = {}
         key = "Actions"

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -90,6 +90,14 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
+  - name: Set chassis indicator LED to blink
+    redfish_command:
+      category: Chassis
+      command: IndicatorLedBlink
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+
   - name: Add and enable user
     redfish_command:
       category: Accounts
@@ -242,8 +250,10 @@ def main():
         num_led_commands = sum([command in led_commands for command in command_list])
         if num_led_commands > 1:
             result = {'ret': False, 'msg': "Only one IndicatorLed command should be sent at a time."}
-        elif num_led_commands == 1:
-            result = rf_utils.manage_indicator_led(command)
+        else:
+            for command in command_list:
+                if command in led_commands:
+                    result = rf_utils.manage_indicator_led(command)
 
     elif category == "Manager":
         MANAGER_COMMANDS = {

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -231,6 +231,20 @@ def main():
             elif command == "SetOneTimeBoot":
                 result = rf_utils.set_one_time_boot_device(module.params['bootdevice'])
 
+    elif category == "Chassis":
+        result = rf_utils._find_chassis_resource(rf_uri)
+        if result['ret'] is False:
+            module.fail_json(msg=to_native(result['msg']))
+
+        led_commands = ["IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink"]
+
+        # Check if more than one led_command is present
+        num_led_commands = sum([command in led_commands for command in command_list])
+        if num_led_commands > 1:
+            result = {'ret': False, 'msg': "Only one IndicatorLed command should be sent at a time."}
+        elif num_led_commands == 1:
+            result = rf_utils.manage_indicator_led(command)
+
     elif category == "Manager":
         MANAGER_COMMANDS = {
             "GracefulRestart": rf_utils.restart_manager_gracefully,

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -147,6 +147,7 @@ from ansible.module_utils._text import to_native
 CATEGORY_COMMANDS_ALL = {
     "Systems": ["PowerOn", "PowerForceOff", "PowerGracefulRestart",
                 "PowerGracefulShutdown", "PowerReboot", "SetOneTimeBoot"],
+    "Chassis": ["IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink"],
     "Accounts": ["AddUser", "EnableUser", "DeleteUser", "DisableUser",
                  "UpdateUserRole", "UpdateUserPassword"],
     "Manager": ["GracefulRestart", "ClearLogs"],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request adds functionality to control a system's indicator LED via the `redfish_command` module. This adds a `Chassis` category with new commands `IndicatorLedOn`, `IndicatorLedOff`, and `IndicatorLedBlink`. The design currently only allows a single LED command to be sent in a single task, since in a list of commands only the last one would take effect if they were executed in order, since each necessarily configures a single state of the LED. 


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command

##### ADDITIONAL INFORMATION
