### PR TITLE
Keep existing to_yaml behavior with pyyaml >= 5.1.

### DIFF
--- a/changelogs/fragments/to_yaml-default_flow_style.yaml
+++ b/changelogs/fragments/to_yaml-default_flow_style.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "``to_yaml`` filter updated to maintain formatting consistency when used with ``pyyaml`` versions 5.1 and later (https://github.com/ansible/ansible/pull/53772)"

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -61,7 +61,8 @@ UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
 
 def to_yaml(a, *args, **kw):
     '''Make verbose, human readable yaml'''
-    transformed = yaml.dump(a, Dumper=AnsibleDumper, default_flow_style=None, allow_unicode=True, **kw)
+    default_flow_style = kw.pop('default_flow_style', None)
+    transformed = yaml.dump(a, Dumper=AnsibleDumper, default_flow_style=default_flow_style, allow_unicode=True, **kw)
     return to_text(transformed)
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -62,7 +62,7 @@ UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
 def to_yaml(a, *args, **kw):
     '''Make verbose, human readable yaml'''
     default_flow_style = kw.pop('default_flow_style', None)
-    transformed = yaml.dump(a, Dumper=AnsibleDumper, default_flow_style=default_flow_style, allow_unicode=True, **kw)
+    transformed = yaml.dump(a, Dumper=AnsibleDumper, allow_unicode=True, default_flow_style=default_flow_style, **kw)
     return to_text(transformed)
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -61,7 +61,7 @@ UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
 
 def to_yaml(a, *args, **kw):
     '''Make verbose, human readable yaml'''
-    transformed = yaml.dump(a, Dumper=AnsibleDumper, allow_unicode=True, **kw)
+    transformed = yaml.dump(a, Dumper=AnsibleDumper, default_flow_style=None, allow_unicode=True, **kw)
     return to_text(transformed)
 
 


### PR DESCRIPTION
##### SUMMARY

Keep existing to_yaml behavior with pyyaml >= 5.1.

In pyyaml versions before 5.1 the default_flow_style for yaml.dump was None. Starting with 5.1 it is now False. This change explicitly sets the value to None to maintain the original to_yaml behavior.

The change to pyyaml was made in the following commit:

https://github.com/yaml/pyyaml/commit/507a464ce62c933bf667b2296a96ad45f0147873

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

to_yaml filter
