### PR TITLE
[stable-2.6] Disable failing azure_rm_managed_disk test.

### DIFF
--- a/test/integration/targets/azure_rm_managed_disk/aliases
+++ b/test/integration/targets/azure_rm_managed_disk/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group3
 destructive
+disabled


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Disable failing azure_rm_managed_disk test.

Backport of https://github.com/ansible/ansible/pull/54154

(cherry picked from commit 1a286a95e5ae2f5495bc22723e6676b559aec03f)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_managed_disk integration test
