### PR TITLE
Add support for raw cron schedules

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -117,6 +117,7 @@ options:
     description:
       - Raw cron schedule (0 0 * * *)
     type: str
+    version_added: "2.8"
   disabled:
     description:
       - If the job should be disabled (commented out) in the crontab.


### PR DESCRIPTION
##### SUMMARY
This adds support for using raw cron schedules such as `0 23 * * *` rather than specifying the minutes, hours, etc. individually. Some people are used to doing cron lines and similar to how the file module lets people use octal or symbolic mode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cron

##### ADDITIONAL INFORMATION
Example of equivalent cron jobs with old and new format
```YAML
- name: Creates and entry with minute and hour settings
    become: yes
    cron:
      name: "a cron job"
      minute: "30"
      hour: "20"
      job: "/bin/tar cf backup.tar /backup"

  - name: Creates and entry with a raw cron schedule string
    become: yes
    cron:
      name: "a raw cron job"
      schedule: "30 20 * * *"
      job: "/bin/tar cf backup.tar /backup"

```
