### PR TITLE
Mark azure_rm_hdinsightcluster test unstable.

### DIFF
--- a/test/integration/targets/azure_rm_hdinsightcluster/aliases
+++ b/test/integration/targets/azure_rm_hdinsightcluster/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 destructive
 shippable/azure/group1
+unstable # test is slow (~30 minute run time), not unstable, but this is better than unsupported


### PR DESCRIPTION
##### SUMMARY

Mark azure_rm_hdinsightcluster test unstable.

The unstable alias wasn't intended for slow but otherwise stable tests. However, the alternatives are to either dedicate an entire test group to this one test or mark it unsupported.

Marking it unstable at least permits the test to run when changes are made to the integration test or the module itself, which is better than not running the tests at all.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_hdinsightcluster integration test
