### PR TITLE
win_get_url - fix glob like paths

### DIFF
--- a/changelogs/fragments/win_get_url-paths.yaml
+++ b/changelogs/fragments/win_get_url-paths.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_get_url - Fix issues when using paths with glob like characters, e.g. ``[``, ``]``

--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -290,7 +290,7 @@ Function Invoke-DownloadFile {
         }
 
         if ($download) {
-            Copy-Item -Path $tmp_dest -Destination $Dest -Force -WhatIf:$Module.CheckMode > $null
+            Copy-Item -LiteralPath $tmp_dest -Destination $Dest -Force -WhatIf:$Module.CheckMode > $null
             $Module.Result.changed = $true
         }
     }

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -1,28 +1,45 @@
 ---
+- name: set fact out special testing dir
+  set_fact:
+    testing_dir: '{{ remote_tmp_dir }}\win_get_url .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+
+- name: create test directory with space and special chars
+  win_file:
+    path: '{{ testing_dir }}'
+    state: directory
+
 - name: copy across testing files
   win_copy:
     src: files/
-    dest: '{{ remote_tmp_dir }}'
+    dest: '{{ testing_dir }}'
 
 - name: download SlimFTPd binary
   win_get_url:
     url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_get_url/SlimFTPd.exe
-    dest: '{{ remote_tmp_dir }}\SlimFTPd.exe'
+    dest: '{{ testing_dir }}\SlimFTPd.exe'
+
+# SlimFTPd does not work with special chars because it is so old, use a symlink as a workaround
+- name: set fact of temp symlink for SlimFTPd
+  set_fact:
+    slimftpd_link: C:\SlimFTPd
 
 - name: template SlimFTPd configuration file
   win_template:
     src: slimftpd.conf.tmpl
-    dest: '{{ remote_tmp_dir }}\slimftpd.conf'
-
-- name: create SlimFTPd service
-  win_service:
-    name: SlimFTPd
-    path: '"{{ remote_tmp_dir }}\SlimFTPd.exe" -service'
-    state: started
-    dependencies:
-    - tcpip
+    dest: '{{ testing_dir }}\slimftpd.conf'
 
 - block:
+  - name: create SLimFTPd symlink
+    win_command: cmd.exe /c mklink /d "{{ slimftpd_link }}" "{{ testing_dir }}"
+
+  - name: create SlimFTPd service
+    win_service:
+      name: SlimFTPd
+      path: '"{{ slimftpd_link }}\SlimFTPd.exe" -service'
+      state: started
+      dependencies:
+      - tcpip
+
   - name: run URL tests
     import_tasks: tests_url.yml
 
@@ -36,4 +53,9 @@
   - name: remove SlimFTPd service
     win_service:
       name: SlimFTPd
+      state: absent
+
+  - name: remove temp symlink
+    win_file:
+      path: '{{ slimftpd_link }}'
       state: absent

--- a/test/integration/targets/win_get_url/tasks/tests_checksum.yml
+++ b/test/integration/targets/win_get_url/tasks/tests_checksum.yml
@@ -10,7 +10,7 @@
 - name: download file with sha1 checksum url
   win_get_url:
     url: https://{{ httpbin_host }}/base64/cHR1eA==
-    dest: '{{ remote_tmp_dir }}\sha1.txt'
+    dest: '{{ testing_dir }}\sha1.txt'
     checksum_url: https://{{ httpbin_host }}/base64/{{ sha1sum }}
     force: True
   register: download_sha1_url
@@ -18,7 +18,7 @@
 - name: download file with sha1 checksum value
   win_get_url:
     url: https://{{ httpbin_host }}/base64/cHR1eA==
-    dest: '{{ remote_tmp_dir }}\sha1.txt'
+    dest: '{{ testing_dir }}\sha1.txt'
     checksum: a97e6837f60cec6da4491bab387296bbcd72bdba
     force: True
   register: download_sha1_value
@@ -36,7 +36,7 @@
 - name: download file with sha256 checksum ftp
   win_get_url:
     url: https://{{ httpbin_host }}/base64/cHR1eA==
-    dest: '{{ remote_tmp_dir }}\sha256.txt'
+    dest: '{{ testing_dir }}\sha256.txt'
     checksum_url: ftp://localhost/anon/sha256sum.txt  # tests that a checksum can be from an FTP URI
     checksum_algorithm: sha256
     force: True
@@ -45,8 +45,8 @@
 - name: download file with sha256 checksum dot leading source as file
   win_get_url:
     url: https://{{ httpbin_host }}/base64/cHR1eA==
