### PR TITLE
docker_host_info and docker_node: fix return variable names

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_host_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_info.py
@@ -132,7 +132,7 @@ EXAMPLES = '''
   register: result
 
 - debug:
-    var: result.docker_host_facts
+    var: result.host_info
 
 '''
 
@@ -143,7 +143,7 @@ can_talk_to_docker:
     returned: both on success and on error
     type: bool
 
-host_facts:
+host_info:
     description:
       - Facts representing the basic state of the docker host. Matches the C(docker system info) output.
     returned: always
@@ -209,7 +209,7 @@ class DockerHostManager(DockerBaseClass):
 
         listed_objects = ['volumes', 'networks', 'containers', 'images']
 
-        self.results['host_facts'] = self.get_docker_host_facts()
+        self.results['host_info'] = self.get_docker_host_info()
 
         if self.client.module.params['disk_usage']:
             self.results['disk_usage'] = self.get_docker_disk_usage_facts()
@@ -221,7 +221,7 @@ class DockerHostManager(DockerBaseClass):
                 filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name))
                 self.results[returned_name] = self.get_docker_items_list(docker_object, filters)
 
-    def get_docker_host_facts(self):
+    def get_docker_host_info(self):
         try:
             return self.client.info()
         except APIError as exc:

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -122,7 +122,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-node_facts:
+node:
   description: Information about node after 'update' operation
   returned: success
   type: dict
@@ -253,10 +253,10 @@ class SwarmNodeManager(DockerBaseClass):
                                             node_spec=node_spec)
                 except APIError as exc:
                     self.client.fail("Failed to update node : %s" % to_native(exc))
-            self.results['node_facts'] = self.client.get_node_inspect(node_id=node_info['ID'])
+            self.results['node'] = self.client.get_node_inspect(node_id=node_info['ID'])
             self.results['changed'] = changed
         else:
-            self.results['node_facts'] = node_info
+            self.results['node'] = node_info
             self.results['changed'] = changed
 
 

--- a/test/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/test/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -15,7 +15,7 @@
   - name: assert reading docker host facts when docker is running
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks is not defined'
          - 'output.volumes is not defined'
@@ -55,7 +55,7 @@
   - name: assert reading docker host facts when docker is running and list containers
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.networks is not defined'
          - 'output.volumes is not defined'
          - 'output.images is not defined'
@@ -72,7 +72,7 @@
   - name: assert reading docker host facts when docker is running and list containers with verbose output
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.networks is not defined'
          - 'output.volumes is not defined'
          - 'output.images is not defined'
@@ -88,7 +88,7 @@
   - name: assert reading docker host facts when docker is running and list images
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks is not defined'
          - 'output.volumes is not defined'
@@ -105,7 +105,7 @@
   - name: assert reading docker host facts when docker is running and list images with verbose output
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks is not defined'
          - 'output.volumes is not defined'
@@ -121,7 +121,7 @@
   - name: assert reading docker host facts when docker is running and list networks
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks[0].Id is string'
          - 'output.networks[0].Created is not defined'
@@ -138,7 +138,7 @@
   - name: assert reading docker host facts when docker is running and list networks with verbose output
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks[0].Id is string'
          - 'output.networks[0].Created is string'
@@ -154,7 +154,7 @@
   - name: assert reading docker host facts when docker is running and list volumes
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks is not defined'
          - 'output.volumes[0].Name is string'
@@ -171,7 +171,7 @@
   - name: assert reading docker host facts when docker is running and list volumes with verbose output
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks is not defined'
          - 'output.volumes[0].Name is string'
@@ -187,7 +187,7 @@
   - name: assert reading docker host facts when docker is running and get disk usage
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks is not defined'
          - 'output.volumes is not defined'
@@ -204,7 +204,7 @@
   - name: assert reading docker host facts when docker is running and get disk usage with verbose output
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers is not defined'
          - 'output.networks is not defined'
          - 'output.volumes is not defined'
@@ -224,7 +224,7 @@
   - name: assert reading docker host facts when docker is running, disk usage and get lists together
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers[0].Image is string'
          - 'output.containers[0].ImageID is not defined'
          - 'output.networks[0].Id is string'
@@ -249,7 +249,7 @@
   - name: assert reading docker host facts when docker is running and get disk usage with verbose output
     assert:
       that:
