### PR TITLE
Remove "legacy" code from PlayIterator

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -305,7 +305,9 @@ class PlayIterator:
                         state.cur_regular_task = 0
                         state.cur_rescue_task = 0
                         state.cur_always_task = 0
-                        state.child_state = None
+                        state.tasks_child_state = None
+                        state.rescue_child_state = None
+                        state.always_child_state = None
 
             elif state.run_state == self.ITERATING_TASKS:
                 # clear the pending setup flag, since we're past that and it didn't fail
@@ -342,7 +344,7 @@ class PlayIterator:
                         task = block.block[state.cur_regular_task]
                         # if the current task is actually a child block, create a child
                         # state for us to recurse into on the next pass
-                        if isinstance(task, Block) or state.tasks_child_state is not None:
+                        if isinstance(task, Block):
                             state.tasks_child_state = HostState(blocks=[task])
                             state.tasks_child_state.run_state = self.ITERATING_TASKS
                             # since we've created the child state, clear the task
@@ -375,7 +377,7 @@ class PlayIterator:
                         state.did_rescue = True
                     else:
                         task = block.rescue[state.cur_rescue_task]
-                        if isinstance(task, Block) or state.rescue_child_state is not None:
+                        if isinstance(task, Block):
                             state.rescue_child_state = HostState(blocks=[task])
                             state.rescue_child_state.run_state = self.ITERATING_TASKS
                             task = None
@@ -416,7 +418,7 @@ class PlayIterator:
                                 block._role._completed[host.name] = True
                     else:
                         task = block.always[state.cur_always_task]
-                        if isinstance(task, Block) or state.always_child_state is not None:
+                        if isinstance(task, Block):
                             state.always_child_state = HostState(blocks=[task])
                             state.always_child_state.run_state = self.ITERATING_TASKS
                             task = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While debugging something I came across:
1. `state.child_state` does not exist.
2. `state.tasks_child_state is not None` conditional in a code branch where `state.tasks_child_state` is `None` (same for rescue and always).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
PlayIterator
