### PR TITLE
fix traceback if no file in include_task

### DIFF
--- a/changelogs/fragments/54044-fix-include_task-no-file-traceback.yml
+++ b/changelogs/fragments/54044-fix-include_task-no-file-traceback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - include_task - Fixed an unexpected exception if no file was given to include.

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -68,7 +68,7 @@ class TaskInclude(Task):
         if bad_opts and task.action in ('include_tasks', 'import_tasks'):
             raise AnsibleParserError('Invalid options for %s: %s' % (task.action, ','.join(list(bad_opts))), obj=data)
 
-        if not task.args.get('_raw_params'):
+        if not task.args.get('_raw_params') and 'file' in task.args:
             task.args['_raw_params'] = task.args.pop('file')
 
         apply_attrs = task.args.get('apply', {})

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -68,8 +68,8 @@ class TaskInclude(Task):
         if bad_opts and task.action in ('include_tasks', 'import_tasks'):
             raise AnsibleParserError('Invalid options for %s: %s' % (task.action, ','.join(list(bad_opts))), obj=data)
 
-        if not task.args.get('_raw_params') and 'file' in task.args:
-            task.args['_raw_params'] = task.args.pop('file')
+        if not task.args.get('_raw_params'):
+            task.args['_raw_params'] = task.args.pop('file', None)
 
         apply_attrs = task.args.get('apply', {})
         if apply_attrs and task.action != 'include_tasks':

--- a/test/integration/targets/include_import/tasks/test_include_tasks.yml
+++ b/test/integration/targets/include_import/tasks/test_include_tasks.yml
@@ -42,3 +42,13 @@
 
     - name: include_tasks + action
       action: include_tasks tasks1.yml
+
+    - name: test fail as expected without file
+      include_tasks:
+      ignore_errors: yes
+      register: res
+
+    - name: verify fail as expected without file
+      assert:
+        that:
+          - res.msg == 'No include file was specified to the include'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

given an include task without a file
~~~yaml
---
- name: run for each disk config
  include_tasks:
  loop: "{{ disk_configs }}"
  loop_control:
    loop_var: disk
~~~

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
include_task

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before

```paste below
ERROR! Unexpected Exception, this is probably a bug: 'file'
the full traceback was:

Traceback (most recent call last):
  File "/home/rmoser/Projects/resmo/ansible/bin/ansible-playbook", line 110, in <module>
    exit_code = cli.run()
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/cli/playbook.py", line 119, in run
    results = pbex.run()
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/executor/playbook_executor.py", line 92, in run
    pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/__init__.py", line 50, in load
    pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/__init__.py", line 98, in _load_playbook_data
    entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader, vars=vars)
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/play.py", line 113, in load
    return p.load_data(data, variable_manager=variable_manager, loader=loader)
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/base.py", line 240, in load_data
    self._attributes[target_name] = method(name, ds[name])
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/play.py", line 198, in _load_roles
    roles.append(Role.load(ri, play=self))
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/role/__init__.py", line 164, in load
    r._load_role_data(role_include, parent_role=parent_role)
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/role/__init__.py", line 224, in _load_role_data
    self._task_blocks = load_list_of_blocks(task_data, play=self._play, role=self, loader=self._loader, variable_manager=self._variable_manager)
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/helpers.py", line 77, in load_list_of_blocks
    loader=loader,
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/block.py", line 94, in load
    return b.load_data(data, variable_manager=variable_manager, loader=loader)
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/base.py", line 240, in load_data
    self._attributes[target_name] = method(name, ds[name])
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/block.py", line 130, in _load_block
    use_handlers=self._use_handlers,
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/helpers.py", line 144, in load_list_of_tasks
    loader=loader
  File "/home/rmoser/Projects/resmo/ansible/lib/ansible/playbook/task_include.py", line 72, in load
    task.args['_raw_params'] = task.args.pop('file')
KeyError: 'file'

```
after 
~~~
failed: [example] (item={'device': 'vdb', 'mountpoint': '/var/opt/foo', 'fstype': 'ext4'}) => {
    "disk": {
        "device": "vdb",
        "fstype": "ext4",
        "mountpoint": "/var/opt/foo"
    },
    "msg": "No include file was specified to the include"
}
~~~