### PR TITLE
win_firewall_rule only change arguments passed by user

### DIFF
--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -114,8 +114,8 @@ $diff_support = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool"
 
 $name = Get-AnsibleParam -obj $params -name "name" -failifempty $true
 $description = Get-AnsibleParam -obj $params -name "description" -type "str"
-$direction = Get-AnsibleParam -obj $params -name "direction" -type "str" -failifempty $true -validateset "in","out"
-$action = Get-AnsibleParam -obj $params -name "action" -type "str" -failifempty $true -validateset "allow","block"
+$direction = Get-AnsibleParam -obj $params -name "direction" -type "str" -validateset "in","out"
+$action = Get-AnsibleParam -obj $params -name "action" -type "str" -validateset "allow","block"
 $program = Get-AnsibleParam -obj $params -name "program" -type "str"
 $service = Get-AnsibleParam -obj $params -name "service" -type "str"
 $enabled = Get-AnsibleParam -obj $params -name "enabled" -type "bool" -aliases "enable"
@@ -156,8 +156,8 @@ try {
     # the default for enabled in module description is "true", but the actual COM object defaults to "false" when created
     if ($null -ne $enabled) { $new_rule.Enabled = $enabled } else { $new_rule.Enabled = $true }
     if ($null -ne $description) { $new_rule.Description = $description }
-    if ($null -ne $program) { $new_rule.ApplicationName = $program }
-    if ($null -ne $service) { $new_rule.ServiceName = $service }
+    if ($null -ne $program -and $program -ne "any") { $new_rule.ApplicationName = $program }
+    if ($null -ne $service -and $program -ne "any") { $new_rule.ServiceName = $service }
     if ($null -ne $protocol -and $protocol -ne "any") { $new_rule.Protocol = Parse-ProtocolType -protocol $protocol }
     if ($null -ne $localport -and $localport -ne "any") { $new_rule.LocalPorts = $localport }
     if ($null -ne $remoteport -and $remoteport -ne "any") { $new_rule.RemotePorts = $remoteport }
@@ -216,7 +216,7 @@ try {
         } else {
             for($i = 0; $i -lt $fwPropertiesToCompare.Length; $i++) {
                 $prop = $fwPropertiesToCompare[$i]
-                if($null -ne $userPassedArguments[$i]) { # the value was specified
+                if($null -ne $userPassedArguments[$i]) { # only change values the user passes in task definition
                     if ($existingRule.$prop -ne $new_rule.$prop) {
                         if ($diff_support) {
                             $result.diff.prepared += "-[$($prop)='$($existingRule.$prop)']`n"

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -19,7 +19,8 @@ description:
 options:
   enabled:
     description:
-      - Whether this firewall rule is enabled or disabled. Defaults to C(true) when creating a new rule.
+      - Whether this firewall rule is enabled or disabled.
+      - Defaults to C(true) when creating a new rule.
     type: bool
     aliases: [ enable ]
   state:
@@ -35,12 +36,14 @@ options:
     required: yes
   direction:
     description:
-      - Whether this rule is for inbound or outbound traffic. Defaults to C(in) when creating a new rule.
+      - Whether this rule is for inbound or outbound traffic.
+      - Defaults to C(in) when creating a new rule.
     type: str
     choices: [ in, out ]
   action:
     description:
-      - What to do with the items this rule is for. Defaults to C(allow) when creating a new rule.
+      - What to do with the items this rule is for.
+      - Defaults to C(allow) when creating a new rule.
     type: str
     choices: [ allow, block ]
   description:
@@ -49,35 +52,50 @@ options:
     type: str
   localip:
     description:
-      - The local ip address this rule applies to. Set to C(any) to apply to all local ip addresses. Defaults to C(any) when creating a new rule.
+      - The local ip address this rule applies to.
+      - Set to C(any) to apply to all local ip addresses.
+      - Defaults to C(any) when creating a new rule.
     type: str
   remoteip:
     description:
-      - The remote ip address/range this rule applies to. Set to C(any) to apply to all remote ip addresses. Defaults to C(any) when creating a new rule.
+      - The remote ip address/range this rule applies to.
+      - Set to C(any) to apply to all remote ip addresses.
+      - Defaults to C(any) when creating a new rule.
     type: str
   localport:
     description:
-      - The local port this rule applies to. Set to C(any) to apply to all local ports. Defaults to C(any) when creating a new rule.
+      - The local port this rule applies to.
+      - Set to C(any) to apply to all local ports.
+      - Defaults to C(any) when creating a new rule.
     type: str
   remoteport:
     description:
-      - The remote port this rule applies to. Set to C(any) to apply to all remote ports. Defaults to C(any) when creating a new rule.
+      - The remote port this rule applies to.
+      - Set to C(any) to apply to all remote ports.
+      - Defaults to C(any) when creating a new rule.
     type: str
   program:
     description:
-      - The program this rule applies to. Set to C(any) to apply to all programs. Defaults to C(any) when creating a new rule.
+      - The program this rule applies to.
+      - Set to C(any) to apply to all programs.
+      - Defaults to C(any) when creating a new rule.
     type: str
   service:
     description:
-      - The service this rule applies to. Set to C(any) to apply to all services. Defaults to C(any) when creating a new rule.
+      - The service this rule applies to.
+      - Set to C(any) to apply to all services.
+      - Defaults to C(any) when creating a new rule.
     type: str
   protocol:
     description:
-      - The protocol this rule applies to. Set to C(any) to apply to all services. Defaults to C(any) when creating a new rule.
+      - The protocol this rule applies to.
+      - Set to C(any) to apply to all services.
+      - Defaults to C(any) when creating a new rule.
     type: str
   profiles:
     description:
-      - The profile this rule applies to. Defaults to C(domain,private,public) when creating a new rule.
+      - The profile this rule applies to.
+      - Defaults to C(domain,private,public) when creating a new rule.
     type: list
     aliases: [ profile ]
   force:

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -19,9 +19,8 @@ description:
 options:
   enabled:
     description:
-      - Whether this firewall rule is enabled or disabled.
+      - Whether this firewall rule is enabled or disabled. Defaults to C(true) when creating a new rule.
     type: bool
-    default: yes
     aliases: [ enable ]
   state:
     description:
@@ -31,20 +30,18 @@ options:
     default: present
   name:
     description:
-      - The rules name.
+      - The rule's display name.
     type: str
     required: yes
   direction:
     description:
-      - Whether this rule is for inbound or outbound traffic.
+      - Whether this rule is for inbound or outbound traffic. Defaults to C(in) when creating a new rule.
     type: str
-    required: yes
     choices: [ in, out ]
   action:
     description:
-      - What to do with the items this rule is for.
+      - What to do with the items this rule is for. Defaults to C(allow) when creating a new rule.
     type: str
-    required: yes
     choices: [ allow, block ]
   description:
     description:
@@ -52,40 +49,36 @@ options:
     type: str
   localip:
     description:
-      - The local ip address this rule applies to.
+      - The local ip address this rule applies to. Set to C(any) to apply to all local ip addresses. Defaults to C(any) when creating a new rule.
     type: str
-    default: any
   remoteip:
     description:
-      - The remote ip address/range this rule applies to.
+      - The remote ip address/range this rule applies to. Set to C(any) to apply to all remote ip addresses. Defaults to C(any) when creating a new rule.
     type: str
-    default: any
   localport:
     description:
-      - The local port this rule applies to.
+      - The local port this rule applies to. Set to C(any) to apply to all local ports. Defaults to C(any) when creating a new rule.
     type: str
   remoteport:
     description:
-      - The remote port this rule applies to.
+      - The remote port this rule applies to. Set to C(any) to apply to all remote ports. Defaults to C(any) when creating a new rule.
     type: str
   program:
     description:
-      - The program this rule applies to.
+      - The program this rule applies to. Set to C(any) to apply to all programs. Defaults to C(any) when creating a new rule.
     type: str
   service:
     description:
-      - The service this rule applies to.
+      - The service this rule applies to. Set to C(any) to apply to all services. Defaults to C(any) when creating a new rule.
     type: str
   protocol:
     description:
-      - The protocol this rule applies to.
+      - The protocol this rule applies to. Set to C(any) to apply to all services. Defaults to C(any) when creating a new rule.
     type: str
-    default: any
   profiles:
     description:
-      - The profile this rule applies to.
+      - The profile this rule applies to. Defaults to C(domain,private,public) when creating a new rule.
     type: list
-    default: domain,private,public
     aliases: [ profile ]
   force:
     description:

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -393,3 +393,21 @@
   assert:
     that:
     - add_firewall_rule_with_list_profiles.changed == true
+
+- name: Enable a built-in rule
+  win_firewall_rule:
+    name: 'World Wide Web Services (HTTP Traffic-In)'
+    action: allow
+    direction: in
+    enabled: yes
+    state: present
+  register: change_built_in_rule
+
+- name: Disable a built-in rule if previous changed (reset)
+  win_firewall_rule:
+    name: 'World Wide Web Services (HTTP Traffic-In)'
+    action: allow
+    direction: in
+    enabled: no
+    state: present
+  when: change_built_in_rule.changed

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -113,7 +113,6 @@
       - "firewall_rule_actual.stdout_lines[3] == '1'" # Direction = in
       - "firewall_rule_actual.stdout_lines[4] == '6'" # Protocol = tcp
 
-
 - name: Add firewall rule when remoteip is range
   win_firewall_rule:
     name: http

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -95,6 +95,25 @@
     that:
     - change_firewall_rule.changed == true
 
+- name: Disable firewall rule
+  win_firewall_rule:
+    name: http
+    enabled: no
+
+- name: Get the actual values from the changed firewall rule
+  win_shell: '(New-Object -ComObject HNetCfg.FwPolicy2).Rules | Where-Object { $_.Name -eq "http" } | Foreach-Object { $_.LocalPorts; $_.Enabled; $_.Action; $_.Direction; $_.Protocol }'
+  register: firewall_rule_actual
+
+- name: Ensure that disabling the rule did not change the previous values
+  assert:
+    that:
+      - "firewall_rule_actual.stdout_lines[0] == '80'" # LocalPorts = 80
+      - "firewall_rule_actual.stdout_lines[1] == 'False'" # Enabled = False
+      - "firewall_rule_actual.stdout_lines[2] == '0'" # Action = block
+      - "firewall_rule_actual.stdout_lines[3] == '1'" # Direction = in
+      - "firewall_rule_actual.stdout_lines[4] == '6'" # Protocol = tcp
+
+
 - name: Add firewall rule when remoteip is range
   win_firewall_rule:
     name: http
@@ -393,21 +412,3 @@
   assert:
     that:
     - add_firewall_rule_with_list_profiles.changed == true
-
-- name: Enable a built-in rule
-  win_firewall_rule:
-    name: 'World Wide Web Services (HTTP Traffic-In)'
-    action: allow
-    direction: in
-    enabled: yes
-    state: present
-  register: change_built_in_rule
-
-- name: Disable a built-in rule if previous changed (reset)
-  win_firewall_rule:
-    name: 'World Wide Web Services (HTTP Traffic-In)'
-    action: allow
-    direction: in
-    enabled: no
-    state: present
-  when: change_built_in_rule.changed

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -72,7 +72,6 @@ lib/ansible/modules/windows/win_file_version.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_find.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_find.ps1 PSAvoidUsingEmptyCatchBlock
 lib/ansible/modules/windows/win_find.ps1 PSAvoidUsingWMICmdlet
-lib/ansible/modules/windows/win_firewall_rule.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_firewall_rule.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_get_url.ps1 PSUsePSCredentialType  # Credential param can take a base64 encoded string as well as a PSCredential
 lib/ansible/modules/windows/win_hotfix.ps1 PSAvoidTrailingWhitespace


### PR DESCRIPTION
defaults are controlled by com object
integration test for built in rule

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
the current win_firewall_rule module will reset an existing firewall rule's options to the defaults for any unspecified parameters. This is especially a problem when trying to enable a built-in windows firewall rule since changing them is protected.
This just keeps unspecified parameters as null so that they can be checked for existence when changing an existing rule.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #34392
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_firewall_rule
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is the result of the change, instead of needing to pass back in the port and protocol, the module only changes action, because it was different from the existing rule.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
tasks:
- name: Add firewall rule
  win_firewall_rule:
    name: http
    enabled: yes
    state: present
    localport: 80
    action: allow
    direction: in
    protocol: tcp

- name: Change firewall rule
  win_firewall_rule:
    name: http
    state: present
    action: block
    direction: in
```
output (diff):
```
TASK [win_firewall_rule : Add firewall rule] *********************************************************************************************************************
+[Name='http']
+[Description='']
+[Direction='1']
+[Action='1']
+[ApplicationName='']
+[ServiceName='']
+[Enabled='True']
+[Profiles='2147483647']
+[LocalAddresses='*']
+[RemoteAddresses='*']
+[LocalPorts='80']
+[RemotePorts='*']
+[Protocol='6']
+[InterfaceTypes='All']
+[EdgeTraversalOptions='0']
+[SecureFlags='0']
changed: [testhost]

TASK [win_firewall_rule : Change firewall rule] ******************************************************************************************************************
-[Action='1']
+[Action='0']
changed: [testhost]

```