### PR TITLE
Meraki - Convert response keys to snake_case from camelCase

### DIFF
--- a/changelogs/53891-meraki_snake_case_conversion.yml
+++ b/changelogs/53891-meraki_snake_case_conversion.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Meraki modules now return data in snake_case instead of camelCase. The ANSIBLE_MERAKI_FORMAT environment variable can be set to camelcase to revert back to camelcase until deprecation in Ansible 2.13.

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -359,12 +359,13 @@ class MerakiModule(object):
             self.result['url'] = self.url
         self.result.update(**kwargs)
         if self.params['output_format'] == 'camelcase':
-            self.module.deprecate("Ansible's Meraki modules will stop supporting camel case output in Ansible 2.12. Please update your playbooks.")
+            self.module.deprecate("Update your playbooks to support snake_case format instead of camelCase format.", version=2.13)
         else:
-            try:
-                self.result['data'] = camel_dict_to_snake_dict(self.result['data'])
-            except KeyError:
-                pass
+            if 'data' in self.result:
+                try:
+                    self.result['data'] = camel_dict_to_snake_dict(self.result['data'])
+                except (KeyError, AttributeError):
+                    pass
         self.module.exit_json(**self.result)
 
     def fail_json(self, msg, **kwargs):

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -377,7 +377,6 @@ class MerakiModule(object):
         else:
             if 'data' in self.result:
                 try:
-                    # self.fail_json(msg="here", converted=self.convert_camel_to_snake(self.result['data']))
                     self.result['data'] = self.convert_camel_to_snake(self.result['data'])
                 except (KeyError, AttributeError):
                     pass

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -282,6 +282,20 @@ class MerakiModule(object):
                 return template['id']
         self.fail_json(msg='No configuration template named {0} found'.format(name))
 
+    def convert_camel_to_snake(self, data):
+        """
+        Converts a dictionary or list to snake case from camel case
+        :type data: dict or list
+        :return: Converted data structure, if list or dict
+        """
+
+        if isinstance(data, dict):
+            return camel_dict_to_snake_dict(data, ignore_list=('tags', 'tag'))
+        elif isinstance(data, list):
+            return [camel_dict_to_snake_dict(item, ignore_list=('tags', 'tag')) for item in data]
+        else:
+            return data
+
     def construct_params_list(self, keys, aliases=None):
         qs = {}
         for key in keys:
@@ -363,7 +377,8 @@ class MerakiModule(object):
         else:
             if 'data' in self.result:
                 try:
-                    self.result['data'] = camel_dict_to_snake_dict(self.result['data'])
+                    # self.fail_json(msg="here", converted=self.convert_camel_to_snake(self.result['data']))
+                    self.result['data'] = self.convert_camel_to_snake(self.result['data'])
                 except (KeyError, AttributeError):
                     pass
         self.module.exit_json(**self.result)

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -355,16 +355,13 @@ class MerakiModule(object):
         if self.params['output_level'] == 'debug':
             self.result['method'] = self.method
             self.result['url'] = self.url
-
         self.result.update(**kwargs)
         try:
             if os.environ['ANSIBLE_MERAKI_FORMAT'] == 'camelcase':
                 self.module.deprecate("Ansible's Meraki modules will stop supporting camel case output in Ansible 2.12. Please update your playbooks.")
-                self.result['data'] = self.result['data']
-            else:
-                self.result['data'] = self.sanitize_keys(self.result['data'])
+                # self.result['data'] = self.result['data']
         except KeyError:
-            pass
+            self.result['data'] = self.sanitize_keys(self.result['data'])
         self.module.exit_json(**self.result)
 
     def fail_json(self, msg, **kwargs):

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -43,6 +43,7 @@ def meraki_argument_spec():
                 use_proxy=dict(type='bool', default=False),
                 use_https=dict(type='bool', default=True),
                 validate_certs=dict(type='bool', default=True),
