### PR TITLE
Ansible validate variable module

### DIFF
--- a/lib/ansible/modules/utilities/logic/validate.py
+++ b/lib/ansible/modules/utilities/logic/validate.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: validation
+module: validate
 
 short_description: This module validate an Ansible variable against a JSON schema
 
@@ -73,4 +73,5 @@ RETURN = '''
 message:
     description: In case of failure return the reason for failure
     type: str
+    returned: on error
 '''

--- a/lib/ansible/modules/utilities/logic/validate.py
+++ b/lib/ansible/modules/utilities/logic/validate.py
@@ -3,6 +3,7 @@
 # Copyright: (c) 2019, Virgil Chereches <virgil.chereches@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -31,9 +32,12 @@ options:
             - Schema file in JSON, YAML or plain (text) format
         required: true
 notes:
-    - This plugin uses JSONSchema python implementation (https://python-jsonschema.readthedocs.io/en/stable/) to validate variable data structure against schemas.
-    - Due to some bug in jsonschema python module there is not possible to use relative references and in file reference in the schema without a patch:
-https://github.com/Julian/jsonschema/issues/313#issuecomment-300478317. Since maintaining such a patch over the jsonschema library is out of discussion, the ansible plugin doesn't work with relative references.
+    - 'This plugin uses JSONSchema python implementation (https://python-jsonschema.readthedocs.io/en/stable/)
+      to validate variable data structure against schemas.'
+    - 'Due to some bug in jsonschema python module there is not possible to use relative references and in file reference
+       in the schema without a patch: https://github.com/Julian/jsonschema/issues/313#issuecomment-300478317.
+       Since maintaining such a patch over the jsonschema library is out of discussion,
+       the ansible plugin doesn't work with relative references.'
 
 author:
     - Virgil Chereches (@brutus333)
@@ -44,7 +48,7 @@ EXAMPLES = '''
 - name: Test with a variable
   validate:
     var: ansible_date_time
-    schema: "{{ { "type": "object","properties": { "date": { "type":"string", "format": "date" } } } }}"
+    schema: "{{ { 'type': 'object','properties': { 'date': { 'type':'string', 'format': 'date' } } } }}"
 
 # Pass in a variable and a schema dictionary in yaml format
 - name: Test with a variable
@@ -63,7 +67,6 @@ EXAMPLES = '''
   validate:
     var: ansible_ipv4
     schema: ansible_date_schema.json
-
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/utilities/logic/validate.py
+++ b/lib/ansible/modules/utilities/logic/validate.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2019, Virgil Chereches <virgil.chereches@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+__metaclass__ = type
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: validation
+
+short_description: This module validate an Ansible variable against a JSON schema
+
+version_added: "2.8"
+
+description:
+    - "This module uses JSON schema to validate data structure of an Ansibile variable; Schema may be provided in JSON or YAML format"
+
+options:
+    var:
+        description:
+            - This is the name of the Ansible variable
+        required: true
+    schema:
+        description:
+            - Schema file in JSON, YAML or plain (text) format
+        required: true
+notes:
+    - This plugin uses JSONSchema python implementation (https://python-jsonschema.readthedocs.io/en/stable/) to validate variable data structure against schemas.
+    - Due to some bug in jsonschema python module there is not possible to use relative references and in file reference in the schema without a patch:
+https://github.com/Julian/jsonschema/issues/313#issuecomment-300478317. Since maintaining such a patch over the jsonschema library is out of discussion, the ansible plugin doesn't work with relative references.
+
+author:
+    - Virgil Chereches (@brutus333)
+'''
+
+EXAMPLES = '''
+# Pass in a variable and a schema dictionary
+- name: Test with a variable
+  validate:
+    var: ansible_date_time
+    schema: "{{ { "type": "object","properties": { "date": { "type":"string", "format": "date" } } } }}"
+
+# Pass in a variable and a schema dictionary in yaml format
+- name: Test with a variable
+  validate:
+    var: ansible_date_time
+    schema:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+
+# Pass in a variable and a schema file
+# File ansible_ipv4_schema contains equivalent information in json or yaml format
+- name: Test with a variable
+  validate:
+    var: ansible_ipv4
+    schema: ansible_date_schema.json
+
+'''
+
+RETURN = '''
+message:
+    description: In case of failure return the reason for failure
+    type: str
+'''

--- a/lib/ansible/modules/utilities/logic/validate.py
+++ b/lib/ansible/modules/utilities/logic/validate.py
@@ -33,11 +33,11 @@ options:
         required: true
 notes:
     - 'This plugin uses JSONSchema python implementation (https://python-jsonschema.readthedocs.io/en/stable/)
-      to validate variable data structure against schemas.'
+       to validate variable data structure against schemas.'
     - 'Due to some bug in jsonschema python module there is not possible to use relative references and in file reference
        in the schema without a patch: https://github.com/Julian/jsonschema/issues/313#issuecomment-300478317.
        Since maintaining such a patch over the jsonschema library is out of discussion,
-       the ansible plugin doesn't work with relative references.'
+       the ansible plugin is not working with relative references.'
 
 author:
     - Virgil Chereches (@brutus333)

--- a/lib/ansible/plugins/action/validate.py
+++ b/lib/ansible/plugins/action/validate.py
@@ -121,12 +121,12 @@ class ActionModule(ActionBase):
                 variable_value = self._templar.template("{{" + variable_value + "}}",
                                                         convert_bare=True, fail_on_undefined=True)
         except AnsibleUndefinedVariable as e:
-            raise AnsibleActionFail("'var' {} is not defined".format(self.var))
+            raise AnsibleActionFail("'var' {0} is not defined".format(self.var))
 
         try:
             validate(instance=variable_value, schema=schema_data,
                      format_checker=draft7_format_checker,)
         except exceptions.ValidationError as e:
-            raise AnsibleActionFail("Failed validating {} in {}: {}".format(e.validator, e.schema_path, e.message))
+            raise AnsibleActionFail("Failed validating {0} in {1}: {2}".format(e.validator, e.schema_path, e.message))
 
         return result

--- a/lib/ansible/plugins/action/validate.py
+++ b/lib/ansible/plugins/action/validate.py
@@ -86,7 +86,7 @@ class ActionModule(ActionBase):
         self._set_args()
 
         try:
-            from jsonschema import validate,draft7_format_checker,exceptions,RefResolver
+            from jsonschema import validate, draft7_format_checker, exceptions
         except ImportError as e:
             raise AnsibleError("The validate module requires jsonschema python module.")
 
@@ -99,7 +99,7 @@ class ActionModule(ActionBase):
         elif isinstance(self.schema, string_types):
             try:
                 failed, err_msg, schema_data = (
-                    self._load_files(self.schema,validate_extensions=True)
+                    self._load_files(self.schema, validate_extensions=True)
                 )
                 if failed:
                     raise AnsibleActionFail(err_msg)
@@ -123,12 +123,10 @@ class ActionModule(ActionBase):
         except AnsibleUndefinedVariable as e:
             raise AnsibleActionFail("'var' {} is not defined".format(self.var))
 
-
         try:
-
-            validate(instance=variable_value,schema=schema_data,
+            validate(instance=variable_value, schema=schema_data,
                      format_checker=draft7_format_checker,)
         except exceptions.ValidationError as e:
-            raise AnsibleActionFail("Failed validating {} in {}: {}".format(e.validator,e.schema_path,e.message))
+            raise AnsibleActionFail("Failed validating {} in {}: {}".format(e.validator, e.schema_path, e.message))
 
         return result

--- a/lib/ansible/plugins/action/validate.py
+++ b/lib/ansible/plugins/action/validate.py
@@ -1,0 +1,134 @@
+# Copyright 2012, Dag Wieers <dag@wieers.com>
+# Copyright 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+# Copyright 2019, Virgil Chereches <virgil.chereches@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError, AnsibleUndefinedVariable, AnsibleActionFail
+from ansible.module_utils.six import string_types
+from ansible.plugins.action import ActionBase
+from ansible.module_utils._text import to_text, to_native
+from os import path
+
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = False
+    _VALID_ARGS = frozenset(('var', 'schema', 'extensions'))
+    VALID_FILE_EXTENSIONS = ['yaml', 'yml', 'json']
+
+    def _is_valid_file_ext(self, source_file):
+        """ Verify if source file has a valid extension
+        Args:
+            source_file (str): The full path of source file or source file.
+        Returns:
+            Bool
+        """
+        file_ext = path.splitext(source_file)
+        return bool(len(file_ext) > 1 and file_ext[-1][1:] in self.valid_extensions)
+
+    def _load_files(self, filename, validate_extensions=False):
+        """ Loads a file and converts the output into a valid Python dict.
+        Args:
+            filename (str): The source file.
+
+        Returns:
+            Tuple (bool, str, dict)
+        """
+
+        data = dict()
+        failed = False
+        err_msg = ''
+        if validate_extensions and not self._is_valid_file_ext(filename):
+            failed = True
+            err_msg = ('{0} does not have a valid extension: {1}'.format(to_native(filename), ', '.join(self.valid_extensions)))
+        else:
+            b_data, show_content = self._loader._get_file_contents(filename)
+            data = to_text(b_data, errors='surrogate_or_strict')
+
+            self.show_content = show_content
+            data = self._loader.load(data, file_name=filename, show_content=show_content)
+
+            if not isinstance(data, dict):
+                failed = True
+                err_msg = ('{0} must be stored as a dictionary/hash'.format(to_native(filename)))
+
+        return failed, err_msg, data
+
+    def _set_args(self):
+        """ Set instance variables based on the arguments that were passed """
+        if not ('schema' in self._task.args and 'var' in self._task.args):
+            return {"failed": True, "msg": "'var' and 'schema' are required options"}
+        self.var = self._task.args['var']
+        self.schema = self._task.args['schema']
+        self.valid_extensions = self._task.args.get('extensions', self.VALID_FILE_EXTENSIONS)
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        # set internal vars from args
+        self._set_args()
+
+        try:
+            from jsonschema import validate,draft7_format_checker,exceptions,RefResolver
+        except ImportError as e:
+            raise AnsibleError("The validate module requires jsonschema python module.")
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        # Check type of schema - inline dictionary passed via Jinja2 or filename
+        if isinstance(self.schema, dict):
+            schema_data = self.schema
+        elif isinstance(self.schema, string_types):
+            try:
+                failed, err_msg, schema_data = (
+                    self._load_files(self.schema,validate_extensions=True)
+                )
+                if failed:
+                    raise AnsibleActionFail(err_msg)
+
+            except AnsibleError as e:
+                raise AnsibleActionFail(to_native(e))
+
+        else:
+            raise AnsibleActionFail("'schema' parameter should be a filename or a dictionary")
+
+        # Variable substitution code borrowed from debug plugin
+        try:
+            variable_value = self._templar.template(self.var, convert_bare=True, fail_on_undefined=True)
+            if variable_value == self.var:
+                # if variable_value is not str/unicode type, raise an exception
+                if not isinstance(variable_value, string_types):
+                    raise AnsibleUndefinedVariable
+                # If var name is same as result, try to template it
+                variable_value = self._templar.template("{{" + variable_value + "}}",
+                                                        convert_bare=True, fail_on_undefined=True)
+        except AnsibleUndefinedVariable as e:
+            raise AnsibleActionFail("'var' {} is not defined".format(self.var))
+
+
+        try:
+
+            validate(instance=variable_value,schema=schema_data,
+                     format_checker=draft7_format_checker,)
+        except exceptions.ValidationError as e:
+            raise AnsibleActionFail("Failed validating {} in {}: {}".format(e.validator,e.schema_path,e.message))
+
+        return result


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This commit adds a new Ansible action plugin and corresponding module
that can be used to validate Ansible variables against JSON Schema
provided as an Ansible dictionary, Jinja2 expression or schema file.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`validate`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

For complex data structures used in Ansible roles it is important to validate the input variables provided as inventory variables or extra vars since otherwise a large  playbook may fail after running for a long time due to variable mismatch.
This allows a fast-fail behavior.

The `validate` module implements this validation using standard JSON schema implementations.

An added benefit of using JSON schema is the ability to document the data structure inside schema and use JSON to md or JSON to html converters to dynamically generate the documentation.
 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