-    dest: '{{ remote_tmp_dir }}\sha256.txt'
-    checksum_url: '{{ remote_tmp_dir }}\ftp\anon\sha256sum_with_dot.txt'
+    dest: '{{ testing_dir }}\sha256.txt'
+    checksum_url: '{{ testing_dir }}\ftp\anon\sha256sum_with_dot.txt'
     checksum_algorithm: sha256
     force: True
   register: download_sha256_file
@@ -54,7 +54,7 @@
 - name: download file with sha256 checksum value
   win_get_url:
     url: https://{{ httpbin_host }}/base64/cHR1eA==
-    dest: '{{ remote_tmp_dir }}\sha256.txt'
+    dest: '{{ testing_dir }}\sha256.txt'
     checksum: b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006
     checksum_algorithm: sha256
   register: download_sha256_value
@@ -75,7 +75,7 @@
 - name: fail download with invalid checksum and force=no
   win_get_url:
     url: https://{{ httpbin_host }}/base64/cHR1eA==
-    dest: '{{ remote_tmp_dir }}\fail.txt'
+    dest: '{{ testing_dir }}\fail.txt'
     checksum: invalid
     force: no
   register: fail_checksum_force_no
@@ -84,7 +84,7 @@
 - name: fail download with invalid checksum and force=yes
   win_get_url:
     url: https://{{ httpbin_host }}/base64/cHR1eA==
-    dest: '{{ remote_tmp_dir }}\fail.txt'
+    dest: '{{ testing_dir }}\fail.txt'
     checksum: invalid
     force: yes
   register: fail_checksum_force_yes

--- a/test/integration/targets/win_get_url/tasks/tests_ftp.yml
+++ b/test/integration/targets/win_get_url/tasks/tests_ftp.yml
@@ -2,13 +2,13 @@
 - name: download file from FTP source (check)
   win_get_url:
     url: ftp://localhost/anon/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    dest: '{{ testing_dir }}\ftp-anon.txt'
   check_mode: yes
   register: ftp_anon_check
 
 - name: get results of download file from FTP source (check)
   win_stat:
-    path: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    path: '{{ testing_dir }}\ftp-anon.txt'
   register: ftp_anon_result_check
 
 - name: assert download file from FTP source (check)
@@ -20,12 +20,12 @@
 - name: download file from FTP source
   win_get_url:
     url: ftp://localhost/anon/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    dest: '{{ testing_dir }}\ftp-anon.txt'
   register: ftp_anon
 
 - name: get results of download file from FTP source
   win_stat:
-    path: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    path: '{{ testing_dir }}\ftp-anon.txt'
   register: ftp_anon_result
 
 - name: assert download file from FTP source
@@ -38,7 +38,7 @@
 - name: download file from FTP source (idempotent)
   win_get_url:
     url: ftp://localhost/anon/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    dest: '{{ testing_dir }}\ftp-anon.txt'
   register: ftp_anon_again
 
 - name: assert download file from FTP source (idempotent)
@@ -49,7 +49,7 @@
 - name: download file from FTP source with force no (check)
   win_get_url:
     url: ftp://localhost/anon/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    dest: '{{ testing_dir }}\ftp-anon.txt'
     force: no
   check_mode: yes
   register: ftp_anon_force_no_check
@@ -62,7 +62,7 @@
 - name: download file from FTP source with force no
   win_get_url:
     url: ftp://localhost/anon/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    dest: '{{ testing_dir }}\ftp-anon.txt'
     force: no
   register: ftp_anon_force_no
 
@@ -72,19 +72,19 @@
     - ftp_anon_force_no is not changed
 
 - name: set last modified time on FTP source to newer datetime
-  win_shell: (Get-Item -Path '{{ remote_tmp_dir }}\ftp\anon\file2.txt').LastWriteTime = (Get-Date).AddHours(24)
+  win_shell: (Get-Item -LiteralPath '{{ testing_dir }}\ftp\anon\file2.txt').LastWriteTime = (Get-Date).AddHours(24)
 
 - name: download newer file from FTP source to same dest (check)
   win_get_url:
     url: ftp://localhost/anon/file2.txt
-    dest: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    dest: '{{ testing_dir }}\ftp-anon.txt'
     force: no
   check_mode: yes
   register: ftp_anon_force_no_different_check
 
 - name: get result of download newer file from FTP source to same dest (check)
   win_stat:
-    path: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    path: '{{ testing_dir }}\ftp-anon.txt'
   register: ftp_anon_force_no_different_result_check
 
 - name: assert download newer file from FTP source to same dest (check)
@@ -96,13 +96,13 @@
 - name: download newer file from FTP source to same dest
   win_get_url:
     url: ftp://localhost/anon/file2.txt
-    dest: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    dest: '{{ testing_dir }}\ftp-anon.txt'
     force: no
   register: ftp_anon_force_no_different
 
 - name: get result of download newer file from FTP source to same dest
   win_stat:
