### PR TITLE
Avoid errors on host group confusion in keyed groups

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -428,7 +428,7 @@ class Constructable(object):
                         for bare_name in new_raw_group_names:
                             gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             result_gname = self.inventory.add_group(gname)
-                            self.inventory.add_child(result_gname, host)
+                            self.inventory.add_host(host, result_gname)
 
                             if raw_parent_name:
                                 parent_name = self._sanitize_group_name(raw_parent_name)

--- a/test/units/plugins/inventory/test_constructed.py
+++ b/test/units/plugins/inventory/test_constructed.py
@@ -93,6 +93,26 @@ def test_keyed_group_empty_construction(inventory_module):
     assert host.groups == []
 
 
+def test_keyed_group_host_confusion(inventory_module):
+    inventory_module.inventory.add_host('cow')
+    inventory_module.inventory.add_group('cow')
+    host = inventory_module.inventory.get_host('cow')
+    host.vars['species'] = 'cow'
+    keyed_groups = [
+        {
+            'separator': '',
+            'prefix': '',
+            'key': 'species'
+        }
+    ]
+    inventory_module._add_host_to_keyed_groups(
+        keyed_groups, host.vars, host.name, strict=True
+    )
+    group = inventory_module.inventory.groups['cow']
+    # group cow has host of cow
+    assert group.hosts == [host]
+
+
 def test_keyed_parent_groups(inventory_module):
     inventory_module.inventory.add_host('web1')
     inventory_module.inventory.add_host('web2')


### PR DESCRIPTION
##### SUMMARY
Alternative to https://github.com/ansible/ansible/pull/54074

This avoids errors (ultimately mis-configured user errors) where a group is selected instead of a host for creating entries in keyed groups.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
constructed inventory plugin

##### ADDITIONAL INFORMATION
This is more direct than that other PR. Either this one or that one should work for the issue.
