### PR TITLE
Remove systems_uri as parameter from get_psu_inventory method

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -940,7 +940,7 @@ class RedfishUtils(object):
                                inventory['entries']))
         return dict(ret=ret, entries=entries)
 
-    def get_psu_inventory(self, systems_uri):
+    def get_psu_inventory(self):
         result = {}
         psu_list = []
         psu_results = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
At some point `systems_uri` was added as a parameter to `get_psu_inventory()`, removing it since it's not needed and is causing errors.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

