### PR TITLE
Update an example in developing_modules_documenting.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -117,7 +117,7 @@ Module documentation should briefly and accurately define what each module and o
     * Descriptions should always start with a capital letter and end with a full stop. Consistency always helps.
     * Verify that arguments in doc and module spec dict are identical.
     * For password / secret arguments no_log=True should be set.
-    * If an optional parameter is sometimes required, reflect this fact in the documentation, e.g. "Required when C(state=present)."
+    * If an optional parameter is sometimes required, reflect this fact in the documentation, e.g. "Required when I(state=present)."
     * If your module allows ``check_mode``, reflect this fact in the documentation.
 
 Each documentation field is described below. Before committing your module documentation, please test it at the command line and as HTML:


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
According to the `Linking within module documentation` section, the right syntax should be `I(state=present)`.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
