### PR TITLE
docker modules: default config path is $HOME/.docker/config.json, not $HOME/docker/config.json

### DIFF
--- a/lib/ansible/plugins/doc_fragments/docker.py
+++ b/lib/ansible/plugins/doc_fragments/docker.py
@@ -99,7 +99,7 @@ notes:
   - When connecting to Docker daemon with TLS, you might need to install additional Python packages.
     For the Docker SDK for Python, version 2.4 or newer, this can be done by installing C(docker[tls]) with M(pip).
   - Note that the Docker SDK for Python only allows to specify the path to the Docker configuration for very few functions.
-    In general, it will use C($HOME/docker/config.json) if the C(DOCKER_CONFIG) environment variable is not specified,
+    In general, it will use C($HOME/.docker/config.json) if the C(DOCKER_CONFIG) environment variable is not specified,
     and use C($DOCKER_CONFIG/config.json) otherwise.
 '''
 


### PR DESCRIPTION
##### SUMMARY
See https://github.com/docker/docker-py/blob/master/docker/utils/config.py#L7

(Browsing the git history also shows that this was probably always the case.)

Thanks to @pmossakx for reporting #53857.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/doc_fragments/docker.py
