### PR TITLE
Adding delay param to ipmi_power module

### DIFF
--- a/lib/ansible/modules/remote_management/ipmi/ipmi_power.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_power.py
@@ -51,6 +51,11 @@ options:
     description:
       - Maximum number of seconds before interrupt request.
     default: 300
+  delay:
+    description:
+      - Number of seconds before ipmi cmd is executed.
+    default: 0
+    version_added: "2.8"
 requirements:
   - "python >= 2.6"
   - pyghmi
@@ -75,6 +80,7 @@ EXAMPLES = '''
 '''
 
 import traceback
+import time
 
 PYGHMI_IMP_ERR = None
 try:
@@ -95,6 +101,7 @@ def main():
             user=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
             timeout=dict(default=300, type='int'),
+            delay=dict(default=0, type='int')
         ),
         supports_check_mode=True,
     )
@@ -108,6 +115,7 @@ def main():
     password = module.params['password']
     state = module.params['state']
     timeout = module.params['timeout']
+    delay = module.params['delay']
 
     # --- run command ---
     try:
@@ -117,6 +125,8 @@ def main():
         module.debug('ipmi instantiated - name: "%s"' % name)
 
         current = ipmi_cmd.get_power()
+        if delay:
+            time.sleep(delay)
         if current['powerstate'] != state:
             response = {'powerstate': state} if module.check_mode else ipmi_cmd.set_power(state, wait=timeout)
             changed = True


### PR DESCRIPTION
##### SUMMARY
Adding delay parameter to ipmi_power module.
Helps with triggering ipmi cmd with added delay, for randomizing execution in order to not overload power supply whilst running over large number of nodes

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
remote_managment/ipmi_power

##### ADDITIONAL INFORMATION
When running ipmi cmd, especially reboot over large inventory it can trigger power surge. Allowing for delay parameter can utilize randomized delay generated in previous task.
