### PR TITLE
the "deepdiff" module has dropped support for python 2

### DIFF
--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -25,7 +25,8 @@ solidfire-sdk-python
 # requirements for F5 specific modules
 f5-sdk ; python_version >= '2.7'
 f5-icontrol-rest ; python_version >= '2.7'
-deepdiff
+deepdiff < 3.4; python_version <= '2.7'
+deepdiff; python_version > '2.7'
 
 # requirement for Fortinet specific modules
 pyFMG


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The "deepdiff" module (required by the F5 modules) has dropped support
for Python 2 in versions > 3.3.  This change pins deepdiff to 3.3 for
python_version <= 2.7.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unit tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```