### PR TITLE
docs: Add returned key to module dev example

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -119,8 +119,11 @@ To create a new module:
     original_message:
         description: The original name param that was passed in
         type: str
+        returned: always
     message:
         description: The output message that the sample module generates
+        type: str
+        returned: always
     '''
 
     from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
Add 'returned' key to RETURN block example

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
developing_modules_general.rst

