### PR TITLE
docker: improve TLS config

### DIFF
--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -357,25 +357,6 @@ class AnsibleDockerClient(Client):
         if auth['tls'] or auth['tls_verify']:
             auth['docker_host'] = auth['docker_host'].replace('tcp://', 'https://')
 
-        if auth['tls'] and auth['cert_path'] and auth['key_path']:
-            # TLS with certs and no host verification
-            tls_config = self._get_tls_config(client_cert=(auth['cert_path'], auth['key_path']),
-                                              verify=False,
-                                              ssl_version=auth['ssl_version'])
-            return dict(base_url=auth['docker_host'],
-                        tls=tls_config,
-                        version=auth['api_version'],
-                        timeout=auth['timeout'])
-
-        if auth['tls']:
-            # TLS with no certs and not host verification
-            tls_config = self._get_tls_config(verify=False,
-                                              ssl_version=auth['ssl_version'])
-            return dict(base_url=auth['docker_host'],
-                        tls=tls_config,
-                        version=auth['api_version'],
-                        timeout=auth['timeout'])
-
         if auth['tls_verify'] and auth['cert_path'] and auth['key_path']:
             # TLS with certs and host verification
             if auth['cacert_path']:
@@ -415,6 +396,26 @@ class AnsibleDockerClient(Client):
                         tls=tls_config,
                         version=auth['api_version'],
                         timeout=auth['timeout'])
