### PR TITLE
Handle empty output in remote_exists (backport of #52010 to 2.7)

### DIFF
--- a/changelogs/fragments/52010-handle-empty-output-in-remote_exists.yaml
+++ b/changelogs/fragments/52010-handle-empty-output-in-remote_exists.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - flatpak_remote - Handle empty output in remote_exists, fixes https://github.com/ansible/ansible/issues/51481 

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -169,6 +169,8 @@ def remote_exists(module, binary, name, method):
     output = _flatpak_command(module, False, command)
     for line in output.splitlines():
         listed_remote = line.split()
+        if len(listed_remote) == 0:
+            continue
         if listed_remote[0] == to_native(name):
             return True
     return False


### PR DESCRIPTION
##### SUMMARY
Backports #52010 to 2.7

Fixes #51481

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak_remote
