### PR TITLE
BIGIP: Bugfix.multiple modules 3

### DIFF
--- a/lib/ansible/module_utils/network/f5/compare.py
+++ b/lib/ansible/module_utils/network/f5/compare.py
@@ -6,6 +6,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.six import iteritems
+
 
 def cmp_simple_list(want, have):
     if want is None:
@@ -27,4 +29,56 @@ def cmp_str_with_none(want, have):
     if have is None and want == '':
         return None
     if want != have:
+        return want
+
+
+def compare_complex_list(want, have):
+    """Performs a complex list comparison
+
+    A complex list is a list of dictionaries
+
+    Args:
+        want (list): List of dictionaries to compare with second parameter.
+        have (list): List of dictionaries compare with first parameter.
+
+    Returns:
+        bool:
+    """
+    if want == [] and have is None:
+        return None
+    if want is None:
+        return None
+    w = []
+    h = []
+    for x in want:
+        tmp = [(str(k), str(v)) for k, v in iteritems(x)]
+        w += tmp
+    for x in have:
+        tmp = [(str(k), str(v)) for k, v in iteritems(x)]
+        h += tmp
+    if set(w) == set(h):
+        return None
+    else:
+        return want
+
+
+def compare_dictionary(want, have):
+    """Performs a dictionary comparison
+
+    Args:
+        want (dict): Dictionary to compare with second parameter.
+        have (dict): Dictionary to compare with first parameter.
+
+    Returns:
+        bool:
+    """
+    if want == {} and have is None:
+        return None
+    if want is None:
+        return None
+    w = [(str(k), str(v)) for k, v in iteritems(want)]
+    h = [(str(k), str(v)) for k, v in iteritems(have)]
+    if set(w) == set(h):
+        return None
+    else:
         return want

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_external.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_external.py
@@ -23,39 +23,46 @@ options:
   name:
     description:
       - Specifies the name of the monitor.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(http)
         parent on the C(Common) partition.
+    type: str
     default: "/Common/external"
   arguments:
     description:
       - Specifies any command-line arguments that the script requires.
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified.
+    type: str
   external_program:
     description:
       - Specifies the name of the file for the monitor to use. In order to reference
         a file, you must first import it using options on the System > File Management > External
         Monitor Program File List > Import screen. The BIG-IP system automatically
         places the file in the proper location on the file system.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 30. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -65,22 +72,26 @@ options:
         number to any number you want, however, it should be 3 times the
         interval number of seconds plus 1 second. If this parameter is not
         provided when creating a new monitor, then the default value will be 120.
+    type: int
   variables:
     description:
       - Specifies any variables that the script requires.
       - Note that double quotes in values will be suppressed.
+    type: dict
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -162,26 +173,20 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
-    from library.module_utils.network.f5.common import compare_dictionary
+    from library.module_utils.network.f5.compare import compare_dictionary
     from library.module_utils.network.f5.icontrol import module_provisioned
     from library.module_utils.network.f5.ipaddress import is_valid_ip
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
-    from ansible.module_utils.network.f5.common import compare_dictionary
+    from ansible.module_utils.network.f5.compare import compare_dictionary
     from ansible.module_utils.network.f5.icontrol import module_provisioned
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
 
@@ -429,7 +434,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -689,16 +694,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
@@ -25,15 +25,18 @@ options:
   name:
     description:
       - Specifies the name of the virtual server.
+    type: str
     version_added: 2.6
   server_name:
     description:
       - Specifies the name of the server that the virtual server is associated with.
+    type: str
     version_added: 2.6
   address:
     description:
       - Specifies the IP Address of the virtual server.
       - When creating a new GTM virtual server, this parameter is required.
+    type: str
     version_added: 2.6
   port:
     description:
@@ -42,12 +45,14 @@ options:
       - To specify all ports, use an C(*).
       - When creating a new GTM virtual server, if this parameter is not specified, a
         default of C(*) will be used.
+    type: int
   translation_address:
     description:
       - Specifies the translation IP address for the virtual server.
       - To unset this parameter, provide an empty string (C("")) as a value.
       - When creating a new GTM virtual server, if this parameter is not specified, a
         default of C(::) will be used.
+    type: str
     version_added: 2.6
   translation_port:
     description:
@@ -55,24 +60,31 @@ options:
       - To specify all ports, use an C(*).
       - When creating a new GTM virtual server, if this parameter is not specified, a
         default of C(*) will be used.
