### PR TITLE
add option to display per host start to default

### DIFF
--- a/changelogs/fragments/show_host_start.yml
+++ b/changelogs/fragments/show_host_start.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Add toggle to show per host task start on default callback

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -227,6 +227,10 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_handler_task_start(self, task):
         self._task_start(task, prefix='RUNNING HANDLER')
 
+    def v2_runner_on_start(self, host, task):
+        if self.get_option('show_per_host_start'):
+            self._display.display(" [started %s on %s]" % (task, host), color=C.COLOR_OK)
+
     def v2_playbook_on_play_start(self, play):
         name = play.get_name().strip()
         if not name:

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -50,4 +50,15 @@ class ModuleDocFragment(object):
         ini:
           - key: show_custom_stats
             section: defaults
+      show_per_host_start:
+        name: Show per host task start
+        description: 'This adds output that shows when a task is started to execute for each host'
+        type: bool
+        default: no
+        env:
+          - name: ANSIBLE_SHOW_PER_HOST_START
+        ini:
+          - key: show_per_host_start
+            section: defaults
+        version_added: '2.9'
 '''

--- a/test/integration/targets/ansible-runner/tasks/playbook_example1.yml
+++ b/test/integration/targets/ansible-runner/tasks/playbook_example1.yml
@@ -12,5 +12,5 @@
 - assert:
     that:
         - "pbexec_json.rc == 0"
-        - "pbexec_json.events|length == 6"
+        - "pbexec_json.events|length == 7"
         - "'localhost' in pbexec_json.stats.ok"


### PR DESCRIPTION
fixes #53779
fixes #51042, might need tweaking to deal with task banners being displayed when not displaying 'skipped'

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
callbacks/default