### PR TITLE
BIGIP: multiple_modules_fix_8

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_qkview.py
+++ b/lib/ansible/modules/network/f5/bigip_qkview.py
@@ -27,35 +27,39 @@ options:
   filename:
     description:
       - Name of the qkview to create on the remote BIG-IP.
+    type: str
     default: "localhost.localdomain.qkview"
   dest:
     description:
       - Destination on your local filesystem when you want to save the qkview.
+    type: path
     required: True
   asm_request_log:
     description:
       - When C(True), includes the ASM request log data. When C(False),
         excludes the ASM request log data.
-    default: no
     type: bool
+    default: no
   max_file_size:
     description:
       - Max file size, in bytes, of the qkview to create. By default, no max
         file size is specified.
+    type: int
     default: 0
   complete_information:
     description:
       - Include complete information in the qkview.
-    default: no
     type: bool
+    default: no
   exclude_core:
     description:
       - Exclude core files from the qkview.
-    default: no
     type: bool
+    default: no
   exclude:
     description:
       - Exclude various file from the qkview.
+    type: list
     choices:
       - all
       - audit
@@ -65,8 +69,8 @@ options:
     description:
       - If C(no), the file will only be transferred if the destination does not
         exist.
-    default: yes
     type: bool
+    default: yes
 notes:
   - This module does not include the "max time" or "restrict to blade" options.
   - If you are using this module with either Ansible Tower or Ansible AWX, you
@@ -115,20 +119,14 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.icontrol import download_file
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.icontrol import download_file
 
@@ -220,7 +218,7 @@ class Parameters(AnsibleF5Parameters):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.kwargs = kwargs
 
     def exec_module(self):
