### PR TITLE
Add new CloudStack module cs_physical_network

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -106,6 +106,7 @@ class AnsibleCloudStack:
         self.project = None
         self.ip_address = None
         self.network = None
+        self.physical_network = None
         self.vpc = None
         self.zone = None
         self.vm = None

--- a/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
@@ -1,0 +1,493 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2017, Netservers Ltd. <support@netservers.co.uk>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: cs_physical_network
+short_description: Manages physical networks on Apache CloudStack based clouds.
+description:
+    - Create, update and remove networks.
+    - Enabled and disabled Network Service Providers
+    - Enables Internal LoadBalancer and VPC/VirtualRouter elements as required
+version_added: "2.4"
+author: "Netservers Ltd. (@netservers)"
+options:
+  name:
+    description:
+      - name of the network.
+    required: true
+  zone:
+    description:
+      - Name of the zone in which the network belongs.
+      - If not set, default zone is used.
+    required: true
+    default: null
+  broadcastdomainrange:
+    description:
+      - broadcast domain range for the physical network[Pod or Zone].
+    required: false
+    default: none
+    choices: [ 'POD', 'ZONE' ]
+  domain:
+    description:
+      - Domain the network is owned by.
+    required: false
+    default: null
+  isolation_method:
+    description:
+      - Isolation method for the physical network.
+    required: false
+    default: none
+    choices: [ 'VLAN', 'GRE', 'L3' ]
+  network_speed:
+    description:
+      - the speed for the physical network[1G/10G]
+    required: false
+    default: null
+  tags:
+    description:
+      - "A tag to identify this network"
+      - "Physical networks support only one tag"
+      - "To remove an existing tag pass an empty string"
+    required: false
+    default: null
+    aliases:
+      - tag
+  vlan:
+    description:
+      - The VLAN/VNI Ranges of the physical network.
+    required: false
+    default: null
+  nsps_enabled:
+    description:
+      - List of Network Service Providers to enable
+    required: false
+    default: null
+  nsps_disabled:
+    description:
+      - List of Network Service Providers to disable
+    required: false
+    default: null
+  url:
+    description:
+      - URL for the cluster
+    required: false
+    default: null
+  username:
+    description:
+      - Username for the cluster.
+    required: false
+    default: null
+  password:
+    description:
+      - Password for the cluster.
+    required: false
+    default: null
+  state:
+    description:
+      - State of the cluster.
+    required: false
+    default: 'present'
+    choices: [ 'present', 'absent', 'disabled', 'enabled' ]
+extends_documentation_fragment: cloudstack
+'''
+
+EXAMPLES = '''
+# Ensure a network is present
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+
+# Set a tag on a network
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    tag: overlay
+
+# Remove tag on a network
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    tag: ""
+
+# Ensure a network is enabled with specific nsps enabled
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    isolation_method: VLAN
+    vlan: 100-200,300-400
+    broadcast_domain_range: ZONE
+    state: enabled
+    nsps_enabled:
+      - Ovs
+      - VirtualRouter
+      - InternalLbVm
+      - VpcVirtualRouter
+
+# Ensure a network is disabled
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    state: disabled
+
+# Ensure a network is enabled
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    state: enabled
+
+# Ensure a network is absent
+- local_action:
+    module: cs_phsyical_network
+    name: net01
+    zone: zone01
+    state: absent
+'''
+
+RETURN = '''
+---
+id:
+  description: UUID of the network.
+  returned: success
+  type: string
+  sample: 3f8f25cd-c498-443f-9058-438cfbcbff50
+name:
+  description: Name of the network.
+  returned: success
+  type: string
+  sample: net01
+state:
+  description: State of the network [Enabled/Disabled].
+  returned: success
+  type: string
+  sample: Enabled
+broadcast_domain_range:
+  description: broadcastdomainrange of the network [POD / ZONE].
+  returned: success
+  type: string
+  sample: ZONE
+isolation_method:
+  description: isolationmethod of the network [VLAN/GRE/L3].
+  returned: success
+  type: string
+  sample: VLAN
+network_speed:
+  description: networkspeed of the network [1G/10G].
+  returned: success
+  type: string
+  sample: 1G
+zone:
+  description: Name of zone the cluster is in.
+  returned: success
+  type: string
+  sample: ch-gva-2
+domain:
+  description: Name of domain the network is in.
+  returned: success
+  type: string
+  sample: domain1
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import (
+    AnsibleCloudStack,
+    CloudStackException,
+    cs_argument_spec,
+    cs_required_together,
+)
+
+
+class AnsibleCloudStackCluster(AnsibleCloudStack):
+
+    def __init__(self, module):
+        super(AnsibleCloudStackCluster, self).__init__(module)
+        self.returns = {
+            'isolationmethods': 'isolation_method',
+            'broadcastdomainrange': 'broadcast_domain_range',
+            'networkspeed': 'network_speed',
+            'vlan': 'vlan',
+            'tags': 'tags',
+        }
+        self.network = None
+        self.nsps = []
+        self.vrouters = None
+        self.loadbalancers = None
+
+    def _get_common_args(self):
+        args = {
+            'name': self.module.params.get('name'),
+            'isolationmethods': self.module.params.get('isolation_method'),
+            'broadcastdomainrange': self.module.params.get('broadcast_domain_range'),
+            'networkspeed': self.module.params.get('network_speed'),
+            'tags': self.module.params.get('tags'),
+            'vlan': self.module.params.get('vlan'),
+        }
+        if args['tags'] and len(args['tags']) > 1:
+            self.module.fail_json(msg="Failed: Physical networks can only have one tag")
+
+        state = self.module.params.get('state')
+        if state in ['enabled', 'disabled']:
+            args['state'] = state.capitalize()
+        return args
+
+    def get_network(self, key=None):
+        if self.network:
+            return self.network
+        args = {
+            'zoneid': self.get_zone(key='id'),
+            'name': self.module.params.get('name'),
+        }
+        nets = self.cs.listPhysicalNetworks(**args)
+        if nets:
+            self.network = nets['physicalnetwork'][0]
+        return self.network
+
+    def get_nsp(self, name=None):
+        if not self.nsps:
+            network = self.get_network()
+            args = {
+                'physicalnetworkid': network['id']
+            }
+            res = self.cs.listNetworkServiceProviders(**args)
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            self.nsps = res['networkserviceprovider']
+
+        names = []
+        for nsp in self.nsps:
+            names.append(nsp['name'])
+            if nsp['name'] == name:
+                return nsp
+
+        self.module.fail_json(msg="Failed: '{}' not in network service providers list '[{}]'".format(name, names))
+
+    def _update_nsp(self, name=None, state=None, service_list=None):
+        nsp = self.get_nsp(name)
+        if not service_list and nsp['state'] == state:
+            return nsp
+
+        args = {
+            'id': nsp['id'],
+            'servicelist': service_list,
+            'state': state
+        }
+        res = self.cs.updateNetworkServiceProvider(**args)
+        if 'errortext' in res:
+            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+
+        self.result['changed'] = True
+        return res
+
+    def get_vrouter_element(self, nsp_name='VirtualRouter'):
+        nsp = self.get_nsp(nsp_name)
+        nspid = nsp['id']
+        if self.vrouters is None:
+            self.vrouters = dict()
+            res = self.cs.listVirtualRouterElements()
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            for vrouter in res['virtualrouterelement']:
+                self.vrouters[vrouter['nspid']] = vrouter
+
+        if nspid not in self.vrouters:
+            self.module.fail_json(msg="Failed: No VirtualRouterElement founf for nsp '%s'" % nsp_name)
+
+        return self.vrouters[nspid]
+
+    def get_loadbalancer_element(self, nsp_name='InternalLbVm'):
+        nsp = self.get_nsp(nsp_name)
+        nspid = nsp['id']
+        if self.loadbalancers is None:
+            self.loadbalancers = dict()
+            res = self.cs.listInternalLoadBalancerElements()
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            for loadbalancer in res['internalloadbalancerelement']:
+                self.loadbalancers[loadbalancer['nspid']] = loadbalancer
+
+            if nspid not in self.loadbalancers:
+                self.module.fail_json(msg="Failed: No Loadbalancer found for nsp '%s'" % nsp_name)
+
+        return self.loadbalancers[nspid]
+
+    def set_vrouter_element_state(self, enabled, nsp_name='VirtualRouter'):
+        vrouter = self.get_vrouter_element(nsp_name)
+        if vrouter['enabled'] == enabled:
+            return vrouter
+
+        args = {
+            'id': vrouter['id'],
+            'enabled': enabled
+        }
+        res = self.cs.configureVirtualRouterElement(**args)
+        if 'errortext' in res:
+            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+
+        self.result['changed'] = True
+        return res
+
+    def set_loadbalancer_element_state(self, enabled, nsp_name='InternalLbVm'):
+        loadbalancer = self.get_loadbalancer_element(nsp_name=nsp_name)
+        if loadbalancer['enabled'] == enabled:
+            return loadbalancer
+
+        args = {
+            'id': loadbalancer['id'],
+            'enabled': enabled
+        }
+        res = self.cs.configureInternalLoadBalancerElement(**args)
+        if 'errortext' in res:
+            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+
+        self.result['changed'] = True
+        return res
+
+    def present_network(self):
+        network = self.get_network()
+        if network:
+            network = self._update_network()
+        else:
+            network = self._create_network()
+        return network
+
+    def _create_network(self):
+        required_params = [
+            'name',
+            'zone',
+        ]
+        self.module.fail_on_missing_params(required_params=required_params)
+
+        args = self._get_common_args()
+        args['zoneid'] = self.get_zone(key='id')
+        args['domainid'] = self.get_domain(key='id')
+        args['url'] = self.module.params.get('url')
+        args['username'] = self.module.params.get('username')
+        args['password'] = self.module.params.get('password')
+
+        self.result['changed'] = True
+
+        id = None
+        if not self.module.check_mode:
+            res = self.cs.createPhysicalNetwork(**args)
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            id = res['id']
+        return id
+
+    def _update_network(self):
+        network = self.get_network()
+
+        args = self._get_common_args()
+        args['id'] = network['id']
+
+        if self.has_changed(args, network):
+            self.result['changed'] = True
+
+            if not self.module.check_mode:
+                res = self.cs.updatePhysicalNetwork(**args)
+                if 'errortext' in res:
+                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        return network
+
+    def absent_network(self):
+        network = self.get_network()
+        if network:
+            self.result['changed'] = True
+
+            args = {
+                'id': network['id'],
+            }
+            if not self.module.check_mode:
+                res = self.cs.deletePhysicalNetwork(**args)
+                if 'errortext' in res:
+                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        return network
+
+
+def main():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        zone=dict(default=None),
+        domain=dict(default=None),
+        vlan=dict(default=None),
+        nsps_disabled=dict(default=None, type='list'),
+        nsps_enabled=dict(default=None, type='list'),
+        network_speed=dict(choices=['1G', '10G'], default=None),
+        broadcast_domain_range=dict(choices=['POD', 'ZONE'], default=None),
+        isolation_method=dict(choices=['VLAN', 'GRE', 'L3'], default=None),
+        state=dict(choices=['present', 'enabled', 'disabled', 'absent'], default='present'),
+        url=dict(default=None),
+        username=dict(default=None),
+        password=dict(default=None, no_log=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=cs_required_together(),
+        supports_check_mode=True
+    )
+
+    try:
+        acs_network = AnsibleCloudStackCluster(module)
+
+        state = module.params.get('state')
+        nsps_disabled = module.params.get('nsps_disabled', [])
+        nsps_enabled = module.params.get('nsps_enabled', [])
+
+        if state in ['absent']:
+            network = acs_network.absent_network()
+        else:
+            network = acs_network.present_network()
+
+        if nsps_disabled is not None:
+            for name in nsps_disabled:
+                acs_network._update_nsp(name=name, state='Disabled')
+
+        if nsps_enabled is not None:
+            for nsp_name in nsps_enabled:
+                if nsp_name in ['VirtualRouter', 'VpcVirtualRouter']:
+                    acs_network.set_vrouter_element_state(enabled=True, nsp_name=nsp_name)
+                elif nsp_name == 'InternalLbVm':
+                    acs_network.set_loadbalancer_element_state(enabled=True, nsp_name=nsp_name)
+
+                acs_network._update_nsp(name=nsp_name, state='Enabled')
+
+        result = acs_network.get_result(network)
+
+    except CloudStackException as e:
+        module.fail_json(msg='CloudStackException: %s' % str(e))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_physical_network.py
@@ -2,23 +2,9 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2017, Netservers Ltd. <support@netservers.co.uk>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -31,118 +17,99 @@ description:
     - Create, update and remove networks.
     - Enabled and disabled Network Service Providers
     - Enables Internal LoadBalancer and VPC/VirtualRouter elements as required
