### PR TITLE
Strip None values from mod_args in gather_facts action

### DIFF
--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -35,6 +35,10 @@ class ActionModule(ActionBase):
             if fact_filter is not None:
                 self._display.warning('Ignoring filter(%s) for %s' % (fact_filter, fact_module))
 
+        # Strip out keys with ``None`` values, effectively mimicking ``omit`` behavior
+        # This ensures we don't pass a ``None`` value as an argument expecting a specific type
+        mod_args = dict((k, v) for k, v in mod_args.items() if v is not None)
+
         return mod_args
 
     def run(self, tmp=None, task_vars=None):


### PR DESCRIPTION
##### SUMMARY
Strip None values from mod_args in gather_facts action

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/gather_facts.py

##### ADDITIONAL INFORMATION
This solves the following exception:

```
Traceback (most recent call last):
  File "/home/tguha/.ansible/tmp/ansible-local-21298ceurWH/ansible-tmp-1552493046.19-208435969262766/AnsiballZ_eos_facts.py", line 114, in <module>
    _ansiballz_main()
  File "/home/tguha/.ansible/tmp/ansible-local-21298ceurWH/ansible-tmp-1552493046.19-208435969262766/AnsiballZ_eos_facts.py", line 106, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/tguha/.ansible/tmp/ansible-local-21298ceurWH/ansible-tmp-1552493046.19-208435969262766/AnsiballZ_eos_facts.py", line 49, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_eos_facts_payload_d5_B3S/__main__.py", line 403, in <module>
  File "/tmp/ansible_eos_facts_payload_d5_B3S/__main__.py", line 354, in main
TypeError: 'NoneType' object is not iterable
```