### PR TITLE
docker_image: allow proxy config

### DIFF
--- a/changelogs/fragments/53905-docker_image-proxy-config.yml
+++ b/changelogs/fragments/53905-docker_image-proxy-config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_image - add option ``build.use_proxy_config`` to pass proxy config from the docker client configuration to the container while building."

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -811,10 +811,10 @@ def main():
     ]
 
     def detect_build_cache_from(client):
-        return bool(client.params['build'] and client.params['build']['cache_from'] is not None)
+        return client.params['build'] and client.params['build']['cache_from'] is not None
 
     def detect_build_network(client):
-        return bool(client.params['build'] and client.params['build']['network'] is not None)
+        return client.params['build'] and client.params['build']['network'] is not None
 
     option_minimal_versions = dict()
     option_minimal_versions["build.cache_from"] = dict(docker_py_version='2.1.0', docker_api_version='1.25', detect_usage=detect_build_cache_from)

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -721,6 +721,10 @@ class ImageManager(DockerBaseClass):
             params['network_mode'] = self.network
         if self.use_config_proxy:
             params['use_config_proxy'] = self.use_config_proxy
+            # Due to a bug in docker-py, it will crash if
+            # use_config_proxy is True and buildargs is None
+            if 'buildargs' not in params:
+                params['buildargs'] = {}
 
         for line in self.client.build(**params):
             # line = json.loads(line)


### PR DESCRIPTION
##### SUMMARY
When building a docker image with `docker_image`, allows to use the proxy config specified in the client config. Fixes #53857.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
docker_image
