### PR TITLE
Core: add __dict__ representation for HostVars

### DIFF
--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -106,12 +106,15 @@ class HostVars(Mapping):
         return len(self._inventory.hosts)
 
     def __repr__(self):
-        return repr(self.__dict__())
+        out = {}
+        for host in self._inventory.hosts:
+            out[host] = self.get(host)
+        return repr(out)
 
     def __dict__(self):
         out = {}
         for host in self._inventory.hosts:
-            out[host] = self.get(host)
+            out[host] = self.get(host).__dict__()
         return out
 
 

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -138,3 +138,6 @@ class HostVarsVars(Mapping):
 
     def __repr__(self):
         return repr(self._vars)
+
+    def __dict__(self):
+        return self._vars

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -111,6 +111,9 @@ class HostVars(Mapping):
             out[host] = self.get(host)
         return repr(out)
 
+    def __dict__(self):
+        return self.__repr__()
+
 
 class HostVarsVars(Mapping):
 

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -106,13 +106,13 @@ class HostVars(Mapping):
         return len(self._inventory.hosts)
 
     def __repr__(self):
+        return repr(self.__dict__())
+
+    def __dict__(self):
         out = {}
         for host in self._inventory.hosts:
             out[host] = self.get(host)
-        return repr(out)
-
-    def __dict__(self):
-        return self.__repr__()
+        return out
 
 
 class HostVarsVars(Mapping):


### PR DESCRIPTION
##### SUMMARY
Adding dict serializable representation functionality to be used in HostVars
Currently, when dict is needed, simply calling repr(hostvars) isn't informative on final type in a place of usage.

```
host_vars = HostVars()
# Not informative
repr(host_vars)
host_vars

# Informative
host_vars.__dict__
```

This may broke some tests, just looking on places where this may matter.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/vars/hostvars.py`
