### PR TITLE
[2.6] openssl_publickey: fix handling of OpenSSH private keys with passphrase

### DIFF
--- a/changelogs/fragments/54192-openssl_publickey-openssh-passphrase.yml
+++ b/changelogs/fragments/54192-openssl_publickey-openssh-passphrase.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_publickey - fixed crash on Python 3 when OpenSSH private keys were used with passphrases."


### PR DESCRIPTION
##### SUMMARY
Backport of #54192 to stable-2.6: fix Python 3 bug when handling OpenSSH keys with passphrases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_publickey
