### PR TITLE
Fix test_oneview_ethernet_network unit test.

### DIFF
--- a/test/units/modules/remote_management/oneview/test_oneview_ethernet_network.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_ethernet_network.py
@@ -93,7 +93,7 @@ DEFAULT_BULK_ENET_TEMPLATE = [
     {'name': 'TestNetwork_10', 'vlanId': 10},
 ]
 
-DICT_PARAMS_WITH_CHANGES = yaml.load(YAML_PARAMS_WITH_CHANGES)["data"]
+DICT_PARAMS_WITH_CHANGES = yaml.safe_load(YAML_PARAMS_WITH_CHANGES)["data"]
 
 
 class EthernetNetworkModuleSpec(unittest.TestCase,


### PR DESCRIPTION
##### SUMMARY

Fix test_oneview_ethernet_network unit test.

Use yaml.safe_load since yaml.load without a loader is deprecated.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test_oneview_ethernet_network unit test