-         - 'output.host_facts.Name is string'
+         - 'output.host_info.Name is string'
          - 'output.containers[0].Image is string'
          - 'output.containers[0].ImageID is string'
          - 'output.networks[0].Id is string'

--- a/test/integration/targets/docker_node/tasks/test_node.yml
+++ b/test/integration/targets/docker_node/tasks/test_node.yml
@@ -80,10 +80,10 @@
          - 'set_as_manager_2 is not changed'
          - 'set_as_manager_3 is not changed'
          - 'set_as_manager_4 is not changed'
-         - 'set_as_manager_1.node_facts.Spec.Role == "manager"'
-         - 'set_as_manager_2.node_facts.Spec.Role == "manager"'
-         - 'set_as_manager_3.node_facts.Spec.Role == "manager"'
-         - 'set_as_manager_4.node_facts.Spec.Role == "manager"'
+         - 'set_as_manager_1.node.Spec.Role == "manager"'
+         - 'set_as_manager_2.node.Spec.Role == "manager"'
+         - 'set_as_manager_3.node.Spec.Role == "manager"'
+         - 'set_as_manager_4.node.Spec.Role == "manager"'
 
 ####################################################################
 ## Set node as swarm worker ########################################
@@ -147,7 +147,7 @@
          - 'set_as_paused_2 is changed'
          - 'set_as_paused_3 is not changed'
          - 'set_as_paused_4 is not changed'
-         - 'set_as_paused_2.node_facts.Spec.Availability == "pause"'
+         - 'set_as_paused_2.node.Spec.Availability == "pause"'
 
 ####################################################################
 ## Set node as drained #############################################
@@ -186,7 +186,7 @@
          - 'output_drain_2 is changed'
          - 'output_drain_3 is not changed'
          - 'output_drain_4 is not changed'
-         - 'output_drain_2.node_facts.Spec.Availability == "drain"'
+         - 'output_drain_2.node.Spec.Availability == "drain"'
 
 
 ####################################################################
@@ -226,7 +226,7 @@
          - 'output_active_2 is changed'
          - 'output_active_3 is not changed'
          - 'output_active_4 is not changed'
-         - 'output_active_2.node_facts.Spec.Availability == "active"'
+         - 'output_active_2.node.Spec.Availability == "active"'
 
 ####################################################################
 ## Add single label ###############################################
@@ -269,8 +269,8 @@
          - 'output_add_single_label_2 is changed'
          - 'output_add_single_label_3 is not changed'
          - 'output_add_single_label_4 is not changed'
-         - 'output_add_single_label_2.node_facts.Spec.Labels | length == 1'
-         - 'output_add_single_label_2.node_facts.Spec.Labels.label1 == "value1"'
+         - 'output_add_single_label_2.node.Spec.Labels | length == 1'
+         - 'output_add_single_label_2.node.Spec.Labels.label1 == "value1"'
 
 ####################################################################
 ## Add multiple labels #############################################
@@ -329,9 +329,9 @@
          - 'output_add_multiple_labels_2 is changed'
          - 'output_add_multiple_labels_3 is not changed'
          - 'output_add_multiple_labels_4 is not changed'
-         - 'output_add_multiple_labels_2.node_facts.Spec.Labels | length == 6'
-         - 'output_add_multiple_labels_2.node_facts.Spec.Labels.label1 == "value1"'
-         - 'output_add_multiple_labels_2.node_facts.Spec.Labels.label6 == "value6"'
+         - 'output_add_multiple_labels_2.node.Spec.Labels | length == 6'
+         - 'output_add_multiple_labels_2.node.Spec.Labels.label1 == "value1"'
+         - 'output_add_multiple_labels_2.node.Spec.Labels.label6 == "value6"'
 
 ####################################################################
 ## Update label value ##############################################
@@ -374,9 +374,9 @@
          - 'output_update_label_2 is changed'
          - 'output_update_label_3 is not changed'
          - 'output_update_label_4 is not changed'
