### PR TITLE
BIGIP: multiple_modules_fix_4

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_firewall_address_list.py
+++ b/lib/ansible/modules/network/f5/bigip_firewall_address_list.py
@@ -24,14 +24,17 @@ options:
   name:
     description:
       - Specifies the name of the address list.
+    type: str
     required: True
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   description:
     description:
       - Description of the address list
+    type: str
   geo_locations:
     description:
       - List of geolocations specified by their C(country) and C(region).
@@ -42,19 +45,23 @@ options:
           - In addition to the country full names, you may also specify their abbreviated
             form, such as C(US) instead of C(United States).
           - Valid country codes can be found here https://countrycode.org/.
-        required: true
+        type: str
+        required: True
         choices:
           - Any valid 2 character ISO country code.
           - Any valid country name.
       region:
         description:
           - Region name of the country to use.
+        type: str
+    type: list
   addresses:
     description:
       - Individual addresses that you want to add to the list. These addresses differ
         from ranges, and lists of lists such as what can be used in C(address_ranges)
         and C(address_lists) respectively.
       - This list can also include networks that have CIDR notation.
+    type: list
   address_ranges:
     description:
       - A list of address ranges where the range starts with a port number, is followed
@@ -62,12 +69,14 @@ options:
       - If the first address is greater than the second number, the numbers will be
         reversed so-as to be properly formatted. ie, C(2.2.2.2-1.1.1). would become
         C(1.1.1.1-2.2.2.2).
+    type: list
   address_lists:
     description:
       - Simple list of existing address lists to add to this list. Address lists can be
         specified in either their fully qualified name (/Common/foo) or their short
         name (foo). If a short name is used, the C(partition) argument will automatically
         be prepended to the short name.
+    type: list
   fqdns:
     description:
       - A list of fully qualified domain names (FQDNs).
@@ -77,14 +86,16 @@ options:
         of BIG-IP. If using C(bigip_command), this can be done with C(tmsh modify security
         firewall global-fqdn-policy FOO) where C(FOO) is a DNS resolver configured
         at C(tmsh create net dns-resolver FOO).
+    type: list
   state:
     description:
       - When C(present), ensures that the address list and entries exists.
       - When C(absent), ensures the address list is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -158,11 +169,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.compat.ipaddress import ip_address
     from library.module_utils.compat.ipaddress import ip_interface
@@ -172,11 +180,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.compat.ipaddress import ip_address
     from ansible.module_utils.compat.ipaddress import ip_interface
@@ -744,7 +749,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -961,16 +966,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_firewall_global_rules.py
+++ b/lib/ansible/modules/network/f5/bigip_firewall_global_rules.py
@@ -27,6 +27,7 @@ options:
     description:
       - Specifies an enforced firewall policy.
       - C(enforced_policy) rules are enforced globally.
+    type: str
   service_policy:
     description:
       - Specifies a service policy that would apply to traffic globally.
@@ -39,15 +40,18 @@ options:
         policy setting at the global level.
       - The service policy associated here can be created using the
         C(bigip_service_policy) module.
+    type: str
   staged_policy:
     description:
       - Specifies a staged firewall policy.
       - C(staged_policy) rules are not enforced while all the visibility
         aspects namely statistics, reporting and logging function as if
         the staged-policy rules were enforced globally.
+    type: str
   description:
     description:
       - Description for the global list of firewall rules.
+    type: str
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -93,21 +97,15 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
 
@@ -243,7 +241,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -371,16 +369,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_firewall_policy.py
+++ b/lib/ansible/modules/network/f5/bigip_firewall_policy.py
@@ -23,16 +23,19 @@ options:
   name:
     description:
       - The name of the policy to create.
+    type: str
     required: True
   description:
     description:
       - The description to attach to the policy.
       - This parameter is only supported on versions of BIG-IP >= 12.1.0. On earlier
         versions it will simply be ignored.
+    type: str
   state:
     description:
       - When C(state) is C(present), ensures that the policy exists.
       - When C(state) is C(absent), ensures that the policy is removed.
