### PR TITLE
BOTMETA: associate docker_swarm inventory plugin to $team_docker

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1115,6 +1115,7 @@ files:
 # plugins/inventory
   $plugins/inventory/__init__.py:
     support: core
+  $plugins/inventory/docker_swarm.py: *docker
   $plugins/inventory/gcp_compute.py:
     maintainers: $team_google
     supershipit: $team_google


### PR DESCRIPTION
##### SUMMARY
This will associate the new docker_swarm inventory plugin (#53058) to $team_docker. This means that $team_docker is also informed about PRs/issues for this inventory plugin, and that we can `shipit` changes (by counting as maintainers).

CC @morph027 @akshay196 @danihodovic @dariko @DBendit @jwitko @kassiansun @tbouvet @WojciechowskiPiotr

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
