### PR TITLE
na_ontap_gather_facts: Add gather subset system_node_info

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
@@ -268,7 +268,7 @@ class NetAppONTAPGatherFacts(object):
                 'kwargs': {},
                 'min_version': '0',
             },
-           'system_node_info': {
+            'system_node_info': {
                 'method': self.get_generic_get_iter,
                 'kwargs': {
                     'call': 'system-node-get-iter',

--- a/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
@@ -268,6 +268,16 @@ class NetAppONTAPGatherFacts(object):
                 'kwargs': {},
                 'min_version': '0',
             },
+           'system_node_info': {
+                'method': self.get_generic_get_iter,
+                'kwargs': {
+                    'call': 'system-node-get-iter',
+                    'attribute': 'node-details-info',
+                    'field': 'node',
+                    'query': {'max-records': '1024'},
+                },
+                'min_version': '0',
+            },
             # supported in ONTAP 9.4 and onwards
             'nvme_info': {
                 'method': self.get_generic_get_iter,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the subset system_node_info to get information about the node like model, serial etc.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_gather_facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Added to geth further information about the hardware.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
"key": "system_node_info",
            "value": {
                "<node-name>": {
                    "cpu_busytime": "211044",
                    "cpu_firmware_release": "11.2.1",
                    "env_failed_fan_count": "0",
                    "env_failed_fan_message": "There are no failed fans.",
                    "env_failed_power_supply_count": "0",
                    "env_failed_power_supply_message": "There are no failed power supplies.",
                    "env_over_temperature": "false",
                    "is_all_flash_optimized": "false",
                    "is_cloud_optimized": "false",
                    "is_diff_svcs": "false",
                    "is_epsilon_node": "false",
                    "is_node_cluster_eligible": "true",
                    "is_node_healthy": "true",
                    "maximum_aggregate_size": "439804651110400",
                    "maximum_number_of_volumes": "1000",
                    "maximum_volume_size": "109951162777600",
                    "node": "<node_name>",
                    "node_location": "<location>",
                    "node_model": "FAS2750",
                    "node_nvram_id": "<nvramid>",
                    "node_owner": null,
                    "node_serial_number": "<serial>",
                    "node_storage_configuration": "multi_path_ha",
                    "node_system_id": "<systemid>",
                    "node_uptime": "5676782",
                    "node_uuid": "<uuid>",
                    "node_vendor": "NetApp",
                    "nvram_battery_status": "battery_ok",
                    "product_version": "NetApp Release 9.4P5: Thu Dec 13 14:13:50 UTC 2018"
                },....
```
