### PR TITLE
Add an integration test for deleting Cloudstack image stores in check mode

### DIFF
--- a/test/integration/targets/cs_image_store/tasks/main.yml
+++ b/test/integration/targets/cs_image_store/tasks/main.yml
@@ -122,6 +122,21 @@
       - "ss.name == 'storage_pool_adv'"
       - "ss.zone == cs_common_zone_adv"
 
+- name: delete the image store in check_mode
+  cs_image_store:
+    name: "storage_pool_adv"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: ss
+  check_mode: yes
+- name: verify results for delete the image store in check_mode
+  assert:
+    that:
+      - ss is successful
+      - ss is changed
+      - "ss.name == 'storage_pool_adv'"
+      - "ss.zone == cs_common_zone_adv"
+
 - name: delete the image store
   cs_image_store:
     name: "storage_pool_adv"


### PR DESCRIPTION
##### SUMMARY
Add an integration test for deleting CloudStack Image Stores in check mode

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
cs_image_store

##### ADDITIONAL INFORMATION
It was requested in #53617 to include an integration test for deleting a CloudStack Image Store in check mode.