@@ -256,7 +254,7 @@ class ModuleManager(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = Parameters(params=self.module.params)
         self.changes = Parameters()
@@ -595,16 +593,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_service_policy.py
+++ b/lib/ansible/modules/network/f5/bigip_service_policy.py
@@ -25,27 +25,33 @@ options:
     description:
       - Name of the service policy.
     required: True
+    type: str
   description:
     description:
       - Description of the service policy.
+    type: str
   timer_policy:
     description:
       - The timer policy to attach to the service policy.
+    type: str
   port_misuse_policy:
     description:
       - The port misuse policy to attach to the service policy.
       - Requires that C(afm) be provisioned to use. If C(afm) is not provisioned, this parameter
         will be ignored.
+    type: str
   state:
     description:
       - Whether the resource should exist or not.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
 extends_documentation_fragment: f5
 author:
@@ -94,22 +100,16 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import fq_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import fq_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.icontrol import module_provisioned
 
@@ -206,7 +206,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -428,16 +428,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_smtp.py
+++ b/lib/ansible/modules/network/f5/bigip_smtp.py
@@ -24,33 +24,39 @@ options:
   name:
     description:
       - Specifies the name of the SMTP server configuration.
+    type: str
     required: True
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   smtp_server:
     description:
       - SMTP server host name in the format of a fully qualified domain name.
       - This value is required when create a new SMTP configuration.
+    type: str
   smtp_server_port:
     description:
       - Specifies the SMTP port number.
       - When creating a new SMTP configuration, the default is C(25) when
-        C(encryption) is C(none) or C(tls). The default is C(465) when C(ssl)
-         is selected.
+        C(encryption) is C(none) or C(tls). The default is C(465) when C(ssl) is selected.
+    type: int
   local_host_name:
     description:
       - Host name used in SMTP headers in the format of a fully qualified
         domain name. This setting does not refer to the BIG-IP system's hostname.
+    type: str
   from_address:
     description:
       - Email address that the email is being sent from. This is the "Reply-to"
         address that the recipient sees.
+    type: str
   encryption:
     description:
       - Specifies whether the SMTP server requires an encrypted connection in
         order to send mail.
+    type: str
     choices:
       - none
       - ssl
@@ -67,17 +73,20 @@ options:
   smtp_server_username:
     description:
       - User name that the SMTP server requires when validating a user.
+    type: str
   smtp_server_password:
     description:
       - Password that the SMTP server requires when validating a user.
+    type: str
   state:
     description:
       - When C(present), ensures that the SMTP configuration exists.
       - When C(absent), ensures that the SMTP configuration does not exist.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   update_password:
     description:
       - Passwords are stored encrypted, so the module cannot know if the supplied
@@ -87,10 +96,11 @@ options:
       - When C(always), will always update the password.
       - When C(on_create), will only set the password for newly created SMTP server
         configurations.
-    default: always
+    type: str
     choices:
       - always
       - on_create
+    default: always
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -153,10 +163,7 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import is_valid_hostname
     from library.module_utils.network.f5.ipaddress import is_valid_ip
@@ -164,10 +171,7 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import is_valid_hostname
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
@@ -332,7 +336,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -552,16 +556,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_snat_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_snat_pool.py
@@ -24,21 +24,26 @@ options:
     description:
       - List of members to put in the SNAT pool. When a C(state) of present is
         provided, this parameter is required. Otherwise, it is optional.
+    type: list
     aliases:
       - member
   name:
-    description: The name of the SNAT pool.
+    description:
+      - The name of the SNAT pool.
+    type: str
     required: True
   state:
     description:
       - Whether the SNAT pool should exist or not.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
 extends_documentation_fragment: f5
@@ -101,23 +106,17 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
 
 
@@ -221,7 +220,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -443,16 +442,12 @@ def main():
         required_if=spec.required_if
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_snmp_trap.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp_trap.py
@@ -23,22 +23,29 @@ options:
   name:
     description:
       - Name of the SNMP configuration endpoint.
+    type: str
     required: True
   snmp_version:
     description:
       - Specifies to which Simple Network Management Protocol (SNMP) version
         the trap destination applies.
-    choices: ['1', '2c']
+    type: str
+    choices:
+      - '1'
+      - '2c'
   community:
     description:
       - Specifies the community name for the trap destination.
+    type: str
   destination:
     description:
       - Specifies the address for the trap destination. This can be either an
         IP address or a hostname.
+    type: str
   port:
     description:
       - Specifies the port for the trap destination.
+    type: str
   network:
     description:
       - Specifies the name of the trap network. This option is not supported in
@@ -48,6 +55,7 @@ options:
         value when configuring a BIG-IP will cause the module to stop and report
         an error. The usual remedy is to choose one of the other options, such as
         C(management).
+    type: str
     choices:
       - other
       - management
@@ -56,13 +64,15 @@ options:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures that the resource does not exist.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
 notes:
@@ -142,21 +152,15 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import tmos_version
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import tmos_version
 
 
@@ -296,7 +300,7 @@ class V1Parameters(Parameters):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.kwargs = kwargs
 
     def exec_module(self):
@@ -337,7 +341,7 @@ class ModuleManager(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
 
     def exec_module(self):
@@ -665,16 +669,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
@@ -27,28 +27,33 @@ options:
       - Sets the contents of a certificate directly to the specified value.
         This is used with lookup plugins or for anything with formatting or
       - C(content) must be provided when C(state) is C(present).
+    type: str
     aliases: ['cert_content']
   state:
     description:
       - Certificate state. This determines if the provided certificate
         and key is to be made C(present) on the device or C(absent).
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
   name:
     description:
       - SSL Certificate Name. This is the cert name used when importing a certificate
         into the F5. It also determines the filenames of the objects on the LTM.
+    type: str
     required: True
   issuer_cert:
     description:
       - Issuer certificate used for OCSP monitoring.
       - This parameter is only valid on versions of BIG-IP 13.0.0 or above.
+    type: str
     version_added: 2.5
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
 notes:
@@ -134,10 +139,7 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.icontrol import upload_file
@@ -145,10 +147,7 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.icontrol import upload_file
@@ -311,7 +310,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -568,16 +567,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_ssl_ocsp.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_ocsp.py
@@ -23,10 +23,12 @@ options:
   name:
     description:
       - Specifies the name of the OCSP certificate validator.
+    type: str
     required: True
   cache_error_timeout:
     description:
       - Specifies the lifetime of an error response in the cache, in seconds.
+    type: int
   proxy_server_pool:
     description:
       - Specifies the proxy server pool the BIG-IP system uses to fetch the OCSP
@@ -35,17 +37,21 @@ options:
       - Use this option when either the OCSP responder cannot be reached on any of
         BIG-IP system's interfaces or one or more servers can proxy an HTTP request
         to an external server and fetch the response.
+    type: str
   cache_timeout:
     description:
       - Specifies the lifetime of the OCSP response in the cache, in seconds.
+    type: str
   clock_skew:
     description:
       - Specifies the tolerable absolute difference in the clocks of the responder
         and the BIG-IP system, in seconds.
+    type: int
   connections_limit:
     description:
       - Specifies the maximum number of connections per second allowed for the
         OCSP certificate validator.
+    type: int
   dns_resolver:
     description:
       - Specifies the internal DNS resolver the BIG-IP system uses to fetch the
@@ -55,29 +61,36 @@ options:
       - Use this option when either there is a DNS server that can do the
         name-resolution of the OCSP responders or the OCSP responder can be
         reached on one of BIG-IP system's interfaces.
+    type: str
   route_domain:
     description:
       - Specifies the route domain for fetching an OCSP response using HTTP
         forward proxy.
+    type: str
   hash_algorithm:
     description:
       - Specifies a hash algorithm used to sign an OCSP request.
+    type: str
     choices:
       - sha256
       - sha1
   certificate:
     description:
       - Specifies a certificate used to sign an OCSP request.
+    type: str
   key:
     description:
       - Specifies a key used to sign an OCSP request.
+    type: str
   passphrase:
     description:
       - Specifies a passphrase used to sign an OCSP request.
+    type: str
   status_age:
     description:
       - Specifies the maximum allowed lag time that the BIG-IP system accepts for
         the 'thisUpdate' time in the OCSP response.
+    type: int
   strict_responder_checking:
     description:
       - Specifies whether the responder's certificate is checked for an OCSP
@@ -87,36 +100,42 @@ options:
     description:
       - Specifies the time interval that the BIG-IP system waits for before
         ending the connection to the OCSP responder, in seconds.
+    type: int
   trusted_responders:
     description:
       - Specifies the certificates used for validating the OCSP response
         when the responder's certificate has been omitted from the response.
+    type: str
   responder_url:
     description:
       - Specifies the absolute URL that overrides the OCSP responder URL
         obtained from the certificate's AIA extensions. This should be an
         HTTP-based URL.
+    type: str
   update_password:
     description:
       - C(always) will allow to update passwords if the user chooses to do so.
         C(on_create) will only set the password for newly created OCSP validators.
-    default: always
+    type: str
     choices:
       - always
       - on_create
+    default: always
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures that the resource does not exist.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 notes:
   - Requires BIG-IP >= 13.x.
@@ -222,11 +241,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.icontrol import tmos_version
@@ -234,11 +250,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.icontrol import tmos_version
@@ -490,7 +503,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -750,16 +763,12 @@ def main():
         required_together=spec.required_together,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_static_route.py
+++ b/lib/ansible/modules/network/f5/bigip_static_route.py
@@ -23,21 +23,25 @@ options:
   name:
     description:
       - Name of the static route.
+    type: str
     required: True
   description:
     description:
       - Descriptive text that identifies the route.
+    type: str
   destination:
     description:
       - Specifies an IP address for the static entry in the routing table.
         When creating a new static route, this value is required.
       - This value cannot be changed once it is set.
+    type: str
   netmask:
     description:
       - The netmask for the static route. When creating a new static route, this value
         is required.
       - This value can be in either IP or CIDR format.
       - This value cannot be changed once it is set.
+    type: str
   gateway_address:
     description:
       - Specifies the router for the system to use when forwarding packets
@@ -46,15 +50,18 @@ options:
         IPv6 address that starts with C(FE80:), the address will be treated
         as a link-local address. This requires that the C(vlan) parameter
         also be supplied.
+    type: str
   vlan:
     description:
       - Specifies the VLAN or Tunnel through which the system forwards packets
         to the destination. When C(gateway_address) is a link-local IPv6
-        address, this value is required
+        address, this value is required.
+    type: str
   pool:
     description:
       - Specifies the pool through which the system forwards packets to the
         destination.
+    type: str
   reject:
     description:
       - Specifies that the system drops packets sent to the destination.
@@ -62,24 +69,28 @@ options:
   mtu:
     description:
       - Specifies a specific maximum transmission unit (MTU).
+    type: str
   route_domain:
     description:
       - The route domain id of the system. When creating a new static route, if
         this value is not specified, a default value of C(0) will be used.
       - This value cannot be changed once it is set.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.6
   state:
     description:
       - When C(present), ensures that the static route exists.
       - When C(absent), ensures that the static does not exist.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -158,12 +169,9 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.ipaddress import ipv6_netmask_to_cidr
     from library.module_utils.compat.ipaddress import ip_address
@@ -173,12 +181,9 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     from ansible.module_utils.network.f5.ipaddress import ipv6_netmask_to_cidr
     from ansible.module_utils.compat.ipaddress import ip_address
@@ -446,7 +451,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
@@ -686,16 +691,12 @@ def main():
         mutually_exclusive=spec.mutually_exclusive,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_sys_daemon_log_tmm.py
+++ b/lib/ansible/modules/network/f5/bigip_sys_daemon_log_tmm.py
@@ -24,6 +24,7 @@ options:
     description:
       - Specifies the lowest level of ARP messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - debug
       - error
@@ -34,6 +35,7 @@ options:
     description:
       - Specifies the lowest level of HTTP compression messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - debug
       - error
@@ -44,6 +46,7 @@ options:
     description:
       - Specifies the lowest level of HTTP messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - debug
       - error
@@ -54,6 +57,7 @@ options:
     description:
       - Specifies the lowest level of IP address messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - debug
       - informational
@@ -63,6 +67,7 @@ options:
     description:
       - Specifies the lowest level of iRule messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - debug
       - error
@@ -73,6 +78,7 @@ options:
     description:
       - Specifies the lowest level of Layer 4 messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - debug
       - informational
@@ -81,6 +87,7 @@ options:
     description:
       - Specifies the lowest level of network messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - critical
       - debug
@@ -92,6 +99,7 @@ options:
     description:
       - Specifies the lowest level of operating system messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - alert
       - critical
@@ -105,6 +113,7 @@ options:
     description:
       - Specifies the lowest level of PVA messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - debug
       - informational
@@ -113,6 +122,7 @@ options:
     description:
       - Specifies the lowest level of SSL messages from the tmm daemon
         to include in the system log.
+    type: str
     choices:
       - alert
       - critical
@@ -126,9 +136,10 @@ options:
     description:
       - The state of the log level on the system. When C(present), guarantees
         that an existing log level is set to C(value).
-    default: present
+    type: str
     choices:
       - present
+    default: present
 extends_documentation_fragment: f5
 author:
   - Wojciech Wypior (@wojtek0806)
@@ -204,18 +215,12 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -325,7 +330,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -476,16 +481,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_sys_global.py
+++ b/lib/ansible/modules/network/f5/bigip_sys_global.py
@@ -23,10 +23,12 @@ options:
   banner_text:
     description:
       - Specifies the text to present in the advisory banner.
+    type: str
   console_timeout:
     description:
       - Specifies the number of seconds of inactivity before the system logs
         off a user that is logged on.
+    type: int
   gui_setup:
     description:
       - C(yes) or C(no) the Setup utility in the browser-based
@@ -65,9 +67,10 @@ options:
     description:
       - The state of the variable on the system. When C(present), guarantees
         that an existing variable is set to C(value).
-    default: present
+    type: str
     choices:
       - present
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -140,19 +143,13 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
 
 
@@ -347,7 +344,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -497,16 +494,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_qkview.py
+++ b/test/units/modules/network/f5/test_bigip_qkview.py
@@ -106,9 +106,11 @@ class TestMadmLocationManager(unittest.TestCase):
     def test_create_qkview_default_options(self, *args):
         set_module_args(dict(
             dest='/tmp/foo.qkview',
-            server='localhost',
-            user='admin',
-            password='password'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -144,9 +146,11 @@ class TestBulkLocationManager(unittest.TestCase):
     def test_create_qkview_default_options(self, *args):
         set_module_args(dict(
             dest='/tmp/foo.qkview',
-            server='localhost',
-            user='admin',
-            password='password'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_remote_role.py
+++ b/test/units/modules/network/f5/test_bigip_remote_role.py
@@ -90,9 +90,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             line_order=1000,
             attribute_string='bar',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_routedomain.py
+++ b/test/units/modules/network/f5/test_bigip_routedomain.py
@@ -106,14 +106,17 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             id=1234,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_one_of=self.spec.required_one_of
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_selfip.py
+++ b/test/units/modules/network/f5/test_bigip_selfip.py
@@ -149,9 +149,11 @@ class TestManager(unittest.TestCase):
             state='present',
             traffic_group='traffic-group-local-only',
             vlan='net1',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -183,9 +185,11 @@ class TestManager(unittest.TestCase):
             state='present',
             traffic_group='traffic-group-local-only',
             vlan='net1',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_tm_net_self.json'))

--- a/test/units/modules/network/f5/test_bigip_service_policy.py
+++ b/test/units/modules/network/f5/test_bigip_service_policy.py
@@ -109,9 +109,11 @@ class TestManager(unittest.TestCase):
             port_misuse_policy='misuse1',
             partition='Common',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_smtp.py
+++ b/test/units/modules/network/f5/test_bigip_smtp.py
@@ -124,9 +124,11 @@ class TestManager(unittest.TestCase):
             from_address='no-reply@mydomain.com',
             authentication=True,
             partition='Common',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_snat_pool.py
+++ b/test/units/modules/network/f5/test_bigip_snat_pool.py
@@ -99,14 +99,17 @@ class TestManager(unittest.TestCase):
             name='my-snat-pool',
             state='present',
             members=['10.10.10.10', '20.20.20.20'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         mm = ModuleManager(module=module)
 
@@ -126,16 +129,19 @@ class TestManager(unittest.TestCase):
             name='asdasd',
             state='present',
             members=['1.1.1.1', '2.2.2.2'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_ltm_snatpool.json'))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         mm = ModuleManager(module=module)
 
@@ -152,16 +158,19 @@ class TestManager(unittest.TestCase):
             name='asdasd',
             state='present',
             members=['30.30.30.30'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_ltm_snatpool.json'))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_snmp.py
+++ b/test/units/modules/network/f5/test_bigip_snmp.py
@@ -72,9 +72,6 @@ class TestParameters(unittest.TestCase):
             contact='Alice@foo.org',
             device_warning_traps='enabled',
             location='Lunar orbit',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = ModuleParameters(params=args)
         assert p.agent_status_traps == 'enabled'
@@ -88,9 +85,6 @@ class TestParameters(unittest.TestCase):
             agent_status_traps='disabled',
             agent_authentication_traps='disabled',
             device_warning_traps='disabled',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = ModuleParameters(params=args)
         assert p.agent_status_traps == 'disabled'
@@ -132,9 +126,11 @@ class TestManager(unittest.TestCase):
     def test_update_agent_status_traps(self, *args):
         set_module_args(dict(
             agent_status_traps='enabled',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -168,9 +164,11 @@ class TestManager(unittest.TestCase):
                 'foo',
                 'baz.foo.com'
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -204,9 +202,11 @@ class TestManager(unittest.TestCase):
             allowed_addresses=[
                 'default'
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -236,9 +236,11 @@ class TestManager(unittest.TestCase):
     def test_update_allowed_addresses_empty(self, *args):
         set_module_args(dict(
             allowed_addresses=[''],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the

--- a/test/units/modules/network/f5/test_bigip_snmp_community.py
+++ b/test/units/modules/network/f5/test_bigip_snmp_community.py
@@ -170,14 +170,17 @@ class TestManager(unittest.TestCase):
             ip_version=4,
             state='present',
             partition='Common',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         m1 = V1Manager(module=module)
 
@@ -194,6 +197,7 @@ class TestManager(unittest.TestCase):
 
     def test_create_v1_community_1(self, *args):
         set_module_args(dict(
+            name='foo',
             version='v1',
             community='foo',
             source='1.1.1.1',
@@ -203,14 +207,17 @@ class TestManager(unittest.TestCase):
             ip_version=4,
             state='present',
             partition='Common',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         m1 = V1Manager(module=module)
 
@@ -237,14 +244,17 @@ class TestManager(unittest.TestCase):
             snmp_privacy_password='secretsecret',
             state='present',
             partition='Common',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         m1 = V2Manager(module=module)
 
@@ -270,14 +280,17 @@ class TestManager(unittest.TestCase):
             snmp_privacy_password='secretsecret',
             state='present',
             partition='Common',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         m1 = V2Manager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_snmp_trap.py
+++ b/test/units/modules/network/f5/test_bigip_snmp_trap.py
@@ -79,9 +79,6 @@ class TestParameters(unittest.TestCase):
             destination='10.10.10.10',
             port=1000,
             network='other',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = V2Parameters(params=args)
         assert p.name == 'foo'
@@ -99,9 +96,6 @@ class TestParameters(unittest.TestCase):
             destination='10.10.10.10',
             port=1000,
             network='other',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = V1Parameters(params=args)
         assert p.name == 'foo'
@@ -142,9 +136,11 @@ class TestManager(unittest.TestCase):
             destination='10.10.10.10',
             port=1000,
             network='other',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -177,9 +173,11 @@ class TestManager(unittest.TestCase):
             community='public',
             destination='10.10.10.10',
             port=1000,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_software_image.py
+++ b/test/units/modules/network/f5/test_bigip_software_image.py
@@ -100,9 +100,11 @@ class TestManager(unittest.TestCase):
     def test_create(self, *args):
         set_module_args(dict(
             image='/path/to/BIGIP-13.0.0.0.0.1645.iso',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters(params=load_fixture('load_sys_software_image_1.json'))

--- a/test/units/modules/network/f5/test_bigip_software_install.py
+++ b/test/units/modules/network/f5/test_bigip_software_install.py
@@ -85,9 +85,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             image='BIGIP-13.0.0.0.0.1645.iso',
             volume='HD1.2',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         current = ApiParameters()

--- a/test/units/modules/network/f5/test_bigip_software_update.py
+++ b/test/units/modules/network/f5/test_bigip_software_update.py
@@ -94,9 +94,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             auto_check='no',
             auto_phone_home='no',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the

--- a/test/units/modules/network/f5/test_bigip_ssl_certificate.py
+++ b/test/units/modules/network/f5/test_bigip_ssl_certificate.py
@@ -106,9 +106,11 @@ class TestCertificateManager(unittest.TestCase):
             name='foo',
             content=load_fixture('cert1.crt'),
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -130,9 +132,11 @@ class TestCertificateManager(unittest.TestCase):
             name='foo',
             content=load_fixture('chain1.crt'),
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_ssl_key.py
+++ b/test/units/modules/network/f5/test_bigip_ssl_key.py
@@ -93,9 +93,11 @@ class TestModuleManager(unittest.TestCase):
             name='foo',
             content=load_fixture('cert1.key'),
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_ssl_ocsp.py
+++ b/test/units/modules/network/f5/test_bigip_ssl_ocsp.py
@@ -106,14 +106,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             clock_skew=100,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive,
+            required_together=self.spec.required_together
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_static_route.py
+++ b/test/units/modules/network/f5/test_bigip_static_route.py
@@ -157,13 +157,15 @@ class TestManager(unittest.TestCase):
     def test_create_blackhole(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
             state='present',
             destination='10.10.10.10',
             netmask='255.255.255.255',
-            reject='yes'
+            reject='yes',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -183,13 +185,15 @@ class TestManager(unittest.TestCase):
     def test_create_route_to_pool(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
             state='present',
             destination='10.10.10.10',
             netmask='255.255.255.255',
-            pool="test-pool"
+            pool="test-pool",
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -210,13 +214,15 @@ class TestManager(unittest.TestCase):
     def test_create_route_to_vlan(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
             state='present',
             destination='10.10.10.10',
             netmask='255.255.255.255',
-            vlan="test-vlan"
+            vlan="test-vlan",
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -237,11 +243,13 @@ class TestManager(unittest.TestCase):
     def test_update_description(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
             state='present',
-            description='foo description'
+            description='foo description',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -264,11 +272,13 @@ class TestManager(unittest.TestCase):
     def test_update_description_idempotent(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
             state='present',
-            description='asdasd'
+            description='asdasd',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -292,10 +302,12 @@ class TestManager(unittest.TestCase):
     def test_delete(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
-            state='absent'
+            state='absent',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -316,11 +328,13 @@ class TestManager(unittest.TestCase):
     def test_invalid_unknown_params(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
             state='present',
-            foo="bar"
+            foo="bar",
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
         with patch('ansible.module_utils.f5_utils.AnsibleModule.fail_json') as mo:
             mo.return_value = True
@@ -334,14 +348,16 @@ class TestManager(unittest.TestCase):
     def test_create_with_route_domain(self, *args):
         set_module_args(dict(
             name='test-route',
-            password='admin',
-            server='localhost',
-            user='admin',
             state='present',
             destination='10.10.10.10',
             netmask='255.255.255.255',
             route_domain=1,
-            reject='yes'
+            reject='yes',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_sys_daemon_log_tmm.py
+++ b/test/units/modules/network/f5/test_bigip_sys_daemon_log_tmm.py
@@ -115,9 +115,11 @@ class TestManager(unittest.TestCase):
             arp_log_level='debug',
             layer4_log_level='debug',
             password='admin',
-            server='localhost',
-            user='admin',
-            state='present'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the

--- a/test/units/modules/network/f5/test_bigip_sys_db.py
+++ b/test/units/modules/network/f5/test_bigip_sys_db.py
@@ -67,9 +67,6 @@ class TestParameters(unittest.TestCase):
         args = dict(
             key='foo',
             value='bar',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = Parameters(params=args)
         assert p.key == 'foo'
@@ -79,10 +76,7 @@ class TestParameters(unittest.TestCase):
         args = dict(
             key='foo',
             value='bar',
-            password='password',
-            server='localhost',
             defaultValue='baz',
-            user='admin'
 
         )
         p = Parameters(params=args)
@@ -99,10 +93,12 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             key='provision.cpu.afm',
             value='1',
-            password='admin',
-            server='localhost',
-            user='admin',
-            state='present'
+            state='present',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the

--- a/test/units/modules/network/f5/test_bigip_sys_global.py
+++ b/test/units/modules/network/f5/test_bigip_sys_global.py
@@ -108,10 +108,12 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             banner_text='this is a banner',
             console_timeout=100,
-            password='admin',
-            server='localhost',
-            user='admin',
-            state='present'
+            state='present',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_qkview.py
lib/ansible/modules/network/f5/bigip_remote_role.py
lib/ansible/modules/network/f5/bigip_routedomain.py
lib/ansible/modules/network/f5/bigip_selfip.py
lib/ansible/modules/network/f5/bigip_service_policy.py
lib/ansible/modules/network/f5/bigip_smtp.py
lib/ansible/modules/network/f5/bigip_snat_pool.py
lib/ansible/modules/network/f5/bigip_snmp.py
lib/ansible/modules/network/f5/bigip_snmp_community.py
lib/ansible/modules/network/f5/bigip_snmp_trap.py
lib/ansible/modules/network/f5/bigip_software_image.py
lib/ansible/modules/network/f5/bigip_software_install.py
lib/ansible/modules/network/f5/bigip_software_update.py
lib/ansible/modules/network/f5/bigip_ssl_certificate.py
lib/ansible/modules/network/f5/bigip_ssl_key.py
lib/ansible/modules/network/f5/bigip_ssl_ocsp.py
lib/ansible/modules/network/f5/bigip_static_route.py
lib/ansible/modules/network/f5/bigip_sys_daemon_log_tmm.py
lib/ansible/modules/network/f5/bigip_sys_db.py
lib/ansible/modules/network/f5/bigip_sys_global.py



##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.