### PR TITLE
inventory plugins: authors -> author in metadata

### DIFF
--- a/lib/ansible/plugins/inventory/hcloud.py
+++ b/lib/ansible/plugins/inventory/hcloud.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
     name: hcloud
     plugin_type: inventory
-    authors:
+    author:
       - Lukas Kaemmerling (@lkaemmerling)
     short_description: Ansible dynamic inventory plugin for the Hetzner Cloud.
     version_added: "2.8"

--- a/lib/ansible/plugins/inventory/linode.py
+++ b/lib/ansible/plugins/inventory/linode.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
     name: linode
     plugin_type: inventory
-    authors:
+    author:
       - Luke Murphy (@lwm)
     short_description: Ansible dynamic inventory plugin for Linode.
     version_added: "2.8"


### PR DESCRIPTION
##### SUMMARY
The field is called `author`, not `authors`. This causes ansibot to ignore it and not to notify authors (if they aren't somehow listed as maintainers in BOTMETA). Fix for the third inventory plugin which does this is integrated in #53893.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/hcloud.py
lib/ansible/plugins/inventory/linode.py
