### PR TITLE
BIGIP: multiple_modules_fix_7

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_node.py
+++ b/lib/ansible/modules/network/f5/bigip_node.py
@@ -34,16 +34,18 @@ options:
         cannot be resolved. These situations disable your ability to change their
         C(state) to C(disabled) or C(offline). They will remain in an
         *Unavailable - Enabled* state.
-    default: present
+    type: str
     choices:
       - present
       - absent
       - enabled
       - disabled
       - offline
+    default: present
   name:
     description:
       - Specifies the name of the node.
+    type: str
     required: True
   monitor_type:
     description:
@@ -55,21 +57,28 @@ options:
         or it has a list of one. Where they differ is in the extra guards that
         C(single) provides; namely that it only allows a single monitor.
     version_added: "1.3"
-    choices: ['and_list', 'm_of_n', 'single']
+    type: str
+    choices:
+     - and_list
+     - m_of_n
+     - single
   quorum:
     description:
       - Monitor quorum value when C(monitor_type) is C(m_of_n).
+    type: int
     version_added: 2.2
   monitors:
     description:
       - Specifies the health monitors that the system currently uses to
         monitor this node.
+    type: list
     version_added: 2.2
   address:
     description:
       - IP address of the node. This can be either IPv4 or IPv6. When creating a
         new node, one of either C(address) or C(fqdn) must be provided. This
         parameter cannot be updated after it is set.
+    type: str
     aliases:
       - ip
       - host
@@ -84,6 +93,7 @@ options:
       - FQDN names must end with a letter or a number.
       - When creating a new node, one of either C(address) or C(fqdn) must be
         provided. This parameter cannot be updated after it is set.
+    type: str
     aliases:
       - hostname
     version_added: 2.5
@@ -93,6 +103,7 @@ options:
       - When creating a new node, if this parameter is not specified and C(fqdn) is
         specified, this parameter will default to C(ipv4).
       - This parameter cannot be changed after it has been set.
+    type: str
     choices:
       - ipv4
       - ipv6
@@ -124,6 +135,7 @@ options:
         the FQDN. The default TTL interval is akin to specifying C(3600).
       - When creating a new node, if this parameter is not specified and C(fqdn) is
         specified, this parameter will default to C(3600).
+    type: str
     version_added: 2.6
   fqdn_down_interval:
     description:
@@ -131,31 +143,37 @@ options:
         The associated monitor continues polling as long as the DNS server is down.
       - When creating a new node, if this parameter is not specified and C(fqdn) is
         specified, this parameter will default to C(5).
+    type: int
     version_added: 2.6
   description:
     description:
       - Specifies descriptive text that identifies the node.
       - You can remove a description by either specifying an empty string, or by
         specifying the special value C(none).
+    type: str
   connection_limit:
     description:
       - Node connection limit. Setting this to 0 disables the limit.
+    type: int
     version_added: 2.7
   rate_limit:
     description:
       - Node rate limit (connections-per-second). Setting this to 0 disables the limit.
+    type: int
     version_added: 2.7
   ratio:
     description:
       - Node ratio weight. Valid values range from 1 through 100.
       - When creating a new node, if this parameter is not specified, the default of
         C(1) will be used.
+    type: int
     version_added: 2.7
   dynamic_ratio:
     description:
       - The dynamic ratio number for the node. Used for dynamic ratio load balancing.
       - When creating a new node, if this parameter is not specified, the default of
         C(1) will be used.
+    type: int
     version_added: 2.7
   availability_requirements:
     description:
@@ -168,17 +186,22 @@ options:
           - Monitor rule type when C(monitors) is specified.
           - When creating a new pool, if this value is not specified, the default of
             'all' will be used.
-        choices: ['all', 'at_least']
+        choices:
+          - all
+          - at_least
       at_least:
         description:
           - Specifies the minimum number of active health monitors that must be successful
             before the link is considered up.
           - This parameter is only relevant when a C(type) of C(at_least) is used.
           - This parameter will be ignored if a type of C(all) is used.
+        type: int
+    type: dict
     version_added: 2.8
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
 extends_documentation_fragment: f5
@@ -765,11 +788,10 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
-        self.client = F5RestClient(**self.module.params)
 
     def _set_changed_options(self):
         changed = {}
@@ -1157,6 +1179,7 @@ def main():
     module = AnsibleModule(
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode,
+        mutually_exclusive=spec.mutually_exclusive
     )
 
     try:

