### PR TITLE
virtualbox: fix regression byte-string

### DIFF
--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -61,7 +61,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     ''' Host inventory parser for ansible using local virtualbox. '''
 
     NAME = 'virtualbox'
-    VBOX = b"VBoxManage"
+    VBOX = "VBoxManage"
 
     def __init__(self):
         self._vbox_path = None


### PR DESCRIPTION
##### SUMMARY
All paths in get_bin_path are string type and vboxmanage was byte-string type.
So os.path.join was failing to join these two.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/virtualbox.py
