### PR TITLE
Fix inconsistencies in config.

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -367,14 +367,15 @@ LOCALHOST_WARNING:
   - {key: localhost_warning, section: defaults}
   type: boolean
   version_added: "2.6"
-DOC_FRAGMENT_PLUGIN_PATH:
+DOC_FRAGMENTS_PLUGIN_PATH:
   name: documentation fragment plugins path
   default: ~/.ansible/plugins/doc_fragments:/usr/share/ansible/plugins/doc_fragments
   description: Colon separated paths in which Ansible will search for Documentation Fragments Plugins.
-  env: [{name: ANSIBLE_DOC_FRAGMENT_PLUGINS}]
+  env: [{name: ANSIBLE_DOC_FRAGMENTS_PLUGINS}]
   ini:
-  - {key: doc_fragment_plugins, section: defaults}
+  - {key: doc_fragments_plugins, section: defaults}
   type: pathspec
+  version_added: "2.8"
 DEFAULT_ACTION_PLUGIN_PATH:
   name: Action plugins path
   default: ~/.ansible/plugins/action:/usr/share/ansible/plugins/action
@@ -384,6 +385,15 @@ DEFAULT_ACTION_PLUGIN_PATH:
   - {key: action_plugins, section: defaults}
   type: pathspec
   yaml: {key: plugins.action.path}
+SHELL_PLUGIN_PATH:
+  name: Shell plugins path
+  default: ~/.ansible/plugins/shell:/usr/share/ansible/plugins/shell
+  description: Colon separated paths in which Ansible will search for Shell Plugins.
+  env: [{name: ANSIBLE_SHELL_PLUGINS}]
+  ini:
+  - {key: shell_plugins, section: defaults}
+  type: pathspec
+  version_added: "2.8"
 DEFAULT_ALLOW_UNSAFE_LOOKUPS:
   name: Allow unsafe lookups
   default: False
@@ -482,14 +492,15 @@ DEFAULT_BECOME_FLAGS:
   env: [{name: ANSIBLE_BECOME_FLAGS}]
   ini:
   - {key: become_flags, section: privilege_escalation}
-DEFAULT_BECOME_PLUGIN_PATH:
+BECOME_PLUGIN_PATH:
   name: Become plugins path
-  default: ~/.ansible/plugins/become:/usr/share/ansible/become
+  default: ~/.ansible/plugins/become:/usr/share/ansible/plugins/become
   description: Colon separated paths in which Ansible will search for Become Plugins.
   env: [{name: ANSIBLE_BECOME_PLUGINS}]
   ini:
   - {key: become_plugins, section: defaults}
   type: pathspec
+  version_added: "2.8"
 DEFAULT_BECOME_USER:
   # FIXME: should really be blank and make -u passing optional depending on it
   name: Set the user you 'become' via privilege escalation

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -704,7 +704,7 @@ _PLUGIN_FILTERS = _load_plugin_filter()
 fragment_loader = PluginLoader(
     'ModuleDocFragment',
     'ansible.plugins.doc_fragments',
-    C.DOC_FRAGMENT_PLUGIN_PATH,
+    C.DOC_FRAGMENTS_PLUGIN_PATH,
     'doc_fragments',
 )
 
@@ -742,7 +742,7 @@ connection_loader = PluginLoader(
 shell_loader = PluginLoader(
     'ShellModule',
     'ansible.plugins.shell',
-    'shell_plugins',
+    C.SHELL_PLUGIN_PATH,
     'shell_plugins',
 )
 
@@ -848,6 +848,6 @@ httpapi_loader = PluginLoader(
 become_loader = PluginLoader(
     'BecomeModule',
     'ansible.plugins.become',
-    C.DEFAULT_BECOME_PLUGIN_PATH,
+    C.BECOME_PLUGIN_PATH,
     'become_plugins'
 )


### PR DESCRIPTION
##### SUMMARY

Fix inconsistencies in config:

- Update `DOC_FRAGMENTS_PLUGIN_PATH` to match plural `doc_fragments` plugin type.
- Add missing version_added for `PLUGIN_PATH` entries new in 2.8.
- Drop `DEFAULT_` prefix from newly added `BECOME_PLUGIN_PATH`.
- Add missing `SHELL_PLUGIN_PATH`.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

config and config loader