+    type: str
     choices:
       - present
       - absent
@@ -48,9 +51,11 @@ options:
         configuration for these rules.
       - The C(bigip_firewall_rule) module can be used to also create, as well as
         edit, existing and new rules.
+    type: list
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
 extends_documentation_fragment: f5
 author:
@@ -92,19 +97,13 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import fail_json
-    from library.module_utils.network.f5.common import exit_json
     from library.module_utils.network.f5.common import transform_name
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import fail_json
-    from ansible.module_utils.network.f5.common import exit_json
     from ansible.module_utils.network.f5.common import transform_name
 
 
@@ -206,7 +205,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -521,16 +520,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_firewall_port_list.py
+++ b/lib/ansible/modules/network/f5/bigip_firewall_port_list.py
@@ -24,37 +24,44 @@ options:
   name:
     description:
       - Specifies the name of the port list.
+    type: str
     required: True
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   description:
     description:
       - Description of the port list
+    type: str
   ports:
     description:
       - Simple list of port values to add to the list
+    type: list
   port_ranges:
     description:
       - A list of port ranges where the range starts with a port number, is followed
         by a dash (-) and then a second number.
       - If the first number is greater than the second number, the numbers will be
         reversed so-as to be properly formatted. ie, 90-78 would become 78-90.
+    type: list
   port_lists:
     description:
       - Simple list of existing port lists to add to this list. Port lists can be
         specified in either their fully qualified name (/Common/foo) or their short
         name (foo). If a short name is used, the C(partition) argument will automatically
         be prepended to the short name.
+    type: list
   state:
     description:
       - When C(present), ensures that the address list and entries exists.
       - When C(absent), ensures the address list is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -172,23 +179,17 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import module_provisioned
 
 
@@ -413,7 +414,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -632,16 +633,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_firewall_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_firewall_rule.py
@@ -26,15 +26,18 @@ options:
   name:
     description:
       - Specifies the name of the rule.
+    type: str
     required: True
   parent_policy:
     description:
       - The policy which contains the rule to be managed.
       - One of either C(parent_policy) or C(parent_rule_list) is required.
+    type: str
   parent_rule_list:
     description:
       - The rule list which contains the rule to be managed.
       - One of either C(parent_policy) or C(parent_rule_list) is required.
+    type: str
   action:
     description:
       - Specifies the action for the firewall rule.
@@ -56,6 +59,7 @@ options:
         or self IP firewall rule, then Accept Decisively is equivalent to Accept.
       - When creating a new rule, if this parameter is not provided, the default is
         C(reject).
+    type: str
     choices:
       - accept
       - drop
@@ -71,6 +75,7 @@ options:
         according to the specified schedule.
       - When creating a new rule, if this parameter is not provided, the default
         is C(enabled).
+    type: str
     choices:
       - enabled
       - disabled
@@ -80,19 +85,23 @@ options:
       - Specifies a schedule for the firewall rule.
       - You configure schedules to define days and times when the firewall rule is
         made active.
+    type: str
   description:
     description:
       - The rule description.
+    type: str
   irule:
     description:
-      - Specifies an iRule that is applied to the rule.
+      - Specifies an iRule that is applied to the firewall rule.
       - An iRule can be started when the firewall rule matches traffic.
+    type: str
   protocol:
     description:
       - Specifies the protocol to which the rule applies.
       - Protocols may be specified by either their name or numeric value.
       - A special protocol value C(any) can be specified to match any protocol. The
         numeric equivalent of this protocol is C(255).
+    type: str
   source:
     description:
       - Specifies packet sources to which the rule applies.
@@ -105,29 +114,42 @@ options:
       address:
         description:
           - Specifies a specific IP address.
+        type: str
       address_list:
         description:
           - Specifies an existing address list.
+        type: str
       address_range:
         description:
           - Specifies an address range.
+        type: str
       country:
         description:
           - Specifies a country code.
+        type: str
       port:
         description:
           - Specifies a single numeric port.
           - This option is only valid when C(protocol) is C(tcp)(6) or C(udp)(17).
