### PR TITLE
Correctly update tags when os_stack invokes update_stack

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -181,6 +181,7 @@ def _update_stack(module, stack, cloud, sdk):
     try:
         stack = cloud.update_stack(
             module.params['name'],
+            tags=module.params['tag'],
             template_file=module.params['template'],
             environment_files=module.params['environment'],
             timeout=module.params['timeout'],

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -251,7 +251,7 @@ def main():
             else:
                 if module.params['tags']:
                     from distutils.version import StrictVersion
-                    min_version = '0.27.0'
+                    min_version = '0.28.0'
                     if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):
                         module.warn("To update tags using os_stack module, the"
                                     "installed version of the openstacksdk"

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -249,6 +249,13 @@ def main():
             if not stack:
                 stack = _create_stack(module, stack, cloud, sdk)
             else:
+                if module.params['tags']:
+                    from distutils.version import StrictVersion
+                    min_version = '0.27.0'
+                    if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):
+                        module.warn("To update tags using os_stack module, the"
+                                "installed version of the openstacksdk library"
+                                "MUST be >={min_version}".format(min_version=min_version))                
                 stack = _update_stack(module, stack, cloud, sdk)
             changed = True
             module.exit_json(changed=changed,

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -254,8 +254,9 @@ def main():
                     min_version = '0.27.0'
                     if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):
                         module.warn("To update tags using os_stack module, the"
-                                "installed version of the openstacksdk library"
-                                "MUST be >={min_version}".format(min_version=min_version))                
+                                    "installed version of the openstacksdk"
+                                    "library MUST be >={min_version}"
+                                    "".format(min_version=min_version))
                 stack = _update_stack(module, stack, cloud, sdk)
             changed = True
             module.exit_json(changed=changed,


### PR DESCRIPTION
<!--- Your description here -->

Correctly update tags when os_stack invokes update_stack

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

If a user invokes os_stack on a cluster that already exists and tag is supplied, it is not applied correctly. This patch addresses this issue by supplying tag to update_stack invocation.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_stack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
