### PR TITLE
Fix SetOneTimeBoot to use standard ComputerSystem 'Boot' property

### DIFF
--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -74,6 +74,16 @@ options:
     default: 10
     type: int
     version_added: '2.8'
+  uefi_target:
+    required: false
+    description:
+      - UEFI target when bootdevice is "UefiTarget"
+    version_added: "2.9"
+  boot_next:
+    required: false
+    description:
+      - BootNext target when bootdevice is "UefiBootNext"
+    version_added: "2.9"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -92,6 +102,26 @@ EXAMPLES = '''
       category: Systems
       command: SetOneTimeBoot
       bootdevice: "{{ bootdevice }}"
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+
+  - name: Set one-time boot device to UefiTarget of "/0x31/0x33/0x01/0x01"
+    redfish_command:
+      category: Systems
+      command: SetOneTimeBoot
+      bootdevice: "UefiTarget"
+      uefi_target: "/0x31/0x33/0x01/0x01"
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+
+  - name: Set one-time boot device to BootNext target of "Boot0001"
+    redfish_command:
+      category: Systems
+      command: SetOneTimeBoot
+      bootdevice: "UefiBootNext"
+      boot_next: "Boot0001"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -183,7 +213,9 @@ def main():
             new_password=dict(no_log=True),
             roleid=dict(),
             bootdevice=dict(),
-            timeout=dict(type='int', default=10)
+            timeout=dict(type='int', default=10),
+            uefi_target=dict(),
+            boot_next=dict()
         ),
         supports_check_mode=False
     )
@@ -248,7 +280,10 @@ def main():
             if "Power" in command:
                 result = rf_utils.manage_system_power(command)
             elif command == "SetOneTimeBoot":
-                result = rf_utils.set_one_time_boot_device(module.params['bootdevice'])
+                result = rf_utils.set_one_time_boot_device(
+                    module.params['bootdevice'],
+                    module.params['uefi_target'],
+                    module.params['boot_next'])
 
     elif category == "Chassis":
         result = rf_utils._find_chassis_resource(rf_uri)

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -283,7 +283,8 @@ def main():
     # Return data back or fail with proper message
     if result['ret'] is True:
         del result['ret']
-        module.exit_json(changed=True, msg='Action was successful')
+        changed = result.get('changed', True)
+        module.exit_json(changed=changed, msg='Action was successful')
     else:
         module.fail_json(msg=to_native(result['msg']))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated the logic for the SetOneTimeBoot command to use the standard 'Boot' property in the ComputerSystem resource. The original code was using Bios attributes which is not conformant with the Redfish spec.

I also updated the logic to not PATCH the system if the Boot properties are already set to the needed values. In this case, the Ansible 'changed' property is returned as False.

If the PATCH is applied, the 'changed' property is returned as True.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #51814

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

Playbooks from the original problem description in issue #51814:

```
---
- hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.240.50.78
    user: USERID
    password: PASSW0RD
  tasks:
    - name: Set one time boot option
      redfish_command:
        category: Systems
        command: SetOneTimeBoot
        bootdevice: "NIC 1 PXE Boot - IPv4"
        baseuri: "{{ baseuri }}"
        username: "{{ username }}"
        password: "{{ password }}"
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Error result from the original problem description in issue #51814:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ bin/ansible-playbook ../test_redfish_command.yml  -vvvv
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible
  executable location = bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does
not match 'all'

Loading callback plugin default of type stdout, v2.0 from /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: test_redfish_command.yml ***************************************************************************Positional arguments: ../test_redfish_command.yml
become_user: root
become_method: sudo
inventory: (u'/etc/ansible/hosts',)
tags: (u'all',)
forks: 5
verbosity: 4
connection: smart
timeout: 10
1 plays in ../test_redfish_command.yml

PLAY [localhost] *********************************************************************************************META: ran handlers

TASK [Set one time boot option] ******************************************************************************task path: /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_command.yml:9
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588 `" && echo ansible-tmp-1549463086.08-258158793933588="` echo /home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/modules/remote_management/redfish/redfish_command.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-1602jVNR9M/tmpEuc2cS TO /home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/ /home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py", line 113, in <module>
    _ansiballz_main()
  File "/home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_redfish_command_payload_yaYKzO/__main__.py", line 256, in <module>
  File "/tmp/ansible_redfish_command_payload_yaYKzO/__main__.py", line 231, in main
  File "/tmp/ansible_redfish_command_payload_yaYKzO/ansible_redfish_command_payload.zip/ansible/module_utils/redfish_utils.py", line 679, in set_one_time_boot_device
KeyError: 'BootMode'

fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py\", line 113, in <module>\n    _ansiballz_main()\n  File
\"/home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/xander/.ansible/tmp/ansible-tmp-1549463086.08-258158793933588/AnsiballZ_redfish_command.py\", line 48, in invoke_module\n
  imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_redfish_command_payload_yaYKzO/__main__.py\", line 256, in <module>\n  File \"/tmp/ansible_redfish_command_payload_yaYKzO/__main__.py\", line 231, in main\n  File \"/tmp/ansible_redfish_command_payload_yaYKzO/ansible_redfish_command_payload.zip/ansible/module_utils/redfish_utils.py\", line 679, in set_one_time_boot_device\nKeyError: 'BootMode'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
        to retry, use: --limit @/mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_command.retry

PLAY RECAP ***************************************************************************************************localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0
```

After the fix, the `KeyError: 'BootMode'` error is no longer seen.