+    type: str
     version_added: 2.6
   availability_requirements:
     description:
       - Specifies, if you activate more than one health monitor, the number of health
         monitors that must receive successful responses in order for the link to be
         considered available.
+    type: dict
     suboptions:
       type:
         description:
           - Monitor rule type when C(monitors) is specified.
           - When creating a new virtual, if this value is not specified, the default of 'all' will be used.
-        choices: ['all', 'at_least', 'require']
+        type: str
+        choices:
+          - all
+          - at_least
+          - require
       at_least:
         description:
           - Specifies the minimum number of active health monitors that must be successful
             before the link is considered up.
           - This parameter is only relevant when a C(type) of C(at_least) is used.
           - This parameter will be ignored if a type of either C(all) or C(require) is used.
+        type: int
       number_of_probes:
         description:
           - Specifies the minimum number of probes that must succeed for this server to be declared up.
@@ -81,6 +93,7 @@ options:
           - The value of this parameter should always be B(lower) than, or B(equal to), the value of C(number_of_probers).
           - This parameter is only relevant when a C(type) of C(require) is used.
           - This parameter will be ignored if a type of either C(all) or C(at_least) is used.
+        type: int
       number_of_probers:
         description:
           - Specifies the number of probers that should be used when running probes.
@@ -89,30 +102,36 @@ options:
           - The value of this parameter should always be B(higher) than, or B(equal to), the value of C(number_of_probers).
           - This parameter is only relevant when a C(type) of C(require) is used.
           - This parameter will be ignored if a type of either C(all) or C(at_least) is used.
+        type: int
     version_added: 2.6
   monitors:
     description:
       - Specifies the health monitors that the system currently uses to monitor this resource.
       - When C(availability_requirements.type) is C(require), you may only have a single monitor in the
         C(monitors) list.
+    type: list
     version_added: 2.6
   virtual_server_dependencies:
     description:
       - Specifies the virtual servers on which the current virtual server depends.
       - If any of the specified servers are unavailable, the current virtual server is also listed as unavailable.
+    type: list
     suboptions:
       server:
         description:
           - Server which the dependant virtual server is part of.
+        type: str
         required: True
       virtual_server:
         description:
           - Virtual server to depend on.
+        type: str
         required: True
     version_added: 2.6
   link:
     description:
       - Specifies a link to assign to the server or virtual server.
+    type: str
     version_added: 2.6
   limits:
     description:
@@ -123,6 +142,7 @@ options:
         threshold limit requirement, the system marks the entire server as unavailable and directs load-balancing
         traffic to another resource.
       - The limit settings available depend on the type of server.
+    type: dict
     suboptions:
       bits_enabled:
         description:
@@ -143,30 +163,35 @@ options:
         description:
           - Specifies the maximum allowable data throughput rate, in bits per second, for the virtual servers on the server.
           - If the network traffic volume exceeds this limit, the system marks the server as unavailable.
+        type: int
       packets_limit:
         description:
           - Specifies the maximum allowable data transfer rate, in packets per second, for the virtual servers on the server.
           - If the network traffic volume exceeds this limit, the system marks the server as unavailable.
+        type: int
       connections_limit:
         description:
           - Specifies the maximum number of concurrent connections, combined, for all of the virtual servers on the server.
           - If the connections exceed this limit, the system marks the server as unavailable.
+        type: int
     version_added: 2.6
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.6
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
       - enabled
       - disabled
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -250,13 +275,10 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
-    from library.module_utils.network.f5.common import compare_complex_list
+    from library.module_utils.network.f5.compare import compare_complex_list
     from library.module_utils.network.f5.icontrol import module_provisioned
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.ipaddress import validate_ip_v6_address
@@ -265,13 +287,10 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
-    from ansible.module_utils.network.f5.common import compare_complex_list
+    from ansible.module_utils.network.f5.compare import compare_complex_list
     from ansible.module_utils.network.f5.icontrol import module_provisioned
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.ipaddress import validate_ip_v6_address
@@ -886,7 +905,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -1165,16 +1184,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_external.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_external.py
@@ -23,43 +23,51 @@ options:
   name:
     description:
       - Specifies the name of the monitor.
+    type: str
     required: True
   description:
     description:
       - The description of the monitor.
+    type: str
     version_added: 2.7
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(http)
         parent on the C(Common) partition.
