### PR TITLE
[2.7] include_tasks: fix traceback if no file specified (#54044)

### DIFF
--- a/changelogs/fragments/54044-fix-include_task-no-file-traceback.yml
+++ b/changelogs/fragments/54044-fix-include_task-no-file-traceback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - include_task - Fixed an unexpected exception if no file was given to include.

--- a/changelogs/fragments/54044-fix-include_task-no-file-traceback.yml
+++ b/changelogs/fragments/54044-fix-include_task-no-file-traceback.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - include_task - Fixed an unexpected exception if no file was given to include.
+  - include_tasks - Fixed an unexpected exception if no file was given to include.

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -67,7 +67,7 @@ class TaskInclude(Task):
             raise AnsibleParserError('Invalid options for %s: %s' % (task.action, ','.join(list(bad_opts))), obj=data)
 
         if not task.args.get('_raw_params'):
-            task.args['_raw_params'] = task.args.pop('file')
+            task.args['_raw_params'] = task.args.pop('file', None)
 
         apply_attrs = task.args.get('apply', {})
         if apply_attrs and task.action != 'include_tasks':

--- a/test/integration/targets/include_import/tasks/test_include_tasks.yml
+++ b/test/integration/targets/include_import/tasks/test_include_tasks.yml
@@ -42,3 +42,13 @@
 
     - name: include_tasks + action
       action: include_tasks tasks1.yml
+
+    - name: test fail as expected without file
+      include_tasks:
+      ignore_errors: yes
+      register: res
+
+    - name: verify fail as expected without file
+      assert:
+        that:
+          - res.msg == 'No include file was specified to the include'


### PR DESCRIPTION
##### SUMMARY
Backport of #54044
(cherry picked from commit c5609c51bffb552d53aa91491430b46774a7f572)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
include_tasks

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
