### PR TITLE
win_psexec - support paths with a space

### DIFF
--- a/changelogs/fragments/win_psexec-paths.yaml
+++ b/changelogs/fragments/win_psexec-paths.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_psexec - Support executables with a space in the path

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -57,79 +57,79 @@ If (-Not (Get-Command $executable -ErrorAction SilentlyContinue)) {
     $module.FailJson("Executable '$executable' was not found.")
 }
 
-$arguments = @()
+$arguments = [System.Collections.Generic.List`1[String]]@($executable)
 
 If ($nobanner -eq $true) {
-    $arguments += "-nobanner"
+    $arguments.Add("-nobanner")
 }
 
 # Support running on local system if no hostname is specified
 If ($hostnames) {
     $hostname_argument = ($hostnames | sort -Unique) -join ','
-    $arguments += "\\$hostname_argument"
+    $arguments.Add("\\$hostname_argument")
 }
 
 # Username is optional
-If ($username -ne $null) {
-    $arguments += "-u"
-    $arguments += $username
+If ($null -ne $username) {
+    $arguments.Add("-u")
+    $arguments.Add($username)
 }
 
 # Password is optional
-If ($password -ne $null) {
-    $arguments += "-p"
-    $arguments += $password
+If ($null -ne $password) {
+    $arguments.Add("-p")
+    $arguments.Add($password)
 }
 
-If ($chdir -ne $null) {
-    $arguments += "-w"
-    $arguments += $chdir
+If ($null -ne $chdir) {
+    $arguments.Add("-w")
+    $arguments.Add($chdir)
 }
 
 If ($wait -eq $false) {
-    $arguments += "-d"
+    $arguments.Add("-d")
 }
 
 If ($noprofile -eq $true) {
-    $arguments += "-e"
+    $arguments.Add("-e")
 }
 
 If ($elevated -eq $true) {
-    $arguments += "-h"
+    $arguments.Add("-h")
 }
 
 If ($system -eq $true) {
-    $arguments += "-s"
+    $arguments.Add("-s")
 }
 
 If ($interactive -eq $true) {
-    $arguments += "-i"
-    If ($session -ne $null) {
-        $arguments += $session
+    $arguments.Add("-i")
+    If ($null -ne $session) {
+        $arguments.Add($session)
     }
 }
 
 If ($limited -eq $true) {
-    $arguments += "-l"
+    $arguments.Add("-l")
 }
 
-If ($priority -ne $null) {
-    $arguments += "-$priority"
+If ($null -ne $priority) {
+    $arguments.Add("-$priority")
 }
 
-If ($timeout -ne $null) {
-    $arguments += "-n"
-    $arguments += $timeout
+If ($null -ne $timeout) {
+    $arguments.Add("-n")
+    $arguments.Add($timeout)
 }
 
 # Add additional advanced options
 If ($extra_opts) {
     ForEach ($opt in $extra_opts) {
-        $arguments += $opt
+        $arguments.Add($opt)
     }
 }
 
-$arguments += "-accepteula"
+$arguments.Add("-accepteula")
 
 $argument_string = Argv-ToString -arguments $arguments
 
@@ -138,9 +138,9 @@ $argument_string = Argv-ToString -arguments $arguments
 $argument_string += " $command"
 
 $start_datetime = [DateTime]::UtcNow
-$module.Result.psexec_command = "$executable $argument_string"
+$module.Result.psexec_command = $argument_string
 
-$command_result = Run-Command -command "$executable $argument_string"
+$command_result = Run-Command -command $argument_string
 
 $end_datetime = [DateTime]::UtcNow
 

--- a/test/integration/targets/win_psexec/tasks/main.yml
+++ b/test/integration/targets/win_psexec/tasks/main.yml
@@ -1,7 +1,17 @@
+# Would use [] but this has troubles with PATH and trying to find the executable so just resort to keeping a space
+- name: record special path for tests
+  set_fact:
+    testing_dir: '{{ remote_tmp_dir }}\ansible win_psexec'
+
+- name: create special path testing dir
+  win_file:
+    path: '{{ testing_dir }}'
+    state: directory
+
 - name: Download PsExec
   win_get_url:
     url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/win_psexec/PsExec.exe
-    dest: '{{ remote_tmp_dir }}\PsExec.exe'
+    dest: '{{ testing_dir }}\PsExec.exe'
 
 - name: Get the existing PATH env var
   win_shell: '$env:PATH'
@@ -14,7 +24,7 @@
     nobanner: true
   register: whoami
   environment:
-    PATH: '{{ remote_tmp_dir }};{{ system_path.stdout | trim }}'
+    PATH: '{{ testing_dir }};{{ system_path.stdout | trim }}'
 
 - name: Test whoami
   assert:
@@ -29,7 +39,7 @@
     command: whoami.exe
     system: yes
     nobanner: true
-    executable: '{{ remote_tmp_dir }}\PsExec.exe'
+    executable: '{{ testing_dir }}\PsExec.exe'
   register: whoami_as_system
   # Seems to be a bug with PsExec where the stdout can be empty, just retry the task to make this test a bit more stable
   until: whoami_as_system.rc == 0 and whoami_as_system.stdout == 'nt authority\system'
@@ -61,7 +71,7 @@
   ignore_errors: yes
   register: whoami_multiple_args
   environment:
-    PATH: '{{ remote_tmp_dir }};{{ system_path.stdout | trim }}'
+    PATH: '{{ testing_dir }};{{ system_path.stdout | trim }}'
 
 - name: Test command with multiple argumetns
   assert:


### PR DESCRIPTION
##### SUMMARY
Allow specifying an executable that has a space in the path for win_psexec.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psexec