-version_added: "2.4"
-author: "Netservers Ltd. (@netservers)"
+version_added: "2.8"
+author:
+ - Netservers Ltd. (@netservers)
+ - Patryk Cichy (@PatTheSilent)
 options:
-  name:
+  physical_network:
     description:
-      - name of the network.
+      - Name of the physical network.
     required: true
+    aliases:
+      - name
+    type: str
   zone:
     description:
       - Name of the zone in which the network belongs.
       - If not set, default zone is used.
-    required: true
-    default: null
-  broadcastdomainrange:
+    type: str
+  broadcast_domain_range:
     description:
       - broadcast domain range for the physical network[Pod or Zone].
-    required: false
-    default: none
-    choices: [ 'POD', 'ZONE' ]
+    choices: [ POD, ZONE ]
+    type: str
   domain:
     description:
       - Domain the network is owned by.
-    required: false
-    default: null
+    type: str
   isolation_method:
     description:
       - Isolation method for the physical network.
-    required: false
-    default: none
-    choices: [ 'VLAN', 'GRE', 'L3' ]
+    choices: [ VLAN, GRE, L3 ]
+    type: str
   network_speed:
     description:
-      - the speed for the physical network[1G/10G]
-    required: false
-    default: null
+      - The speed for the physical network.
+    choices: [1G, 10G]
+    type: str
   tags:
     description:
-      - "A tag to identify this network"
-      - "Physical networks support only one tag"
-      - "To remove an existing tag pass an empty string"
-    required: false
-    default: null
+      - A tag to identify this network.
+      - Physical networks support only one tag.
+      - To remove an existing tag pass an empty string.
     aliases:
       - tag
+    type: str
   vlan:
     description:
       - The VLAN/VNI Ranges of the physical network.
-    required: false
-    default: null
+    type: str
   nsps_enabled:
     description:
-      - List of Network Service Providers to enable
-    required: false
-    default: null
+      - List of Network Service Providers to enable.
+    type: list
   nsps_disabled:
     description:
-      - List of Network Service Providers to disable
-    required: false
-    default: null
-  url:
-    description:
-      - URL for the cluster
-    required: false
-    default: null
-  username:
-    description:
-      - Username for the cluster.
-    required: false
-    default: null
-  password:
-    description:
-      - Password for the cluster.
-    required: false
-    default: null
+      - List of Network Service Providers to disable.
+    type: list
   state:
     description:
-      - State of the cluster.
-    required: false
-    default: 'present'
-    choices: [ 'present', 'absent', 'disabled', 'enabled' ]
+      - State of the physical network.
+    default: present
+    type: str
+    choices: [ present, absent, disabled, enabled ]
   poll_async:
     description:
-      - "Poll async jobs until job has finished."
-    required: false
-    default: true
+      - Poll async jobs until job has finished.
+    default: yes
+    type: bool
 extends_documentation_fragment: cloudstack
 '''
 
 EXAMPLES = '''
-# Ensure a network is present
-- local_action:
-    module: cs_phsyical_network
+- name: Ensure a network is present
+  cs_physical_network:
     name: net01
     zone: zone01
     isolation_method: VLAN
     broadcast_domain_range: ZONE
+  delegate_to: localhost
 
-# Set a tag on a network
-- local_action:
-    module: cs_phsyical_network
+- name: Set a tag on a network
+  cs_physical_network:
     name: net01
     tag: overlay
+  delegate_to: localhost
 
-# Remove tag on a network
-- local_action:
-    module: cs_phsyical_network
+- name: Remove tag on a network
+  cs_physical_network:
     name: net01
     tag: ""
+  delegate_to: localhost
 
-# Ensure a network is enabled with specific nsps enabled
-- local_action:
-    module: cs_phsyical_network
+- name: Ensure a network is enabled with specific nsps enabled
+  cs_physical_network:
     name: net01
     zone: zone01
     isolation_method: VLAN
@@ -150,31 +117,31 @@ EXAMPLES = '''
     broadcast_domain_range: ZONE
     state: enabled
     nsps_enabled:
-      - Ovs
       - VirtualRouter
       - InternalLbVm
       - VpcVirtualRouter
+  delegate_to: localhost
 
-# Ensure a network is disabled
-- local_action:
-    module: cs_phsyical_network
+- name: Ensure a network is disabled
+  cs_physical_network:
     name: net01
     zone: zone01
     state: disabled
+  delegate_to: localhost
 
-# Ensure a network is enabled
-- local_action:
-    module: cs_phsyical_network
+- name: Ensure a network is enabled
+  cs_physical_network:
     name: net01
     zone: zone01
     state: enabled
+  delegate_to: localhost
 
-# Ensure a network is absent
-- local_action:
-    module: cs_phsyical_network
+- name: Ensure a network is absent
+  cs_physical_network:
     name: net01
     zone: zone01
     state: absent
+  delegate_to: localhost
 '''
 
 RETURN = '''
@@ -182,58 +149,75 @@ RETURN = '''
 id:
   description: UUID of the network.
   returned: success
-  type: string
+  type: str
   sample: 3f8f25cd-c498-443f-9058-438cfbcbff50
 name:
   description: Name of the network.
   returned: success
-  type: string
+  type: str
   sample: net01
 state:
   description: State of the network [Enabled/Disabled].
   returned: success
-  type: string
+  type: str
   sample: Enabled
 broadcast_domain_range:
   description: broadcastdomainrange of the network [POD / ZONE].
   returned: success
-  type: string
+  type: str
   sample: ZONE
 isolation_method:
   description: isolationmethod of the network [VLAN/GRE/L3].
   returned: success
-  type: string
+  type: str
   sample: VLAN
 network_speed:
   description: networkspeed of the network [1G/10G].
   returned: success
-  type: string
+  type: str
   sample: 1G
 zone:
-  description: Name of zone the cluster is in.
+  description: Name of zone the physical network is in.
   returned: success
-  type: string
+  type: str
   sample: ch-gva-2
 domain:
   description: Name of domain the network is in.
   returned: success
-  type: string
+  type: str
   sample: domain1
+nsps:
+  description: list of enabled or disabled Network Service Providers
+  type: complex
+  returned: on enabling/disabling of Network Service Providers
+  contains:
+    enabled:
+      description: list of Network Service Providers that were enabled
+      returned: on Network Service Provider enabling
+      type: list
+      sample:
+       - VirtualRouter
+    disabled:
+      description: list of Network Service Providers that were disabled
+      returned: on Network Service Provider disabling
+      type: list
+      sample:
+       - InternalLbVm
+
 '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
-    CloudStackException,
     cs_argument_spec,
     cs_required_together,
 )
 
 
-class AnsibleCloudStackCluster(AnsibleCloudStack):
+class AnsibleCloudStackPhysicalNetwork(AnsibleCloudStack):
 
     def __init__(self, module):
-        super(AnsibleCloudStackCluster, self).__init__(module)
+        super(AnsibleCloudStackPhysicalNetwork, self).__init__(module)
         self.returns = {
             'isolationmethods': 'isolation_method',
             'broadcastdomainrange': 'broadcast_domain_range',
@@ -241,49 +225,50 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'vlan': 'vlan',
             'tags': 'tags',
         }
-        self.network = None
         self.nsps = []
         self.vrouters = None
         self.loadbalancers = None
 
     def _get_common_args(self):
         args = {
-            'name': self.module.params.get('name'),
+            'name': self.module.params.get('physical_network'),
             'isolationmethods': self.module.params.get('isolation_method'),
             'broadcastdomainrange': self.module.params.get('broadcast_domain_range'),
             'networkspeed': self.module.params.get('network_speed'),
             'tags': self.module.params.get('tags'),
             'vlan': self.module.params.get('vlan'),
         }
-        if args['tags'] and len(args['tags']) > 1:
-            self.module.fail_json(msg="Failed: Physical networks can only have one tag")
 
         state = self.module.params.get('state')
         if state in ['enabled', 'disabled']:
             args['state'] = state.capitalize()
         return args
 
-    def get_network(self, key=None):
-        if self.network:
-            return self.network
+    def get_physical_network(self, key=None):
+        physical_network = self.module.params.get('physical_network')
+        if self.physical_network:
+            return self._get_by_key(key, self.physical_network)
+
         args = {
-            'zoneid': self.get_zone(key='id'),
-            'name': self.module.params.get('name'),
+            'zoneid': self.get_zone(key='id')
         }
-        nets = self.cs.listPhysicalNetworks(**args)
-        if nets:
-            self.network = nets['physicalnetwork'][0]
-        return self.network
+        physical_networks = self.query_api('listPhysicalNetworks', **args)
+        if physical_networks:
+            for net in physical_networks['physicalnetwork']:
+                if physical_network.lower() in [net['name'].lower(), net['id']]:
+                    self.physical_network = net
+                    self.result['physical_network'] = net['name']
+                    break
+
+        return self._get_by_key(key, self.physical_network)
 
     def get_nsp(self, name=None):
         if not self.nsps:
-            network = self.get_network()
             args = {
-                'physicalnetworkid': network['id']
+                'physicalnetworkid': self.get_physical_network(key='id')
             }
-            res = self.cs.listNetworkServiceProviders(**args)
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            res = self.query_api('listNetworkServiceProviders', **args)
+
             self.nsps = res['networkserviceprovider']
 
         names = []
@@ -292,9 +277,9 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             if nsp['name'] == name:
                 return nsp
 
-        self.module.fail_json(msg="Failed: '{}' not in network service providers list '[{}]'".format(name, names))
+        self.module.fail_json(msg="Failed: '{0}' not in network service providers list '[{1}]'".format(name, names))
 
-    def _update_nsp(self, name=None, state=None, service_list=None):
+    def update_nsp(self, name=None, state=None, service_list=None):
         nsp = self.get_nsp(name)
         if not service_list and nsp['state'] == state:
             return nsp
@@ -304,9 +289,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'servicelist': service_list,
             'state': state
         }
-        res = self.cs.updateNetworkServiceProvider(**args)
-        if 'errortext' in res:
-            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        res = self.query_api('updateNetworkServiceProvider', **args)
 
         poll_async = self.module.params.get('poll_async')
         if poll_async:
@@ -320,14 +303,12 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         nspid = nsp['id']
         if self.vrouters is None:
             self.vrouters = dict()
-            res = self.cs.listVirtualRouterElements()
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            res = self.query_api('listVirtualRouterElements', )
             for vrouter in res['virtualrouterelement']:
                 self.vrouters[vrouter['nspid']] = vrouter
 
         if nspid not in self.vrouters:
-            self.module.fail_json(msg="Failed: No VirtualRouterElement founf for nsp '%s'" % nsp_name)
+            self.module.fail_json(msg="Failed: No VirtualRouterElement found for nsp '%s'" % nsp_name)
 
         return self.vrouters[nspid]
 
@@ -336,9 +317,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         nspid = nsp['id']
         if self.loadbalancers is None:
             self.loadbalancers = dict()
-            res = self.cs.listInternalLoadBalancerElements()
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            res = self.query_api('listInternalLoadBalancerElements', )
             for loadbalancer in res['internalloadbalancerelement']:
                 self.loadbalancers[loadbalancer['nspid']] = loadbalancer
 
@@ -356,9 +335,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'id': vrouter['id'],
             'enabled': enabled
         }
-        res = self.cs.configureVirtualRouterElement(**args)
-        if 'errortext' in res:
-            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        res = self.query_api('configureVirtualRouterElement', **args)
 
         poll_async = self.module.params.get('poll_async')
         if poll_async:
@@ -376,9 +353,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
             'id': loadbalancer['id'],
             'enabled': enabled
         }
-        res = self.cs.configureInternalLoadBalancerElement(**args)
-        if 'errortext' in res:
-            self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        res = self.query_api('configureInternalLoadBalancerElement', **args)
 
         poll_async = self.module.params.get('poll_async')
         if poll_async:
@@ -388,7 +363,7 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         return loadbalancer
 
     def present_network(self):
-        network = self.get_network()
+        network = self.get_physical_network()
         if network:
             network = self._update_network()
         else:
@@ -396,92 +371,68 @@ class AnsibleCloudStackCluster(AnsibleCloudStack):
         return network
 
     def _create_network(self):
-        required_params = [
-            'name',
-            'zone',
-        ]
-        self.module.fail_on_missing_params(required_params=required_params)
-
-        args = self._get_common_args()
-        args['zoneid'] = self.get_zone(key='id')
-        args['domainid'] = self.get_domain(key='id')
-        args['url'] = self.module.params.get('url')
-        args['username'] = self.module.params.get('username')
-        args['password'] = self.module.params.get('password')
-
         self.result['changed'] = True
+        args = dict(zoneid=self.get_zone(key='id'))
+        args.update(self._get_common_args())
+        if self.get_domain(key='id'):
+            args['domainid'] = self.get_domain(key='id')
 
-        id = None
         if not self.module.check_mode:
-            res = self.cs.createPhysicalNetwork(**args)
-            if 'errortext' in res:
-                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            resource = self.query_api('createPhysicalNetwork', **args)
 
             poll_async = self.module.params.get('poll_async')
             if poll_async:
-                self.network = self.poll_job(res, 'physicalnetwork')
+                self.network = self.poll_job(resource, 'physicalnetwork')
 
         return self.network
 
     def _update_network(self):
-        network = self.get_network()
+        network = self.get_physical_network()
 
-        args = self._get_common_args()
-        args['id'] = network['id']
+        args = dict(id=network['id'])
+        args.update(self._get_common_args())
 
         if self.has_changed(args, network):
             self.result['changed'] = True
 
             if not self.module.check_mode:
-                res = self.cs.updatePhysicalNetwork(**args)
-                if 'errortext' in res:
-                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+                resource = self.query_api('updatePhysicalNetwork', **args)
 
                 poll_async = self.module.params.get('poll_async')
                 if poll_async:
-                    network = self.poll_job(res, 'physicalnetwork')
-        return network
+                    self.physical_network = self.poll_job(resource, 'physicalnetwork')
+        return self.physical_network
 
     def absent_network(self):
-        network = self.get_network()
-        if network:
+        physical_network = self.get_physical_network()
+        if physical_network:
             self.result['changed'] = True
-
             args = {
-                'id': network['id'],
+                'id': physical_network['id'],
             }
             if not self.module.check_mode:
-                res = self.cs.deletePhysicalNetwork(**args)
-                if 'errortext' in res:
-                    self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
-
+                resource = self.query_api('deletePhysicalNetwork', **args)
                 poll_async = self.module.params.get('poll_async')
                 if poll_async:
-                    success = self.poll_job(res, 'success')
+                    self.poll_job(resource, 'success')
 
-                if not success:
-                    self.module.fail_json(msg="Failed: Network not deleted")
-
-        return network
+        return physical_network
 
 
 def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
