### PR TITLE
proxysql query rules

### DIFF
--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -72,6 +72,7 @@ options:
         With C(CASELESS) the match is case insensitive. With C(GLOBAL) the replace
         is global (replaces all matches and not just the first).
         For backward compatibility, only C(CASELESS) is the enabled by default.
+    version_added: "2.8"
   flagOUT:
     description:
       - Used in combination with I(flagIN) and apply to create chains of rules.
@@ -111,6 +112,7 @@ options:
   next_query_flagIN:
     description:
       - When is set, its value will become the I(flagIN) value for the next queries.
+    version_added: "2.8"
   mirror_flagOUT:
     description:
       - Enables query mirroring. If set I(mirror_flagOUT) can be used to
@@ -126,6 +128,7 @@ options:
   OK_msg:
     description:
       - The specified message will be returned for a query that uses the defined rule.
+    version_added: "2.8"
   multiplex:
     description:
       - If C(0), multiplex will be disabled. If C(1), multiplex could be re-enabled if
@@ -134,6 +137,7 @@ options:
         Default is NULL, thus not modifying multiplexing policies.
         See U(https://github.com/sysown/proxysql/wiki/Multiplexing#ad-hoc-enabledisable-of-multiplexing)
     choices: [ 0, 1, 2 ]
+    version_added: "2.8"
   log:
     description:
       - Query will be logged.

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -133,8 +133,7 @@ options:
         transactions). If C(2), multiplexing is not disabled for just the current query.
         Default is NULL, thus not modifying multiplexing policies.
         See U(https://github.com/sysown/proxysql/wiki/Multiplexing#ad-hoc-enabledisable-of-multiplexing)
-    choices: [ null, 0, 1, 2 ]
-    default: null
+    choices: [ 0, 1, 2 ]
   log:
     description:
       - Query will be logged.
@@ -551,7 +550,7 @@ def main():
             mirror_hostgroup=dict(type='int'),
             error_msg=dict(type='str'),
             OK_msg=dict(type='str'),
-            multiplex=dict(default=null, choices=[null, 0, 1, 2]),
+            multiplex=dict(choices=[0, 1, 2]),
             log=dict(type='bool'),
             apply=dict(type='bool'),
             comment=dict(type='str'),

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -72,7 +72,7 @@ options:
         With C(CASELESS) the match is case insensitive. With C(GLOBAL) the replace
         is global (replaces all matches and not just the first).
         For backward compatibility, only C(CASELESS) is the enabled by default.
-    version_added: "2.8"
+    version_added: "2.9"
   flagOUT:
     description:
       - Used in combination with I(flagIN) and apply to create chains of rules.
@@ -112,7 +112,7 @@ options:
   next_query_flagIN:
     description:
       - When is set, its value will become the I(flagIN) value for the next queries.
-    version_added: "2.8"
+    version_added: "2.9"
   mirror_flagOUT:
     description:
       - Enables query mirroring. If set I(mirror_flagOUT) can be used to
@@ -128,7 +128,7 @@ options:
   OK_msg:
     description:
       - The specified message will be returned for a query that uses the defined rule.
-    version_added: "2.8"
+    version_added: "2.9"
   multiplex:
     description:
       - If C(0), multiplex will be disabled. If C(1), multiplex could be re-enabled if
@@ -137,7 +137,7 @@ options:
         Default is NULL, thus not modifying multiplexing policies.
         See U(https://github.com/sysown/proxysql/wiki/Multiplexing#ad-hoc-enabledisable-of-multiplexing)
     choices: [ 0, 1, 2 ]
-    version_added: "2.8"
+    version_added: "2.9"
   log:
     description:
       - Query will be logged.

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -554,7 +554,7 @@ def main():
             mirror_hostgroup=dict(type='int'),
             error_msg=dict(type='str'),
             OK_msg=dict(type='str'),
-            multiplex=dict(choices=[0, 1, 2]),
+            multiplex=dict(type='int', choices=[0, 1, 2]),
             log=dict(type='bool'),
             apply=dict(type='bool'),
             comment=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
Added support for query rule options re_modifiers, next_query_flagIN, OK_msg and multiplex (added in ProxySQL 1.4). 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxysql_query_rules

##### ADDITIONAL INFORMATION
With ProxySQL 1.4.0 some important improvements like the explicite management of the multiplex behavior (needed to call stored procedures with return values) was released, see https://proxysql.com/blog/releasing-proxysql-140 for a full list. To use them with Ansible proxysql_query_rules four new options had to be added to the module.