### PR TITLE
scaleway_compute: partial fix of registered public_ip=UUID

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -297,7 +297,7 @@ def public_ip_payload(compute_api, public_ip):
 
     lookup = [ip["id"] for ip in ip_list]
     if public_ip in lookup:
-        return {"public_ip": public_ip}
+        return {"dynamic_ip_required": False, "public_ip": public_ip}
 
 
 def create_server(compute_api, server):
@@ -311,6 +311,9 @@ def create_server(compute_api, server):
             "name": server["name"],
             "organization": server["organization"]
             }
+
+    if "public_ip" in server:
+        data["public_ip"] = server["public_ip"]
 
     if server["security_group"]:
         data["security_group"] = server["security_group"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows to use the public_ip parameter with value of existing
Scaleway IP address UUID (as said in the docs but didn't work).

Known limitation of the fix: a registered IP UUID can only be set
for new server. It will not be updated if server already exists.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scaleway_compute

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It should also allow to attach an IP to existing server (not currently implemented).
But this solution is better than nothing.
