### PR TITLE
fixing status option in documentation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
@@ -21,8 +21,7 @@ options:
   statuses:
     description:
       - Status to filter the certificate results
-    choices: ['PENDING_VALIDATION', 'ISSUED', 'INACTIVE', 'EXPIRED', 'VALIDATION_TIMED_OUT']
-
+    choices: ['PENDING_VALIDATION', 'ISSUED', 'INACTIVE', 'EXPIRED', 'VALIDATION_TIMED_OUT', 'REVOKED', 'FAILED']
 requirements:
   - boto3
 author:
@@ -311,7 +310,7 @@ def main():
     argument_spec.update(
         dict(
             domain_name=dict(aliases=['name']),
-            statuses=dict(type='list'),
+            statuses=dict(type='list', choices=['PENDING_VALIDATION', 'ISSUED', 'INACTIVE', 'EXPIRED', 'VALIDATION_TIMED_OUT', 'REVOKED', 'FAILED']),
         )
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
@@ -18,7 +18,7 @@ options:
       - The domain name of an ACM certificate to limit the search to
     aliases:
       - name
-  status:
+  statuses:
     description:
       - Status to filter the certificate results
     choices: ['PENDING_VALIDATION', 'ISSUED', 'INACTIVE', 'EXPIRED', 'VALIDATION_TIMED_OUT']

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1,7 +1,5 @@
 lib/ansible/modules/cloud/amazon/_ec2_ami_find.py E322
 lib/ansible/modules/cloud/amazon/_ec2_ami_find.py E323
-lib/ansible/modules/cloud/amazon/aws_acm_facts.py E322
-lib/ansible/modules/cloud/amazon/aws_acm_facts.py E323
 lib/ansible/modules/cloud/amazon/aws_api_gateway.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E326


### PR DESCRIPTION
changing status option to statuses in the documentation

+label: docsite_pr

##### SUMMARY
Documentation currently has "status" option when it is actually "statuses"

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws_acm_facts

##### ADDITIONAL INFORMATION