-        name=dict(required=True),
-        zone=dict(default=None),
-        domain=dict(default=None),
-        vlan=dict(default=None),
-        nsps_disabled=dict(default=None, type='list'),
-        nsps_enabled=dict(default=None, type='list'),
-        network_speed=dict(choices=['1G', '10G'], default=None),
-        broadcast_domain_range=dict(choices=['POD', 'ZONE'], default=None),
-        isolation_method=dict(choices=['VLAN', 'GRE', 'L3'], default=None),
+        physical_network=dict(required=True, aliases=['name']),
+        zone=dict(),
+        domain=dict(),
+        vlan=dict(),
+        nsps_disabled=dict(type='list'),
+        nsps_enabled=dict(type='list'),
+        network_speed=dict(choices=['1G', '10G']),
+        broadcast_domain_range=dict(choices=['POD', 'ZONE']),
+        isolation_method=dict(choices=['VLAN', 'GRE', 'L3']),
         state=dict(choices=['present', 'enabled', 'disabled', 'absent'], default='present'),
-        url=dict(default=None),
-        username=dict(default=None),
-        password=dict(default=None, no_log=True),
-        tags=dict(type='list', aliases=['tag'], default=None),
+        tags=dict(aliases=['tag']),
         poll_async=dict(type='bool', default=True),
     ))
 
@@ -491,37 +442,37 @@ def main():
         supports_check_mode=True
     )
 
-    try:
-        acs_network = AnsibleCloudStackCluster(module)
+    acs_network = AnsibleCloudStackPhysicalNetwork(module)
+    state = module.params.get('state')
+    nsps_disabled = module.params.get('nsps_disabled', [])
+    nsps_enabled = module.params.get('nsps_enabled', [])
 
-        state = module.params.get('state')
-        nsps_disabled = module.params.get('nsps_disabled', [])
-        nsps_enabled = module.params.get('nsps_enabled', [])
+    if state in ['absent']:
+        network = acs_network.absent_network()
+    else:
+        network = acs_network.present_network()
+    if nsps_disabled is not None:
+        for name in nsps_disabled:
+            acs_network.update_nsp(name=name, state='Disabled')
 
-        if state in ['absent']:
-            network = acs_network.absent_network()
-        else:
-            network = acs_network.present_network()
+    if nsps_enabled is not None:
+        for nsp_name in nsps_enabled:
+            if nsp_name in ['VirtualRouter', 'VpcVirtualRouter']:
+                acs_network.set_vrouter_element_state(enabled=True, nsp_name=nsp_name)
+            elif nsp_name == 'InternalLbVm':
+                acs_network.set_loadbalancer_element_state(enabled=True, nsp_name=nsp_name)
 
-        if nsps_disabled is not None:
-            for name in nsps_disabled:
-                acs_network._update_nsp(name=name, state='Disabled')
+            acs_network.update_nsp(name=nsp_name, state='Enabled')
 
-        if nsps_enabled is not None:
-            for nsp_name in nsps_enabled:
-                if nsp_name in ['VirtualRouter', 'VpcVirtualRouter']:
-                    acs_network.set_vrouter_element_state(enabled=True, nsp_name=nsp_name)
-                elif nsp_name == 'InternalLbVm':
-                    acs_network.set_loadbalancer_element_state(enabled=True, nsp_name=nsp_name)
+    result = acs_network.get_result(network)
 
