### PR TITLE
[Doc UFW] Precise proto when using multiple ports

### DIFF
--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -191,6 +191,7 @@ EXAMPLES = r'''
   ufw:
     rule: allow
     port: 60000:61000
+    proto: tcp
 
 - name: Allow all access to tcp port 80
   ufw:


### PR DESCRIPTION
Little precision on documentation. When using range port syntax on UFW module, we need to precise tcp or udp protocol.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
