### PR TITLE
Expose timeout option to Redfish modules

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -15,9 +15,10 @@ HEADERS = {'content-type': 'application/json'}
 
 class RedfishUtils(object):
 
-    def __init__(self, creds, root_uri):
+    def __init__(self, creds, root_uri, timeout):
         self.root_uri = root_uri
         self.creds = creds
+        self.timeout = timeout
         self._init_session()
         return
 
@@ -29,7 +30,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
             data = json.loads(resp.read())
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -49,7 +50,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
         except URLError as e:
@@ -68,7 +69,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
         except URLError as e:
@@ -87,7 +88,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
         except URLError as e:

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
@@ -41,6 +41,12 @@ options:
     required: true
     description:
       - Password for authentication with OOB controller
+  timeout:
+    required: false
+    description:
+      - Timeout in seconds for URL requests to OOB controller
+    default: 10
+    version_added: "2.8"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -126,7 +132,8 @@ def main():
             command=dict(required=True, type='list'),
             baseuri=dict(required=True),
             username=dict(required=True),
-            password=dict(required=True, no_log=True)
+            password=dict(required=True, no_log=True),
+            timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False
     )
@@ -138,10 +145,13 @@ def main():
     creds = {'user': module.params['username'],
              'pswd': module.params['password']}
 
+    # timeout
+    timeout = module.params['timeout']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_uri = "/redfish/v1/"
-    rf_utils = IdracRedfishUtils(creds, root_uri)
+    rf_utils = IdracRedfishUtils(creds, root_uri, timeout)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
@@ -42,11 +42,11 @@ options:
     description:
       - Password for authentication with OOB controller
   timeout:
-    required: false
     description:
       - Timeout in seconds for URL requests to OOB controller
     default: 10
-    version_added: "2.8"
+    type: int
+    version_added: '2.8'
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -68,6 +68,12 @@ options:
     required: false
     description:
       - bootdevice when setting boot configuration
+  timeout:
+    required: false
+    description:
+      - Timeout in seconds for URL requests to OOB controller
+    default: 10
+    version_added: "2.8"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -121,13 +127,14 @@ EXAMPLES = '''
       id: "{{ id }}"
       new_password: "{{ new_password }}"
 
-  - name: Clear Manager Logs
+  - name: Clear Manager Logs with a timeout of 20 seconds
     redfish_command:
       category: Manager
       command: ClearLogs
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
+      timeout: 20
 '''
 
 RETURN = '''
@@ -167,6 +174,7 @@ def main():
             new_password=dict(no_log=True),
             roleid=dict(),
             bootdevice=dict(),
+            timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False
     )
@@ -184,10 +192,13 @@ def main():
             'userpswd': module.params['new_password'],
             'userrole': module.params['roleid']}
 
+    # timeout
+    timeout = module.params['timeout']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri)
+    rf_utils = RedfishUtils(creds, root_uri, timeout)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -69,11 +69,11 @@ options:
     description:
       - bootdevice when setting boot configuration
   timeout:
-    required: false
     description:
       - Timeout in seconds for URL requests to OOB controller
     default: 10
-    version_added: "2.8"
+    type: int
+    version_added: '2.8'
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -55,6 +55,12 @@ options:
       - value of BIOS attribute to update
     default: 'null'
     version_added: "2.8"
+  timeout:
+    required: false
+    description:
+      - Timeout in seconds for URL requests to OOB controller
+    default: 10
+    version_added: "2.8"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -90,13 +96,14 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
-  - name: Set BIOS default settings
+  - name: Set BIOS default settings with a timeout of 20 seconds
     redfish_config:
       category: Systems
       command: SetBiosDefaultSettings
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
+      timeout: 20
 '''
 
 RETURN = '''
@@ -129,6 +136,7 @@ def main():
             password=dict(required=True, no_log=True),
             bios_attribute_name=dict(default='null'),
             bios_attribute_value=dict(default='null'),
+            timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False
     )
@@ -140,6 +148,9 @@ def main():
     creds = {'user': module.params['username'],
              'pswd': module.params['password']}
 
+    # timeout
+    timeout = module.params['timeout']
+
     # BIOS attributes to update
     bios_attributes = {'bios_attr_name': module.params['bios_attribute_name'],
                        'bios_attr_value': module.params['bios_attribute_value']}
@@ -147,7 +158,7 @@ def main():
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri)
+    rf_utils = RedfishUtils(creds, root_uri, timeout)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -56,10 +56,10 @@ options:
     default: 'null'
     version_added: "2.8"
   timeout:
-    required: false
     description:
       - Timeout in seconds for URL requests to OOB controller
     default: 10
+    type: int
     version_added: "2.8"
 
 author: "Jose Delarosa (@jose-delarosa)"

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -43,6 +43,12 @@ options:
     required: true
     description:
       - Password for authentication with OOB controller
+  timeout:
+    required: false
+    description:
+      - Timeout in seconds for URL requests to OOB controller
+    default: 10
+    version_added: "2.8"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -56,13 +62,14 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
-  - name: Get fan inventory
+  - name: Get fan inventory with a timeout of 20 seconds
     redfish_facts:
       category: Chassis
       command: GetFanInventory
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
+      timeout: 20
 
   - name: Get default inventory information
     redfish_facts:
@@ -158,6 +165,7 @@ def main():
             baseuri=dict(required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),
+            timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False
     )
@@ -166,10 +174,13 @@ def main():
     creds = {'user': module.params['username'],
              'pswd': module.params['password']}
 
+    # timeout
+    timeout = module.params['timeout']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri)
+    rf_utils = RedfishUtils(creds, root_uri, timeout)
 
     # Build Category list
     if "all" in module.params['category']:

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -44,11 +44,11 @@ options:
     description:
       - Password for authentication with OOB controller
   timeout:
-    required: false
     description:
       - Timeout in seconds for URL requests to OOB controller
     default: 10
-    version_added: "2.8"
+    type: int
+    version_added: '2.8'
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some operations on some Redfish service implementations/environments may take longer than the default 10 second timeout used in the Ansible `ansible.module_utils.urls.open_url` function.

This change exposes a `timeout` option to allow the operator to override the 10 second default.

Fixes #52332 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils
redfish_facts
redfish_config
redfish_command
idrac_redfish_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
**Before**

Given a task like this:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  tasks:
    - name: Set BIOS to defaults
      redfish_config:
        category: Systems
        command: SetBiosDefaultSettings
        baseuri: "{{ baseuri }}"
        username: "{{ username }}"
        password: "{{ password }}"
```

If the default timeout is too short for the command on a service, it will get an error like this:

```
TASK [Set BIOS to defaults] ************************************************
fatal: [sys1]: FAILED! => {"changed": false, "msg": "Failed POST operation against Redfish API server: ('The read operation timed out',)"}

PLAY RECAP *********************************************************************
sys1                      : ok=4    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
``` 

**After**

Now the task can be updated like this to override the default timeout and obtain a successful result:

```
  tasks:
    - name: Set BIOS to defaults
      redfish_config:
        category: Systems
        command: SetBiosDefaultSettings
        baseuri: "{{ baseuri }}"
        username: "{{ username }}"
        password: "{{ password }}"
        timeout: 30
```

```
TASK [Set BIOS to defaults] ************************************************
ok: [sys1]

PLAY RECAP *********************************************************************
sys1                      : ok=6    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```


