### PR TITLE
BIGIP: multiple_modules_fix_9

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_traffic_selector.py
+++ b/lib/ansible/modules/network/f5/bigip_traffic_selector.py
@@ -23,20 +23,24 @@ options:
   name:
     description:
       - Specifies the name of the traffic selector.
+    type: str
     required: True
   destination_address:
     description:
       - Specifies the host or network IP address to which the application traffic is destined.
       - When creating a new traffic selector, this parameter is required.
+    type: str
   source_address:
     description:
       - Specifies the host or network IP address from which the application traffic originates.
       - When creating a new traffic selector, this parameter is required.
+    type: str
   ipsec_policy:
     description:
       - Specifies the IPsec policy that tells the BIG-IP system how to handle the packets.
       - When creating a new traffic selector, if this parameter is not specified, the default
         is C(default-ipsec-policy).
+    type: str
   order:
     description:
       - Specifies the order in which traffic is matched, if traffic can be matched to multiple
@@ -44,21 +48,25 @@ options:
       - Traffic is matched to the traffic selector with the highest priority (lowest order number).
       - When creating a new traffic selector, if this parameter is not specified, the default
         is C(last).
+    type: int
   description:
     description:
       - Description of the traffic selector.
+    type: str
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -112,11 +120,8 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.compat.ipaddress import ip_interface
     from library.module_utils.network.f5.compare import cmp_str_with_none
@@ -124,11 +129,8 @@ except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.compat.ipaddress import ip_interface
     from ansible.module_utils.network.f5.compare import cmp_str_with_none
@@ -282,7 +284,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -495,16 +497,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_trunk.py
+++ b/lib/ansible/modules/network/f5/bigip_trunk.py
@@ -23,14 +23,17 @@ options:
   name:
     description:
       - Specifies the name of the trunk.
+    type: str
     required: True
   interfaces:
     description:
       - The interfaces that are part of the trunk.
       - To clear the list of interfaces, specify an empty list.
+    type: list
   description:
     description:
       - Description of the trunk.
+    type: str
     version_added: 2.7
   link_selection_policy:
     description:
@@ -42,6 +45,7 @@ options:
         same media type and speed.
       - When C(maximum-bandwidth), specifies that the system determines which interfaces
         can handle new traffic based on the members' maximum bandwidth.
+    type: str
     choices:
       - auto
       - maximum-bandwidth
@@ -58,6 +62,7 @@ options:
         address of the destination.
       - When C(source-destination-ip), specifies that the system bases the hash on the
         combined IP addresses of the source and the destination.
+    type: str
     choices:
       - destination-mac
       - source-destination-ip
@@ -83,6 +88,7 @@ options:
         regardless of whether the partner system has issued a request.
       - When C(passive), specifies that the system sends control packets only when
         the partner system has issued a request.
+    type: str
     choices:
       - active
       - passive
@@ -93,6 +99,7 @@ options:
         C(long).
       - When C(long), specifies that the system sends an LACP control packet every 30 seconds.
       - When C(short), specifies that the system sends an LACP control packet every 1 seconds.
+    type: str
     choices:
       - long
       - short
@@ -105,15 +112,17 @@ options:
       - This parameter is not supported on Virtual Editions.
       - You should always wrap this value in quotes to prevent Ansible from interpreting
         the value as a literal hexadecimal number and converting it to an integer.
+    type: raw
     version_added: 2.7
   state:
     description:
       - When C(present), ensures that the resource exists.
       - When C(absent), ensures the resource is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -190,18 +199,12 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.compare import cmp_simple_list
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.compare import cmp_simple_list
 
@@ -365,7 +368,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -590,16 +593,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_tunnel.py
+++ b/lib/ansible/modules/network/f5/bigip_tunnel.py
@@ -30,15 +30,18 @@ options:
   name:
     description:
       - Specifies the name of the tunnel.
+    type: str
     required: True
   description:
     description:
       - Description of the tunnel.
+    type: str
   profile:
     description:
       - Specifies the profile to associate with the tunnel for handling traffic.
       - Depending on your selection, other settings become available or disappear.
       - This parameter may not be changed after it is set.
+    type: str
   key:
     description:
       - When applied to a GRE tunnel, this value specifies an optional field in the GRE header,
@@ -48,24 +51,29 @@ options:
       - When applied to an NVGRE tunnel, this value specifies the Virtual Subnet Identifier (VSID).
       - When creating a new tunnel, if this parameter is supported by the tunnel profile but not
         specified, the default value is C(0).
+    type: int
   local_address:
     description:
       - Specifies the IP address of the local endpoint of the tunnel.
+    type: str
   remote_address:
     description:
       - Specifies the IP address of the remote endpoint of the tunnel.
       - For C(dslite), C(fec) (when configuring the FEC tunnel for receiving traffic only),
         C(v6rd) (configured as a border relay), or C(map), the tunnel must have an unspecified
         remote address (any).
+    type: str
   secondary_address:
     description:
       - Specifies a non-floating IP address for the tunnel, to be used with host-initiated traffic.
+    type: str
   mtu:
     description:
       - Specifies the maximum transmission unit (MTU) of the tunnel.
       - When creating a new tunnel, if this parameter is supported by the tunnel profile but not
         specified, the default value is C(0).
       - The valid range is from C(0) to C(65515).
+    type: int
   use_pmtu:
     description:
       - Enables or disables the tunnel to use the PMTU (Path MTU) information provided by ICMP
