### PR TITLE
meraki_switchport - Improve reliability

### DIFF
--- a/changelogs/fragments/53601-meraki_switchport_improve_vlan_reliability.yml
+++ b/changelogs/fragments/53601-meraki_switchport_improve_vlan_reliability.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "meraki_switchport - improve reliability with native VLAN functionality."

--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -261,6 +261,7 @@ param_map = {'access_policy_number': 'accessPolicyNumber',
              'voice_vlan': 'voiceVlan',
              }
 
+
 def sort_vlans(meraki, vlans):
     converted = set()
     for vlan in vlans:

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -3,38 +3,38 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test an API key is provided
-  fail:
-    msg: Please define an API key
-  when: auth_key is not defined
+# - name: Test an API key is provided
+#   fail:
+#     msg: Please define an API key
+#   when: auth_key is not defined
   
-- name: Use an invalid domain
-  meraki_switchport:
-    auth_key: '{{ auth_key }}'
-    host: marrrraki.com
-    state: query
-    serial: Q2HP-2C6E-GTLD
-    org_name: IntTestOrg
-  delegate_to: localhost
-  register: invaliddomain
-  ignore_errors: yes
+# - name: Use an invalid domain
+#   meraki_switchport:
+#     auth_key: '{{ auth_key }}'
+#     host: marrrraki.com
+#     state: query
+#     serial: Q2HP-2C6E-GTLD
+#     org_name: IntTestOrg
+#   delegate_to: localhost
+#   register: invaliddomain
+#   ignore_errors: yes
   
-- name: Disable HTTP
-  meraki_switchport:
-    auth_key: '{{ auth_key }}'
-    use_https: false
-    state: query
-    serial: Q2HP-2C6E-
-    output_level: debug
-  delegate_to: localhost
-  register: http
-  ignore_errors: yes
+# - name: Disable HTTP
+#   meraki_switchport:
+#     auth_key: '{{ auth_key }}'
+#     use_https: false
+#     state: query
+#     serial: Q2HP-2C6E-
+#     output_level: debug
+#   delegate_to: localhost
+#   register: http
+#   ignore_errors: yes
 
-- name: Connection assertions
-  assert:
-    that:
-      - '"Failed to connect to" in invaliddomain.msg'
-      - '"http" in http.url'
+# - name: Connection assertions
+#   assert:
+#     that:
+#       - '"Failed to connect to" in invaliddomain.msg'
+#       - '"http" in http.url'
 
 - name: Query all switchports
   meraki_switchport:
@@ -132,6 +132,48 @@
     that:
       - update_access_port.data.vlan == 10
 
+- name: Configure port as trunk
+  meraki_switchport:
+    auth_key: '{{auth_key}}'
+    state: present
+    serial: Q2HP-2C6E-GTLD
+    number: 8
+    enabled: true
+    name: Test Port
+    type: trunk
+    vlan: 10
+    allowed_vlans: 10, 100, 200
+  delegate_to: localhost
+
+- name: Convert trunk port to access
+  meraki_switchport:
+    auth_key: '{{auth_key}}'
+    state: present
+    serial: Q2HP-2C6E-GTLD
+    number: 8
+    enabled: true
+    name: Test Port
+    type: access
+    vlan: 10
+  delegate_to: localhost
+
+- name: Test converted port for idempotency
+  meraki_switchport:
+    auth_key: '{{auth_key}}'
+    state: present
+    serial: Q2HP-2C6E-GTLD
+    number: 8
+    enabled: true
+    name: Test Port
+    type: access
+    vlan: 10
+  delegate_to: localhost
+  register: convert_idempotent
+
+- assert:
+    that:
+      - convert_idempotent.changed == False
+
 - name: Configure access port with voice VLAN
   meraki_switchport:
     auth_key: '{{auth_key}}'
@@ -188,6 +230,7 @@
     tags: server
     type: trunk
     allowed_vlans: all
+    vlan: 8
   delegate_to: localhost
   register: update_trunk
 
@@ -210,6 +253,7 @@
     name: Server port
     tags: server
     type: trunk
+    vlan: 8
     allowed_vlans:
       - 10
       - 15
@@ -224,7 +268,7 @@
     that:
       - update_trunk.data.tags == 'server'
       - update_trunk.data.type == 'trunk'
-      - update_trunk.data.allowedVlans == '10,15,20'
+      - update_trunk.data.allowedVlans == '8,10,15,20'
 
 - name: Configure trunk port with specific VLANs and native VLAN
   meraki_switchport:

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -3,38 +3,38 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-# - name: Test an API key is provided
-#   fail:
-#     msg: Please define an API key
-#   when: auth_key is not defined
+- name: Test an API key is provided
+  fail:
+    msg: Please define an API key
+  when: auth_key is not defined
   
-# - name: Use an invalid domain
-#   meraki_switchport:
-#     auth_key: '{{ auth_key }}'
-#     host: marrrraki.com
-#     state: query
-#     serial: Q2HP-2C6E-GTLD
-#     org_name: IntTestOrg
-#   delegate_to: localhost
-#   register: invaliddomain
-#   ignore_errors: yes
+- name: Use an invalid domain
+  meraki_switchport:
+    auth_key: '{{ auth_key }}'
+    host: marrrraki.com
+    state: query
+    serial: Q2HP-2C6E-GTLD
+    org_name: IntTestOrg
+  delegate_to: localhost
+  register: invaliddomain
+  ignore_errors: yes
   
-# - name: Disable HTTP
-#   meraki_switchport:
-#     auth_key: '{{ auth_key }}'
-#     use_https: false
-#     state: query
-#     serial: Q2HP-2C6E-
-#     output_level: debug
-#   delegate_to: localhost
-#   register: http
-#   ignore_errors: yes
+- name: Disable HTTP
+  meraki_switchport:
+    auth_key: '{{ auth_key }}'
+    use_https: false
+    state: query
+    serial: Q2HP-2C6E-GTLD
+    output_level: debug
+  delegate_to: localhost
+  register: http
+  ignore_errors: yes
 
-# - name: Connection assertions
-#   assert:
-#     that:
-#       - '"Failed to connect to" in invaliddomain.msg'
-#       - '"http" in http.url'
+- name: Connection assertions
+  assert:
+    that:
+      - '"Failed to connect to" in invaliddomain.msg'
+      - '"http" in http.url'
 
 - name: Query all switchports
   meraki_switchport:


### PR DESCRIPTION
##### SUMMARY
`meraki_switchport` wasn't very reliable when it came to the `allowed_vlans` statement. These changes are a significant rewrite of the logic to make this work.

Additionally, payload creation was simplified.

Fixes #53601

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_switchport
