### PR TITLE
grafana_datasource: use the Ansible helpers to get basic auth header

### DIFF
--- a/changelogs/fragments/grafana_datasource_fix_basic_auth_python3_issue.yaml
+++ b/changelogs/fragments/grafana_datasource_fix_basic_auth_python3_issue.yaml
@@ -1,4 +1,3 @@
-
 bugfixes:
   - grafana_datasource - Fixed an issue when running Python3 and using basic auth
     (https://github.com/ansible/ansible/issues/49147)

--- a/changelogs/fragments/grafana_datasource_fix_basic_auth_python3_issue.yaml
+++ b/changelogs/fragments/grafana_datasource_fix_basic_auth_python3_issue.yaml
@@ -1,0 +1,4 @@
+
+bugfixes:
+  - grafana_datasource - Fixed an issue when running Python3 and using basic auth
+    (https://github.com/ansible/ansible/issues/49147)

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -259,7 +259,7 @@ import json
 import base64
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible.module_utils._text import to_bytes
 
 __metaclass__ = type
@@ -373,8 +373,7 @@ def grafana_create_datasource(module, data):
     if 'grafana_api_key' in data and data['grafana_api_key'] is not None:
         headers['Authorization'] = "Bearer %s" % data['grafana_api_key']
     else:
-        auth = base64.b64encode(to_bytes('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', ''))
-        headers['Authorization'] = 'Basic %s' % auth
+        headers['Authorization'] = basic_auth_header(data['grafana_user'], data['grafana_password'])
         grafana_switch_organisation(module, data['grafana_url'], data['org_id'], headers)
 
     # test if datasource already exists
@@ -433,8 +432,7 @@ def grafana_delete_datasource(module, data):
     if 'grafana_api_key' in data and data['grafana_api_key']:
         headers['Authorization'] = "Bearer %s" % data['grafana_api_key']
     else:
-        auth = base64.b64encode(to_bytes('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', ''))
-        headers['Authorization'] = 'Basic %s' % auth
+        headers['Authorization'] = basic_auth_header(data['grafana_user'], data['grafana_password'])
         grafana_switch_organisation(module, data['grafana_url'], data['org_id'], headers)
 
     # test if datasource already exists


### PR DESCRIPTION

##### SUMMARY

Module was not using the helpers, so an error occured in python3.

Fixes #49147

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

grafana_datasource.py

##### ADDITIONAL INFORMATION

Pushing for stable-2.7 because the module code changed a lot on devel and now use url_argument_spec() heper function.