### PR TITLE
Removing include_role from the var precedence list

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -1025,7 +1025,7 @@ Here is the order of precedence from least to greatest (the last listed variable
   #. task vars (only for the task)
   #. include_vars
   #. set_facts / registered vars
-  #. role (and include_role) params
+  #. role params
   #. include params
   #. extra vars (always win precedence)
 


### PR DESCRIPTION
##### SUMMARY
This PR removes `include_role` from the variables precedence list as discussed with @bcoca.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
Variable precedence.

##### ADDITIONAL INFORMATION
N/A