### PR TITLE
[stable-2.5] Add constraint for deepdiff.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,5 +1,6 @@
 coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
+deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 pywinrm >= 0.3.0 # message encryption support
 astroid == 1.5.3 ; python_version >= '3.5' # newer versions of astroid require newer versions of pylint to avoid bugs


### PR DESCRIPTION
##### SUMMARY

[stable-2.5] Add constraint for deepdiff.

Backport of https://github.com/ansible/ansible/pull/54036

(cherry picked from commit 9a135fbcefe8d3b458e0f7f326b5b7b29159cc48)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/runner/requirements/constraints.txt