### PR TITLE
docker_swarm_service: Support resolving images from private registries 

### DIFF
--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -700,7 +700,7 @@ class AnsibleDockerClient(Client):
             if header:
                 return self._result(self._get(
                     self._url("/distribution/{0}/json", image),
-                    headers={'X-Registry-Auth':header}
+                    headers={'X-Registry-Auth': header}
                 ), json=True)
         return super(AnsibleDockerClient, self).inspect_distribution(image)
 

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -689,6 +689,21 @@ class AnsibleDockerClient(Client):
         elif isinstance(result, string_types) and result:
             self.module.warn('Docker warning: {0}'.format(result))
 
+    def inspect_distribution(self, image):
+        '''
+        Get image digest by directly calling the Docker API when running Docker SDK < 4.0.0
+        since prior versions did not support accessing private repositories.
+        '''
+        if self.docker_py_version < LooseVersion('4.0.0'):
+            registry = auth.resolve_repository_name(image)[0]
+            header = auth.get_config_header(self, registry)
+            if header:
+                return self._result(self._get(
+                    self._url("/distribution/{0}/json", image),
+                    headers={'X-Registry-Auth':header}
+                ), json=True)
+        return super(AnsibleDockerClient, self).inspect_distribution(image)
+
 
 def compare_dict_allow_more_present(av, bv):
     '''

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -699,7 +699,7 @@ class AnsibleDockerClient(Client):
             header = auth.get_config_header(self, registry)
             if header:
                 return self._result(self._get(
-                    self._url("/distribution/{0}/json", image),
+                    self._url('/distribution/{0}/json', image),
                     headers={'X-Registry-Auth': header}
                 ), json=True)
         return super(AnsibleDockerClient, self).inspect_distribution(image)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Support for resolving image digests from private registries will not be supported until Docker SDK 4.0.0. This PR adds support by overriding `inspect_distribution` to send the correct authentication headers.

Fixes #53941

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service