+        type: int
       port_list:
         description:
           - Specifes an existing port list.
           - This option is only valid when C(protocol) is C(tcp)(6) or C(udp)(17).
+        type: str
       port_range:
         description:
           - Specifies a range of ports, which is two port values separated by
             a hyphen. The port to the left of the hyphen should be less than the
             port to the right.
           - This option is only valid when C(protocol) is C(tcp)(6) or C(udp)(17).
+        type: str
+      vlan:
+        description:
+          - Specifies VLANs to which the rule applies.
+          - The VLAN source refers to the packet's source.
+        type: str
+    type: list
   destination:
     description:
       - Specifies packet destinations to which the rule applies.
@@ -140,29 +162,37 @@ options:
       address:
         description:
           - Specifies a specific IP address.
+        type: str
       address_list:
         description:
           - Specifies an existing address list.
+        type: str
       address_range:
         description:
           - Specifies an address range.
+        type: str
       country:
         description:
           - Specifies a country code.
+        type: str
       port:
         description:
           - Specifies a single numeric port.
           - This option is only valid when C(protocol) is C(tcp)(6) or C(udp)(17).
+        type: int
       port_list:
         description:
           - Specifes an existing port list.
           - This option is only valid when C(protocol) is C(tcp)(6) or C(udp)(17).
+        type: str
       port_range:
         description:
           - Specifies a range of ports, which is two port values separated by
             a hyphen. The port to the left of the hyphen should be less than the
             port to the right.
           - This option is only valid when C(protocol) is C(tcp)(6) or C(udp)(17).
+        type: str
+    type: list
   logging:
     description:
       - Specifies whether logging is enabled or disabled for the firewall rule.