-    path: '{{ remote_tmp_dir }}\ftp-anon.txt'
+    path: '{{ testing_dir }}\ftp-anon.txt'
   register: ftp_anon_force_no_different_result
 
 - name: assert download newer file from FTP source to same dest (check)
@@ -114,7 +114,7 @@
 - name: fail to download file from ftp protected by username
   win_get_url:
     url: ftp://localhost/user/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-user.txt'
+    dest: '{{ testing_dir }}\ftp-user.txt'
   register: fail_ftp_no_user
   ignore_errors: yes
 
@@ -129,13 +129,13 @@
 - name: download FTP file protected by username
   win_get_url:
     url: ftp://localhost/user/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-user.txt'
+    dest: '{{ testing_dir }}\ftp-user.txt'
     url_username: username
   register: ftp_user_file
 
 - name: get result of download FTP file protected by username
   win_stat:
-    path: '{{ remote_tmp_dir }}\ftp-user.txt'
+    path: '{{ testing_dir }}\ftp-user.txt'
   register: ftp_user_file_result
 
 - name: assert download FTP file protected by username
@@ -148,14 +148,14 @@
 - name: download FTP file protected by username and password
   win_get_url:
     url: ftp://localhost/user-pass/file.txt
-    dest: '{{ remote_tmp_dir }}\ftp-user-pass.txt'
+    dest: '{{ testing_dir }}\ftp-user-pass.txt'
     url_username: userpass
     url_password: password
   register: ftp_user_pass_file
 
 - name: get result of download FTP file protected by username and password
   win_stat:
-    path: '{{ remote_tmp_dir }}\ftp-user-pass.txt'
+    path: '{{ testing_dir }}\ftp-user-pass.txt'
   register: ftp_user_pass_file_result
 
 - name: assert download FTP file protected by username and password

--- a/test/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/test/integration/targets/win_get_url/tasks/tests_url.yml
@@ -1,13 +1,13 @@
 - name: download single file (check)
   win_get_url:
     url: https://{{ httpbin_host }}/base64/SG93IG5vdyBicm93biBjb3c=
-    dest: '{{ remote_tmp_dir }}\output.txt'
+    dest: '{{ testing_dir }}\output.txt'
   check_mode: yes
   register: http_download_check
 
 - name: get result of download single file (check)
   win_stat:
-    path: '{{ remote_tmp_dir }}\output.txt'
+    path: '{{ testing_dir }}\output.txt'
   register: http_download_result_check
 
 - name: assert download single file (check)
@@ -22,12 +22,12 @@
 - name: download single file
   win_get_url:
     url: https://{{ httpbin_host }}/base64/SG93IG5vdyBicm93biBjb3c=
-    dest: '{{ remote_tmp_dir }}\output.txt'
+    dest: '{{ testing_dir }}\output.txt'
   register: http_download
 
 - name: get result of download single file
   win_stat:
-    path: '{{ remote_tmp_dir }}\output.txt'
+    path: '{{ testing_dir }}\output.txt'
   register: http_download_result
 
 - name: assert download single file
@@ -42,7 +42,7 @@
 - name: download single file (idempotent)
   win_get_url:
     url: https://{{ httpbin_host }}/base64/SG93IG5vdyBicm93biBjb3c=
-    dest: '{{ remote_tmp_dir }}\output.txt'
+    dest: '{{ testing_dir }}\output.txt'
   register: http_download_again
 
 - name: assert download single file (idempotent)
@@ -54,12 +54,12 @@
 - name: download file for force=no tests
   win_get_url:
     url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_get_url/SlimFTPd.exe
-    dest: '{{ remote_tmp_dir }}\output'
+    dest: '{{ testing_dir }}\output'
 
 - name: download single file with force no
   win_get_url:
     url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_get_url/SlimFTPd.exe
-    dest: '{{ remote_tmp_dir }}\output'
+    dest: '{{ testing_dir }}\output'
     force: no
   register: http_download_no_force
 
@@ -70,14 +70,14 @@
 
 - name: manually change the content and last modified time on FTP source to older datetime
   win_shell: |
-      $path = '{{ remote_tmp_dir }}\output'
-      Set-Content -Path $path -Value 'abc'
-      (Get-Item -Path $path).LastWriteTime = (Get-Date -Date "01/01/1970")
+      $path = '{{ testing_dir }}\output'
+      Set-Content -LiteralPath $path -Value 'abc'
+      (Get-Item -LiteralPath $path).LastWriteTime = (Get-Date -Date "01/01/1970")
 
 - name: download newer file with force no
   win_get_url:
     url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_get_url/SlimFTPd.exe