--- a/lib/ansible/modules/network/f5/bigip_partition.py
+++ b/lib/ansible/modules/network/f5/bigip_partition.py
@@ -23,22 +23,26 @@ options:
   name:
     description:
       - Name of the partition
+    type: str
     required: True
   description:
     description:
       - The description to attach to the Partition.
+    type: str
   route_domain:
     description:
       - The default Route Domain to assign to the Partition. If no route domain
         is specified, then the default route domain for the system (typically
         zero) will be used only when creating a new partition.
+    type: int
   state:
     description:
       - Whether the partition should exist or not.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 notes:
   - Requires BIG-IP software version >= 12
 extends_documentation_fragment: f5
@@ -118,18 +122,12 @@ try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
 
@@ -238,7 +236,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -486,16 +484,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_password_policy.py
+++ b/lib/ansible/modules/network/f5/bigip_password_policy.py
@@ -25,21 +25,26 @@ options:
       - Specifies the number of days before a password expires.
       - Based on this value, the BIG-IP system automatically warns users when their
         password is about to expire.
+    type: int
   max_duration:
     description:
       - Specifies the maximum number of days a password is valid.
+    type: int
   max_login_failures:
     description:
       - Specifies the number of consecutive unsuccessful login attempts
         that the system allows before locking out the user.
       - Specify zero (0) to disable this parameter.
+    type: int
   min_duration:
     description:
       - Specifies the minimum number of days a password is valid.
+    type: int
   min_length:
     description:
       - Specifies the minimum number of characters in a valid password.
       - This value must be between 6 and 255.
+    type: int
   policy_enforcement:
     description:
       - Enables or disables the password policy on the BIG-IP system.
@@ -48,23 +53,28 @@ options:
     description:
       - Specifies the number of lowercase alpha characters that must be
         present in a password for the password to be valid.
+    type: int
   required_numeric:
     description:
       - Specifies the number of numeric characters that must be present in
         a password for the password to be valid.
+    type: int
   required_special:
     description:
       - Specifies the number of special characters that must be present in
         a password for the password to be valid.
+    type: int
   required_uppercase:
     description:
       - Specifies the number of uppercase alpha characters that must be
         present in a password for the password to be valid.
+    type: int
   password_memory:
     description:
       - Specifies whether the user has configured the BIG-IP system to
         remember a password on a specific computer and how many passwords
         to remember.
+    type: int
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -145,23 +155,17 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
 
 
@@ -288,7 +292,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -423,16 +427,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_pool_member.py
+++ b/lib/ansible/modules/network/f5/bigip_pool_member.py
@@ -27,31 +27,36 @@ options:
       - This parameter is optional and, if not specified, a node name will be
         created automatically from either the specified C(address) or C(fqdn).
       - The C(enabled) state is an alias of C(present).
+    type: str
     version_added: 2.6
   state:
     description:
       - Pool member state.
+    type: str
     required: True
-    default: present
     choices:
       - present
       - absent
       - enabled
       - disabled
       - forced_offline
+    default: present
   pool:
     description:
       - Pool name. This pool must exist.
+    type: str
     required: True
   partition:
     description:
-      - Partition
+      - Partition to manage resources on.
+    type: str
     default: Common
   address:
     description:
       - IP address of the pool member. This can be either IPv4 or IPv6. When creating a
         new pool member, one of either C(address) or C(fqdn) must be provided. This
         parameter cannot be updated after it is set.
+    type: str
     aliases:
       - ip
       - host
@@ -66,6 +71,7 @@ options:
       - FQDN names must end with a letter or a number.
       - When creating a new pool member, one of either C(address) or C(fqdn) must be
         provided. This parameter cannot be updated after it is set.
+    type: str
     aliases:
       - hostname
     version_added: 2.6
@@ -73,22 +79,27 @@ options:
     description:
       - Pool member port.
       - This value cannot be changed after it has been set.
+    type: int
     required: True
   connection_limit:
     description:
       - Pool member connection limit. Setting this to 0 disables the limit.
+    type: int
   description:
     description:
       - Pool member description.
+    type: str
   rate_limit:
     description:
       - Pool member rate limit (connections-per-second). Setting this to 0
         disables the limit.
+    type: int
   ratio:
     description:
       - Pool member ratio weight. Valid values range from 1 through 100.
         New pool members -- unless overridden with this value -- default
         to 1.
