### PR TITLE
special case for azure_rm_resource module

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_resource.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource.py
@@ -272,6 +272,9 @@ class AzureRMResource(AzureRMModuleBase):
                         if rt['resourceType'].lower() == resourceType.lower():
                             self.api_version = rt['apiVersions'][0]
                             break
+                else:
+                    # if there's no provider in API version, assume Microsoft.Resources
+                    self.api_version = '2018-05-01'
                 if not self.api_version:
                     self.fail("Couldn't find api version for {0}/{1}".format(provider, resourceType))
             except Exception as exc:

--- a/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
@@ -73,6 +73,11 @@ EXAMPLES = '''
       resource_type: virtualmachinescalesets
       resource_name: myVmss
       api_version: "2017-12-01"
+
+  - name: Query all the resources in the resource group
+    azure_rm_resource_facts:
+      resource_group: "{{ resource_group }}"
+      resource_type: resources
 '''
 
 RETURN = '''
@@ -187,6 +192,9 @@ class AzureRMResourceFacts(AzureRMModuleBase):
                         if rt['resourceType'].lower() == resourceType.lower():
                             self.api_version = rt['apiVersions'][0]
                             break
+                else:
+                    # if there's no provider in API version, assume Microsoft.Resources
+                    self.api_version = '2018-05-01'
                 if not self.api_version:
                     self.fail("Couldn't find api version for {0}/{1}".format(provider, resourceType))
             except Exception as exc:

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -99,6 +99,17 @@
       - output.response[0]['name'] != None
       - output.response | length >= 1
 
+- name: Query all the resources in the resource group
+  azure_rm_resource_facts:
+    resource_group: "{{ resource_group }}"
+    resource_type: resources
+  register: output
+- name: Assert value was returned
+  assert:
+    that:
+      - not output.changed
+      - output.response | length >= 1
+
 - name: Create storage account that requires LRO polling
   azure_rm_resource:
     polling_timeout: 600


### PR DESCRIPTION
##### SUMMARY
This issue fixes special case for obtaining deault api_version in case of Microsoft.Resources namespace.
In such case namespace doesn't appear as a part of url.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_resource
azure_rm_resource_facts

##### ADDITIONAL INFORMATION
