### PR TITLE
Close files before opening new ones in cgroup_perf_recap

### DIFF
--- a/lib/ansible/plugins/callback/cgroup_perf_recap.py
+++ b/lib/ansible/plugins/callback/cgroup_perf_recap.py
@@ -364,6 +364,14 @@ class CallbackModule(CallbackBase):
     def _profile(self, obj=None):
         prev_task = None
         results = dict.fromkeys(self._features)
+        for dummy, f in self._files.items():
+            if f is None:
+                continue
+            try:
+                f.close()
+            except Exception:
+                pass
+
         try:
             for name, prof in self._profilers.items():
                 prof.running = False
@@ -396,12 +404,6 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_stats(self, stats):
         self._profile()
-
-        for dummy, f in self._files.items():
-            try:
-                f.close()
-            except Exception:
-                pass
 
         if not self._display_recap:
             return


### PR DESCRIPTION
##### SUMMARY
Close files before opening new ones in cgroup_perf_recap

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/cgroup_perf_recap.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```