### PR TITLE
Fix wrong `date_size` skip logic in s3_sync module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -436,7 +436,7 @@ def filter_list(s3, bucket, s3filelist, strategy):
                 entry['whytime'] = '{0} / {1}'.format(local_modified_epoch, remote_modified_epoch)
                 entry['whysize'] = '{0} / {1}'.format(local_size, remote_size)
 
-                if local_modified_epoch <= remote_modified_epoch or local_size == remote_size:
+                if local_modified_epoch <= remote_modified_epoch and local_size == remote_size:
                     entry['skip_flag'] = True
             else:
                 entry['why'] = "no s3_head"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

While the documentation of s3_sync claims setting file_change_strategy as `date_size` will upload if file sizes don't match or if local file modified date is newer than s3's version but the implementation doesn't look like that.
In the current implementation, the file which is the same size as s3's version won't be uploaded even if the local file has a newer modified epoch than s3's one.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- s3_sync

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

n/a
