### PR TITLE
Additional network support for Cloudstack

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible. If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -31,89 +31,70 @@ description:
     - Create, update and remove networks.
     - Enabled and disabled Network Service Providers
     - Enables Internal LoadBalancer and VPC/VirtualRouter elements as required
-version_added: "2.4"
-author: "Netservers Ltd. (@netservers)"
+version_added: "2.8"
+author:
+ - Netservers Ltd. (@netservers)
+ - Patryk Cichy (@PatTheSilent)
 options:
-  name:
+  physical_network:
     description:
-      - name of the network.
+      - Name of the physical network.
     required: true
+    aliases:
+      - name
   zone:
     description:
       - Name of the zone in which the network belongs.
       - If not set, default zone is used.
     required: true
-    default: null
-  broadcastdomainrange:
+  broadcast_domain_range:
     description:
       - broadcast domain range for the physical network[Pod or Zone].
     required: false
-    default: none
-    choices: [ 'POD', 'ZONE' ]
+    choices: [ POD, ZONE ]
   domain:
     description:
       - Domain the network is owned by.
     required: false
-    default: null
   isolation_method:
     description:
       - Isolation method for the physical network.
     required: false
-    default: none
-    choices: [ 'VLAN', 'GRE', 'L3' ]
+    choices: [ VLAN, GRE, L3 ]
   network_speed:
     description:
-      - the speed for the physical network[1G/10G]
+      - The speed for the physical network.
     required: false
-    default: null
+    choices: [1G, 10G]
   tags:
     description:
-      - "A tag to identify this network"
-      - "Physical networks support only one tag"
-      - "To remove an existing tag pass an empty string"
+      - A tag to identify this network.
+      - Physical networks support only one tag.
+      - To remove an existing tag pass an empty string.
     required: false
-    default: null
     aliases:
       - tag
   vlan:
     description:
       - The VLAN/VNI Ranges of the physical network.
     required: false
-    default: null
   nsps_enabled:
     description:
       - List of Network Service Providers to enable
     required: false
-    default: null
   nsps_disabled:
     description:
       - List of Network Service Providers to disable
     required: false
-    default: null
-  url:
-    description:
-      - URL for the cluster
-    required: false
-    default: null
-  username:
-    description:
-      - Username for the cluster.
-    required: false
-    default: null
-  password:
-    description:
-      - Password for the cluster.
-    required: false
-    default: null
   state:
     description:
-      - State of the cluster.
+      - State of the physical network.
     required: false
-    default: 'present'
-    choices: [ 'present', 'absent', 'disabled', 'enabled' ]
+    default: present
+    choices: [ present, absent, disabled, enabled ]
   poll_async:
     description:
-      - "Poll async jobs until job has finished."
+      - Poll async jobs until job has finished.
     required: false
     default: true
 extends_documentation_fragment: cloudstack
@@ -122,7 +103,7 @@ extends_documentation_fragment: cloudstack
 EXAMPLES = '''
 # Ensure a network is present
 - local_action:
-    module: cs_phsyical_network
+    module: cs_physical_network
     name: net01
     zone: zone01
     isolation_method: VLAN
@@ -130,19 +111,19 @@ EXAMPLES = '''
 
 # Set a tag on a network
 - local_action:
-    module: cs_phsyical_network
+    module: cs_physical_network
     name: net01
     tag: overlay
 
 # Remove tag on a network
 - local_action:
-    module: cs_phsyical_network
+    module: cs_physical_network
     name: net01
     tag: ""
 
 # Ensure a network is enabled with specific nsps enabled
 - local_action:
-    module: cs_phsyical_network
+    module: cs_physical_network
     name: net01
     zone: zone01
     isolation_method: VLAN
@@ -150,28 +131,27 @@ EXAMPLES = '''
     broadcast_domain_range: ZONE
     state: enabled
     nsps_enabled:
-      - Ovs
       - VirtualRouter
       - InternalLbVm
       - VpcVirtualRouter
 
 # Ensure a network is disabled
 - local_action:
-    module: cs_phsyical_network
+    module: cs_physical_network
     name: net01
     zone: zone01
     state: disabled
 
 # Ensure a network is enabled
 - local_action:
-    module: cs_phsyical_network
+    module: cs_physical_network
     name: net01
     zone: zone01
     state: enabled
 
 # Ensure a network is absent
 - local_action:
-    module: cs_phsyical_network
+    module: cs_physical_network
     name: net01
     zone: zone01
     state: absent
@@ -182,58 +162,57 @@ RETURN = '''
 id:
   description: UUID of the network.
   returned: success
-  type: string
+  type: str
   sample: 3f8f25cd-c498-443f-9058-438cfbcbff50
 name:
   description: Name of the network.
   returned: success
-  type: string
+  type: str
   sample: net01
 state:
   description: State of the network [Enabled/Disabled].
   returned: success
-  type: string
+  type: str
   sample: Enabled
 broadcast_domain_range:
   description: broadcastdomainrange of the network [POD / ZONE].
   returned: success
-  type: string
+  type: str
   sample: ZONE
 isolation_method:
   description: isolationmethod of the network [VLAN/GRE/L3].
   returned: success
-  type: string
+  type: str
   sample: VLAN
 network_speed:
   description: networkspeed of the network [1G/10G].
   returned: success
-  type: string
+  type: str
   sample: 1G
 zone:
-  description: Name of zone the cluster is in.
+  description: Name of zone the physical network is in.
   returned: success
-  type: string
+  type: str
   sample: ch-gva-2
 domain:
   description: Name of domain the network is in.
   returned: success
-  type: string
+  type: str
   sample: domain1
 '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
-    CloudStackException,
     cs_argument_spec,
     cs_required_together,
 )
 
 
-class AnsibleCloudStackCluster(AnsibleCloudStack):
+class AnsibleCloudStackPhysicalNetwork(AnsibleCloudStack):
 
     def __init__(self, module):
-        super(AnsibleCloudStackCluster, self).__init__(module)
+        super(AnsibleCloudStackPhysicalNetwork, self).__init__(module)
         self.returns = {
             'isolationmethods': 'isolation_method',
             'broadcastdomainrange': 'broadcast_domain_range',
@@ -241,14 +220,13 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'vlan': 'vlan',
             'tags': 'tags',
         }
