### PR TITLE
BIGIP: feature_bigip_profile_client_ssl

### DIFF
--- a/test/units/modules/network/f5/test_bigip_profile_client_ssl.py
+++ b/test/units/modules/network/f5/test_bigip_profile_client_ssl.py
@@ -109,9 +109,11 @@ class TestManager(unittest.TestCase):
                     chain='bigip_ssl_cert1'
                 )
             ],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
adds strict resume parameter to the module
Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_profile_client_ssl.py


##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.