### PR TITLE
Backport/2.7/54028 tower_settings: "get" isn't implemented, "value" parameter is required

### DIFF
--- a/changelogs/fragments/54028_tower_settings_value_param_required.yml
+++ b/changelogs/fragments/54028_tower_settings_value_param_required.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "tower_settings - 'name' and 'value' parameters are always required, module can not be used in order to get a setting"

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -20,15 +20,17 @@ author: "Nikhil Jain (@jainnikhil30)"
 version_added: "2.7"
 short_description: Modify Ansible Tower settings.
 description:
-    - Get, Modify Ansible Tower settings. See
+    - Modify Ansible Tower settings. See
       U(https://www.ansible.com/tower) for an overview.
 options:
     name:
       description:
-        - Name of setting to get/modify
+        - Name of setting to modify
+      required: True
     value:
       description:
         - Value to be modified for given setting.
+      required: True
 extends_documentation_fragment: tower
 '''
 
@@ -67,8 +69,8 @@ except ImportError:
 
 def main():
     argument_spec = dict(
-        name=dict(Required=True),
-        value=dict(Required=True),
+        name=dict(required=True),
+        value=dict(required=True),
     )
 
     module = TowerModule(


### PR DESCRIPTION
##### SUMMARY
Backport/2.7/#54028 `tower_settings` bugfix:
* `get` isn't implemented
* `value` parameter is required

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower_settings

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
