### PR TITLE
helper: raise Exception when ds is not dict type

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -102,7 +102,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
     task_list = []
     for task_ds in ds:
         if not isinstance(task_ds, dict):
-            AnsibleAssertionError('The ds (%s) should be a dict but was a %s' % (ds, type(ds)))
+            raise AnsibleAssertionError('The ds (%s) should be a dict but was a %s' % (ds, type(ds)))
 
         if 'block' in task_ds:
             t = Block.load(

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -97,6 +97,11 @@ class TestLoadListOfTasks(unittest.TestCase, MixinForMocks):
         self.assertRaises(AssertionError, helpers.load_list_of_tasks,
                           ds, self.mock_play, block=None, role=None, task_include=None, use_handlers=False, variable_manager=None, loader=None)
 
+    def test_ds_not_dict(self):
+        ds = [[]]
+        self.assertRaises(AssertionError, helpers.load_list_of_tasks,
+                          ds, self.mock_play, block=None, role=None, task_include=None, use_handlers=False, variable_manager=None, loader=None)
+
     def test_empty_task(self):
         ds = [{}]
         self.assertRaisesRegexp(errors.AnsibleParserError,


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/helpers.py