@@ -84,6 +92,7 @@ options:
         specified, the default value is C(preserve).
       - When C(preserve), the system copies the TOS value from the inner header to the outer header.
       - You may also specify a numeric value. The possible values are from C(0) to C(255).
+    type: str
   auto_last_hop:
     description:
       - Allows you to configure auto last hop on a per-tunnel basis.
@@ -94,6 +103,7 @@ options:
       - When C(enabled), allows the system to send return traffic to the MAC address that transmitted
         the request, even if the routing table points to a different network or interface. As a
         result, the system can send return traffic to clients even when there is no matching route.
+    type: str
     choices:
       - default
       - enabled
@@ -102,6 +112,7 @@ options:
     description:
       - Specifies the traffic group to associate with the tunnel.
       - This value cannot be changed after it is set. This is a limitation of BIG-IP.
+    type: str
   mode:
     description:
       - Specifies how the tunnel carries traffic.
@@ -110,6 +121,7 @@ options:
       - When C(bidirectional), specifies that the tunnel carries both inbound and outbound traffic.
       - When C(inbound), specifies that the tunnel carries only incoming traffic.
       - When C(outbound), specifies that the tunnel carries only outgoing traffic.
+    type: str
     choices:
       - bidirectional
       - inbound
@@ -126,15 +138,17 @@ options:
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
   state:
     description:
       - When C(present), ensures that the tunnel exists.
       - When C(absent), ensures the tunnel is removed.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -180,22 +194,16 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.common import transform_name
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.common import transform_name
 
@@ -368,7 +376,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -599,16 +607,12 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_ucs.py
+++ b/lib/ansible/modules/network/f5/bigip_ucs.py
@@ -34,6 +34,7 @@ options:
         ignored and only the filename will be used to select a UCS for removal.
         Therefore you could specify C(/mickey/mouse/test.ucs) and this module
         would only look for C(test.ucs).
+    type: str
   force:
     description:
       - If C(yes) will upload the file every time and replace the file on the
@@ -70,11 +71,12 @@ options:
         When C(absent), the UCS will be removed from the system. When
         C(installed), the uploading of the UCS is idempotent, however the
         installation of that configuration is not idempotent.
-    default: present
+    type: str
     choices:
       - absent
       - installed
       - present
+    default: present
 notes:
    - Only the most basic checks are performed by this module. Other checks and
      considerations need to be taken into account. See the following URL.
@@ -184,20 +186,14 @@ try:
     from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import upload_file
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.icontrol import tmos_version
     from ansible.module_utils.network.f5.icontrol import upload_file
 
@@ -306,8 +302,9 @@ class UsableChanges(Changes):
 
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
-        self.client = kwargs.get('client', None)
         self.kwargs = kwargs
+        self.module = kwargs.get('module', None)
+        self.client = F5RestClient(**self.module.params)
 
     def exec_module(self):
         if self.is_version_v1():
@@ -341,7 +338,7 @@ class Difference(object):
 class BaseManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params)
         self.changes = UsableChanges()
 
@@ -709,16 +706,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_virtual_server.py
+++ b/lib/ansible/modules/network/f5/bigip_virtual_server.py
@@ -26,12 +26,13 @@ options:
         if it exists. C(present) creates the virtual server and enable it.
         If C(enabled), enable the virtual server if it exists. If C(disabled),
         create the virtual server if needed, and set state to C(disabled).
-    default: present
+    type: str
     choices:
       - present
       - absent
       - enabled
       - disabled
+    default: present
   type:
     description:
       - Specifies the network service provided by this virtual server.
@@ -73,6 +74,7 @@ options:
         profile and adding Request Adapt or Response Adapt profiles to the virtual server.
       - When C(message-routing), specifies a virtual server that uses a SIP application protocol
         and functions in accordance with a SIP session profile and SIP router profile.
+    type: str
     choices:
       - standard
       - forwarding-l2
@@ -89,6 +91,7 @@ options:
   name:
     description:
       - Virtual server name.
+    type: str
     required: True
     aliases:
       - vs
@@ -99,6 +102,7 @@ options:
       - When C(type) is C(internal), this parameter is ignored. For all other types,
         it is required.
       - Destination can also be specified as a name for an existing Virtual Address.
+    type: str
     aliases:
       - address
       - ip
@@ -113,6 +117,7 @@ options:
       - Specify the IP address in Classless Inter-Domain Routing (CIDR) format; address/prefix,
         where the prefix length is in bits. For example, for IPv4, 10.0.0.1/32 or 10.0.0.0/24,
         and for IPv6, ffe1::0020/64 or 2001:ed8:77b5:2:10:10:100:42/64.
+    type: str
     version_added: 2.5
   port:
     description:
@@ -136,6 +141,7 @@ options:
       - The string C(isakmp) may be substituted for for port C(500).
       - The string C(mqtt) may be substituted for for port C(1883).
       - The string C(mqtt-tls) may be substituted for for port C(8883).
+    type: str
   profiles:
     description:
       - List of profiles (HTTP, ClientSSL, ServerSSL, etc) to apply to both sides
@@ -166,14 +172,17 @@ options:
           - If this is not specified, then it is assumed that the profile item is
             only a name of a profile.
           - This must be specified if a context is specified.
+        type: str
       context:
         description:
           - The side of the connection on which the profile should be applied.
+        type: str
         choices:
           - all
           - server-side
           - client-side
         default: all
+    type: list
     aliases:
       - all_profiles
   irules:
@@ -186,22 +195,25 @@ options:
       - When C(type) is C(stateless), this parameter will be ignored.
       - When C(type) is C(reject), this parameter will be ignored.
       - When C(type) is C(internal), this parameter will be ignored.
+    type: list
     aliases:
       - all_rules
   enabled_vlans:
-    version_added: "2.2"
     description:
       - List of VLANs to be enabled. When a VLAN named C(all) is used, all
         VLANs will be allowed. VLANs can be specified with or without the
         leading partition. If the partition is not specified in the VLAN,
         then the C(partition) option of this module will be used.
       - This parameter is mutually exclusive with the C(disabled_vlans) parameter.
+    type: list
+    version_added: 2.2
   disabled_vlans:
-    version_added: 2.5
     description:
       - List of VLANs to be disabled. If the partition is not specified in the VLAN,
         then the C(partition) option of this module will be used.
       - This parameter is mutually exclusive with the C(enabled_vlans) parameters.
+    type: list
+    version_added: 2.5
   pool:
     description:
       - Default pool for the virtual server.
@@ -211,12 +223,14 @@ options:
         is required.
       - If C(type) is C(stateless), the C(pool) that is used must not have any members
         which define a C(rate_limit).
+    type: str
   policies:
     description:
       - Specifies the policies for the virtual server.
       - When C(type) is C(dhcp), this parameter will be ignored.
       - When C(type) is C(reject), this parameter will be ignored.
       - When C(type) is C(internal), this parameter will be ignored.
+    type: list
     aliases:
       - all_policies
   snat:
@@ -229,15 +243,18 @@ options:
         with the specific pool.
       - To remove SNAT, specify the word C(none).
       - To specify automap, use the word C(automap).
+    type: str
   default_persistence_profile:
     description:
       - Default Profile which manages the session persistence.
       - If you want to remove the existing default persistence profile, specify an
         empty value; C(""). See the documentation for an example.
       - When C(type) is C(dhcp), this parameter will be ignored.
+    type: str
   description:
     description:
       - Virtual server description.
+    type: str
   fallback_persistence_profile:
     description:
       - Specifies the persistence profile you want the system to use if it
@@ -245,10 +262,12 @@ options:
       - If you want to remove the existing fallback persistence profile, specify an
         empty value; C(""). See the documentation for an example.
       - When C(type) is C(dhcp), this parameter will be ignored.
+    type: str
     version_added: 2.3
   partition:
     description:
       - Device partition to manage resources on.
+    type: str
     default: Common
     version_added: 2.5
   metadata:
@@ -259,6 +278,7 @@ options:
       - Values for all of the keys will be stored as strings; this includes values
         that are numbers.
       - Data will be persisted, not ephemeral.
+    type: raw
     version_added: 2.5
   insert_metadata:
     description:
@@ -293,6 +313,7 @@ options:
     description:
       - Specifies whether the system preserves the source port of the connection.
       - When creating a new virtual server, if this parameter is not specified, the default is C(preserve).
+    type: str
     choices:
       - preserve
       - preserve-strict
@@ -317,6 +338,7 @@ options:
         inferred from C(destination).
       - When C(destination) is provided as Virtual Address name, and C(mask) is not specified,
         the mask will be C(None) allowing device set it with its internal defaults.
+   type: str
    version_added: 2.8
   ip_protocol:
     description:
@@ -329,6 +351,7 @@ options:
       - For a list of valid IP protocol numbers, refer to this page
         https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers
       - When C(type) is C(dhcp), this module will force the C(ip_protocol) parameter to be C(17) (UDP).
+    type: str
     choices:
       - ah
       - any
@@ -355,6 +378,7 @@ options:
       - Applies the specify AFM policy to the virtual in an enforcing way.
       - When creating a new virtual, if this parameter is not specified, the enforced
         policy is disabled.
+    type: str
     version_added: 2.6
   firewall_staged_policy:
     description:
@@ -363,6 +387,7 @@ options:
         actually applying the rules to traffic.
       - When creating a new virtual, if this parameter is not specified, the staged
         policy is disabled.
+    type: str
     version_added: 2.6
   security_log_profiles:
     description:
@@ -370,6 +395,7 @@ options:
       - To make use of this feature, the AFM module must be licensed and provisioned.
       - The C(Log all requests) and C(Log illegal requests) are mutually exclusive and
         therefore, this module will raise an error if the two are specified together.
+    type: list
     version_added: 2.6
   security_nat_policy:
     description:
@@ -386,6 +412,7 @@ options:
           - The virtual server NAT policy is the most specific, and overrides a
             route domain and device policy, if specified.
           - To remove the policy, specify an empty string value.
+        type: str
       use_device_policy:
         description:
           - Specify that the virtual server uses the device NAT policy, as specified
@@ -400,11 +427,13 @@ options:
           - When specified, the route domain policy overrides the device policy, and
             is overridden by a virtual server policy.
         type: bool
+    type: dict
   ip_intelligence_policy:
     description:
       - Specifies the IP intelligence policy applied to the virtual server.
       - This parameter requires that a valid BIG-IP security module such as ASM or AFM
         be provisioned.
+    type: str
     version_added: 2.8
   rate_limit:
     description:
