### PR TITLE
puppet module is not using debug/summarize/verbose parameters in server-mode

### DIFF
--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -252,50 +252,39 @@ def main():
             cmd += " --server %s" % pipes.quote(p['puppetmaster'])
         if p['show_diff']:
             cmd += " --show_diff"
-        if p['environment']:
-            cmd += " --environment '%s'" % p['environment']
-        if p['tags']:
-            cmd += " --tags '%s'" % ','.join(p['tags'])
-        if p['certname']:
-            cmd += " --certname='%s'" % p['certname']
-        if module.check_mode:
-            cmd += " --noop"
-        elif 'noop' in p:
-            if p['noop']:
-                cmd += " --noop"
-            else:
-                cmd += " --no-noop"
     else:
         cmd = "%s apply --detailed-exitcodes " % base_cmd
-        if p['logdest'] == 'syslog':
-            cmd += "--logdest syslog "
-        if p['logdest'] == 'all':
-            cmd += " --logdest syslog --logdest stdout"
         if p['modulepath']:
-            cmd += "--modulepath='%s'" % p['modulepath']
-        if p['environment']:
-            cmd += "--environment '%s' " % p['environment']
-        if p['certname']:
-            cmd += " --certname='%s'" % p['certname']
-        if p['tags']:
-            cmd += " --tags '%s'" % ','.join(p['tags'])
-        if module.check_mode:
-            cmd += "--noop "
-        elif 'noop' in p:
-            if p['noop']:
-                cmd += " --noop"
-            else:
-                cmd += " --no-noop"
+            cmd += " --modulepath='%s'" % p['modulepath']
         if p['execute']:
             cmd += " --execute '%s'" % p['execute']
         else:
             cmd += pipes.quote(p['manifest'])
         if p['summarize']:
             cmd += " --summarize"
-        if p['debug']:
-            cmd += " --debug"
-        if p['verbose']:
-            cmd += " --verbose"
+
+    if p['certname']:
+        cmd += " --certname='%s'" % p['certname']
+    if p['logdest'] == 'syslog':
+        cmd += " --logdest syslog"
+    if p['logdest'] == 'all':
+        cmd += " --logdest syslog --logdest stdout"
+    if p['tags']:
+        cmd += " --tags '%s'" % ','.join(p['tags'])
+    if p['environment']:
+        cmd += " --environment '%s' " % p['environment']
+    if module.check_mode:
+        cmd += " --noop"
+    elif 'noop' in p:
+        if p['noop']:
+            cmd += " --noop"
+        else:
+            cmd += " --no-noop"
+    if p['debug']:
+        cmd += " --debug"
+    if p['verbose']:
+        cmd += " --verbose"
+
     rc, stdout, stderr = module.run_command(cmd)
 
     if rc == 0:


### PR DESCRIPTION
##### SUMMARY
tried to enable the --debug and --summarize options of puppet via ansible, but even if the docs tell me this is supported, the resulting puppet-cli-call didnt had the --debug/--summarize options set.

##### ISSUE TYPE
- Bug Report

##### COMPONENT NAME
system/puppet

##### ANSIBLE VERSION
2.7+

##### CONFIGURATION
-

##### OS / ENVIRONMENT
-

##### STEPS TO REPRODUCE
- name: puppet
  puppet:
    puppetmaster: "{{pa_master_fqdn}}"
    debug: true
    summarize: true
 
##### EXPECTED RESULTS
puppet is executed with --debug --summarize

##### ACTUAL RESULTS
puppet is executed without --debug --summarize

I took a look into the code and it seems the options are only used if puppet-module is called with execute/manifest parameter. I will try to fix this myself and submit a suitable patch.