-         - 'output_update_label_2.node_facts.Spec.Labels | length == 6'
-         - 'output_update_label_2.node_facts.Spec.Labels.label1 == "value1111"'
-         - 'output_update_label_2.node_facts.Spec.Labels.label5 == "value5"'
+         - 'output_update_label_2.node.Spec.Labels | length == 6'
+         - 'output_update_label_2.node.Spec.Labels.label1 == "value1111"'
+         - 'output_update_label_2.node.Spec.Labels.label5 == "value5"'
 
 ####################################################################
 ## Update multiple labels values ###################################
@@ -423,10 +423,10 @@
          - 'output_update_labels_2 is changed'
          - 'output_update_labels_3 is not changed'
          - 'output_update_labels_4 is not changed'
-         - 'output_update_labels_2.node_facts.Spec.Labels | length == 6'
-         - 'output_update_labels_2.node_facts.Spec.Labels.label1 == "value1111"'
-         - 'output_update_labels_2.node_facts.Spec.Labels.label3 == "value3333"'
-         - 'output_update_labels_2.node_facts.Spec.Labels.label5 == "value5"'
+         - 'output_update_labels_2.node.Spec.Labels | length == 6'
+         - 'output_update_labels_2.node.Spec.Labels.label1 == "value1111"'
+         - 'output_update_labels_2.node.Spec.Labels.label3 == "value3333"'
+         - 'output_update_labels_2.node.Spec.Labels.label5 == "value5"'
 
 ####################################################################
 ## Remove single label #############################################
@@ -469,10 +469,10 @@
          - 'output_remove_label_2 is changed'
          - 'output_remove_label_3 is not changed'
          - 'output_remove_label_4 is not changed'
-         - 'output_remove_label_2.node_facts.Spec.Labels | length == 5'
-         - '"label1" not in output_remove_label_2.node_facts.Spec.Labels'
-         - 'output_remove_label_2.node_facts.Spec.Labels.label3 == "value3333"'
-         - 'output_remove_label_2.node_facts.Spec.Labels.label5 == "value5"'
+         - 'output_remove_label_2.node.Spec.Labels | length == 5'
+         - '"label1" not in output_remove_label_2.node.Spec.Labels'
+         - 'output_remove_label_2.node.Spec.Labels.label3 == "value3333"'
+         - 'output_remove_label_2.node.Spec.Labels.label5 == "value5"'
 
 
 ####################################################################
@@ -516,10 +516,10 @@
          - 'output_remove_nonexist_label_2 is not changed'
          - 'output_remove_nonexist_label_3 is not changed'
          - 'output_remove_nonexist_label_4 is not changed'
-         - 'output_remove_nonexist_label_2.node_facts.Spec.Labels | length == 5'
-         - '"label1" not in output_remove_nonexist_label_2.node_facts.Spec.Labels'
-         - 'output_remove_nonexist_label_2.node_facts.Spec.Labels.label3 == "value3333"'
-         - 'output_remove_nonexist_label_2.node_facts.Spec.Labels.label5 == "value5"'
+         - 'output_remove_nonexist_label_2.node.Spec.Labels | length == 5'
+         - '"label1" not in output_remove_nonexist_label_2.node.Spec.Labels'
+         - 'output_remove_nonexist_label_2.node.Spec.Labels.label3 == "value3333"'
+         - 'output_remove_nonexist_label_2.node.Spec.Labels.label5 == "value5"'
 
 ####################################################################
 ## Remove multiple labels ##########################################
@@ -566,10 +566,10 @@
          - 'output_remove_label_2 is changed'
          - 'output_remove_label_3 is not changed'
          - 'output_remove_label_4 is not changed'
-         - 'output_remove_label_2.node_facts.Spec.Labels | length == 3'
-         - '"label1" not in output_remove_label_2.node_facts.Spec.Labels'
-         - '"label2" not in output_remove_label_2.node_facts.Spec.Labels'
-         - 'output_remove_label_2.node_facts.Spec.Labels.label5 == "value5"'
+         - 'output_remove_label_2.node.Spec.Labels | length == 3'
+         - '"label1" not in output_remove_label_2.node.Spec.Labels'
+         - '"label2" not in output_remove_label_2.node.Spec.Labels'
+         - 'output_remove_label_2.node.Spec.Labels.label5 == "value5"'
 
 ####################################################################
 ## Remove multiple labels, mix assigned and not assigned  ##########
@@ -616,10 +616,10 @@
         - 'output_remove_mix_labels_2 is changed'
         - 'output_remove_mix_labels_3 is not changed'
         - 'output_remove_mix_labels_4 is not changed'
