### PR TITLE
Remove nose from unittests

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -62,18 +62,15 @@ If you make multiple changes to the documentation, or add more than a line to it
 
 To work with documentation on your local machine, you need the following packages installed:
 
-.. code-block:: none
-
-   - libyaml
-   - PyYAML
-   - nose
-   - six
-   - tornado
-   - pyparsing
-   - gcc
-   - jinja2
-   - rstcheck
-   - sphinx
+- libyaml
+- PyYAML
+- six
+- tornado
+- pyparsing
+- gcc
+- jinja2
+- rstcheck
+- sphinx
 
 .. note::
 

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -4,7 +4,6 @@ cryptography
 pycrypto
 jinja2
 mock
-nose
 passlib
 pytest
 pytest-mock

--- a/test/sanity/validate-modules/test_validate_modules_regex.py
+++ b/test/sanity/validate-modules/test_validate_modules_regex.py
@@ -6,10 +6,10 @@
 # To execute this by hand:
 #   1) cd <checkoutdir>
 #   2) source hacking/env-setup
-#   3) PYTHONPATH=./lib nosetests -d -w test -v --nocapture sanity/validate-modules
+#   3) PYTHONPATH=./lib pytest -v sanity/validate-modules
 
 import re
-from ansible.compat.tests import unittest
+import unittest
 
 # TYPE_REGEX = re.compile(r'.*\stype\(.*')
 # TYPE_REGEX = re.compile(r'.*(if|or)\stype\(.*')

--- a/test/units/modules/network/f5/test_bigip_gtm_facts.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_facts.py
@@ -64,6 +64,9 @@ except ImportError:
         from units.modules.utils import set_module_args
     except ImportError:
         pytestmark.append(pytest.mark.skip("F5 Ansible modules require the f5-sdk Python library"))
+        # pytestmark will cause this test to skip but we have to define A so that classes can be
+        # defined below
+        A = object
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_facts.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_facts.py
@@ -10,9 +10,12 @@ import os
 import json
 import sys
 
-from nose.plugins.skip import SkipTest
+import pytest
+
+pytestmark = []
+
 if sys.version_info < (2, 7):
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+    pytestmark.append(pytest.mark.skip("F5 Ansible modules require Python >= 2.7"))
 
 from units.compat import unittest
 from units.compat.mock import Mock
@@ -60,7 +63,7 @@ except ImportError:
         from f5.utils.responses.handlers import Stats
         from units.modules.utils import set_module_args
     except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+        pytestmark.append(pytest.mark.skip("F5 Ansible modules require the f5-sdk Python library"))
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_security_address_list.py
+++ b/test/units/modules/network/f5/test_bigip_security_address_list.py
@@ -11,9 +11,10 @@ import json
 import pytest
 import sys
 
-from nose.plugins.skip import SkipTest
+pytestmark = []
+
 if sys.version_info < (2, 7):
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+    pytestmark.append(pytest.mark.skip("F5 Ansible modules require Python >= 2.7"))
 
 from units.compat import unittest
 from units.compat.mock import Mock
@@ -38,7 +39,8 @@ except ImportError:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+        pytestmark.append(pytest.mark.skip("F5 Ansible modules require the f5-sdk Python library"))
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_security_port_list.py
+++ b/test/units/modules/network/f5/test_bigip_security_port_list.py
@@ -11,9 +11,10 @@ import json
 import pytest
 import sys
 
-from nose.plugins.skip import SkipTest
+pytestmark = []
+
 if sys.version_info < (2, 7):
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+    pytestmark.append(pytest.mark.skip("F5 Ansible modules require Python >= 2.7"))
 
 from units.compat import unittest
 from units.compat.mock import Mock
@@ -38,7 +39,8 @@ except ImportError:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+        pytestmark.append(pytest.mark.skip("F5 Ansible modules require the f5-sdk Python library"))
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}


### PR DESCRIPTION
This PR migrates the last of our unittests from using nose to using
pytest.  We don't need to install nose in our testing environments
anymore


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
unittests

##### ADDITIONAL INFORMATION
\cc @acozine @caphrim007 @mattclay 