### PR TITLE
BOTMETA: add morph027 manually as docker_swarm inventory plugin maintainer

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1127,6 +1127,9 @@ files:
   $plugins/inventory/__init__.py:
     support: core
   $plugins/inventory/docker: *docker
+  $plugins/inventory/docker_swarm.py:
+    <<: *docker
+    maintainers: $team_docker morph027
   $plugins/inventory/gcp_compute.py:
     maintainers: $team_google
     supershipit: $team_google


### PR DESCRIPTION
##### SUMMARY
Somehow ansibot doesn't seem to recognize him as author (see #54266 for example), despite being [correctly listed (IMO)](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/inventory/docker_swarm.py#L15) in the plugin and the [generated documentation](https://docs.ansible.com/ansible/devel/plugins/inventory/docker_swarm.html#authors).

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
