### PR TITLE
win_slurp - fix glob like paths

### DIFF
--- a/changelogs/fragments/win_slurp-paths.yaml
+++ b/changelogs/fragments/win_slurp-paths.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- slurp - Fix issues when using paths on Windows with glob like characters, e.g. ``[``, ``]``

--- a/lib/ansible/modules/windows/slurp.ps1
+++ b/lib/ansible/modules/windows/slurp.ps1
@@ -11,14 +11,14 @@ $result = @{
     changed = $false;
 }
 
-If (Test-Path -Path $src -PathType Leaf)
+If (Test-Path -LiteralPath $src -PathType Leaf)
 {
     $bytes = [System.IO.File]::ReadAllBytes($src);
     $result.content = [System.Convert]::ToBase64String($bytes);
     $result.encoding = "base64";
     Exit-Json $result;
 }
-ElseIf (Test-Path -Path $src -PathType Container)
+ElseIf (Test-Path -LiteralPath $src -PathType Container)
 {
     Fail-Json $result "Path $src is a directory";
 }

--- a/test/integration/targets/win_slurp/defaults/main.yml
+++ b/test/integration/targets/win_slurp/defaults/main.yml
@@ -1,0 +1,1 @@
+test_win_slurp_dir: C:\ansible\win_slurp .ÅÑŚÌβŁÈ [$!@^&test(;)]

--- a/test/integration/targets/win_slurp/handlers/main.yml
+++ b/test/integration/targets/win_slurp/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: remove test directory
+  win_file:
+    path: '{{ test_win_slurp_dir }}'
+    state: absent

--- a/test/integration/targets/win_slurp/tasks/main.yml
+++ b/test/integration/targets/win_slurp/tasks/main.yml
@@ -16,20 +16,37 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: create test directory
+  win_file:
+    path: '{{ test_win_slurp_dir }}'
+    state: directory
+  notify: remove test directory
+
+# removes reliance on win_copy, set back once win_copy supports glob like chars
+- name: create test file
+  win_shell: |
+    $file = '{{ test_win_slurp_dir }}\slurp.txt'
+    if (Test-Path -LiteralPath $file) {
+        Remove-Item -LiteralPath $file -Force
+    }
+    Set-Content -LiteralPath $file -Value 'Slurp this!'
+
 - name: test slurping an existing file
-  slurp: src="C:/Windows/win.ini"
+  slurp:
+    src: '{{ test_win_slurp_dir }}\slurp.txt'
   register: slurp_existing
 
 - name: check slurp existing result
   assert:
     that:
-      - "slurp_existing.content"
+      - "slurp_existing.content == 'U2x1cnAgdGhpcyENCg=='"
       - "slurp_existing.encoding == 'base64'"
       - "slurp_existing is not changed"
       - "slurp_existing is not failed"
 
 - name: test slurping a large binary file with path param and backslashes
-  slurp: path="C:\Windows\explorer.exe"
+  slurp:
+    path: C:\Windows\explorer.exe
   register: slurp_path_backslashes
   no_log: true
 
@@ -42,7 +59,8 @@
       - "slurp_path_backslashes is not failed"
 
 - name: test slurping a non-existent file
-  slurp: src="C:/this_file_should_not_exist.txt"
+  slurp:
+    src: C:\this_file_should_not_exist.txt
   register: slurp_missing
   ignore_errors: true
 
@@ -54,7 +72,8 @@
       - "slurp_missing is not changed"
 
 - name: test slurping a directory
-  slurp: src="C:/Windows"
+  slurp:
+    src: '{{ test_win_slurp_dir }}\missing'
   register: slurp_dir
   ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY
Fixes slurp on Windows to work with glob like chars.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
slurp.ps1