### PR TITLE
BIGIP: multiple_modules_fix_6

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_hostname.py
+++ b/lib/ansible/modules/network/f5/bigip_hostname.py
@@ -23,6 +23,7 @@ options:
   hostname:
     description:
       - Hostname of the BIG-IP host.
+    type: str
     required: True
 extends_documentation_fragment: f5
 author:
@@ -56,18 +57,12 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -134,7 +129,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = ApiParameters()
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
@@ -301,16 +296,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_iapp_service.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_service.py
@@ -25,6 +25,7 @@ options:
   name:
     description:
       - The name of the iApp service that you want to deploy.
+    type: str
     required: True
   template:
     description:
@@ -32,6 +33,7 @@ options:
         template must exist on your BIG-IP before you can successfully
         create a service.
       - When creating a new service, this parameter is required.
+    type: str
   parameters:
     description:
       - A hash of all the required template variables for the iApp template.
@@ -40,6 +42,7 @@ options:
         to supply the expected parameters.
       - These parameters typically consist of the C(lists), C(tables), and
         C(variables) fields.
+    type: dict
   force:
     description:
       - Forces the updating of an iApp service even if the parameters to the
@@ -47,19 +50,21 @@ options:
         the iApp template that underlies the service has been updated in-place.
         This option is equivalent to re-configuring the iApp if that template
         has changed.
-    default: no
     type: bool
+    default: no
   state:
     description:
       - When C(present), ensures that the iApp service is created and running.
         When C(absent), ensures that the iApp service has been removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   strict_updates:
@@ -74,8 +79,8 @@ options:
       - If this option is specified in the Ansible task, it will take precedence
         over any similar setting in the iApp Service payload that you provide in
         the C(parameters) field.
-    default: yes
     type: bool
+    default: yes
     version_added: 2.5
   traffic_group:
     description:
@@ -85,6 +90,7 @@ options:
       - If this option is specified in the Ansible task, it will take precedence
         over any similar setting in the iApp Service payload that you provide in
         the C(parameters) field.
+    type: str
     version_added: 2.5
   metadata:
     description:
@@ -92,6 +98,7 @@ options:
       - If this option is specified in the Ansible task, it will take precedence
         over any similar setting in the iApp Service payload that you provide in
         the C(parameters) field.
+    type: list
     version_added: 2.7
   description:
     description:
@@ -99,6 +106,7 @@ options:
       - If this option is specified in the Ansible task, it will take precedence
         over any similar setting in the iApp Service payload that you provide in
         the C(parameters) field.
+    type: str
     version_added: 2.7
   device_group:
     description:
@@ -106,6 +114,7 @@ options:
       - If this option is specified in the Ansible task, it will take precedence
         over any similar setting in the iApp Service payload that you provide in
         the C(parameters) field.
+    type: str
     version_added: 2.7
 extends_documentation_fragment: f5
 author:
@@ -264,11 +273,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.urls import build_service_uri
@@ -276,11 +282,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.urls import build_service_uri
@@ -676,7 +679,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
@@ -979,16 +982,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_ike_peer.py
+++ b/lib/ansible/modules/network/f5/bigip_ike_peer.py
@@ -23,10 +23,12 @@ options:
   name:
     description:
       - Specifies the name of the IKE peer.
+    type: str
     required: True
   description:
     description:
       - Description of the IKE peer.
+    type: str
   version:
     description:
       - Specifies which version of IKE is used.
@@ -37,6 +39,7 @@ options:
       - If the system you are configuring is the IPsec responder, and you select
         both versions, the IPsec initiator system determines which IKE version to use.
       - When creating a new IKE peer, this value is required.
+    type: list
     choices:
       - v1
       - v2
@@ -44,6 +47,7 @@ options:
     description:
       - Specifies the identifier type that the local system uses to identify
         itself to the peer during IKE Phase 1 negotiations.
+    type: str
     choices:
       - address
       - asn1dn
@@ -56,6 +60,7 @@ options:
       - This is a required value when C(version) includes (Cv2).
       - Specifies a value for the identity when using a C(presented_id_type) of
         C(override).
+    type: str
   verified_id_type:
     description:
       - Specifies the identifier type that the local system uses to identify
@@ -63,6 +68,7 @@ options:
       - This is a required value when C(version) includes (Cv2).
       - When C(user-fqdn), value of C(verified_id_value) must be in the form of
         User @ DNS domain string.
+    type: str
     choices:
       - address
       - asn1dn
@@ -75,11 +81,13 @@ options:
       - This is a required value when C(version) includes (Cv2).
       - Specifies a value for the identity when using a C(verified_id_type) of
         C(override).
+    type: str
   phase1_auth_method:
     description:
       - Specifies the authentication method for phase 1 negotiation.
       - When creating a new IKE peer, if this value is not specified, the default is
         C(rsa-signature).
+    type: str
     choices:
       - pre-shared-key
       - rsa-signature
@@ -89,12 +97,14 @@ options:
       - When creating a new IKE peer, if this value is not specified, and
         C(phase1_auth_method) is C(rsa-signature), the default is C(default.crt).
       - This parameter is invalid when C(phase1_auth_method) is C(pre-shared-key).
+    type: str
   phase1_key:
     description:
       - Specifies the public key that the digital certificate contains.
       - When creating a new IKE peer, if this value is not specified, and
         C(phase1_auth_method) is C(rsa-signature), the default is C(default.key).
       - This parameter is invalid when C(phase1_auth_method) is C(pre-shared-key).
+    type: str
   phase1_verify_peer_cert:
     description:
       - In IKEv2, specifies whether the certificate sent by the IKE peer is verified
