### PR TITLE
docker_image: stop pulling by default on build

### DIFF
--- a/changelogs/fragments/53911-docker_image-build-pull-default.yml
+++ b/changelogs/fragments/53911-docker_image-build-pull-default.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_image - the default for ``build.pull`` will change from ``yes`` to ``no`` in Ansible 2.12. Please update your playbooks/roles now."

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -21,6 +21,7 @@
         TEST1: val1
         TEST2: val2
         TEST3: "True"
+      pull: no
     source: build
   register: buildargs_1
 
@@ -33,6 +34,7 @@
         TEST1: val1
         TEST2: val2
         TEST3: "True"
+      pull: no
     source: build
   register: buildargs_2
 
@@ -65,6 +67,7 @@
       path: "{{ role_path }}/files"
       container_limits:
         memory: 4000
+      pull: no
     source: build
   ignore_errors: yes
   register: container_limits_1
@@ -77,6 +80,7 @@
       container_limits:
         memory: 5000000
         memswap: 7000000
+      pull: no
     source: build
   register: container_limits_2
 
@@ -107,6 +111,7 @@
     build:
       path: "{{ role_path }}/files"
       dockerfile: "MyDockerfile"
+      pull: no
     source: build
   register: dockerfile_1
 
@@ -136,6 +141,7 @@
     name: "{{ iname }}"
     build:
       path: "{{ role_path }}/files"
+      pull: no
     repository: "{{ registry_address }}/test/{{ iname }}"
     source: build
   register: repository_1
@@ -145,6 +151,7 @@
     name: "{{ iname }}"
     build:
       path: "{{ role_path }}/files"
+      pull: no
     repository: "{{ registry_address }}/test/{{ iname }}"
     source: build
   register: repository_2
@@ -178,6 +185,7 @@
     name: "{{ iname }}"
     build:
       path: "{{ role_path }}/files"
+      pull: no
     source: build
 
 - name: force (changed)
@@ -186,6 +194,7 @@
     build:
       path: "{{ role_path }}/files"
       dockerfile: "MyDockerfile"
+      pull: no
     source: build
     force_source: yes
   register: force_1
@@ -196,6 +205,7 @@
     build:
       path: "{{ role_path }}/files"
       dockerfile: "MyDockerfile"
+      pull: no
     source: build
     force_source: yes
   register: force_2
@@ -257,6 +267,7 @@
     name: "{{ iname }}"
     build:
       path: "{{ role_path }}/files"
+      pull: no
     source: build
   register: path_1
 
@@ -265,6 +276,7 @@
     name: "{{ iname }}"
     build:
        path: "{{ role_path }}/files"
+      pull: no
     source: build
   register: path_2
 

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -275,7 +275,7 @@
   docker_image:
     name: "{{ iname }}"
     build:
-       path: "{{ role_path }}/files"
+      path: "{{ role_path }}/files"
       pull: no
     source: build
   register: path_2


### PR DESCRIPTION
##### SUMMARY
When building an image with `docker_image`, by default the `FROM` image is pulled. This is contrary to the default option for both `docker build` on CLI, and the Docker SDK for Python. This PR removes the default, prints a warning when the value is not explicitly specified

Fixes #49909.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
docker_image
