### PR TITLE
BIGIP: multiple_module changes

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_apm_policy_import.py
+++ b/lib/ansible/modules/network/f5/bigip_apm_policy_import.py
@@ -23,10 +23,12 @@ options:
   name:
     description:
       - The name of the APM policy or APM access profile to create or override.
+    type: str
     required: True
   type:
     description:
       - Specifies the type of item to export from device.
+    type: str
     choices:
       - profile_access
       - access_policy
@@ -120,12 +122,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import upload_file
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
@@ -133,12 +132,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import upload_file
     from ansible.module_utils.network.f5.icontrol import tmos_version
     from ansible.module_utils.network.f5.icontrol import module_provisioned
@@ -218,7 +214,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
 
@@ -397,16 +393,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_asm_policy_fetch.py
+++ b/lib/ansible/modules/network/f5/bigip_asm_policy_fetch.py
@@ -23,6 +23,7 @@ options:
   name:
     description:
       - The name of the policy exported to create a file on the remote device for downloading.
+    type: str
     required: True
   dest:
     description:
@@ -33,6 +34,7 @@ options:
     description:
       - The name of the file to be create on the remote device for downloading.
       - When C(binary) is set to C(no) the ASM policy will be in XML format.
+    type: str
   inline:
     description:
       - If C(yes), the ASM policy will be exported C(inline) as a string instead of a file.
@@ -61,6 +63,7 @@ options:
   partition:
     description:
       - Device partition which contains ASM policy to export.
+    type: str
     default: Common
 extends_documentation_fragment: f5
 author:
@@ -177,11 +180,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.icontrol import download_file
     from library.module_utils.network.f5.icontrol import module_provisioned
@@ -189,11 +189,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.icontrol import download_file
     from ansible.module_utils.network.f5.icontrol import module_provisioned
@@ -353,7 +350,7 @@ class ReportableChanges(Changes):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
 
@@ -679,16 +676,12 @@ def main():
         mutually_exclusive=spec.mutually_exclusive,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_asm_policy_signature_set.py
+++ b/lib/ansible/modules/network/f5/bigip_asm_policy_signature_set.py
@@ -80,10 +80,12 @@ options:
       - When C(XPath Injection Signatures), configures signatures targeting attacks that attempt to gain access
         to data structures or bypass permissions when a web site uses user-supplied information
         to construct XPath queries for XML data.
+    type: str
     required: True
   policy_name:
     description:
       - Specifies the name of an existing ASM policy to add or remove signature sets.
+    type: str
     required: True
   alarm:
     description:
@@ -107,6 +109,7 @@ options:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
+    type: str
     default: present
     choices:
       - present
@@ -114,6 +117,7 @@ options:
   partition:
     description:
       - This parameter is only used when identifying ASM policy.
+    type: str
     default: Common
 notes:
   - This module is primarily used as a component of configuring ASM policy in Ansible Galaxy ASM Policy Role.
@@ -180,12 +184,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
@@ -193,12 +194,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.icontrol import tmos_version
     from ansible.module_utils.network.f5.icontrol import module_provisioned
@@ -415,7 +413,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params, client=self.client)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -711,16 +709,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_apm_policy_fetch.py
+++ b/test/units/modules/network/f5/test_bigip_apm_policy_fetch.py
@@ -70,9 +70,11 @@ class TestParameters(unittest.TestCase):
             dest='/tmp/',
             force='yes',
             file='foo_export',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         )
         p = ModuleParameters(params=args)
         assert p.file == 'foo_export'
@@ -102,9 +104,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             file='foo_export',
             dest='/tmp/',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_apm_policy_import.py
+++ b/test/units/modules/network/f5/test_bigip_apm_policy_import.py
@@ -103,9 +103,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             source=self.policy,
             type='access_policy',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            ),
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_appsvcs_extension.py
+++ b/test/units/modules/network/f5/test_bigip_appsvcs_extension.py
@@ -85,14 +85,17 @@ class TestManager(unittest.TestCase):
     def test_create(self, *args):
         set_module_args(dict(
             content='{ "foo": "bar" }',
-            server='localhost',
-            user='admin',
-            password='password'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_asm_policy_fetch.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy_fetch.py
@@ -72,10 +72,7 @@ class TestParameters(unittest.TestCase):
             base64='yes',
             dest='/tmp/foo.xml',
             force='yes',
-            file='foo.xml',
-            password='password',
-            server='localhost',
-            user='admin'
+            file='foo.xml'
         )
         p = ModuleParameters(params=args)
         assert p.inline is True
@@ -108,9 +105,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             file='foobar.xml',
             dest='/tmp/foobar.xml',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_asm_policy_import.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy_import.py
@@ -101,14 +101,17 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='fake_policy',
             source=self.policy,
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive,
         )
 
         # Override methods to force specific logic in the module to happen

--- a/test/units/modules/network/f5/test_bigip_asm_policy_manage.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy_manage.py
@@ -112,9 +112,11 @@ class TestManager(unittest.TestCase):
             template='OWA Exchange 2007 (https)',
             state='present',
             active='yes',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
@@ -149,9 +151,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             state='present',
             active='yes',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
@@ -186,9 +190,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             state='present',
             active='yes',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
@@ -219,9 +225,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             state='present',
             active='yes',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_active.json'))
@@ -248,10 +256,12 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='fake_policy',
             state='present',
-            server='localhost',
-            password='password',
-            user='admin',
-            active='no'
+            active='no',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_active.json'))
@@ -280,10 +290,12 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='fake_policy',
             state='present',
-            server='localhost',
-            password='password',
-            user='admin',
-            active='no'
+            active='no',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
@@ -311,9 +323,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             template='LotusDomino 6.5 (http)',
             state='present',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
@@ -346,9 +360,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='fake_policy',
             state='present',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
@@ -382,9 +398,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='fake_policy',
             state='absent',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -411,9 +429,11 @@ class TestManager(unittest.TestCase):
             name='fake_policy',
             state='present',
             active='yes',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
@@ -444,9 +464,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='fake_policy',
             state='present',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -474,9 +496,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='fake_policy',
             state='absent',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_asm_policy_server_technology.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy_server_technology.py
@@ -99,9 +99,11 @@ class TestManager(unittest.TestCase):
             policy_name='fake_policy',
             state='present',
             name='IIS',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            ),
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_asm_policy_signature_set.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy_signature_set.py
@@ -126,9 +126,11 @@ class TestManager(unittest.TestCase):
             alarm='yes',
             block='no',
             learn='yes',
-            server='localhost',
-            password='password',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

bigip_apm_policy_fetch.py
bigip_apm_policy_import.py
bigip_appsvcs_extension.py
bigip_asm_policy_fetch.py
bigip_asm_policy_import.py
bigip_asm_policy_manage.py
bigip_asm_policy_server_technology.py
bigip_asm_policy_signature_set.py

##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.
