### PR TITLE
Remove myself as maintainer of zypper and zypper_repository

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -401,8 +401,7 @@ files:
     maintainers: $team_ansible kustodian
     ignored: skvidal
   $modules/packaging/os/zypper.py:
-    ignored: dirtyharrycallahan
-  $modules/packaging/os/zypper_repository.py: robinro
+    ignored: dirtyharrycallahan robinro
   $modules/remote_management/foreman/: ehelms
   $modules/remote_management/hpilo/: dagwieers haad
   $modules/remote_management/imc/:


### PR DESCRIPTION
##### SUMMARY
Remove myself as maintainer of zypper and zypper_repository.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zypper, zypper_repository.

##### ADDITIONAL INFORMATION
The modules are now effectively unmaintained, maybe someone else can take over?