### PR TITLE
[stable-2.7] Pin the ansible-runner version in tests.

### DIFF
--- a/test/integration/targets/ansible-runner/tasks/setup.yml
+++ b/test/integration/targets/ansible-runner/tasks/setup.yml
@@ -5,6 +5,7 @@
 - name: Install ansible-runner
   pip:
     name: ansible-runner
+    version: 1.2.0
 
 - name: Find location of ansible-runner installation
   command: "'{{ ansible_python_interpreter }}' -c 'import os, ansible_runner; print(os.path.dirname(ansible_runner.__file__))'"


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Pin the ansible-runner version in tests.

Backport of PR: https://github.com/ansible/ansible/pull/54135

The tests need to be updated to support newer ansible-runner releases.

(cherry picked from commit 777b726e4f4701d68aa06abbe6a5ed67497ad46c)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-runner integration test
