### PR TITLE
[cloudwatchevent_rule] convert task_count

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -274,7 +274,11 @@ class CloudWatchEventRule(object):
                 if 'task_definition_arn' in target['ecs_parameters']:
                     target_request['EcsParameters']['TaskDefinitionArn'] = ecs_parameters['task_definition_arn']
                 if 'task_count' in target['ecs_parameters']:
-                    target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count'] if type(ecs_parameters['task_count']) in [int, long] else long(ecs_parameters['task_count'])
+                    target_request['EcsParameters'][
+                        'TaskCount'] = ecs_parameters[
+                            'task_count'] if isinstance(
+                                ecs_parameters['task_count'], int) else int(
+                                    ecs_parameters['task_count'])
             targets_request.append(target_request)
         return targets_request
 

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -274,7 +274,7 @@ class CloudWatchEventRule(object):
                 if 'task_definition_arn' in target['ecs_parameters']:
                     target_request['EcsParameters']['TaskDefinitionArn'] = ecs_parameters['task_definition_arn']
                 if 'task_count' in target['ecs_parameters']:
-                    target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count']
+                    target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count'] if type(ecs_parameters['task_count']) in [int, long] else long(ecs_parameters['task_count'])
             targets_request.append(target_request)
         return targets_request
 


### PR DESCRIPTION
allows easier usage of jinja2 templating for task_count

##### SUMMARY
Underneath dependencies aren't accepting str as acceptable type for task_count and Jinja2 templating often ends with a str.
Here we're trying to use the given input assuming its type is of type int or long, otherwise attends to convert it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module cloudwatchevent_rule / cloudwatchevent_rule.py

