### PR TITLE
tower_settings: "get" isn't implemented, "value" parameter is required

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -26,9 +26,11 @@ options:
     name:
       description:
         - Name of setting to modify
+      required: True
     value:
       description:
         - Value to be modified for given setting.
+      required: True
 extends_documentation_fragment: tower
 '''
 
@@ -67,8 +69,8 @@ except ImportError:
 
 def main():
     argument_spec = dict(
-        name=dict(Required=True),
-        value=dict(Required=True),
+        name=dict(required=True),
+        value=dict(required=True),
     )
 
     module = TowerModule(

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -20,12 +20,12 @@ author: "Nikhil Jain (@jainnikhil30)"
 version_added: "2.7"
 short_description: Modify Ansible Tower settings.
 description:
-    - Get, Modify Ansible Tower settings. See
+    - Modify Ansible Tower settings. See
       U(https://www.ansible.com/tower) for an overview.
 options:
     name:
       description:
-        - Name of setting to get/modify
+        - Name of setting to modify
     value:
       description:
         - Value to be modified for given setting.


### PR DESCRIPTION
##### SUMMARY
tower_settings module:
* `get` isn't implemented: update docstrings
* `value` parameter is required
  * fix typo in `argument_spec`
  * update doc

Thanks to `sg10` for pointing this issue on `#ansible-awx` IRC channel.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower_settings

##### ADDITIONAL INFORMATION
I didn't find any other Ansible module using `Required` instead of `required`.