+    type: int
   preserve_node:
     description:
       - When state is C(absent) attempts to remove the node that the pool
@@ -108,6 +119,7 @@ options:
         assigned to the pool member.
       - The higher the number, the higher the priority, so a member with a priority
         of 3 has higher priority than a member with a priority of 1.
+    type: int
     version_added: 2.5
   fqdn_auto_populate:
     description:
@@ -128,13 +140,14 @@ options:
   reuse_nodes:
     description:
       - Reuses node definitions if requested.
-    default: yes
     type: bool
+    default: yes
     version_added: 2.6
   monitors:
     description:
       - Specifies the health monitors that the system currently uses to monitor
         this resource.
+    type: list
     version_added: 2.8
   availability_requirements:
     description:
@@ -147,13 +160,18 @@ options:
           - Monitor rule type when C(monitors) is specified.
           - When creating a new pool, if this value is not specified, the default of
             'all' will be used.
-        choices: ['all', 'at_least']
+        type: str
+        choices:
+          - all
+          - at_least
       at_least:
         description:
           - Specifies the minimum number of active health monitors that must be successful
             before the link is considered up.
           - This parameter is only relevant when a C(type) of C(at_least) is used.
           - This parameter will be ignored if a type of C(all) is used.
+        type: int
+    type: dict
     version_added: 2.8
   ip_encapsulation:
     description:
@@ -163,10 +181,12 @@ options:
       - When C(none), disables IP encapsulation.
       - When C(inherit), inherits IP encapsulation setting from the member's pool.
       - When any other value, Options are None, Inherit from Pool, and Member Specific.
+    type: str
     version_added: 2.8
   aggregate:
     description:
       - List of pool member definitions to be created, modified or removed.
+    type: list
     aliases:
       - members
     version_added: 2.8
@@ -175,8 +195,8 @@ options:
       - Remove members not defined in the C(aggregate) parameter.
       - This operation is all or none, meaning that it will stop if there are some pool members
         that cannot be removed.
-    default: no
     type: bool
+    default: no
     aliases:
       - purge
     version_added: 2.8
