### PR TITLE
Ignore group recursion if not strict

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -174,7 +174,7 @@ class Group:
     def add_child_group(self, group):
 
         if self == group:
-            raise Exception("can't add group to itself")
+            raise AnsibleError("can't add group to itself")
 
         # don't add if it's already there
         if group not in self.child_groups:

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -428,12 +428,24 @@ class Constructable(object):
                         for bare_name in new_raw_group_names:
                             gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             result_gname = self.inventory.add_group(gname)
-                            self.inventory.add_child(result_gname, host)
+                            try:
+                                self.inventory.add_child(result_gname, host)
+                            except AnsibleError:  # catch recusion errors
+                                if strict:
+                                    raise
+                                else:
+                                    continue
 
                             if raw_parent_name:
                                 parent_name = self._sanitize_group_name(raw_parent_name)
                                 self.inventory.add_group(parent_name)
-                                self.inventory.add_child(parent_name, result_gname)
+                                try:
+                                    self.inventory.add_child(parent_name, result_gname)
+                                except AnsibleError:  # catch recusion errors
+                                    if strict:
+                                        raise
+                                    else:
+                                        continue
 
                     else:
                         # exclude case of empty list and dictionary, because these are valid constructions


### PR DESCRIPTION
##### SUMMARY
This allows users to re-create the wrong behavior of `azure_rm.py`. Reason differs slightly from the test case - I have an Azure case where a host name and group name conflict. Well, this is a problem when you add that host as a child to a group by the same name, which totally happens.

Previously, this issue was skirted by running the `azure_rm.py` through the script inventory plugin, which applies a different processing methodology. By doing the same thing via keyed groups, we introduce a form of host/group confusion that didn't exist before.

This allows us to skip over recursion errors in the grouping steps made unnecessary by host / group confusion.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
constructed inventory plugin
azure_rm inventory plugin

##### ADDITIONAL INFORMATION
Just a theory, but I believe the script skirted the issue by using `add_host`, instead of `add_child`. The latter will add either a host or a group, the former will only add a host.

https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/inventory/script.py#L179

We could potentially be able to do the same thing by changing L431 here to `add_host`, but I believe this goes against the design principle, where it is intended for inventory plugins to be able to use keyed groups to construct nested groups as well as grouping plain hosts.

----

Anyway, it would be kind of weird / awkward to start out with host / group name confusion in the test case, because you would be starting from a misconfigured state. So I used parent / grandparent group confusion instead, which is very reasonable to expect users will hit.