### PR TITLE
BIGIP: bugfix.server_ssl_profile

### DIFF
--- a/test/units/modules/network/f5/test_bigip_profile_server_ssl.py
+++ b/test/units/modules/network/f5/test_bigip_profile_server_ssl.py
@@ -94,14 +94,17 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             name='foo',
             server_name='foo.bar.com',
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode
+            supports_check_mode=self.spec.supports_check_mode,
+            required_together=self.spec.required_together
         )
         mm = ModuleManager(module=module)
 


### PR DESCRIPTION
##### SUMMARY
Refactors main() function and module manager in multiple modules in line with recent changes
Adds variable types to docs
Refactors unit tests to remove deprecated parameters


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/f5/bigip_profile_server_ssl.py


##### ADDITIONAL INFORMATION
Adding a new way to handle F5 tokens have made some functions redundant, this is one of a series of PRs that will update all F5 modules to use new patterns.