+                output_format=dict(type='str', choices=['camelcase', 'snakecase'], default='snakecase', fallback=(env_fallback, ['ANSIBLE_MERAKI_FORMAT'])),
                 output_level=dict(type='str', default='normal', choices=['normal', 'debug']),
                 timeout=dict(type='int', default=30),
                 org_name=dict(type='str', aliases=['organization']),
@@ -357,9 +358,8 @@ class MerakiModule(object):
             self.result['url'] = self.url
         self.result.update(**kwargs)
         try:
-            if os.environ['ANSIBLE_MERAKI_FORMAT'] == 'camelcase':
+            if self.params['output_format'] == 'camelcase':
                 self.module.deprecate("Ansible's Meraki modules will stop supporting camel case output in Ansible 2.12. Please update your playbooks.")
-                # self.result['data'] = self.result['data']
         except KeyError:
             self.result['data'] = self.sanitize_keys(self.result['data'])
         self.module.exit_json(**self.result)

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -32,6 +32,7 @@
 import os
 import re
 from ansible.module_utils.basic import AnsibleModule, json, env_fallback
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils._text import to_native, to_bytes, to_text
@@ -357,11 +358,13 @@ class MerakiModule(object):
             self.result['method'] = self.method
             self.result['url'] = self.url
         self.result.update(**kwargs)
-        try:
-            if self.params['output_format'] == 'camelcase':
-                self.module.deprecate("Ansible's Meraki modules will stop supporting camel case output in Ansible 2.12. Please update your playbooks.")
-        except KeyError:
-            self.result['data'] = self.sanitize_keys(self.result['data'])
+        if self.params['output_format'] == 'camelcase':
+            self.module.deprecate("Ansible's Meraki modules will stop supporting camel case output in Ansible 2.12. Please update your playbooks.")
+        else:
+            try:
+                self.result['data'] = camel_dict_to_snake_dict(self.result['data'])
+            except KeyError:
+                pass
         self.module.exit_json(**self.result)
 
     def fail_json(self, msg, **kwargs):

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -47,7 +47,6 @@ def meraki_argument_spec():
                 timeout=dict(type='int', default=30),
                 org_name=dict(type='str', aliases=['organization']),
                 org_id=dict(type='str'),
-                output_version=dict(type='str', choices=['old', 'new'], default='new'),
                 )
 
 
@@ -138,11 +137,11 @@ class MerakiModule(object):
             items = {}
             for k, v in data.items():
                 try:
-                    new = { self.key_map[k]: data[k] }
+                    new = {self.key_map[k]: data[k]}
                     items[self.key_map[k]] = self.sanitize_keys(data[k])
                 except KeyError:
                     snake_k = re.sub('([a-z0-9])([A-Z])', r'\1_\2', k).lower()
-                    new = { snake_k: data[k] }
+                    new = {snake_k: data[k]}
                     items[snake_k] = self.sanitize_keys(data[k])
             return items
         elif isinstance(data, list):

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -358,11 +358,14 @@ class MerakiModule(object):
             self.result['url'] = self.url
 
         self.result.update(**kwargs)
-        if self.params['output_version'] == 'new':
-            try:
+        try:
+            if os.environ['ANSIBLE_MERAKI_FORMAT'] == 'camelcase':
+                self.module.deprecate("Ansible's Meraki modules will stop supporting camel case output in Ansible 2.12. Please update your playbooks.")
+                self.result['data'] = self.result['data']
+            else:
                 self.result['data'] = self.sanitize_keys(self.result['data'])
-            except KeyError:
-                pass
+        except KeyError:
+            pass
         self.module.exit_json(**self.result)
 
     def fail_json(self, msg, **kwargs):

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -193,22 +193,22 @@ data:
             returned: success
             type: str
             sample: John Doe
-        accountStatus:
+        account_status:
             description: Status of account.
             returned: success
             type: str
             sample: ok
