### PR TITLE
cliconf and httpapi are documentable plugins now

### DIFF
--- a/test/runner/lib/sanity/ansible_doc.py
+++ b/test/runner/lib/sanity/ansible_doc.py
@@ -46,9 +46,7 @@ class AnsibleDocTest(SanityMultipleVersion):
             # not supported by ansible-doc
             'action',
             'doc_fragments',
-            'cliconf',
             'filter',
-            'httpapi',
             'netconf',
             'terminal',
             'test',


### PR DESCRIPTION
##### SUMMARY
cliconf and httpapi are documentable plugins now

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/runner/lib/sanity/ansible_doc.py

##### ADDITIONAL INFORMATION
Without this change, we are missing doc verification on these plugins. See https://github.com/ansible/ansible/pull/53735