### PR TITLE
win_chocolatey - Fix incompatibilities with latest Chocolatey release

### DIFF
--- a/changelogs/fragments/win_chocolatey-update.yaml
+++ b/changelogs/fragments/win_chocolatey-update.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_chocolatey - Fix incompatibilities with the latest release of Chocolatey ``v0.10.12+``

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -326,7 +326,10 @@ Function Get-ChocolateyPackageVersion {
 
     $command = Argv-ToString -arguments @($choco_path, "list", "--local-only", "--exact", "--limit-output", "--all-versions", $name)
     $res = Run-Command -command $command
-    if ($res.rc -ne 0) {
+
+    # Chocolatey v0.10.12 introduced enhanced exit codes, 2 means no results, e.g. no package
+    # 
+    if ($res.rc -notin @(0, 2)) {
         $module.Result.command = $command
         $module.Result.rc = $res.rc
         $module.Result.stdout = $res.stdout

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -23,6 +23,7 @@
 - name: get result of install package (check mode)
   win_command: choco.exe list --local-only --exact --limit-output {{ test_choco_package1|quote }}
   register: install_actual_check
+  failed_when: not install_actual_check.rc in [0, 2]  # v0.10.12+ returns 2 for no package
 
 - name: assert install package (check mode)
   assert:
@@ -96,6 +97,7 @@
 - name: get result of remove package
   win_command: choco.exe list --local-only --exact --limit-output {{ test_choco_package1|quote }}
   register: remove_actual
+  failed_when: not remove_actual.rc in [0, 2]
 
 - name: check if removed package file still exists
   win_stat:
@@ -183,6 +185,7 @@
 - name: get list of installed packages after removal
   win_command: choco.exe list --local-only --limit-output ansible
   register: remove_multiple_actual
+  failed_when: not remove_multiple_actual.rc in [0, 2]
 
 - name: get info on package 1
   win_stat:


### PR DESCRIPTION
##### SUMMARY
The command `choco list` can now return an rc of `2` if no packages were found based on https://github.com/chocolatey/choco/issues/1602. This fixes the module to not error out on this return code so it continues to work with the latest Chocolatey version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey