### PR TITLE
BIGIP: deprecates the old package name bigip_iapplx_package

### DIFF
--- a/lib/ansible/modules/network/f5/_bigip_iapplx_package.py
+++ b/lib/ansible/modules/network/f5/_bigip_iapplx_package.py
@@ -1,0 +1,1 @@
+bigip_lx_package.py

--- a/test/units/modules/network/f5/test_bigip_lx_package.py
+++ b/test/units/modules/network/f5/test_bigip_lx_package.py
@@ -17,9 +17,9 @@ if sys.version_info < (2, 7):
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.modules.bigip_iapp_template import Parameters
-    from library.modules.bigip_iapp_template import ModuleManager
-    from library.modules.bigip_iapp_template import ArgumentSpec
+    from library.modules.bigip_lx_package import Parameters
+    from library.modules.bigip_lx_package import ModuleManager
+    from library.modules.bigip_lx_package import ArgumentSpec
 
     # In Ansible 2.8, Ansible changed import paths.
     from test.units.compat import unittest
@@ -28,9 +28,9 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    from ansible.modules.network.f5.bigip_iapp_template import Parameters
-    from ansible.modules.network.f5.bigip_iapp_template import ArgumentSpec
-    from ansible.modules.network.f5.bigip_iapp_template import ModuleManager
+    from ansible.modules.network.f5.bigip_lx_package import Parameters
+    from ansible.modules.network.f5.bigip_lx_package import ArgumentSpec
+    from ansible.modules.network.f5.bigip_lx_package import ModuleManager
 
     # Ansible 2.8 imports
     from units.compat import unittest
@@ -79,28 +79,44 @@ class TestManager(unittest.TestCase):
         self.patcher1 = patch('time.sleep')
         self.patcher1.start()
 
+        try:
+            self.p1 = patch('library.modules.bigip_lx_package.tmos_version')
+            self.m1 = self.p1.start()
+            self.m1.return_value = '12.1.3'
+        except Exception:
+            self.p1 = patch('ansible.modules.network.f5.bigip_lx_package.tmos_version')
+            self.m1 = self.p1.start()
+            self.m1.return_value = '12.1.3'
+
     def tearDown(self):
         self.patcher1.stop()
 
     def test_create_iapp_template(self, *args):
+        package_name = os.path.join(fixture_path, 'MyApp-0.1.0-0001.noarch.rpm')
         # Configure the arguments that would be sent to the Ansible module
         set_module_args(dict(
-            content='fixtures/MyApp-0.1.0-0001.noarch.rpm',
+            package=package_name,
             state='present',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
         )
         mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
+        mm.upload_to_device = Mock(return_value=True)
+        mm.enable_iapplx_on_device = Mock(return_value=True)
+        mm.remove_package_file_from_device = Mock(return_value=True)
 
         results = mm.exec_module()
 


### PR DESCRIPTION
##### SUMMARY

deprecates the old package name bigip_iapplx_package
Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_lx_package.py
test/units/modules/network/f5/test_bigip_lx_package.py


##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.