### PR TITLE
This was supposed to be named snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ sdist: sdist_check clean docs
 # Snapshots shouldn't result in new checkins so the changelog is generated as
 # part of creating the tarball.
 .PHONY: snapshot
-sdist: sdist_check clean docs changelog
+snapshot: sdist_check clean docs changelog
 	_ANSIBLE_SDIST_FROM_MAKEFILE=1 $(PYTHON) setup.py sdist
 
 .PHONY: sdist_upload


### PR DESCRIPTION
Corrected it being a duplicate of sdist

When I added snapshot capability I mistakenly changed .PHONY but not the actual target's name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Makefile
