### PR TITLE
windows - Fix module utils with glob paths

### DIFF
--- a/changelogs/fragments/win_mod_utils-paths.yaml
+++ b/changelogs/fragments/win_mod_utils-paths.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- windows - Fixed various module utils that did not work with path that had glob like chars

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1
@@ -46,12 +46,12 @@ Function Get-ExecutablePath {
     $full_path = [System.IO.Path]::GetFullPath($executable)
 
     if ($full_path -ne $executable -and $directory -ne $null) {
-        $file = Get-Item -Path "$directory\$executable" -Force -ErrorAction SilentlyContinue
+        $file = Get-Item -LiteralPath "$directory\$executable" -Force -ErrorAction SilentlyContinue
     } else {
-        $file = Get-Item -Path $executable -Force -ErrorAction SilentlyContinue
+        $file = Get-Item -LiteralPath $executable -Force -ErrorAction SilentlyContinue
     }
 
-    if ($file -ne $null) {
+    if ($null -ne $file) {
         $executable_path = $file.FullName
     } else {
         $executable_path = [Ansible.Process.ProcessUtil]::SearchPath($executable)
@@ -93,7 +93,7 @@ Function Run-Command {
     # need to validate the working directory if it is set
     if ($working_directory) {
         # validate working directory is a valid path
-        if (-not (Test-Path -Path $working_directory)) {
+        if (-not (Test-Path -LiteralPath $working_directory)) {
             throw "invalid working directory path '$working_directory'"
         }
     }

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -321,7 +321,7 @@ Function Get-FileChecksum($path, $algorithm = 'sha1')
     Helper function to calculate a hash of a file in a way which PowerShell 3
     and above can handle
 #>
-    If (Test-Path -Path $path -PathType Leaf)
+    If (Test-Path -LiteralPath $path -PathType Leaf)
     {
         switch ($algorithm)
         {
@@ -334,7 +334,7 @@ Function Get-FileChecksum($path, $algorithm = 'sha1')
         }
 
         If ($PSVersionTable.PSVersion.Major -ge 4) {
-            $raw_hash = Get-FileHash $path -Algorithm $algorithm
+            $raw_hash = Get-FileHash -LiteralPath $path -Algorithm $algorithm
             $hash = $raw_hash.Hash.ToLower()
         } Else {
             $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite);
@@ -342,7 +342,7 @@ Function Get-FileChecksum($path, $algorithm = 'sha1')
             $fp.Dispose();
         }
     }
-    ElseIf (Test-Path -Path $path -PathType Container)
+    ElseIf (Test-Path -LiteralPath $path -PathType Container)
     {
         $hash = "3";
     }

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
@@ -425,7 +425,7 @@ Function Remove-Link($link_path) {
 }
 
 Function New-Link($link_path, $link_target, $link_type) {
-    if (-not (Test-Path -Path $link_target)) {
+    if (-not (Test-Path -LiteralPath $link_target)) {
         throw "link_target '$link_target' does not exist, cannot create link"
     }
     
@@ -434,13 +434,13 @@ Function New-Link($link_path, $link_target, $link_type) {
             $type = [Ansible.LinkType]::SymbolicLink
         }
         "junction" {
-            if (Test-Path -Path $link_target -PathType Leaf) {
+            if (Test-Path -LiteralPath $link_target -PathType Leaf) {
                 throw "cannot set the target for a junction point to a file"
             }
             $type = [Ansible.LinkType]::JunctionPoint
         }
         "hard" {
-            if (Test-Path -Path $link_target -PathType Container) {
+            if (Test-Path -LiteralPath $link_target -PathType Container) {
                 throw "cannot set the target for a hard link to a directory"
             }
             $type = [Ansible.LinkType]::HardLink

--- a/test/integration/targets/win_module_utils/library/command_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/command_util_test.ps1
@@ -29,6 +29,21 @@ Assert-Equals -actual $actual.stdout -expected "arg1`r`narg2`r`narg 3`r`n"
 Assert-Equals -actual $actual.stderr -expected ""
 Assert-Equals -actual $actual.executable -expected $exe
 
+$test_name = "exe in special char dir"
+$tmp_dir = Join-Path -Path $env:TEMP -ChildPath "ansible .ÅÑŚÌβŁÈ [$!@^&test(;)]"
+try {
+    New-Item -Path $tmp_dir -ItemType Directory > $null
+    $exe_special = Join-Path $tmp_dir -ChildPath "PrintArgv.exe"
+    Copy-Item -LiteralPath $exe -Destination $exe_special
+    $actual = Run-Command -command "`"$exe_special`" arg1 arg2 `"arg 3`""
+} finally {
+    Remove-Item -LiteralPath $tmp_dir -Force -Recurse
+}
+Assert-Equals -actual $actual.rc -expected 0
+Assert-Equals -actual $actual.stdout -expected "arg1`r`narg2`r`narg 3`r`n"
+Assert-Equals -actual $actual.stderr -expected ""
+Assert-Equals -actual $actual.executable -expected $exe_special
+
 $test_name = "invalid exe path"
 try {
     $actual = Run-Command -command "C:\fakepath\$exe_filename arg1"
@@ -86,7 +101,7 @@ $test_name = "test default environment variable"
 Set-Item -Path env:TESTENV -Value "test"
 $actual = Run-Command -command "cmd.exe /c set"
 $env_present = $actual.stdout -split "`r`n" | Where-Object { $_ -eq "TESTENV=test" }
-if ($env_present -eq $null) {
+if ($null -eq $env_present) {
     Fail-Json -obj $result -message "Test $test_name failed`nenvironment variable TESTENV not found in stdout`n$($actual.stdout)"
 }
 
@@ -94,10 +109,10 @@ $test_name = "test custom environment variable1"
 $actual = Run-Command -command "cmd.exe /c set" -environment @{ TESTENV2 = "testing" }
 $env_not_present = $actual.stdout -split "`r`n" | Where-Object { $_ -eq "TESTENV=test" }
 $env_present = $actual.stdout -split "`r`n" | Where-Object { $_ -eq "TESTENV2=testing" }
-if ($env_not_present -ne $null) {
+if ($null -ne $env_not_present) {
     Fail-Json -obj $result -message "Test $test_name failed`nenvironment variabel TESTENV found in stdout when it should be`n$($actual.stdout)"
 }
-if ($env_present -eq $null) {
+if ($null -eq $env_present) {
     Fail-json -obj $result -message "Test $test_name failed`nenvironment variable TESTENV2 not found in stdout`n$($actual.stdout)"
 }
 

--- a/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
+++ b/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
@@ -6,7 +6,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$path = Join-Path -Path $env:TEMP -ChildPath '.ansible  .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+$path = Join-Path -Path ([System.IO.Path]::GetFullPath($env:TEMP)) -ChildPath '.ansible .ÅÑŚÌβŁÈ [$!@^&test(;)]'
 
 $folder_target = "$path\folder"
 $file_target = "$path\file"

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -116,7 +116,6 @@
 
 - name: call module with symbolic link tests
   symbolic_link_test:
-    path: C:\ansible testing
   register: symbolic_link
 
 - assert:


### PR DESCRIPTION
##### SUMMARY
Fix current PowerShell module utils that do not work with glob like file paths.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.CommandUtil.psm1
Ansible.ModuleUtils.Legacy.psm1
Ansible.ModuleUtils.LinkUtil.psm1