@@ -113,14 +123,17 @@ options:
       - Specifies a string that the IKE peers share for authenticating each other.
       - This parameter is only relevant when C(phase1_auth_method) is C(pre-shared-key).
       - This parameter is invalid when C(phase1_auth_method) is C(rsa-signature).
+    type: str
   remote_address:
     description:
       - Displays the IP address of the BIG-IP system that is remote to the system
         you are configuring.
+    type: str
   phase1_encryption_algorithm:
     description:
       - Specifies the algorithm to use for IKE encryption.
       - IKE C(version) C(v2) does not support C(blowfish), C(camellia), or C(cast128).
+    type: str
     choices:
       - 3des
       - des
@@ -133,6 +146,7 @@ options:
   phase1_hash_algorithm:
     description:
       - Specifies the algorithm to use for IKE authentication.
+    type: str
     choices:
       - sha1
       - md5
@@ -142,6 +156,7 @@ options:
   phase1_perfect_forward_secrecy:
     description:
       - Specifies the Diffie-Hellman group to use for IKE Phase 1 and Phase 2 negotiations.
+    type: str
     choices:
       - ecp256
       - ecp384
@@ -158,22 +173,25 @@ options:
     description:
       - C(always) will allow to update passwords if the user chooses to do so.
         C(on_create) will only set the password for newly created IKE peers.
-    default: always
+    type: str
     choices:
       - always
       - on_create
+    default: always
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -181,9 +199,33 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Create a ...
+- name: Create new IKE peer
   bigip_ike_peer:
-    name: foo
+    name: ike1
+    remote_address: 1.2.3.4
+    version:
+      - v1
+    provider:
+      password: secret
+      server: lb.mydomain.com
+      user: admin
+  delegate_to: localhost
+
+- name: Change presented id type - keyid-tag
+  bigip_ike_peer:
+    name: ike1
+    presented_id_type: keyid-tag
+    presented_id_value: key1
+    provider:
+      password: secret
+      server: lb.mydomain.com
+      user: admin
+  delegate_to: localhost
+
+- name: Remove IKE peer
+  bigip_ike_peer:
+    name: ike1
+    state: absent
     provider:
       password: secret
       server: lb.mydomain.com
@@ -266,11 +308,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.compare import cmp_str_with_none
@@ -278,11 +317,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
@@ -461,7 +497,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -756,16 +792,12 @@ def main():
         required_together=spec.required_together,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_irule.py
+++ b/lib/ansible/modules/network/f5/bigip_irule.py
@@ -26,9 +26,11 @@ options:
         the specified value. This is for simple values, but can be used with
         lookup plugins for anything complex or with formatting. Either one
         of C(src) or C(content) must be provided.
+    type: str
   module:
     description:
       - The BIG-IP module to add the iRule to.
+    type: str
     required: True
     choices:
       - ltm
@@ -36,22 +38,26 @@ options:
   name:
     description:
       - The name of the iRule.
+    type: str
     required: True
   src:
     description:
       - The iRule file to interpret and upload to the BIG-IP. Either one
         of C(src) or C(content) must be provided.
+    type: path
     required: True
   state:
     description:
       - Whether the iRule should exist or not.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
 extends_documentation_fragment: f5