-        twoFactorAuthEnabled:
+        two_factor_auth_enabled:
             description: Enabled state of two-factor authentication for administrator.
             returned: success
             type: bool
             sample: false
-        hasApiKey:
+        has_api_key:
             description: Defines whether administrator has an API assigned to their account.
             returned: success
             type: bool
             sample: false
-        lastActive:
+        last_active:
             description: Date and time of time the administrator was active within Dashboard.
             returned: success
             type: str
@@ -243,7 +243,7 @@ data:
                     returned: when tag permissions are set
                     type: str
                     sample: full
-        orgAccess:
+        org_access:
             description: The privilege of the dashboard administrator on the organization. Options are 'full', 'read-only', or 'none'.
             returned: success
             type: str

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -154,7 +154,7 @@ data:
         returned: success
         type: str
         sample: YourNet
-      organizationId:
+      organization_id:
         description: Organization ID which owns the network.
         returned: success
         type: str
@@ -164,7 +164,7 @@ data:
         returned: success
         type: str
         sample: " production wireless "
-      timeZone:
+      time_zone:
         description: Timezone where network resides.
         returned: success
         type: str
@@ -174,7 +174,7 @@ data:
         returned: success
         type: str
         sample: switch
-      disableMyMerakiCom:
+      disable_my_meraki_com:
         description: States whether U(my.meraki.com) and other device portals should be disabled.
         returned: success
         type: bool

--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -117,32 +117,32 @@ data:
             returned: success
             type: str
             sample: 16100
-        v2cEnabled:
+        v2c_enabled:
             description: Shows enabled state of SNMPv2c
             returned: success
             type: bool
             sample: true
-        v3Enabled:
+        v3_enabled:
             description: Shows enabled state of SNMPv3
             returned: success
             type: bool
             sample: true
-        v3AuthMode:
+        v3_auth_mode:
             description: The SNMP version 3 authentication mode either MD5 or SHA.
             returned: success
             type: str
             sample: SHA
-        v3PrivMode:
+        v3_priv_mode:
             description: The SNMP version 3 privacy mode DES or AES128.
             returned: success
             type: str
             sample: AES128
-        v2CommunityString:
+        v2_community_string:
             description: Automatically generated community string for SNMPv2c.
             returned: When SNMPv2c is enabled.
             type: str
             sample: o/8zd-JaSb
-        v3User:
+        v3_user:
             description: Automatically generated username for SNMPv3.
             returned: When SNMPv3c is enabled.
             type: str

--- a/lib/ansible/modules/network/meraki/meraki_ssid.py
+++ b/lib/ansible/modules/network/meraki/meraki_ssid.py
@@ -294,17 +294,17 @@ data:
             returned: success
             type: bool
             sample: true
-        splashPage:
+        splash_page:
             description: Splash page to show when user authenticates.
             returned: success
             type: str
             sample: Click-through splash page
-        ssidAdminAccessible:
+        ssid_admin_accessible:
             description: Whether SSID is administratively accessible.
             returned: success
             type: bool
             sample: true
-        authMode:
+        auth_mode:
             description: Authentication method.
             returned: success
             type: str
@@ -314,37 +314,37 @@ data:
             returned: success
             type: str
             sample: SecretWiFiPass
-        encryptionMode:
+        encryption_mode:
             description: Wireless traffic encryption method.
             returned: success
             type: str
             sample: wpa
-        wpaEncryptionMode:
+        wpa_encryption_mode:
             description: Enabled WPA versions.
             returned: success
             type: str
             sample: WPA2 only
-        ipAssignmentMode:
+        ip_assignment_mode:
             description: Wireless client IP assignment method.
             returned: success
             type: str
             sample: NAT mode
-        minBitrate:
+        min_bitrate:
             description: Minimum bitrate a wireless client can connect at.
             returned: success
             type: int
             sample: 11
-        bandSelection:
+        band_selection:
             description: Wireless RF frequency wireless network will be broadcast on.
             returned: success
             type: str
             sample: 5 GHz band only
