### PR TITLE
[2.7] docker_container tests: only use ports in the range 9001-9060

### DIFF
--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1109,8 +1109,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "1234"
-    - "5678"
+    - "9001"
+    - "9002"
   register: exposed_ports_1
 
 - name: exposed_ports (idempotency)
@@ -1120,8 +1120,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "5678"
-    - "1234"
+    - "9002"
+    - "9001"
   register: exposed_ports_2
 
 - name: exposed_ports (less ports)
@@ -1131,7 +1131,7 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "1234"
+    - "9002"
   register: exposed_ports_3
 
 - name: exposed_ports (more ports)
@@ -1141,8 +1141,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "1234"
-    - "1235"
+    - "9002"
+    - "9003"
     stop_timeout: 1
   register: exposed_ports_4
 
@@ -2476,8 +2476,8 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 1234
-    - 5678
+    - 9001
+    - 9002
   register: published_ports_1
 
 - name: published_ports (idempotency)
@@ -2487,8 +2487,8 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 5678
-    - 1234
+    - 9002
+    - 9001
   register: published_ports_2
 
 - name: published_ports (less published_ports)
@@ -2498,7 +2498,7 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 1234
+    - 9002
   register: published_ports_3
 
 - name: published_ports (more published_ports)
@@ -2508,8 +2508,8 @@
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 1234
-    - 2345
+    - 9002
+    - 9003
     stop_timeout: 1
   register: published_ports_4
 

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -14,8 +14,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
     - all
     stop_timeout: 1
@@ -28,8 +28,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
     - all
     stop_timeout: 1
@@ -42,11 +42,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     stop_timeout: 1
   register: published_ports_3
 
@@ -57,11 +57,11 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
-    - "8080"
-    - "8081"
+    - "9002"
+    - "9001"
     stop_timeout: 1
   register: published_ports_4
 
@@ -72,8 +72,8 @@
     name: "{{ cname }}"
     state: started
     exposed_ports:
-    - "8080"
-    - "8081"
+    - "9001"
+    - "9002"
     published_ports:
     - all
     stop_timeout: 1


### PR DESCRIPTION
##### SUMMARY
Backport of #53840 to stable-2.7. Only uses ports 9001 to 9003 since port ranges can only be specified in docker_container from 2.8 on.

Mainly needed in case #53816 gets backported to stable-2.7 (or something similar is done), to avoid port clashes. (In fact the problems as in #53816 won't happen here since the 2.7 docker_container tests don't use port 8080, but I think it's nice if all docker_container tests in all Ansible versions use the same range of ports.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