@@ -257,16 +277,16 @@ EXAMPLES = '''
       password: secret
   delegate_to: localhost
   loop:
-    - host: 1.1.1.1
+    - address: 1.1.1.1
       name: web1
       priority_group: 4
-    - host: 2.2.2.2
+    - address: 2.2.2.2
       name: web2
       priority_group: 3
-    - host: 3.3.3.3
+    - address: 3.3.3.3
       name: web3
       priority_group: 2
-    - host: 4.4.4.4
+    - address: 4.4.4.4
       name: web4
       priority_group: 1
 
@@ -403,10 +423,7 @@ try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import fq_name
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import is_valid_hostname
     from library.module_utils.network.f5.common import flatten_boolean
@@ -419,13 +436,9 @@ except ImportError:
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import fq_name
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import is_valid_hostname
-    from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
@@ -990,7 +1003,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = None
         self.have = None
         self.changes = None
@@ -1618,16 +1631,12 @@ def main():
         required_one_of=spec.required_one_of,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_profile_analytics.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_analytics.py
@@ -23,15 +23,18 @@ options:
   name:
     description:
       - Specifies the name of the profile.
+    type: str
     required: True
   parent:
     description:
       - Specifies the profile from which this profile inherits settings.
       - When creating a new profile, if this parameter is not specified, the default
         is the system-supplied C(analytics) profile.
+    type: str
   description:
     description:
       - Description of the profile.
+    type: str
   collect_geo:
     description:
       - Enables or disables the collection of the names of the countries
@@ -77,6 +80,7 @@ options:
     description:
       - Specifies the external logging publisher used to send statistical
         data to one or more destinations.
+    type: str
   notification_by_syslog:
     description:
       - Enables or disables logging of the analytics alerts into the
@@ -90,18 +94,21 @@ options:
     description:
       - Specifies which email addresses receive alerts by email when
         C(notification_by_email) is enabled.
+    type: list
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the profile exists.
       - When C(absent), ensures the profile is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -138,24 +145,18 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.compare import cmp_simple_list
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.compare import cmp_simple_list
 
@@ -523,7 +524,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -748,16 +749,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_profile_dns.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_dns.py
@@ -26,12 +26,14 @@ options:
   name:
     description:
       - Specifies the name of the DNS profile.
+    type: str
     required: True
   parent:
     description:
       - Specifies the profile from which this profile inherits settings.
       - When creating a new profile, if this parameter is not specified, the default
         is the system-supplied C(dns) profile.
+    type: str
   enable_dns_express:
     description:
       - Specifies whether the DNS Express engine is enabled.
@@ -112,6 +114,7 @@ options:
       - Specifies the user-created cache that the system uses to cache DNS responses.
       - When you select a cache for the system to use, you must also set C(enable_dns_cache)
         to C(yes)
+    type: str
     version_added: 2.7
   unhandled_query_action:
     description:
@@ -125,6 +128,7 @@ options:
       - When C(no-error), the BIG-IP system returns the query with the NOERROR return code.
       - When creating a new profile, if this parameter is not specified, the default
         is provided by the parent profile.
+    type: str
     choices:
       - allow
       - drop
@@ -135,15 +139,17 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the profile exists.
       - When C(absent), ensures the profile is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -226,7 +232,6 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
@@ -234,7 +239,6 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
@@ -503,7 +507,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -735,15 +739,11 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
         module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
         module.fail_json(msg=str(ex))
 
 

--- a/lib/ansible/modules/network/f5/bigip_profile_fastl4.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_fastl4.py
@@ -23,12 +23,14 @@ options:
   name:
     description:
       - Specifies the name of the profile.
+    type: str
     required: True
   parent:
     description:
       - Specifies the profile from which this profile inherits settings.
       - When creating a new profile, if this parameter is not specified, the default
         is the system-supplied C(fastL4) profile.
+    type: str
   idle_timeout:
     description:
       - Specifies the length of time that a connection is idle (has no traffic) before
@@ -42,6 +44,7 @@ options:
         regardless of how long they remain idle.
       - When C(0), or C(immediate), specifies that the system deletes connections
         immediately when they become idle.
+    type: str
   client_timeout:
     description:
       - Specifies a timeout for Late Binding.
@@ -53,9 +56,11 @@ options:
         transmission.
       - When C(indefinite), disables the limit. This allows the client unlimited time
         to send the sender and target information.
+    type: str
   description:
     description:
       - Description of the profile.
+    type: str
   explicit_flow_migration:
     description:
       - Specifies whether a qualified late-binding connection requires an explicit iRule
@@ -75,6 +80,7 @@ options:
         Header DF bit.
       - When C(set), sets the outgoing packet's IP Header DF bit.
       - When C(clear), clears the outgoing packet's IP Header DF bit.
+    type: str
     choices:
       - pmtu
       - preserve
@@ -89,6 +95,7 @@ options:
       - When C(pass-through), specifies that the IP ToS setting remains unchanged.
       - When C(mimic), specifies that the system sets the ToS level of outgoing packets to
         the same ToS level of the most-recently received incoming packet.
+    type: str
   ip_tos_to_server:
     description:
       - Specifies, for IP traffic passing through the system to back-end servers, whether
@@ -98,6 +105,7 @@ options:
       - When C(pass-through), specifies that the IP ToS setting remains unchanged.
       - When C(mimic), specifies that the system sets the ToS level of outgoing packets to
         the same ToS level of the most-recently received incoming packet.
+    type: str
   ip_ttl_mode:
     description:
       - Specifies the outgoing TCP packet's IP Header TTL mode.
@@ -108,6 +116,7 @@ options:
         incoming TTL value.
       - When C(set), sets the outgoing IP Header TTL value to a specific value(as specified
         by C(ip_ttl_v4) or C(ip_ttl_v6).
+    type: str
     choices:
       - proxy
       - preserve
@@ -117,13 +126,16 @@ options:
     description:
       - Specifies the outgoing packet's IP Header TTL value for IPv4 traffic.
       - Maximum TTL value that can be specified is 255.
+    type: int
   ip_ttl_v6:
     description:
       - Specifies the outgoing packet's IP Header TTL value for IPv6 traffic.
       - Maximum TTL value that can be specified is 255.
+    type: int
   keep_alive_interval:
     description:
       - Specifies the keep-alive probe interval, in seconds.
+    type: int
   late_binding:
     description:
       - Enables intelligent selection of a back-end server or pool, using an
@@ -140,6 +152,7 @@ options:
       - When a number, specifies the link QoS setting that the system inserts
         in the IP packet header.
       - When C(pass-through), specifies that the link QoS setting remains unchanged.
+    type: str
   link_qos_to_server:
     description:
       - Specifies, for IP traffic passing through the system to back-end servers,
@@ -151,6 +164,7 @@ options:
       - When a number, specifies the link QoS setting that the system inserts
         in the IP packet header.
       - When C(pass-through), specifies that the link QoS setting remains unchanged.
+    type: str
   loose_close:
     description:
       - When C(yes), specifies, that the system closes a loosely-initiated connection
@@ -166,6 +180,7 @@ options:
     description:
       - Specifies a maximum segment size (MSS) override for server-side connections.
       - Valid range is 256 to 9162 or 0 to disable.
+    type: int
   reassemble_fragments:
     description:
       - When C(yes), specifies that the system reassembles IP fragments.
@@ -174,6 +189,7 @@ options:
     description:
       - Specifies the amount of data the BIG-IP system can accept without acknowledging
         the server.
+    type: int
   reset_on_timeout:
     description:
       - When C(yes), specifies that the system sends a reset packet (RST) in addition
@@ -204,9 +220,11 @@ options:
       - Specifies a value that overrides the SYN cookie maximum segment size (MSS)
         value in the SYN-ACK packet that is returned to the client.
       - Valid values are 0, and values from 256 through 9162.
+    type: int
   tcp_close_timeout:
     description:
       - Specifies the length of time a connection can remain idle before deletion.
+    type: str
   tcp_generate_isn:
     description:
       - When C(yes), specifies that the system generates initial sequence numbers
@@ -223,6 +241,7 @@ options:
       - When C(disabled), specifies that the system does not apply a timeout to a
         TCP handshake.
       - When C(indefinite), specifies that attempting a TCP handshake never times out.
+    type: str
   tcp_strip_sack:
     description:
       - When C(yes), specifies that the system blocks a TCP selective ACK SackOK
@@ -232,9 +251,11 @@ options:
     description:
       - Specifies the number of milliseconds that a connection is in the TIME-WAIT
         state before closing.
+    type: int
   tcp_timestamp_mode:
     description:
       - Specifies the action that the system should take on TCP timestamps.
+    type: str
     choices:
       - preserve
       - rewrite
@@ -242,6 +263,7 @@ options:
   tcp_wscale_mode:
     description:
       - Specifies the action that the system should take on TCP windows.
+    type: str
     choices:
       - preserve
       - rewrite
@@ -254,21 +276,24 @@ options:
       - When C(fallback), reverts the connection to normal FastL4 load-balancing,
         based on the client's TCP header. This causes the BIG-IP system to choose
         a back-end server based only on the source address and port.
+    type: str
     choices:
       - disconnect
       - fallback
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the profile exists.
       - When C(absent), ensures the profile is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -460,22 +485,16 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import flatten_boolean
 
@@ -1115,7 +1134,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -1368,16 +1387,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_profile_http2.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_http2.py
@@ -23,16 +23,19 @@ options:
   name:
     description:
       - Specifies the name of the profile.
+    type: str
     required: True
   parent:
     description:
       - Specifies the profile from which this profile inherits settings.
       - When creating a new profile, if this parameter is not specified, the default
         is the system-supplied C(http2) profile.
+    type: str
     default: /Common/http2
   description:
     description:
       - Description of the profile.
+    type: str
   streams:
     description:
       - Specifies the number of outstanding concurrent requests that are allowed on a single HTTP/2 connection.
@@ -54,6 +57,7 @@ options:
     description:
       - Specifies the name of the HTTP header controlled by C(insert_header) parameter.
       - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+    type: str
   enforce_tls_requirements:
     description:
       - Specifies whether the system requires TLS for communications between specified senders and recipients.
@@ -64,10 +68,10 @@ options:
       - Specifies what will cause an incoming connection to be handled as a HTTP/2 connection.
       - The C(alpn) and C(always) are mutually exclusive.
       - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+    type: list
     choices:
       - alpn
       - always
-    type: list
   frame_size:
     description:
       - Specifies the size of data frames, in bytes, that HTTP/2 sends to the client.
@@ -95,15 +99,17 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the profile exists.
       - When C(absent), ensures the profile is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Wojciech Wypior (@wojtek0806)
@@ -184,26 +190,20 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.common import is_empty_list
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.common import is_empty_list
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -440,7 +440,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -667,16 +667,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_profile_http_compression.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_http_compression.py
@@ -23,27 +23,32 @@ options:
   name:
     description:
       - Specifies the name of the compression profile.
+    type: str
     required: True
   parent:
     description:
       - Specifies the profile from which this profile inherits settings.
       - When creating a new profile, if this parameter is not specified, the default
         is the system-supplied C(httpcompression) profile.
+    type: str
   description:
     description:
       - Description of the HTTP compression profile.
+    type: str
   buffer_size:
     description:
       - Maximum number of compressed bytes that the system buffers before inserting
         a Content-Length header (which specifies the compressed size) into the response.
       - When creating a new profile, if this parameter is not specified, the default
         is provided by the parent profile.
+    type: int
   gzip_level:
     description:
       - Specifies the degree to which the system compresses the content.
       - Higher compression levels cause the compression process to be slower.
       - Valid values are between 1 (least compression and fastest) to 9 (most
         compression and slowest).
+    type: int
     choices:
       - 1
       - 2
@@ -58,6 +63,7 @@ options:
     description:
       - Number of kilobytes of memory that the system uses for internal compression
         buffers when compressing a server response.
+    type: int
     choices:
       - 1
       - 2
@@ -72,6 +78,7 @@ options:
     description:
       - Number of kilobytes in the window size that the system uses when compressing
         a server response.
+    type: int
     choices:
       - 1
       - 2
@@ -84,15 +91,17 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the profile exists.
       - When C(absent), ensures the profile is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -149,21 +158,15 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
 
 
@@ -303,7 +306,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -527,16 +530,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_profile_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_tcp.py
@@ -26,12 +26,14 @@ options:
   name:
     description:
       - Specifies the name of the profile.
+    type: str
     required: True
   parent:
     description:
       - Specifies the profile from which this profile inherits settings.
       - When creating a new profile, if this parameter is not specified, the default
         is the system-supplied C(tcp) profile.
+    type: str
   idle_timeout:
     description:
       - Specifies the length of time that a connection is idle (has no traffic) before
@@ -43,6 +45,7 @@ options:
         connection can remain idle before the system deletes it.
       - When C(0), or C(indefinite), specifies that the system does not delete TCP connections
         regardless of how long they remain idle.
+    type: str
   time_wait_recycle:
     description:
       - Specifies that connections in a TIME-WAIT state are reused, if a SYN packet,
@@ -55,15 +58,17 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the profile exists.
       - When C(absent), ensures the profile is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -110,24 +115,18 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -254,7 +253,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -469,16 +468,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_profile_udp.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_udp.py
@@ -26,12 +26,14 @@ options:
   name:
     description:
       - Specifies the name of the profile.
+    type: str
     required: True
   parent:
     description:
       - Specifies the profile from which this profile inherits settings.
       - When creating a new profile, if this parameter is not specified, the default
         is the system-supplied C(udp) profile.
+    type: str
   idle_timeout:
     description:
       - Specifies the length of time that a connection is idle (has no traffic) before
@@ -45,6 +47,7 @@ options:
         indefinitely.
       - When C(immediate), specifies that you do not want the UDP connection to
         remain idle, and that it is therefore immediately eligible for deletion.
+    type: str
   datagram_load_balancing:
     description:
       - Specifies, when C(yes), that the system load balances UDP traffic
@@ -53,15 +56,17 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the profile exists.
       - When C(absent), ensures the profile is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -107,22 +112,16 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -235,7 +234,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -448,16 +447,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_provision.py
+++ b/lib/ansible/modules/network/f5/bigip_provision.py
@@ -24,7 +24,8 @@ options:
   module:
     description:
       - The module to provision in BIG-IP.
-    required: true
+    type: str
+    required: True
     choices:
       - am
       - afm
@@ -52,11 +53,12 @@ options:
         the module is not activated.
       - This parameter is not relevant to C(cgnat) and will not be applied to the
         C(cgnat) module.
-    default: nominal
+    type: str
     choices:
       - dedicated
       - nominal
       - minimum
+    default: nominal
   state:
     description:
       - The state of the provisioned module on the system. When C(present),
@@ -64,10 +66,11 @@ options:
         level provided that there are sufficient resources on the device (such
         as physical RAM) to support the provisioned module. When C(absent),
         de-provision the module.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -111,19 +114,13 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import TransactionContextManager
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import TransactionContextManager
 
 
@@ -205,7 +202,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
@@ -883,14 +880,12 @@ def main():
         mutually_exclusive=spec.mutually_exclusive
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_node.py
+++ b/test/units/modules/network/f5/test_bigip_node.py
@@ -98,14 +98,17 @@ class TestManager(unittest.TestCase):
             ],
             partition='Common',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
         mm = ModuleManager(module=module)
 
@@ -126,16 +129,19 @@ class TestManager(unittest.TestCase):
             ],
             partition='Common',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_ltm_node_3.json'))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
         mm = ModuleManager(module=module)
 
@@ -156,14 +162,17 @@ class TestManager(unittest.TestCase):
             ],
             partition='Common',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
         mm = ModuleManager(module=module)
 
@@ -185,15 +194,18 @@ class TestManager(unittest.TestCase):
             ],
             partition='Common',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_ltm_node_2.json'))
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
         mm = ModuleManager(module=module)
 
@@ -217,15 +229,18 @@ class TestManager(unittest.TestCase):
             ],
             partition='Common',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_ltm_node_2.json'))
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_partition.py
+++ b/test/units/modules/network/f5/test_bigip_partition.py
@@ -109,9 +109,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             description='my description',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -133,9 +135,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             description='my description',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_tm_auth_partition.json'))
@@ -158,9 +162,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             description='another description',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_tm_auth_partition.json'))
@@ -185,9 +191,11 @@ class TestManagerEcho(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             route_domain=1,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_tm_auth_partition.json'))

--- a/test/units/modules/network/f5/test_bigip_password_policy.py
+++ b/test/units/modules/network/f5/test_bigip_password_policy.py
@@ -128,9 +128,11 @@ class TestManager(unittest.TestCase):
             required_numeric=0,
             required_special=0,
             required_uppercase=0,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_tm_auth_password_policy_1.json'))

--- a/test/units/modules/network/f5/test_bigip_policy.py
+++ b/test/units/modules/network/f5/test_bigip_policy.py
@@ -71,9 +71,6 @@ class TestParameters(unittest.TestCase):
         args = dict(
             name='foo',
             description='asdf asdf asdf',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = Parameters(params=args)
         assert p.name == 'foo'
@@ -84,10 +81,7 @@ class TestParameters(unittest.TestCase):
         args = dict(
             name='foo',
             description='asdf asdf asdf',
-            password='password',
-            server='localhost',
             strategy='foo',
-            user='admin',
             partition='Common'
         )
         p = Parameters(params=args)
@@ -99,10 +93,7 @@ class TestParameters(unittest.TestCase):
         args = dict(
             name='foo',
             description='asdf asdf asdf',
-            password='password',
-            server='localhost',
             strategy='/Common/foo',
-            user='admin',
             partition='Common'
         )
         p = Parameters(params=args)
@@ -114,10 +105,7 @@ class TestParameters(unittest.TestCase):
         args = dict(
             name='foo',
             description='asdf asdf asdf',
-            password='password',
-            server='localhost',
             strategy='/Foo/bar',
-            user='admin',
             partition='Common'
         )
         p = Parameters(params=args)
@@ -147,9 +135,11 @@ class TestSimpleTrafficPolicyManager(unittest.TestCase):
             name="Policy-Foo",
             state='present',
             strategy='best',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_policy_rule.py
+++ b/test/units/modules/network/f5/test_bigip_policy_rule.py
@@ -134,9 +134,11 @@ class TestManager(unittest.TestCase):
                     path_begins_with_any=['/ABC']
                 )
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -173,9 +175,11 @@ class TestManager(unittest.TestCase):
                     path_begins_with_any=['/ABC']
                 )
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_ltm_policy_draft_rule_http-uri_forward.json'))

--- a/test/units/modules/network/f5/test_bigip_profile_analytics.py
+++ b/test/units/modules/network/f5/test_bigip_profile_analytics.py
@@ -101,9 +101,11 @@ class TestManager(unittest.TestCase):
             description='foo',
             collect_geo=True,
             collect_ip=True,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_client_ssl.py
+++ b/test/units/modules/network/f5/test_bigip_profile_client_ssl.py
@@ -109,9 +109,11 @@ class TestManager(unittest.TestCase):
                     chain='bigip_ssl_cert1'
                 )
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_dns.py
+++ b/test/units/modules/network/f5/test_bigip_profile_dns.py
@@ -120,9 +120,11 @@ class TestManager(unittest.TestCase):
             process_recursion_desired=True,
             use_local_bind=True,
             enable_dns_firewall=True,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_fastl4.py
+++ b/test/units/modules/network/f5/test_bigip_profile_fastl4.py
@@ -158,9 +158,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             parent='bar',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_http.py
+++ b/test/units/modules/network/f5/test_bigip_profile_http.py
@@ -106,9 +106,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             insert_xforwarded_for='yes',
             parent='bar',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_http2.py
+++ b/test/units/modules/network/f5/test_bigip_profile_http2.py
@@ -109,9 +109,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             enforce_tls_requirements='yes',
             parent='bar',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_http_compression.py
+++ b/test/units/modules/network/f5/test_bigip_profile_http_compression.py
@@ -109,9 +109,11 @@ class TestManager(unittest.TestCase):
             gzip_memory_level=64,
             gzip_level=2,
             gzip_window_size=128,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_oneconnect.py
+++ b/test/units/modules/network/f5/test_bigip_profile_oneconnect.py
@@ -103,9 +103,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             parent='bar',
             maximum_reuse=1000,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_persistence_cookie.py
+++ b/test/units/modules/network/f5/test_bigip_profile_persistence_cookie.py
@@ -103,9 +103,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             match_across_virtuals='yes',
             parent='bar',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_persistence_src_addr.py
+++ b/test/units/modules/network/f5/test_bigip_profile_persistence_src_addr.py
@@ -107,9 +107,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             match_across_virtuals='yes',
             parent='bar',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_server_ssl.py
+++ b/test/units/modules/network/f5/test_bigip_profile_server_ssl.py
@@ -94,14 +94,17 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             server_name='foo.bar.com',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_together=self.spec.required_together
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_profile_tcp.py
+++ b/test/units/modules/network/f5/test_bigip_profile_tcp.py
@@ -95,9 +95,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             parent='bar',
             idle_timeout=500,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_profile_udp.py
+++ b/test/units/modules/network/f5/test_bigip_profile_udp.py
@@ -98,9 +98,11 @@ class TestManager(unittest.TestCase):
             parent='bar',
             idle_timeout=500,
             datagram_load_balancing=True,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_provision.py
+++ b/test/units/modules/network/f5/test_bigip_provision.py
@@ -66,9 +66,6 @@ class TestParameters(unittest.TestCase):
     def test_module_parameters(self):
         args = dict(
             module='gtm',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = Parameters(params=args)
         assert p.module == 'gtm'
@@ -88,9 +85,11 @@ class TestManager(unittest.TestCase):
         # Configure the arguments that would be sent to the Ansible module
         set_module_args(dict(
             module='gtm',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -103,7 +102,8 @@ class TestManager(unittest.TestCase):
         )
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
         mm = ModuleManager(module=module)
 
@@ -133,14 +133,17 @@ class TestManager(unittest.TestCase):
             # Configure the arguments that would be sent to the Ansible module
             set_module_args(dict(
                 module=module,
-                password='password',
-                server='localhost',
-                user='admin'
+                provider=dict(
+                    server='localhost',
+                    password='password',
+                    user='admin'
+                )
             ))
 
             with patch('ansible.module_utils.basic.AnsibleModule.fail_json') as mo:
                 AnsibleModule(
                     argument_spec=self.spec.argument_spec,
                     supports_check_mode=self.spec.supports_check_mode,
+                    mutually_exclusive=self.spec.mutually_exclusive
                 )
                 mo.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_node.py
lib/ansible/modules/network/f5/bigip_partition.py
lib/ansible/modules/network/f5/bigip_password_policy.py
lib/ansible/modules/network/f5/bigip_policy.py
lib/ansible/modules/network/f5/bigip_policy_rule.py
lib/ansible/modules/network/f5/bigip_pool.py
lib/ansible/modules/network/f5/bigip_pool_member.py
lib/ansible/modules/network/f5/bigip_profile_analytics.py
lib/ansible/modules/network/f5/bigip_profile_dns.py
lib/ansible/modules/network/f5/bigip_profile_fastl4.py
lib/ansible/modules/network/f5/bigip_profile_http.py
lib/ansible/modules/network/f5/bigip_profile_http2.py
lib/ansible/modules/network/f5/bigip_profile_http_compression.py
lib/ansible/modules/network/f5/bigip_profile_oneconnect.py
lib/ansible/modules/network/f5/bigip_profile_persistence_src_addr.py
lib/ansible/modules/network/f5/bigip_profile_tcp.py
lib/ansible/modules/network/f5/bigip_profile_udp.py
lib/ansible/modules/network/f5/bigip_provision.py



##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.