-        perClientBandwidthLimitUp:
+        per_client_bandwidth_limit_up:
             description: Maximum upload bandwidth a client can use.
             returned: success
             type: int
             sample: 1000
-        perClientBandwidthLimitDown:
+        per_client_bandwidth_limit_down:
             description: Maximum download bandwidth a client can use.
             returned: success
             type: int

--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -192,7 +192,7 @@ data:
             returned: success
             type: bool
             sample: true
-        poeEnabled:
+        poe_enabled:
             description: Power Over Ethernet enabled state of port.
             returned: success
             type: bool
@@ -207,32 +207,32 @@ data:
             returned: success
             type: int
             sample: 10
-        voiceVlan:
+        voice_vlan:
             description: VLAN assigned to port with voice VLAN enabled devices.
             returned: success
             type: int
             sample: 20
-        isolationEnabled:
+        isolation_enabled:
             description: Port isolation status of port.
             returned: success
             type: bool
             sample: true
-        rstpEnabled:
+        rstp_enabled:
             description: Enabled or disabled state of Rapid Spanning Tree Protocol (RSTP)
             returned: success
             type: bool
             sample: true
-        stpGuard:
+        stp_guard:
             description: State of STP guard
             returned: success
             type: str
             sample: "Root Guard"
-        accessPolicyNumber:
+        access_policy_number:
             description: Number of assigned access policy. Only applicable to access ports.
             returned: success
             type: int
             sample: 1234
-        linkNegotiation:
+        link_negotiation:
             description: Link speed for the port.
             returned: success
             type: str

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -138,7 +138,7 @@ response:
   returned: success
   type: complex
   contains:
-    applianceIp:
+    appliance_ip:
       description: IP address of Meraki appliance in the VLAN
       returned: success
       type: str
@@ -148,7 +148,7 @@ response:
       returned: success
       type: str
       sample: upstream_dns
-    fixedIpAssignments:
+    fixed_ip_assignments:
       description: List of MAC addresses which have IP addresses assigned.
       returned: success
       type: complex
@@ -168,7 +168,7 @@ response:
               returned: success
               type: str
               sample: fixed_ip
-    reservedIpRanges:
+    reserved_ip_ranges:
       description: List of IP address ranges which are reserved for static assignment.
       returned: success
       type: complex
@@ -208,32 +208,32 @@ response:
       returned: success
       type: str
       sample: "192.0.1.0/24"
-    dhcpHandling:
+    dhcp_handling:
       description: Status of DHCP server on VLAN.
       returned: success
       type: str
       sample: Run a DHCP server
-    dhcpLeaseTime:
+    dhcp_lease_time:
       description: DHCP lease time when server is active.
       returned: success
       type: str
       sample: 1 day
-    dhcpBootOptionsEnabled:
+    dhcp_boot_options_enabled:
       description: Whether DHCP boot options are enabled.
       returned: success
       type: bool
       sample: no
-    dhcpBootNextServer:
+    dhcp_boot_next_server:
       description: DHCP boot option to direct boot clients to the server to load the boot file from.
       returned: success
       type: str
       sample: 192.0.1.2
-    dhcpBootFilename:
+    dhcp_boot_filename:
       description: Filename for boot file.
       returned: success
       type: str
       sample: boot.txt
-    dhcpOptions:
+    dhcp_options:
       description: DHCP options.
       returned: success
       type: complex

--- a/lib/ansible/plugins/doc_fragments/meraki.py
+++ b/lib/ansible/plugins/doc_fragments/meraki.py
@@ -10,7 +10,7 @@ class ModuleDocFragment(object):
 notes:
 - More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
 - Some of the options are likely only used for developers within Meraki.
