### PR TITLE
XenServer: Minor bug fixes

### DIFF
--- a/lib/ansible/module_utils/xenserver.py
+++ b/lib/ansible/module_utils/xenserver.py
@@ -647,22 +647,24 @@ def wait_for_task(module, task_ref, timeout=300):
 
     result = ""
 
-    # If we have to wait indefinitely, make timeout larger than 0 so we can
+    # If we have to wait indefinitely, make time_left larger than 0 so we can
     # enter while loop.
     if timeout == 0:
-        timeout = 1
+        time_left = 1
+    else:
+        time_left = timeout
 
     try:
-        while timeout > 0:
+        while time_left > 0:
             task_status = xapi_session.xenapi.task.get_status(task_ref).lower()
 
             if task_status == "pending":
                 # Task is still running.
                 time.sleep(interval)
 
-                # We decrease timeout only if we don't wait indefinitely.
+                # We decrease time_left only if we don't wait indefinitely.
                 if timeout != 0:
-                    timeout -= interval
+                    time_left -= interval
 
                 continue
             elif task_status == "success":
@@ -860,11 +862,7 @@ class XenServerObject(object):
                                                  "Please download XenServer SDK and copy XenAPI.py to your Python site-packages. "
                                                  "Check Notes section in module documentation for more info."))
 
-        if module:
-            self.module = module
-        else:
-            module.fail_json(msg="XenServerObject: Invalid module object passed!")
-
+        self.module = module
         self.xapi_session = XAPI.connect(module)
 
         try:

--- a/lib/ansible/modules/cloud/xenserver/xenserver_guest.py
+++ b/lib/ansible/modules/cloud/xenserver/xenserver_guest.py
@@ -438,7 +438,6 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils import six
 from ansible.module_utils.xenserver import (xenserver_common_argument_spec, XAPI, XenServerObject, get_object_ref,
                                             gather_vm_params, gather_vm_facts, set_vm_power_state, wait_for_vm_ip_address,


### PR DESCRIPTION
 - xenserver module_util: removed dead code. Attempting to call fail_json() on
   nonexistent/bad module reference is a bad idea.
 - xenserver module_util: fixed a bug in wait_for_task function where function
   will fail to wait indefinitely when timeout=0 is used.
 - xenserver_guest module: removed unused imports.

##### SUMMARY
Fixes a number of minor bugs discovered.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xenserver
xenserver_guest

##### ADDITIONAL INFORMATION
No additional info.