### PR TITLE
openssl_privatekey: fix broken backup option

### DIFF
--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -273,7 +273,7 @@ class PrivateKeyBase(crypto_utils.OpenSSLObject):
         self.fingerprint = {}
 
         self.backup = module.params['backup']
-        self.backup_path = None
+        self.backup_file = None
 
         self.mode = module.params.get('mode', None)
         if self.mode is None:
@@ -352,8 +352,8 @@ class PrivateKeyBase(crypto_utils.OpenSSLObject):
             'changed': self.changed,
             'fingerprint': self.fingerprint,
         }
-        if self.backup_path:
-            result['backup_path'] = self.backup_path
+        if self.backup_file:
+            result['backup_file'] = self.backup_file
 
         return result
 

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -115,14 +115,14 @@
       - passphrase_5 is changed
       - passphrase_1.backup_file is undefined
       - passphrase_2.backup_file is undefined
-      - passphrase_3.backup_file is not none
+      - passphrase_3.backup_file is string
       - passphrase_4.backup_file is undefined
-      - passphrase_5.backup_file is not none
+      - passphrase_5.backup_file is string
 
 - name: Validate remove
   assert:
     that:
       - remove_1 is changed
       - remove_2 is not changed
-      - remove_1.backup_file is not none
+      - remove_1.backup_file is string
       - remove_2.backup_file is undefined


### PR DESCRIPTION
##### SUMMARY
The new `backup` option (PR #53593) has a bug: the return value `backup_file` is not returned properly. The tests didn't detect this since `AnsibleUndefined` satisfies `is not none`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_privatekey
