### PR TITLE
docker_swarm_service: Make resolve_image default to false

### DIFF
--- a/changelogs/fragments/51134-docker_swarm_service-change-on-updated-image.yml
+++ b/changelogs/fragments/51134-docker_swarm_service-change-on-updated-image.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "docker_swarm_service - Resolve image digest from registry to detect and deploy changed images. This behaviour can be turned of by using the new option ``resolve_image: false``"
+  - "docker_swarm_service - Added option ``resolve_image`` which enables resolving image digests from registry to detect and deploy changed images."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2617,6 +2617,7 @@ def main():
         stop_signal=dict(docker_py_version='2.6.0', docker_api_version='1.28'),
         publish=dict(docker_py_version='3.0.0', docker_api_version='1.25'),
         read_only=dict(docker_py_version='2.6.0', docker_api_version='1.28'),
+        resolve_image=dict(docker_api_version='1.30', docker_py_version='3.2.0'),
         rollback_config=dict(docker_py_version='3.5.0', docker_api_version='1.28'),
         # specials
         publish_mode=dict(
@@ -2688,12 +2689,6 @@ def main():
             ) is not None,
             usage_msg='set rollback_config.order'
         ),
-        resolve_image_is_true=dict(
-            docker_api_version='1.30',
-            docker_py_version='3.2.0',
-            detect_usage=lambda c: c.module.params['resolve_image'] is True,
-            usage_msg='set resolve_image'
-        )
     )
     required_if = [
         ('state', 'present', ['image'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The current default of `resolve_image` is `true` which might cause peoples services to be updated when not expected when updating to Ansible 2.8 (as this was not the previous behaviour). This PR changes the default to `false`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