@@ -113,20 +119,14 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -244,7 +244,7 @@ class ModuleManager(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
@@ -565,16 +565,12 @@ def main():
         mutually_exclusive=spec.mutually_exclusive
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_log_destination.py
+++ b/lib/ansible/modules/network/f5/bigip_log_destination.py
@@ -23,11 +23,13 @@ options:
   name:
     description:
       - Specifies the name of the log destination.
+    type: str
     required: True
   type:
     description:
       - Specifies the type of log destination.
       - Once created, this parameter cannot be changed.
+    type: str
     choices:
       - remote-high-speed-log
       - remote-syslog
@@ -39,6 +41,7 @@ options:
   description:
     description:
       - The description of the log destination.
+    type: str
   pool_settings:
     description:
       - This parameter is only available when C(type) is C(remote-high-speed-log).
@@ -49,12 +52,14 @@ options:
           - Specifies the existing pool of remote high-speed log servers where logs will be sent.
           - When creating a new destination (and C(type) is C(remote-high-speed-log)), this parameter
             is required.
+        type: str
       protocol:
         description:
           - Specifies the protocol for the system to use to send logs to the pool of remote high-speed
             log servers, where the logs are stored.
           - When creating a new log destination (and C(type) is C(remote-high-speed-log)), if this
             parameter is not specified, the default is C(tcp).
+        type: str
         choices:
           - tcp
           - udp
@@ -70,10 +75,12 @@ options:
           - When C(replicated), replicates each log to all pool members, for redundancy.
           - When creating a new log destination (and C(type) is C(remote-high-speed-log)), if this
             parameter is not specified, the default is C(adaptive).
+        type: str
         choices:
           - adaptive
           - balanced
           - replicated
+    type: dict
   syslog_settings:
     description:
       - This parameter is only available when C(type) is C(remote-syslog).
@@ -86,6 +93,7 @@ options:
             not specified, the default is C(bsd-syslog).
           - The C(syslog) and C(rfc5424) choices are two ways of saying the same thing.
           - The C(bsd-syslog) and C(rfc3164) choices are two ways of saying the same thing.
+        type: str
         choices:
           - bsd-syslog
           - syslog
@@ -98,6 +106,8 @@ options:
             single log server, or a remote high-speed log destination, which will be used to forward the
             logs to a pool of remote log servers.
           - When creating a new log destination (and C(type) is C(remote-syslog)), this parameter is required.
+        type: str
+    type: dict
   syslog_format:
     description:
       - Specifies the method to use to format the logs associated with the remote Syslog log destination.
@@ -105,6 +115,7 @@ options:
         not specified, the default is C(bsd-syslog).
       - The C(syslog) and C(rfc5424) choices are two ways of saying the same thing.
       - The C(bsd-syslog) and C(rfc3164) choices are two ways of saying the same thing.
+    type: str
     choices:
       - bsd-syslog
       - syslog
@@ -123,6 +134,7 @@ options:
         ArcSight or Splunk server.
       - When creating a new log destination and C(type) is C(remote-syslog), C(splunk), or C(arcsight),
         this parameter is required.
+    type: str
     version_added: 2.8
   pool:
     description:
@@ -133,6 +145,7 @@ options:
         of collectors.
       - When creating a new destination and C(type) is C(remote-high-speed-log) or C(ipfix), this
         parameter is required.
+    type: str
     version_added: 2.8
   protocol:
     description:
@@ -143,6 +156,7 @@ options:
       - When C(type) is C(management-port), specifies the protocol used to send messages to the
         specified location.
       - When C(type) is C(management-port), only C(tcp) and C(udp) are valid values.
+    type: str
     choices:
       - tcp
       - udp
@@ -161,6 +175,7 @@ options:
       - When C(replicated), replicates each log to all pool members, for redundancy.
       - When creating a new log destination and C(type) is C(remote-high-speed-log), if this
         parameter is not specified, the default is C(adaptive).
+    type: str
     choices:
       - adaptive
       - balanced
@@ -172,6 +187,7 @@ options:
       - This parameter is only available when C(type) is C(management-port).
       - When creating a new log destination and C(type) is C(management-port), this parameter
         is required.
+    type: str
     version_added: 2.8
   port:
     description:
@@ -180,6 +196,7 @@ options:
       - This parameter is only available when C(type) is C(management-port).
       - When creating a new log destination and C(type) is C(management-port), this parameter
         is required.
+    type: int
     version_added: 2.8
   transport_profile:
     description:
@@ -187,6 +204,7 @@ options:
       - This profile defines the TCP or UDP options used to send IP-traffic logs
         to the pool of collectors.
       - This parameter is only available when C(type) is C(ipfix).
+    type: str
     version_added: 2.8
   server_ssl_profile:
     description:
@@ -196,6 +214,7 @@ options:
       - An SSL server profile defines how to communicate securely over SSL or
         Transport Layer Security (TLS).
       - This parameter is only available when C(type) is C(ipfix).
+    type: str
     version_added: 2.8
   template_retransmit_interval:
     description:
@@ -205,6 +224,7 @@ options:
         at the interval you set in this field. These retransmissions are helpful
         for UDP, a lossy transport mechanism.
       - This parameter is only available when C(type) is C(ipfix).
+    type: int
     version_added: 2.8
   template_delete_delay:
     description:
@@ -212,19 +232,22 @@ options:
         deleting an obsolete IPFIX template and reusing its template ID.
       - This feature is useful for systems where you use iRules to create
         customized IPFIX templates.
+    type: int
     version_added: 2.8
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -320,23 +343,17 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
 
@@ -683,7 +700,7 @@ class Difference(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
 
     def _set_changed_options(self):
         changed = {}
@@ -1732,19 +1749,16 @@ def main():
 
     module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode
+        supports_check_mode=spec.supports_check_mode,
+        mutually_exclusive=spec.mutually_exclusive
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_log_publisher.py
+++ b/lib/ansible/modules/network/f5/bigip_log_publisher.py
@@ -23,25 +23,30 @@ options:
   name:
     description:
       - Specifies the name of the log publisher.
+    type: str
     required: True
   description:
     description:
       - Specifies a description for the log publisher.
+    type: str
   destinations:
     description:
       - Specifies log destinations for this log publisher to use.
+    type: list
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -83,23 +88,17 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.compare import cmp_simple_list
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.compare import cmp_simple_list
 
 
@@ -200,7 +199,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -414,16 +413,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_management_route.py
+++ b/lib/ansible/modules/network/f5/bigip_management_route.py
@@ -23,14 +23,17 @@ options:
   name:
     description:
       - Specifies the name of the management route.
+    type: str
     required: True
   description:
     description:
       - Description of the management route.
+    type: str
   gateway:
     description:
       - Specifies that the system forwards packets to the destination through the
         gateway with the specified IP address.
+    type: str
   network:
     description:
       - The subnet and netmask to be used for the route.
@@ -39,18 +42,21 @@ options:
       - Only one C(default) entry is allowed.
       - This parameter cannot be changed after it is set. Therefore, if you do need to change
         it, it is required that you delete and create a new route.
+    type: str
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -97,20 +103,14 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.compat.ipaddress import ip_network
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.compat.ipaddress import ip_network
 
@@ -226,7 +226,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -441,16 +441,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_dns.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_dns.py
@@ -29,10 +29,12 @@ options:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(dns)
         parent on the C(Common) partition.
+    type: str
     default: /Common/dns
   description:
     description:
       - The description of the monitor.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
@@ -40,6 +42,7 @@ options:
       - This value B(must) be less than the C(timeout) value.
       - When creating a new monitor, if this parameter is not provided, the
         default C(5) will be used.
+    type: int
   up_interval:
     description:
       - Specifies the interval for the system to use to perform the health check
@@ -50,6 +53,7 @@ options:
         use when checking the health of a resource that is up.
       - When creating a new monitor, if this parameter is not provided, the
         default C(0) will be used.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -60,6 +64,7 @@ options:
         interval number of seconds plus 1 second.
       - If this parameter is not provided when creating a new monitor, then the default
         value will be C(16).
+    type: int
   transparent:
     description:
       - Specifies whether the monitor operates in transparent mode.
@@ -82,6 +87,7 @@ options:
       - Specifies the IP address that the monitor uses from the resource record sections
         of the DNS response.
       - The IP address should be specified in the dotted-decimal notation or IPv6 notation.
+    type: str
   time_until_up:
     description:
       - Specifies the amount of time in seconds after the first successful
@@ -90,6 +96,7 @@ options:
         response is received from the node.
       - If this parameter is not provided when creating a new monitor, then the default
         value will be C(0).
+    type: int
   manual_resume:
     description:
       - Specifies whether the system automatically changes the status of a resource
@@ -108,15 +115,18 @@ options:
       - IP address part of the IP/port definition.
       - If this parameter is not provided when creating a new monitor, then the
         default value will be C(*).
+    type: str
   port:
     description:
       - Port address part of the IP/port definition.
       - If this parameter is not provided when creating a new monitor, then the default
         value will be C(*).
       - Note that if specifying an IP address, a value between 1 and 65535 must be specified.
+    type: str
   query_name:
     description:
       - Specifies a query name for the monitor to use in a DNS query.
+    type: str
   query_type:
     description:
       - Specifies the type of DNS query that the monitor sends.
@@ -124,6 +134,7 @@ options:
         value is C(a).
       - When C(a), specifies that the monitor will send a DNS query of type A.
       - When C(aaaa), specifies that the monitor will send a DNS query of type AAAA.
+    type: str
     choices:
       - a
       - aaaa
@@ -137,6 +148,7 @@ options:
       - When C(any-type), specifies that the DNS message should contain at least one answer.
       - When C(anything), specifies that an empty answer is enough to mark the status of
         the node up.
+    type: str
     choices:
       - any-type
       - anything
@@ -152,6 +164,7 @@ options:
         irrespective of the RCODE in the DNS message received.
       - If this parameter is set to C(anything), it will disregard the C(receive)
         string, and nullify it if the monitor is being updated.
+    type: str
     choices:
       - no-error
       - anything
@@ -175,6 +188,7 @@ options:
         latency value you set, the pool member or node is marked down.
       - When C(relative), the percentage of deviation the latency of a monitor probe
         can exceed the mean latency of a monitor probe for the service being probed.
+    type: str
     choices:
       - relative
       - absolute
@@ -182,6 +196,7 @@ options:
     description:
       - When specifying a new monitor, if C(adaptive) is C(yes), and C(type) is
         C(relative), the default is C(25) percent.
+    type: int
   adaptive_limit:
     description:
       - Specifies the absolute number of milliseconds that may not be exceeded by a monitor
@@ -190,24 +205,28 @@ options:
       - This value applies regardless of the value of the C(allowed_divergence) setting.
       - While this value can be configured when C(adaptive) is C(no), it will not take
         effect on the system until C(adaptive) is C(yes).
+    type: int
   sampling_timespan:
     description:
       - Specifies the length, in seconds, of the probe history window that the system
         uses to calculate the mean latency and standard deviation of a monitor probe.
       - While this value can be configured when C(adaptive) is C(no), it will not take
         effect on the system until C(adaptive) is C(yes).
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -352,12 +371,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.ipaddress import validate_ip_v6_address
@@ -367,12 +383,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.ipaddress import validate_ip_v6_address
@@ -708,7 +721,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -1002,16 +1015,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_http.py
@@ -22,47 +22,56 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(http)
         parent on the C(Common) partition.
+    type: str
     default: /Common/http
   description:
     description:
       - The description of the monitor.
+    type: str
     version_added: 2.7
   send:
     description:
       - The send string for the monitor call. When creating a new monitor, if
         this value is not provided, the default C(GET /\r\n) will be used.
+    type: str
   receive:
     description:
       - The receive string for the monitor call.
+    type: str
   receive_disable:
     description:
       - This setting works like C(receive), except that the system marks the node
         or pool member disabled when its response matches the C(receive_disable)
         string but not C(receive). To use this setting, you must specify both
         C(receive_disable) and C(receive).
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 5. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -72,6 +81,7 @@ options:
         number to any number you want, however, it should be 3 times the
         interval number of seconds plus 1 second. If this parameter is not
         provided when creating a new monitor, then the default value will be 16.
+    type: int
   time_until_up:
     description:
       - Specifies the amount of time in seconds after the first successful
@@ -79,12 +89,15 @@ options:
         node to be marked up immediately after a valid response is received
         from the node. If this parameter is not provided when creating
         a new monitor, then the default value will be 0.
+    type: int
   target_username:
     description:
       - Specifies the user name, if the monitored target requires authentication.
+    type: str
   target_password:
     description:
       - Specifies the password, if the monitored target requires authentication.
+    type: str
   reverse:
     description:
       - Specifies whether the monitor operates in reverse mode.
@@ -99,16 +112,18 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
@@ -198,12 +213,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.compare import cmp_str_with_none
@@ -211,12 +223,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
@@ -480,7 +489,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -734,16 +743,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_https.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_https.py
@@ -22,47 +22,56 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   description:
     description:
       - The description of the monitor.
+    type: str
     version_added: 2.7
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(https)
         parent on the C(Common) partition.
+    type: str
     default: /Common/https
   send:
     description:
       - The send string for the monitor call. When creating a new monitor, if
         this value is not provided, the default C(GET /\\r\\n) will be used.
+    type: str
   receive:
     description:
       - The receive string for the monitor call.
+    type: str
   receive_disable:
     description:
       - This setting works like C(receive), except that the system marks the node
         or pool member disabled when its response matches the C(receive_disable)
         string but not C(receive). To use this setting, you must specify both
         C(receive_disable) and C(receive).
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 5. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -72,6 +81,7 @@ options:
         number to any number you want, however, it should be 3 times the
         interval number of seconds plus 1 second. If this parameter is not
         provided when creating a new monitor, then the default value will be 16.
+    type: int
   time_until_up:
     description:
       - Specifies the amount of time in seconds after the first successful
@@ -79,18 +89,22 @@ options:
         node to be marked up immediately after a valid response is received
         from the node. If this parameter is not provided when creating
         a new monitor, then the default value will be 0.
+    type: int
   target_username:
     description:
       - Specifies the user name, if the monitored target requires authentication.
+    type: str
   target_password:
     description:
       - Specifies the password, if the monitored target requires authentication.
+    type: str
   ssl_profile:
     description:
       - Specifies the SSL profile to use for the HTTPS monitor.
       - Defining SSL profiles enables refined customization of the SSL attributes
         for an HTTPS monitor.
       - This parameter is only supported on BIG-IP versions 13.x and later.
+    type: str
     version_added: 2.8
   up_interval:
     description:
@@ -100,19 +114,22 @@ options:
         C(interval) to check the health of the resource.
       - When any other number, enables specification of a different interval to
         use when checking the health of a resource that is up.
+    type: int
     version_added: 2.8
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
@@ -190,12 +207,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.compare import cmp_str_with_none
 
@@ -203,12 +217,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
@@ -482,7 +493,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -719,16 +730,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_ldap.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_ldap.py
@@ -23,21 +23,25 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   description:
     description:
       - Specifies descriptive text that identifies the monitor.
+    type: str
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed.
       - By default, this value is the C(ldap) parent on the C(Common) partition.
+    type: str
     default: "/Common/ldap"
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
@@ -45,11 +49,13 @@ options:
         '*'.
       - Note that if specifying an IP address, a value between 1 and 65535
         must be specified.
+    type: str
   interval:
     description:
       - Specifies, in seconds, the frequency at which the system issues the
         monitor check when either the resource is down or the status of the
         resource is unknown.
+    type: int
   timeout:
     description:
       - Specifies the number of seconds the target has in which to respond to
@@ -60,6 +66,7 @@ options:
         from the parent monitor.
       - Note that C(timeout) and C(time_until_up) combine to control when a
         resource is set to up.
+    type: int
   time_until_up:
     description:
       - Specifies the number of seconds to wait after a resource first responds
@@ -68,6 +75,7 @@ options:
       - When the interval expires, the resource is marked 'up'.
       - A value of 0, means that the resource is marked up immediately upon
         receipt of the first correct response.
+    type: int
   up_interval:
     description:
       - Specifies the interval for the system to use to perform the health check
@@ -76,6 +84,7 @@ options:
         C(interval) to check the health of the resource.
       - When any other number, enables specification of a different interval to
         use when checking the health of a resource that is up.
+    type: int
   manual_resume:
     description:
       - Specifies whether the system automatically changes the status of a resource
@@ -90,19 +99,24 @@ options:
   target_username:
     description:
       - Specifies the user name, if the monitored target requires authentication.
+    type: str
   target_password:
     description:
       - Specifies the password, if the monitored target requires authentication.
+    type: str
   base:
     description:
       - Specifies the location in the LDAP tree from which the monitor starts the
         health check.
+    type: str
   filter:
     description:
       - Specifies an LDAP key for which the monitor searches.
+    type: str
   security:
     description:
       - Specifies the secure protocol type for communications with the target.
+    type: str
     choices:
       - none
       - ssl
@@ -126,22 +140,25 @@ options:
     description:
       - C(always) will update passwords if the C(target_password) is specified.
       - C(on_create) will only set the password for newly created monitors.
-    default: always
+    type: str
     choices:
       - always
       - on_create
+    default: always
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -233,11 +250,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.ipaddress import is_valid_ip
@@ -246,11 +260,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
@@ -560,7 +571,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -798,16 +809,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
@@ -25,21 +25,25 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   description:
     description:
       - Specifies descriptive text that identifies the monitor.
+    type: str
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(snmp_dca)
         parent on the C(Common) partition.
+    type: str
     default: "/Common/snmp_dca"
   interval:
     description:
       - Specifies, in seconds, the frequency at which the system issues the
         monitor check when either the resource is down or the status of the
         resource is unknown. When creating a new monitor, the default is C(10).
+    type: int
   timeout:
     description:
       - Specifies the number of seconds the target has in which to respond to
@@ -50,6 +54,7 @@ options:
         the system uses the interval from the parent monitor. Note that
         C(timeout) and C(time_until_up) combine to control when a resource is
         set to up.
+    type: int
   time_until_up:
     description:
       - Specifies the number of seconds to wait after a resource first responds
@@ -58,17 +63,20 @@ options:
         interval expires, the resource is marked 'up'. A value of 0, means
         that the resource is marked up immediately upon receipt of the first
         correct response. When creating a new monitor, the default is C(0).
+    type: int
   community:
     description:
       - Specifies the community name that the system must use to authenticate
         with the host server through SNMP. When creating a new monitor, the
         default value is C(public). Note that this value is case sensitive.
+    type: str
   version:
     description:
       - Specifies the version of SNMP that the host server uses. When creating
         a new monitor, the default is C(v1). When C(v1), specifies that the
         host server uses SNMP version 1. When C(v2c), specifies that the host
         server uses SNMP version 2c.
+    type: str
     choices:
       - v1
       - v2c
@@ -76,6 +84,7 @@ options:
     description:
       - Specifies the SNMP agent running on the monitored server. When creating
         a new monitor, the default is C(UCD) (UC-Davis).
+    type: str
     choices:
       - UCD
       - WIN2000
@@ -85,40 +94,48 @@ options:
       - Specifies the coefficient that the system uses to calculate the weight
         of the CPU threshold in the dynamic ratio load balancing algorithm.
         When creating a new monitor, the default is C(1.5).
+    type: str
   cpu_threshold:
     description:
       - Specifies the maximum acceptable CPU usage on the target server. When
         creating a new monitor, the default is C(80) percent.
+    type: int
   memory_coefficient:
     description:
       - Specifies the coefficient that the system uses to calculate the weight
         of the memory threshold in the dynamic ratio load balancing algorithm.
         When creating a new monitor, the default is C(1.0).
+    type: str
   memory_threshold:
     description:
       - Specifies the maximum acceptable memory usage on the target server.
         When creating a new monitor, the default is C(70) percent.
+    type: int
   disk_coefficient:
     description:
       - Specifies the coefficient that the system uses to calculate the weight
         of the disk threshold in the dynamic ratio load balancing algorithm.
         When creating a new monitor, the default is C(2.0).
+    type: str
   disk_threshold:
     description:
       - Specifies the maximum acceptable disk usage on the target server. When
         creating a new monitor, the default is C(90) percent.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
@@ -234,23 +251,17 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
 
@@ -490,7 +501,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -741,16 +752,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
@@ -22,23 +22,28 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(tcp)
         parent on the C(Common) partition.
+    type: str
     default: /Common/tcp
   description:
     description:
       - The description of the monitor.
+    type: str
     version_added: 2.7
   send:
     description:
       - The send string for the monitor call.
+    type: str
   receive:
     description:
       - The receive string for the monitor call.
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
@@ -46,6 +51,7 @@ options:
         '*'.
       - If this value is an IP address, and the C(type) is C(tcp) (the default),
         then a C(port) number must be specified.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
@@ -53,12 +59,14 @@ options:
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified
       - This argument is not supported for TCP Echo types.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 5. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -68,6 +76,7 @@ options:
         number to any number you want, however, it should be 3 times the
         interval number of seconds plus 1 second. If this parameter is not
         provided when creating a new monitor, then the default value will be 16.
+    type: int
   time_until_up:
     description:
       - Specifies the amount of time in seconds after the first successful
@@ -75,19 +84,22 @@ options:
         node to be marked up immediately after a valid response is received
         from the node. If this parameter is not provided when creating
         a new monitor, then the default value will be 0.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
@@ -176,12 +188,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.compare import cmp_str_with_none
 
@@ -189,12 +198,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
@@ -419,7 +425,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -649,16 +655,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
@@ -22,28 +22,33 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(tcp_echo)
         parent on the C(Common) partition.
+    type: str
     default: /Common/tcp_echo
   description:
     description:
       - The description of the monitor.
+    type: str
     version_added: 2.7
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 5. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -53,6 +58,7 @@ options:
         number to any number you want, however, it should be 3 times the
         interval number of seconds plus 1 second. If this parameter is not
         provided when creating a new monitor, then the default value will be 16.
+    type: int
   time_until_up:
     description:
       - Specifies the amount of time in seconds after the first successful
@@ -60,19 +66,22 @@ options:
         node to be marked up immediately after a valid response is received
         from the node. If this parameter is not provided when creating
         a new monitor, then the default value will be 0.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
@@ -147,22 +156,16 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
@@ -360,7 +363,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -585,16 +588,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
@@ -22,16 +22,19 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(tcp_half_open)
         parent on the C(Common) partition.
+    type: str
     default: /Common/tcp_half_open
   description:
     description:
       - The description of the monitor.
+    type: str
     version_added: 2.7
   ip:
     description:
@@ -40,12 +43,14 @@ options:
         '*'.
       - If this value is an IP address, and the C(type) is C(tcp) (the default),
         then a C(port) number must be specified.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified
+    type: str
     version_added: 2.5
   interval:
     description:
@@ -53,6 +58,7 @@ options:
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 5. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -62,6 +68,7 @@ options:
         number to any number you want, however, it should be 3 times the
         interval number of seconds plus 1 second. If this parameter is not
         provided when creating a new monitor, then the default value will be 16.
+    type: int
   time_until_up:
     description:
       - Specifies the amount of time in seconds after the first successful
@@ -69,19 +76,22 @@ options:
         node to be marked up immediately after a valid response is received
         from the node. If this parameter is not provided when creating
         a new monitor, then the default value will be 0.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
@@ -167,22 +177,16 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
@@ -407,7 +411,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -635,16 +639,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_udp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_udp.py
@@ -22,47 +22,56 @@ options:
   name:
     description:
       - Monitor name.
+    type: str
     required: True
   parent:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(udp)
         parent on the C(Common) partition.
+    type: str
     default: /Common/udp
   description:
     description:
       - The description of the monitor.
+    type: str
     version_added: 2.7
   send:
     description:
       - The send string for the monitor call. When creating a new monitor, if
         this value is not provided, the default C(default send string) will be used.
+    type: str
   receive:
     description:
       - The receive string for the monitor call.
+    type: str
   receive_disable:
     description:
       - This setting works like C(receive), except that the system marks the node
         or pool member disabled when its response matches the C(receive_disable)
         string but not C(receive). To use this setting, you must specify both
         C(receive_disable) and C(receive).
+    type: str
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
+    type: str
   port:
     description:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
         must be specified.
+    type: str
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
         template will run. If this parameter is not provided when creating
         a new monitor, then the default value will be 5. This value B(must)
         be less than the C(timeout) value.
+    type: int
   timeout:
     description:
       - The number of seconds in which the node or service must respond to
@@ -72,6 +81,7 @@ options:
         number to any number you want, however, it should be 3 times the
         interval number of seconds plus 1 second. If this parameter is not
         provided when creating a new monitor, then the default value will be 16.
+    type: int
   time_until_up:
     description:
       - Specifies the amount of time in seconds after the first successful
@@ -79,19 +89,22 @@ options:
         node to be marked up immediately after a valid response is received
         from the node. If this parameter is not provided when creating
         a new monitor, then the default value will be 0.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   state:
     description:
       - When C(present), ensures that the monitor exists.
       - When C(absent), ensures the monitor is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
@@ -165,12 +178,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.compare import cmp_str_with_none
     from library.module_utils.network.f5.ipaddress import is_valid_ip
 
@@ -178,12 +188,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
 
@@ -411,7 +418,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -644,16 +651,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_hostname.py
+++ b/test/units/modules/network/f5/test_bigip_hostname.py
@@ -81,9 +81,11 @@ class TestManager(unittest.TestCase):
     def test_update_hostname(self, *args):
         set_module_args(dict(
             hostname='foo2.internal.com',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the

--- a/test/units/modules/network/f5/test_bigip_iapp_service.py
+++ b/test/units/modules/network/f5/test_bigip_iapp_service.py
@@ -323,9 +323,11 @@ class TestManager(unittest.TestCase):
             template='f5.http',
             parameters=parameters,
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -349,9 +351,11 @@ class TestManager(unittest.TestCase):
             template='f5.http',
             parameters=parameters,
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the

--- a/test/units/modules/network/f5/test_bigip_iapp_template.py
+++ b/test/units/modules/network/f5/test_bigip_iapp_template.py
@@ -101,9 +101,11 @@ class TestManager(unittest.TestCase):
         # Configure the arguments that would be sent to the Ansible module
         set_module_args(dict(
             content=load_fixture('basic-iapp.tmpl'),
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -124,9 +126,11 @@ class TestManager(unittest.TestCase):
         # Configure the arguments that would be sent to the Ansible module
         set_module_args(dict(
             content=load_fixture('basic-iapp.tmpl'),
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current1 = Parameters(params=load_fixture('load_sys_application_template_w_new_checksum.json'))
@@ -153,10 +157,12 @@ class TestManager(unittest.TestCase):
     def test_delete_iapp_template(self, *args):
         set_module_args(dict(
             content=load_fixture('basic-iapp.tmpl'),
-            password='password',
-            server='localhost',
-            user='admin',
-            state='absent'
+            state='absent',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -176,10 +182,12 @@ class TestManager(unittest.TestCase):
     def test_delete_iapp_template_idempotent(self, *args):
         set_module_args(dict(
             content=load_fixture('basic-iapp.tmpl'),
-            password='password',
-            server='localhost',
-            user='admin',
-            state='absent'
+            state='absent',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_ike_peer.py
+++ b/test/units/modules/network/f5/test_bigip_ike_peer.py
@@ -89,14 +89,18 @@ class TestUntypedManager(unittest.TestCase):
         set_module_args(dict(
             name='ike1',
             version=['v1'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if,
+            required_together=self.spec.required_together
         )
 
         # Override methods to force specific logic in the module to happen

--- a/test/units/modules/network/f5/test_bigip_imish_config.py
+++ b/test/units/modules/network/f5/test_bigip_imish_config.py
@@ -82,15 +82,20 @@ class TestManager(unittest.TestCase):
             parents='router bgp 64664',
             before='bfd slow-timer 2000',
             match='exact',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = load_fixture('load_imish_output_1.json')
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive,
+            required_if=self.spec.required_if,
+            add_file_common_args=self.spec.add_file_common_args
         )
 
         # Override methods in the specific type of manager

--- a/test/units/modules/network/f5/test_bigip_ipsec_policy.py
+++ b/test/units/modules/network/f5/test_bigip_ipsec_policy.py
@@ -88,14 +88,17 @@ class TestUntypedManager(unittest.TestCase):
     def test_create(self, *args):
         set_module_args(dict(
             name='ipsec1',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         # Override methods to force specific logic in the module to happen

--- a/test/units/modules/network/f5/test_bigip_irule.py
+++ b/test/units/modules/network/f5/test_bigip_irule.py
@@ -140,9 +140,11 @@ class TestManager(unittest.TestCase):
             module='ltm',
             content='this is my content',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -171,9 +173,11 @@ class TestManager(unittest.TestCase):
             module='gtm',
             content='this is my content',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -202,9 +206,11 @@ class TestManager(unittest.TestCase):
             module='gtm',
             src='{0}/create_ltm_irule.tcl'.format(fixture_path),
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -244,9 +250,11 @@ class TestManager(unittest.TestCase):
             state='present',
             src='/path/to/irules/foo.tcl',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         with patch('ansible.module_utils.basic.AnsibleModule.fail_json', unsafe=True) as mo:

--- a/test/units/modules/network/f5/test_bigip_log_destination.py
+++ b/test/units/modules/network/f5/test_bigip_log_destination.py
@@ -80,9 +80,11 @@ class TestV1Parameters(unittest.TestCase):
                 forward_to='pool1',
                 syslog_format='rfc5424'
             ),
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         )
         p = V1ModuleParameters(params=args)
         assert p.name == 'foo'
@@ -110,14 +112,17 @@ class TestV1Manager(unittest.TestCase):
                 forward_to='pool1',
             ),
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods in the specific type of manager

--- a/test/units/modules/network/f5/test_bigip_log_publisher.py
+++ b/test/units/modules/network/f5/test_bigip_log_publisher.py
@@ -73,9 +73,11 @@ class TestParameters(unittest.TestCase):
                 'dest1',
                 'dest2'
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         )
         p = ModuleParameters(params=args)
         assert p.name == 'foo'
@@ -108,9 +110,11 @@ class TestManager(unittest.TestCase):
                 'dest2'
             ],
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_management_route.py
+++ b/test/units/modules/network/f5/test_bigip_management_route.py
@@ -101,9 +101,11 @@ class TestManager(unittest.TestCase):
             network='default',
             description='my description',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_monitor_dns.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_dns.py
@@ -107,9 +107,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -135,9 +137,11 @@ class TestManager(unittest.TestCase):
             timeout=30,
             time_until_up=60,
             description='Important Description',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_monitor_gateway_icmp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_gateway_icmp.py
@@ -106,9 +106,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -133,9 +135,11 @@ class TestManager(unittest.TestCase):
             timeout=30,
             time_until_up=60,
             description='Important Description',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_monitor_http.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_http.py
@@ -164,9 +164,11 @@ class TestManager(unittest.TestCase):
             timeout=30,
             time_until_up=60,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -196,9 +198,11 @@ class TestManager(unittest.TestCase):
             timeout=16,
             time_until_up=0,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -221,9 +225,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             port=800,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -248,9 +254,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             interval=10,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -275,9 +283,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             interval=30,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -303,9 +313,11 @@ class TestManager(unittest.TestCase):
             interval=10,
             timeout=5,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -330,9 +342,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             send='this is another send string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -357,9 +371,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             receive='this is another receive string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -384,9 +400,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             timeout=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
@@ -411,9 +429,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             time_until_up=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))

--- a/test/units/modules/network/f5/test_bigip_monitor_https.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_https.py
@@ -164,9 +164,11 @@ class TestManager(unittest.TestCase):
             timeout=30,
             time_until_up=60,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -196,9 +198,11 @@ class TestManager(unittest.TestCase):
             timeout=16,
             time_until_up=0,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -221,9 +225,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             port=800,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -248,9 +254,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             interval=10,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -275,9 +283,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             interval=30,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -303,9 +313,11 @@ class TestManager(unittest.TestCase):
             interval=10,
             timeout=5,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -330,9 +342,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             send='this is another send string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -357,9 +371,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             receive='this is another receive string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -384,9 +400,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             timeout=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
@@ -411,9 +429,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             time_until_up=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))

--- a/test/units/modules/network/f5/test_bigip_monitor_ldap.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_ldap.py
@@ -92,9 +92,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_monitor_snmp_dca.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_snmp_dca.py
@@ -155,9 +155,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp.py
@@ -166,9 +166,11 @@ class TestManager(unittest.TestCase):
             timeout=30,
             time_until_up=60,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -198,9 +200,11 @@ class TestManager(unittest.TestCase):
             timeout=30,
             time_until_up=60,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -223,9 +227,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             port=800,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -250,9 +256,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             interval=10,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -277,9 +285,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             interval=30,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -305,9 +315,11 @@ class TestManager(unittest.TestCase):
             interval=10,
             timeout=5,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -332,9 +344,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             send='this is another send string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -359,9 +373,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             receive='this is another receive string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -386,9 +402,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             timeout=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
@@ -413,9 +431,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             time_until_up=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
@@ -142,9 +142,11 @@ class TestManagerEcho(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -168,9 +170,11 @@ class TestManagerEcho(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
@@ -192,9 +196,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             interval=10,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
@@ -218,9 +224,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             interval=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
@@ -245,9 +253,11 @@ class TestManagerEcho(unittest.TestCase):
             name='foo',
             interval=10,
             timeout=5,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
@@ -271,9 +281,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             timeout=300,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
@@ -296,9 +308,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             time_until_up=300,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
@@ -148,9 +148,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -175,9 +177,11 @@ class TestManager(unittest.TestCase):
             interval=20,
             timeout=30,
             time_until_up=60,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
@@ -199,9 +203,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             interval=10,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
@@ -225,9 +231,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             interval=30,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
@@ -252,9 +260,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             interval=10,
             timeout=5,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
@@ -278,9 +288,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             timeout=300,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
@@ -303,9 +315,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             time_until_up=300,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))

--- a/test/units/modules/network/f5/test_bigip_monitor_udp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_udp.py
@@ -164,9 +164,11 @@ class TestManager(unittest.TestCase):
             timeout=30,
             time_until_up=60,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -196,9 +198,11 @@ class TestManager(unittest.TestCase):
             timeout=16,
             time_until_up=0,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -221,9 +225,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             port=800,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -248,9 +254,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             interval=10,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -275,9 +283,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             interval=30,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -303,9 +313,11 @@ class TestManager(unittest.TestCase):
             interval=10,
             timeout=5,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -330,9 +342,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             send='this is another send string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -357,9 +371,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             receive='this is another receive string',
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -384,9 +400,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             timeout=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
@@ -411,9 +429,11 @@ class TestManager(unittest.TestCase):
             name='asdf',
             time_until_up=300,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_hostname.py
lib/ansible/modules/network/f5/bigip_iapp_service.py
lib/ansible/modules/network/f5/bigip_iapp_template.py
lib/ansible/modules/network/f5/bigip_ike_peer.py
lib/ansible/modules/network/f5/bigip_imish_config.py
lib/ansible/modules/network/f5/bigip_ipsec_policy.py
lib/ansible/modules/network/f5/bigip_irule.py
lib/ansible/modules/network/f5/bigip_log_destination.py
lib/ansible/modules/network/f5/bigip_log_publisher.py
lib/ansible/modules/network/f5/bigip_management_route.py
lib/ansible/modules/network/f5/bigip_monitor_dns.py
lib/ansible/modules/network/f5/bigip_monitor_gateway_icmp.py
lib/ansible/modules/network/f5/bigip_monitor_http.py
lib/ansible/modules/network/f5/bigip_monitor_https.py
lib/ansible/modules/network/f5/bigip_monitor_ldap.py
lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
lib/ansible/modules/network/f5/bigip_monitor_tcp.py
lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
lib/ansible/modules/network/f5/bigip_monitor_udp.py


##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.