-- As of Ansible 2.9, the Meraki modules output snake case keys in return data. If you need to retain camel case, set the C(ANSIBLE_MERAKI_FORMAT) environment variable to C(camelcase).
+- As of Ansible 2.9, Meraki modules output keys as snake case. To use camel case, set the C(ANSIBLE_MERAKI_FORMAT) environment variable to C(camelcase).
 - Ansible's Meraki modules will stop supporting camel case output in Ansible 2.13. Please update your playbooks.
 options:
     auth_key:

--- a/lib/ansible/plugins/doc_fragments/meraki.py
+++ b/lib/ansible/plugins/doc_fragments/meraki.py
@@ -34,6 +34,12 @@ options:
         - Only useful for internal Meraki developers.
         type: bool
         default: yes
+    output_format:
+        description:
+        - Instructs module whether response keys should be snake case (ex. C(net_id)) or camel case (ex. C(netId)).
+        type: str
+        choices: [snakecase, camelcase]
+        default: snakecase
     output_level:
         description:
         - Set amount of debug output during module execution.

--- a/lib/ansible/plugins/doc_fragments/meraki.py
+++ b/lib/ansible/plugins/doc_fragments/meraki.py
@@ -10,6 +10,8 @@ class ModuleDocFragment(object):
 notes:
 - More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
 - Some of the options are likely only used for developers within Meraki.
+- As of Ansible 2.9, the Meraki modules output snake case keys in return data. If you need to retain camel case, set the C(ANSIBLE_MERAKI_FORMAT) environment variable to C(camelcase).
+- Ansible's Meraki modules will stop supporting camel case output in Ansible 2.13. Please update your playbooks.
 options:
     auth_key:
         description:

--- a/test/integration/targets/meraki_content_filtering/tasks/main.yml
+++ b/test/integration/targets/meraki_content_filtering/tasks/main.yml
@@ -49,7 +49,7 @@
 
   - assert:
       that:
-        - single_allowed_check.data.allowedUrlPatterns | length == 1
+        - single_allowed_check.data.allowed_url_patterns | length == 1
         - single_allowed_check is changed
 
   - name: Set single allowed URL pattern
@@ -64,7 +64,7 @@
 
   - assert:
       that:
-        - single_allowed.data.allowedUrlPatterns | length == 1
+        - single_allowed.data.allowed_url_patterns | length == 1
 
   - name: Set single allowed URL pattern for idempotency with check mode
     meraki_content_filtering:
@@ -83,6 +83,7 @@
   - assert:
       that:
         - single_allowed_idempotent_check is not changed
+        - single_allowed.data.allowed_url_patterns | length == 1
 
   - name: Set single allowed URL pattern for idempotency
     meraki_content_filtering:
@@ -117,7 +118,7 @@
 
   - assert:
       that:
-        - single_blocked.data.blockedUrlPatterns | length == 1
+        - single_blocked.data.blocked_url_patterns | length == 1
 
   - name: Set two allowed URL pattern
     meraki_content_filtering:
@@ -136,7 +137,7 @@
   - assert:
       that:
         - two_allowed.changed == True
-        - two_allowed.data.allowedUrlPatterns | length == 2
+        - two_allowed.data.allowed_url_patterns | length == 2
 
   - name: Set blocked URL category
     meraki_content_filtering:
@@ -155,8 +156,8 @@
   - assert:
       that:
         - blocked_category.changed == True
-        - blocked_category.data.blockedUrlCategories | length == 1
-        - blocked_category.data.urlCategoryListSize == "fullList"
+        - blocked_category.data.blocked_url_categories | length == 1
+        - blocked_category.data.url_category_list_size == "fullList"
 
   - name: Set blocked URL category with top sites
     meraki_content_filtering:
@@ -175,8 +176,8 @@
   - assert:
       that:
         - blocked_category.changed == True
-        - blocked_category.data.blockedUrlCategories | length == 1
-        - blocked_category.data.urlCategoryListSize == "topSites"
+        - blocked_category.data.blocked_url_categories | length == 1
+        - blocked_category.data.url_category_list_size == "topSites"
 
   always:
     - name: Reset policies

