### PR TITLE
BIGIP: mutliple_modules_fix_5

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
@@ -26,15 +26,19 @@ options:
   contact:
     description:
       - The name of the contact for the data center.
+    type: str
   description:
     description:
       - The description of the data center.
+    type: str
   location:
     description:
       - The location of the data center.
+    type: str
   name:
     description:
       - The name of the data center.
+    type: str
     required: True
   state:
     description:
@@ -44,15 +48,17 @@ options:
         the virtual address and enables it. If C(enabled), enable the virtual
         address if it exists. If C(disabled), create the virtual address if
         needed, and set state to C(disabled).
-    default: present
+    type: str
     choices:
       - present
       - absent
       - enabled
       - disabled
+    default: present
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
 extends_documentation_fragment: f5
@@ -113,23 +119,17 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import module_provisioned
 
 
@@ -266,7 +266,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.pop('module', None)
-        self.client = kwargs.pop('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -478,16 +478,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_global.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_global.py
@@ -33,6 +33,7 @@ options:
   synchronization_group_name:
     description:
       - Specifies the name of the synchronization group to which the system belongs.
+    type: str
   synchronize_zone_files:
     description:
       - Specifies that the system synchronizes Domain Name System (DNS) zone files among the
@@ -82,21 +83,15 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import module_provisioned
 
 
@@ -219,7 +214,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -342,16 +337,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_http.py
@@ -23,33 +23,39 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(tcp)
         parent on the C(Common) partition.
+    type: str
     default: /Common/http
   send:
     description:
       - The send string for the monitor call.
       - When creating a new monitor, if this parameter is not provided, the
         default of C(GET /\r\n) will be used.
+    type: str
   receive:
     description:
       - The receive string for the monitor call.
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
       - If this value is an IP address, then a C(port) number must be specified.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
@@ -57,6 +63,7 @@ options:
       - If this parameter is not provided when creating a new monitor, then the
         default value will be 30.
       - This value B(must) be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -67,24 +74,28 @@ options:
         interval number of seconds plus 1 second.
       - If this parameter is not provided when creating a new monitor, then the
         default value will be 120.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   probe_timeout:
     description:
       - Specifies the number of seconds after which the system times out the probe request
         to the system.
       - When creating a new monitor, if this parameter is not provided, then the default
         value will be C(5).
+    type: int
   ignore_down_response:
     description:
       - Specifies that the monitor allows more than one probe attempt per interval.
@@ -119,17 +130,20 @@ options:
   target_username:
     description:
       - Specifies the user name, if the monitored target requires authentication.
+    type: str
   target_password:
     description:
       - Specifies the password, if the monitored target requires authentication.
+    type: str
   update_password:
     description:
       - C(always) will update passwords if the C(target_password) is specified.
       - C(on_create) will only set the password for newly created monitors.
-    default: always
+    type: str
     choices:
       - always
       - on_create
+    default: always
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -237,24 +251,18 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import module_provisioned
     from library.module_utils.network.f5.ipaddress import is_valid_ip
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import module_provisioned
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
 
@@ -567,7 +575,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -817,16 +825,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_https.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_https.py
@@ -23,33 +23,39 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(tcp)
         parent on the C(Common) partition.
+    type: str
     default: /Common/https
   send:
     description:
       - The send string for the monitor call.
       - When creating a new monitor, if this parameter is not provided, the
         default of C(GET /\r\n) will be used.
+    type: str
   receive:
     description:
       - The receive string for the monitor call.
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
       - If this value is an IP address, then a C(port) number must be specified.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
@@ -57,6 +63,7 @@ options:
       - If this parameter is not provided when creating a new monitor, then
         the default value will be 30.
       - This value B(must) be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -67,24 +74,28 @@ options:
         interval number of seconds plus 1 second.
       - If this parameter is not provided when creating a new monitor, then the
         default value will be 120.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   probe_timeout:
     description:
       - Specifies the number of seconds after which the system times out the probe request
         to the system.
       - When creating a new monitor, if this parameter is not provided, then the default
         value will be C(5).
+    type: int
   ignore_down_response:
     description:
       - Specifies that the monitor allows more than one probe attempt per interval.
@@ -119,23 +130,27 @@ options:
   target_username:
     description:
       - Specifies the user name, if the monitored target requires authentication.
+    type: str
   target_password:
     description:
       - Specifies the password, if the monitored target requires authentication.
+    type: str
   update_password:
     description:
       - C(always) will update passwords if the C(target_password) is specified.
       - C(on_create) will only set the password for newly created monitors.
-    default: always
+    type: str
     choices:
       - always
       - on_create
+    default: always
   cipher_list:
     description:
       - Specifies the list of ciphers for this monitor.
       - The items in the cipher list are separated with the colon C(:) symbol.
       - When creating a new monitor, if this parameter is not specified, the default
         list is C(DEFAULT:+SHA:+3DES:+kEDH).
+    type: str
   compatibility:
     description:
       - Specifies, when enabled, that the SSL options setting (in OpenSSL) is set to B(all).
@@ -146,9 +161,11 @@ options:
     description:
       - Specifies a fully-qualified path for a client certificate that the monitor sends to
         the target SSL server.
+    type: str
   client_key:
     description:
       - Specifies a key for a client certificate that the monitor sends to the target SSL server.
+    type: str
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -276,24 +293,18 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import module_provisioned
     from library.module_utils.network.f5.ipaddress import is_valid_ip
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import module_provisioned
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
 
@@ -679,7 +690,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -937,16 +948,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp.py
@@ -23,31 +23,37 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(tcp)
         parent on the C(Common) partition.
+    type: str
     default: /Common/tcp
   send:
     description:
       - The send string for the monitor call.
+    type: str
   receive:
     description:
       - The receive string for the monitor call.
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
       - If this value is an IP address, then a C(port) number must be specified.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
@@ -55,6 +61,7 @@ options:
       - If this parameter is not provided when creating a new monitor, then the
         default value will be 30.
       - This value B(must) be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -65,24 +72,28 @@ options:
         interval number of seconds plus 1 second.
       - If this parameter is not provided when creating a new monitor, then the
         default value will be 120.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   probe_timeout:
     description:
       - Specifies the number of seconds after which the system times out the probe request
         to the system.
       - When creating a new monitor, if this parameter is not provided, then the default
         value will be C(5).
+    type: int
   ignore_down_response:
     description:
       - Specifies that the monitor allows more than one probe attempt per interval.
@@ -221,24 +232,18 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import module_provisioned
     from library.module_utils.network.f5.ipaddress import is_valid_ip
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import module_provisioned
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
 
@@ -537,7 +542,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -779,16 +784,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool.py
@@ -26,6 +26,7 @@ options:
         When C(absent), ensures that the pool is removed from the system. When
         C(enabled) or C(disabled), ensures that the pool is enabled or disabled
         (respectively) on the remote device.
+    type: str
     choices:
       - present
       - absent
@@ -35,6 +36,7 @@ options:
   preferred_lb_method:
     description:
       - The load balancing mode that the system tries first.
+    type: str
     choices:
       - round-robin
       - return-to-dns
@@ -58,6 +60,7 @@ options:
     description:
       - The load balancing mode that the system tries if the
         C(preferred_lb_method) is unsuccessful in picking a pool.
+    type: str
     choices:
       - round-robin
       - return-to-dns
@@ -76,6 +79,7 @@ options:
       - The load balancing mode that the system tries if both the
         C(preferred_lb_method) and C(alternate_lb_method)s are unsuccessful
         in picking a pool.
+    type: str
     choices:
       - round-robin
       - return-to-dns
@@ -102,11 +106,13 @@ options:
         directs requests when it cannot use one of its pools to do so.
         Note that the system uses the fallback IP only if you select the
         C(fallback_ip) load balancing method.
+    type: str
   type:
     description:
       - The type of GTM pool that you want to create. On BIG-IP releases
         prior to version 12, this parameter is not required. On later versions
         of BIG-IP, this is a required parameter.
+    type: str
     choices:
       - a
       - aaaa
@@ -117,10 +123,12 @@ options:
   name:
     description:
       - Name of the GTM pool.
+    type: str
     required: True
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   members:
@@ -131,17 +139,21 @@ options:
       server:
         description:
           - Name of the server which the pool member is a part of.
+        type: str
         required: True
       virtual_server:
         description:
           - Name of the virtual server, associated with the server, that the pool member is a part of.
+        type: str
         required: True
+    type: list
     version_added: 2.6
   monitors:
     description:
       - Specifies the health monitors that the system currently uses to monitor this resource.
       - When C(availability_requirements.type) is C(require), you may only have a single monitor in the
         C(monitors) list.
+    type: list
     version_added: 2.6
   availability_requirements:
     description:
@@ -153,13 +165,18 @@ options:
         description:
           - Monitor rule type when C(monitors) is specified.
           - When creating a new pool, if this value is not specified, the default of 'all' will be used.
-        choices: ['all', 'at_least', 'require']
+        type: str
+        choices:
+          - all
+          - at_least
+          - require
       at_least:
         description:
           - Specifies the minimum number of active health monitors that must be successful
             before the link is considered up.
           - This parameter is only relevant when a C(type) of C(at_least) is used.
           - This parameter will be ignored if a type of either C(all) or C(require) is used.
+        type: int
       number_of_probes:
         description:
           - Specifies the minimum number of probes that must succeed for this server to be declared up.
@@ -168,6 +185,7 @@ options:
           - The value of this parameter should always be B(lower) than, or B(equal to), the value of C(number_of_probers).
           - This parameter is only relevant when a C(type) of C(require) is used.
           - This parameter will be ignored if a type of either C(all) or C(at_least) is used.
+        type: int
       number_of_probers:
         description:
           - Specifies the number of probers that should be used when running probes.
@@ -176,15 +194,19 @@ options:
           - The value of this parameter should always be B(higher) than, or B(equal to), the value of C(number_of_probers).
           - This parameter is only relevant when a C(type) of C(require) is used.
           - This parameter will be ignored if a type of either C(all) or C(at_least) is used.
+        type: int
+    type: dict
     version_added: 2.6
   max_answers_returned:
     description:
       - Specifies the maximum number of available virtual servers that the system lists in a response.
       - The maximum is 500.
+    type: int
     version_added: 2.8
   ttl:
     description:
       - Specifies the number of seconds that the IP address, once found, is valid.
+    type: int
     version_added: 2.8
 extends_documentation_fragment: f5
 author:
@@ -270,12 +292,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
     from library.module_utils.network.f5.ipaddress import is_valid_ip
@@ -283,12 +302,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import tmos_version
     from ansible.module_utils.network.f5.icontrol import module_provisioned
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
@@ -791,8 +807,9 @@ class Difference(object):
 
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = F5RestClient(**self.module.params)
         self.kwargs = kwargs
-        self.client = kwargs.get('client', None)
 
     def exec_module(self):
         if not module_provisioned(self.client, 'gtm'):
@@ -822,7 +839,7 @@ class ModuleManager(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
@@ -1232,18 +1249,15 @@ def main():
     module = AnsibleModule(
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode,
+        required_if=spec.required_if
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_server.py
@@ -24,6 +24,7 @@ options:
   name:
     description:
       - The name of the server.
+    type: str
     required: True
   state:
     description:
@@ -32,16 +33,18 @@ options:
         C(present) creates the server and enables it. If C(enabled), enable the server
         if it exists. If C(disabled), create the server if needed, and set state to
         C(disabled).
-    default: present
+    type: str
     choices:
       - present
       - absent
       - enabled
       - disabled
+    default: present
   datacenter:
     description:
       - Data center the server belongs to. When creating a new GTM server, this value
         is required.
+    type: str
   devices:
     description:
       - Lists the self IP addresses and translations for each device. When creating a
@@ -56,11 +59,13 @@ options:
       - Specifying duplicate C(name) fields is a supported means of providing device
         addresses. In this scenario, the addresses will be assigned to the C(name)'s list
         of addresses.
+    type: list
   server_type:
     description:
       - Specifies the server type. The server type determines the metrics that the
         system can collect from the server. When creating a new GTM server, the default
         value C(bigip) is used.
+    type: str
     choices:
       - alteon-ace-director
       - cisco-css
@@ -88,6 +93,7 @@ options:
       - If you set this parameter to C(enabled) or C(enabled-no-delete), you must
         also ensure that the C(virtual_server_discovery) parameter is also set to
         C(enabled) or C(enabled-no-delete).
+    type: str
     choices:
       - enabled
       - disabled
@@ -97,6 +103,7 @@ options:
       - Specifies whether the system auto-discovers the virtual servers for this server.
         When creating a new GTM server, if this parameter is not specified, the default
         value C(disabled) is used.
+    type: str
     choices:
       - enabled
       - disabled
@@ -104,6 +111,7 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   iquery_options:
@@ -126,12 +134,14 @@ options:
           - Specifies that the system checks the performance of a server running an SNMP
             agent.
         type: bool
+    type: dict
     version_added: 2.7
   monitors:
     description:
       - Specifies the health monitors that the system currently uses to monitor this resource.
       - When C(availability_requirements.type) is C(require), you may only have a single monitor in the
         C(monitors) list.
+    type: list
     version_added: 2.8
   availability_requirements:
     description:
@@ -143,13 +153,18 @@ options:
         description:
           - Monitor rule type when C(monitors) is specified.
           - When creating a new pool, if this value is not specified, the default of 'all' will be used.
-        choices: ['all', 'at_least', 'require']
+        type: str
+        choices:
+          - all
+          - at_least
+          - require
       at_least:
         description:
           - Specifies the minimum number of active health monitors that must be successful
             before the link is considered up.
           - This parameter is only relevant when a C(type) of C(at_least) is used.
           - This parameter will be ignored if a type of either C(all) or C(require) is used.
+        type: int
       number_of_probes:
         description:
           - Specifies the minimum number of probes that must succeed for this server to be declared up.
@@ -158,6 +173,7 @@ options:
           - The value of this parameter should always be B(lower) than, or B(equal to), the value of C(number_of_probers).
           - This parameter is only relevant when a C(type) of C(require) is used.
           - This parameter will be ignored if a type of either C(all) or C(at_least) is used.
+        type: int
       number_of_probers:
         description:
           - Specifies the number of probers that should be used when running probes.
@@ -166,6 +182,8 @@ options:
           - The value of this parameter should always be B(higher) than, or B(equal to), the value of C(number_of_probers).
           - This parameter is only relevant when a C(type) of C(require) is used.
           - This parameter will be ignored if a type of either C(all) or C(at_least) is used.
+        type: int
+    type: dict
     version_added: 2.8
   prober_preference:
     description:
@@ -173,6 +191,7 @@ options:
       - This option is ignored in C(TMOS) version C(12.x).
       - From C(TMOS) version C(13.x) and up, when prober_preference is set to C(pool)
         a C(prober_pool) parameter must be specified.
+    type: str
     choices:
       - inside-datacenter
       - outside-datacenter
@@ -188,6 +207,7 @@ options:
         a C(prober_pool) parameter must be specified.
       - The choices are mutually exclusive with prober_preference parameter,
         with the exception of C(any-available) or C(none) option.
+    type: str
     choices:
       - any
       - inside-datacenter
@@ -203,6 +223,7 @@ options:
       - Format of the name can be either be prepended by partition (C(/Common/foo)), or specified
         just as an object name (C(foo)).
       - In C(TMOS) version C(12.x) prober_pool can be set to empty string to revert to default setting of inherit.
+    type: str
     version_added: 2.8
   limits:
     description:
@@ -212,7 +233,6 @@ options:
       - You can define limits for any or all of the limit settings. However, when a
         member does not meet the resource threshold limit requirement, the system marks
         the member as unavailable and directs load-balancing traffic to another resource.
-    version_added: 2.8
     suboptions:
       bits_enabled:
         description:
@@ -245,26 +265,33 @@ options:
             for the member.
           - If the network traffic volume exceeds this limit, the system marks the
             member as unavailable.
+        type: int
       packets_limit:
         description:
           - Specifies the maximum allowable data transfer rate, in packets per second,
             for the member.
           - If the network traffic volume exceeds this limit, the system marks the
             member as unavailable.
+        type: int
       connections_limit:
         description:
           - Specifies the maximum number of concurrent connections, combined, for all of
             the member.
           - If the connections exceed this limit, the system marks the server as
             unavailable.
+        type: int
       cpu_limit:
         description:
           - Specifies the percent of CPU usage.
           - If percent of CPU usage goes above the limit, the system marks the server as unavailable.
+        type: int
       memory_limit:
         description:
           - Specifies the available memory required by the virtual servers on the server.
           - If available memory falls below this limit, the system marks the server as unavailable.
+        type: int
+    type: dict
+    version_added: 2.8
 extends_documentation_fragment: f5
 author:
   - Robert Teller (@r-teller)
@@ -405,12 +432,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import is_empty_list
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
@@ -418,12 +442,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import is_empty_list
     from ansible.module_utils.network.f5.icontrol import tmos_version
     from ansible.module_utils.network.f5.icontrol import module_provisioned
@@ -1327,7 +1348,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.kwargs = kwargs
 
     def exec_module(self):
@@ -1358,7 +1379,7 @@ class ModuleManager(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.want.update(dict(client=self.client))
         self.have = ApiParameters()
@@ -1748,16 +1769,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_topology_record.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_topology_record.py
@@ -32,28 +32,34 @@ options:
       subnet:
         description:
           - An IP address and network mask in the CIDR format.
+        type: str
       region:
         description:
           - Specifies the name of region already defined in the configuration.
+        type: str
       continent:
         description:
           - Specifies one of the seven continents, along with the C(Unknown) setting.
           - Specifying C(Unknown) forces the system to use a default resolution
             if the system cannot determine the location of the local DNS making the request.
           - Full continent names and their abbreviated versions are supported.
+        type: str
       country:
         description:
           - Specifies a country.
           - In addition to the country full names, you may also specify their abbreviated
             form, such as C(US) instead of C(United States).
           - Valid country codes can be found here https://countrycode.org/.
+        type: str
       state:
         description:
           - Specifies a state in a given country.
           - This parameter requires country option to be provided.
+        type: str
       isp:
         description:
           - Specifies an Internet service provider.
+        type: str
         choices:
           - AOL
           - BeijingCNC
@@ -70,6 +76,8 @@ options:
       geo_isp:
         description:
           - Specifies a geolocation ISP
+        type: str
+    type: dict
     required: True
   destination:
     description:
@@ -83,32 +91,40 @@ options:
       subnet:
         description:
           - An IP address and network mask in the CIDR format.
+        type: str
       region:
         description:
           - Specifies the name of region already defined in the configuration.
+        type: str
       continent:
         description:
           - Specifies one of the seven continents, along with the C(Unknown) setting.
           - Specifying C(Unknown) forces the system to use a default resolution
             if the system cannot determine the location of the local DNS making the request.
           - Full continent names and their abbreviated versions are supported.
+        type: str
       country:
         description:
           - Specifies a country.
           - Full continent names and their abbreviated versions are supported.
+        type: str
       state:
         description:
           - Specifies a state in a given country.
           - This parameter requires country option to be provided.
+        type: str
       pool:
         description:
           - Specifies the name of GTM pool already defined in the configuration.
+        type: str
       datacenter:
         description:
           - Specifies the name of GTM data center already defined in the configuration.
+        type: str
       isp:
         description:
           - Specifies an Internet service provider.
+        type: str
         choices:
           - AOL
           - BeijingCNC
@@ -125,6 +141,8 @@ options:
       geo_isp:
         description:
           - Specifies a geolocation ISP
+        type: str
+    type: dict
     required: True
   weight:
      description:
@@ -142,11 +160,13 @@ options:
       - Device partition to manage resources on.
       - Partition parameter is taken into account when used in conjunction with C(pool), C(data_center),
         and C(region) parameters, it is ignored otherwise.
+    type: str
     default: Common
   state:
     description:
       - When C(state) is C(present), ensures that the record exists.
       - When C(state) is C(absent), ensures that the record is removed.
+    type: str
     choices:
       - present
       - absent
@@ -214,11 +234,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.ipaddress import is_valid_ip_network
@@ -226,11 +243,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip_network
@@ -788,7 +802,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -1054,16 +1068,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
@@ -27,6 +27,7 @@ options:
         for a wide IP.
       - The C(round_robin) value is deprecated and will be removed in Ansible 2.9.
       - The C(global_availability) value is deprecated and will be removed in Ansible 2.9.
+    type: str
     required: True
     aliases: ['lb_method']
     choices:
@@ -42,6 +43,7 @@ options:
       - Wide IP name. This name must be formatted as a fully qualified
         domain name (FQDN). You can also use the alias C(wide_ip) but this
         is deprecated and will be removed in a future Ansible version.
+    type: str
     required: True
     aliases:
       - wide_ip
@@ -51,6 +53,7 @@ options:
         type in addition to name, since pool members need different attributes
         depending on the response RDATA they are meant to supply. This value
         is required if you are using BIG-IP versions >= 12.0.0.
+    type: str
     choices:
       - a
       - aaaa
@@ -65,16 +68,18 @@ options:
         is enabled.
       - When C(absent), ensures that the Wide IP has been removed.
       - When C(disabled), ensures that the Wide IP exists and is disabled.
-    default: present
+    type: str
     choices:
       - present
       - absent
       - disabled
       - enabled
+    default: present
     version_added: 2.4
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   pools:
@@ -82,21 +87,25 @@ options:
       - The pools that you want associated with the Wide IP.
       - If C(ratio) is not provided when creating a new Wide IP, it will default
         to 1.
+    type: list
     suboptions:
       name:
         description:
           - The name of the pool to include.
+        type: str
         required: True
       ratio:
         description:
           - Ratio for the pool.
           - The system uses this number with the Ratio load balancing method.
+        type: int
     version_added: 2.5
   irules:
     description:
       - List of rules to be applied.
       - If you want to remove all existing iRules, specify a single empty value; C("").
         See the documentation for an example.
+    type: list
     version_added: 2.6
   aliases:
     description:
@@ -104,6 +113,7 @@ options:
         balancing.
       - You can use the same wildcard characters for aliases as you can for actual
         wide IP names.
+    type: list
     version_added: 2.7
   last_resort_pool:
     description:
@@ -111,6 +121,7 @@ options:
         the wide IP.
       - The valid pools for this parameter are those with the C(type) specified in this
         module.
+    type: str
     version_added: 2.8
 extends_documentation_fragment: f5
 author:
@@ -211,12 +222,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import is_valid_fqdn
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
@@ -224,12 +232,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import is_valid_fqdn
     from ansible.module_utils.network.f5.icontrol import tmos_version
     from ansible.module_utils.network.f5.icontrol import module_provisioned
@@ -560,7 +565,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.kwargs = kwargs
 
     def exec_module(self):
@@ -591,7 +596,7 @@ class ModuleManager(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -939,16 +944,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_gtm_datacenter.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_datacenter.py
@@ -134,11 +134,13 @@ class TestManager(unittest.TestCase):
 
     def test_create_datacenter(self, *args):
         set_module_args(dict(
+            name='foo',
             state='present',
-            password='admin',
-            server='localhost',
-            user='admin',
-            name='foo'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -158,11 +160,14 @@ class TestManager(unittest.TestCase):
 
     def test_create_disabled_datacenter(self, *args):
         set_module_args(dict(
+            name='foo',
             state='disabled',
-            password='admin',
-            server='localhost',
-            user='admin',
-            name='foo'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
+
         ))
 
         module = AnsibleModule(
@@ -183,11 +188,14 @@ class TestManager(unittest.TestCase):
 
     def test_create_enabled_datacenter(self, *args):
         set_module_args(dict(
+            name='foo',
             state='enabled',
-            password='admin',
-            server='localhost',
-            user='admin',
-            name='foo'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
+
         ))
 
         module = AnsibleModule(
@@ -208,11 +216,14 @@ class TestManager(unittest.TestCase):
 
     def test_idempotent_disable_datacenter(self, *args):
         set_module_args(dict(
+            name='foo',
             state='disabled',
-            password='admin',
-            server='localhost',
-            user='admin',
-            name='foo'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
+
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_global.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_global.py
@@ -96,9 +96,11 @@ class TestManager(unittest.TestCase):
             synchronization="yes",
             synchronization_group_name='foo',
             synchronize_zone_files="yes",
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_gtm_global_settings_general_1.json'))

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_bigip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_bigip.py
@@ -156,9 +156,11 @@ class TestManager(unittest.TestCase):
             port=80,
             interval=20,
             timeout=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_firepass.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_firepass.py
@@ -133,9 +133,11 @@ class TestManager(unittest.TestCase):
             port=80,
             interval=20,
             timeout=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_http.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_http.py
@@ -139,9 +139,11 @@ class TestManager(unittest.TestCase):
             port=80,
             interval=20,
             timeout=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_https.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_https.py
@@ -147,9 +147,11 @@ class TestManager(unittest.TestCase):
             port=80,
             interval=20,
             timeout=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp.py
@@ -139,9 +139,11 @@ class TestManager(unittest.TestCase):
             port=80,
             interval=20,
             timeout=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -166,9 +168,11 @@ class TestManager(unittest.TestCase):
             port=80,
             interval=20,
             timeout=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_gtm_monitor_tcp_1.json'))
@@ -193,9 +197,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             ignore_down_response=True,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_gtm_monitor_tcp_1.json'))

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp_half_open.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp_half_open.py
@@ -170,9 +170,11 @@ class TestManager(unittest.TestCase):
             port=80,
             interval=20,
             timeout=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_pool.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_pool.py
@@ -145,14 +145,17 @@ class TestUntypedManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             preferred_lb_method='round-robin',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         # Override methods in the specific type of manager
@@ -178,14 +181,17 @@ class TestUntypedManager(unittest.TestCase):
             preferred_lb_method='topology',
             alternate_lb_method='drop-packet',
             fallback_lb_method='cpu',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         current = ApiParameters(params=load_fixture('load_gtm_pool_untyped_default.json'))
@@ -214,14 +220,17 @@ class TestUntypedManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             state='absent',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         # Override methods in the specific type of manager
@@ -263,14 +272,17 @@ class TestTypedManager(unittest.TestCase):
             name='foo',
             preferred_lb_method='round-robin',
             type='a',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         # Override methods in the specific type of manager
@@ -297,14 +309,17 @@ class TestTypedManager(unittest.TestCase):
             alternate_lb_method='drop-packet',
             fallback_lb_method='cpu',
             type='a',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         current = ApiParameters(params=load_fixture('load_gtm_pool_a_default.json'))
@@ -334,14 +349,17 @@ class TestTypedManager(unittest.TestCase):
             name='foo',
             type='a',
             state='absent',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         # Override methods in the specific type of manager

--- a/test/units/modules/network/f5/test_bigip_gtm_server.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_server.py
@@ -164,9 +164,6 @@ class TestV1Manager(unittest.TestCase):
 
     def test_create(self, *args):
         set_module_args(dict(
-            server='lb.mydomain.com',
-            user='admin',
-            password='secret',
             name='GTM_Server',
             datacenter='/Common/New York',
             server_type='bigip',
@@ -209,7 +206,12 @@ class TestV1Manager(unittest.TestCase):
                         )
                     ]
                 )
-            ]
+            ],
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -265,9 +267,6 @@ class TestV2Manager(unittest.TestCase):
 
     def test_create(self, *args):
         set_module_args(dict(
-            server='lb.mydomain.com',
-            user='admin',
-            password='secret',
             name='GTM_Server',
             datacenter='/Common/New York',
             server_type='bigip',
@@ -310,7 +309,12 @@ class TestV2Manager(unittest.TestCase):
                         )
                     ]
                 )
-            ]
+            ],
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_topology_record.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_topology_record.py
@@ -111,7 +111,12 @@ class TestManager(unittest.TestCase):
             destination=dict(
                 region='Foobar',
             ),
-            weight=10
+            weight=10,
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_gtm_topology_region.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_topology_region.py
@@ -110,7 +110,7 @@ class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
 
-    def test_create_topology_record(self, *args):
+    def test_create_topology_region(self, *args):
         set_module_args(dict(
             name='foobar',
             region_members=[
@@ -122,7 +122,12 @@ class TestManager(unittest.TestCase):
                     datacenter='bazcenter'
                 )
             ],
-            partition='Common'
+            partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         )
         )
 
@@ -133,7 +138,7 @@ class TestManager(unittest.TestCase):
 
         # Override methods in the specific type of manager
         mm = ModuleManager(module=module)
-        mm.exists = Mock(side_effect=[False, True])
+        mm.exists = Mock(return_value=False)
         mm.create_on_device = Mock(return_value=True)
 
         results = mm.exec_module()

--- a/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
@@ -143,9 +143,11 @@ class TestUntypedManager(unittest.TestCase):
         set_module_args(dict(
             name='foo.baz.bar',
             lb_method='round-robin',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -192,9 +194,11 @@ class TestTypedManager(unittest.TestCase):
             name='foo.baz.bar',
             lb_method='round-robin',
             type='a',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -224,9 +228,11 @@ class TestTypedManager(unittest.TestCase):
             name='foo.baz.bar',
             lb_method='round_robin',
             type='a',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -256,9 +262,11 @@ class TestTypedManager(unittest.TestCase):
             name='foo.baz.bar',
             lb_method='global_availability',
             type='a',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -294,9 +302,11 @@ class TestTypedManager(unittest.TestCase):
                     ratio=10
                 )
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -332,9 +342,11 @@ class TestTypedManager(unittest.TestCase):
                     ratio=10
                 )
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_gtm_wide_ip_with_pools.json'))
@@ -372,9 +384,11 @@ class TestTypedManager(unittest.TestCase):
                     ratio=100
                 )
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_gtm_wide_ip_with_pools.json'))


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters
Adds RETURN values that were previously missing
Removes redundant unit tests files

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
lib/ansible/modules/network/f5/bigip_gtm_global.py
lib/ansible/modules/network/f5/bigip_gtm_monitor_bigip.py
lib/ansible/modules/network/f5/bigip_gtm_monitor_firepass.py
lib/ansible/modules/network/f5/bigip_gtm_monitor_http.py
lib/ansible/modules/network/f5/bigip_gtm_monitor_https.py
lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp.py
lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp_half_open.py
lib/ansible/modules/network/f5/bigip_gtm_pool.py
lib/ansible/modules/network/f5/bigip_gtm_pool_member.py
lib/ansible/modules/network/f5/bigip_gtm_server.py
lib/ansible/modules/network/f5/bigip_gtm_topology_record.py
lib/ansible/modules/network/f5/bigip_gtm_topology_region.py
lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py



##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.