### PR TITLE
Fix missing internal options when running module directly

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -764,6 +764,7 @@ class AnsibleModule(object):
         self._legal_inputs = []
         self._options_context = list()
         self._tmpdir = None
+        self._remote_tmp = None
 
         if add_file_common_args:
             for k, v in FILE_COMMON_ARGUMENTS.items():
@@ -848,8 +849,9 @@ class AnsibleModule(object):
         if self._tmpdir is None:
             basedir = None
 
-            basedir = os.path.expanduser(os.path.expandvars(self._remote_tmp))
-            if not os.path.exists(basedir):
+            if self._remote_tmp is not None:
+                basedir = os.path.expanduser(os.path.expandvars(self._remote_tmp))
+            if basedir is not None and not os.path.exists(basedir):
                 try:
                     os.makedirs(basedir, mode=0o700)
                 except (OSError, IOError) as e:
@@ -871,7 +873,7 @@ class AnsibleModule(object):
                     msg="Failed to create remote module tmp path at dir %s "
                         "with prefix %s: %s" % (basedir, basefile, to_native(e))
                 )
-            if not self._keep_remote_files:
+            if not getattr(self, '_keep_remote_files', None):
                 atexit.register(shutil.rmtree, tmpdir)
             self._tmpdir = tmpdir
 

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -58,6 +58,11 @@ class TestAnsibleModuleTmpDir:
             False,
             os.path.join(os.environ['HOME'], ".test/ansible-moduletmp-42-")
         ),
+        (
+            {},
+            False,
+            '/tmp/ansible-moduletmp-42-'
+        ),
     )
 
     # pylint bug: https://github.com/PyCQA/pylint/issues/511
@@ -67,6 +72,8 @@ class TestAnsibleModuleTmpDir:
         makedirs = {'called': False}
 
         def mock_mkdtemp(prefix, dir):
+            if dir is None:
+                return os.path.join(os.path.join('/tmp', prefix))
             return os.path.join(dir, prefix)
 
         def mock_makedirs(path, mode):
@@ -90,7 +97,7 @@ class TestAnsibleModuleTmpDir:
         # verify subsequent calls always produces the same tmpdir
         assert am.tmpdir == actual_tmpdir
 
-        if not stat_exists:
+        if am._remote_tmp and not stat_exists:
             assert makedirs['called']
             expected = os.path.expanduser(os.path.expandvars(am._remote_tmp))
             assert makedirs['path'] == expected


### PR DESCRIPTION
##### SUMMARY

Fixes #53872

When running modules directly, .e.g., `python mymodule.py args.json`, the default attributes for internal options are not set on the module object. This results in an `AttributeError` in the rare cases where modules are run directly and those attributes are requested. 

Add unit tests for scenario with no default internal options.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/basic.py`

##### ADDITIONAL INFORMATION

This is a minimally invasive fix. A complete fix would require the default values for all internal options to be populated when the module is executed directly and not via the action plugin. That will require a larger refactor allowing default values for internal options to exist in `modue_utils` so that config and the module can both access them. Since this is for development and testing purposes only, the larger refactor may not be worth it.

Related to #53875.