### PR TITLE
Update roadmap with the slipped dates for 2.8.x

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
@@ -13,17 +13,16 @@ Expected
 
 PRs must be raised well in advance of the dates below to have a chance of being included in this Ansible release.
 
-- 2019-03-14 Alpha 1 **Core freeze**
+- 2019-03-21 Alpha 1 **Core freeze**
 
   No new features to ``support:core`` code.
   Includes no new options to existing Core modules
-- 2019-03-21 Beta 1 **Feature freeze**
+- 2019-03-28 Beta 1 **Feature freeze**
 
   No new functionality (including modules/plugins) to any code
-- 2019-04-04 Release Candidate 1
-- 2019-04-11 Release Candidate 2 (if needed)
-- 2019-04-18 Release Candidate 3 (if needed)
-- 2019-04-25 Release Candidate 4 (if needed)
+- 2019-04-11 Release Candidate 1
+- 2019-04-18 Release Candidate 2 (if needed)
+- 2019-04-25 Release Candidate 3 (if needed)
 - 2019-05-02 Release
 
 


### PR DESCRIPTION
##### SUMMARY
Update roadmap with the slipped dates.

Remove one release candidate.  Slip the schedule by one week for everything but final.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
\cc @acozine @gundalow @thaumos