### PR TITLE
Disable tests for broken win_chocolatey module.

### DIFF
--- a/test/integration/targets/win_chocolatey/aliases
+++ b/test/integration/targets/win_chocolatey/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group4
+disabled


### PR DESCRIPTION
##### SUMMARY

Disable tests for broken win_chocolatey module.

Ansible 2.5 is only receiving security fixes at this point, so the module isn't going to be fixed.

Fixes for later releases are available:

- devel (future 2.8) - https://github.com/ansible/ansible/pull/53841
- stable-2.7 - https://github.com/ansible/ansible/pull/53842
- stable-2.6 - https://github.com/ansible/ansible/pull/53843

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_chocolatey integration test
