### PR TITLE
add in tiered execution by inventory key

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -116,7 +116,7 @@ You can also mix and match the values::
 Rolling Update Tiered
 ``````````````````````````
 
-In additoin to the ``serial`` parameter you can also specify updates roll out in a tiered fasion based off fact from the specified hosts. You can use the ``serial_tier_fact`` parameter to specify the item to group nodes by. When using ``serial_tier_fact`` the ``serial`` parameter will still be honored but will apply to each tier individually::
+In addition to the ``serial`` parameter you can also specify updates roll out in a tiered fasion based off a fact from the specified hosts. You can use the ``serial_tier_fact`` parameter to specify the fact to group nodes by. When using ``serial_tier_fact`` the ``serial`` parameter will still be honored but will apply to each tier individually::
 
     - name: example play
       hosts: databases
@@ -134,7 +134,7 @@ In additoin to the ``serial`` parameter you can also specify updates roll out in
         debug:
           msg: "{{ inventory_hostname }}"
 
-In the above example nodes would be grouped based off the host fact ``rack_id``. Hosts that do not have a value set will go into the same group::
+In the above example hosts would be grouped based off the host fact ``rack_id``. Hosts that do not have a value set will go into the same group::
 
     [databases]
     db1 rack_id=rack1

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -111,6 +111,105 @@ You can also mix and match the values::
 .. note::
      No matter how small the percentage, the number of hosts per pass will always be 1 or greater.
 
+.. _rolling_tiered_updates:
+
+Rolling Update Tiered
+``````````````````````````
+
+In additoin to the ``serial`` parameter you can also specify updates roll out in a tiered fasion based off an inventory item on hosts. You can use the ``serial_inv_tier`` parameter to specify the item to group nodes by. When using this parameter the ``serial`` parameter will be ignored::
+
+    - name: test play
+      hosts: databases
+      serial_inv_tier: rack_id
+      tasks:
+      - name: task one
+        debug:
+          msg: "{{ inventory_hostname }}"
+      - name: task two
+        debug:
+          msg: "{{ inventory_hostname }}"
+
+In the above example nodes would be grouped based off the inventory item ``rack_id``. Hosts that do not have a value set will go into the same group::
+
+    [databases]
+    db1 rack_id=rack1
+    db2 rack_id=rack1
+    db3 rack_id=rack2
+    db4 rack_id=rack5
+    db5 
+    db6 
+
+The above inventory example would execute like below::
+
+    PLAY [test play] ******************************************
+    
+    TASK [task one] *******************************************
+    ok: [db5] => {
+        "msg": "db5"
+    }
+    ok: [db6] => {
+        "msg": "db6"
+    }
+    
+    TASK [task two] *******************************************
+    ok: [db5] => {
+        "msg": "db5"
+    }
+    ok: [db6] => {
+        "msg": "db6"
+    }
+    
+    PLAY [test play] ******************************************
+    
+    TASK [task one] *******************************************
+    ok: [db4] => {
+        "msg": "db4"
+    }
+    
+    TASK [task two] *******************************************
+    ok: [db4] => {
+        "msg": "db4"
+    }
+    
+    PLAY [test play] ******************************************
+    
+    TASK [task one] *******************************************
+    ok: [db3] => {
+        "msg": "db3"
+    }
+    
+    TASK [task two] *******************************************
+    ok: [db3] => {
+        "msg": "db3"
+    }
+    
+    PLAY [test play] ******************************************
+    
+    TASK [task one] *******************************************
+    ok: [db1] => {
+        "msg": "db1"
+    }
+    ok: [db2] => {
+        "msg": "db2"
+    }
+    
+    TASK [task two] *******************************************
+    ok: [db1] => {
+        "msg": "db1"
+    }
+    ok: [db2] => {
+        "msg": "db2"
+    }
+    
+    PLAY RECAP ************************************************
+    db1  : ok=2    changed=0    unreachable=0    failed=0
+    db2  : ok=2    changed=0    unreachable=0    failed=0
+    db3  : ok=2    changed=0    unreachable=0    failed=0
+    db4  : ok=2    changed=0    unreachable=0    failed=0
+    db5  : ok=2    changed=0    unreachable=0    failed=0
+    db6  : ok=2    changed=0    unreachable=0    failed=0
+
+
 
 .. _maximum_failure_percentage:
 

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -116,20 +116,25 @@ You can also mix and match the values::
 Rolling Update Tiered
 ``````````````````````````
 
-In additoin to the ``serial`` parameter you can also specify updates roll out in a tiered fasion based off an inventory item on hosts. You can use the ``serial_inv_tier`` parameter to specify the item to group nodes by. When using this parameter the ``serial`` parameter will be ignored::
+In additoin to the ``serial`` parameter you can also specify updates roll out in a tiered fasion based off fact from the specified hosts. You can use the ``serial_tier_fact`` parameter to specify the item to group nodes by. When using ``serial_tier_fact`` the ``serial`` parameter will still be honored but will apply to each tier individually::
 
-    - name: test play
+    - name: example play
       hosts: databases
