### PR TITLE
win_find - fix glob like paths

### DIFF
--- a/changelogs/fragments/win_find-paths.yaml
+++ b/changelogs/fragments/win_find-paths.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_find - Fix issues when using paths with glob like characters, e.g. ``[``, ``]``
+- win_find - Ensure found files are sorted alphabetically by the path instead of it being random

--- a/lib/ansible/modules/windows/win_find.py
+++ b/lib/ansible/modules/windows/win_find.py
@@ -214,7 +214,8 @@ matched:
     type: int
     sample: 2
 files:
-    description: Information on the files/folders that match the criteria returned as a list of dictionary elements for each file matched.
+    description: Information on the files/folders that match the criteria returned as a list of dictionary elements
+      for each file matched. The entries are sorted by the path value alphabetically.
     returned: success
     type: complex
     contains:

--- a/test/integration/targets/win_find/defaults/main.yml
+++ b/test/integration/targets/win_find/defaults/main.yml
@@ -1,2 +1,2 @@
-win_find_dir: "{{win_output_dir}}\\win_find"
+win_find_dir: '{{ win_output_dir }}\win_find .ÅÑŚÌβŁÈ [$!@^&test(;)]'
 test_win_find_username: testuser

--- a/test/integration/targets/win_find/tasks/main.yml
+++ b/test/integration/targets/win_find/tasks/main.yml
@@ -22,8 +22,10 @@
         "emptynested\nest\dir1",
         "emptynested\nest\dir2"
     )
+
+    $tmp_dir = '{{ win_find_dir }}'
     foreach ($directory in $directories) {
-        New-Item -Path "{{win_find_dir}}\$directory" -ItemType Directory
+        New-Item -Path "$tmp_dir\$directory" -ItemType Directory
     }
 
     $normal_content = "abcdefg1234567"
@@ -42,40 +44,42 @@
         "hard-link-dest\file-abc.log"
     )
     foreach ($file in $normal_files) {
-        New-Item -Path "{{win_find_dir}}\$file" -ItemType File
-        [System.IO.File]::WriteAllText("{{win_find_dir}}\$file", $normal_content)
+        New-Item -Path "$tmp_dir\$file" -ItemType File
+        [System.IO.File]::WriteAllText("$tmp_dir\$file", $normal_content)
     }
 
-    New-Item -Path "{{win_find_dir}}\single\small.ps1" -ItemType File
-    [System.IO.File]::WriteAllText("{{win_find_dir}}\single\small.ps1", "a")
+    New-Item -Path "$tmp_dir\single\small.ps1" -ItemType File
+    [System.IO.File]::WriteAllText("$tmp_dir\single\small.ps1", "a")
 
-    New-Item -Path "{{win_find_dir}}\date\new.ps1" -ItemType File
-    [System.IO.File]::WriteAllText("{{win_find_dir}}\date\new.ps1", "random text for new date")
+    New-Item -Path "$tmp_dir\date\new.ps1" -ItemType File
+    [System.IO.File]::WriteAllText("$tmp_dir\date\new.ps1", "random text for new date")
 
-    New-Item -Path "{{win_find_dir}}\date\old.ps1" -ItemType File
-    [System.IO.File]::WriteAllText("{{win_find_dir}}\date\old.ps1", "random text for old date")
+    New-Item -Path "$tmp_dir\date\old.ps1" -ItemType File
+    [System.IO.File]::WriteAllText("$tmp_dir\date\old.ps1", "random text for old date")
 
-    New-Item -Path "{{win_find_dir}}\single\large.ps1" -ItemType File
-    Set-Content -Path "{{win_find_dir}}\single\large.ps1" -Value ('abcdefghijklmnopqrstuvwxyz' * 10000)
+    New-Item -Path "$tmp_dir\single\large.ps1" -ItemType File
+    Set-Content -LiteralPath "$tmp_dir\single\large.ps1" -Value ('abcdefghijklmnopqrstuvwxyz' * 10000)
 
     $share_stat = Get-WmiObject -Class Win32_Share -Filter "name='folder-share'"
     if ($share_stat) {
         $share_stat.Delete()
     }
     $wmi = [wmiClass] 'Win32_Share'
