### PR TITLE
Update inventory plugins using caching to remove deprecation warnings

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -600,7 +600,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         cache_needs_update = False
         if cache:
             try:
-                results = self.cache.get(cache_key)
+                results = self._cache[cache_key]
             except KeyError:
                 # if cache expires or cache file doesn't exist
                 cache_needs_update = True
@@ -613,7 +613,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # If the cache has expired/doesn't exist or if refresh_inventory/flush cache is used
         # when the user is using caching, update the cached inventory
         if cache_needs_update or (not cache and self.get_option('cache')):
-            self.cache.set(cache_key, results)
+            self._cache[cache_key] = results
 
     @staticmethod
     def _legacy_script_compatible_group_sanitization(name):

--- a/lib/ansible/plugins/inventory/aws_rds.py
+++ b/lib/ansible/plugins/inventory/aws_rds.py
@@ -333,7 +333,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         cache_needs_update = False
         if cache:
             try:
-                results = self.cache.get(cache_key)
+                results = self._cache[cache_key]
             except KeyError:
                 # if cache expires or cache file doesn't exist
                 cache_needs_update = True
@@ -348,4 +348,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # If the cache has expired/doesn't exist or if refresh_inventory/flush cache is used
         # when the user is using caching, update the cached inventory
         if cache_needs_update or (not cache and self.get_option('cache')):
-            self.cache.set(cache_key, formatted_inventory)
+            self._cache[cache_key] = formatted_inventory

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -370,7 +370,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         cache_needs_update = False
         if cache:
             try:
-                results = self.cache.get(cache_key)
+                results = self._cache[cache_key]
                 for project in results:
                     for zone in results[project]:
                         self._add_hosts(results[project][zone], config_data, False)
@@ -392,7 +392,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     cached_data[project][zone] = resp.get('items')
 
         if cache_needs_update:
-            self.cache.set(cache_key, cached_data)
+            self._cache[cache_key] = cached_data
 
     @staticmethod
     def _legacy_script_compatible_group_sanitization(name):

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -156,14 +156,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if 'clouds' in self._config_data:
             self._config_data = {}
 
+        # update cache if the user has caching enabled and the cache is being refreshed
+        # will update variable below in the case of an expired cache
+        cache_needs_update = not cache and self.get_option('cache')
+
         if cache:
             cache = self.get_option('cache')
         source_data = None
         if cache:
             try:
-                source_data = self.cache.get(cache_key)
+                source_data = self._cache[cache_key]
             except KeyError:
-                pass
+                # cache expired or doesn't exist yet
+                cache_needs_update = True
 
         if not source_data:
             clouds_yaml_path = self._config_data.get('clouds_yaml_path')
@@ -199,8 +204,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             source_data = cloud_inventory.list_hosts(
                 expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
 
-            if self.cache is not None:
-                self.cache.set(cache_key, source_data)
+            if cache_needs_update:
+                self._cache[cache_key] = source_data
 
         self._populate_from_source(source_data)
 

--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -244,7 +244,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         update_cache = False
         if cache:
             try:
-                source_data = self.cache.get(cache_key)
+                source_data = self._cache[cache_key]
             except KeyError:
                 update_cache = True
 
@@ -274,4 +274,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         cacheable_results = self._populate_from_source(source_data, using_current_cache)
 
         if update_cache:
-            self.cache.set(cache_key, cacheable_results)
+            self._cache[cache_key] = cacheable_results

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -356,7 +356,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         update_cache = False
         if cache:
             try:
-                source_data = self.cache.get(cache_key)
+                source_data = self._cache[cache_key]
             except KeyError:
                 update_cache = True
 
@@ -364,7 +364,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         cacheable_results = self._populate_from_source(source_data, using_current_cache)
 
         if update_cache:
-            self.cache.set(cache_key, cacheable_results)
+            self._cache[cache_key] = cacheable_results
 
     def _populate_from_cache(self, source_data):
         """ Populate cache using source data """


### PR DESCRIPTION
##### SUMMARY
Caching works regardless but this resolves the deprecation warnings for inventory plugins using self.cache instead of self._cache.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugins

