### PR TITLE
Fix _hashable_policy for python3

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -560,10 +560,11 @@ def _hashable_policy(policy, policy_list):
                 tupleified = tuple(tupleified)
             policy_list.append(tupleified)
     elif isinstance(policy, string_types) or isinstance(policy, binary_type):
+        policy = to_text(policy)
         # convert root account ARNs to just account IDs
         if policy.startswith('arn:aws:iam::') and policy.endswith(':root'):
             policy = policy.split(':')[4]
-        return [(to_text(policy))]
+        return [policy]
     elif isinstance(policy, dict):
         sorted_keys = list(policy.keys())
         sorted_keys.sort()


### PR DESCRIPTION
##### SUMMARY

Convert policy to string before using `startswith(str)`

Fixes #53932


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/ec2

##### ADDITIONAL INFORMATION
Tests previously failing with python3 (`aws_waf_web_acl`) now pass