-    $wmi.Create("{{win_find_dir}}\shared\folder", "folder-share", 0)
+    $wmi.Create("$tmp_dir\shared\folder", "folder-share", 0)
 
-    cmd.exe /c mklink /D "{{win_find_dir}}\nested\link" "{{win_find_dir}}\link-dest"
-    cmd.exe /c mklink /D "{{win_find_dir}}\broken-link" "{{win_find_dir}}\broken-link-dest"
-    cmd.exe /c mklink /H "{{win_find_dir}}\hard-link-dest\hard-link.log" "{{win_find_dir}}\hard-link-dest\file-abc.log"
-    cmd.exe /c mklink /J "{{win_find_dir}}\junction-link" "{{win_find_dir}}\junction-link-dest"
-  
+    cmd.exe /c mklink /D "$tmp_dir\nested\link" "$tmp_dir\link-dest"
+    cmd.exe /c mklink /D "$tmp_dir\broken-link" "$tmp_dir\broken-link-dest"
+    cmd.exe /c mklink /H "$tmp_dir\hard-link-dest\hard-link.log" "$tmp_dir\hard-link-dest\file-abc.log"
+    cmd.exe /c mklink /J "$tmp_dir\junction-link" "$tmp_dir\junction-link-dest"
+
     $date = Get-Date -Year 2016 -Month 11 -Day 1 -Hour 7 -Minute 10 -Second 5 -Millisecond 0