--- a/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -81,7 +81,7 @@
   - assert:
       that:
         - create_one.data|length == 2
-        - create_one.data.0.destCidr == '192.0.1.1/32'
+        - create_one.data.0.dest_cidr == '192.0.1.1/32'
         - create_one.data.0.protocol == 'tcp'
         - create_one.data.0.policy == 'deny'
         - create_one.changed == True
@@ -165,7 +165,7 @@
 
   - assert:
       that:
-        - query.data.1.syslogEnabled == True
+        - query.data.1.syslog_enabled == True
         - default_syslog.changed == True
 
   - name: Disable syslog for default rule
@@ -207,7 +207,7 @@
 
   - assert:
       that:
-        - query.data.1.syslogEnabled == False
+        - query.data.1.syslog_enabled == False
         - disable_syslog.changed == True
 
   always:

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -300,8 +300,8 @@
     assert:
       that:
         - create_net_combined.data.type == 'combined'
-        - create_net_combined.data.disableMyMerakiCom == True
-        - enable_meraki_com.data.disableMyMerakiCom == False
+        - create_net_combined.data.disable_my_meraki_com == True
+        - enable_meraki_com.data.disable_my_meraki_com == False
         - '"org_name or org_id parameters are required" in create_net_no_org.msg'
         - '"IntTestNetworkAppliance" in create_net_appliance_no_tz.data.name'
         - create_net_appliance_no_tz.changed == True

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -198,7 +198,7 @@
 
   - assert:
       that:
-        - disable_remote_status.data.disableRemoteStatusPage == False
+        - disable_remote_status.data.disable_remote_status_page == False
 
   - name: Disable remote status page
     meraki_network:
@@ -215,7 +215,7 @@
 
   - assert:
       that:
-        - enable_remote_status.data.disableRemoteStatusPage == True
+        - enable_remote_status.data.disable_remote_status_page == True
 
   - name: Test status pages are mutually exclusive when on
     meraki_network:
@@ -308,7 +308,7 @@
         - '"IntTestNetworkSwitch" in create_net_switch.data.name'
         - '"IntTestNetworkSwitchOrgID" in create_net_switch_org_id.data.name'
         - '"IntTestNetworkWireless" in create_net_wireless.data.name'
-        - create_net_wireless.data.disableMyMerakiCom == True
+        - create_net_wireless.data.disable_my_meraki_com == True
         - create_net_wireless_idempotent.changed == False
         - create_net_wireless_idempotent.data is defined
         - '"first_tag" in create_net_tag.data.tags'

--- a/test/integration/targets/meraki_snmp/tasks/main.yml
+++ b/test/integration/targets/meraki_snmp/tasks/main.yml
@@ -33,8 +33,8 @@
 
 - assert:
     that:
-      - snmp_v2_enable.data.v2CommunityString is defined
-      - snmp_v2_enable.data.v2cEnabled == true
+      - snmp_v2_enable.data.v2_community_string is defined
+      - snmp_v2_enable.data.v2c_enabled == true
 
 - name: Disable SNMPv2c
   meraki_snmp:
@@ -47,8 +47,8 @@
 
 - assert:
     that:
-      - snmp_v2_disable.data.v2CommunityString is not defined
-      - snmp_v2_disable.data.v2cEnabled == False
+      - snmp_v2_disable.data.v2_community_string is not defined
+      - snmp_v2_disable.data.v2c_enabled == False
 
 - name: Enable SNMPv2c with org_id
   meraki_snmp:
@@ -64,8 +64,8 @@
 
 - assert:
     that:
-      - snmp_v2_enable_id.data.v2CommunityString is defined
-      - snmp_v2_enable_id.data.v2cEnabled == true
+      - snmp_v2_enable_id.data.v2_community_string is defined
+      - snmp_v2_enable_id.data.v2c_enabled == true
 
 - name: Disable SNMPv2c with org_id
   meraki_snmp:
