### PR TITLE
aws_ecs_taskdefinition: doc fix

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -154,7 +154,7 @@ EXAMPLES = '''
       - containerPort: 8080
         hostPort:      8080
       cpu: 512
-      memory: 1GB
+      memory: 1024
     state: present
 
 - name: Create task definition
@@ -169,7 +169,7 @@ EXAMPLES = '''
         hostPort:      8080
     launch_type: FARGATE
     cpu: 512
-    memory: 1GB
+    memory: 1024
     state: present
     network_mode: awsvpc
 '''


### PR DESCRIPTION
##### SUMMARY
Some of the examples for creating an ECS task definition fail because the memory value is given as 1GB, but the module attempts to cast this as an int.   In the container definition changing 1GB to 1024 fixes the problem.

The error thrown, although it's quite buried in a lot of other text:
```
ValueError: invalid literal for int() with base 10: '1GB'
```

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ecs_taskdefinition

##### ADDITIONAL INFORMATION
Using the following original example (memory: 1GB):
```
- name: Create task definition
  ecs_taskdefinition:
    family: nginx
    containers:
    - name: nginx
      essential: true
      image: "nginx"
      portMappings:
      - containerPort: 8080
        hostPort:      8080
      cpu: 512
      memory: 1GB
    state: present
```

```
TASK [aws_ecs_cluster : Create task definition] ************************************************************************
fatal: [frontend.ansible]: FAILED! => {"changed": false, "module_stderr": "/Users/dougb/.ansible/tmp/ansible-tmp-1552816797.9780369-216541469603074/AnsiballZ_ecs_taskdefinition.py:17: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\nTraceback (most recent call last):\n  File \"/Users/dougb/.ansible/tmp/ansible-tmp-1552816797.9780369-216541469603074/AnsiballZ_ecs_taskdefinition.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/Users/dougb/.ansible/tmp/ansible-tmp-1552816797.9780369-216541469603074/AnsiballZ_ecs_taskdefinition.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/dougb/.ansible/tmp/ansible-tmp-1552816797.9780369-216541469603074/AnsiballZ_ecs_taskdefinition.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/imp.py\", line 169, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 630, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/var/folders/7w/lnj27mtd4238ll_r_7wx4gb80000gn/T/ansible_ecs_taskdefinition_payload_rn4p5z5c/__main__.py\", line 494, in <module>\n  File \"/var/folders/7w/lnj27mtd4238ll_r_7wx4gb80000gn/T/ansible_ecs_taskdefinition_payload_rn4p5z5c/__main__.py\", line 462, in main\n  File \"/var/folders/7w/lnj27mtd4238ll_r_7wx4gb80000gn/T/ansible_ecs_taskdefinition_payload_rn4p5z5c/__main__.py\", line 216, in register_task\nValueError: invalid literal for int() with base 10: '1GB'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP *************************************************************************************************************
frontend.ansible           : ok=9    changed=0    unreachable=0    failed=1   
```
after changing 1GB to 1024, this runs ok:
```
TASK [aws_ecs_cluster : Create task definition] ************************************************************************
changed: [frontend.ansible]

PLAY RECAP *************************************************************************************************************
frontend.ansible           : ok=10   changed=1    unreachable=0    failed=0
```

Ansible version:
```
$ ansible --version
ansible 2.7.8
  config file = None
  configured module search path = ['/Users/dougb/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dougb/.virtualenvs/ansible/lib/python3.7/site-packages/ansible
  executable location = /Users/dougb/.virtualenvs/ansible/bin/ansible
  python version = 3.7.2 (default, Feb 12 2019, 08:16:38) [Clang 10.0.0 (clang-1000.11.45.5)]
```