### PR TITLE
Make test-module use default value for interpreter

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -64,7 +64,8 @@ def parse():
         help="path to python debugger (e.g. /usr/bin/pdb)")
     parser.add_option('-I', '--interpreter', dest='interpreter',
         help="path to interpreter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
-        metavar='INTERPRETER_TYPE=INTERPRETER_PATH')
+        metavar='INTERPRETER_TYPE=INTERPRETER_PATH',
+        default="ansible_python_interpreter=/usr/bin/python")
     parser.add_option('-c', '--check', dest='check', action='store_true',
         help="run the module in check mode")
     parser.add_option('-n', '--noexecute', dest='execute', action='store_false',

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -65,7 +65,7 @@ def parse():
     parser.add_option('-I', '--interpreter', dest='interpreter',
         help="path to interpreter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
         metavar='INTERPRETER_TYPE=INTERPRETER_PATH',
-        default="ansible_python_interpreter=/usr/bin/python")
+        default="ansible_python_interpreter=%s" % (sys.executable if sys.executable else '/usr/bin/python'))
     parser.add_option('-c', '--check', dest='check', action='store_true',
         help="run the module in check mode")
     parser.add_option('-n', '--noexecute', dest='execute', action='store_false',

--- a/test/integration/targets/test_infra/runme.sh
+++ b/test/integration/targets/test_infra/runme.sh
@@ -24,8 +24,12 @@ echo "$PB_OUT" | grep -F "assert works (True)" || exit 1
 
 set -e
 
-# ensure test-module script works well
 PING_MODULE_PATH="../../../../lib/ansible/modules/system/ping.py"
+
+# ensure test-module script works without passing Python interpreter path
+../../../../hacking/test-module -m "$PING_MODULE_PATH"
+
+# ensure test-module script works well
 ../../../../hacking/test-module -m "$PING_MODULE_PATH" -I ansible_python_interpreter="$(which python)"
 
 # ensure module.ansible_version is defined when using test-module


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Since #50163 changes to Python interpreter discovery Ansible attempts to use the interpreter from discovered facts, however fact discovery is not performed in test-module, facts dict is empty, thus invocation always fails with **ansible.executor.interpreter_discovery.InterpreterDiscoveryRequiredError** raised in https://github.com/ansible/ansible/blob/devel/lib/ansible/executor/module_common.py#L496.

That is, unless -I or -interpreter is passed to test-module for every run, making this a required param. Rather than this being required we might consider defaulting to /usr/bin/python as was before, for module test purposes.

Test system: macOS 10.14.3, Python 2.7.15.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request