-    dest: '{{ remote_tmp_dir }}\output'
+    dest: '{{ testing_dir }}\output'
     force: no
   register: http_download_newer_no_force
 
@@ -89,12 +89,12 @@
 - name: download file to directory
   win_get_url:
     url: https://{{ httpbin_host }}/image/png
-    dest: '{{ remote_tmp_dir }}'
+    dest: '{{ testing_dir }}'
   register: http_download_to_directory
 
 - name: get result of download to directory
   win_stat:
-    path: '{{ remote_tmp_dir }}\png'
+    path: '{{ testing_dir }}\png'
   register: http_download_to_directory_result
 
 - name: assert download file to directory
@@ -109,11 +109,11 @@
     dest: '%TEST_WIN_GET_URL%\jpeg.jpg'
   register: http_download_with_env
   environment:
-    TEST_WIN_GET_URL: '{{ remote_tmp_dir }}'
+    TEST_WIN_GET_URL: '{{ testing_dir }}'
 
 - name: get result of download to path with env var
   win_stat:
-    path: '{{ remote_tmp_dir }}\jpeg.jpg'
+    path: '{{ testing_dir }}\jpeg.jpg'
   register: http_download_with_env_result
 
 - name: assert download to path with env var
@@ -125,7 +125,7 @@
 - name: fail when link returns 404
   win_get_url:
     url: https://{{ httpbin_host }}/status/404
-    dest: '{{ remote_tmp_dir }}\skynet_module.html'
+    dest: '{{ testing_dir }}\skynet_module.html'
   ignore_errors: yes
   register: fail_download_404
 
@@ -146,7 +146,7 @@
 - name: test basic authentication
   win_get_url:
     url: http://{{ httpbin_host }}/basic-auth/username/password
-    dest: '{{ remote_tmp_dir }}\basic.txt'
+    dest: '{{ testing_dir }}\basic.txt'
     url_username: username
     url_password: password
   register: basic_auth
@@ -162,7 +162,7 @@
 - name: test force basic authentication
   win_get_url:
     url: http://{{ httpbin_host }}/hidden-basic-auth/username/password
-    dest: '{{ remote_tmp_dir }}\force-basic.txt'
+    dest: '{{ testing_dir }}\force-basic.txt'
     url_username: username
     url_password: password
     force_basic_auth: yes
@@ -177,7 +177,7 @@
 - name: timeout request
   win_get_url:
     url: https://{{ httpbin_host }}/delay/7
-    dest: '{{ remote_tmp_dir }}\timeout.txt'
+    dest: '{{ testing_dir }}\timeout.txt'
     timeout: 3
   register: timeout_req
   failed_when: timeout_req.msg != "Error requesting 'https://" + httpbin_host + "/delay/7'. The operation has timed out"
@@ -185,14 +185,14 @@
 - name: send request with headers
   win_get_url:
     url: https://{{ httpbin_host }}/headers
-    dest: '{{ remote_tmp_dir }}\headers.txt'
+    dest: '{{ testing_dir }}\headers.txt'
     headers:
       testing: 123
   register: headers
 
 - name: get result of send request with headers
   slurp:
-    path: '{{ remote_tmp_dir }}\headers.txt'
+    path: '{{ testing_dir }}\headers.txt'
   register: headers_actual
 
 - name: assert send request with headers

--- a/test/integration/targets/win_get_url/templates/slimftpd.conf.tmpl
+++ b/test/integration/targets/win_get_url/templates/slimftpd.conf.tmpl
@@ -8,14 +8,14 @@ LookupHosts On
 
 <User "anonymous">
   Password ""
-  Mount / "{{ remote_tmp_dir | replace('\\', '\\\\') }}\\ftp"
+  Mount / "{{ slimftpd_link | replace('\\', '\\\\') }}\\ftp"
   Allow /anon All
   Deny /user All
   Deny /user-pass All
 </User>
 
 <User "username">
-  Mount / "{{ remote_tmp_dir | replace('\\', '\\\\') }}\\ftp"
+  Mount / "{{ slimftpd_link | replace('\\', '\\\\') }}\\ftp"
   Allow /anon All
   Allow /user All
   Deny /user-pass All
@@ -23,6 +23,6 @@ LookupHosts On
 
 <User "userpass">
   Password "password"
-  Mount / "{{ remote_tmp_dir | replace('\\', '\\\\') }}\\ftp"
+  Mount / "{{ slimftpd_link | replace('\\', '\\\\') }}\\ftp"
   Allow / All
 </User>


### PR DESCRIPTION
##### SUMMARY
Fix minor issue where win_get_url would fail to find files when a path contains `[]` was used. Also ensures the output paths are always in alphabetical order.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_get_url