### PR TITLE
Netbox Inventory plugin enhancements

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -44,10 +44,7 @@ DOCUMENTATION = '''
                 - If True, it adds dcim interface information in host vars.
             default: False
             type: boolean
-<<<<<<< HEAD
             version_added: "2.8"
-=======
->>>>>>> added var extractor for dcim interfaces + option to turn it off
         token:
             required: True
             description: NetBox token.

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -44,7 +44,10 @@ DOCUMENTATION = '''
                 - If True, it adds dcim interface information in host vars.
             default: False
             type: boolean
+<<<<<<< HEAD
             version_added: "2.8"
+=======
+>>>>>>> added var extractor for dcim interfaces + option to turn it off
         token:
             required: True
             description: NetBox token.

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -273,10 +273,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         try:
             if self.config_context:
 <<<<<<< HEAD
+<<<<<<< HEAD
                 if 'device_role' in host:
 =======
                 if 'device_role' in host: 
 >>>>>>> added differentiator for retrieving config context for vm's
+=======
+                if 'device_role' in host:
+>>>>>>> fixed identified pep8 issue
                     url = self.api_endpoint + "/api/dcim/devices/" + str(host["id"])
                 elif 'role' in host:
                     url = self.api_endpoint + "/api/virtualization/virtual-machines/" + str(host["id"])

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -44,6 +44,7 @@ DOCUMENTATION = '''
                 - If True, it adds dcim interface information in host vars.
             default: False
             type: boolean
+            version_added: "2.8"
         token:
             required: True
             description: NetBox token.

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -269,15 +269,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_config_context(self, host):
         try:
             if self.config_context:
-<<<<<<< HEAD
-<<<<<<< HEAD
                 if 'device_role' in host:
-=======
-                if 'device_role' in host: 
->>>>>>> added differentiator for retrieving config context for vm's
-=======
-                if 'device_role' in host:
->>>>>>> fixed identified pep8 issue
                     url = self.api_endpoint + "/api/dcim/devices/" + str(host["id"])
                 elif 'role' in host:
                     url = self.api_endpoint + "/api/virtualization/virtual-machines/" + str(host["id"])

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -41,7 +41,7 @@ DOCUMENTATION = '''
             type: boolean
         interfaces:
             description:
-                - If True, it adds dcim interface information in host vars.
+                - If True, it adds the device or virtual machine interface information in host vars.
             default: False
             type: boolean
             version_added: "2.8"
@@ -311,7 +311,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_interfaces(self, host):
         try:
             if self.interfaces:
-                url = urljoin(self.api_endpoint, "/api/dcim/interfaces/?limit=0&device_id=%s" % (to_text(host["id"])))
+                if 'device_role' in host:
+                    url = urljoin(self.api_endpoint, "/api/dcim/interfaces/?limit=0&device_id=%s" % (to_text(host["id"])))
+                elif 'role' in host:
+                    url = urljoin(self.api_endpoint, "/api/virtualization/interfaces/?limit=0&virtual_machine_id=%s" %(to_text(host["id"])))
                 interface_lookup = self.get_resource_list(api_url=url)
                 return interface_lookup
         except Exception:

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -270,9 +270,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         try:
             if self.config_context:
                 if 'device_role' in host:
-                    url = self.api_endpoint + "/api/dcim/devices/" + str(host["id"])
+                    url = self.api_endpoint + "/api/dcim/devices/" + to_text(host["id"])
                 elif 'role' in host:
-                    url = self.api_endpoint + "/api/virtualization/virtual-machines/" + str(host["id"])
+                    url = self.api_endpoint + "/api/virtualization/virtual-machines/" + to_text(host["id"])
                 device_lookup = self._fetch_information(url)
                 return [device_lookup["config_context"]]
         except Exception:
@@ -287,21 +287,21 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_primary_ip(self, host):
         try:
             address = host["primary_ip"]["address"]
