### PR TITLE
VMware: Tag various VMware objects

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -74,7 +74,7 @@ EXAMPLES = r'''
     state: add
   delegate_to: localhost
 
-- name: Remove a tag to a virtual machine
+- name: Remove a tag from a virtual machine
   vmware_tag_manager:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -87,7 +87,7 @@ EXAMPLES = r'''
     state: remove
   delegate_to: localhost
 
-- name: Add a tags to a distributed virtual switch
+- name: Add tags to a distributed virtual switch
   vmware_tag_manager:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -100,7 +100,7 @@ EXAMPLES = r'''
     state: add
   delegate_to: localhost
 
-- name: Add a tags to a distributed virtual portgroup
+- name: Add tags to a distributed virtual portgroup
   vmware_tag_manager:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -50,7 +50,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, VmwareDistributedVirtualSwitch, DistributedVirtualPortgroup ]
+      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup ]
     object_name:
       description:
       - Name of the object to work with.
@@ -96,7 +96,7 @@ EXAMPLES = r'''
     tag_names:
       - Sample_Tag_0003
     object_name: Switch_0001
-    object_type: VmwareDistributedVirtualSwitch
+    object_type: DistributedVirtualSwitch
     state: add
   delegate_to: localhost
 
@@ -167,8 +167,9 @@ class VmwareTagManager(VmwareRestClient):
         if self.object_type == 'HostSystem':
             self.managed_object = self.pyv.find_hostsystem_by_name(self.object_name)
 
-        if self.object_type == 'VmwareDistributedVirtualSwitch':
+        if self.object_type == 'DistributedVirtualSwitch':
             self.managed_object = find_dvs_by_name(self.pyv.content, self.object_name)
+            self.object_type = 'VmwareDistributedVirtualSwitch'
 
         if self.object_type == 'DistributedVirtualPortgroup':
             dvs_name, pg_name = self.object_name.split(":", 1)
@@ -269,7 +270,7 @@ def main():
         state=dict(type='str', choices=['absent', 'add', 'present', 'remove', 'set'], default='add'),
         object_name=dict(type='str', required=True),
         object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource',
-                                                             'HostSystem', 'VmwareDistributedVirtualSwitch',
+                                                             'HostSystem', 'DistributedVirtualSwitch',
                                                              'DistributedVirtualPortgroup']),
     )
     module = AnsibleModule(argument_spec=argument_spec)

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -50,7 +50,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, VmwareDistributedVirtualSwitch, DistributedVirtualPortgroup ]
+      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, VmwareDistributedVirtualSwitch, DistributedVirtualPortgroup ]
     object_name:
       description:
       - Name of the object to work with.
@@ -157,12 +157,15 @@ class VmwareTagManager(VmwareRestClient):
 
         if self.object_type == 'VirtualMachine':
             self.managed_object = self.pyv.get_vm_or_template(self.object_name)
-        
+
         if self.object_type == 'Datacenter':
             self.managed_object = self.pyv.find_datacenter_by_name(self.object_name)
 
         if self.object_type == 'ClusterComputeResource':
             self.managed_object = self.pyv.find_cluster_by_name(self.object_name)
+
+        if self.object_type == 'HostSystem':
+            self.managed_object = self.pyv.find_hostsystem_by_name(self.object_name)
 
         if self.object_type == 'VmwareDistributedVirtualSwitch':
             self.managed_object = find_dvs_by_name(self.pyv.content, self.object_name)
@@ -265,7 +268,8 @@ def main():
         tag_names=dict(type='list', required=True),
         state=dict(type='str', choices=['absent', 'add', 'present', 'remove', 'set'], default='add'),
         object_name=dict(type='str', required=True),
-        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource', 'VmwareDistributedVirtualSwitch', 'DistributedVirtualPortgroup']),
+        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource', 
+        'HostSystem', 'VmwareDistributedVirtualSwitch', 'DistributedVirtualPortgroup']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -50,7 +50,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, VmwareDistributedVirtualSwitch, DistributedVirtualPortgroup ]
+      choices: [ VirtualMachine, Datacenter, VmwareDistributedVirtualSwitch, DistributedVirtualPortgroup ]
     object_name:
       description:
       - Name of the object to work with.
@@ -157,6 +157,9 @@ class VmwareTagManager(VmwareRestClient):
 
         if self.object_type == 'VirtualMachine':
             self.managed_object = self.pyv.get_vm_or_template(self.object_name)
+        
+        if self.object_type == 'Datacenter':
+            self.managed_object = self.pyv.find_datacenter_by_name(self.object_name)
 
         if self.object_type == 'VmwareDistributedVirtualSwitch':
             self.managed_object = find_dvs_by_name(self.pyv.content, self.object_name)
@@ -259,7 +262,7 @@ def main():
         tag_names=dict(type='list', required=True),
         state=dict(type='str', choices=['absent', 'add', 'present', 'remove', 'set'], default='add'),
         object_name=dict(type='str', required=True),
-        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'VmwareDistributedVirtualSwitch', 'DistributedVirtualPortgroup']),
+        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter','VmwareDistributedVirtualSwitch', 'DistributedVirtualPortgroup']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -50,7 +50,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, Datacenter, VmwareDistributedVirtualSwitch, DistributedVirtualPortgroup ]
+      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, VmwareDistributedVirtualSwitch, DistributedVirtualPortgroup ]
     object_name:
       description:
       - Name of the object to work with.
@@ -161,6 +161,9 @@ class VmwareTagManager(VmwareRestClient):
         if self.object_type == 'Datacenter':
             self.managed_object = self.pyv.find_datacenter_by_name(self.object_name)
 
+        if self.object_type == 'ClusterComputeResource':
+            self.managed_object = self.pyv.find_cluster_by_name(self.object_name)
+
         if self.object_type == 'VmwareDistributedVirtualSwitch':
             self.managed_object = find_dvs_by_name(self.pyv.content, self.object_name)
 
@@ -262,7 +265,7 @@ def main():
         tag_names=dict(type='list', required=True),
         state=dict(type='str', choices=['absent', 'add', 'present', 'remove', 'set'], default='add'),
         object_name=dict(type='str', required=True),
-        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter','VmwareDistributedVirtualSwitch', 'DistributedVirtualPortgroup']),
+        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource', 'VmwareDistributedVirtualSwitch', 'DistributedVirtualPortgroup']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -268,8 +268,9 @@ def main():
         tag_names=dict(type='list', required=True),
         state=dict(type='str', choices=['absent', 'add', 'present', 'remove', 'set'], default='add'),
         object_name=dict(type='str', required=True),
-        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource', 
-        'HostSystem', 'VmwareDistributedVirtualSwitch', 'DistributedVirtualPortgroup']),
+        object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource',
+                                                             'HostSystem', 'VmwareDistributedVirtualSwitch',
+                                                             'DistributedVirtualPortgroup']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 


### PR DESCRIPTION
##### SUMMARY
Adds option to also tag DistributedVirtualPortgroup and VmwareDistributedVirtualSwitch objects aside from VirtualMachines

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_tag_manager.py

##### ADDITIONAL INFORMATION
Pretty simple change, works the same way as tagging VM's, but adds extra choices