@@ -432,6 +461,7 @@ options:
       - Indicates whether the rate limit is applied per virtual object, per source address, per destination address,
         or some combination thereof.
       - The default value is 'object', which does not use the source or destination address as part of the key.
+    type: str
     choices:
       - object
       - object-source
@@ -447,7 +477,6 @@ options:
       - Specifies a pool or list of pools that the virtual server uses to replicate either client-side
         or server-side traffic.
       - Typically this option is used for intrusion detection.
-    version_added: 2.8
     suboptions:
       pool_name:
         description:
@@ -455,13 +484,17 @@ options:
           - Only pools created on Common partition or on the same partition as the virtual server can be used.
           - Referencing pool on common partition needs to be done in the full path format,
             for example, C(/Common/pool_name).
+        type: str
         required: True
       context:
         description:
           - The context option for a clone pool to replicate either client-side or server-side traffic.
+        type: str
         choices:
          - clientside
          - serverside
+    type: list
+    version_added: 2.8
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -852,11 +885,8 @@ try:
     from library.module_utils.network.f5.common import MANAGED_BY_ANNOTATION_MODIFIED
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import fail_json
-    from library.module_utils.network.f5.common import exit_json
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import mark_managed_by
     from library.module_utils.network.f5.common import only_has_managed_metadata
@@ -874,11 +904,8 @@ except ImportError:
     from ansible.module_utils.network.f5.common import MANAGED_BY_ANNOTATION_MODIFIED
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import fail_json
-    from ansible.module_utils.network.f5.common import exit_json
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import mark_managed_by
     from ansible.module_utils.network.f5.common import only_has_managed_metadata
@@ -3250,7 +3277,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = ApiParameters(client=self.client)
         self.want = ModuleParameters(client=self.client, params=self.module.params)
         self.changes = UsableChanges()
