### PR TITLE
fix nxos install os timeout regular expression

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -267,7 +267,7 @@ def parse_show_install(data):
         # We get these messages when the upgrade is non-disruptive and
         # we loose connection with the switchover but far enough along that
         # we can be confident the upgrade succeeded.
-        if re.search(r'timeout trying to send command: install', x):
+        if re.search(r'timeout .*trying to send command: install', x):
             ud['upgrade_succeeded'] = True
             ud['use_impact_data'] = True
             break


### PR DESCRIPTION
##### SUMMARY
This PR fixes the regular expression used by `nxos_install_os` to capture a timeout event.

In the latest `devel` branch the message returned by `module_utils/nxos.py` is different then what was returned by earlier versions.

This fix makes the regexp a bit more lenient.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_install_os`
