### PR TITLE
Check for existence of object attr login_handle

### DIFF
--- a/lib/ansible/module_utils/remote_management/ucs.py
+++ b/lib/ansible/module_utils/remote_management/ucs.py
@@ -5,7 +5,7 @@
 # to the complete work.
 #
 # (c) 2016 Red Hat Inc.
-# (c) 2017 Cisco Systems Inc.
+# (c) 2019 Cisco Systems Inc.
 #
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
@@ -76,12 +76,14 @@ class UCSModule():
             proxy = {}
 
         try:
-            handle = UcsHandle(ip=self.module.params['hostname'],
-                               username=self.module.params['username'],
-                               password=self.module.params['password'],
-                               port=self.module.params['port'],
-                               secure=self.module.params['use_ssl'],
-                               proxy=proxy)
+            handle = UcsHandle(
+                ip=self.module.params['hostname'],
+                username=self.module.params['username'],
+                password=self.module.params['password'],
+                port=self.module.params['port'],
+                secure=self.module.params['use_ssl'],
+                proxy=proxy
+            )
             handle.login()
         except Exception as e:
             self.result['msg'] = str(e)
@@ -89,7 +91,7 @@ class UCSModule():
         self.login_handle = handle
 
     def logout(self):
-        if self.login_handle:
+        if hasattr(self, 'login_handle'):
             self.login_handle.logout()
             return True
         return False


### PR DESCRIPTION
##### SUMMARY
module_utils/remote_management/ucs.py

On deconstruction of UCS Manager login session, UCSModule object will throw the unhandled exception AttributeError: 'UCSModule' object has no attribute 'login_handle' if the login credentials are incorrect or if the UCS Manager is unreachable. In either case, the UCSModule object attempts to access a nonexistent attribute login_handle. The attribute will not exist in these cases because a successful login did not take place.

Playbook running of the module masks the exception, local testing with an args.json file shows the unhandled exception.

The fix checks for the existence of the login_handle attribute before attempting 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/remote_management/ucs.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
(venv) JOMCDONO-M-P1AL:ucsm-ansible jomcdono$ ansible --version
ansible 2.8.0.dev0
  config file = /Users/jomcdono/.ansible.cfg
  configured module search path = ['/Users/jomcdono/Documents/src/ucs/ansible/lib/ansible/modules/remote_management/ucs']
  ansible python module location = /Users/jomcdono/Desktop/sxsw/ansible/lib/ansible
  executable location = /Users/jomcdono/Desktop/sxsw/ansible/bin/ansible
  python version = 3.7.2 (default, Feb 12 2019, 08:15:36) [Clang 10.0.0 (clang-1000.11.45.5)]

BEFORE - INVALID UCS MANAGER IP/HOST
(venv) JOMCDONO-M-P1AL:ucsm-ansible jomcdono$ python ucs_org.py args.json 

{"msg": "<urlopen error [Errno 51] Network is unreachable>", "failed": true, "invocation": {"module_args": {"hostname": "10.201.0.5", "username": "admin", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "org_name": "test", "description": "Testing org", "state": "present", "delegate_to": "localhost", "use_ssl": true, "use_proxy": true, "parent_org_path": "root", "port": null, "proxy": null}}}
Exception ignored in: <function UCSModule.__del__ at 0x10c921d90>
Traceback (most recent call last):
  File "/Users/jomcdono/Desktop/sxsw/ansible/lib/ansible/module_utils/remote_management/ucs.py", line 63, in __del__
    self.logout()
  File "/Users/jomcdono/Desktop/sxsw/ansible/lib/ansible/module_utils/remote_management/ucs.py", line 94, in logout
    if self.login_handle:
AttributeError: 'UCSModule' object has no attribute 'login_handle'
AFTER - INVALID UCS MANAGER IP/HOST

(venv) JOMCDONO-M-P1AL:ucsm-ansible jomcdono$ python ucs_org.py args.json 

{"msg": "<urlopen error [Errno 60] Operation timed out>", "failed": true, "invocation": {"module_args": {"hostname": "10.201.0.5", "username": "admin", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "org_name": "test", "description": "Testing org", "state": "present", "delegate_to": "localhost", "use_ssl": true, "use_proxy": true, "parent_org_path": "root", "port": null, "proxy": null}}}

BEFORE - INVALID CREDENTIALS
(venv) JOMCDONO-M-P1AL:ucsm-ansible jomcdono$ python ucs_org.py args.json 

{"msg": "[ErrorCode]: 551[ErrorDescription]: Authentication failed", "failed": true, "invocation": {"module_args": {"hostname": "10.200.0.5", "username": "admin", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "org_name": "test", "description": "Testing org", "state": "present", "delegate_to": "localhost", "use_ssl": true, "use_proxy": true, "parent_org_path": "root", "port": null, "proxy": null}}}
Exception ignored in: <function UCSModule.__del__ at 0x110470e18>
Traceback (most recent call last):
  File "/Users/jomcdono/Desktop/sxsw/ansible/lib/ansible/module_utils/remote_management/ucs.py", line 63, in __del__
    self.logout()
  File "/Users/jomcdono/Desktop/sxsw/ansible/lib/ansible/module_utils/remote_management/ucs.py", line 94, in logout
    if self.login_handle:
AttributeError: 'UCSModule' object has no attribute 'login_handle'

AFTER - INVALID CREDENTIALS
(venv) JOMCDONO-M-P1AL:ucsm-ansible jomcdono$ python ucs_org.py args.json 

{"msg": "[ErrorCode]: 551[ErrorDescription]: Authentication failed", "failed": true, "invocation": {"module_args": {"hostname": "10.200.0.5", "username": "admin", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "org_name": "test", "description": "Testing org", "state": "present", "delegate_to": "localhost", "use_ssl": true, "use_proxy": true, "parent_org_path": "root", "port": null, "proxy": null}}}
(venv) JOMCDONO-M-P1AL:ucsm-ansible jomcdono$ python ucs_org.py args.json
```
