### PR TITLE
Update aruba modules to handle prompt and syntax changes

### DIFF
--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -105,13 +105,13 @@ options:
         changes are not copied to non-volatile storage by default.  Using
         this argument will change that before.  If the argument is set to
         I(always), then the running-config will always be copied to the
-        startup-config and the I(modified) flag will always be set to
+        startup configuration and the I(modified) flag will always be set to
         True.  If the argument is set to I(modified), then the running-config
-        will only be copied to the startup-config if it has changed since
-        the last save to startup-config.  If the argument is set to
+        will only be copied to the startup configuration if it has changed since
+        the last save to startup configuration.  If the argument is set to
         I(never), the running-config will never be copied to the
-        startup-config.  If the argument is set to I(changed), then the running-config
-        will only be copied to the startup-config if the task has made a change.
+        startup configuration.  If the argument is set to I(changed), then the running-config
+        will only be copied to the startup configuration if the task has made a change.
     default: never
     choices: ['always', 'never', 'modified', 'changed']
     version_added: "2.5"
@@ -120,7 +120,7 @@ options:
       - When using the C(ansible-playbook --diff) command line argument
         the module can generate diffs against different sources.
       - When this option is configure as I(startup), the module will return
-        the diff of the running-config against the startup-config.
+        the diff of the running-config against the startup configuration.
       - When this option is configured as I(intended), the module will
         return the diff of the running-config against the configuration
         provided in the C(intended_config) argument.
@@ -261,9 +261,9 @@ def get_candidate(module):
 def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
-        run_commands(module, 'copy running-config startup-config')
+        run_commands(module, 'write memory')
     else:
-        module.warn('Skipping command `copy running-config startup-config` '
+        module.warn('Skipping command `write memory` '
                     'due to check_mode.  Configuration not copied to '
                     'non-volatile storage')
 
@@ -369,7 +369,7 @@ def main():
     if module.params['save_when'] == 'always':
         save_config(module, result)
     elif module.params['save_when'] == 'modified':
-        output = run_commands(module, ['show running-config', 'show startup-config'])
+        output = run_commands(module, ['show running-config', 'show configuration'])
 
         running_config = NetworkConfig(contents=output[0], ignore_lines=diff_ignore_lines)
         startup_config = NetworkConfig(contents=output[1], ignore_lines=diff_ignore_lines)
@@ -399,7 +399,7 @@ def main():
 
         elif module.params['diff_against'] == 'startup':
             if not startup_config:
-                output = run_commands(module, 'show startup-config')
+                output = run_commands(module, 'show configuration')
                 contents = output[0]
             else:
                 contents = startup_config.config_text

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -72,7 +72,7 @@ class Cliconf(CliconfBase):
         if source == 'running':
             cmd = 'show running-config all'
         else:
-            cmd = 'show startup-config'
+            cmd = 'show configuration'
         return self.send_command(cmd)
 
     @enable_mode

--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -37,7 +37,7 @@ class TerminalModule(TerminalBase):
     ]
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w]*\(.+\) ?#(?:\s*)$"),
+        re.compile(br"[\r\n]?[\w]*\(.+\)\s*[\^\*]?(?:\[.+\])? ?#(?:\s*)$"),
         re.compile(br"[pP]assword:$"),
         re.compile(br"(?<=\s)[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\s*#\s*$"),
         re.compile(br"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$"),

--- a/test/units/modules/network/aruba/test_aruba_config.py
+++ b/test/units/modules/network/aruba/test_aruba_config.py
@@ -87,7 +87,7 @@ class TestArubaConfigModule(TestArubaModule):
         self.assertEqual(self.get_config.call_count, 0)
         self.assertEqual(self.load_config.call_count, 0)
         args = self.run_commands.call_args[0][1]
-        self.assertIn('copy running-config startup-config', args)
+        self.assertIn('write memory', args)
 
     def test_aruba_config_save_changed_true(self):
         src = load_fixture('aruba_config_src.cfg')
@@ -104,7 +104,7 @@ class TestArubaConfigModule(TestArubaModule):
         self.assertEqual(self.get_config.call_count, 1)
         self.assertEqual(self.load_config.call_count, 1)
         args = self.run_commands.call_args[0][1]
-        self.assertIn('copy running-config startup-config', args)
+        self.assertIn('write memory', args)
 
     def test_aruba_config_save_changed_false(self):
         set_module_args(dict(save_when='changed'))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In ArubaOS 8.x, changes were introduced to the prompt and some commands were removed. This should add support for ArubaOS 8.x while retaining support for older versions. 
Fixes #47764   
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aruba modules
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
`show startup-config` and `copy running-config startup-config` were removed. The alternate commands `show configuration` and `write memory` have been present since ArubaOS 1.0 and should therefore be backwards compatible to all supported versions. 

Default prompts will now be variations of the below. 
For a mobility master controller:
`(hostname) [nodename] #`
`(hostname) ^[nodename] #` When unsaved changes are present
`(hostname) *[nodename] #` When a crash dump is stored on the flash
For a standard controller:
`(hostname) #`
`(hostname) ^#`
`(hostname) *#`