@@ -175,6 +205,7 @@ options:
       - This parameter is mutually exclusive with many of the other individual-rule
         specific settings. This includes C(logging), C(action), C(source),
         C(destination), C(irule'), C(protocol) and C(logging).
+    type: str
   icmp_message:
     description:
       - Specifies the Internet Control Message Protocol (ICMP) or ICMPv6 message
@@ -191,6 +222,7 @@ options:
           - You can also specify an arbitrary ICMP message.
           - The ICMP protocol contains definitions for the existing message type and
             number pairs.
+        type: str
       code:
         description:
           - Specifies the code returned in response to the specified ICMP message type.
@@ -202,14 +234,18 @@ options:
           - You can also specify an arbitrary code.
           - The ICMP protocol contains definitions for the existing message code and
             number pairs.
+        type: str
+    type: list
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(state) is C(present), ensures that the rule exists.
       - When C(state) is C(absent), ensures that the rule is removed.
+    type: str
     choices:
       - present
       - absent
@@ -217,6 +253,7 @@ options:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -281,16 +318,164 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-param1:
-  description: The new param1 value of the resource.
-  returned: changed
-  type: bool
-  sample: true
-param2:
-  description: The new param2 value of the resource.
+name:
+  description: Name of the rule.
   returned: changed
   type: str
-  sample: Foo is bar
+  sample: FooRule
+parent_policy:
+  description: The policy which contains the rule to be managed.
+  returned: changed
+  type: str
+  sample: FooPolicy
+parent_rule_list:
+  description: The rule list which contains the rule to be managed.
+  returned: changed
+  type: str
+  sample: FooRuleList
+action:
+  description: The action for the firewall rule.
+  returned: changed
+  type: str
+  sample: drop
+status:
+  description: The activity state of the rule or rule list.
+  returned: changed
+  type: str
+  sample: scheduled
+schedule:
+  description: The schedule for the firewall rule.
+  returned: changed
+  type: str
+  sample: Foo_schedule
+description:
+  description: The rule description.
+  returned: changed
+  type: str
+  sample: MyRule
+irule:
+  description: The iRule that is applied to the firewall rule.
+  returned: changed
+  type: str
+  sample: _sys_auth_radius
+protocol:
+  description: The protocol to which the rule applies.
+  returned: changed
+  type: str
+  sample: any
+source:
+  description: The packet sources to which the rule applies
+  returned: changed
+  type: complex
+  contains:
+    address:
+      description: A specific IP address.
+      returned: changed
+      type: str
+      sample: 192.168.1.1
+    address_list:
+      description: An existing address list.
+      returned: changed
+      type: str
+      sample: foo-list1
+    address_range:
+      description: The address range.
+      returned: changed
+      type: str
+      sample: 1.1.1.1-2.2.2.2
+    country:
+      description: A country code.
+      returned: changed
+      type: str
+      sample: US
+    port:
+      description: Single numeric port.
+      returned: changed
+      type: int
+      sample: 8080
+    port_list:
+      description: An existing port list.
+      returned: changed
+      type: str
+      sample: port-list1
+    port_range:
+      description: The port range.
+      returned: changed
+      type: str
+      sample: 80-443
+    vlan:
+      description: Source VLANs for the packets.
+      returned: changed
+      type: str
+      sample: vlan1
+  sample: hash/dictionary of values
+destination:
+  description: The packet destinations to which the rule applies.
+  returned: changed
+  type: complex
+  contains:
+    address:
+      description: A specific IP address.
+      returned: changed
+      type: str
+      sample: 192.168.1.1
+    address_list:
+      description: An existing address list.
+      returned: changed
+      type: str
+      sample: foo-list1
+    address_range:
+      description: The address range.
+      returned: changed
+      type: str
+      sample: 1.1.1.1-2.2.2.2
+    country:
+      description: A country code.
+      returned: changed
+      type: str
+      sample: US
+    port:
+      description: Single numeric port.
+      returned: changed
+      type: int
+      sample: 8080
+    port_list:
+      description: An existing port list.
+      returned: changed
+      type: str
+      sample: port-list1
+    port_range:
+      description: The port range.
+      returned: changed
+      type: str
+      sample: 80-443
+  sample: hash/dictionary of values
+logging:
+  description: Enable or Disable logging for the firewall rule.
+  returned: changed
+  type: bool
+  sample: yes
+rule_list:
+  description: An existing rule list to use in the rule.
+  returned: changed
+  type: str
+  sample: rule-list-1
+icmp_message:
+  description: The (ICMP) or ICMPv6 message C(type) and C(code) that the rule uses.
+  returned: changed
+  type: complex
+  contains:
+    type:
+      description: The type of ICMP message.
+      returned: changed
+      type: str
+      sample: 0
+    code:
+      description: The code returned in response to the specified ICMP message type.
+      returned: changed
+      type: str
+      sample: 1
+  sample: hash/dictionary of values
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -300,24 +485,16 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import fq_name
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import fq_name
 
 
 class Parameters(AnsibleF5Parameters):
@@ -752,7 +929,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -1102,16 +1279,12 @@ def main():
         required_one_of=spec.required_one_of
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_firewall_rule_list.py
+++ b/lib/ansible/modules/network/f5/bigip_firewall_rule_list.py
@@ -23,16 +23,19 @@ options:
   name:
     description:
       - The name of the policy to create.
+    type: str
     required: True
   description:
     description:
       - The description to attach to the policy.
       - This parameter is only supported on versions of BIG-IP >= 12.1.0. On earlier
         versions it will simply be ignored.
+    type: str
   state:
     description:
       - When C(state) is C(present), ensures that the rule list exists.
       - When C(state) is C(absent), ensures that the rule list is removed.
+    type: str
     choices:
       - present
       - absent
@@ -48,9 +51,11 @@ options:
         configuration for these rules.
       - The C(bigip_firewall_rule) module can be used to also create, as well as
         edit, existing and new rules.
+    type: list
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
 extends_documentation_fragment: f5
 author:
@@ -92,19 +97,13 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import fail_json
-    from library.module_utils.network.f5.common import exit_json
     from library.module_utils.network.f5.common import transform_name
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import fail_json
-    from ansible.module_utils.network.f5.common import exit_json
     from ansible.module_utils.network.f5.common import transform_name
 
 
@@ -206,7 +205,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -521,16 +520,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_dns_cache_resolver.py
+++ b/test/units/modules/network/f5/test_bigip_dns_cache_resolver.py
@@ -93,9 +93,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             route_domain=20,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_dns_nameserver.py
+++ b/test/units/modules/network/f5/test_bigip_dns_nameserver.py
@@ -106,9 +106,11 @@ class TestManager(unittest.TestCase):
             route_domain=20,
             tsig_key='key1',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_dns_resolver.py
+++ b/test/units/modules/network/f5/test_bigip_dns_resolver.py
@@ -104,9 +104,11 @@ class TestManager(unittest.TestCase):
         # Configure the arguments that would be sent to the Ansible module
         set_module_args(dict(
             name='foo',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_dns_zone.py
+++ b/test/units/modules/network/f5/test_bigip_dns_zone.py
@@ -108,9 +108,11 @@ class TestManager(unittest.TestCase):
         # Configure the arguments that would be sent to the Ansible module
         set_module_args(dict(
             name='foo',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_file_copy.py
+++ b/test/units/modules/network/f5/test_bigip_file_copy.py
@@ -95,14 +95,17 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             source='file.txt',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         tm = IFileManager(module=module)

--- a/test/units/modules/network/f5/test_bigip_firewall_address_list.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_address_list.py
@@ -113,9 +113,11 @@ class TestManager(unittest.TestCase):
                 dict(country='EU')
             ],
             fqdns=['google.com', 'mit.edu'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_firewall_dos_profile.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_dos_profile.py
@@ -91,9 +91,11 @@ class TestManager(unittest.TestCase):
             description='this is a description',
             threshold_sensitivity='low',
             default_whitelist='whitelist1',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_firewall_dos_vector.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_dos_vector.py
@@ -88,9 +88,11 @@ class TestManager(unittest.TestCase):
             name='aaaa',
             state='mitigate',
             profile='foo',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_firewall_global_rules.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_global_rules.py
@@ -93,9 +93,11 @@ class TestUntypedManager(unittest.TestCase):
             enforced_policy='enforced1',
             staged_policy='staged1',
             service_policy='service1',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_firewall_policy.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_policy.py
@@ -96,9 +96,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             description='this is a description',
             rules=['rule1', 'rule2', 'rule3'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_firewall_port_list.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_port_list.py
@@ -117,9 +117,11 @@ class TestManager(unittest.TestCase):
             ports=[1, 2, 3, 4],
             port_ranges=['10-20', '30-40', '50-60'],
             port_lists=['/Common/foo', 'foo'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_firewall_rule.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_rule.py
@@ -136,11 +136,18 @@ class TestManager(unittest.TestCase):
             irule='irule1',
             action='accept',
             logging='yes',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive,
+            required_one_of=self.spec.required_one_of
         )
 
         # Override methods in the specific type of manager

--- a/test/units/modules/network/f5/test_bigip_firewall_rule_list.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_rule_list.py
@@ -88,9 +88,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             description='this is a description',
             rules=['rule1', 'rule2', 'rule3'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters
Adds RETURN values that were previously missing
Removes redundant unit tests files

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

lib/ansible/modules/network/f5/bigip_dns_cache_resolver.py
lib/ansible/modules/network/f5/bigip_dns_nameserver.py
lib/ansible/modules/network/f5/bigip_dns_resolver.py
lib/ansible/modules/network/f5/bigip_dns_zone.py
lib/ansible/modules/network/f5/bigip_file_copy.py
lib/ansible/modules/network/f5/bigip_firewall_address_list.py
lib/ansible/modules/network/f5/bigip_firewall_dos_profile.py
lib/ansible/modules/network/f5/bigip_firewall_dos_vector.py
lib/ansible/modules/network/f5/bigip_firewall_global_rules.py
lib/ansible/modules/network/f5/bigip_firewall_policy.py
lib/ansible/modules/network/f5/bigip_firewall_port_list.py
lib/ansible/modules/network/f5/bigip_firewall_rule.py
lib/ansible/modules/network/f5/bigip_firewall_rule_list.py


##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.