### PR TITLE
nxos_interfaces_ospf: fix passive-interface states & check_mode

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -71,8 +71,7 @@ options:
         true - (enable) Prevent OSPF from establishing an adjacency or
                        sending routing updates on this interface.
         false - (disable) Override global 'passive-interface default' for this interface.
-        default - Remove existing (enabled or disabled) passive-interface setting.
-    choices: ['true', 'false', 'default']
+    type: bool
   network:
     description:
       - Specifies interface ospf network type. Valid values are 'point-to-point' or 'broadcast'.
@@ -316,7 +315,7 @@ def state_present(module, existing, proposed, candidate):
         elif value is False:
             commands.append('no {0}'.format(key))
         elif value == 'default':
-            if existing_commands.get(key) or 'ip ospf passive-interface' in key and existing_commands.get(key) is not None:
+            if existing_commands.get(key):
                 commands.extend(get_default_commands(existing, proposed,
                                                      existing_commands, key,
                                                      module))
@@ -392,7 +391,7 @@ def main():
         cost=dict(required=False, type='str'),
         hello_interval=dict(required=False, type='str'),
         dead_interval=dict(required=False, type='str'),
-        passive_interface=dict(required=False, type='str', choices=['true', 'false', 'default']),
+        passive_interface=dict(required=False, type='bool'),
         network=dict(required=False, type='str', choices=['broadcast', 'point-to-point']),
         message_digest=dict(required=False, type='bool'),
         message_digest_key_id=dict(required=False, type='str'),

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -316,8 +316,7 @@ def state_present(module, existing, proposed, candidate):
         elif value is False:
             commands.append('no {0}'.format(key))
         elif value == 'default':
-            if existing_commands.get(key) or \
-                'ip ospf passive-interface' in key and existing_commands.get(key) is not None:
+            if existing_commands.get(key) or 'ip ospf passive-interface' in key and existing_commands.get(key) is not None:
                 commands.extend(get_default_commands(existing, proposed,
                                                      existing_commands, key,
                                                      module))

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -68,10 +68,10 @@ options:
   passive_interface:
     description:
       - Enable or disable passive-interface state on this interface.
-        true: (enable) Prevent OSPF from establishing an adjacency or
+        true - (enable) Prevent OSPF from establishing an adjacency or
                        sending routing updates on this interface.
-        false: (disable) Override global 'passive-interface default' for this interface.
-        default: Remove existing (enabled or disabled) passive-interface setting.
+        false - (disable) Override global 'passive-interface default' for this interface.
+        default - Remove existing (enabled or disabled) passive-interface setting.
     choices: [true, false, default]
   network:
     description:

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -72,7 +72,7 @@ options:
                        sending routing updates on this interface.
         false - (disable) Override global 'passive-interface default' for this interface.
         default - Remove existing (enabled or disabled) passive-interface setting.
-    choices: [true, false, default]
+    choices: ['true', 'false', 'default']
   network:
     description:
       - Specifies interface ospf network type. Valid values are 'point-to-point' or 'broadcast'.

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -72,17 +72,6 @@
       that:
         - "result.changed == false"
 
-  - name: passive from true to default
-    nxos_interface_ospf:
-      interface: "{{ nxos_int1|upper }}"
-      ospf: 1
-      area: 12345678
-      passive_interface: default
-      state: present
-    register: result
-
-  - assert: *true
-
   - name: Modify properties
     nxos_interface_ospf: &modify
       interface: "{{ testint }}"
@@ -111,7 +100,6 @@
       ospf: 1
       area: 12345678
       cost: default
-      passive_interface: default
       hello_interval: 10
       dead_interval: default
       provider: "{{ connection }}"

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -72,6 +72,17 @@
       that:
         - "result.changed == false"
 
+  - name: passive from true to default
+    nxos_interface_ospf:
+      interface: "{{ nxos_int1|upper }}"
+      ospf: 1
+      area: 12345678
+      passive_interface: default
+      state: present
+    register: result
+
+  - assert: *true
+
   - name: Modify properties
     nxos_interface_ospf: &modify
       interface: "{{ testint }}"
@@ -100,6 +111,7 @@
       ospf: 1
       area: 12345678
       cost: default
+      passive_interface: default
       hello_interval: 10
       dead_interval: default
       provider: "{{ connection }}"

--- a/test/units/modules/network/nxos/fixtures/nxos_interface_ospf/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_interface_ospf/config.cfg
@@ -1,0 +1,7 @@
+interface Ethernet1/33
+interface Ethernet1/34
+  ip router ospf 1 area 0.0.0.1
+  ip ospf passive-interface
+interface Ethernet1/35
+  ip router ospf 1 area 0.0.0.1
+  no ip ospf passive-interface

