### PR TITLE
Feat/add GetChassisInventory to Chassis category of redfish_facts

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -967,6 +967,30 @@ class RedfishUtils(object):
             return response
         return {'ret': True, 'changed': True, 'msg': "Modified BIOS attribute"}
 
+    def get_chassis_inventory(self):
+        result = {}
+        chassis_results = []
+
+        # Get these entries, but does not fail if not found
+        properties = ['ChassisType', 'PartNumber', 'AssetTag',
+                      'Manufacturer', 'IndicatorLED', 'SerialNumber', 'Model']
+
+        # Go through list
+        for chassis_uri in self.chassis_uri_list:
+            response = self.get_request(self.root_uri + chassis_uri)
+            if response['ret'] is False:
+                return response
+            result['ret'] = True
+            data = response['data']
+            chassis_result = {}
+            for property in properties:
+                if property in data:
+                    chassis_result[property] = data[property]
+            chassis_results.append(chassis_result)
+
+        result["entries"] = chassis_results
+        return result
+
     def get_fan_inventory(self):
         result = {}
         fan_results = []

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -129,17 +129,18 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
-<<<<<<< HEAD
   - name: Get boot override information
     redfish_facts:
       category: Systems
       command: GetBootOverride
-=======
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      
   - name: Get chassis inventory
     redfish_facts:
       category: Chassis
       command: GetChassisInventory
->>>>>>> 981cba59b8... Add GetChassisInventory command to redfish_facts
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -296,15 +297,12 @@ def main():
                     result["fan"] = rf_utils.get_fan_inventory()
                 elif command == "GetPsuInventory":
                     result["psu"] = rf_utils.get_psu_inventory()
-<<<<<<< HEAD
                 elif command == "GetChassisThermals":
                     result["thermals"] = rf_utils.get_chassis_thermals()
                 elif command == "GetChassisPower":
                     result["chassis_power"] = rf_utils.get_chassis_power()
-=======
                 elif command == "GetChassisInventory":
                     result["chassis"] = rf_utils.get_chassis_inventory()
->>>>>>> 981cba59b8... Add GetChassisInventory command to redfish_facts
 
         elif category == "Accounts":
             # execute only if we find an Account service resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -129,10 +129,17 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
+<<<<<<< HEAD
   - name: Get boot override information
     redfish_facts:
       category: Systems
       command: GetBootOverride
+=======
+  - name: Get chassis inventory
+    redfish_facts:
+      category: Chassis
+      command: GetChassisInventory
+>>>>>>> 981cba59b8... Add GetChassisInventory command to redfish_facts
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -178,7 +185,7 @@ CATEGORY_COMMANDS_ALL = {
                 "GetMemoryInventory", "GetNicInventory",
                 "GetStorageControllerInventory", "GetDiskInventory",
                 "GetBiosAttributes", "GetBootOrder", "GetBootOverride"],
-    "Chassis": ["GetFanInventory", "GetPsuInventory", "GetChassisPower", "GetChassisThermals"],
+    "Chassis": ["GetFanInventory", "GetPsuInventory", "GetChassisPower", "GetChassisThermals", "GetChassisInventory"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory", "GetFirmwareUpdateCapabilities"],
     "Manager": ["GetManagerNicInventory", "GetLogs"],
@@ -289,10 +296,15 @@ def main():
                     result["fan"] = rf_utils.get_fan_inventory()
                 elif command == "GetPsuInventory":
                     result["psu"] = rf_utils.get_psu_inventory()
+<<<<<<< HEAD
                 elif command == "GetChassisThermals":
                     result["thermals"] = rf_utils.get_chassis_thermals()
                 elif command == "GetChassisPower":
                     result["chassis_power"] = rf_utils.get_chassis_power()
+=======
+                elif command == "GetChassisInventory":
+                    result["chassis"] = rf_utils.get_chassis_inventory()
+>>>>>>> 981cba59b8... Add GetChassisInventory command to redfish_facts
 
         elif category == "Accounts":
             # execute only if we find an Account service resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -136,7 +136,7 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      
+
   - name: Get chassis inventory
     redfish_facts:
       category: Chassis


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request adds a GetChassisInventory command to the Chassis category of redfish_facts, and returns a list of Chassis and some useful Chassis properties for each Chassis found in the chassis_uri_list.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #54233
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->   
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.243.5.31
    user: USERID
    password: PASSW0RD

  tasks:

    - name: Get Chassis Inventory
      redfish_facts:
        category: Chassis
        command: GetChassisInventory
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/xandermadsen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/xandermadsen/ansible/lib/ansible
  executable location = /Users/xandermadsen/ansible/bin/ansible-playbook
  python version = 2.7.15 (default, Feb 12 2019, 11:00:12) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.5)]
No config file found; using defaults
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: test_redfish_facts.yml **************************************************************************************************************************************************************************
1 plays in ../test_redfish_facts.yml

PLAY [Test Redfish modules] *******************************************************************************************************************************************************************************
META: ran handlers

TASK [Get all information available in Update category] ***************************************************************************************************************************************************
task path: /Users/xandermadsen/test_redfish_facts.yml:11
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xandermadsen
<127.0.0.1> EXEC /bin/sh -c 'echo ~xandermadsen && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553293199.69-162779276806352 `" && echo ansible-tmp-1553293199.69-162779276806352="` echo /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553293199.69-162779276806352 `" ) && sleep 0'
Using module file /Users/xandermadsen/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /Users/xandermadsen/.ansible/tmp/ansible-local-425987mDPpi/tmpWe33D3 TO /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553293199.69-162779276806352/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553293199.69-162779276806352/ /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553293199.69-162779276806352/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/local/opt/python@2/bin/python2.7 /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553293199.69-162779276806352/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /Users/xandermadsen/.ansible/tmp/ansible-tmp-1553293199.69-162779276806352/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "chassis": {
                "entries": [
                    {
                        "AssetTag": "12345", 
                        "ChassisType": "RackMount", 
                        "IndicatorLED": "Off", 
                        "Manufacturer": "Lenovo", 
                        "Model": "7X05RCZ000", 
                        "PartNumber": "SB27A18446", 
                        "SerialNumber": "PROD00000A"
                    }
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31", 
            "category": [
                "Chassis"
            ], 
            "command": [
                "GetChassisInventory"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }
}
```