-      serial_inv_tier: rack_id
+      serial_tier_fact: rack_id
       tasks:
       - name: task one
         debug:
           msg: "{{ inventory_hostname }}"
+    - name: example play 2
+      hosts: databases
+      serial: 1
+      serial_tier_fact: rack_id
+      tasks:
       - name: task two
         debug:
           msg: "{{ inventory_hostname }}"
 
-In the above example nodes would be grouped based off the inventory item ``rack_id``. Hosts that do not have a value set will go into the same group::
+In the above example nodes would be grouped based off the host fact ``rack_id``. Hosts that do not have a value set will go into the same group::
 
     [databases]
     db1 rack_id=rack1
@@ -141,9 +146,9 @@ In the above example nodes would be grouped based off the inventory item ``rack_
 
 The above inventory example would execute like below::
 
-    PLAY [test play] ******************************************
+    PLAY [example play] **********************************************************************************************
     
-    TASK [task one] *******************************************
+    TASK [task one] **************************************************************************************************
     ok: [db5] => {
         "msg": "db5"
     }
@@ -151,64 +156,79 @@ The above inventory example would execute like below::
         "msg": "db6"
     }
     
-    TASK [task two] *******************************************
+    PLAY [example play] **********************************************************************************************
+    
+    TASK [task one] **************************************************************************************************
+    ok: [db1] => {
+        "msg": "db1"
+    }
+    ok: [db2] => {
+        "msg": "db2"
+    }
+    
+    PLAY [example play] **********************************************************************************************
+    
+    TASK [task one] **************************************************************************************************
+    ok: [db3] => {
+        "msg": "db3"
+    }
+    
+    PLAY [example play] **********************************************************************************************
+    
+    TASK [task one] **************************************************************************************************
+    ok: [db4] => {
+        "msg": "db4"
+    }
+    
+    PLAY [example play 2] ********************************************************************************************
+    
+    TASK [task two] **************************************************************************************************
     ok: [db5] => {
         "msg": "db5"
     }
+    
+    PLAY [example play 2] ********************************************************************************************
+    
+    TASK [task two] **************************************************************************************************
     ok: [db6] => {
         "msg": "db6"
     }
     
-    PLAY [test play] ******************************************
+    PLAY [example play 2] ********************************************************************************************
     
-    TASK [task one] *******************************************
-    ok: [db4] => {
-        "msg": "db4"
-    }
-    
-    TASK [task two] *******************************************
-    ok: [db4] => {
-        "msg": "db4"
-    }
-    
-    PLAY [test play] ******************************************
-    
-    TASK [task one] *******************************************
-    ok: [db3] => {
-        "msg": "db3"
-    }
-    
-    TASK [task two] *******************************************
-    ok: [db3] => {
-        "msg": "db3"
-    }
-    
-    PLAY [test play] ******************************************
-    
-    TASK [task one] *******************************************
+    TASK [task two] **************************************************************************************************
     ok: [db1] => {
         "msg": "db1"
     }
+    
+    PLAY [example play 2] ********************************************************************************************
+    
+    TASK [task two] **************************************************************************************************
     ok: [db2] => {
         "msg": "db2"
     }
     
