### PR TITLE
Ignore AnsibleUndefinedVariable for set_fact, include_vars, and gather_facts tasks

### DIFF
--- a/changelogs/fragments/ignore-undefined-errors-for-env-var-on-certain-tasks.yaml
+++ b/changelogs/fragments/ignore-undefined-errors-for-env-var-on-certain-tasks.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - tasks - ignore undefined errors in variables used in environment settings or certain tasks (https://github.com/ansible/ansible/pull/53978)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -315,7 +315,12 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
                     env[k] = templar.template(v, convert_bare=False)
                 except AnsibleUndefinedVariable as e:
                     error = to_native(e)
-                    if self.action in ('setup', 'gather_facts') and 'ansible_facts.env' in error or 'ansible_env' in error:
+
+                    if (self.action in ('setup', 'gather_facts') and 'ansible_facts.env' in error or
+                            'ansible_env' in error or
+                            # Ignore undefined errors for set_fact, include_vars, and fact gathering since those tasks
+                            # can set variables later used to set environment variables, or environment has no effect on those tasks
+                            self.action in ('setup', 'gather_facts', 'set_fact', 'include_vars')) and 'is undefined' in error:
                         # ignore as fact gathering is required for 'env' facts
                         return
                     raise

--- a/test/integration/targets/environment/test_environment.yml
+++ b/test/integration/targets/environment/test_environment.yml
@@ -171,3 +171,41 @@
       assert:
         that:
           - "{{ test_foo.results[0].stdout == 'outer' }}"
+
+- name: Test setting environment using set_fact
+  hosts: testhost
+  environment:
+    http_proxy: "{{ proxy_var }}"
+
+  pre_tasks:
+    - set_fact:
+        proxy_var: proxyserver1
+
+  tasks:
+    - shell: echo $http_proxy
+      register: set_fact_test
+
+    - name: Ensure environment variable was set properly from set_fact
+      assert:
+        that:
+          - "'proxyserver1' in set_fact_test.stdout_lines"
+
+- name: Test setting environment using include_vars
+  hosts: testhost
+  environment:
+    http_proxy: "{{ include_proxy_var }}"
+
+  tasks:
+    - include_vars: testvars.yml
+
+    - shell: echo $http_proxy
+      register: include_vars_test
+
+    - debug:
+        var: include_vars_test
+      tags: debug
+
+    - name: Ensure environment variable was set properly from include_vars
+      assert:
+        that:
+          - "'from include vars' in include_vars_test.stdout_lines"

--- a/test/integration/targets/environment/test_environment.yml
+++ b/test/integration/targets/environment/test_environment.yml
@@ -172,40 +172,76 @@
         that:
           - "{{ test_foo.results[0].stdout == 'outer' }}"
 
-- name: Test setting environment using set_fact
+- name: Test undefined environment value with set_fact
   hosts: testhost
   environment:
-    http_proxy: "{{ proxy_var }}"
+    env_testvar1: "{{ proxy_var }}"
 
   pre_tasks:
     - set_fact:
         proxy_var: proxyserver1
 
   tasks:
-    - shell: echo $http_proxy
+    - shell: echo $env_testvar1
       register: set_fact_test
 
-    - name: Ensure environment variable was set properly from set_fact
-      assert:
+    - assert:
         that:
-          - "'proxyserver1' in set_fact_test.stdout_lines"
+          - "'proxyserver1' in set_fact_test.stdout"
 
-- name: Test setting environment using include_vars
+- name: Test undefined environment value with include_vars
   hosts: testhost
   environment:
-    http_proxy: "{{ include_proxy_var }}"
+    env_testvar2: "{{ include_proxy_var }}"
 
   tasks:
     - include_vars: testvars.yml
 
-    - shell: echo $http_proxy
+    - shell: echo $env_testvar2
       register: include_vars_test
 
     - debug:
         var: include_vars_test
       tags: debug
 
-    - name: Ensure environment variable was set properly from include_vars
-      assert:
+    - assert:
         that:
-          - "'from include vars' in include_vars_test.stdout_lines"
+          - "'from include vars' in include_vars_test.stdout"
+
+- name: Test undefined environment value with add_host
+  hosts: testhost
+  environment:
+    env_testvar3: "{{ testvar3 }}"
+
+  tasks:
+    - add_host:
+        name: envtest_host
+
+    - set_fact:
+        testvar3: testvar3 set
+
+    - shell: echo $env_testvar3
+      register: add_host_test
+
+    - assert:
+        that:
+          - "'testvar3 set' in add_host_test.stdout"
+
+- name: Test undefined environment value with group_by
+  hosts: testhost
+  environment:
+    env_testvar4: "{{ testvar4 }}"
+
+  tasks:
+    - group_by:
+        key: env_test_group
+
+    - set_fact:
+        testvar4: testvar4 set
+
+    - shell: echo $env_testvar4
+      register: add_host_test
+
+    - assert:
+        that:
+          - "'testvar4 set' in add_host_test.stdout"

--- a/test/integration/targets/environment/testvars.yml
+++ b/test/integration/targets/environment/testvars.yml
@@ -1,0 +1,1 @@
+include_proxy_var: from include vars


### PR DESCRIPTION
##### SUMMARY
#41411 fixed an issue where any undefined environment variable was silently ignored. That had the side effect of failing the play too early if environment settings are populated by variables set in `set_fact` and `include_vars` tasks.

This PR adds more conditions under which the exception is ignored, allowing `set_fact` and `include_vars` to be used to set values for variables used in `environment`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/playbook/task.py`

##### ADDITIONAL INFORMATION

This may be the incorrect way to solve this. I am quite open to feedback on the bigger issue and how to better solve it.