### PR TITLE
Add send string to wait_for module

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -87,7 +87,7 @@ options:
       - String to send to socket
       - Defaults to None.
     type: str
-    version_added: "2.7"
+    version_added: "2.8"
   exclude_hosts:
     description:
       - List of hosts or IPs to ignore when looking for active TCP connections for C(drained) state.
@@ -461,7 +461,7 @@ def _create_connection(host, port, connect_timeout, send_string=None):
         connect_socket.connect((host, port))
     else:
         connect_socket = socket.create_connection((host, port), connect_timeout)
-    if send_string != None:
+    if send_string is not None:
         connect_socket.sendall(bytes(send_string))
     return connect_socket
 

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -84,7 +84,8 @@ options:
     version_added: "1.4"
   send_string:
     description:
-      - String to send to socket
+      - String to send to socket. Can be used for any service which expect some handshake message.
+      - For example: You can send a string with the ssh version and have clear auth.log.
       - Defaults to None.
     type: str
     version_added: "2.8"

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -85,7 +85,7 @@ options:
   send_string:
     description:
       - String to send to socket. Can be used for any service which expect some handshake message.
-      - For example: You can send a string with the ssh version and have clear auth.log.
+      - For example, You can send a string with the ssh version and have clear auth.log.
       - Defaults to None.
     type: str
     version_added: "2.8"

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -160,6 +160,5 @@
     host: 'localhost'
     port: 22
     search_regex: OpenSSH
-    send_string: 'SSH-2.0-OpenSSH_7.4p1\n'
+    request: 'SSH-2.0-OpenSSH_7.4p1\n'
     delay: 10
-

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -154,3 +154,12 @@
       - waitfor is successful
       - waitfor is not changed
       - "waitfor.port == {{ http_port }}"
+
+- name: test wait for ssh with clear log
+  wait_for:
+    host: 'localhost'
+    port: 22
+    search_regex: OpenSSH
+    request: 'SSH-2.0-OpenSSH_7.4p1\n'
+    delay: 10
+

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -160,6 +160,6 @@
     host: 'localhost'
     port: 22
     search_regex: OpenSSH
-    request: 'SSH-2.0-OpenSSH_7.4p1\n'
+    send_string: 'SSH-2.0-OpenSSH_7.4p1\n'
     delay: 10
 


### PR DESCRIPTION
##### SUMMARY
Useful for checking ssh server. You can send a string with the ssh version and have clear auth.log, without messages like 
```
Did not receive identification string from
```
Fixes #54024 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module **wait_for**

##### ADDITIONAL INFORMATION
Add the ability to send any string to the socket. This may remove annoying errors in auth.log.

Without this patch during ssh server checks you'll see in auth.log:
```
sshd[20751]: Did not receive identification string from ::1 port 54116
```
With patch and with the given parameter *send_string* equal to the *"SSH-2.0-OpenSSH_7.4p1\n"* there is no errors:
```
sshd[20993]: Connection closed by ::1 port 54120 [preauth]
```