-    TASK [task two] *******************************************
-    ok: [db1] => {
-        "msg": "db1"
-    }
-    ok: [db2] => {
-        "msg": "db2"
+    PLAY [example play 2] ********************************************************************************************
+    
+    TASK [task two] **************************************************************************************************
+    ok: [db3] => {
+        "msg": "db3"
     }
     
-    PLAY RECAP ************************************************
-    db1  : ok=2    changed=0    unreachable=0    failed=0
-    db2  : ok=2    changed=0    unreachable=0    failed=0
-    db3  : ok=2    changed=0    unreachable=0    failed=0
-    db4  : ok=2    changed=0    unreachable=0    failed=0
-    db5  : ok=2    changed=0    unreachable=0    failed=0
-    db6  : ok=2    changed=0    unreachable=0    failed=0
-
+    PLAY [example play 2] ********************************************************************************************
+    
+    TASK [task two] **************************************************************************************************
+    ok: [db4] => {
+        "msg": "db4"
+    }
+    
+    PLAY RECAP *******************************************************************************************************
+    db1                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+    db2                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+    db3                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+    db4                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+    db5                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+    db6                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
 
 .. _maximum_failure_percentage:

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -281,7 +281,6 @@ class PlaybookExecutor:
 
         return serialized_batches
 
-
     def _get_batches_from_int(self, play):
         # make sure we have a unique list of hosts
         all_hosts = self._inventory.get_hosts(play.hosts, order=play.order)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -77,6 +77,7 @@ class Play(Base, Taggable, Become):
     _force_handlers = FieldAttribute(isa='bool', default=context.cliargs_deferred_get('force_handlers'), always_post_validate=True)
     _max_fail_percentage = FieldAttribute(isa='percent', always_post_validate=True)
     _serial = FieldAttribute(isa='list', default=list, always_post_validate=True)
+    _serial_inv_tier = FieldAttribute(isa='string', default=None, always_post_validate=True)
     _strategy = FieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
     _order = FieldAttribute(isa='string', always_post_validate=True)
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -77,7 +77,7 @@ class Play(Base, Taggable, Become):
     _force_handlers = FieldAttribute(isa='bool', default=context.cliargs_deferred_get('force_handlers'), always_post_validate=True)
     _max_fail_percentage = FieldAttribute(isa='percent', always_post_validate=True)
     _serial = FieldAttribute(isa='list', default=list, always_post_validate=True)
-    _serial_inv_tier = FieldAttribute(isa='string', default=None, always_post_validate=True)
+    _serial_tier_fact = FieldAttribute(isa='string', default=None, always_post_validate=True)
     _strategy = FieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
     _order = FieldAttribute(isa='string', always_post_validate=True)
 

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -40,8 +40,10 @@ class TestPlaybookExecutor(unittest.TestCase):
         # And cleanup after ourselves too
         co.GlobalCLIArgs._Singleton__instance = None
 
-    def mock_host(self,name,vars={}):
-        return MagicMock(name=name,vars=vars)
+    def mock_host(self, name, vars=None):
+        if vars is None:
+            vars = {}
+        return MagicMock(name=name, vars=vars)
 
     def test_get_serialized_batches(self):
         fake_loader = DictDataLoader({
@@ -146,7 +148,7 @@ class TestPlaybookExecutor(unittest.TestCase):
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         hosts = []
-        for id in range(0,10):
+        for id in range(0, 10):
             hosts.append(self.mock_host("host%i" % id))
         mock_inventory.get_hosts.return_value = hosts
         self.assertEqual(pbe._get_serialized_batches(play), [hosts])
@@ -156,13 +158,13 @@ class TestPlaybookExecutor(unittest.TestCase):
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         hosts = []
-        for id in range(0,3):
-            hosts.append(self.mock_host("host%i" % id, { "test": "group1" }))
-        for id in range(3,7):
-            hosts.append(self.mock_host("host%i" % id, { "test": "group2" }))
-        for id in range(7,8):
-            hosts.append(self.mock_host("host%i" % id, { "test": "group3" }))
-        for id in range(8,10):
+        for id in range(0, 3):
+            hosts.append(self.mock_host("host%i" % id, {"test": "group1"}))
+        for id in range(3, 7):
+            hosts.append(self.mock_host("host%i" % id, {"test": "group2"}))
+        for id in range(7, 8):
+            hosts.append(self.mock_host("host%i" % id, {"test": "group3"}))
+        for id in range(8, 10):
             hosts.append(self.mock_host("host%i" % id))
         mock_inventory.get_hosts.return_value = hosts
         # need to ensure the same elements exist. order does not matter

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -91,7 +91,7 @@ class TestPlaybookExecutor(unittest.TestCase):
             'serial_tier_fact_with_serial.yml': '''
             - hosts: all
               gather_facts: no
-              serial: 
+              serial:
                 - 1
                 - 2
                 - 5
@@ -107,7 +107,8 @@ class TestPlaybookExecutor(unittest.TestCase):
         templar = Templar(loader=fake_loader)
 
         pbe = PlaybookExecutor(
-            playbooks=['no_serial.yml', 'serial_int.yml', 'serial_pct.yml', 'serial_list.yml', 'serial_list_mixed.yml', 'serial_tier_fact.yml', 'serial_tier_fact_with_serial.yml'],
+            playbooks=['no_serial.yml', 'serial_int.yml', 'serial_pct.yml', 'serial_list.yml',
+                       'serial_list_mixed.yml', 'serial_tier_fact.yml', 'serial_tier_fact_with_serial.yml'],
             inventory=mock_inventory,
             variable_manager=mock_var_manager,
             loader=fake_loader,
@@ -194,9 +195,9 @@ class TestPlaybookExecutor(unittest.TestCase):
         mock_inventory.get_hosts.return_value = hosts
         print(pbe._get_serialized_batches(play))
         self.assertEqual(pbe._get_serialized_batches(play), [
-            hosts[0:1], hosts[1:3], hosts[3:7], # group1
-            hosts[7:8], hosts[8:10], hosts[10:11], # group2
-            hosts[11:12], hosts[12:14], hosts[14:19], hosts[19:22], #group3
+            hosts[0:1], hosts[1:3], hosts[3:7],  # group1
+            hosts[7:8], hosts[8:10], hosts[10:11],  # group2
+            hosts[11:12], hosts[12:14], hosts[14:19], hosts[19:22],  # group3
         ])
 
         # Test when serial percent is under 1.0


### PR DESCRIPTION
##### SUMMARY
This change allows use of an inventory key when grouping changes during a play. The existing `serial` functionality allows percentages or counts. For my use-case I am using ansible to orchestrate changes rack-by-rack. The number of nodes in each rack, the number of racks, and the rack names vary in different environments. This makes usage of serial difficult for grouping. The alternative of doing separate plays for each rack requires templating the playbook out for each environment which is also not desirable. 

I choose to implement this as a new parameter since the existing serial parameter took in a list and had special logic to handle percents vs integers. For the tier based grouping I made it only group on a single parameter since I didn't know if there was any desire to group on multiple inventory keys. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
playbook_executor
