### PR TITLE
Add shippable/posix/group4/ for CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -105,6 +105,22 @@ matrix:
     - env: T=linux/ubuntu1604py3/3
     - env: T=linux/ubuntu1804/3
 
+    - env: T=osx/10.11/4
+    - env: T=rhel/7.6/4
+    - env: T=rhel/8.0/4
+    - env: T=freebsd/11.1/4
+    - env: T=freebsd/12.0/4
+    - env: T=linux/centos6/4
+    - env: T=linux/centos7/4
+    - env: T=linux/fedora28/4
+    - env: T=linux/fedora29/4
+    - env: T=linux/opensuse15py2/4
+    - env: T=linux/opensuse15/4
+    - env: T=linux/ubuntu1404/4
+    - env: T=linux/ubuntu1604/4
+    - env: T=linux/ubuntu1604py3/4
+    - env: T=linux/ubuntu1804/4
+
     - env: T=aws/2.7/1
     - env: T=aws/3.6/1
 

--- a/test/integration/targets/ansible/aliases
+++ b/test/integration/targets/ansible/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group4

--- a/test/integration/targets/dnf/aliases
+++ b/test/integration/targets/dnf/aliases
@@ -1,4 +1,4 @@
 destructive
-shippable/posix/group1
+shippable/posix/group4
 skip/freebsd
 skip/osx

--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group3
+shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_network/aliases
+++ b/test/integration/targets/docker_network/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group2
+shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1
+shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/git/aliases
+++ b/test/integration/targets/git/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group4

--- a/test/integration/targets/ignore_errors/aliases
+++ b/test/integration/targets/ignore_errors/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_passwordstore/aliases
+++ b/test/integration/targets/lookup_passwordstore/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group2
+shippable/posix/group4
 destructive
 skip/rhel

--- a/test/integration/targets/luks_device/aliases
+++ b/test/integration/targets/luks_device/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group2
+shippable/posix/group4
 skip/osx
 skip/freebsd
 skip/docker

--- a/test/integration/targets/plugin_filtering/aliases
+++ b/test/integration/targets/plugin_filtering/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group4

--- a/test/integration/targets/postgresql/aliases
+++ b/test/integration/targets/postgresql/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group1
+shippable/posix/group4
 postgresql_db
 postgresql_privs
 postgresql_user

--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -1,3 +1,3 @@
 destructive
-shippable/posix/group1
+shippable/posix/group4
 needs/httptester

--- a/test/integration/targets/var_precedence/aliases
+++ b/test/integration/targets/var_precedence/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group4

--- a/test/integration/targets/vars_prompt/aliases
+++ b/test/integration/targets/vars_prompt/aliases
@@ -1,3 +1,3 @@
 setup/always/setup_passlib
 setup/always/setup_pexpect
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -1,4 +1,4 @@
 destructive
-shippable/posix/group1
+shippable/posix/group4
 skip/freebsd
 skip/osx


### PR DESCRIPTION
##### SUMMARY

Add shippable/posix/group4/ for CI.

The additional group provides two benefits:

1. Reduces the lines of console output in each group to stay under Shippable's 30K viewer limit.
2. Reduces run time in each group to stay under execution time limits on nightly coverage runs.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml
