### PR TITLE
Add nxos_config sanity test

### DIFF
--- a/test/integration/targets/nxos_config/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_config/tests/common/sanity.yaml
@@ -38,4 +38,41 @@
     match: none
     provider: "{{ connection }}"
 
+- debug: msg='Verify https://github.com/ansible/ansible/issues/50635'
+
+- name: PUT INTERFACE INTO DEFAULT STATE
+  nxos_config:
+    lines:
+      - "default interface {{ nxos_int1 }}"
+    provider: "{{ connection }}"
+
+- name: MAKE INTERFACE A SWITCHPORT
+  nxos_config:
+    lines:
+      - switchport
+    parents: "interface {{ nxos_int1 }}"
+    provider: "{{ connection }}"
+
+- name: CONFIGURE EDGE TRUNK TYPE
+  nxos_config: &config
+    lines:
+      - description foo
+      - switchport access vlan 3333
+      - spanning-tree port type edge
+    parents: "interface {{ nxos_int1 }}"
+    provider: "{{ connection }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: IDEMPOTENCE CHECK
+  nxos_config: *config
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
 - debug: msg="END common/sanity.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
This test guards against the issue described in https://github.com/ansible/ansible/issues/50635

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
nxos_config

##### ADDITIONAL INFORMATION
The issue described in https://github.com/ansible/ansible/issues/50635 is fixed in the latest `devel` branch.  At the time of opening this PR the issue is still a problem in `2.7.x` releases.  This test is to ensure it does not break again in the future.