### PR TITLE
Azure dynamic inventory groups are missing "tag_" entries

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -858,6 +858,16 @@ class AzureInventory(object):
                 self._inventory[safe_key].append(host_name)
                 self._inventory[safe_value].append(host_name)
 
+                if value:
+                    key = self._to_safe("tag_" + key + "=" + value)
+                else:
+                    key = self._to_safe("tag_" + key)
+
+                if not self._inventory.get(key):
+                    self._inventory[key] = []
+
+                self._inventory[key].append(host_name)
+
     def _json_format_dict(self, pretty=False):
         # convert inventory to json
         if pretty:


### PR DESCRIPTION
##### SUMMARY
We are experimenting with instances in both EC2 and Azure, and want to use the same groups file to group instances. azure_rm.py and ec2.py dynamically create groups using instance tags differently and this is preventing us from using the same groups file.

This commit changes azure_rm.py to mimic ec2.py's behaviour. Note that current groups are still created so that existing implementations do not break :)

Specifically, ec2.py creates groups out of tags like so:

- groups are created from tag key + value, or tag key if no value exists
- "tag" is prepended to these groups

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm.py

##### ADDITIONAL INFORMATION
Test instance tags are:
```
        "tags": {
          "testpost": "please!ignore",
          "blanktag": ""
        },
```
Before this change, the following subset of groups are created based on the tags:
```
  "testpost_please_ignore": [
    "dns-test"
  ],
  "testpost": [
    "dns-test"
  ],
  "blanktag_": [
    "dns-test"
  ],
  "blanktag": [
    "dns-test"
  ]
```
After this change, the following new groups are created:
```
  "tag_blanktag": [
    "dns-test"
  ],
  "tag_testpost_please_ignore": [
    "dns-test"
  ],
```