### PR TITLE
Added missing roles to the team_role module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -113,7 +113,8 @@ def main():
     argument_spec = dict(
         user=dict(),
         team=dict(),
-        role=dict(choices=["admin", "read", "member", "execute", "adhoc", "update", "use", "auditor"]),
+        role=dict(choices=["admin", "read", "member", "execute", "adhoc", "update", "use", "auditor",
+                            "project_admin", "inventory_admin", "credential_admin", "workflow_admin","notification_admin"]),
         target_team=dict(),
         inventory=dict(),
         job_template=dict(),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some organization roles were missing at tower_role

"project_admin", "inventory_admin", "credential_admin", "workflow_admin","notification_admin"
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tower_role module
