### PR TITLE
VMware: Fix network condition in DHCP mode in debian 9 template

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2156,7 +2156,8 @@ class PyVmomiHelper(PyVmomi):
         for nw in self.params['networks']:
             for key in nw:
                 # We don't need customizations for these keys
-                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected'):
+                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected') or key == 'type' \
+                        and nw['type'] != 'dhcp':
                     network_changes = True
                     break
 


### PR DESCRIPTION
##### SUMMARY
In vmware_guest.py, in the "deploy_vm" method, the network parameters of the VM is checked in order to launch or not the VMWare OS customization. When we deploy a Linux Debian9 from a template, VMware tries to  launch the customization and fails. We get the following error message:
```
TASK [VMWARE_GUEST | Create VM xxx on vcenter] (Mar 13, 2019 10:32:57) ***************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "msg": "Failed to create a virtual machine : Customization of the guest operating system 'debian7_64Guest' is not supported in this configuration. Microsoft Vista (TM) and Linux guests with Logical Volume Manager are supported only for recent ESX host and VMware Tools versions. Refer to vCenter documentation for supported configurations."
}
```
The OS customization is triggered because in the network parameter of the VM, we use 'dhcp'. 
I suggest to ignore the customization when the network type is DHCP

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
vcenter: 6.0
vmware ESX 5.5
ansible: 2.7.8

In our playbook, we only set a name for the 'networks' parameter of the vmware guest module. 
According to documentation the default value attributed to the type is 'dhcp'. 
We are trying to deploy a debian 9 VM through a VMware template


