### PR TITLE
Fix openstack bug with transforming group names

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -258,9 +258,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self._config_data.get('keyed_groups'), hostvars[host], host)
 
         for group_name, group_hosts in groups.items():
-            self.inventory.add_group(group_name)
+            gname = self.inventory.add_group(group_name)
             for host in group_hosts:
-                self.inventory.add_child(group_name, host)
+                self.inventory.add_child(gname, host)
 
     def _get_groups_from_server(self, server_vars, namegroup=True):
         groups = []


### PR DESCRIPTION
##### SUMMARY
Fixes the error linked in the issue, gives full inventory output with this again

link https://github.com/ansible/ansible/issues/53703

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openstack inventory plugin

##### ADDITIONAL INFORMATION


```
ANSIBLE_JINJA2_NATIVE=true ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS=always ansible-inventory -i private/openstack/openstack.yml --list --export -vvv
```

finishes without an error
