### PR TITLE
Add GetSupportedFirmwareUpdateMethods to redfish_facts/Update commands

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -511,6 +511,32 @@ class RedfishUtils(object):
             return response
         return {'ret': True}
 
+    def get_supported_firmware_update_methods(self):
+        result = {}
+        response = self.get_request(self.root_uri + "/redfish/v1")
+
+        if response['ret'] is False:
+            return response
+
+        result['ret'] = True
+
+        result['entries'] = []
+        data = response['data']
+        if "UpdateService" in data:
+            response = self.get_request(self.root_uri + "/redfish/v1/UpdateService")
+
+            data = response['data']
+
+            if "Actions" in data:
+                if "#UpdateService.SimpleUpdate" in data["Actions"]:
+                    if "TransferProtocol@Redfish.AllowableValues" in data["Actions"]["#UpdateService.SimpleUpdate"]:
+                        result['entries'] = data["Actions"]["#UpdateService.SimpleUpdate"]["TransferProtocol@Redfish.AllowableValues"]
+            else:
+                return {'ret': "False", 'msg': "Key Actions not found."}
+        else:
+            return {'ret': "False", 'msg': "Key UpdateService not found."}
+        return result
+
     def get_firmware_inventory(self):
         result = {}
         response = self.get_request(self.root_uri + self.firmware_uri)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -537,7 +537,7 @@ class RedfishUtils(object):
                             title = action['title']
                         else:
                             title = key
-                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', 
+                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues',
                                                                 ["Key TransferProtocol@Redfish.AllowableValues not found"])
                 else:
                     return {'ret': "False", 'msg': "Actions list is empty."}

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -531,8 +531,13 @@ class RedfishUtils(object):
             if "Actions" in data:
                 actions = data['Actions']
                 if len(actions) > 0:
-                    for action in actions.values():
-                        result['entries'][action['title']] = action['TransferProtocol@Redfish.AllowableValues']
+                    for key in actions.keys():
+                        action = actions.get(key)
+                        if 'title' in action:
+                            title = action['title']
+                        else:
+                            title = key
+                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', ["Key TransferProtocol@Redfish.AllowableValues not found"])
                 else:
                     return {'ret': "False", 'msg': "Actions list is empty."}
             else:

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -538,7 +538,7 @@ class RedfishUtils(object):
                         else:
                             title = key
                         result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues',
-                                                                ["Key TransferProtocol@Redfish.AllowableValues not found"])
+                                                              ["Key TransferProtocol@Redfish.AllowableValues not found"])
                 else:
                     return {'ret': "False", 'msg': "Actions list is empty."}
             else:

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -513,7 +513,7 @@ class RedfishUtils(object):
 
     def get_firmware_update_capabilities(self):
         result = {}
-        response = self.get_request(self.root_uri + "/redfish/v1")
+        response = self.get_request(self.root_uri + self.update_uri)
         if response['ret'] is False:
             return response
 
@@ -522,29 +522,22 @@ class RedfishUtils(object):
         result['entries'] = {}
 
         data = response['data']
-        if "UpdateService" in data:
-            updateservce_uri = data['UpdateService']["@odata.id"]
-            response = self.get_request(self.root_uri + updateservce_uri)
 
-            data = response['data']
-
-            if "Actions" in data:
-                actions = data['Actions']
-                if len(actions) > 0:
-                    for key in actions.keys():
-                        action = actions.get(key)
-                        if 'title' in action:
-                            title = action['title']
-                        else:
-                            title = key
-                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues',
-                                                              ["Key TransferProtocol@Redfish.AllowableValues not found"])
-                else:
-                    return {'ret': "False", 'msg': "Actions list is empty."}
+        if "Actions" in data:
+            actions = data['Actions']
+            if len(actions) > 0:
+                for key in actions.keys():
+                    action = actions.get(key)
+                    if 'title' in action:
+                        title = action['title']
+                    else:
+                        title = key
+                    result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues',
+                                                          ["Key TransferProtocol@Redfish.AllowableValues not found"])
             else:
-                return {'ret': "False", 'msg': "Key Actions not found."}
+                return {'ret': "False", 'msg': "Actions list is empty."}
         else:
-            return {'ret': "False", 'msg': "Key UpdateService not found."}
+            return {'ret': "False", 'msg': "Key Actions not found."}
         return result
 
     def get_firmware_inventory(self):

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -520,7 +520,7 @@ class RedfishUtils(object):
         result['ret'] = True
 
         result['entries'] = {}
-        
+
         data = response['data']
         if "UpdateService" in data:
             updateservce_uri = data['UpdateService']["@odata.id"]
@@ -529,7 +529,7 @@ class RedfishUtils(object):
             data = response['data']
 
             if "Actions" in data:
-                actions = data['Actions']                
+                actions = data['Actions']
                 if len(actions) > 0:
                     for action in actions.values():
                         result['entries'][action['title']] = action['TransferProtocol@Redfish.AllowableValues']
@@ -635,16 +635,14 @@ class RedfishUtils(object):
         boot_options_dict = {}
         for member in members:
             if '@odata.id' not in member:
-                return {'ret': False,
-                        'msg': "@odata.id not found in BootOptions"}
+                return {'ret': False, 'msg': "@odata.id not found in BootOptions"}
             boot_option_uri = member['@odata.id']
             response = self.get_request(self.root_uri + boot_option_uri)
             if response['ret'] is False:
                 return response
             data = response['data']
             if 'BootOptionReference' not in data:
-                return {'ret': False,
-                        'msg': "BootOptionReference not found in BootOption"}
+                return {'ret': False, 'msg': "BootOptionReference not found in BootOption"}
             boot_option_ref = data['BootOptionReference']
 
             # fetch the props to display for this boot device

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -537,8 +537,7 @@ class RedfishUtils(object):
                             title = action['title']
                         else:
                             title = key
-                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', 
-                        ["Key TransferProtocol@Redfish.AllowableValues not found"])
+                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', ["Key TransferProtocol@Redfish.AllowableValues not found"])
                 else:
                     return {'ret': "False", 'msg': "Actions list is empty."}
             else:

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -511,7 +511,7 @@ class RedfishUtils(object):
             return response
         return {'ret': True}
 
-    def get_supported_firmware_update_methods(self):
+    def get_firmware_update_capabilities(self):
         result = {}
         response = self.get_request(self.root_uri + "/redfish/v1")
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -537,7 +537,8 @@ class RedfishUtils(object):
                             title = action['title']
                         else:
                             title = key
-                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', ["Key TransferProtocol@Redfish.AllowableValues not found"])
+                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', 
+                        ["Key TransferProtocol@Redfish.AllowableValues not found"])
                 else:
                     return {'ret': "False", 'msg': "Actions list is empty."}
             else:

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -537,7 +537,8 @@ class RedfishUtils(object):
                             title = action['title']
                         else:
                             title = key
-                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', ["Key TransferProtocol@Redfish.AllowableValues not found"])
+                        result['entries'][title] = action.get('TransferProtocol@Redfish.AllowableValues', 
+                                                                ["Key TransferProtocol@Redfish.AllowableValues not found"])
                 else:
                     return {'ret': "False", 'msg': "Actions list is empty."}
             else:

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -255,6 +255,8 @@ def main():
             for command in command_list:
                 if command == "GetFirmwareInventory":
                     result["firmware"] = rf_utils.get_firmware_inventory()
+                elif command == "GetSupportedFirmwareUpdateMethods":
+                    result["firmware_update_methods"] = rf_utils.get_supported_firmware_update_methods()
 
         elif category == "Manager":
             # execute only if we find a Manager service resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -134,7 +134,7 @@ CATEGORY_COMMANDS_ALL = {
                 "GetDiskInventory", "GetBiosAttributes", "GetBootOrder"],
     "Chassis": ["GetFanInventory"],
     "Accounts": ["ListUsers"],
-    "Update": ["GetFirmwareInventory"],
+    "Update": ["GetFirmwareInventory", "GetSupportedFirmwareUpdateMethods"],
     "Manager": ["GetManagerNicInventory", "GetLogs"],
 }
 

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -108,6 +108,14 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
+  - name: Get firmware update capability information
+    redfish_facts:
+      category: Update
+      command: GetFirmwareUpdateCapabilities
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+
   - name: Get all information available in all categories
     redfish_facts:
       category: all