-        self.network = None
         self.nsps = []
         self.vrouters = None
         self.loadbalancers = None
 
     def _get_common_args(self):
         args = {
-            'name': self.module.params.get('name'),
+            'name': self.module.params.get('physical_network'),
             'isolationmethods': self.module.params.get('isolation_method'),
             'broadcastdomainrange': self.module.params.get('broadcast_domain_range'),
             'networkspeed': self.module.params.get('network_speed'),
@@ -263,27 +241,31 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             args['state'] = state.capitalize()
         return args
 
-    def get_network(self, key=None):
-        if self.network:
-            return self.network
+    def get_physical_network(self, key=None):
+        physical_network = self.module.params.get('physical_network')
+        if self.physical_network:
+            return self._get_by_key(key, self.physical_network)
+
         args = {
-            'zoneid': self.get_zone(key='id'),
-            'name': self.module.params.get('name'),
+            'zoneid': self.get_zone(key='id')
         }
-        nets = self.cs.listPhysicalNetworks(**args)
-        if nets:
-            self.network = nets['physicalnetwork'][0]
-        return self.network
+        physical_networks = self.query_api('listPhysicalNetworks', **args)
+        if physical_networks:
+            for net in physical_networks['physicalnetwork']:
+                if physical_network.lower() in [net['name'].lower(), net['id']]:
+                    self.physical_network = net
+                    self.result['physical_network'] = net['name']
+                    break
+
+        return self._get_by_key(key, self.physical_network)
 
     def get_nsp(self, name=None):
         if not self.nsps:
-            network = self.get_network()
             args = {
-                'physicalnetworkid': network['id']
+                'physicalnetworkid': self.get_physical_network(key='id')
             }
-            res = self.cs.listNetworkServiceProviders(**args)
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            res = self.query_api('listNetworkServiceProviders', **args)
+
             self.nsps = res['networkserviceprovider']
 
         names = []
@@ -294,7 +276,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
 
         self.module.fail_json(msg="Failed: '{}' not in network service providers list '[{}]'".format(name, names))
 
-    def _update_nsp(self, name=None, state=None, service_list=None):
+    def update_nsp(self, name=None, state=None, service_list=None):
         nsp = self.get_nsp(name)
         if not service_list and nsp['state'] == state:
             return nsp
@@ -304,9 +286,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'servicelist': service_list,
             'state': state
         }
-        res = self.cs.updateNetworkServiceProvider(**args)
-        if 'errortext' in res:
-            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        res = self.query_api('updateNetworkServiceProvider', **args)
 
         poll_async = self.module.params.get('poll_async')
         if poll_async:
@@ -320,14 +300,12 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         nspid = nsp['id']
         if self.vrouters is None:
             self.vrouters = dict()
-            res = self.cs.listVirtualRouterElements()
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            res = self.query_api('listVirtualRouterElements', )
             for vrouter in res['virtualrouterelement']:
                 self.vrouters[vrouter['nspid']] = vrouter
 
         if nspid not in self.vrouters:
-            self.module.fail_json(msg="Failed: No VirtualRouterElement founf for nsp '%s'" % nsp_name)
+            self.module.fail_json(msg="Failed: No VirtualRouterElement found for nsp '%s'" % nsp_name)
 
         return self.vrouters[nspid]
 
@@ -336,9 +314,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         nspid = nsp['id']
         if self.loadbalancers is None:
             self.loadbalancers = dict()
-            res = self.cs.listInternalLoadBalancerElements()
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            res = self.query_api('listInternalLoadBalancerElements', )
             for loadbalancer in res['internalloadbalancerelement']:
                 self.loadbalancers[loadbalancer['nspid']] = loadbalancer
 
@@ -356,9 +332,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'id': vrouter['id'],
             'enabled': enabled
         }
-        res = self.cs.configureVirtualRouterElement(**args)
-        if 'errortext' in res:
-            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        res = self.query_api('configureVirtualRouterElement', **args)
 
         poll_async = self.module.params.get('poll_async')
         if poll_async:
@@ -376,9 +350,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'id': loadbalancer['id'],
             'enabled': enabled
         }
-        res = self.cs.configureInternalLoadBalancerElement(**args)
-        if 'errortext' in res:
-            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        res = self.query_api('configureInternalLoadBalancerElement', **args)
 
         poll_async = self.module.params.get('poll_async')
         if poll_async:
@@ -388,7 +360,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         return loadbalancer
 
     def present_network(self):
-        network = self.get_network()
+        network = self.get_physical_network()
         if network:
             network = self._update_network()
         else:
@@ -396,79 +368,58 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         return network
 
     def _create_network(self):
-        required_params = [
-            'name',
-            'zone',
-        ]
-        self.module.fail_on_missing_params(required_params=required_params)
-
-        args = self._get_common_args()
-        args['zoneid'] = self.get_zone(key='id')
-        args['domainid'] = self.get_domain(key='id')
-        args['url'] = self.module.params.get('url')
-        args['username'] = self.module.params.get('username')
-        args['password'] = self.module.params.get('password')
-
         self.result['changed'] = True
+        args = dict(zoneid=self.get_zone(key='id'))
+        args.update(self._get_common_args())
+        if self.get_domain(key='id'):
+            args['domainid'] = self.get_domain(key='id')
 
-        id = None
         if not self.module.check_mode:
-            res = self.cs.createPhysicalNetwork(**args)
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            resource = self.query_api('createPhysicalNetwork', **args)
 
             poll_async = self.module.params.get('poll_async')
             if poll_async:
-                self.network = self.poll_job(res, 'physicalnetwork')
+                self.network = self.poll_job(resource, 'physicalnetwork')
 
         return self.network
 
     def _update_network(self):
-        network = self.get_network()
+        network = self.get_physical_network()
 
-        args = self._get_common_args()
-        args['id'] = network['id']
+        args = dict(id=network['id'])
+        args.update(self._get_common_args())
 
         if self.has_changed(args, network):
             self.result['changed'] = True
 
             if not self.module.check_mode:
-                res = self.cs.updatePhysicalNetwork(**args)
-                if 'errortext' in res:
-                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+                resource = self.query_api('updatePhysicalNetwork', **args)
 
                 poll_async = self.module.params.get('poll_async')
                 if poll_async:
-                    network = self.poll_job(res, 'physicalnetwork')
-        return network
+                    self.physical_network = self.poll_job(resource, 'physicalnetwork')
+        return self.physical_network
 
     def absent_network(self):
-        network = self.get_network()
-        if network:
+        physical_network = self.get_physical_network()
+        if physical_network:
             self.result['changed'] = True
-
             args = {
-                'id': network['id'],
+                'id': physical_network['id'],
             }
             if not self.module.check_mode:
-                res = self.cs.deletePhysicalNetwork(**args)
-                if 'errortext' in res:
-                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
-
+                resource = self.query_api('deletePhysicalNetwork', **args)
                 poll_async = self.module.params.get('poll_async')
                 if poll_async:
-                    success = self.poll_job(res, 'success')
+                    self.poll_job(resource, 'success')
 
-                if not success:
-                    self.module.fail_json(msg="Failed: Network not deleted")
-
-        return network
+        return physical_network
 
 
 def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
-        name=dict(required=True),
+        physical_network=dict(required=True, aliases=['name']),
         zone=dict(default=None),
         domain=dict(default=None),
         vlan=dict(default=None),
@@ -478,9 +429,6 @@ def main():
         broadcast_domain_range=dict(choices=['POD', 'ZONE'], default=None),
         isolation_method=dict(choices=['VLAN', 'GRE', 'L3'], default=None),
         state=dict(choices=['present', 'enabled', 'disabled', 'absent'], default='present'),
-        url=dict(default=None),
-        username=dict(default=None),
-        password=dict(default=None, no_log=True),
         tags=dict(type='list', aliases=['tag'], default=None),
         poll_async=dict(type='bool', default=True),
     ))
@@ -491,37 +439,32 @@ def main():
         supports_check_mode=True
     )
 
-    try:
-        acs_network = AnsibleCloudStackCluster(module)
+    acs_network = AnsibleCloudStackPhysicalNetwork(module)
+    state = module.params.get('state')
+    nsps_disabled = module.params.get('nsps_disabled', [])
+    nsps_enabled = module.params.get('nsps_enabled', [])
 
-        state = module.params.get('state')
-        nsps_disabled = module.params.get('nsps_disabled', [])
-        nsps_enabled = module.params.get('nsps_enabled', [])
+    if state in ['absent']:
+        network = acs_network.absent_network()
+    else:
+        network = acs_network.present_network()
+    if nsps_disabled is not None:
+        for name in nsps_disabled:
+            acs_network.update_nsp(name=name, state='Disabled')
 
-        if state in ['absent']:
-            network = acs_network.absent_network()
-        else:
-            network = acs_network.present_network()
+    if nsps_enabled is not None:
+        for nsp_name in nsps_enabled:
+            if nsp_name in ['VirtualRouter', 'VpcVirtualRouter']:
+                acs_network.set_vrouter_element_state(enabled=True, nsp_name=nsp_name)
+            elif nsp_name == 'InternalLbVm':
+                acs_network.set_loadbalancer_element_state(enabled=True, nsp_name=nsp_name)
 
-        if nsps_disabled is not None:
-            for name in nsps_disabled:
-                acs_network._update_nsp(name=name, state='Disabled')
+            acs_network.update_nsp(name=nsp_name, state='Enabled')
 