@@ -78,8 +78,8 @@
 
 - assert:
     that:
-      - snmp_v2_disable_id.data.v2CommunityString is not defined
-      - snmp_v2_disable_id.data.v2cEnabled == False
+      - snmp_v2_disable_id.data.v2_community_string is not defined
+      - snmp_v2_disable_id.data.v2c_enabled == False
 
 - name: Enable SNMPv3
   meraki_snmp:
@@ -96,7 +96,7 @@
 
 - assert:
     that:
-      - snmp_v3_enable.data.v3Enabled == True
+      - snmp_v3_enable.data.v3_enabled == True
       - snmp_v3_enable.changed == True
 
 - name: Check for idempotency
@@ -139,7 +139,7 @@
 
 - assert:
     that:
-      - peers.data.peerIps is defined
+      - peers.data.peer_ips is defined
 
 - name: Add invalid peer IPs
   meraki_snmp:

--- a/test/integration/targets/meraki_ssid/tasks/main.yml
+++ b/test/integration/targets/meraki_ssid/tasks/main.yml
@@ -229,9 +229,9 @@
 
   - assert:
       that:
-        - psk.data.authMode == 'psk'
-        - psk.data.encryptionMode == 'wpa'
-        - psk.data.wpaEncryptionMode == 'WPA2 only'
+        - psk.data.auth_mode == 'psk'
+        - psk.data.encryption_mode == 'wpa'
+        - psk.data.wpa_encryption_mode == 'WPA2 only'
 
   - name: Set PSK with idempotency
     meraki_ssid:
@@ -269,7 +269,7 @@
 
   - assert:
       that:
-        - splash_click.data.splashPage == 'Click-through splash page'
+        - splash_click.data.splash_page == 'Click-through splash page'
 
   - name: Configure RADIUS servers
     meraki_ssid:
@@ -291,7 +291,7 @@
 
   - assert:
       that:
-        - set_radius_server.data.radiusServers.0.host == '192.0.1.200'
+        - set_radius_server.data.radius_servers.0.host == '192.0.1.200'
 
   - name: Configure RADIUS servers with idempotency
     meraki_ssid:

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -194,7 +194,7 @@
 
 - assert:
     that:
-      - update_port_vvlan.data.voiceVlan == 11
+      - update_port_vvlan.data.voice_vlan == 11
       - update_port_vvlan.changed == True
 
 - name: Check access port for idempotenty
@@ -242,7 +242,7 @@
     that:
       - update_trunk.data.tags == 'server'
       - update_trunk.data.type == 'trunk'
-      - update_trunk.data.allowedVlans == 'all'
+      - update_trunk.data.allowed_vlans == 'all'
 
 - name: Configure trunk port with specific VLANs
   meraki_switchport:
@@ -269,7 +269,7 @@
     that:
       - update_trunk.data.tags == 'server'
       - update_trunk.data.type == 'trunk'
-      - update_trunk.data.allowedVlans == '8,10,15,20'
+      - update_trunk.data.allowed_vlans == '8,10,15,20'
 
 - name: Configure trunk port with specific VLANs and native VLAN
   meraki_switchport:
@@ -296,7 +296,7 @@
     that:
       - update_trunk.data.tags == 'server'
       - update_trunk.data.type == 'trunk'
-      - update_trunk.data.allowedVlans == '2,10,15,20'
+      - update_trunk.data.allowed_vlans == '2,10,15,20'
 
 - name: Check for idempotency on trunk port
   meraki_switchport:

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -20,7 +20,7 @@
     register: invalid_domain
     ignore_errors: yes
     
-  - name: Disable HTTP
+  - name: Disable HTTPS
     meraki_vlan:
       auth_key: '{{ auth_key }}'
       use_https: false
@@ -111,6 +111,7 @@
       that:
         - create_vlan.data.id == 2
         - create_vlan.changed == True