+    type: str
     default: /Common/external
   arguments:
     description:
       - Specifies any command-line arguments that the script requires.
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified.
+    type: str
   external_program:
     description:
       - Specifies the name of the file for the monitor to use. In order to reference
         a file, you must first import it using options on the System > File Management > External
         Monitor Program File List > Import screen. The BIG-IP system automatically
         places the file in the proper location on the file system.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 5. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -71,22 +79,26 @@ options:
         3 times the interval number of seconds plus 1 second.
       - If this parameter is not provided when creating a new monitor, then the
         default value will be C(16).
+    type: int
   variables:
     description:
       - Specifies any variables that the script requires.
       - Note that double quotes in values will be suppressed.
+    type: dict
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -172,26 +184,20 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
-    from library.module_utils.network.f5.common import compare_dictionary
+    from library.module_utils.network.f5.compare import compare_dictionary
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import compare_dictionary
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
+    from ansible.module_utils.network.f5.compare import compare_dictionary
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
@@ -470,7 +476,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -726,16 +732,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_external.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_external.py
@@ -113,9 +113,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_virtual_server.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_virtual_server.py
@@ -157,9 +157,11 @@ class TestManager(unittest.TestCase):
             name='vs1',
             address='1.1.1.1',
             state='present',
-            password='admin',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_monitor_external.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_external.py
@@ -101,9 +101,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_remote_syslog.py
+++ b/test/units/modules/network/f5/test_bigip_remote_syslog.py
@@ -90,9 +90,11 @@ class TestManager(unittest.TestCase):
     def test_create_remote_syslog(self, *args):
         set_module_args(dict(
             remote_host='1.1.1.1',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         fixture = load_fixture('load_tm_sys_syslog_1.json')
@@ -117,9 +119,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='remotesyslog1',
             remote_host='10.10.10.10',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         fixture = load_fixture('load_tm_sys_syslog_1.json')
@@ -143,9 +147,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             remote_host='10.10.10.10',
             remote_port=800,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         fixture = load_fixture('load_tm_sys_syslog_1.json')
@@ -171,9 +177,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             remote_host='10.10.10.10',
             local_ip='2.2.2.2',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         fixture = load_fixture('load_tm_sys_syslog_1.json')
@@ -199,9 +207,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             remote_host='10.10.10.10',
             local_ip='2.2.2.2',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         fixture = load_fixture('load_tm_sys_syslog_2.json')

--- a/test/units/modules/network/f5/test_bigip_timer_policy.py
+++ b/test/units/modules/network/f5/test_bigip_timer_policy.py
@@ -92,9 +92,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             description='my description',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_vlan.py
+++ b/test/units/modules/network/f5/test_bigip_vlan.py
@@ -107,15 +107,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='somevlan',
             description='fakevlan',
-            server='localhost',
-            password='password',
-            user='admin',
-            partition='Common'
+            partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -133,15 +136,18 @@ class TestManager(unittest.TestCase):
             name='somevlan',
             tagged_interface=['2.1'],
             tag=213,
-            server='localhost',
-            password='password',
-            user='admin',
-            partition='Common'
+            partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -159,15 +165,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='somevlan',
             untagged_interface=['2.1'],
-            server='localhost',
-            password='password',
-            user='admin',
-            partition='Common'
+            partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -185,15 +194,18 @@ class TestManager(unittest.TestCase):
             name='somevlan',
             tagged_interface=['2.1', '1.1'],
             tag=213,
-            server='localhost',
-            password='password',
-            user='admin',
-            partition='Common'
+            partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -211,15 +223,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='somevlan',
             untagged_interface=['2.1', '1.1'],
-            server='localhost',
-            password='password',
-            user='admin',
             partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -236,15 +251,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='somevlan',
             untagged_interface=['2.1'],
-            server='localhost',
-            password='password',
-            user='admin',
             partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -267,15 +285,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='somevlan',
             tagged_interface=['2.1'],
-            server='localhost',
-            password='password',
-            user='admin',
             partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -296,15 +317,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='somevlan',
             description='changed_that',
-            server='localhost',
-            password='password',
-            user='admin',
             partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters
Adds RETURN values that were previously missing
Removes redundant unit tests files

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

lib/ansible/modules/network/f5/bigip_gtm_monitor_external.py
lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
lib/ansible/modules/network/f5/bigip_monitor_external.py
lib/ansible/modules/network/f5/bigip_remote_syslog.py
lib/ansible/modules/network/f5/bigip_timer_policy.py
lib/ansible/modules/network/f5/bigip_vlan.py

##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.