### PR TITLE
Fix failing test modules due to incorrect use of pytest.skip() (#54282)

### DIFF
--- a/test/units/modules/storage/netapp/test_na_ontap_aggregate.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_aggregate.py
@@ -14,7 +14,7 @@ from ansible.modules.storage.netapp.na_ontap_aggregate \
     import NetAppOntapAggregate as my_module  # module under test
 
 if not netapp_utils.has_netapp_lib():
-    pytestmark = pytest.skip('skipping as missing required netapp_lib')
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
 
 
 def set_module_args(args):

--- a/test/units/modules/storage/netapp/test_na_ontap_cifs.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_cifs.py
@@ -17,7 +17,7 @@ from ansible.modules.storage.netapp.na_ontap_cifs \
     import NetAppONTAPCifsShare as my_module  # module under test
 
 if not netapp_utils.has_netapp_lib():
-    pytestmark = pytest.skip('skipping as missing required netapp_lib')
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
 
 
 def set_module_args(args):

--- a/test/units/modules/storage/netapp/test_na_ontap_cifs_server.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_cifs_server.py
@@ -17,7 +17,7 @@ from ansible.modules.storage.netapp.na_ontap_cifs_server \
     import NetAppOntapcifsServer as my_module  # module under test
 
 if not netapp_utils.has_netapp_lib():
-    pytestmark = pytest.skip('skipping as missing required netapp_lib')
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
 
 
 def set_module_args(args):

--- a/test/units/modules/storage/netapp/test_na_ontap_interface.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_interface.py
@@ -17,7 +17,7 @@ from ansible.modules.storage.netapp.na_ontap_interface \
     import NetAppOntapInterface as interface_module  # module under test
 
 if not netapp_utils.has_netapp_lib():
-    pytestmark = pytest.skip('skipping as missing required netapp_lib')
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
 
 
 def set_module_args(args):

--- a/test/units/modules/storage/netapp/test_na_ontap_job_schedule.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_job_schedule.py
@@ -17,7 +17,7 @@ from ansible.modules.storage.netapp.na_ontap_job_schedule \
     import NetAppONTAPJob as job_module  # module under test
 
 if not netapp_utils.has_netapp_lib():
-    pytestmark = pytest.skip('skipping as missing required netapp_lib')
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
 
 
 def set_module_args(args):

--- a/test/units/modules/storage/netapp/test_na_ontap_net_ifgrp.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_net_ifgrp.py
@@ -17,7 +17,7 @@ from ansible.modules.storage.netapp.na_ontap_net_ifgrp \
     import NetAppOntapIfGrp as ifgrp_module  # module under test
 
 if not netapp_utils.has_netapp_lib():
-    pytestmark = pytest.skip('skipping as missing required netapp_lib')
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
 
 
 def set_module_args(args):

--- a/test/units/modules/storage/netapp/test_na_ontap_svm.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_svm.py
@@ -17,7 +17,7 @@ from ansible.modules.storage.netapp.na_ontap_svm \
     import NetAppOntapSVM as svm_module  # module under test
 
 if not netapp_utils.has_netapp_lib():
-    pytestmark = pytest.skip('skipping as missing required netapp_lib')
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
 
 
 def set_module_args(args):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #54282 

In recent versions of Pytest (e.g. 4.3.1), the use of the method `pytest.skip()` is not allowed outside of test methods anymore. This causes several unit tests to break with an error.

This patch changes the affected lines of code to use the recommended `pytest.mark.skip()` instead. 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
test