-        if nsps_enabled is not None:
-            for nsp_name in nsps_enabled:
-                if nsp_name in ['VirtualRouter', 'VpcVirtualRouter']:
-                    acs_network.set_vrouter_element_state(enabled=True, nsp_name=nsp_name)
-                elif nsp_name == 'InternalLbVm':
-                    acs_network.set_loadbalancer_element_state(enabled=True, nsp_name=nsp_name)
-
-                acs_network._update_nsp(name=nsp_name, state='Enabled')
-
-        result = acs_network.get_result(network)
-
-    except CloudStackException as e:
-        module.fail_json(msg='CloudStackException: %s' % str(e))
+    result = acs_network.get_result(network)
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
@@ -1,0 +1,493 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2017, Netservers Ltd. <support@netservers.co.uk>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: cs_physical_network
+short_description: Manages physical networks on Apache CloudStack based clouds.
+description:
+    - Create, update and remove networks.
+    - Enabled and disabled Network Service Providers
+    - Enables Internal LoadBalancer and VPC/VirtualRouter elements as required
+version_added: "2.4"
+author: "Netservers Ltd. (@netservers)"
+options:
+  name:
+    description:
+      - name of the network.
+    required: true
+  zone:
+    description:
+      - Name of the zone in which the network belongs.
+      - If not set, default zone is used.
+    required: true
+    default: null
+  broadcastdomainrange:
+    description:
+      - broadcast domain range for the physical network[Pod or Zone].
+    required: false
+    default: none
+    choices: [ 'POD', 'ZONE' ]
+  domain:
+    description:
+      - Domain the network is owned by.
+    required: false
+    default: null
+  isolation_method:
+    description:
+      - Isolation method for the physical network.
+    required: false
+    default: none
+    choices: [ 'VLAN', 'GRE', 'L3' ]
+  network_speed:
+    description:
+      - the speed for the physical network[1G/10G]
+    required: false
+    default: null
+  tags:
+    description:
+      - "A tag to identify this network"
+      - "Physical networks support only one tag"
+      - "To remove an existing tag pass an empty string"
+    required: false
+    default: null
+    aliases:
+      - tag
+  vlan:
+    description:
+      - The VLAN/VNI Ranges of the physical network.
+    required: false
+    default: null
+  nsps_enabled:
+    description:
+      - List of Network Service Providers to enable
+    required: false
+    default: null
+  nsps_disabled:
+    description:
+      - List of Network Service Providers to disable
+    required: false
+    default: null
+  url:
+    description:
+      - URL for the cluster
+    required: false
+    default: null
+  username:
+    description:
+      - Username for the cluster.
+    required: false
+    default: null
+  password:
+    description:
+      - Password for the cluster.
+    required: false
+    default: null
+  state:
+    description:
+      - State of the cluster.
+    required: false
+    default: 'present'
+    choices: [ 'present', 'absent', 'disabled', 'enabled' ]
+extends_documentation_fragment: cloudstack
+'''
+
+EXAMPLES = '''
+# Ensure a network is present
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+
+# Set a tag on a network
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    tag: overlay
+
+# Remove tag on a network
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    tag: ""
+
+# Ensure a network is enabled with specific nsps enabled
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    isolation_method: VLAN
+    vlan: 100-200,300-400
+    broadcast_domain_range: ZONE
+    state: enabled
+    nsps_enabled:
+      - Ovs
+      - VirtualRouter
+      - InternalLbVm
+      - VpcVirtualRouter
+
+# Ensure a network is disabled
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    state: disabled
+
+# Ensure a network is enabled
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    state: enabled
+
+# Ensure a network is absent
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    state: absent
+'''
+
+RETURN = '''
+---
+id:
+  description: UUID of the network.
+  returned: success
+  type: string
+  sample: 3f8f25cd-c498-443f-9058-438cfbcbff50
+name:
+  description: Name of the network.
+  returned: success
+  type: string
+  sample: net01
+state:
+  description: State of the network [Enabled/Disabled].
+  returned: success
+  type: string
+  sample: Enabled
+broadcast_domain_range:
+  description: broadcastdomainrange of the network [POD / ZONE].
+  returned: success
+  type: string
+  sample: ZONE
+isolation_method:
+  description: isolationmethod of the network [VLAN/GRE/L3].
+  returned: success
+  type: string
+  sample: VLAN
+network_speed:
+  description: networkspeed of the network [1G/10G].
+  returned: success
+  type: string
+  sample: 1G
+zone:
+  description: Name of zone the cluster is in.
+  returned: success
+  type: string
+  sample: ch-gva-2
+domain:
+  description: Name of domain the network is in.
+  returned: success
+  type: string
+  sample: domain1
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import (
+    AnsibleCloudStack,
+    CloudStackException,
+    cs_argument_spec,
+    cs_required_together,
+)
+
+
+class AnsibleCloudStackCluster(AnsibleCloudStack):
+
+    def __init__(self, module):
+        super(AnsibleCloudStackCluster, self).__init__(module)
+        self.returns = {
+            'isolationmethods': 'isolation_method',
+            'broadcastdomainrange': 'broadcast_domain_range',
+            'networkspeed': 'network_speed',
+            'vlan': 'vlan',
+            'tags': 'tags',
+        }
+        self.network = None
+        self.nsps = []
+        self.vrouters = None
+        self.loadbalancers = None
+
+    def _get_common_args(self):
+        args = {
+            'name': self.module.params.get('name'),
+            'isolationmethods': self.module.params.get('isolation_method'),
+            'broadcastdomainrange': self.module.params.get('broadcast_domain_range'),
+            'networkspeed': self.module.params.get('network_speed'),
+            'tags': self.module.params.get('tags'),
+            'vlan': self.module.params.get('vlan'),
+        }
+        if args['tags'] and len(args['tags']) > 1:
+            self.module.fail_json(msg="Failed: Physical networks can only have one tag")
+
+        state = self.module.params.get('state')
+        if state in ['enabled', 'disabled']:
+            args['state'] = state.capitalize()
+        return args
+
+    def get_network(self, key=None):
+        if self.network:
+            return self.network
+        args = {
+            'zoneid': self.get_zone(key='id'),
+            'name': self.module.params.get('name'),
+        }
+        nets = self.cs.listPhysicalNetworks(**args)
+        if nets:
+            self.network = nets['physicalnetwork'][0]
+        return self.network
+
+    def get_nsp(self, name=None):
+        if not self.nsps:
+            network = self.get_network()
+            args = {
+                'physicalnetworkid': network['id']
+            }
+            res = self.cs.listNetworkServiceProviders(**args)
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            self.nsps = res['networkserviceprovider']
+
+        names = []
+        for nsp in self.nsps:
+            names.append(nsp['name'])
+            if nsp['name'] == name:
+                return nsp
+
+        self.module.fail_json(msg="Failed: '{}' not in network service providers list '[{}]'".format(name, names))
+
+    def _update_nsp(self, name=None, state=None, service_list=None):
+        nsp = self.get_nsp(name)
+        if not service_list and nsp['state'] == state:
+            return nsp
+
+        args = {
+            'id': nsp['id'],
+            'servicelist': service_list,
+            'state': state
+        }
+        res = self.cs.updateNetworkServiceProvider(**args)
+        if 'errortext' in res:
+            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+
+        self.result['changed'] = True
+        return res
+
+    def get_vrouter_element(self, nsp_name='VirtualRouter'):
+        nsp = self.get_nsp(nsp_name)
+        nspid = nsp['id']
+        if self.vrouters is None:
+            self.vrouters = dict()
+            res = self.cs.listVirtualRouterElements()
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            for vrouter in res['virtualrouterelement']:
+                self.vrouters[vrouter['nspid']] = vrouter
+
+        if nspid not in self.vrouters:
+            self.module.fail_json(msg="Failed: No VirtualRouterElement founf for nsp '%s'" % nsp_name)
+
+        return self.vrouters[nspid]
+
+    def get_loadbalancer_element(self, nsp_name='InternalLbVm'):
+        nsp = self.get_nsp(nsp_name)
+        nspid = nsp['id']
+        if self.loadbalancers is None:
+            self.loadbalancers = dict()
+            res = self.cs.listInternalLoadBalancerElements()
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            for loadbalancer in res['internalloadbalancerelement']:
+                self.loadbalancers[loadbalancer['nspid']] = loadbalancer
+
+            if nspid not in self.loadbalancers:
+                self.module.fail_json(msg="Failed: No Loadbalancer found for nsp '%s'" % nsp_name)
+
+        return self.loadbalancers[nspid]
+
+    def set_vrouter_element_state(self, enabled, nsp_name='VirtualRouter'):
+        vrouter = self.get_vrouter_element(nsp_name)
+        if vrouter['enabled'] == enabled:
+            return vrouter
+
+        args = {
+            'id': vrouter['id'],
+            'enabled': enabled
+        }
+        res = self.cs.configureVirtualRouterElement(**args)
+        if 'errortext' in res:
+            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+
+        self.result['changed'] = True
+        return res
+
+    def set_loadbalancer_element_state(self, enabled, nsp_name='InternalLbVm'):
+        loadbalancer = self.get_loadbalancer_element(nsp_name=nsp_name)
+        if loadbalancer['enabled'] == enabled:
+            return loadbalancer
+
+        args = {
+            'id': loadbalancer['id'],
+            'enabled': enabled
+        }
+        res = self.cs.configureInternalLoadBalancerElement(**args)
+        if 'errortext' in res:
+            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+
+        self.result['changed'] = True
+        return res
+
+    def present_network(self):
+        network = self.get_network()
+        if network:
+            network = self._update_network()
+        else:
+            network = self._create_network()
+        return network
+
+    def _create_network(self):
+        required_params = [
+            'name',
+            'zone',
+        ]
+        self.module.fail_on_missing_params(required_params=required_params)
+
+        args = self._get_common_args()
+        args['zoneid'] = self.get_zone(key='id')
+        args['domainid'] = self.get_domain(key='id')
+        args['url'] = self.module.params.get('url')
+        args['username'] = self.module.params.get('username')
+        args['password'] = self.module.params.get('password')
+
+        self.result['changed'] = True
+
+        id = None
+        if not self.module.check_mode:
+            res = self.cs.createPhysicalNetwork(**args)
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            id = res['id']
+        return id
+
+    def _update_network(self):
+        network = self.get_network()
+
+        args = self._get_common_args()
+        args['id'] = network['id']
+
+        if self.has_changed(args, network):
+            self.result['changed'] = True
+
+            if not self.module.check_mode:
+                res = self.cs.updatePhysicalNetwork(**args)
+                if 'errortext' in res:
+                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        return network
+
+    def absent_network(self):
+        network = self.get_network()
+        if network:
+            self.result['changed'] = True
+
+            args = {
+                'id': network['id'],
+            }
+            if not self.module.check_mode:
+                res = self.cs.deletePhysicalNetwork(**args)
+                if 'errortext' in res:
+                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        return network
+
+
+def main():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        zone=dict(default=None),
+        domain=dict(default=None),
+        vlan=dict(default=None),
+        nsps_disabled=dict(default=None, type='list'),
+        nsps_enabled=dict(default=None, type='list'),
+        network_speed=dict(choices=['1G', '10G'], default=None),
+        broadcast_domain_range=dict(choices=['POD', 'ZONE'], default=None),
+        isolation_method=dict(choices=['VLAN', 'GRE', 'L3'], default=None),
+        state=dict(choices=['present', 'enabled', 'disabled', 'absent'], default='present'),
+        url=dict(default=None),
+        username=dict(default=None),
+        password=dict(default=None, no_log=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=cs_required_together(),
+        supports_check_mode=True
+    )
+
+    try:
+        acs_network = AnsibleCloudStackCluster(module)
+
+        state = module.params.get('state')
+        nsps_disabled = module.params.get('nsps_disabled', [])
+        nsps_enabled = module.params.get('nsps_enabled', [])
+
+        if state in ['absent']:
+            network = acs_network.absent_network()
+        else:
+            network = acs_network.present_network()
+
+        if nsps_disabled is not None:
+            for name in nsps_disabled:
+                acs_network._update_nsp(name=name, state='Disabled')
+
+        if nsps_enabled is not None:
+            for nsp_name in nsps_enabled:
+                if nsp_name in ['VirtualRouter', 'VpcVirtualRouter']:
+                    acs_network.set_vrouter_element_state(enabled=True, nsp_name=nsp_name)
+                elif nsp_name == 'InternalLbVm':
+                    acs_network.set_loadbalancer_element_state(enabled=True, nsp_name=nsp_name)
+
+                acs_network._update_nsp(name=nsp_name, state='Enabled')
+
+        result = acs_network.get_result(network)
+
+    except CloudStackException as e:
+        module.fail_json(msg='CloudStackException: %s' % str(e))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_traffic_type.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_traffic_type.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2019, Patryk D. Cichy <patryk.d.cichy@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: cs_traffic_type
+short_description: Manages traffic types on Cloudstach Physical Networks
+description:
+ - Add, remove, update Traffic Types assiciated with Cloudstack Physical Networks.
+extends_documentation_fragment: cloudstack
+version_added: "2.8"
+author:
+ - Patryk Cichy (@PatTheSilent)
+options:
+  physical_network:
+    description:
+      - the name of the Physical Network
+    required: true
+  zone:
+    description:
+      - Name of the zone with the physical network.
+      - Default zone will be used if this is empty.
+    required: false
+  traffic_type:
+    description:
+      - the trafficType to be added to the physical network
+    required: true
+    choices: [Management, Guest, Public, Storage]
+  state:
+    description:
+      - State of the traffic type
+    choices: [present, absent]
+    default: present
+  hyperv_networklabel:
+    description:
+      - The network name label of the physical device dedicated to this traffic on a Hyperv host
+    required: false
+  isolation_method:
+    description:
+      - Use if the physical network has multiple isolation types and traffic type is public.
+    choices: [vlan, vxlan]
+    required: false
+  kvm_networklabel:
+    description:
+      - The network name label of the physical device dedicated to this traffic on a KVM host
+    required: false
+  ovm3_networklabel:
+    description:
+      - The network name of the physical device dedicated to this traffic on an OVM3 host
+    required: false
+  vlan:
+    description:
+      - The VLAN id to be used for Management traffic by VMware host
+    required: false
+  vmware_networklabel:
+    description:
+      - The network name label of the physical device dedicated to this traffic on a VMware host
+    required: false
+  xen_networklabel:
+    description:
+      - The network name label of the physical device dedicated to this traffic on a XenServer host
+    required: false
+  poll_async:
+    description:
+      - Poll async jobs until job has finished.
+    required: false
+    default: true
+'''
+
+EXAMPLES = '''
+
+'''
+
+RETURN = '''
+---
+id:
+  description: ID of the network provider
+  returned: success
+  type: str
+  sample: 659c1840-9374-440d-a412-55ca360c9d3c
+traffic_type:
+  description: the trafficType that was added to the physical network
+  returned: success
+  type: str
+  sample: Public
+hyperv_networklabel:
+  description: The network name label of the physical device dedicated to this traffic on a HyperV host
+  returned: success
+  type: str
+  sample: HyperV Internal Switch
+kvm_networklabel:
+  description: The network name label of the physical device dedicated to this traffic on a KVM host
+  returned: success
+  type: str
+  sample: cloudbr0
+ovm3_networklabel:
+  description: The network name of the physical device dedicated to this traffic on an OVM3 host
+  returned: success
+  type: str
+  sample: cloudbr0
+physicalnetwork_id:
+  description: the physical network this belongs to
+  returned: success
+  type: str
+  sample: 28ed70b7-9a1f-41bf-94c3-53a9f22da8b6
+vmware_networklabel:
+  description: The network name label of the physical device dedicated to this traffic on a VMware host
+  returned: success
+  type: str
+  sample: Management Network
+xen_networklabel:
+  description: The network name label of the physical device dedicated to this traffic on a XenServer host
+  returned: success
+  type: str
+  sample: xenbr0
+zone:
+  description: Name of zone the physical network is in.
+  returned: success
+  type: str
+  sample: ch-gva-2
+'''
+
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
+from ansible.module_utils.basic import AnsibleModule
+
+
+class AnsibleCloudStackTrafficType(AnsibleCloudStack):
+
+    def __init__(self, module):
+        super(AnsibleCloudStackTrafficType, self).__init__(module)
+        self.returns = {
+            'traffictype': 'traffic_type',
+            'hypervnetworklabel': 'hyperv_networklabel',
+            'kvmnetworklabel': 'kvm_networklabel',
+            'ovm3networklabel': 'ovm3_networklabel',
+            'physicalnetworkid': 'physicalnetwork_id',
+            'vmwarenetworklabel': 'vmware_networklabel',
+            'xennetworklabel': 'xen_networklabel'
+        }
+
+        self.traffic_type = None
+
+    def _get_label_args(self):
+        label_args = dict()
+        if self.module.params.get('hyperv_networklabel'):
+            label_args.update(dict(hypervnetworklabel=self.module.params.get('hyperv_networklabel')))
+        if self.module.params.get('kvm_networklabel'):
+            label_args.update(dict(kvmnetworklabel=self.module.params.get('kvm_networklabel')))
+        if self.module.params.get('ovm3_networklabel'):
+            label_args.update(dict(ovm3networklabel=self.module.params.get('ovm3_networklabel')))
+        if self.module.params.get('vmware_networklabel'):
+            label_args.update(dict(vmwarenetworklabel=self.module.params.get('vmware_networklabel')))
+        return label_args
+
+    def _get_additional_args(self):
+        additional_args = dict()
+
+        if self.module.params.get('isolation_method'):
+            additional_args.update(dict(isolationmethod=self.module.params.get('isolation_method')))
+
+        if self.module.params.get('vlan'):
+            additional_args.update(dict(vlan=self.module.params.get('vlan')))
+
+        additional_args.update(self._get_label_args())
+
+        return additional_args
+
+    def get_traffic_types(self):
+        args = {
+            'physicalnetworkid': self.get_physical_network(key='id')
+        }
+        traffic_types = self.query_api('listTrafficTypes', **args)
+        return traffic_types
+
+    def get_traffic_type(self):
+        if self.traffic_type:
+            return self.traffic_type
+
+        traffic_type = self.module.params.get('traffic_type')
+
+        traffic_types = self.get_traffic_types()
+
+        if traffic_types:
+            for t_type in traffic_types['traffictype']:
+                if traffic_type.lower() in [t_type['traffictype'].lower(), t_type['id']]:
+                    self.traffic_type = t_type
+                    break
+        return self.traffic_type
+
+    def present_traffic_type(self):
+        traffic_type = self.get_traffic_type()
+        if traffic_type:
+            self.traffic_type = self.update_traffic_type()
+        else:
+            self.result['changed'] = True
+            self.traffic_type = self.add_traffic_type()
+
+        return self.traffic_type
+
+    def add_traffic_type(self):
+        traffic_type = self.module.params.get('traffic_type')
+        args = {
+            'physicalnetworkid': self.get_physical_network(key='id'),
+            'traffictype': traffic_type
+        }
+        args.update(self._get_additional_args())
+        if not self.module.check_mode:
+            resource = self.query_api('addTrafficType', **args)
+            poll_async = self.module.params.get('poll_async')
+            if poll_async:
+                self.traffic_type = self.poll_job(resource, 'traffictype')
+        return self.traffic_type
+
+    def absent_traffic_type(self):
+        traffic_type = self.get_traffic_type()
+        if traffic_type:
+
+            args = {
+                'id': traffic_type['id']
+            }
+            self.result['changed'] = True
+            if not self.module.check_mode:
+                resource = self.query_api('deleteTrafficType', **args)
+                poll_async = self.module.params.get('poll_async')
+                if poll_async:
+                    self.poll_job(resource, 'traffictype')
+
+        return traffic_type
+
+    def update_traffic_type(self):
+
+        traffic_type = self.get_traffic_type()
+        args = {
+            'id': traffic_type['id']
+        }
+        args.update(self._get_label_args())
+        if self.has_changed(args, traffic_type):
+            self.result['changed'] = True
+            if not self.module.check_mode:
+                resource = self.query_api('updateTrafficType', **args)
+                poll_async = self.module.params.get('poll_async')
+                if poll_async:
+                    self.traffic_type = self.poll_job(resource, 'traffictype')
+
+        return self.traffic_type
+
+
+def setup_module_object():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(dict(
+        physical_network=dict(required=True),
+        zone=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+        traffic_type=dict(required=True, choices=['Management', 'Guest', 'Public', 'Storage']),
+        hyperv_networklabel=dict(),
+        isolation_method=dict(choices=['vlan', 'vxlan']),
+        kvm_networklabel=dict(),
+        ovm3_networklabel=dict(),
+        vlan=dict(),
+        vmware_networklabel=dict(),
+        xen_networklabel=dict(),
+        poll_async=dict(type=bool, default=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=cs_required_together(),
+        supports_check_mode=True
+    )
+    return module
+
+
+def execute_module(module):
+    actt = AnsibleCloudStackTrafficType(module)
+    state = module.params.get('state')
+
+    if state in ['present']:
+        result = actt.present_traffic_type()
+    else:
+        result = actt.absent_traffic_type()
+
+    return actt.get_result(result)
+
+
+def main():
+    module = setup_module_object()
+    result = execute_module(module)
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/cs_physical_network/aliases
+++ b/test/integration/targets/cs_physical_network/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_physical_network/meta/main.yml
+++ b/test/integration/targets/cs_physical_network/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/test/integration/targets/cs_physical_network/tasks/main.yml
+++ b/test/integration/targets/cs_physical_network/tasks/main.yml
@@ -1,0 +1,205 @@
+---
+# Create a new zone - the default one is enabled
+- name: assure zone for tests
+  cs_zone:
+    name: cs-test-zone
+    state: present
+    dns1: 8.8.8.8
+    network_type: advanced
+  register: cszone
+
+- name: ensure the zone is disabled
+  cs_zone:
+    name: "{{ cszone.name }}"
+    state: disabled
+  register: cszone
+
+- name: setup a network in check_mode
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+  check_mode: yes
+  register: pn
+- name: validate setup a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.zone == cszone.name
+
+- name: setup a network
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+  register: pn
+- name: validate setup a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.state == 'Disabled'
+
+- name: setup a network idempotence
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+  register: pn
+- name: validate setup a network idempotence
+  assert:
+    that:
+      - pn is successful
+      - pn is not changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.state == 'Disabled'
+
+- name: set a tag on a network
+  cs_physical_network:
+    name: net01
+    tag: overlay
+    zone: "{{ cszone.name }}"
+  ignore_errors: true
+  register: pn
+- name: validate set a tag on a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags == 'overlay'
+      - pn.state == 'Disabled'
+
+- name: Remove tag on a network
+  cs_physical_network:
+    name: net01
+    tag: ""
+    zone: "{{ cszone.name }}"
+  register: pn
+- name: validate remove tag on a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags is undefined
+      - pn.state == 'Disabled'
+
+- name: ensure a network is enabled with specific nsps enabled
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    vlan: 100-200,300-400
+    broadcast_domain_range: ZONE
+    state: enabled
+    nsps_enabled:
+      - VirtualRouter
+      - InternalLbVm
+      - VpcVirtualRouter
+  register: pn
+- name: validate ensure a network is enabled with specific nsps enabled
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.vlan == '100-200,300-400'
+      - pn.state == 'Enabled'
+
+- name: ensure a network is disabled
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: disabled
+  register: pn
+- name: validate ensure a network is disabled
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags is undefined
+      - pn.state == 'Disabled'
+
+- name: ensure a network is enabled
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: enabled
+  register: pn
+- name: validate ensure a network is enabled
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags is undefined
+      - pn.state == 'Enabled'
+
+- name: ensure a network is not absent in check mode
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: absent
+  check_mode: yes
+  register: pn
+- name: validate ensure a network is absent
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.zone == cszone.name
+
+- name: ensure a network is absent
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: absent
+  register: pn
+- name: validate ensure a network is absent
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.zone == cszone.name
+      - pn.name == 'net01'
+
+- name: ensure a network is absent idempotence
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: absent
+  register: pn
+- name: validate ensure a network is absent idempotence
+  assert:
+    that:
+      - pn is successful
+      - pn is not changed
+      - pn.zone == cszone.name

--- a/test/integration/targets/cs_traffic_type/aliases
+++ b/test/integration/targets/cs_traffic_type/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_traffic_type/meta/main.yml
+++ b/test/integration/targets/cs_traffic_type/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/test/integration/targets/cs_traffic_type/tasks/main.yml
+++ b/test/integration/targets/cs_traffic_type/tasks/main.yml
@@ -1,0 +1,163 @@
+---
+# Create a new zone - the default one is enabled
+- name: assure zone for tests
+  cs_zone:
+    name: cs-test-zone
+    state: present
+    dns1: 8.8.8.8
+    network_type: advanced
+  register: cszone
+
+- name: ensure the zone is disabled
+  cs_zone:
+    name: "{{ cszone.name }}"
+    state: disabled
+  register: cszone
+
+- name: setup a network
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+  ignore_errors: true
+  register: pn
+
+
+- name: fail on missing params
+  cs_traffic_type:
+  ignore_errors: true
+  register: tt
+- name: validate fail on missing params
+  assert:
+    that:
+      - tt is failed
+      - 'tt.msg == "missing required arguments: physical_network, traffic_type"'
+
+- name: add a traffic type in check mode
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Guest
+    zone: "{{ pn.zone }}"
+  register: tt
+  check_mode: yes
+- name: validate add a traffic type in check mode
+  assert:
+    that:
+      - tt is changed
+      - tt.zone == pn.zone
+
+- name: add a traffic type
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Guest
+    zone: "{{ pn.zone }}"
+  register: tt
+- name: validate add a traffic type
+  assert:
+    that:
+      - tt is changed
+      - tt.physical_network == pn.name
+      - tt.traffic_type == 'Guest'
+      - tt.zone == pn.zone
+
+- name: add a traffic type idempotence
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Guest
+    zone: "{{ pn.zone }}"
+  register: tt
+- name: validate add a traffic type idempotence
+  assert:
+    that:
+      - tt is not changed
+      - tt.physical_network == pn.name
+      - tt.traffic_type == 'Guest'
+      - tt.zone == pn.zone
+
+- name: update traffic type
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Guest
+    kvm_networklabel: cloudbr0
+    zone: "{{ pn.zone }}"
+  register: tt
+- name: validate update traffic type
+  assert:
+    that:
+      - tt is changed
+      - tt.physical_network == pn.name
+      - tt.traffic_type == 'Guest'
+      - tt.zone == pn.zone
+      - tt.kvm_networklabel == 'cloudbr0'
+
+- name: update traffic type idempotence
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Guest
+    kvm_networklabel: cloudbr0
+    zone: "{{ pn.zone }}"
+  register: tt
+- name: validate update traffic type idempotence
+  assert:
+    that:
+      - tt is not changed
+      - tt.physical_network == pn.name
+      - tt.traffic_type == 'Guest'
+      - tt.zone == pn.zone
+      - tt.kvm_networklabel == 'cloudbr0'
+
+- name: add a removable traffic type
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Public
+    kvm_networklabel: cloudbr1
+    zone: "{{ pn.zone }}"
+  register: tt
+- name: validate add a removable traffic type
+  assert:
+    that:
+      - tt is changed
+      - tt.physical_network == pn.name
+      - tt.traffic_type == 'Public'
+      - tt.zone == pn.zone
+      - tt.kvm_networklabel == 'cloudbr1'
+
+- name: remove traffic type in check mode
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Public
+    state: absent
+    zone: "{{ pn.zone }}"
+  check_mode: yes
+  register: tt
+- name: validate remove traffic type in check mode
+  assert:
+    that:
+      - tt is changed
+
+- name: remove traffic type
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Public
+    state: absent
+    zone: "{{ pn.zone }}"
+  register: tt
+- name: validate remove traffic type
+  assert:
+    that:
+      - tt is changed
+      - tt.zone == pn.zone
+
+- name: remove traffic type idempotence
+  cs_traffic_type:
+    physical_network: "{{ pn.name }}"
+    traffic_type: Public
+    state: absent
+    zone: "{{ pn.zone }}"
+  register: tt
+- name: validate
+  assert:
+    that:
+      - tt is not changed
+      - tt.zone == pn.zone

--- a/test/units/modules/cloud/cloudstack/test_cs_traffic_type.py
+++ b/test/units/modules/cloud/cloudstack/test_cs_traffic_type.py
@@ -1,0 +1,120 @@
+from ansible.modules.cloud.cloudstack.cs_traffic_type import AnsibleCloudStackTrafficType, \
+    setup_module_object
+from units.modules.utils import set_module_args
+from units.compat.mock import MagicMock
+import units.compat.unittest as unittest
+from units.compat.unittest import TestCase
+
+EXISTING_TRAFFIC_TYPES_RESPONSE = {
+  "count": 3,
+  "traffictype": [
+    {
+      "id": "9801cf73-5a73-4883-97e4-fa20c129226f",
+      "kvmnetworklabel": "cloudbr0",
+      "physicalnetworkid": "659c1840-9374-440d-a412-55ca360c9d3c",
+      "traffictype": "Management"
+    },
+    {
+      "id": "28ed70b7-9a1f-41bf-94c3-53a9f22da8b6",
+      "kvmnetworklabel": "cloudbr0",
+      "physicalnetworkid": "659c1840-9374-440d-a412-55ca360c9d3c",
+      "traffictype": "Guest"
+    },
+    {
+      "id": "9c05c802-84c0-4eda-8f0a-f681364ffb46",
+      "kvmnetworklabel": "cloudbr0",
+      "physicalnetworkid": "659c1840-9374-440d-a412-55ca360c9d3c",
+      "traffictype": "Storage"
+    }
+  ]
+}
+
+VALID_LIST_NETWORKS_RESPONSE = {
+  "count": 1,
+  "physicalnetwork": [
+    {
+      "broadcastdomainrange": "ZONE",
+      "id": "659c1840-9374-440d-a412-55ca360c9d3c",
+      "name": "eth1",
+      "state": "Enabled",
+      "vlan": "3900-4000",
+      "zoneid": "49acf813-a8dd-4da0-aa53-1d826d6003e7"
+    }
+  ]
+}
+
+VALID_LIST_ZONES_RESPONSE = {
+  "count": 1,
+  "zone": [
+    {
+      "allocationstate": "Enabled",
+      "dhcpprovider": "VirtualRouter",
+      "dns1": "8.8.8.8",
+      "dns2": "8.8.4.4",
+      "guestcidraddress": "10.10.0.0/16",
+      "id": "49acf813-a8dd-4da0-aa53-1d826d6003e7",
+      "internaldns1": "192.168.56.1",
+      "localstorageenabled": True,
+      "name": "DevCloud-01",
+      "networktype": "Advanced",
+      "securitygroupsenabled": False,
+      "tags": [],
+      "zonetoken": "df20d65a-c6c8-3880-9064-4f77de2291ef"
+    }
+  ]
+}
+
+
+base_module_args = {
+    "api_key": "api_key",
+    "api_secret": "very_secret_content",
+    "api_url": "http://localhost:8888/api/client",
+    "kvm_networklabel": "cloudbr0",
+    "physical_network": "eth1",
+    "poll_async": True,
+    "state": "present",
+    "traffic_type": "Guest",
+    "zone": "DevCloud-01"
+}
+
+
+class TestAnsibleCloudstackTraffiType(TestCase):
+
+    def test_module_is_created_sensibly(self):
+        set_module_args(base_module_args)
+        module = setup_module_object()
+        assert module.params['traffic_type'] == 'Guest'
+
+    def test_update_called_when_traffic_type_exists(self):
+        set_module_args(base_module_args)
+        module = setup_module_object()
+        actt = AnsibleCloudStackTrafficType(module)
+        actt.get_traffic_type = MagicMock(return_value=EXISTING_TRAFFIC_TYPES_RESPONSE['traffictype'][0])
+        actt.update_traffic_type = MagicMock()
+        actt.present_traffic_type()
+        self.assertTrue(actt.update_traffic_type.called)
+
+    def test_update_not_called_when_traffic_type_doesnt_exist(self):
+        set_module_args(base_module_args)
+        module = setup_module_object()
+        actt = AnsibleCloudStackTrafficType(module)
+        actt.get_traffic_type = MagicMock(return_value=None)
+        actt.update_traffic_type = MagicMock()
+        actt.add_traffic_type = MagicMock()
+        actt.present_traffic_type()
+        self.assertFalse(actt.update_traffic_type.called)
+        self.assertTrue(actt.add_traffic_type.called)
+
+    def test_traffic_type_returned_if_exists(self):
+        set_module_args(base_module_args)
+        module = setup_module_object()
+        actt = AnsibleCloudStackTrafficType(module)
+        actt.get_physical_network = MagicMock(return_value=VALID_LIST_NETWORKS_RESPONSE['physicalnetwork'][0])
+        actt.get_traffic_types = MagicMock(return_value=EXISTING_TRAFFIC_TYPES_RESPONSE)
+        tt = actt.present_traffic_type()
+        self.assertTrue(tt.get('kvmnetworklabel') == base_module_args['kvm_networklabel'])
+        self.assertTrue(tt.get('traffictype') == base_module_args['traffic_type'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Additional network support for Cloudstack

Add a `get_physical_network` method to Cloudstack module utilities.
Add a new `cs_physical_network` module - resubmit of #25647
Add a new `cs_traffic_type` module

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
module_utils/cloudstack.py
cs_physical_network
cs_traffic_type

##### ADDITIONAL INFORMATION
`get_physical_network` copies the logic of `get_network` from the same class. 
#25647 resubmitted - rebased with adaptation to new APIs
`cs_traffic_type` - new module providing support for Cloudstack Traffic Types
