### PR TITLE
get_url - return filename in dest, not just the path

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -573,6 +573,7 @@ def main():
             # it.
             filename = url_filename(info['url'])
         dest = os.path.join(dest, filename)
+        result['dest'] = dest
 
     # raise an error if there is no tmpsrc file
     if not os.path.exists(tmpsrc):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the `dest` return parameter in the `result` dictionary in case that the `dest` variable gets recomposed from the destination directory and the filename.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #53822
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/net_tools/basics/get_url.py