@@ -3595,13 +3622,11 @@ def main():
     client = F5RestClient(**module.params)
 
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        exit_json(module, results, client)
-        cleanup_tokens(client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_wait.py
+++ b/lib/ansible/modules/network/f5/bigip_wait.py
@@ -29,18 +29,22 @@ options:
       - When used without other conditions it is equivalent of just sleeping.
       - The default timeout is deliberately set to 2 hours because no individual
         REST API.
+    type: int
     default: 7200
   delay:
     description:
       - Number of seconds to wait before starting to poll.
+    type: int
     default: 0
   sleep:
-    default: 1
     description:
       - Number of seconds to sleep between checks, before 2.3 this was hardcoded to 1 second.
+    type: int
+    default: 1
   msg:
     description:
       - This overrides the normal error message from a failure to meet the required conditions.
+    type: str
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -89,15 +93,11 @@ try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 def hard_timeout(module, want, start):
@@ -148,7 +148,7 @@ class Changes(Parameters):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.have = None
         self.want = Parameters(params=self.module.params)
         self.changes = Parameters()
@@ -334,14 +334,12 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigiq_device_facts.py
+++ b/lib/ansible/modules/network/f5/bigiq_device_facts.py
@@ -26,6 +26,7 @@ options:
       - Can specify a list of values to include a larger subset.
       - Values can also be used with an initial C(!) to specify that a specific subset
         should not be collected.
+    type: list
     required: True
     choices:
       - all
@@ -827,7 +828,6 @@ try:
     from library.module_utils.network.f5.bigiq import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
-    from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import flatten_boolean
@@ -837,7 +837,6 @@ except ImportError:
     from ansible.module_utils.network.f5.bigiq import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import flatten_boolean
@@ -2299,15 +2298,11 @@ def main():
         supports_check_mode=spec.supports_check_mode
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
         module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
         module.fail_json(msg=str(ex))
 
 

--- a/lib/ansible/modules/network/f5/bigiq_regkey_license.py
+++ b/lib/ansible/modules/network/f5/bigiq_regkey_license.py
@@ -27,14 +27,17 @@ options:
         BIG-IQ does not require this, this module does. If you do not do this,
         the behavior of the module is undefined and you may end up putting
         licenses in the wrong registration key pool.
+    type: str
     required: True
   license_key:
     description:
       - The license key to put in the pool.
+    type: str
     required: True
   description:
     description:
       - Description of the license.
+    type: str
   accept_eula:
     description:
       - A key that signifies that you accept the F5 EULA for this license.
@@ -46,10 +49,11 @@ options:
       - The state of the regkey license in the pool on the system.
       - When C(present), guarantees that the license exists in the pool.
       - When C(absent), removes the license from the pool.
-    default: present
+    type: str
     choices:
       - absent
       - present
+    default: present
 requirements:
   - BIG-IQ >= 5.3.0
 extends_documentation_fragment: f5
@@ -98,17 +102,11 @@ try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigiq import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -222,7 +220,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(client=self.client, params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -472,16 +470,12 @@ def main():
         required_if=spec.required_if,
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        cleanup_tokens(client)
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        cleanup_tokens(client)
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigiq_regkey_license_assignment.py
+++ b/lib/ansible/modules/network/f5/bigiq_regkey_license_assignment.py
@@ -25,10 +25,12 @@ options:
   pool:
     description:
       - The registration key pool to use.
+    type: str
     required: True
   key:
     description:
       - The registration key that you want to assign from the pool.
+    type: str
     required: True
   device:
     description:
@@ -40,6 +42,7 @@ options:
         one device with the same name. BIG-IQ internally recognizes devices by their ID,
         and therefore, this module's cannot guarantee that the correct device will be
         registered. The device returned is the device that will be used.
+    type: str
   managed:
     description:
       - Whether the specified device is a managed or un-managed device.
@@ -49,6 +52,7 @@ options:
     description:
       - Specifies the port of the remote device to connect to.
       - If this parameter is not specified, the default of C(443) will be used.
+    type: int
     default: 443
   device_username:
     description:
@@ -56,19 +60,22 @@ options:
       - This username should be one that has sufficient privileges on the remote device
         to do licensing. Usually this is the C(Administrator) role.
       - When C(managed) is C(no), this parameter is required.
+    type: str
   device_password:
     description:
       - The password of the C(device_username).
       - When C(managed) is C(no), this parameter is required.
+    type: str
   state:
     description:
       - When C(present), ensures that the device is assigned the specified license.
       - When C(absent), ensures the license is revokes from the remote device and freed
         on the BIG-IQ.
-    default: present
+    type: str
     choices:
       - present
       - absent
+    default: present
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -131,16 +138,12 @@ try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
 except ImportError:
     from ansible.module_utils.network.f5.bigiq import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
 
 
@@ -394,7 +397,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(params=self.module.params, client=self.client)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -620,14 +623,12 @@ def main():
         required_if=spec.required_if
     )
 
-    client = F5RestClient(**module.params)
-
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigiq_regkey_pool.py
+++ b/lib/ansible/modules/network/f5/bigiq_regkey_pool.py
@@ -29,20 +29,23 @@ options:
         BIG-IQ does not require this, this module does. If you do not do this,
         the behavior of the module is undefined and you may end up putting
         licenses in the wrong registration key pool.
+    type: str
     required: True
   description:
     description:
       - A description to attach to the pool.
+    type: str
   state:
     description:
       - The state of the regkey pool on the system.
       - When C(present), guarantees that the pool exists.
       - When C(absent), removes the pool, and the licenses it contains, from the
         system.
-    default: present
+    type: str
     choices:
       - absent
       - present
+    default: present
 requirements:
   - BIG-IQ >= 5.3.0
 extends_documentation_fragment: f5
@@ -198,7 +201,6 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
         self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(client=self.client, params=self.module.params)
         self.have = ApiParameters()

--- a/lib/ansible/modules/network/f5/bigiq_utility_license.py
+++ b/lib/ansible/modules/network/f5/bigiq_utility_license.py
@@ -26,6 +26,7 @@ options:
   license_key:
     description:
       - The license key to install and activate.
+    type: str
     required: True
   accept_eula:
     description:
@@ -38,10 +39,11 @@ options:
       - The state of the utility license on the system.
       - When C(present), guarantees that the license exists.
       - When C(absent), removes the license from the system.
-    default: present
+    type: str
     choices:
       - absent
       - present
+    default: present
 requirements:
   - BIG-IQ >= 5.3.0
 extends_documentation_fragment: f5
@@ -85,15 +87,11 @@ try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
-    from library.module_utils.network.f5.common import exit_json
-    from library.module_utils.network.f5.common import fail_json
 except ImportError:
     from ansible.module_utils.network.f5.bigiq import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    from ansible.module_utils.network.f5.common import exit_json
-    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -179,7 +177,7 @@ class Difference(object):
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
-        self.client = kwargs.get('client', None)
+        self.client = F5RestClient(**self.module.params)
         self.want = ModuleParameters(client=self.client, params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
@@ -453,11 +451,11 @@ def main():
     client = F5RestClient(**module.params)
 
     try:
-        mm = ModuleManager(module=module, client=client)
+        mm = ModuleManager(module=module)
         results = mm.exec_module()
-        exit_json(module, results, client)
+        module.exit_json(**results)
     except F5ModuleError as ex:
-        fail_json(module, ex, client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_traffic_selector.py
+++ b/test/units/modules/network/f5/test_bigip_traffic_selector.py
@@ -88,9 +88,11 @@ class TestUntypedManager(unittest.TestCase):
     def test_create(self, *args):
         set_module_args(dict(
             name='selector1',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_trunk.py
+++ b/test/units/modules/network/f5/test_bigip_trunk.py
@@ -116,9 +116,11 @@ class TestManager(unittest.TestCase):
             lacp_enabled=True,
             lacp_mode='active',
             lacp_timeout='long',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_tunnel.py
+++ b/test/units/modules/network/f5/test_bigip_tunnel.py
@@ -92,9 +92,11 @@ class TestManager(unittest.TestCase):
             name='foo',
             profile='ipip',
             local_address='2.2.2.2.',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_ucs.py
+++ b/test/units/modules/network/f5/test_bigip_ucs.py
@@ -152,10 +152,12 @@ class TestV1Manager(unittest.TestCase):
     def test_ucs_explicit_present(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='present'
+            state='present',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -178,10 +180,12 @@ class TestV1Manager(unittest.TestCase):
     def test_ucs_installed(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='installed'
+            state='installed',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -205,10 +209,12 @@ class TestV1Manager(unittest.TestCase):
     def test_ucs_absent_exists(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='absent'
+            state='absent',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -231,10 +237,12 @@ class TestV1Manager(unittest.TestCase):
     def test_ucs_absent_fails(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='absent'
+            state='absent',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -263,9 +271,11 @@ class TestV2Manager(unittest.TestCase):
     def test_ucs_default_present(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -288,10 +298,12 @@ class TestV2Manager(unittest.TestCase):
     def test_ucs_explicit_present(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='present'
+            state='present',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -314,10 +326,12 @@ class TestV2Manager(unittest.TestCase):
     def test_ucs_installed(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='installed'
+            state='installed',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -341,10 +355,12 @@ class TestV2Manager(unittest.TestCase):
     def test_ucs_absent_exists(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='absent'
+            state='absent',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -367,10 +383,12 @@ class TestV2Manager(unittest.TestCase):
     def test_ucs_absent_fails(self, *args):
         set_module_args(dict(
             ucs="/root/bigip.localhost.localdomain.ucs",
-            server='localhost',
-            password='password',
-            user='admin',
-            state='absent'
+            state='absent',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_ucs_fetch.py
+++ b/test/units/modules/network/f5/test_bigip_ucs_fetch.py
@@ -76,9 +76,6 @@ class TestParameters(unittest.TestCase):
             force='yes',
             fail_on_missing='no',
             src='remote.ucs',
-            password='password',
-            server='localhost',
-            user='admin'
         )
         p = Parameters(params=args)
         assert p.backup == 'yes'
@@ -97,14 +94,17 @@ class TestV1Manager(unittest.TestCase):
             force='yes',
             fail_on_missing='no',
             src='remote.ucs',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            add_file_common_args=self.spec.add_file_common_args
         )
 
         # Override methods to force specific logic in the module to happen

--- a/test/units/modules/network/f5/test_bigip_user.py
+++ b/test/units/modules/network/f5/test_bigip_user.py
@@ -115,10 +115,12 @@ class TestManager(unittest.TestCase):
             username_credential='someuser',
             password_credential='testpass',
             partition_access=access,
-            server='localhost',
-            password='password',
-            user='admin',
-            update_password='on_create'
+            update_password='on_create',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -145,9 +147,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             username_credential='someuser',
             partition_access=access,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -172,9 +176,11 @@ class TestManager(unittest.TestCase):
     def test_create_user_partition_access_raises(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -204,11 +210,13 @@ class TestManager(unittest.TestCase):
             username_credential='someuser',
             password_credential='testpass',
             partition_access=access,
-            password='password',
-            server='localhost',
             update_password='on_create',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -237,10 +245,12 @@ class TestManager(unittest.TestCase):
             password_credential='testpass',
             partition_access=access,
             update_password='on_create',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -268,9 +278,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             username_credential='someuser',
             password_credential='testpass',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -300,9 +312,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             username_credential='someuser',
             password_credential='testpass',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -331,10 +345,12 @@ class TestManager(unittest.TestCase):
     def test_update_user_shell_to_none(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='none'
+            shell='none',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -369,10 +385,12 @@ class TestManager(unittest.TestCase):
     def test_update_user_shell_to_none_shell_attribute_missing(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='none'
+            shell='none',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -408,10 +426,12 @@ class TestManager(unittest.TestCase):
     def test_update_user_shell_to_bash(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -448,10 +468,12 @@ class TestManager(unittest.TestCase):
     def test_update_user_shell_to_bash_mutliple_roles(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -502,10 +524,12 @@ class TestLegacyManager(unittest.TestCase):
             username_credential='someuser',
             password_credential='testpass',
             partition_access=access,
-            server='localhost',
-            password='password',
-            user='admin',
-            update_password='on_create'
+            update_password='on_create',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -532,9 +556,11 @@ class TestLegacyManager(unittest.TestCase):
         set_module_args(dict(
             username_credential='someuser',
             partition_access=access,
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -559,9 +585,11 @@ class TestLegacyManager(unittest.TestCase):
     def test_create_user_partition_access_raises(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -591,11 +619,13 @@ class TestLegacyManager(unittest.TestCase):
             username_credential='someuser',
             password_credential='testpass',
             partition_access=access,
-            password='password',
-            server='localhost',
             update_password='on_create',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -624,10 +654,12 @@ class TestLegacyManager(unittest.TestCase):
             password_credential='testpass',
             partition_access=access,
             update_password='on_create',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -655,9 +687,11 @@ class TestLegacyManager(unittest.TestCase):
         set_module_args(dict(
             username_credential='someuser',
             password_credential='testpass',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -692,10 +726,12 @@ class TestLegacyManager(unittest.TestCase):
     def test_update_user_shell_to_none(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='none'
+            shell='none',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -730,10 +766,12 @@ class TestLegacyManager(unittest.TestCase):
     def test_update_user_shell_to_none_shell_attribute_missing(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='none'
+            shell='none',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -769,10 +807,12 @@ class TestLegacyManager(unittest.TestCase):
     def test_update_user_shell_to_bash(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
@@ -809,10 +849,12 @@ class TestLegacyManager(unittest.TestCase):
     def test_update_user_shell_to_bash_mutliple_roles(self, *args):
         set_module_args(dict(
             username_credential='someuser',
-            password='password',
-            server='localhost',
-            user='admin',
-            shell='bash'
+            shell='bash',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigip_vcmp_guest.py
+++ b/test/units/modules/network/f5/test_bigip_vcmp_guest.py
@@ -156,23 +156,36 @@ class TestManager(unittest.TestCase):
         self.patcher1 = patch('time.sleep')
         self.patcher1.start()
 
+        try:
+            self.p1 = patch('library.modules.bigip_vcmp_guest.ModuleParameters.initial_image_exists')
+            self.m1 = self.p1.start()
+            self.m1.return_value = True
+        except Exception:
+            self.p1 = patch('ansible.modules.network.f5.bigip_vcmp_guest.ModuleParameters.initial_image_exists')
+            self.m1 = self.p1.start()
+            self.m1.return_value = True
+
     def tearDown(self):
         self.patcher1.stop()
+        self.p1.stop()
 
-    def test_create_vlan(self, *args):
+    def test_create_vcmpguest(self, *args):
         set_module_args(dict(
             name="guest1",
             mgmt_network="bridged",
             mgmt_address="10.10.10.10/24",
             initial_image="BIGIP-13.1.0.0.0.931.iso",
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
 
         # Override methods to force specific logic in the module to happen

--- a/test/units/modules/network/f5/test_bigip_virtual_address.py
+++ b/test/units/modules/network/f5/test_bigip_virtual_address.py
@@ -199,14 +199,18 @@ class TestManager(unittest.TestCase):
             icmp_echo='enabled',
             advertise_route='always',
             use_route_advertisement='yes',
-            password='admin',
-            server='localhost',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive,
+            required_one_of=self.spec.required_one_of
         )
         mm = ModuleManager(module=module)
 
@@ -221,14 +225,18 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             state='absent',
             address='1.1.1.1',
-            password='admin',
-            server='localhost',
-            user='admin',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive,
+            required_one_of=self.spec.required_one_of
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigip_virtual_server.py
+++ b/test/units/modules/network/f5/test_bigip_virtual_server.py
@@ -163,9 +163,6 @@ class TestParameters(unittest.TestCase):
 
     def test_module_no_partition_prefix_parameters(self):
         args = dict(
-            server='localhost',
-            user='admin',
-            password='secret',
             state='present',
             partition='Common',
             name='my-virtual-server',
@@ -197,9 +194,6 @@ class TestParameters(unittest.TestCase):
 
     def test_module_partition_prefix_parameters(self):
         args = dict(
-            server='localhost',
-            user='admin',
-            password='secret',
             state='present',
             partition='Common',
             name='my-virtual-server',
@@ -365,10 +359,22 @@ class TestManager(unittest.TestCase):
             self.p3 = patch(
                 'library.modules.bigip_virtual_server.Parameters._read_current_serverssl_profiles_from_device'
             )
+            self.p4 = patch(
+                'library.modules.bigip_virtual_server.VirtualServerValidator.check_create'
+            )
+
+            self.p5 = patch(
+                'library.modules.bigip_virtual_server.VirtualServerValidator.check_update'
+            )
+
             self.m2 = self.p2.start()
             self.m3 = self.p3.start()
+            self.m4 = self.p4.start()
+            self.m5 = self.p5.start()
             self.m2.return_value = ['asda', 'clientssl', 'cs_foobar.star.local']
             self.m3.return_value = ['baz', 'serverssl', 'ss_foobar.star.local']
+            self.m4.return_value = Mock(return_value=True)
+            self.m5.return_value = Mock(return_value=True)
         except Exception:
             self.p1 = patch('ansible.modules.network.f5.bigip_virtual_server.modules_provisioned')
             self.m1 = self.p1.start()
@@ -379,15 +385,27 @@ class TestManager(unittest.TestCase):
             self.p3 = patch(
                 'ansible.modules.network.f5.bigip_virtual_server.Parameters._read_current_serverssl_profiles_from_device'
             )
+            self.p4 = patch(
+                'ansible.modules.network.f5.bigip_virtual_server.VirtualServerValidator.check_create'
+            )
+            self.p5 = patch(
+                'ansible.modules.network.f5.bigip_virtual_server.VirtualServerValidator.check_update'
+            )
             self.m2 = self.p2.start()
             self.m3 = self.p3.start()
+            self.m4 = self.p4.start()
+            self.m5 = self.p5.start()
             self.m2.return_value = ['asda', 'clientssl', 'cs_foobar.star.local']
             self.m3.return_value = ['baz', 'serverssl', 'ss_foobar.star.local']
+            self.m4.return_value = Mock(return_value=True)
+            self.m5.return_value = Mock(return_value=True)
 
     def tearDown(self):
         self.p1.stop()
         self.p2.stop()
         self.p3.stop()
+        self.p4.stop()
+        self.p5.stop()
 
     def test_create_virtual_server(self, *args):
         set_module_args(dict(
@@ -403,18 +421,21 @@ class TestManager(unittest.TestCase):
             destination="10.10.10.10",
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             snat="Automap",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
+
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -434,18 +455,20 @@ class TestManager(unittest.TestCase):
             destination="10.10.10.10",
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             snat="Automap",
             state="absent",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -465,13 +488,14 @@ class TestManager(unittest.TestCase):
             destination="10.10.10.10",
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             snat="Automap",
             state="absent",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -484,7 +508,8 @@ class TestManager(unittest.TestCase):
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -500,12 +525,13 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name="my-virtual-server",
             partition="Common",
-            password="secret",
             port="10443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -514,7 +540,8 @@ class TestManager(unittest.TestCase):
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -530,12 +557,13 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name="my-virtual-server",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -544,7 +572,8 @@ class TestManager(unittest.TestCase):
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -559,14 +588,15 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name="my-virtual-server",
             partition="Common",
-            password="secret",
             disabled_vlans=[
                 "net1"
             ],
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -575,7 +605,8 @@ class TestManager(unittest.TestCase):
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -591,14 +622,15 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name="my-virtual-server",
             partition="Common",
-            password="secret",
             profiles=[
                 'http', 'clientssl'
             ],
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -606,7 +638,8 @@ class TestManager(unittest.TestCase):
         current = ApiParameters(params=load_fixture('load_ltm_virtual_2.json'))
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -642,14 +675,10 @@ class TestManager(unittest.TestCase):
             destination="1.1.1.1",
             name="my-virtual-server",
             partition="Common",
-            password="secret",
             port="8443",
-            server="localhost",
             snat="snat-pool1",
             state="disabled",
             source='1.2.3.4/32',
-            user="admin",
-            validate_certs="no",
             irules=[
                 'irule1',
                 'irule2'
@@ -664,7 +693,12 @@ class TestManager(unittest.TestCase):
             ],
             pool='my-pool',
             default_persistence_profile='source_addr',
-            fallback_persistence_profile='dest_addr'
+            fallback_persistence_profile='dest_addr',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         # Configure the parameters that would be returned by querying the
@@ -673,7 +707,8 @@ class TestManager(unittest.TestCase):
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -725,17 +760,19 @@ class TestManager(unittest.TestCase):
             address_translation=True,
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -753,17 +790,19 @@ class TestManager(unittest.TestCase):
             address_translation='yes',
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -781,17 +820,19 @@ class TestManager(unittest.TestCase):
             address_translation=False,
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -809,17 +850,19 @@ class TestManager(unittest.TestCase):
             address_translation='no',
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -837,17 +880,19 @@ class TestManager(unittest.TestCase):
             port_translation=True,
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -865,17 +910,19 @@ class TestManager(unittest.TestCase):
             port_translation='yes',
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -893,17 +940,19 @@ class TestManager(unittest.TestCase):
             port_translation=False,
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen
@@ -921,17 +970,19 @@ class TestManager(unittest.TestCase):
             port_translation='no',
             name="my-snat-pool",
             partition="Common",
-            password="secret",
             port="443",
-            server="localhost",
             state="present",
-            user="admin",
-            validate_certs="no"
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
         )
 
         # Override methods to force specific logic in the module to happen

--- a/test/units/modules/network/f5/test_bigip_wait.py
+++ b/test/units/modules/network/f5/test_bigip_wait.py
@@ -103,9 +103,11 @@ class TestManager(unittest.TestCase):
 
     def test_wait_already_available(self, *args):
         set_module_args(dict(
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigiq_device_facts.py
+++ b/test/units/modules/network/f5/test_bigiq_device_facts.py
@@ -81,9 +81,11 @@ class TestManager(unittest.TestCase):
     def test_get_facts(self, *args):
         set_module_args(dict(
             gather_subset=['system-info'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         fixture1 = load_fixture('load_shared_system_setup_1.json')

--- a/test/units/modules/network/f5/test_bigiq_regkey_license.py
+++ b/test/units/modules/network/f5/test_bigiq_regkey_license.py
@@ -102,9 +102,11 @@ class TestManager(unittest.TestCase):
             license_key='XXXX-XXXX-XXXX-XXXX-XXXX',
             accept_eula=True,
             description='this is a description',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigiq_regkey_license_assignment.py
+++ b/test/units/modules/network/f5/test_bigiq_regkey_license_assignment.py
@@ -119,9 +119,11 @@ class TestManager(unittest.TestCase):
             device_password='secret',
             managed='no',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigiq_regkey_pool.py
+++ b/test/units/modules/network/f5/test_bigiq_regkey_pool.py
@@ -89,9 +89,11 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             description='bar baz',
-            server='localhost',
-            password='password',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/test/units/modules/network/f5/test_bigiq_utility_license.py
+++ b/test/units/modules/network/f5/test_bigiq_utility_license.py
@@ -88,14 +88,17 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             license_key='XXXX-XXXX-XXXX-XXXX-XXXX',
             accept_eula=True,
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         mm = ModuleManager(module=module)
 

--- a/test/units/modules/network/f5/test_bigiq_utility_license_assignment.py
+++ b/test/units/modules/network/f5/test_bigiq_utility_license_assignment.py
@@ -114,9 +114,11 @@ class TestManager(unittest.TestCase):
             device_password='secret',
             managed='no',
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY

Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_traffic_selector.py
lib/ansible/modules/network/f5/bigip_trunk.py
lib/ansible/modules/network/f5/bigip_tunnel.py
lib/ansible/modules/network/f5/bigip_ucs.py
lib/ansible/modules/network/f5/bigip_ucs_fetch.py
lib/ansible/modules/network/f5/bigip_user.py
lib/ansible/modules/network/f5/bigip_vcmp_guest.py
lib/ansible/modules/network/f5/bigip_virtual_address.py
lib/ansible/modules/network/f5/bigip_virtual_server.py
lib/ansible/modules/network/f5/bigip_wait.py
lib/ansible/modules/network/f5/bigiq_device_facts.py
lib/ansible/modules/network/f5/bigiq_regkey_license.py
lib/ansible/modules/network/f5/bigiq_regkey_license_assignment.py
lib/ansible/modules/network/f5/bigiq_regkey_pool.py
lib/ansible/modules/network/f5/bigiq_utility_license.py
lib/ansible/modules/network/f5/bigiq_utility_license_assignment.py



##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.