### PR TITLE
Allow using Azure rm legacy hostnames

### DIFF
--- a/changelogs/fragments/54060-allow-azure_rm-legacy-hostnames.yml
+++ b/changelogs/fragments/54060-allow-azure_rm-legacy-hostnames.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - add option to azure_rm inventory plugin which will allow the legacy script host names to be used


### PR DESCRIPTION
##### SUMMARY
This allows the azure_rm inventory plugin to return the same hostnames as `azure_rm.py`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm inventory plugin

##### ADDITIONAL INFORMATION
Tested `ansible-inventory` calls between plugin and inventory script side-by-side.

This needs an additional fix due to this error:

```
 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/ansible-inventory-file-examples/private/azure/azure_rm.yml with auto plugin: can't add group to itself

  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/manager.py", line 272, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/azure_rm.py", line 263, in parse
    self._get_hosts()
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/azure_rm.py", line 344, in _get_hosts
    self._add_host_to_keyed_groups(constructable_config_keyed_groups, h.hostvars, inventory_hostname, strict=constructable_config_strict)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/__init__.py", line 431, in _add_host_to_keyed_groups
    self.inventory.add_child(result_gname, host)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/data.py", line 262, in add_child
    g.add_child_group(self.groups[child])
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/group.py", line 177, in add_child_group
    raise Exception("can't add group to itself")
```

This is encountered in the cases where groupings are used of:

 - name
 - security group
 - resource group

Either people will have to lose those groups (unacceptable), or another fix will be needed to the general constructible plugin to allow non-strict recursion. Ping @wenottingham @s-hertel 