+
+        if auth['tls'] and auth['cert_path'] and auth['key_path']:
+            # TLS with certs and no host verification
+            tls_config = self._get_tls_config(client_cert=(auth['cert_path'], auth['key_path']),
+                                              verify=False,
+                                              ssl_version=auth['ssl_version'])
+            return dict(base_url=auth['docker_host'],
+                        tls=tls_config,
+                        version=auth['api_version'],
+                        timeout=auth['timeout'])
+
+        if auth['tls']:
+            # TLS with no certs and not host verification
+            tls_config = self._get_tls_config(verify=False,
+                                              ssl_version=auth['ssl_version'])
+            return dict(base_url=auth['docker_host'],
+                        tls=tls_config,
+                        version=auth['api_version'],
+                        timeout=auth['timeout'])
+
         # No TLS
         return dict(base_url=auth['docker_host'],
                     version=auth['api_version'],

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -93,9 +93,7 @@ DOCKER_COMMON_ARGS = dict(
     debug=dict(type='bool', default=False)
 )
 
-DOCKER_MUTUALLY_EXCLUSIVE = [
-    ['tls', 'tls_verify']
-]
+DOCKER_MUTUALLY_EXCLUSIVE = []
 
 DOCKER_REQUIRED_TOGETHER = [
     ['cert_path', 'key_path']

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -187,17 +187,17 @@ def get_connect_params(auth, fail_function):
         # TLS with certs and host verification
         if auth['cacert_path']:
             tls_config = _get_tls_config(client_cert=(auth['cert_path'], auth['key_path']),
-                                       ca_cert=auth['cacert_path'],
-                                       verify=True,
-                                       assert_hostname=auth['tls_hostname'],
-                                       ssl_version=auth['ssl_version'],
-                                       fail_function=fail_function)
+                                         ca_cert=auth['cacert_path'],
+                                         verify=True,
+                                         assert_hostname=auth['tls_hostname'],
+                                         ssl_version=auth['ssl_version'],
+                                         fail_function=fail_function)
         else:
             tls_config = _get_tls_config(client_cert=(auth['cert_path'], auth['key_path']),
-                                       verify=True,
-                                       assert_hostname=auth['tls_hostname'],
-                                       ssl_version=auth['ssl_version'],
-                                       fail_function=fail_function)
+                                         verify=True,
+                                         assert_hostname=auth['tls_hostname'],
+                                         ssl_version=auth['ssl_version'],
+                                         fail_function=fail_function)
 
         return dict(base_url=auth['docker_host'],
                     tls=tls_config,
@@ -207,10 +207,10 @@ def get_connect_params(auth, fail_function):
     if auth['tls_verify'] and auth['cacert_path']:
         # TLS with cacert only
         tls_config = _get_tls_config(ca_cert=auth['cacert_path'],
-                                   assert_hostname=auth['tls_hostname'],
-                                   verify=True,
-                                   ssl_version=auth['ssl_version'],
-                                   fail_function=fail_function)
+                                     assert_hostname=auth['tls_hostname'],
+                                     verify=True,
+                                     ssl_version=auth['ssl_version'],
+                                     fail_function=fail_function)
         return dict(base_url=auth['docker_host'],
                     tls=tls_config,
                     version=auth['api_version'],
@@ -219,9 +219,9 @@ def get_connect_params(auth, fail_function):
     if auth['tls_verify']:
         # TLS with verify and no certs
         tls_config = _get_tls_config(verify=True,
-                                   assert_hostname=auth['tls_hostname'],
-                                   ssl_version=auth['ssl_version'],
-                                   fail_function=fail_function)
+                                     assert_hostname=auth['tls_hostname'],
+                                     ssl_version=auth['ssl_version'],
+                                     fail_function=fail_function)
         return dict(base_url=auth['docker_host'],
                     tls=tls_config,
                     version=auth['api_version'],
@@ -230,9 +230,9 @@ def get_connect_params(auth, fail_function):
     if auth['tls'] and auth['cert_path'] and auth['key_path']:
         # TLS with certs and no host verification
         tls_config = _get_tls_config(client_cert=(auth['cert_path'], auth['key_path']),
-                                   verify=False,
-                                   ssl_version=auth['ssl_version'],
-                                   fail_function=fail_function)
+                                     verify=False,
+                                     ssl_version=auth['ssl_version'],
+                                     fail_function=fail_function)
         return dict(base_url=auth['docker_host'],
                     tls=tls_config,
                     version=auth['api_version'],
@@ -241,8 +241,8 @@ def get_connect_params(auth, fail_function):
     if auth['tls']:
         # TLS with no certs and not host verification
         tls_config = _get_tls_config(verify=False,
-                                   ssl_version=auth['ssl_version'],
-                                   fail_function=fail_function)
+                                     ssl_version=auth['ssl_version'],
+                                     fail_function=fail_function)
         return dict(base_url=auth['docker_host'],
                     tls=tls_config,
                     version=auth['api_version'],

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -931,7 +931,8 @@ from ansible.module_utils.docker.common import (
     compare_generic,
     is_image_name_id,
     sanitize_result,
-    parse_healthcheck
+    parse_healthcheck,
+    DOCKER_COMMON_ARGS,
 )
 from ansible.module_utils.six import string_types
 
@@ -2642,13 +2643,11 @@ def detect_ipvX_address_usage(client):
 
 class AnsibleDockerClientContainer(AnsibleDockerClient):
     # A list of module options which are not docker container properties
-    __NON_CONTAINER_PROPERTY_OPTIONS = (
-        'docker_host', 'tls_hostname', 'api_version', 'timeout', 'cacert_path', 'cert_path',
-        'key_path', 'ssl_version', 'tls', 'tls_verify', 'debug', 'env_file', 'force_kill',
-        'keep_volumes', 'ignore_image', 'name', 'pull', 'purge_networks', 'recreate',
-        'restart', 'state', 'trust_image_content', 'networks', 'cleanup', 'kill_signal',
+    __NON_CONTAINER_PROPERTY_OPTIONS = tuple([
+        'env_file', 'force_kill', 'keep_volumes', 'ignore_image', 'name', 'pull', 'purge_networks',
+        'recreate', 'restart', 'state', 'trust_image_content', 'networks', 'cleanup', 'kill_signal',
         'output_logs', 'paused'
-    )
+    ] + list(DOCKER_COMMON_ARGS.keys()))
 
     def _parse_comparisons(self):
         comparisons = {}

--- a/lib/ansible/plugins/doc_fragments/docker.py
+++ b/lib/ansible/plugins/doc_fragments/docker.py
@@ -71,8 +71,8 @@ options:
         type: str
     tls:
         description:
-            -  Secure the connection to the API by using TLS without verifying the authenticity of the Docker host
-               server.
+            - Secure the connection to the API by using TLS without verifying the authenticity of the Docker host
+              server. Note that if C(tls_verify) is set to C(yes) as well, it will take precedence.
             - If the value is not specified in the task, the value of environment variable C(DOCKER_TLS) will be used
               instead. If the environment variable is not set, the default value will be used.
         type: bool

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
             type: str
             required: true
             choices: docker_swarm
-        host:
+        docker_host:
             description:
                 - Socket of a Docker swarm manager node (tcp,unix).
                 - "Use C(unix://var/run/docker.sock) to connect via local socket."
@@ -88,20 +88,20 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # Minimal example using local docker
 plugin: docker_swarm
-host: unix://var/run/docker.sock
+docker_host: unix://var/run/docker.sock
 
 # Minimal example using remote docker
 plugin: docker_swarm
-host: tcp://my-docker-host:2375
+docker_host: tcp://my-docker-host:2375
 
 # Example using remote docker with unverified TLS
 plugin: docker_swarm
-host: tcp://my-docker-host:2376
+docker_host: tcp://my-docker-host:2376
 tls: yes
 
 # Example using remote docker with verified TLS and client certificate verification
 plugin: docker_swarm
-host: tcp://my-docker-host:2376
+docker_host: tcp://my-docker-host:2376
 tls_verify: yes
 cacert_path: /somewhere/ca.pem
 key_path: /somewhere/key.pem
@@ -109,7 +109,7 @@ cert_path: /somewhere/cert.pem
 
 # Example using constructed features to create groups and set ansible_host
 plugin: docker_swarm
-host: tcp://my-docker-host:2375
+docker_host: tcp://my-docker-host:2375
 strict: False
 keyed_groups:
   # add e.g. x86_64 hosts to an arch_x86_64 group

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -167,7 +167,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 raise AnsibleError('Argument to timeout function must be an integer')
         update_tls_hostname(raw_params)
         connect_params = get_connect_params(raw_params, fail_function=self._fail)
-        self.client = docker.DockerClient(**get_connect_params)
+        self.client = docker.DockerClient(**connect_params)
         self.inventory.add_group('all')
         self.inventory.add_group('manager')
         self.inventory.add_group('worker')

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -110,6 +110,7 @@ keyed_groups:
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
+from ansible.module_utils.docker.common import update_tls_hostname, get_connect_params
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.parsing.utils.addresses import parse_address
 
@@ -125,60 +126,26 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     NAME = 'docker_swarm'
 
-    def _get_tls_config(self, **kwargs):
-        try:
-            tls_config = docker.tls.TLSConfig(**kwargs)
-            return tls_config
-        except Exception as e:
-            raise AnsibleError('Unable to setup TLS, this was the original exception: %s' % to_native(e))
-
-    def _get_tls_connect_params(self):
-        if self.get_option('tls_verify') and self.get_option('cert_path') and self.get_option('key_path'):
-            # TLS with certs and host verification
-            if self.get_option('cacert_path'):
-                tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'),
-                                                               self.get_option('key_path')),
-                                                  ca_cert=self.get_option('cacert_path'),
-                                                  verify=True,
-                                                  assert_hostname=self.get_option('tls_hostname'))
-            else:
-                tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'),
-                                                               self.get_option('key_path')),
-                                                  verify=True,
-                                                  assert_hostname=self.get_option('tls_hostname'))
-
-            return tls_config
-
-        if self.get_option('tls_verify') and self.get_option('cacert_path'):
-            # TLS with cacert only
-            tls_config = self._get_tls_config(ca_cert=self.get_option('cacert_path'),
-                                              assert_hostname=self.get_option('tls_hostname'),
-                                              verify=True)
-            return tls_config
-
-        if self.get_option('tls_verify'):
-            # TLS with verify and no certs
-            tls_config = self._get_tls_config(verify=True,
-                                              assert_hostname=self.get_option('tls_hostname'))
-            return tls_config
-
-        if self.get_option('tls') and self.get_option('cert_path') and self.get_option('key_path'):
-            # TLS with certs and no host verification
-            tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'), self.get_option('key_path')),
-                                              verify=False)
-            return tls_config
-
-        if self.get_option('tls'):
-            # TLS with no certs and not host verification
-            tls_config = self._get_tls_config(verify=False)
-            return tls_config
-
-        # No TLS
-        return None
+    def _fail(self, msg):
+        raise AnsibleError(msg)
 
     def _populate(self):