-            return str(ip_interface(address).ip)
+            return to_text(ip_interface(address).ip)
         except Exception:
             return
 
     def extract_primary_ip4(self, host):
         try:
             address = host["primary_ip4"]["address"]
-            return str(ip_interface(address).ip)
+            return to_text(ip_interface(address).ip)
         except Exception:
             return
 
     def extract_primary_ip6(self, host):
         try:
             address = host["primary_ip6"]["address"]
-            return str(ip_interface(address).ip)
+            return to_text(ip_interface(address).ip)
         except Exception:
             return
 
@@ -311,7 +311,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_interfaces(self, host):
         try:
             if self.interfaces:
-                url = urljoin(self.api_endpoint, "/api/dcim/interfaces/?limit=0&device_id=%s" % (str(host["id"])))
+                url = urljoin(self.api_endpoint, "/api/dcim/interfaces/?limit=0&device_id=%s" % (to_text(host["id"])))
                 interface_lookup = self.get_resource_list(api_url=url)
                 return interface_lookup
         except Exception:
@@ -410,7 +410,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         # An host in an Ansible inventory requires an hostname.
         # name is an unique but not required attribute for a device in NetBox
         # We default to an UUID for hostname in case the name is not set in NetBox
-        return host["name"] or str(uuid.uuid4())
+        return host["name"] or to_text(uuid.uuid4())
 
     def add_host_to_groups(self, host, hostname):
         for group in self.group_by:

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -268,7 +268,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_config_context(self, host):
         try:
             if self.config_context:
-                if 'device_role' in host: 
+                if 'device_role' in host:
                     url = self.api_endpoint + "/api/dcim/devices/" + str(host["id"])
                 elif 'role' in host:
                     url = self.api_endpoint + "/api/virtualization/virtual-machines/" + str(host["id"])

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -314,7 +314,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if 'device_role' in host:
                     url = urljoin(self.api_endpoint, "/api/dcim/interfaces/?limit=0&device_id=%s" % (to_text(host["id"])))
                 elif 'role' in host:
-                    url = urljoin(self.api_endpoint, "/api/virtualization/interfaces/?limit=0&virtual_machine_id=%s" %(to_text(host["id"])))
+                    url = urljoin(self.api_endpoint, "/api/virtualization/interfaces/?limit=0&virtual_machine_id=%s" % (to_text(host["id"])))
                 interface_lookup = self.get_resource_list(api_url=url)
                 return interface_lookup
         except Exception:

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -262,7 +262,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_config_context(self, host):
         try:
             if self.config_context:
-                url = self.api_endpoint + "/api/dcim/devices/" + str(host["id"])
+                if 'device_role' in host: 
+                    url = self.api_endpoint + "/api/dcim/devices/" + str(host["id"])
+                elif 'role' in host:
+                    url = self.api_endpoint + "/api/virtualization/virtual-machines/" + str(host["id"])
                 device_lookup = self._fetch_information(url)
                 return [device_lookup["config_context"]]
         except Exception:

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -269,7 +269,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_config_context(self, host):
         try:
             if self.config_context:
+<<<<<<< HEAD
                 if 'device_role' in host:
+=======
+                if 'device_role' in host: 
+>>>>>>> added differentiator for retrieving config context for vm's
                     url = self.api_endpoint + "/api/dcim/devices/" + str(host["id"])
                 elif 'role' in host:
                     url = self.api_endpoint + "/api/virtualization/virtual-machines/" + str(host["id"])


### PR DESCRIPTION
##### SUMMARY
- Added the ability for requests for VM inventory information to collect config_context data issue #53393
- Added a function to extract dcim device interface information

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Netbox inventory plugin

##### ADDITIONAL INFORMATION
The inventory extraction is quite expensive and slow.  The Netbox API doesn't appear to lend itself to easy access to this information (except requesting each interface individually)

Tested against Netbox v2.5.3
