### PR TITLE
Handle binary files when scanning metadata in python 3

### DIFF
--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -394,8 +394,12 @@ def analyze_integration_target_dependencies(integration_targets):
 
         for meta_path in meta_paths:
             if os.path.exists(meta_path):
-                with open(meta_path, 'r') as meta_fd:
-                    meta_lines = meta_fd.read().splitlines()
+                with open(meta_path, 'rb') as meta_fd:
+                    # try and decode the file as a utf-8 string, skip if it contains invalid chars (binary file)
+                    try:
+                        meta_lines = meta_fd.read().decode('utf-8').splitlines()
+                    except UnicodeDecodeError:
+                        continue
 
                 for meta_line in meta_lines:
                     if re.search(r'^ *#.*$', meta_line):


### PR DESCRIPTION
##### SUMMARY
When scanning the target role meta dependencies, the code will bomb when running on Python 3 and a binary file is encountered. This can happen if you are using a program like vim that creates temp swap files when editing another one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test