### PR TITLE
Allow terraform lock flag to get set to false

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -337,7 +337,7 @@ def main():
         if module.params.get('lock'):
             command.append('-lock=true')
         else:
-            command.append('-lock=true')
+            command.append('-lock=false')
     if module.params.get('lock_timeout') is not None:
         command.append('-lock-timeout=%ds' % module.params.get('lock_timeout'))
 


### PR DESCRIPTION
The lock flag is currently always set to true, regardless of the ansible parameter value. This change allows a false value to propogate appropriately to the terraform cli.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The terraform module has a bug where the lock flag is always set to true, regardless of user input.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
