### PR TITLE
ini: Don't eval password variable

### DIFF
--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -280,7 +280,10 @@ class InventoryModule(BaseFileInventoryPlugin):
 
         if '=' in line:
             (k, v) = [e.strip() for e in line.split("=", 1)]
-            return (k, self._parse_value(v))
+            if k in ('ansible_ssh_pass', 'ansible_pass'):
+                return (k, to_text(v, nonstring='passthru', errors='surrogate_or_strict'))
+            else:
+                return (k, self._parse_value(v))
 
         self._raise_error("Expected key=value, got: %s" % (line))
 
@@ -313,7 +316,10 @@ class InventoryModule(BaseFileInventoryPlugin):
             if '=' not in t:
                 self._raise_error("Expected key=value host variable assignment, got: %s" % (t))
             (k, v) = t.split('=', 1)
-            variables[k] = self._parse_value(v)
+            if k in ('ansible_ssh_pass', 'ansible_pass'):
+                variables[k] = to_text(v, nonstring='passthru', errors='surrogate_or_strict')
+            else:
+                variables[k] = self._parse_value(v)
 
         return hostnames, port, variables
 


### PR DESCRIPTION
##### SUMMARY
ast.literal_eval evaluates password which looks scientific notation (123e1)
as float value (1230.0).

This fix adds a check to exclude 'ansible_ssh_pass' and 'ansible_pass'
variables from eval parsing.

Fixes: #22767

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/ini.py