### PR TITLE
ACI Private_Key String to Allow for Vaulting

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -204,10 +204,14 @@ Every Ansible ACI module accepts the following parameters that influence the mod
         Password for ``username`` to log on to the APIC, using password-based authentication.
 
     private_key
-        Private key for ``username`` to log on to APIC, using signature-based authentication. *New in version 2.5*
+        Private key for ``username`` to log on to APIC, using signature-based authentication.
+        This could either be the raw private key content (include header/footer) or a file that stores the key content.
+        *New in version 2.5*
 
     certificate_name
-        Name of the certificate in the ACI Web GUI. (Defaults to ``private_key`` file base name) *New in version 2.5*
+        Name of the certificate in the ACI Web GUI.
+        This defaults to either the ``username`` value or the ``private_key`` file base name).
+        *New in version 2.5*
 
     timeout
         Timeout value for socket-level communication.
@@ -366,6 +370,19 @@ You need the following parameters with your ACI module(s) for it to work:
     username: admin
     private_key: pki/admin.key
     certificate_name: admin  # This could be left out !
+
+or you can use the private key content (e.g. when using Vault to store the private key):
+
+.. code-block:: yaml
+   :emphasize-lines: 2,3
+
+    username: admin
+    private_key: |
+        -----BEGIN PRIVATE KEY-----
+        <<your private key content>>
+        -----END PRIVATE KEY-----
+    certificate_name: admin  # This could be left out !
+
 
 .. hint:: If you use a certificate name in ACI that matches the private key's basename, you can leave out the ``certificate_name`` parameter like the example above.
 

--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -371,7 +371,7 @@ You need the following parameters with your ACI module(s) for it to work:
     private_key: pki/admin.key
     certificate_name: admin  # This could be left out !
 
-or you can use the private key content (e.g. when using Vault to store the private key):
+or you can use the private key content:
 
 .. code-block:: yaml
    :emphasize-lines: 2,3