+        - create_vlan.data.networkId is defined
 
   - name: Update VLAN with check mode
     meraki_vlan:
@@ -266,8 +267,8 @@
   - assert:
       that:
         - update_vlan_add_ip.changed == True
-        - update_vlan_add_ip.data.fixedIpAssignments | length == 2
-        - update_vlan_add_ip.data.reservedIpRanges | length == 2
+        - update_vlan_add_ip.data.fixed_ip_assignments | length == 2
+        - update_vlan_add_ip.data.reserved_ip_ranges | length == 2
 
   - name: Remove IP assignments and reserved IP ranges
     meraki_vlan:

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -101,6 +101,8 @@
       appliance_ip: 192.168.250.1
     delegate_to: localhost
     register: create_vlan
+    environment:
+      ANSIBLE_MERAKI_FORMAT: camelcase
 
   - debug:
       msg: '{{create_vlan}}'
@@ -167,7 +169,7 @@
 
   - assert:
       that:
-        - update_vlan.data.applianceIp == '192.168.250.2'
+        - update_vlan.data.appliance_ip == '192.168.250.2'
         - update_vlan.changed == True
 
   - name: Update VLAN with idempotency and check mode
@@ -295,8 +297,8 @@
   - assert:
       that:
         - update_vlan_remove_ip.changed == True
-        - update_vlan_remove_ip.data.fixedIpAssignments | length == 1
-        - update_vlan_remove_ip.data.reservedIpRanges | length == 1
+        - update_vlan_remove_ip.data.fixed_ip_assignments | length == 1
+        - update_vlan_remove_ip.data.reserved_ip_ranges | length == 1
 
   - name: Update VLAN with idempotency
     meraki_vlan:
@@ -355,7 +357,7 @@
 
   - assert:
       that:
-        - '"1.1.1.1" in update_vlan_dns_list.data.dnsNameservers'
+        - '"1.1.1.1" in update_vlan_dns_list.data.dns_nameservers'
         - update_vlan_dns_list.changed == True
 
   - name: Query all VLANs in network


### PR DESCRIPTION
##### SUMMARY
Current Meraki modules respond with camelCase and not Ansible's snake_case format. This proposal is one option of how to fix this.

- `output_version` parameter dictates the response key case
- `new is snake_case, `old` is camelCase
- If `new`, conversion is done at the end of module execution
- This is purely a proposal and not a final draft

I am hoping this can be integrated in Ansible 2.9. This would mean the parameter would be in operation until Ansible 2.12 for a 4 year change schedule. Currently this PR defaults to `new` so it would break existing playbooks which use the keys. However, it could easily be changed to `old` for the 2.9 release.

@felixfontein I'm mrproper from IRC. This is what we were discussing earlier. I thought of this idea and wanted to get your feedback on it. I am open to doing an `update()` on `data` to add both camelCase and snake_case keys, but that would be a lot of duplicate data and verbose. I'm not saying this is the best option either, but wanted to put the idea out there.

Fixes #53598

### Integration Tests Updated
- [x] meraki_network
- [x] meraki_organization
- [x] meraki_ssid
- [x] meraki_admin
- [x] meraki_config_template
- [x] meraki_device
- [x] meraki_switchport
- [x] meraki_mr_l3_firewall
- [x] meraki_mx_l3_firewall
- [x] meraki_content_filtering
- [x] meraki_snmp
- [x] meraki_syslog
- [x] meraki_vlan

### Documentation Updated
- [x] meraki_network
- [x] meraki_organization
- [x] meraki_ssid
- [x] meraki_admin
- [x] meraki_config_template
- [x] meraki_device
- [x] meraki_switchport
- [x] meraki_mr_l3_firewall
- [x] meraki_mx_l3_firewall
- [x] meraki_content_filtering
- [x] meraki_snmp
- [x] meraki_syslog
- [x] meraki_vlan


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meraki
