### PR TITLE
docker_swarm inventory plugin - new attribute with parsed node URI

### DIFF
--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -205,7 +205,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     if self.node_attrs['ManagerStatus'].get('Leader'):
                         # This is workaround of bug in Docker when in some cases the Leader IP is 0.0.0.0
                         # Check moby/moby#35437 for details
-                        swarm_leader_ip = parse_address(self.node_attrs['ManagerStatus']['Addr'])[0] or "0.0.0.0"
+                        swarm_leader_ip = parse_address(self.node_attrs['ManagerStatus']['Addr'])[0] or \
+                                          self.node_attrs['Status']['Addr']
                         if self.get_option('include_host_uri', True):
                             self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host_uri', "tcp://" +
                                                         swarm_leader_ip + ":" + host_uri_port)

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -65,7 +65,7 @@ DOCUMENTATION = '''
             default: no
         include_host_uri_port:
             description: Override the detected port number included in I(ansible_host_uri)
-            type: str
+            type: int
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -56,7 +56,7 @@ DOCUMENTATION = '''
         tls_hostname:
             description: When verifying the authenticity of the Docker Host server, provide the expected name of the server.
             type: str
-        host_uri:
+        include_host_uri:
             description: Toggle to return the additional attribute I(ansible_host_uri) which contains the URI of the
                          swarm leader in format of M(tcp://172.16.0.1:2376). This value may be used without additional
                          modification as value of option I(docker_host) in Docker Swarm modules when connecting via API.
@@ -184,7 +184,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 self.inventory.add_host(self.node_attrs['ID'])
                 self.inventory.add_host(self.node_attrs['ID'], group=self.node_attrs['Spec']['Role'])
                 self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host', self.node_attrs['Status']['Addr'])
-                if self.get_option('host_uri', True):
+                if self.get_option('include_host_uri', True):
                     self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host_uri',
                                                 "tcp://" + self.node_attrs['Status']['Addr'] + ":2376")
                 if self.get_option('verbose_output', True):
@@ -193,7 +193,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     if self.node_attrs['ManagerStatus'].get('Leader'):
                         # This is workaround of bug in Docker when in some cases the Leader IP is 0.0.0.0
                         # Check moby/moby#35437 for details
-                        if self.get_option('host_uri', True):
+                        if self.get_option('include_host_uri', True):
                             self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host_uri', "tcp://" +
                                                         parse_address(self.node_attrs['ManagerStatus']['Addr'])[0] +
                                                         ":2376")

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -135,7 +135,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def _get_tls_connect_params(self):
         if self.get_option('tls') and self.get_option('cert_path') and self.get_option('key_path'):
             # TLS with certs and no host verification
-            tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'), self.get_option('key_path')),
+            tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'),
+                                                           self.get_option('key_path')),
                                               verify=False)
             return tls_config
 
@@ -147,12 +148,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         if self.get_option('tls_verify') and self.get_option('cert_path') and self.get_option('key_path'):
             # TLS with certs and host verification
             if self.get_option('cacert_path'):
-                tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'), self.get_option('key_path')),
+                tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'),
+                                                               self.get_option('key_path')),
                                                   ca_cert=self.get_option('cacert_path'),
                                                   verify=True,
                                                   assert_hostname=self.get_option('tls_hostname'))
             else:
-                tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'), self.get_option('key_path')),
+                tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'),
+                                                               self.get_option('key_path')),
                                                   verify=True,
                                                   assert_hostname=self.get_option('tls_hostname'))
 
@@ -175,7 +178,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         return None
 
     def _populate(self):
-        self.client = docker.DockerClient(base_url=self.get_option('host'), tls=self._get_tls_connect_params())
+        self.client = docker.DockerClient(base_url=self.get_option('host'),
+                                          tls=self._get_tls_connect_params())
         self.inventory.add_group('all')
         self.inventory.add_group('manager')
         self.inventory.add_group('worker')
@@ -195,7 +199,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 self.node_attrs = self.client.nodes.get(self.node.id).attrs
                 self.inventory.add_host(self.node_attrs['ID'])
                 self.inventory.add_host(self.node_attrs['ID'], group=self.node_attrs['Spec']['Role'])
