### PR TITLE
win_shell: Implement option 'profile', allowing the user to control p…

### DIFF
--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -47,6 +47,7 @@ $executable = Get-AnsibleParam -obj $params -name "executable" -type "path"
 $creates = Get-AnsibleParam -obj $params -name "creates" -type "path"
 $removes = Get-AnsibleParam -obj $params -name "removes" -type "path"
 $stdin = Get-AnsibleParam -obj $params -name "stdin" -type "str"
+$profile = Get-AnsibleParam -obj $params -name "profile" -type "bool" -default $true
 
 $raw_command_line = $raw_command_line.Trim()
 
@@ -77,6 +78,10 @@ If(-not $executable -or $executable -eq "powershell") {
         $exec_args = "-encodedcommand $encoded_command"
     } else {
         $exec_args = "-noninteractive -encodedcommand $encoded_command"
+    }
+
+    if (!$profile) {
+      $exec_args = "-noprofile $exec_args"
     }
 }
 Else {

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -47,7 +47,7 @@ $executable = Get-AnsibleParam -obj $params -name "executable" -type "path"
 $creates = Get-AnsibleParam -obj $params -name "creates" -type "path"
 $removes = Get-AnsibleParam -obj $params -name "removes" -type "path"
 $stdin = Get-AnsibleParam -obj $params -name "stdin" -type "str"
-$profile = Get-AnsibleParam -obj $params -name "profile" -type "bool" -default $true
+$no_profile = Get-AnsibleParam -obj $params -name "no_profile" -type "bool" -default $false
 
 $raw_command_line = $raw_command_line.Trim()
 
@@ -80,8 +80,8 @@ If(-not $executable -or $executable -eq "powershell") {
         $exec_args = "-noninteractive -encodedcommand $encoded_command"
     }
 
-    if (!$profile) {
-      $exec_args = "-noprofile $exec_args"
+    if ($no_profile) {
+        $exec_args = "-noprofile $exec_args"
     }
 }
 Else {

--- a/lib/ansible/modules/windows/win_shell.py
+++ b/lib/ansible/modules/windows/win_shell.py
@@ -51,6 +51,7 @@ options:
     description:
     - Load the user profile before running a command. (powershell only)
     type: bool
+    version_added: '2.8'
 notes:
    -  If you want to run an executable securely and predictably, it may be
       better to use the M(win_command) module instead. Best practices when writing

--- a/lib/ansible/modules/windows/win_shell.py
+++ b/lib/ansible/modules/windows/win_shell.py
@@ -47,6 +47,10 @@ options:
     - Set the stdin of the command directly to the specified value.
     type: str
     version_added: '2.5'
+  profile:
+    description:
+    - Load the user profile before running a command. (powershell only)
+    type: bool
 notes:
    -  If you want to run an executable securely and predictably, it may be
       better to use the M(win_command) module instead. Best practices when writing

--- a/lib/ansible/modules/windows/win_shell.py
+++ b/lib/ansible/modules/windows/win_shell.py
@@ -47,10 +47,12 @@ options:
     - Set the stdin of the command directly to the specified value.
     type: str
     version_added: '2.5'
-  profile:
+  no_profile:
     description:
-    - Load the user profile before running a command. (powershell only)
+    - Do not load the user profile before running a command. This is only valid
+      when using PowerShell as the executable.
     type: bool
+    default: no
     version_added: '2.8'
 notes:
    -  If you want to run an executable securely and predictably, it may be

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -257,3 +257,34 @@
     - nonascii_output.stdout_lines|count == 1
     - nonascii_output.stdout_lines[0] == 'über den Fußgängerübergang gehen'
     - nonascii_output.stderr == ''
+
+- name: Add echo to powershell profile
+  win_shell: 'echo "echo PROFILE_LOADED" > $profile'
+
+- name: Validate that profile is loaded by default
+  win_shell: exit 0
+  args:
+      profile: True
+  register: shellout
+
+- name: Check that profile was loaded
+  assert:
+    that:
+      - shellout is successful
+      - shellout is changed
+      - shellout.rc == 0
+      - shellout.stdout == 'PROFILE_LOADED\r\n'
+
+- name: Validate that profile is not loaded
+  win_shell: exit 0
+  args:
+    profile: False
+  register: shellout
+
+- name: Check that profile was not loaded
+  assert:
+    that:
+      - shellout is successful
+      - shellout is changed
+      - shellout.rc == 0
+      - shellout.stdout == ''

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -259,7 +259,7 @@
     - nonascii_output.stderr == ''
 
 - name: Add echo to powershell profile
-  win_shell: 'echo "echo PROFILE_LOADED" > $profile'
+  win_shell: 'mkdir $(Split-Path $profile); echo "echo PROFILE_LOADED" > $profile'
 
 - name: Validate that profile is loaded by default
   win_shell: exit 0

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -258,33 +258,30 @@
     - nonascii_output.stdout_lines[0] == 'über den Fußgängerübergang gehen'
     - nonascii_output.stderr == ''
 
-- name: Add echo to powershell profile
-  win_shell: 'mkdir $(Split-Path $profile); echo "echo PROFILE_LOADED" > $profile'
+- name: execute powershell without no_profile
+  win_shell: '[System.Environment]::CommandLine'
+  register: no_profile
 
-- name: Validate that profile is loaded by default
-  win_shell: exit 0
-  args:
-      profile: True
-  register: shellout
-
-- name: Check that profile was loaded
+- name: assert execute powershell with no_profile
   assert:
     that:
-      - shellout is successful
-      - shellout is changed
-      - shellout.rc == 0
-      - shellout.stdout == 'PROFILE_LOADED\r\n'
+    - no_profile is successful
+    - no_profile is changed
+    - no_profile.cmd == "[System.Environment]::CommandLine"
+    - no_profile.rc == 0
+    - no_profile.stdout is match ('^powershell.exe -noninteractive -encodedcommand')
 
-- name: Validate that profile is not loaded
-  win_shell: exit 0
+- name: execute powershell with no_profile
+  win_shell: '[System.Environment]::CommandLine'
   args:
-    profile: False
-  register: shellout
+    no_profile: yes
+  register: no_profile
 
-- name: Check that profile was not loaded
+- name: assert execute powershell with no_profile
   assert:
     that:
-      - shellout is successful
-      - shellout is changed
-      - shellout.rc == 0
-      - shellout.stdout == ''
+    - no_profile is successful
+    - no_profile is changed
+    - no_profile.cmd == "[System.Environment]::CommandLine"
+    - no_profile.rc == 0
+    - no_profile.stdout is match ('^powershell.exe -noprofile -noninteractive -encodedcommand')


### PR DESCRIPTION
…owershell profile sourcing before running a command

##### SUMMARY
Add a "profile" option to win_shell to allow running powershell withtout a profile (-NoProfile)

Fixes #37756

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
win_shell