### PR TITLE
Terraform, a set of some small fixes, using absolute/relative path, and complex variable types

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -260,7 +260,7 @@ def convertPythonVarValueToTerraformVarCommandlineParameter(varValue):
     elif(isinstance(varValue, dict)):
         varstring = ""
         i = 0
-        for k, v in varValue.items().sort():
+        for k, v in varValue.items():
             varstring = varstring + k + " = " + formatSimpleValue(v)
             if i < (len(varValue) - 1):
                 varstring = varstring + ", "

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -250,7 +250,6 @@ def convertOsLookupPath(path, project_path):
 def convertPythonVarValueToTerraformVarCommandlineParameter(varValue):
     if(isinstance(varValue, list)):
         varstring = ""
-        listVars = []
         for index, val in enumerate(varValue):
             varstring = varstring + formatSimpleValue(val)
 
@@ -261,7 +260,7 @@ def convertPythonVarValueToTerraformVarCommandlineParameter(varValue):
     elif(isinstance(varValue, dict)):
         varstring = ""
         i = 0
-        for k, v in varValue.items():
+        for k, v in varValue.items().sort():
             varstring = varstring + k + " = " + formatSimpleValue(v)
             if i < (len(varValue) - 1):
                 varstring = varstring + ", "

--- a/test/units/modules/cloud/misc/test_terraform.py
+++ b/test/units/modules/cloud/misc/test_terraform.py
@@ -20,7 +20,6 @@ def test_terraform_without_argument(capfd):
     assert 'project_path' in json.loads(out)['msg']
 
 
-
 @pytest.fixture
 def project_path():
     return "terraform_modules/module_tc_0_0_no_config"

--- a/test/units/modules/cloud/misc/test_terraform.py
+++ b/test/units/modules/cloud/misc/test_terraform.py
@@ -18,3 +18,31 @@ def test_terraform_without_argument(capfd):
     assert not err
     assert json.loads(out)['failed']
     assert 'project_path' in json.loads(out)['msg']
+
+@pytest.fixture
+def project_path():
+    return "terraform_modules/module_tc_0_0_no_config"
+
+
+testdataPath = [
+    ("/tmp/testplan.tfpalan","/tmp/testplan.tfpalan"),
+    ("testplan.tfpalan","terraform_modules/module_tc_0_0_no_config/testplan.tfpalan"),
+
+]
+@pytest.mark.parametrize("path,expectedOsCheckPath", testdataPath)
+def test_file_path_handling(project_path, path, expectedOsCheckPath):
+    assert expectedOsCheckPath == convertOsLookupPath(path, project_path)
+
+
+testdata = [
+    ("1",'"1"'),
+    (1,'"1"'),
+    ([1],'["1"]'),
+    ([1,2,3],'["1","2","3"]'),
+    (["1","2","3"],'["1","2","3"]'),
+    ({'content': 'myExample' },'{ content = "myExample" }'),
+    ({'content': 'myExample', 'target_name': '/tmp/test.txt' },'{ content = "myExample", target_name = "/tmp/test.txt" }')
+]
+@pytest.mark.parametrize("varValue,expected", testdata)
+def test_convert_vars_to_commandline_structure(varValue, expected):
+    assert expected == convertPythonVarValueToTerraformVarCommandlineParameter(varValue)

--- a/test/units/modules/cloud/misc/test_terraform.py
+++ b/test/units/modules/cloud/misc/test_terraform.py
@@ -19,30 +19,32 @@ def test_terraform_without_argument(capfd):
     assert json.loads(out)['failed']
     assert 'project_path' in json.loads(out)['msg']
 
+
+
 @pytest.fixture
 def project_path():
     return "terraform_modules/module_tc_0_0_no_config"
 
 
 testdataPath = [
-    ("/tmp/testplan.tfpalan","/tmp/testplan.tfpalan"),
-    ("testplan.tfpalan","terraform_modules/module_tc_0_0_no_config/testplan.tfpalan"),
+    ("/tmp/testplan.tfpalan", "/tmp/testplan.tfpalan"),
+    ("testplan.tfpalan", "terraform_modules/module_tc_0_0_no_config/testplan.tfpalan"),
 
 ]
 @pytest.mark.parametrize("path,expectedOsCheckPath", testdataPath)
 def test_file_path_handling(project_path, path, expectedOsCheckPath):
-    assert expectedOsCheckPath == convertOsLookupPath(path, project_path)
+    assert expectedOsCheckPath == terraform.convertOsLookupPath(path, project_path)
 
 
 testdata = [
-    ("1",'"1"'),
-    (1,'"1"'),
-    ([1],'["1"]'),
-    ([1,2,3],'["1","2","3"]'),
-    (["1","2","3"],'["1","2","3"]'),
-    ({'content': 'myExample' },'{ content = "myExample" }'),
-    ({'content': 'myExample', 'target_name': '/tmp/test.txt' },'{ content = "myExample", target_name = "/tmp/test.txt" }')
+    ("1", '"1"'),
+    (1, '"1"'),
+    ([1], '["1"]'),
+    ([1, 2, 3], '["1","2","3"]'),
+    (["1", "2", "3"], '["1","2","3"]'),
+    ({'content': 'myExample'}, '{ content = "myExample" }'),
+    ({'content': 'myExample', 'target_name': '/tmp/test.txt'}, '{ content = "myExample", target_name = "/tmp/test.txt" }')
 ]
 @pytest.mark.parametrize("varValue,expected", testdata)
 def test_convert_vars_to_commandline_structure(varValue, expected):
-    assert expected == convertPythonVarValueToTerraformVarCommandlineParameter(varValue)
+    assert expected == terraform.convertPythonVarValueToTerraformVarCommandlineParameter(varValue)


### PR DESCRIPTION
##### SUMMARY

Handle the Location of the generated Local Terraform State and Plan Files, used the [Ansible Terraform Module](https://docs.ansible.com/ansible/latest/modules/terraform_module.html).

At the moment the Module has problems with absolut and relative path, when you use the ```state_file``` or ```plan_file``` option. A better handling will Fixes #43405 and #43407.

Another fix is, handling complex variable types like list or map, see #51687, here was the problem, that the variables need a double quotes, now the source is not nice but runs.

Add a one more example for Fixes #49115

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform 

##### ADDITIONAL INFORMATION

You find a example for reproduce the different Issues at [nolte/ansible-terraform-example](https://github.com/nolte/ansible-terraform-example).

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

