### PR TITLE
docker_container tests: only use ports in the range 9001-9060

### DIFF
--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1356,8 +1356,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "1234"
-    - "5678"
+    - "9001"
+    - "9002"
   register: exposed_ports_1
 
 - name: exposed_ports (idempotency)
@@ -1367,8 +1367,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "5678"
-    - "1234"
+    - "9002"
+    - "9001"
   register: exposed_ports_2
 
 - name: exposed_ports (less ports)
@@ -1378,7 +1378,7 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "1234"
+    - "9002"
   register: exposed_ports_3
 
 - name: exposed_ports (more ports)
@@ -1388,8 +1388,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "1234"
-    - "1235"
+    - "9002"
+    - "9003"
     force_kill: yes
   register: exposed_ports_4
 
@@ -2942,8 +2942,8 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 1234
-    - 5678
+    - 9001
+    - 9002
   register: published_ports_1
 
 - name: published_ports (idempotency)
@@ -2953,8 +2953,8 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 5678
-    - 1234
+    - 9002
+    - 9001
   register: published_ports_2
 
 - name: published_ports (less published_ports)
@@ -2964,7 +2964,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 1234
+    - 9002
   register: published_ports_3
 
 - name: published_ports (more published_ports)
@@ -2974,8 +2974,8 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 1234
-    - 2345
+    - 9002
+    - 9003
     force_kill: yes
   register: published_ports_4
 

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -14,8 +14,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
     - all
     force_kill: yes
@@ -28,8 +28,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
     - all
     force_kill: yes
@@ -42,11 +42,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     force_kill: yes
   register: published_ports_3
 
@@ -57,11 +57,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
-    - "8080"
-    - "8081"
+    - "9002"
+    - "9001"
     force_kill: yes
   register: published_ports_4
 
@@ -72,8 +72,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
     - all
     force_kill: yes
@@ -105,11 +105,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "5000-5040"
+    - "9001"
+    - "9010-9050"
     published_ports:
-    - "8080:8080"
-    - "5000-5040:5000-5040"
+    - "9001:9001"
+    - "9010-9050:9010-9050"
     force_kill: yes
   register: published_ports_1
 
@@ -120,11 +120,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "5000-5040"
+    - "9001"
+    - "9010-9050"
     published_ports:
-    - "8080:8080"
-    - "5000-5040:5000-5040"
+    - "9001:9001"
+    - "9010-9050:9010-9050"
     force_kill: yes
   register: published_ports_2
 
@@ -135,11 +135,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "5000-5040"
+    - "9001"
+    - "9010-9050"
     published_ports:
-    - "8080:8080"
-    - "5010-5050:5010-5050"
+    - "9001:9001"
+    - "9020-9060:9020-9060"
     force_kill: yes
   register: published_ports_3
 
@@ -167,7 +167,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - "[::1]:8080:8080"
+    - "[::1]:9001:9001"
     force_kill: yes
   register: published_ports_1
 
@@ -178,7 +178,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - "[::1]:8080:8080"
+    - "[::1]:9001:9001"
     force_kill: yes
   register: published_ports_2
 
@@ -189,7 +189,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - "127.0.0.1:8080:8080"
+    - "127.0.0.1:9001:9001"
     force_kill: yes
   register: published_ports_3
 
@@ -200,7 +200,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - "localhost:8080:8080"
+    - "localhost:9001:9001"
     force_kill: yes
   register: published_ports_4
   ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Fixes CI problems such as https://app.shippable.com/github/ansible/ansible/runs/114040/88/tests (in #53816).

CC @mattclay

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
