### PR TITLE
[stable-2.7] meraki_admin - Add documentation for tags and network access (#51415)

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -39,10 +39,29 @@ options:
         - Tags the administrator has privileges on.
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
         - If C(none) is specified, C(network) or C(tags) must be specified.
+        suboptions:
+            tag:
+                description:
+                - Object tag which privileges should be assigned.
+                type: str
+            access:
+                description:
+                - The privilege of the dashboard administrator for the tag.
+                type: str
     networks:
         description:
         - List of networks the administrator has privileges on.
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
+        suboptions:
+            id:
+                description:
+                - Network ID for which administrator should have privileges assigned.
+                type: str
+            access:
+                description:
+                - The privilege of the dashboard administrator on the network.
+                - Valid options are C(full), C(read-only), or C(none).
+                type: str
     state:
         description:
         - Create or modify an organization
@@ -117,6 +136,32 @@ EXAMPLES = r'''
     org_name: YourOrg
     state: absent
     email: jane@doe.com
+
+- name: Create a new administrator with full access to two tags
+  meraki_admin:
+    auth_key: abc12345
+    org_name: YourOrg
+    state: present
+    name: Jane Doe
+    orgAccess: read-only
+    email: jane@doe.com
+    tags:
+        - tag: tenant
+          access: full
+        - tag: corporate
+          access: read-only
+
+- name: Create a new administrator with full access to a network
+  meraki_admin:
+    auth_key: abc12345
+    org_name: YourOrg
+    state: present
+    name: Jane Doe
+    orgAccess: read-only
+    email: jane@doe.com
+    networks:
+        - id: N_12345
+          access: full
 '''
 
 RETURN = r'''

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -57,7 +57,8 @@
       orgAccess: none
       tags:
         - { "tag": "production", "access": "read-only" }
-        - { "tag": "beta", "access": "full" }
+        - tag: beta
+          access: full
     delegate_to: localhost
     register: create_tags
 


### PR DESCRIPTION
##### SUMMARY
* Add documentation for tags and network access
* Documentation changes from dag and sam
* Change examples to include proper YAML and not dict
* Update lib/ansible/modules/network/meraki/meraki_admin.py

Co-Authored-By: kbreit <kevin.breit@kevinbreit.net>
(cherry picked from commit bcbcd209f4f20e14e460a21ca3eeaec4a4dfaa37)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meraki_admin
