### PR TITLE
Remove conflicting urllib3 from pip in uri test.

### DIFF
--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -233,6 +233,12 @@
       - result is failed
   when: result is not skipped
 
+- name: uninstall conflicting urllib3 pip package
+  pip:
+    name: urllib3
+    state: absent
+  when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
+
 - name: install OS packages that are needed for SNI on old python
   package:
     name: "{{ item }}"


### PR DESCRIPTION
##### SUMMARY

Remove conflicting urllib3 from pip in uri test.

The uri test will fail on centos6 if run after a test that installs urllib3 via pip unless it is uninstalled.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

uri integration test
