### PR TITLE
Fix aws_acm_facts documentation, change status to statuses

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
@@ -18,9 +18,9 @@ options:
       - The domain name of an ACM certificate to limit the search to
     aliases:
       - name
-  status:
+  statuses:
     description:
-      - Status to filter the certificate results
+      - Statuses to filter the certificate results (list or string)
     choices: ['PENDING_VALIDATION', 'ISSUED', 'INACTIVE', 'EXPIRED', 'VALIDATION_TIMED_OUT']
 
 requirements:


### PR DESCRIPTION
Resolves error: unsupported parameters for (aws_acm_facts) module.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
