### PR TITLE
docs: Add example of anchor and aliases in playbook

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -50,6 +50,59 @@ For complex variables such as hashes or arrays, ``!unsafe`` should be used on th
         unsafe_key: !unsafe 'unsafe value'
 
 
+Sharing variable values with YAML anchors and aliases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to share variable values across tasks, `YAML anchors and aliases <https://yaml.org/spec/1.2/spec.html#id2765878>`_ help you define, maintain, and use those values in a flexible way.
+You define an anchor with ``&``, then refer to it using an alias, denoted with ``*``.
+
+Here's an example that sets three values with an anchor, uses two of those values with an alias, and overrides the third value::
+
+    ---
+    ...
+    vars:
+        app1:
+            jvm: &jvm_opts
+                opts: '-Xms1G -Xmx2G'
+                port: 1000
+                path: /usr/lib/app1
+        app2:
+            jvm:
+                <<: *jvm_opts
+                path: /usr/lib/app2
+    ...
+
+Here, ``app1`` and ``app2`` share the values for ``opts`` and ``port`` using the anchor ``&jvm_opts`` and the alias ``*jvm_opts``.
+The value for ``path`` is merged by ``<<`` or `merge operator <https://yaml.org/type/merge.html>`_.
+
+Anchors and aliases let you share complex sets of variable values, including nested variables.
+
+Let us assume you have playbook::
+
+      vars:
+        webapp:
+            app: 1.0
+            custom: ToDo_App-1.0
+
+Now, you want to re-use existing value of ``app`` value in ``custom`` value::
+
+    ---
+    - name: Using values nested inside dictionary
+      hosts: localhost
+      vars:
+        webapp:
+            app_version: &my_version 1.0
+            custom_version:
+                - "ToDo_App"
+                - *my_version
+      tasks:
+      - name: Using Anchor value
+        debug:
+            msg: "{{ webapp.custom_version | join('-') }}"
+
+Here, you can anchor 'app_version' value using ``&my_version`` and re-use later as ``*my_version``.
+This way you can access nested values inside dictionaries.
+
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -4,22 +4,15 @@
 Advanced Syntax
 ***************
 
-The advanced YAML syntax examples on this page give you more control over the data placed in YAML files used by Ansible.
+The advanced YAML syntax examples on this page give you more control over the data placed in YAML files used by Ansible. You can find additional information about Python-specific YAML in the official `PyYAML Documentation <https://pyyaml.org/wiki/PyYAMLDocumentation#YAMLtagsandPythontypes>`_.
 
 .. contents::
    :local:
 
-.. _yaml_tags_and_python_types:
-
-YAML tags and Python types
-==========================
-
-The documentation covered here is an extension of the documentation that can be found in the `PyYAML Documentation <https://pyyaml.org/wiki/PyYAMLDocumentation#YAMLtagsandPythontypes>`_
-
 .. _unsafe_strings:
 
 Unsafe or Raw Strings
----------------------
+=====================
 
 Ansible provides an internal data type for declaring variable values as "unsafe". This means that the data held within the variables value should be treated as unsafe preventing unsafe character substitution and information disclosure.
 
@@ -53,8 +46,8 @@ For complex variables such as hashes or arrays, ``!unsafe`` should be used on th
 
 .. _anchors_and_aliases:
 
-Sharing variable values with YAML anchors and aliases
-=====================================================
+YAML anchors and aliases: sharing variable values
+=================================================
 
 `YAML anchors and aliases <https://yaml.org/spec/1.2/spec.html#id2765878>`_ help you define, maintain, and use shared variable values in a flexible way.
 You define an anchor with ``&``, then refer to it using an alias, denoted with ``*``.

--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -50,9 +50,7 @@ YAML anchors and aliases: sharing variable values
 =================================================
 
 `YAML anchors and aliases <https://yaml.org/spec/1.2/spec.html#id2765878>`_ help you define, maintain, and use shared variable values in a flexible way.
-You define an anchor with ``&``, then refer to it using an alias, denoted with ``*``.
-
-Here's an example that sets three values with an anchor, uses two of those values with an alias, and overrides the third value::
+You define an anchor with ``&``, then refer to it using an alias, denoted with ``*``. Here's an example that sets three values with an anchor, uses two of those values with an alias, and overrides the third value::
 
     ---
     ...
@@ -71,9 +69,7 @@ Here's an example that sets three values with an anchor, uses two of those value
 Here, ``app1`` and ``app2`` share the values for ``opts`` and ``port`` using the anchor ``&jvm_opts`` and the alias ``*jvm_opts``.
 The value for ``path`` is merged by ``<<`` or `merge operator <https://yaml.org/type/merge.html>`_.
 
-Anchors and aliases also let you share complex sets of variable values, including nested variables.
-
-If you have one variable value that includes another variable value, you can define them separately::
+Anchors and aliases also let you share complex sets of variable values, including nested variables. If you have one variable value that includes another variable value, you can define them separately::
 
       vars:
         webapp_version: 1.0


### PR DESCRIPTION
##### SUMMARY
YAML supports anchors and aliases, add examples for explaining
this functionality with respect to Ansible playbook.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst