### PR TITLE
docker_compose: adjust return variable

### DIFF
--- a/changelogs/fragments/docker-facts.yaml
+++ b/changelogs/fragments/docker-facts.yaml
@@ -2,6 +2,7 @@ minor_changes:
 - "docker_container, docker_network, docker_volume - return facts as regular variables ``container``,
    ``network`` respectively ``volume`` additionally to facts. This is now the preferred way to
    obtain results. The facts will be removed in Ansible 2.12."
-- "docker_service - return facts as regular variable ``service_facts``; this is a dictionary mapping
-   service names to container dictionaries. The facts are still returned, but it is recommended to
-   use ``register`` and ``service_facts`` in the future. The facts will be removed in Ansible 2.12."
+- "docker_service - return results as regular variable ``services``; this is a dictionary mapping
+   service names to container dictionaries. The old ansible facts are still returned, but it is
+   recommended to use ``register`` and ``services`` in the future. The facts will be removed in
+   Ansible 2.12."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -299,7 +299,7 @@ Noteworthy module changes
 
 * The ``docker_service`` module was renamed to :ref:`docker_compose <docker_compose_module>`.
 * The renamed ``docker_compose`` module used to return one fact per service, named same as the service. A dictionary
-  of these facts is returned as the regular return value ``service_facts``. The returned facts will be removed in
+  of these facts is returned as the regular return value ``services``. The returned facts will be removed in
   Ansible 2.12.
 
 * The ``docker_swarm_service`` module no longer sets a defaults for the following options:

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -302,7 +302,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-service_facts:
+services:
   description:
   - A dictionary mapping the service's name to a dictionary of containers.
   - Note that facts are part of the registered vars since Ansible 2.8. For compatibility reasons, the facts
@@ -686,7 +686,7 @@ class ContainerManager(DockerBaseClass):
         start_deps = self.dependencies
         service_names = self.services
         detached = True
-        result = dict(changed=False, actions=[], ansible_facts=dict(), service_facts=dict())
+        result = dict(changed=False, actions=[], ansible_facts=dict(), services=dict())
 
         up_options = {
             u'--no-recreate': False,
@@ -772,7 +772,7 @@ class ContainerManager(DockerBaseClass):
         for service in self.project.services:
             service_facts = dict()
             result['ansible_facts'][service.name] = service_facts
-            result['service_facts'][service.name] = service_facts
+            result['services'][service.name] = service_facts
             for container in service.containers(stopped=True):
                 inspection = container.inspect()
                 # pare down the inspection data to the most useful bits


### PR DESCRIPTION
##### SUMMARY
Follow-up to #54124.

The return variable has been introduced for Ansible 2.8, so renaming should be no problem.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_compose
