### PR TITLE
Feat/add GetBootOverride to Systems category of redfish_facts

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -786,6 +786,35 @@ class RedfishUtils(object):
     def get_multi_boot_order(self):
         return self.aggregate(self.get_boot_order)
 
+    def get_boot_override(self):
+        result = {}
+
+        properties = ["BootSourceOverrideEnabled", "BootSourceOverrideTarget",
+                      "BootSourceOverrideMode", "UefiTargetBootSourceOverride"]
+
+        response = self.get_request(self.root_uri + self.systems_uris[0])
+        if response['ret'] is False:
+            return response
+        result['ret'] = True
+        data = response['data']
+
+        if 'Boot' not in data:
+            return {'ret': False, 'msg': "Key Boot not found"}
+
+        boot = data['Boot']
+
+        result['boot_override'] = {}
+        if "BootSourceOverrideEnabled" in boot:
+            if boot["BootSourceOverrideEnabled"] is not False:
+                for property in properties:
+                    if property in boot:
+                        if boot[property] is not None:
+                            result['boot_override'][property] = boot[property]
+        else:
+            return {'ret': False, 'msg': "No boot override is enabled."}
+
+        return result
+
     def set_bios_default_settings(self):
         result = {}
         key = "Bios"

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -786,13 +786,13 @@ class RedfishUtils(object):
     def get_multi_boot_order(self):
         return self.aggregate(self.get_boot_order)
 
-    def get_boot_override(self):
+    def get_boot_override(self, systems_uri):
         result = {}
 
         properties = ["BootSourceOverrideEnabled", "BootSourceOverrideTarget",
-                      "BootSourceOverrideMode", "UefiTargetBootSourceOverride"]
+                      "BootSourceOverrideMode", "UefiTargetBootSourceOverride", "BootSourceOverrideTarget@Redfish.AllowableValues"]
 
-        response = self.get_request(self.root_uri + self.systems_uris[0])
+        response = self.get_request(self.root_uri + systems_uri)
         if response['ret'] is False:
             return response
         result['ret'] = True
@@ -803,23 +803,27 @@ class RedfishUtils(object):
 
         boot = data['Boot']
 
-        result['boot_override'] = {}
+        boot_overrides = {}
         if "BootSourceOverrideEnabled" in boot:
             if boot["BootSourceOverrideEnabled"] is not False:
                 for property in properties:
                     if property in boot:
                         if boot[property] is not None:
-                            result['boot_override'][property] = boot[property]
+                            boot_overrides[property] = boot[property]
         else:
             return {'ret': False, 'msg': "No boot override is enabled."}
 
+        result['entries'] = boot_overrides
         return result
+
+    def get_multi_boot_override(self):
+        return self.aggregate(self.get_boot_override)
 
     def set_bios_default_settings(self):
         result = {}
         key = "Bios"
 
-        # Search for 'key' entry and extract URI from it
+        # Search for 'key' entry asend extract URI from it
         response = self.get_request(self.root_uri + self.systems_uris[0])
         if response['ret'] is False:
             return response

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -823,7 +823,7 @@ class RedfishUtils(object):
         result = {}
         key = "Bios"
 
-        # Search for 'key' entry asend extract URI from it
+        # Search for 'key' entry and extract URI from it
         response = self.get_request(self.root_uri + self.systems_uris[0])
         if response['ret'] is False:
             return response

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -1249,7 +1249,7 @@ class RedfishUtils(object):
             ret = inventory.pop('ret') and ret
             if 'entries' in inventory:
                 entries.append(({'resource_uri': resource_uri},
-                               inventory['entries']))
+                                inventory['entries']))
         return dict(ret=ret, entries=entries)
 
     def get_psu_inventory(self):

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -169,7 +169,7 @@ CATEGORY_COMMANDS_ALL = {
     "Systems": ["GetSystemInventory", "GetPsuInventory", "GetCpuInventory",
                 "GetMemoryInventory", "GetNicInventory",
                 "GetStorageControllerInventory", "GetDiskInventory",
-                "GetBiosAttributes", "GetBootOrder"],
+                "GetBiosAttributes", "GetBootOrder", "GetBootOverride"],
     "Chassis": ["GetFanInventory", "GetPsuInventory", "GetChassisPower", "GetChassisThermals"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory", "GetFirmwareUpdateCapabilities"],

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -129,6 +129,14 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
+  - name: Get boot override information
+    redfish_facts:
+      category: Systems
+      command: GetBootOverride
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+
   - name: Get all information available in the Manager category
     redfish_facts:
       category: Manager

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -267,6 +267,8 @@ def main():
                     result["bios_attribute"] = rf_utils.get_multi_bios_attributes()
                 elif command == "GetBootOrder":
                     result["boot_order"] = rf_utils.get_multi_boot_order()
+                elif command == "GetBootOverride":
+                    result["boot_override"] = rf_utils.get_boot_override()
 
         elif category == "Chassis":
             # execute only if we find Chassis resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -268,7 +268,7 @@ def main():
                 elif command == "GetBootOrder":
                     result["boot_order"] = rf_utils.get_multi_boot_order()
                 elif command == "GetBootOverride":
-                    result["boot_override"] = rf_utils.get_boot_override()
+                    result["boot_override"] = rf_utils.get_multi_boot_override()
 
         elif category == "Chassis":
             # execute only if we find Chassis resource


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a GetBootOverride command to the Systems category of redfish_facts. It returns the target, boot mode, and type of override (once vs. more frequent) for the system, and returns a message indicating there is no override if the state of the override property is not Enabled.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #54205 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
