### PR TITLE
modules: elb_target_group_facts: added targets_health_description

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
@@ -34,7 +34,7 @@ options:
     required: false
   collect_targets_health:
     description:
-      - When set to "yes", output contains targets health list 
+      - When set to "yes", output contains targets health list
     required: false
     default: no
     type: bool
@@ -158,9 +158,9 @@ target_groups:
             type: dict
             sample: "[
                 {
-                    'HealthCheckPort': '80', 
+                    'HealthCheckPort': '80',
                     'Target': {
-                        'Id': 'i-0123456', 
+                        'Id': 'i-0123456',
                         'Port': 80
                     },
                     'TargetHealth': {

--- a/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
@@ -154,21 +154,40 @@ target_groups:
             type: str
             sample: "arn:aws:elasticloadbalancing:ap-southeast-2:01234567890:targetgroup/mytargetgroup/aabbccddee0044332211"
         targets_health_description:
-            description: The targets health of the target group.
+            description: Targets health description.
             returned: when collect_targets_health is enabled
-            type: dict
-            sample: "[
-                {
-                    'health_check_port': '80',
-                    'target': {
-                        'id': 'i-0123456789',
-                        'port': 80
-                    },
-                    'target_health': {
-                        'state': 'healthy'
-                    }
-                }
-            ]"
+            type: complex
+            contains:
+                health_check_port:
+                    description: The port to check target health.
+                    returned: always
+                    type: string
+                    sample: '80'
+                target:
+                    description: The target metadata.
+                    returned: always
+                    type: complex
+                    contains:
+                        id:
+                            description: The ID of the target.
+                            returned: always
+                            type: string
+                            sample: i-0123456789
+                        port:
+                            description: The port to use to connect with the target.
+                            returned: always
+                            type: int
+                            sample: 80
+                target_health:
+                    description: The target health status.
+                    returned: always
+                    type: complex
+                    contains:
+                        state:
+                            description: The state of the target health.
+                            returned: always
+                            type: string
+                            sample: healthy
         target_group_name:
             description: The name of the target group.
             returned: always

--- a/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
@@ -34,7 +34,7 @@ options:
     required: false
   collect_targets_health:
     description:
-      - When set to "yes", output contains targets health list
+      - When set to "yes", output contains targets health description
     required: false
     default: no
     type: bool
@@ -159,13 +159,13 @@ target_groups:
             type: dict
             sample: "[
                 {
-                    'HealthCheckPort': '80',
-                    'Target': {
-                        'Id': 'i-0123456',
-                        'Port': 80
+                    'health_check_port': '80',
+                    'target': {
+                        'id': 'i-0123456789',
+                        'port': 80
                     },
-                    'TargetHealth': {
-                        'State': 'healthy'
+                    'target_health': {
+                        'state': 'healthy'
                     }
                 }
             ]"

--- a/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
@@ -38,6 +38,7 @@ options:
     required: false
     default: no
     type: bool
+    version_added: 2.8
 
 extends_documentation_fragment:
     - aws


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've added possibility of targets health collecting. If **collect_targets_health** parameter is 'true', when each target_group dict in output contains **targets_health_description** list.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elb_target_group_facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example of modules output with **collect_targets_health: yes**
```
...
                "target_type": "instance", 
                "targets_health_description": [
                    {
                        "health_check_port": "80", 
                        "target": {
                            "id": "i-1234567890", 
                            "port": 80
                        }, 
                        "target_health": {
                            "state": "healthy"
                        }
                    }, 
                    {
                        "health_check_port": "80", 
                        "target": {
                            "id": "i-0987654321", 
                            "port": 80
                        }, 
                        "target_health": {
                            "state": "healthy"
                        }
                    }
                ], 
                "unhealthy_threshold_count": 2, 
...
```