-        self.client = docker.DockerClient(base_url=self.get_option('host'),
-                                          tls=self._get_tls_connect_params())
+        raw_params = dict(
+            docker_host=self.get_option('docker_host'),
+            tls=self.get_option('tls'),
+            tls_verify=self.get_option('tls_verify'),
+            key_path=self.get_option('key_path'),
+            cacert_path=self.get_option('cacert_path'),
+            cert_path=self.get_option('cert_path'),
+            tls_hostname=self.get_option('tls_hostname'),
+            api_version=None,
+            timeout=None,
+            ssl_version=None,
+            debug=None,
+        )
+        update_tls_hostname(raw_params)
+        connect_params = get_connect_params(raw_params, fail_function=self._fail)
+        self.client = docker.DockerClient(**get_connect_params)
         self.inventory.add_group('all')
         self.inventory.add_group('manager')
         self.inventory.add_group('worker')

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -133,18 +133,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             raise AnsibleError('Unable to setup TLS, this was the original exception: %s' % to_native(e))
 
     def _get_tls_connect_params(self):
-        if self.get_option('tls') and self.get_option('cert_path') and self.get_option('key_path'):
-            # TLS with certs and no host verification
-            tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'),
-                                                           self.get_option('key_path')),
-                                              verify=False)
-            return tls_config
-
-        if self.get_option('tls'):
-            # TLS with no certs and not host verification
-            tls_config = self._get_tls_config(verify=False)
-            return tls_config
-
         if self.get_option('tls_verify') and self.get_option('cert_path') and self.get_option('key_path'):
             # TLS with certs and host verification
             if self.get_option('cacert_path'):
@@ -172,6 +160,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             # TLS with verify and no certs
             tls_config = self._get_tls_config(verify=True,
                                               assert_hostname=self.get_option('tls_hostname'))
+            return tls_config
+
+        if self.get_option('tls') and self.get_option('cert_path') and self.get_option('key_path'):
+            # TLS with certs and no host verification
+            tls_config = self._get_tls_config(client_cert=(self.get_option('cert_path'), self.get_option('key_path')),
+                                              verify=False)
+            return tls_config
+
+        if self.get_option('tls'):
+            # TLS with no certs and not host verification
+            tls_config = self._get_tls_config(verify=False)
             return tls_config
 
         # No TLS


### PR DESCRIPTION
##### SUMMARY
This PR does several things:
 - unify TLS setup for inventory plugin and docker modules (not done yet)
 - make `tls` and `tls_verify` options no longer mutually exclusive, and let `tls_verify` (host verification) take precedence over `tls` (no host verification) in case both are set to `yes`.

This also fixes #15614 and makes #51271 no longer necessary.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker/common.py
lib/ansible/plugins/doc_fragments/docker.py
lib/ansible/plugins/inventory/docker_swarm.py
