### PR TITLE
Add platform support matrix

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -123,7 +123,6 @@ In this example the ``proxy_env`` variable defined in ``group_vars`` gets passed
 
 .. include:: shared_snippets/SSH_warning.txt
 
-***********************************
 Cisco Nexus Platform Support Matrix
 ***********************************
 

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -126,7 +126,7 @@ In this example the ``proxy_env`` variable defined in ``group_vars`` gets passed
 Cisco Nexus Platform Support Matrix
 ===================================
 
-The following platforms and software versions have been certified to work with this version of Ansible.
+The following platforms and software versions have been certified by Cisco to work with this version of Ansible.
 
   .. table:: Platform / Software Mininum Requirements
      :widths: auto

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -124,7 +124,7 @@ In this example the ``proxy_env`` variable defined in ``group_vars`` gets passed
 .. include:: shared_snippets/SSH_warning.txt
 
 Cisco Nexus Platform Support Matrix
-***********************************
+===================================
 
 The following platforms and software versions have been certified to work with this version of Ansible.
 

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -122,3 +122,37 @@ Example NX-API Task
 In this example the ``proxy_env`` variable defined in ``group_vars`` gets passed to the ``environment`` option of the module used in the task.
 
 .. include:: shared_snippets/SSH_warning.txt
+
+***********************************
+Cisco Nexus Platform Support Matrix
+***********************************
+
+The following platforms and software versions have been certified to work with this version of Ansible.
+
+  .. table:: Platform / Software Mininum Requirements
+     :widths: auto
+     :align: center
+
+     ===================  =====================
+     Supported Platforms  Minimum NX-OS Version
+     ===================  =====================
+     Cisco Nexus N3k      7.0(3)I2(5) and later
+     Cisco Nexus N9k      7.0(3)I2(5) and later
+     Cisco Nexus N5k      7.3(0)N1(1) and later
+     Cisco Nexus N6k      7.3(0)N1(1) and later
+     Cisco Nexus N7k      7.3(0)D1(1) and later
+     ===================  =====================
+
+  .. table:: Platform Models
+     :widths: auto
+     :align: center
+
+     ========  ===========
+     Platform  Description
+     ========  ===========
+     N3k       Support includes N30xx, N31xx and N35xx models
+     N5k       Support includes all N5xxx models
+     N6k       Support includes all N6xxx models
+     N7k       Support includes all N7xxx models
+     N9k       Support includes all N9xxx models
+     ========  ===========


### PR DESCRIPTION
##### SUMMARY
Update nxos platform documentation to include a support matrix.

We often get questions about which platforms we have certified the nxos modules against.  This matrix provides a single pointer that we can share.

**NOTE:** Not sure if this is the best place for it but I could not find any other locations that looked suitable. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
nxos modules 
