### PR TITLE
win_acl - fix glob file paths

### DIFF
--- a/changelogs/fragments/win_acl-paths.yaml
+++ b/changelogs/fragments/win_acl-paths.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_acl - Fix issues when using paths with glob like characters, e.g. ``[``, ``]``

--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -31,9 +31,9 @@ function Get-UserSID {
 
     if ($searchAppPools) {
         Import-Module -Name WebAdministration
-        $testIISPath = Test-Path -Path "IIS:"
+        $testIISPath = Test-Path -LiteralPath "IIS:"
         if ($testIISPath) {
-            $appPoolObj = Get-ItemProperty -Path "IIS:\AppPools\$AccountName"
+            $appPoolObj = Get-ItemProperty -LiteralPath "IIS:\AppPools\$AccountName"
             $userSID = $appPoolObj.applicationPoolSid
         }
     }
@@ -90,7 +90,7 @@ $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "prese
 $inherit = Get-AnsibleParam -obj $params -name "inherit" -type "str"
 $propagation = Get-AnsibleParam -obj $params -name "propagation" -type "str" -default "None" -validateset "InheritOnly","None","NoPropagateInherit"
 
-If (-Not (Test-Path -Path $path)) {
+If (-Not (Test-Path -LiteralPath $path)) {
     Fail-Json -obj $result -message "$path file or directory does not exist on the host"
 }
 
@@ -100,7 +100,7 @@ if (!$sid) {
     Fail-Json -obj $result -message "$user is not a valid user or group on the host machine or domain"
 }
 
-If (Test-Path -Path $path -PathType Leaf) {
+If (Test-Path -LiteralPath $path -PathType Leaf) {
     $inherit = "None"
 }
 ElseIf ($null -eq $inherit) {
@@ -133,7 +133,7 @@ Try {
     Else {
         $objACE = New-Object System.Security.AccessControl.FileSystemAccessRule ($objUser, $colRights, $InheritanceFlag, $PropagationFlag, $objType)
     }
-    $objACL = Get-ACL $path
+    $objACL = Get-ACL -LiteralPath $path
 
     # Check if the ACE exists already in the objects ACL list
     $match = $false
@@ -168,7 +168,7 @@ Try {
     If ($state -eq "present" -And $match -eq $false) {
         Try {
             $objACL.AddAccessRule($objACE)
-            Set-ACL $path $objACL
+            Set-ACL -LiteralPath $path -AclObject $objACL
             $result.changed = $true
         }
         Catch {
@@ -178,7 +178,7 @@ Try {
     ElseIf ($state -eq "absent" -And $match -eq $true) {
         Try {
             $objACL.RemoveAccessRule($objACE)
-            Set-ACL $path $objACL
+            Set-ACL -LiteralPath $path -AclObject $objACL
             $result.changed = $true
         }
         Catch {

--- a/test/integration/targets/win_acl/defaults/main.yml
+++ b/test/integration/targets/win_acl/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-test_acl_path: '{{ win_output_dir }}/win_acl'
+test_acl_path: '{{ win_output_dir }}\win_acl .ÅÑŚÌβŁÈ [$!@^&test(;)]'

--- a/test/integration/targets/win_acl/tasks/main.yml
+++ b/test/integration/targets/win_acl/tasks/main.yml
@@ -12,7 +12,7 @@
     include_tasks: tests.yml
 
   always:
-  - name: clenaup testing dir
+  - name: cleanup testing dir
     win_file:
       path: '{{ test_acl_path }}'
       state: absent

--- a/test/integration/targets/win_acl/tasks/tests.yml
+++ b/test/integration/targets/win_acl/tasks/tests.yml
@@ -3,7 +3,7 @@
 - name: get register cmd that will get ace info
   set_fact:
     test_ace_cmd: |
-      $ace_list = (Get-Acl -Path $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
+      $ace_list = (Get-Acl -LiteralPath $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
           @{
               rights = $_.FileSystemRights.ToString()
               type = $_.AccessControlType.ToString()


### PR DESCRIPTION
##### SUMMARY
The win_acl module will fall flat when dealing with paths that have a glob like character in it. This fixes the issue and adds tests for this scenario.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_acl