-                acs_network._update_nsp(name=nsp_name, state='Enabled')
-
-        result = acs_network.get_result(network)
-
-    except CloudStackException as e:
-        module.fail_json(msg='CloudStackException: %s' % str(e))
+    if nsps_enabled:
+        result['nsps_enabled'] = nsps_enabled
+    if nsps_disabled:
+        result['nsps_disabled'] = nsps_disabled
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/test/integration/targets/cs_physical_network/aliases
+++ b/test/integration/targets/cs_physical_network/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_physical_network/meta/main.yml
+++ b/test/integration/targets/cs_physical_network/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/test/integration/targets/cs_physical_network/tasks/main.yml
+++ b/test/integration/targets/cs_physical_network/tasks/main.yml
@@ -1,0 +1,211 @@
+---
+# Create a new zone - the default one is enabled
+- name: assure zone for tests
+  cs_zone:
+    name: cs-test-zone
+    state: present
+    dns1: 8.8.8.8
+    network_type: advanced
+  register: cszone
+
+- name: ensure the zone is disabled
+  cs_zone:
+    name: "{{ cszone.name }}"
+    state: disabled
+  register: cszone
+
+- name: setup a network in check_mode
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+  check_mode: yes
+  register: pn
+- name: validate setup a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.zone == cszone.name
+
+- name: setup a network
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+  register: pn
+- name: validate setup a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.state == 'Disabled'
+
+- name: setup a network idempotence
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+  register: pn
+- name: validate setup a network idempotence
+  assert:
+    that:
+      - pn is successful
+      - pn is not changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.state == 'Disabled'
+
+- name: set a tag on a network
+  cs_physical_network:
+    name: net01
+    tag: overlay
+    zone: "{{ cszone.name }}"
+  ignore_errors: true
+  register: pn
+- name: validate set a tag on a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags == 'overlay'
+      - pn.state == 'Disabled'
+
+- name: Remove tag on a network
+  cs_physical_network:
+    name: net01
+    tag: ""
+    zone: "{{ cszone.name }}"
+  register: pn
+- name: validate remove tag on a network
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags is undefined
+      - pn.state == 'Disabled'
+
+- name: ensure a network is enabled with specific nsps enabled
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    vlan: 100-200,300-400
+    broadcast_domain_range: ZONE
+    state: enabled
+    nsps_enabled:
+      - VirtualRouter
+      - InternalLbVm
+      - VpcVirtualRouter
+  register: pn
+- name: validate ensure a network is enabled with specific nsps enabled
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.vlan == '100-200,300-400'
+      - pn.state == 'Enabled'
+      - "'InternalLbVm' in pn.nsps_enabled"
+
+- name: ensure a network is disabled
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: disabled
+  register: pn
+- name: validate ensure a network is disabled
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags is undefined
+      - pn.state == 'Disabled'
+
+- name: ensure a network is enabled
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: enabled
+  register: pn
+- name: validate ensure a network is enabled
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.broadcast_domain_range == 'ZONE'
+      - pn.isolation_method == 'VLAN'
+      - pn.zone == cszone.name
+      - pn.tags is undefined
+      - pn.state == 'Enabled'
+
+- name: ensure a network is not absent in check mode
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: absent
+  check_mode: yes
+  register: pn
+- name: validate ensure a network is absent
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.zone == cszone.name
+
+- name: ensure a network is absent
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: absent
+  register: pn
+- name: validate ensure a network is absent
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.zone == cszone.name
+      - pn.name == 'net01'
+
+- name: ensure a network is absent idempotence
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: absent
+  register: pn
+- name: validate ensure a network is absent idempotence
+  assert:
+    that:
+      - pn is successful
+      - pn is not changed
+      - pn.zone == cszone.name
+
+- name: cleanup zone
+  cs_zone:
+    name: "{{ cszone.name }}"
+    state: absent

--- a/test/integration/targets/cs_physical_network/tasks/main.yml
+++ b/test/integration/targets/cs_physical_network/tasks/main.yml
@@ -102,6 +102,31 @@
       - pn.tags is undefined
       - pn.state == 'Disabled'
 
+- name: ensure a network is enabled with specific nsps enabled in check mode
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    vlan: 100-200,300-400
+    broadcast_domain_range: ZONE
+    state: enabled
+    nsps_enabled:
+      - virtualrouter
+      - internallbvm
+      - vpcvirtualrouter
+  check_mode: yes
+  register: pn
+- name: validate ensure a network is enabled with specific nsps enabled
+  assert:
+    that:
+      - pn is successful
+      - pn is changed
+      - pn.name == 'net01'
+      - pn.zone == cszone.name
+      - "'internallbvm' in pn.nsps_enabled"
+      - "'virtualrouter' in pn.nsps_enabled"
+      - "'vpcvirtualrouter' in pn.nsps_enabled"
+
 - name: ensure a network is enabled with specific nsps enabled
   cs_physical_network:
     name: net01
@@ -111,9 +136,9 @@
     broadcast_domain_range: ZONE
     state: enabled
     nsps_enabled:
-      - VirtualRouter
-      - InternalLbVm
-      - VpcVirtualRouter
+      - virtualrouter
+      - internallbvm
+      - vpcvirtualrouter
   register: pn
 - name: validate ensure a network is enabled with specific nsps enabled
   assert:
@@ -126,7 +151,9 @@
       - pn.zone == cszone.name
       - pn.vlan == '100-200,300-400'
       - pn.state == 'Enabled'
-      - "'InternalLbVm' in pn.nsps_enabled"
+      - "'internallbvm' in pn.nsps_enabled"
+      - "'virtualrouter' in pn.nsps_enabled"
+      - "'vpcvirtualrouter' in pn.nsps_enabled"
 
 - name: ensure a network is disabled
   cs_physical_network:


### PR DESCRIPTION
##### SUMMARY
Add new CloudStack module cs_physical_network

Resubmitted #25647 with integration tests and adjustments to the new API

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
cs_physical_network

##### ADDITIONAL INFORMATION
The decision to extend `AnsibleCloudStack` with `self.physical_network` was based on the fact that `physicalnetworkid` just like `networkid` is a property not unique in the CloudStack API but common across multiple endpoints serving different purposes (like traffic types, VLAN IP ranges).
