### PR TITLE
Fix nxos action plugin for nxos_install_os

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -38,6 +38,9 @@ notes:
     - This module requires both the ANSIBLE_PERSISTENT_CONNECT_TIMEOUT and
       ANSIBLE_PERSISTENT_COMMAND_TIMEOUT timers to be set to 600 seconds or higher.
       The module will exit if the timers are not set properly.
+    - When using connection local, ANSIBLE_PERSISTENT_CONNECT_TIMEOUT and
+      ANSIBLE_PERSISTENT_COMMAND_TIMEOUT can only be set using ENV variables or
+      the ansible.cfg file.
     - Do not include full file paths, just the name of the file(s) stored on
       the top level flash directory.
     - This module attempts to install the software immediately,

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -55,10 +55,23 @@ class ActionModule(ActionNetworkModule):
                 self._task.args['username'] = self._play_context.connection_user
 
         if self._task.action == 'nxos_install_os':
+            persistent_command_timeout = 0
+            persistent_connect_timeout = 0
             connection = self._connection
-            if connection.get_option('persistent_command_timeout') < 600 or connection.get_option('persistent_connect_timeout') < 600:
+            if connection.transport == 'local':
+                persistent_command_timeout = C.PERSISTENT_COMMAND_TIMEOUT
+                persistent_connect_timeout = C.PERSISTENT_CONNECT_TIMEOUT
+            else:
+                persistent_command_timeout = connection.get_option('persistent_command_timeout')
+                persistent_connect_timeout = connection.get_option('persistent_connect_timeout')
+
+            display.vvvv('PERSISTENT_COMMAND_TIMEOUT is %s' % str(persistent_command_timeout), self._play_context.remote_addr)
+            display.vvvv('PERSISTENT_CONNECT_TIMEOUT is %s' % str(persistent_connect_timeout), self._play_context.remote_addr)
+            if persistent_command_timeout < 600 or persistent_connect_timeout < 600:
                 msg = 'PERSISTENT_COMMAND_TIMEOUT and PERSISTENT_CONNECT_TIMEOUT'
-                msg += ' must be set to 600 seconds or higher when using nxos_install_os module'
+                msg += ' must be set to 600 seconds or higher when using nxos_install_os module.'
+                msg += ' Current persistent_command_timeout setting:' + str(persistent_command_timeout)
+                msg += ' Current persistent_connect_timeout setting:' + str(persistent_connect_timeout)
                 return {'failed': True, 'msg': msg}
 
         if self._play_context.connection in ('network_cli', 'httpapi'):


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/52206

* Fix checks the connection type before attempting to determine the current values for `PERSISTENT_COMMAND_TIMEOUT` and `PERSISTENT_CONNECT_TIMEOUT`
* Adds additional debug information to display the TIMEOUT values on failure.
* Adds current timer values to the verbose `-vvvv` output.

**NOTE:** For connection: `local (cli) or (nxapi)` setting vars in the playbook task or passing via the `-e` argument  have no effect.  Setting environment variables or setting ansible.cfg however, do work.

I am open to suggestions about how we get playbook task vars to take effect for connection: `local (cli) or (nxapi)`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_install_os`

##### ADDITIONAL INFORMATION

The following tests were run to validate this fix.

#### CONNECTION: network_cli

* TESTCASE: Timers NOT set

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin network_cli
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/bcc36897f8
<n9k> PERSISTENT_COMMAND_TIMEOUT is 30
<n9k> PERSISTENT_CONNECT_TIMEOUT is 30
```

* TESTCASE: Timers set using ENV vars

```bash
(py2-ansible) $env | grep ANSIBLE_PERS
ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=600
ANSIBLE_PERSISTENT_CONNECT_TIMEOUT=600
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin network_cli
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/4ac6359588
<n9k> PERSISTENT_COMMAND_TIMEOUT is 600
<n9k> PERSISTENT_CONNECT_TIMEOUT is 600
```

* TESTCASE: Timers set using ansible.cfg

```bash
$cat /etc/ansible/ansible.cfg 
[persistent_connection]
connect_timeout=800
command_timeout=800
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin network_cli
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/c700b6b398
<n9k> PERSISTENT_COMMAND_TIMEOUT is 800
<n9k> PERSISTENT_CONNECT_TIMEOUT is 800
```

* TESTCASE: Timers set using vars in playbook task

```yaml
- name: "Install OS image {{ si }}"
  check_mode: "{{ checkmode }}"
  nxos_install_os:
    system_image_file: "{{ si }}"
    issu: "{{ issu }}"
    provider: "{{ connection }}"
  vars:
    ansible_command_timeout: 700
    ansible_connect_timeout: 700
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin network_cli
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/e8335c6594
<n9k> PERSISTENT_COMMAND_TIMEOUT is 700
<n9k> PERSISTENT_CONNECT_TIMEOUT is 700
```