--- a/test/units/modules/network/nxos/test_nxos_interface_ospf.py
+++ b/test/units/modules/network/nxos/test_nxos_interface_ospf.py
@@ -56,3 +56,29 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
         self.execute_module(failed=True, changed=False)
         set_module_args(dict(interface='loopback0', ospf=1, area=0, network='broadcast'))
         self.execute_module(failed=True, changed=False)
+
+    def test_nxos_interface_ospf_passive(self):
+        # default -> True
+        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, passive_interface=True))
+        self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1',
+                                                    'ip ospf passive-interface'])
+        # default -> False
+        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, passive_interface=False))
+        self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1',
+                                                    'no ip ospf passive-interface'])
+        # True -> False
+        set_module_args(dict(interface='ethernet1/34', ospf=1, area=1, passive_interface=False))
+        self.execute_module(changed=True, commands=['interface Ethernet1/34',
+                                                    'no ip ospf passive-interface'])
+        # True -> default
+        set_module_args(dict(interface='ethernet1/34', ospf=1, area=1, passive_interface='default'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/34',
+                                                    'default ip ospf passive-interface'])
+        # False -> True
+        set_module_args(dict(interface='ethernet1/35', ospf=1, area=1, passive_interface=True))
+        self.execute_module(changed=True, commands=['interface Ethernet1/35',
+                                                    'ip ospf passive-interface'])
+        # False -> default
+        set_module_args(dict(interface='ethernet1/35', ospf=1, area=1, passive_interface='default'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/35',
+                                                    'default ip ospf passive-interface'])

--- a/test/units/modules/network/nxos/test_nxos_interface_ospf.py
+++ b/test/units/modules/network/nxos/test_nxos_interface_ospf.py
@@ -60,25 +60,29 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
     def test_nxos_interface_ospf_passive(self):
         # default -> True
         set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, passive_interface=True))
-        self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1',
+        self.execute_module(changed=True, commands=['interface Ethernet1/33',
+                                                    'ip router ospf 1 area 0.0.0.1',
                                                     'ip ospf passive-interface'])
         # default -> False
         set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, passive_interface=False))
-        self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1',
+        self.execute_module(changed=True, commands=['interface Ethernet1/33',
+                                                    'ip router ospf 1 area 0.0.0.1',
                                                     'no ip ospf passive-interface'])
         # True -> False
         set_module_args(dict(interface='ethernet1/34', ospf=1, area=1, passive_interface=False))
         self.execute_module(changed=True, commands=['interface Ethernet1/34',
                                                     'no ip ospf passive-interface'])
-        # True -> default
-        set_module_args(dict(interface='ethernet1/34', ospf=1, area=1, passive_interface='default'))
+        # True -> default (absent)
+        set_module_args(dict(interface='ethernet1/34', ospf=1, area=1, state='absent'))
         self.execute_module(changed=True, commands=['interface Ethernet1/34',
+                                                    'no ip router ospf 1 area 0.0.0.1',
                                                     'default ip ospf passive-interface'])
         # False -> True
         set_module_args(dict(interface='ethernet1/35', ospf=1, area=1, passive_interface=True))
         self.execute_module(changed=True, commands=['interface Ethernet1/35',
                                                     'ip ospf passive-interface'])
-        # False -> default
-        set_module_args(dict(interface='ethernet1/35', ospf=1, area=1, passive_interface='default'))
+        # False -> default (absent)
+        set_module_args(dict(interface='ethernet1/35', ospf=1, area=1, state='absent'))
         self.execute_module(changed=True, commands=['interface Ethernet1/35',
+                                                    'no ip router ospf 1 area 0.0.0.1',
                                                     'default ip ospf passive-interface'])


### PR DESCRIPTION
##### SUMMARY
This fix addresses issues #41704 and #45343.

The crux of the problem is that `passive-interface` should have been treated as a tri-state value instead of a boolean.

The `no` form of the command disables the passive state on an interface (allows it to form adjacencies and send routing updates). This `no` config will be present in `running-config`. It's essentially an override for `passive-interface default` which enables passive state on all OSPF interfaces.\*  

   \**See `router ospf` configuration.*

Since both enable and disable states are explicit configs, the proper way to remove either of these is with the `default` syntax.

Passive-interface config syntax:
```
  ip ospf passive-interface              # enable  (nvgens)
  no ip ospf passive-interface           # disable (nvgens)
  default ip ospf passive-interface      # default (removes config, does not nvgen)
```

Code changes:

* `passive_interface` param changed from boolean to string, restricted to `true`,`false`,`default`.

* Several passive-interface specific checks were added because the existing module logic tends to test for true or false and doesn't handle the None case.

* Fixed `check_mode`.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_interface_ospf`

##### ADDITIONAL INFORMATION

Sanity verified on: N9K,N7K,N3K,N6K