@@ -256,7 +264,7 @@ def main():
                 if command == "GetFirmwareInventory":
                     result["firmware"] = rf_utils.get_firmware_inventory()
                 elif command == "GetFirmwareUpdateCapabilities":
-                    result["firmware_update_methods"] = rf_utils.get_firmware_update_capabilities()
+                    result["firmware_update_capabilities"] = rf_utils.get_firmware_update_capabilities()
 
         elif category == "Manager":
             # execute only if we find a Manager service resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -256,7 +256,7 @@ def main():
                 if command == "GetFirmwareInventory":
                     result["firmware"] = rf_utils.get_firmware_inventory()
                 elif command == "GetFirmwareUpdateCapabilities":
-                    result["firmware_update_methods"] = rf_utils.get_supported_firmware_update_methods()
+                    result["firmware_update_methods"] = rf_utils.get_firmware_update_capabilities()
 
         elif category == "Manager":
             # execute only if we find a Manager service resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -134,7 +134,7 @@ CATEGORY_COMMANDS_ALL = {
                 "GetDiskInventory", "GetBiosAttributes", "GetBootOrder"],
     "Chassis": ["GetFanInventory"],
     "Accounts": ["ListUsers"],
-    "Update": ["GetFirmwareInventory", "GetSupportedFirmwareUpdateMethods"],
+    "Update": ["GetFirmwareInventory", "GetFirmwareUpdateCapabilities"],
     "Manager": ["GetManagerNicInventory", "GetLogs"],
 }
 
@@ -255,7 +255,7 @@ def main():
             for command in command_list:
                 if command == "GetFirmwareInventory":
                     result["firmware"] = rf_utils.get_firmware_inventory()
-                elif command == "GetSupportedFirmwareUpdateMethods":
+                elif command == "GetFirmwareUpdateCapabilities":
                     result["firmware_update_methods"] = rf_utils.get_supported_firmware_update_methods()
 
         elif category == "Manager":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request implements GetSupportedFirmwareUpdateMethods, which returns as a list the supported firmware update methods as shown in the UpdateService schema. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #54234 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.243.5.31
    user: USERID
    password: PASSW0RD

  tasks:

    - name: Get all information available in Update category
      redfish_facts:
        category: Update
        command: GetSupportedFirmwareUpdateMethods
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
 ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/xandermadsen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/xandermadsen/ansible/lib/ansible
  executable location = /Users/xandermadsen/ansible/bin/ansible-playbook
  python version = 2.7.15 (default, Feb 12 2019, 11:00:12) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.5)]
No config file found; using defaults
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: test_redfish_facts.yml **************************************************************************************************************************************************************************
1 plays in ../test_redfish_facts.yml

PLAY [Test Redfish modules] *******************************************************************************************************************************************************************************
META: ran handlers

TASK [Get all information available in Update category] ***************************************************************************************************************************************************
task path: /Users/xandermadsen/test_redfish_facts.yml:11
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xandermadsen
<127.0.0.1> EXEC /bin/sh -c 'echo ~xandermadsen && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553292386.15-246599246160697 `" && echo ansible-tmp-1553292386.15-246599246160697="` echo /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553292386.15-246599246160697 `" ) && sleep 0'
Using module file /Users/xandermadsen/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /Users/xandermadsen/.ansible/tmp/ansible-local-419185AEjdJ/tmpDvBITr TO /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553292386.15-246599246160697/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553292386.15-246599246160697/ /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553292386.15-246599246160697/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/local/opt/python@2/bin/python2.7 /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553292386.15-246599246160697/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553292386.15-246599246160697/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => (item=GetFirmwareInventory) => {
    "ansible_facts": {
        "redfish_facts": {
            "firmware_update_methods": {
                "entries": [
                    "TFTP", 
                    "SFTP"
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31", 
            "category": [
                "Update"
            ], 
            "command": [
                "GetSupportedFirmwareUpdateMethods"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }, 
    "item": "GetFirmwareInventory"
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```