@@ -386,9 +386,55 @@ or you can use the private key content (e.g. when using Vault to store the priva
 
 .. hint:: If you use a certificate name in ACI that matches the private key's basename, you can leave out the ``certificate_name`` parameter like the example above.
 
+
+Using Ansible Vault to encrypt the private key
+``````````````````````````````````````````````
+.. versionadded:: 2.8
+
+To start, encrypt the private key and give it a strong password.
+
+.. code-block:: bash
+
+    ansible-vault encrypt admin.key
+
+Use a text editor to open the private-key. You should have an encrypted cert now.
+
+.. code-block:: bash
+
+    $ANSIBLE_VAULT;1.1;AES256
+    56484318584354658465121889743213151843149454864654151618131547984132165489484654
+    45641818198456456489479874513215489484843614848456466655432455488484654848489498
+    ....
+
+Copy and paste the new encrypted cert into your playbook as a new variable. 
+
+.. code-block:: yaml
+
+    private_key: !vault |
+          $ANSIBLE_VAULT;1.1;AES256
+          56484318584354658465121889743213151843149454864654151618131547984132165489484654
+          45641818198456456489479874513215489484843614848456466655432455488484654848489498
+          ....
+
+Use the new variable for the private_key:
+
+.. code-block:: yaml
+
+    username: admin
+    private_key: "{{ private_key }}"
+    certificate_name: admin  # This could be left out !
+
+When running the playbook, use "--ask-vault-pass" to decrypt the private key.
+
+.. code-block:: bash
+
+    ansible-playbook site.yaml --ask-vault-pass
+
+
 More information
 ````````````````
-Detailed information about Signature-based Authentication is available from `Cisco APIC Signature-Based Transactions <https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/kb/b_KB_Signature_Based_Transactions.html>`_.
+- Detailed information about Signature-based Authentication is available from `Cisco APIC Signature-Based Transactions <https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/kb/b_KB_Signature_Based_Transactions.html>`_.
+- More information on Ansible Vault can be found on the :ref:`Ansible Vault <vault>` page.
 
 
 .. _aci_guide_rest:

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -1,3 +1,5 @@
+.. _vault:
+
 Ansible Vault
 =============
 

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -230,15 +230,15 @@ class ACIModule(object):
         if self.params['certificate_name'] is None:
             self.params['certificate_name'] = os.path.basename(os.path.splitext(self.params['private_key'])[0])
 
-        #Checks to verify if the private key was entered as a string instead of a file. This allows the use of vaulting the private key.
+        # Checks to verify if the private_key was entered as a string instead of a file. This allows the use of vaulting the private key.
         str_private_key = self.params['private_key'].startswith('-----BEGIN PRIVATE KEY-----')
 
-        if str_private_key == True:
+        if str_private_key is True:
             try:
-               sig_key = load_privatekey(FILETYPE_PEM, self.params['private_key'])
-            except:
+                sig_key = load_privatekey(FILETYPE_PEM, self.params['private_key'])
+            except Exception:
                 self.module.fail_json(msg='Cannot load private key %s' % self.params['private_key'])
-        else:  
+        else:
             try:
                 with open(self.params['private_key'], 'r') as priv_key_fh:
                     private_key_content = priv_key_fh.read()

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -245,12 +245,12 @@ class ACIModule(object):
                 self.module.fail_json(msg="The provided private key file does not appear to exist. Is it a filename?")
             try:
                 with open(self.params['private_key'], 'r') as fh:
-                    private_key = fh.read()
+                    private_key_content = fh.read()
             except Exception:
                 self.module.fail_json(msg="Cannot open private key file '%s'." % self.params['private_key'])
             if private_key.startswith('-----BEGIN PRIVATE KEY-----'):
                 try:
-                    sig_key = load_privatekey(FILETYPE_PEM, private_key)
+                    sig_key = load_privatekey(FILETYPE_PEM, private_key_content)
                 except Exception:
                     self.module.fail_json(msg="Cannot load private key file '%s'." % self.params['private_key'])
             elif private_key.startswith('-----BEGIN CERTIFICATE-----'):

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -230,12 +230,21 @@ class ACIModule(object):
         if self.params['certificate_name'] is None:
             self.params['certificate_name'] = os.path.basename(os.path.splitext(self.params['private_key'])[0])
 
-        try:
-            with open(self.params['private_key'], 'r') as priv_key_fh:
-                private_key_content = priv_key_fh.read()
-            sig_key = load_privatekey(FILETYPE_PEM, private_key_content)
-        except Exception:
-            self.module.fail_json(msg='Cannot load private key %s' % self.params['private_key'])
+        #Checks to verify if the private key was entered as a string instead of a file. This allows the use of vaulting the private key.
+        str_private_key = self.params['private_key'].startswith('-----BEGIN PRIVATE KEY-----')
+
+        if str_private_key == True:
+            try:
+               sig_key = load_privatekey(FILETYPE_PEM, self.params['private_key'])
+            except:
+                self.module.fail_json(msg='Cannot load private key %s' % self.params['private_key'])
+        else:  
+            try:
+                with open(self.params['private_key'], 'r') as priv_key_fh:
+                    private_key_content = priv_key_fh.read()
+                sig_key = load_privatekey(FILETYPE_PEM, private_key_content)
+            except Exception:
+                self.module.fail_json(msg='Cannot load private key %s' % self.params['private_key'])
 
         # NOTE: ACI documentation incorrectly adds a space between method and path
         sig_request = method + path + payload

--- a/lib/ansible/plugins/doc_fragments/aci.py
+++ b/lib/ansible/plugins/doc_fragments/aci.py
@@ -34,8 +34,8 @@ options:
     required: yes
   private_key:
     description:
-    - PEM formatted file that contains your private key to be used for signature-based authentication.
-    - The name of the key (without extension) is used as the certificate name in ACI, unless C(certificate_name) is specified.
+    - Either a PEM-formatted private key file or the private key content used for signature-based authentication.
+    - This value also influences the default C(certificate_name) that is used.
     - This option is mutual exclusive with C(password). If C(password) is provided too, it will be ignored.
     type: path
     required: yes
@@ -43,7 +43,8 @@ options:
   certificate_name:
     description:
     - The X.509 certificate name attached to the APIC AAA user used for signature-based authentication.
-    - It defaults to the C(private_key) basename, without extension.
+    - If a C(private_key) filename was provided, this defaults to the C(private_key) basename, without extension.
+    - If PEM-formatted content was provided for C(private_key), this defaults to the C(username) value.
     type: str
     aliases: [ cert_name ]
   output_level:

--- a/lib/ansible/plugins/doc_fragments/aci.py
+++ b/lib/ansible/plugins/doc_fragments/aci.py
@@ -37,7 +37,7 @@ options:
     - Either a PEM-formatted private key file or the private key content used for signature-based authentication.
     - This value also influences the default C(certificate_name) that is used.
     - This option is mutual exclusive with C(password). If C(password) is provided too, it will be ignored.
-    type: path
+    type: str
     required: yes
     aliases: [ cert_key ]
   certificate_name:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change is to allow the private_key to be entered as a variable instead of just a file. The main gain from doing this is it allows Ansible-Vault to encrypt the string.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
closes #54189

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aci.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This document will need to be updated if this is approved.
https://docs.ansible.com/ansible/latest/scenario_guides/guide_aci.html
<!--- Paste verbatim command output below, e.g. before and after your change -->

Optional to take a string into a VAR unencrypted but you might as well use the key file at that point.
```yaml
private_key: "
    -----BEGIN PRIVATE KEY-----
    super secret stuff
    -----END PRIVATE KEY-----
"
```
Vaulted VAR Example:
```yaml
private_key: !vault |
      $ANSIBLE_VAULT;1.1;AES256
      super secret stuff
```
```yaml
- name: Add a new contract
  aci_contract:
    host: apic
    username: admin
    private_key: "{{ private_key }}"
    certificate_name: admin.crt
    tenant: production
    contract: web_to_db
    description: Communication between web-servers and database
    scope: application-profile
    state: present
  delegate_to: localhost
```