-                self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host', self.node_attrs['Status']['Addr'])
+                self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host',
+                                            self.node_attrs['Status']['Addr'])
                 if self.get_option('include_host_uri', True):
                     self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host_uri',
                                                 "tcp://" + self.node_attrs['Status']['Addr'] + ":" + host_uri_port)
@@ -206,7 +211,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                         # This is workaround of bug in Docker when in some cases the Leader IP is 0.0.0.0
                         # Check moby/moby#35437 for details
                         swarm_leader_ip = parse_address(self.node_attrs['ManagerStatus']['Addr'])[0] or \
-                                          self.node_attrs['Status']['Addr']
+                            self.node_attrs['Status']['Addr']
                         if self.get_option('include_host_uri', True):
                             self.inventory.set_variable(self.node_attrs['ID'], 'ansible_host_uri', "tcp://" +
                                                         swarm_leader_ip + ":" + host_uri_port)
@@ -215,13 +220,23 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 # Use constructed if applicable
                 strict = self.get_option('strict')
                 # Composed variables
-                self._set_composite_vars(self.get_option('compose'), self.node_attrs, self.node_attrs['ID'], strict=strict)
+                self._set_composite_vars(self.get_option('compose'),
+                                         self.node_attrs,
+                                         self.node_attrs['ID'],
+                                         strict=strict)
                 # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
-                self._add_host_to_composed_groups(self.get_option('groups'), self.node_attrs, self.node_attrs['ID'], strict=strict)
+                self._add_host_to_composed_groups(self.get_option('groups'),
+                                                  self.node_attrs,
+                                                  self.node_attrs['ID'],
+                                                  strict=strict)
                 # Create groups based on variable values and add the corresponding hosts to it
-                self._add_host_to_keyed_groups(self.get_option('keyed_groups'), self.node_attrs, self.node_attrs['ID'], strict=strict)
+                self._add_host_to_keyed_groups(self.get_option('keyed_groups'),
+                                               self.node_attrs,
+                                               self.node_attrs['ID'],
+                                               strict=strict)
         except Exception as e:
-            raise AnsibleError('Unable to fetch hosts from Docker swarm API, this was the original exception: %s' % to_native(e))
+            raise AnsibleError('Unable to fetch hosts from Docker swarm API, this was the original exception: %s' %
+                               to_native(e))
 
     def verify_file(self, path):
         """Return the possibly of a file being consumable by this plugin."""
@@ -231,7 +246,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_DOCKER:
-            raise AnsibleError('The Docker swarm dynamic inventory plugin requires the Docker SDK for Python: https://github.com/docker/docker-py.')
+            raise AnsibleError('The Docker swarm dynamic inventory plugin requires the Docker SDK for Python: '
+                               'https://github.com/docker/docker-py.')
         super(InventoryModule, self).parse(inventory, loader, path, cache)
         self._read_config_data(path)
         self._populate()


### PR DESCRIPTION
##### SUMMARY
New attribute for each inventory entry containing the parsed node URI ready to use as value of `docker_host` option in docker swarm modules

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_swarm

##### ADDITIONAL INFORMATION
If the Ansible module for Docker Swarm family uses API to connect to docker host instead of SSH and local socket on that host, it is required to provide the URI of the docker host module has to connect to as `docker_host` option. The `ansible_host` attribute assigned to each inventory entry contains only the IP address.

To make the playbook developers life a little easier I propose to add new attribute `ansible_docker_uri` with full URI that can easily be provided in playbooks. As a result, it won't be required for the playbook developers to modify the `ansible_host` value in many cases.

Example of such usage below. The playbook runs the `docker_node_facts` locally and using the `leader` group connects to the swarm leader to read the facts about the node. Another use case might be the playbook performing an operation on every node with the role of the `manager`.

```
- name: Inspect leader node
  hosts: leader
  connection: local
  gather_facts: no

    - name: Get leader node facts
      docker_node_facts:
        self: yes
        docker_host: "{{ ansible_host_uri }}"
        tls: true

```

NOTE: The returned value is in the form of `tcp://<IP Address>:2376`. The port is static now but it may be provided as a parameter or set to `2376` or `2375` depending if TLS is in use running the inventory plugin

NOTE: It covers #53893 so needs to be rebased later