### PR TITLE
passwordstore: add hint for subkey=password

### DIFF
--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -38,7 +38,7 @@ DOCUMENTATION = """
         type: bool
         default: 'no'
       subkey:
-        description: Return a specific subkey of the password.
+        description: Return a specific subkey of the password. subkey=password will always return the first line.
         default: password
       userpass:
         description: Specify a password to save, instead of a generated one.

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -38,7 +38,7 @@ DOCUMENTATION = """
         type: bool
         default: 'no'
       subkey:
-        description: Return a specific subkey of the password. subkey=password will always return the first line.
+        description: Return a specific subkey of the password. When set to C(password), always returns the first line.
         default: password
       userpass:
         description: Specify a password to save, instead of a generated one.


### PR DESCRIPTION
##### SUMMARY
Clarify that subkey=password will always return the first line.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
passwordstore

##### ADDITIONAL INFORMATION
Adding a YAML style subkey called "password" is not possible.
