### PR TITLE
check kubernetes version only when the version changed

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_aks.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_aks.py
@@ -539,11 +539,11 @@ class AzureRMManagedCluster(AzureRMModuleBase):
             if agentpoolcount > 1:
                 self.fail('You cannot specify more than one agent_pool_profiles currently')
 
-            available_versions = self.get_all_versions()
-            if self.kubernetes_version not in available_versions.keys():
-                self.fail("Unsupported kubernetes version. Excepted one of {0} but get {1}".format(available_versions.keys(), self.kubernetes_version))
             if not response:
                 to_be_updated = True
+                available_versions = self.get_all_versions()
+                if self.kubernetes_version not in available_versions.keys():
+                    self.fail("Unsupported kubernetes version. Excepted one of {0} but get {1}".format(available_versions.keys(), self.kubernetes_version))
             else:
                 self.results = response
                 self.results['changed'] = False

--- a/lib/ansible/modules/cloud/azure/azure_rm_aks.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_aks.py
@@ -543,7 +543,7 @@ class AzureRMManagedCluster(AzureRMModuleBase):
                 to_be_updated = True
                 available_versions = self.get_all_versions()
                 if self.kubernetes_version not in available_versions.keys():
-                    self.fail("Unsupported kubernetes version. Excepted one of {0} but get {1}".format(available_versions.keys(), self.kubernetes_version))
+                    self.fail("Unsupported kubernetes version. Expected one of {0} but got {1}".format(available_versions.keys(), self.kubernetes_version))
             else:
                 self.results = response
                 self.results['changed'] = False
@@ -582,7 +582,7 @@ class AzureRMManagedCluster(AzureRMModuleBase):
                         to_be_updated = True
 
                     if response['kubernetes_version'] != self.kubernetes_version:
-                        upgrade_versions = available_versions.get(response['kubernetes_version'])
+                        upgrade_versions = available_versions.get(response['kubernetes_version']) or available_versions.keys()
                         if upgrade_versions and self.kubernetes_version not in upgrade_versions:
                             self.fail('Cannot upgrade kubernetes version to {0}, supported value are {1}'.format(self.kubernetes_version, upgrade_versions))
                         to_be_updated = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If I created an AKS with version 1.12.4. Then I wanna update some parameter one month later, at this point, 1.12.4 is not a supported version, but the version should not fail in the client check.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_aks
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
