### PR TITLE
Fix punctuation around issue reporting link

### DIFF
--- a/hacking/release-announcement.py
+++ b/hacking/release-announcement.py
@@ -96,7 +96,14 @@ https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_{{ latest_ve
 
 
 {% filter wordwrap %}
-If you discover any errors or if any of your working playbooks break when you upgrade to {{ latest_ver }}, please report the regression via https://github.com/ansible/ansible/issues/new/choose  In your issue, be sure to mention the Ansible version that works and the one that doesn't.
+If you discover any errors or if any of your working playbooks break when you upgrade to {{ latest_ver }}, please use the following link to report the regression:
+{% endfilter %}
+
+
+  https://github.com/ansible/ansible/issues/new/choose
+
+{% filter wordwrap %}
+In your issue, be sure to mention the Ansible version that works and the one that doesn't.
 {% endfilter %}
 
 


### PR DESCRIPTION
Figure out how to format the release announcement so a link isn't
directly followed by a period which would hinder cutand paste but uses
proper grammar and punctuation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
hacking/release-announcement.py

##### ADDITIONAL INFORMATION
The output from the specific section of the release-announcement being fixed:
```
If you discover any errors or if any of your working playbooks break when you
upgrade to 2.7.9, please use the following link to report the regression:

  https://github.com/ansible/ansible/issues/new/choose

In your issue, be sure to mention the Ansible version that works and the one
that doesn't.
```