### PR TITLE
openssl_dhparam: fix state=absent

### DIFF
--- a/changelogs/fragments/54296-openssl_dhparam-remove.yaml
+++ b/changelogs/fragments/54296-openssl_dhparam-remove.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_dhparam - fix ``state=absent`` idempotency and ``changed`` flag."

--- a/lib/ansible/modules/crypto/openssl_dhparam.py
+++ b/lib/ansible/modules/crypto/openssl_dhparam.py
@@ -136,6 +136,13 @@ class DHParameter(object):
 
         self.changed = changed
 
+    def remove(self, module):
+        try:
+            os.remove(self.path)
+            self.changed = True
+        except OSError as exc:
+            module.fail_json(msg=to_native(exc))
+
     def check(self, module):
         """Ensure the resource is in its desired state."""
         if self.force:
@@ -223,10 +230,11 @@ def main():
             result['changed'] = os.path.exists(module.params['path'])
             module.exit_json(**result)
 
-        try:
-            os.remove(module.params['path'])
-        except OSError as exc:
-            module.fail_json(msg=to_native(exc))
+        if os.path.exists(module.params['path']):
+            try:
+                dhparam.remove(module)
+            except Exception as exc:
+                module.fail_json(msg=to_native(exc))
 
     result = dhparam.dump()
 


### PR DESCRIPTION
##### SUMMARY
`state=absent` is neither idempotent nor does it correctly set `changed`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_dhparam