-    Get-ChildItem -Path "{{win_find_dir}}" -Recurse | Where-Object { $_.Name -ne "new.ps1" } | ForEach-Object {
+    Set-Location -LiteralPath $tmp_dir
+    Get-ChildItem -Recurse | Where-Object { $_.Name -ne "new.ps1" } | ForEach-Object {
         $_.CreationTime = $date
         $_.LastAccessTime = $date
         $_.LastWriteTime = $date
     }
+    Pop-Location
 
     $attributes = @{
         "hidden" = "Hidden"
@@ -85,7 +89,7 @@
         "single\hidden.ps1" = "Hidden"
     }
     foreach ($attribute in $attributes.GetEnumerator()) {
-        $item = Get-Item -Path "{{win_find_dir}}\$($attribute.Name)"
+        $item = Get-Item -LiteralPath "$tmp_dir\$($attribute.Name)"
         $file_attributes = $item.Attributes -split ','
         if ($file_attributes -notcontains $attribute.Value) {
             $file_attributes += $attribute.Value
@@ -93,7 +97,7 @@
         $item.Attributes = $file_attributes -join ','
     }
 
-    Remove-Item -Path "{{win_find_dir}}\broken-link-dest" -Force
+    Remove-Item -LiteralPath "$tmp_dir\broken-link-dest" -Force
 
 - block:
   - include_tasks: tests.yml

--- a/test/integration/targets/win_find/tasks/tests.yml
+++ b/test/integration/targets/win_find/tasks/tests.yml
@@ -7,19 +7,19 @@
 
 - name: expect failure when setting paths to a file
   win_find:
-    paths: "{{win_output_dir}}\\win_find\\single\\large.ps1"
+    paths: "{{win_find_dir}}\\single\\large.ps1"
   register: actual
-  failed_when: actual.msg != 'Argument path ' + win_output_dir + '\\win_find\\single\\large.ps1 is a file not a directory'
+  failed_when: actual.msg != 'Argument path ' + win_find_dir + '\\single\\large.ps1 is a file not a directory'
 
 - name: expect failure when path is set to a non existent folder
   win_find:
-    paths: "{{win_output_dir}}\\win_find\\thisisafakefolder"
+    paths: "{{win_find_dir}}\\thisisafakefolder"
   register: actual
-  failed_when: actual.msg != 'Argument path ' + win_output_dir + '\\win_find\\thisisafakefolder does not exist cannot get information on'
+  failed_when: actual.msg != 'Argument path ' + win_find_dir + '\\thisisafakefolder does not exist cannot get information on'
 
 - name: get files in single directory
   win_find:
-    paths: "{{win_output_dir}}\\win_find\\single"
+    paths: "{{win_find_dir}}\\single"
   register: actual
 
 - name: set expected value for files in a single directory
@@ -197,22 +197,6 @@
           checksum: 8df33cee3325596517df5bb5aa980cf9c5c1fda3,
           creationtime: 1477984205,
           extension: .ps1,
-          filename: test.ps1,
-          ishidden: False,
-          isdir: False,
-          islnk: False,
-          lastaccesstime: 1477984205,
-          lastwritetime: 1477984205,
-          owner: BUILTIN\Administrators,
-          path: "{{win_find_dir}}\\nested\\sub-nest\\test.ps1",
-          isreadonly: False,
-          isshared: False,
-          size: 14 }
-      - { isarchive: True,
-          attributes: Archive,
-          checksum: 8df33cee3325596517df5bb5aa980cf9c5c1fda3,
-          creationtime: 1477984205,
-          extension: .ps1,
           filename: file.ps1,
           ishidden: False,
           isdir: False,
@@ -221,6 +205,22 @@
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
           path: "{{win_find_dir}}\\nested\\file.ps1",
+          isreadonly: False,
+          isshared: False,
+          size: 14 }
+      - { isarchive: True,
+          attributes: Archive,
+          checksum: 8df33cee3325596517df5bb5aa980cf9c5c1fda3,
+          creationtime: 1477984205,
+          extension: .ps1,
+          filename: test.ps1,
+          ishidden: False,
+          isdir: False,
+          islnk: False,
+          lastaccesstime: 1477984205,
+          lastwritetime: 1477984205,
+          owner: BUILTIN\Administrators,
+          path: "{{win_find_dir}}\\nested\\sub-nest\\test.ps1",
           isreadonly: False,
           isshared: False,
           size: 14 }
@@ -266,6 +266,22 @@
           checksum: 8df33cee3325596517df5bb5aa980cf9c5c1fda3,
           creationtime: 1477984205,
           extension: .ps1,
+          filename: file.ps1,
+          ishidden: False,
+          isdir: False,
+          islnk: False,
+          lastaccesstime: 1477984205,
+          lastwritetime: 1477984205,
+          owner: BUILTIN\Administrators,
+          path: "{{win_find_dir}}\\nested\\file.ps1",
+          isreadonly: False,
+          isshared: False,
+          size: 14 }
+      - { isarchive: True,
+          attributes: Archive,
+          checksum: 8df33cee3325596517df5bb5aa980cf9c5c1fda3,
+          creationtime: 1477984205,
+          extension: .ps1,
           filename: link.ps1,
           ishidden: False,
           isdir: False,
@@ -290,22 +306,6 @@
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
           path: "{{win_find_dir}}\\nested\\sub-nest\\test.ps1",
-          isreadonly: False,
-          isshared: False,
-          size: 14 }
-      - { isarchive: True,
-          attributes: Archive,
-          checksum: 8df33cee3325596517df5bb5aa980cf9c5c1fda3,
-          creationtime: 1477984205,
-          extension: .ps1,
-          filename: file.ps1,
-          ishidden: False,
-          isdir: False,
-          islnk: False,
-          lastaccesstime: 1477984205,
-          lastwritetime: 1477984205,
-          owner: BUILTIN\Administrators,
-          path: "{{win_find_dir}}\\nested\\file.ps1",
           isreadonly: False,
           isshared: False,
           size: 14 }


### PR DESCRIPTION
##### SUMMARY
Fix minor issue where win_find would fail to find files when a path contains `[]` was used. Also ensures the output paths are always in alphabetical order.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_find