### PR TITLE
redfish_facts: Extend CPU data example and output results

### DIFF
--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -55,7 +55,19 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-
+  - debug:
+      msg: "{{ redfish_facts.cpu.entries | to_nice_json }}"
+        
+  - name: Get CPU model
+    redfish_facts:
+      category: Systems
+      command: GetCpuInventory
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+  - debug:
+      msg: "{{ redfish_facts.cpu.entries.0.Model }}"
+        
   - name: Get fan inventory
     redfish_facts:
       category: Chassis
@@ -69,6 +81,8 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
+  - debug:
+      msg: "{{ redfish_facts | to_nice_json }}"
 
   - name: Get several inventories
     redfish_facts:

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -57,7 +57,7 @@ EXAMPLES = '''
       password: "{{ password }}"
   - debug:
       msg: "{{ redfish_facts.cpu.entries | to_nice_json }}"
-        
+
   - name: Get CPU model
     redfish_facts:
       category: Systems
@@ -67,7 +67,7 @@ EXAMPLES = '''
       password: "{{ password }}"
   - debug:
       msg: "{{ redfish_facts.cpu.entries.0.Model }}"
-        
+
   - name: Get fan inventory
     redfish_facts:
       category: Chassis


### PR DESCRIPTION
Add "Get CPU Model example" and output result from "Get CPU inventory". Also add example for output of the "Inventory information" to make it easier to use the examples for Ansible beginners.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

