### PR TITLE
fix issue in random_mac filter with short prefixes 

### DIFF
--- a/changelogs/fragments/random_mac-random-int-fix.yaml
+++ b/changelogs/fragments/random_mac-random-int-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - random_mac - generate a proper MAC address when the provided vendor prefix is two or four characters (https://github.com/ansible/ansible/issues/50838)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -36,7 +36,7 @@ import yaml
 
 import datetime
 from functools import partial
-from random import Random, SystemRandom, shuffle, random
+from random import Random, SystemRandom, shuffle, randint
 
 from jinja2.filters import environmentfilter, do_groupby as _do_groupby
 
@@ -555,8 +555,8 @@ def random_mac(value):
     if len(err):
         raise AnsibleFilterError('Invalid value (%s) for random_mac: %s' % (value, err))
 
-    # Generate random float and make it int
-    v = int(random() * 10.0**10)
+    # Generate random int between x10000000 and xFFFFFFFFFF
+    v = randint(68719476736,1099511627775)
     # Select first n chars to complement input prefix
     remain = 2 * (6 - len(mac_items))
     rnd = ('%x' % v)[:remain]

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -555,7 +555,7 @@ def random_mac(value):
     if len(err):
         raise AnsibleFilterError('Invalid value (%s) for random_mac: %s' % (value, err))
 
-    # Generate random int between x10000000 and xFFFFFFFFFF
+    # Generate random int between x1000000000 and xFFFFFFFFFF
     v = randint(68719476736, 1099511627775)
     # Select first n chars to complement input prefix
     remain = 2 * (6 - len(mac_items))

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -556,7 +556,7 @@ def random_mac(value):
         raise AnsibleFilterError('Invalid value (%s) for random_mac: %s' % (value, err))
 
     # Generate random int between x10000000 and xFFFFFFFFFF
-    v = randint(68719476736,1099511627775)
+    v = randint(68719476736, 1099511627775)
     # Select first n chars to complement input prefix
     remain = 2 * (6 - len(mac_items))
     rnd = ('%x' % v)[:remain]

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -235,7 +235,11 @@
 - name:  Verify random_mac filter
   assert:
     that:
+            - "'00' | random_mac is match('^00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
+            - "'00:00' | random_mac is match('^00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"  
             - "'00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
+            - "'00:00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
+            - "'00:00:00:00:00' | random_mac is match('^00:00:00:00:00:[a-f0-9][a-f0-9]$')"  
             - "'00:00:00' | random_mac != '00:00:00' | random_mac"
 
 - name: Verify that union can be chained


### PR DESCRIPTION
##### SUMMARY
Fixes #50838 and add unit tests for random_mac filter

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
component =lib/ansible/plugins/filter/core.py

##### ADDITIONAL INFORMATION
This fix enables the use of MAC prefixes like "AB" and "AB:CD" as parameters of random_mac filter. Previously the use of short prefixes can give invalid MAC addresses. Please note that real MAC prefixes have a length of 3 segments "AB:CD:EF". However shorter or longer prefixes should not result in invalid addresses.