-        - 'output_remove_mix_labels_2.node_facts.Spec.Labels | length == 2'
-        - '"label1" not in output_remove_mix_labels_2.node_facts.Spec.Labels'
-        - '"label4" not in output_remove_mix_labels_2.node_facts.Spec.Labels'
-        - 'output_remove_mix_labels_2.node_facts.Spec.Labels.label5 == "value5"'
+        - 'output_remove_mix_labels_2.node.Spec.Labels | length == 2'
+        - '"label1" not in output_remove_mix_labels_2.node.Spec.Labels'
+        - '"label4" not in output_remove_mix_labels_2.node.Spec.Labels'
+        - 'output_remove_mix_labels_2.node.Spec.Labels.label5 == "value5"'
 
 ####################################################################
 ## Add and remove labels ###########################################
@@ -674,9 +674,9 @@
         - 'output_add_del_labels_2 is changed'
         - 'output_add_del_labels_3 is not changed'
         - 'output_add_del_labels_4 is not changed'
-        - 'output_add_del_labels_2.node_facts.Spec.Labels | length == 3'
-        - '"label5" not in output_add_del_labels_2.node_facts.Spec.Labels'
-        - 'output_add_del_labels_2.node_facts.Spec.Labels.label8 == "value8"'
+        - 'output_add_del_labels_2.node.Spec.Labels | length == 3'
+        - '"label5" not in output_add_del_labels_2.node.Spec.Labels'
+        - 'output_add_del_labels_2.node.Spec.Labels.label8 == "value8"'
 
 ####################################################################
 ## Add and remove labels with label in both lists ##################
@@ -735,10 +735,10 @@
         - 'output_add_del_overlap_lables_2 is changed'
         - 'output_add_del_overlap_lables_3 is not changed'
         - 'output_add_del_overlap_lables_4 is not changed'
-        - 'output_add_del_overlap_lables_2.node_facts.Spec.Labels | length == 3'
-        - '"label7" not in output_add_del_overlap_lables_2.node_facts.Spec.Labels'
-        - 'output_add_del_overlap_lables_2.node_facts.Spec.Labels.label6 == "value6666"'
-        - 'output_add_del_overlap_lables_2.node_facts.Spec.Labels.label22 == "value22"'
+        - 'output_add_del_overlap_lables_2.node.Spec.Labels | length == 3'
+        - '"label7" not in output_add_del_overlap_lables_2.node.Spec.Labels'
+        - 'output_add_del_overlap_lables_2.node.Spec.Labels.label6 == "value6666"'
+        - 'output_add_del_overlap_lables_2.node.Spec.Labels.label22 == "value22"'
 
 ####################################################################
 ## Replace labels #############################################
@@ -789,9 +789,9 @@
         - 'output_replace_labels_2 is changed'
         - 'output_replace_labels_3 is not changed'
         - 'output_replace_labels_4 is not changed'
-        - 'output_replace_labels_2.node_facts.Spec.Labels | length == 2'
-        - '"label6" not in output_replace_labels_2.node_facts.Spec.Labels'
-        - 'output_replace_labels_2.node_facts.Spec.Labels.label12 == "value12"'
+        - 'output_replace_labels_2.node.Spec.Labels | length == 2'
+        - '"label6" not in output_replace_labels_2.node.Spec.Labels'
+        - 'output_replace_labels_2.node.Spec.Labels.label12 == "value12"'
 
 ####################################################################
 ## Remove all labels #############################################
@@ -830,7 +830,7 @@
         - 'output_remove_labels_2 is changed'
         - 'output_remove_labels_3 is not changed'
         - 'output_remove_labels_4 is not changed'
-        - 'output_remove_labels_2.node_facts.Spec.Labels | length == 0'
+        - 'output_remove_labels_2.node.Spec.Labels | length == 0'
 
   always:
   - name: Cleanup


### PR DESCRIPTION
##### SUMMARY
Follow-up PR to #54124.

Changes the name of one of the return values of `docker_host_info` from `host_facts` to `host_info`.

Also changes the name of `docker_node`'s return value `node_facts` to `node`, so that it is more similar to other module's return values and also fits `docker_node_info`'s `nodes` return value name.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_host_info
docker_node