* TESTCASE: Timers set by passing them in to `ansible-playbook` using `-e` option

`ansible-playbook nxos.yaml -e "ansible_command_timeout=1000 ansible_connect_timeout=900"`

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin network_cli
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/01ee8deb61
<n9k> PERSISTENT_COMMAND_TIMEOUT is 1000
<n9k> PERSISTENT_CONNECT_TIMEOUT is 900
```

#### CONNECTION: httpapi

* TESTCASE: Timers NOT set

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin httpapi
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/11c4d12331
<n9k> PERSISTENT_COMMAND_TIMEOUT is 30
<n9k> PERSISTENT_CONNECT_TIMEOUT is 30
```

* TESTCASE: Timers set using ENV vars

```bash
(py2-ansible) $env | grep ANSIBLE_PERS
ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=600
ANSIBLE_PERSISTENT_CONNECT_TIMEOUT=600
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin httpapi
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/0606e69189
<n9k> PERSISTENT_COMMAND_TIMEOUT is 600
<n9k> PERSISTENT_CONNECT_TIMEOUT is 600
```

* TESTCASE: Timers set using ansible.cfg

```bash
$cat /etc/ansible/ansible.cfg 
[persistent_connection]
connect_timeout=800
command_timeout=800
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin httpapi
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/9012e40de0
<n9k> PERSISTENT_COMMAND_TIMEOUT is 800
<n9k> PERSISTENT_CONNECT_TIMEOUT is 800
```

* TESTCASE: Timers set using vars in playbook task

```yaml
- name: "Install OS image {{ si }}"
  check_mode: "{{ checkmode }}"
  nxos_install_os:
    system_image_file: "{{ si }}"
    issu: "{{ issu }}"
    provider: "{{ connection }}"
  vars:
    ansible_command_timeout: 700
    ansible_connect_timeout: 700
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin httpapi
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/b9d0d42858
<n9k> PERSISTENT_COMMAND_TIMEOUT is 700
<n9k> PERSISTENT_CONNECT_TIMEOUT is 700
```

* TESTCASE: Timers set by passing them in to `ansible-playbook` using `-e` option

`ansible-playbook nxos.yaml -e "ansible_command_timeout=1000 ansible_connect_timeout=900"`

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> attempting to start connection
<n9k> using connection plugin httpapi
<n9k> found existing local domain socket, using it!
<n9k> updating play_context for connection
<n9k> 
<n9k> local domain socket path is /Users/mwiebe/.ansible/pc/8bf7088d5a
<n9k> PERSISTENT_COMMAND_TIMEOUT is 1000
<n9k> PERSISTENT_CONNECT_TIMEOUT is 900
```

#### CONNECTION: local (cli)

* TESTCASE: Timers NOT set

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> PERSISTENT_COMMAND_TIMEOUT is 30
<n9k> PERSISTENT_CONNECT_TIMEOUT is 30
```

* TESTCASE: Timers set using ENV vars

```bash
(py2-ansible) $env | grep ANSIBLE_PERS
ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=600
ANSIBLE_PERSISTENT_CONNECT_TIMEOUT=600
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> PERSISTENT_COMMAND_TIMEOUT is 600
<n9k> PERSISTENT_CONNECT_TIMEOUT is 600
```

* TESTCASE: Timers set using ansible.cfg

```bash
$cat /etc/ansible/ansible.cfg 
[persistent_connection]
connect_timeout=800
command_timeout=800
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> PERSISTENT_COMMAND_TIMEOUT is 800
<n9k> PERSISTENT_CONNECT_TIMEOUT is 800
```

* TESTCASE: Timers set using vars in playbook task - FAILED

```yaml
- name: "Install OS image {{ si }}"
  check_mode: "{{ checkmode }}"
  nxos_install_os:
    system_image_file: "{{ si }}"
    issu: "{{ issu }}"
    provider: "{{ connection }}"
  vars:
    ansible_command_timeout: 700
    ansible_connect_timeout: 700
```

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> PERSISTENT_COMMAND_TIMEOUT is 30
<n9k> PERSISTENT_CONNECT_TIMEOUT is 30
```

* TESTCASE: Timers set by passing them in to `ansible-playbook` using `-e` option - FAILED

`ansible-playbook nxos.yaml -e "ansible_command_timeout=1000 ansible_connect_timeout=900"`

```bash
TASK [nxos_install_os : Install OS image nxos.7.0.3.I7.4.bin] ***************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml:2
<n9k> PERSISTENT_COMMAND_TIMEOUT is 30
<n9k> PERSISTENT_CONNECT_TIMEOUT is 30
```

#### CONNECTION: local (nxapi)

* Same results as CONNECTION: local (cli)