### PR TITLE
renaming dtl facts to info

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_devtestlab_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_devtestlab_info.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_devtestlab_facts
+module: azure_rm_devtestlab_info
 version_added: "2.8"
 short_description: Get Azure DevTest Lab facts.
 description:
@@ -41,14 +41,14 @@ author:
 
 EXAMPLES = '''
   - name: List instances of DevTest Lab by resource group
-    azure_rm_devtestlab_facts:
+    azure_rm_devtestlab_info:
       resource_group: testrg
 
   - name: List instances of DevTest Lab in subscription
-    azure_rm_devtestlab_facts:
+    azure_rm_devtestlab_info:
 
   - name: Get instance of DevTest Lab
-    azure_rm_devtestlab_facts:
+    azure_rm_devtestlab_info:
       resource_group: testrg
       name: testlab
 '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_devtestlabarmtemplate_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_devtestlabarmtemplate_info.py
@@ -15,11 +15,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_devtestlabartifact_facts
+module: azure_rm_devtestlabarmtemplate_info
 version_added: "2.8"
-short_description: Get Azure DevTest Lab Artifact facts.
+short_description: Get Azure DevTest Lab ARM Template facts.
 description:
-    - Get facts of Azure DevTest Lab Artifact.
+    - Get facts of Azure DevTest Lab ARM Template.
 
 options:
     resource_group:
@@ -36,7 +36,7 @@ options:
         required: True
     name:
         description:
-            - The name of the artifact.
+            - The name of the ARM template.
 
 extends_documentation_fragment:
     - azure
@@ -47,87 +47,62 @@ author:
 '''
 
 EXAMPLES = '''
-  - name: Get instance of DevTest Lab Artifact
-    azure_rm_devtestlabartifact_facts:
+  - name: Get information on DevTest Lab ARM Template
+    azure_rm_devtestlabarmtemplate_info:
       resource_group: myResourceGroup
       lab_name: myLab
-      artifact_source_name: myArtifactSource
-      name: myArtifact
+      artifact_source_name: public environment repo
+      name: WebApp
 '''
 
 RETURN = '''
-artifacts:
-    description: A list of dictionaries containing facts for DevTest Lab Artifact.
+arm_templates:
+    description: A list of dictionaries containing facts for DevTest Lab ARM Template.
     returned: always
     type: complex
     contains:
         id:
             description:
-                - The identifier of the artifact.
+                - The identifier of the resource.
             returned: always
             type: str
-            sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.DevTestLab/labs/myLab/ar
-                     tifactSources/myArtifactSource/artifacts/myArtifact"
+            sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.DevTestLab/labs/myLab/art
+                     ifactSources/public environment repo/armTemplates/WebApp"
         resource_group:
             description:
-                - Name of the resource group.
+                - Resource group name.
             returned: always
-            type: str
             sample: myResourceGroup
         lab_name:
             description:
-                - Name of the lab.
+                - DevTest Lab name.
             returned: always
-            type: str
             sample: myLab
         artifact_source_name:
             description:
-                - The name of the artifact source.
+                - Artifact source name.
             returned: always
-            type: str
-            sample: myArtifactSource
+            sample: public environment repo
         name:
             description:
-                - The name of the artifact.
+                - ARM Template name.
             returned: always
-            type: str
-            sample: myArtifact
+            sample: WebApp
+        display_name:
+            description:
+                - The tags of the resource.
+            returned: always
+            sample: Web App
         description:
             description:
-                - Description of the artifact.
+                - The tags of the resource.
             returned: always
-            type: str
-            sample: Installs My Software
-        file_path:
-            description:
-                - "Artifact's path in the repo."
-            returned: always
-            type: str
-            sample: Artifacts/myArtifact
+            sample: This template creates an Azure Web App without a data store.
         publisher:
             description:
-                - Publisher name.
+                - The tags of the resource.
             returned: always
-            type: str
-            sample: MyPublisher
-        target_os_type:
-            description:
-                - Target OS type.
-            returned: always
-            type: str
-            sample: Linux
-        title:
-            description:
-                - Title of the artifact.
-            returned: always
-            type: str
-            sample: My Software
-        parameters:
-            description:
-                - A dictionary containing parameters definition of the artifact.
-            returned: always
-            type: complex
-            sample: {}
+            sample: Microsoft
 '''
 
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase
@@ -141,7 +116,7 @@ except ImportError:
     pass
 
 
-class AzureRMArtifactFacts(AzureRMModuleBase):
+class AzureRMDtlArmTemplateFacts(AzureRMModuleBase):
     def __init__(self):
         # define user inputs into argument
         self.module_arg_spec = dict(
@@ -170,7 +145,7 @@ class AzureRMArtifactFacts(AzureRMModuleBase):
         self.lab_name = None
         self.artifact_source_name = None
         self.name = None
-        super(AzureRMArtifactFacts, self).__init__(self.module_arg_spec, supports_tags=False)
+        super(AzureRMDtlArmTemplateFacts, self).__init__(self.module_arg_spec, supports_tags=False)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:
@@ -179,43 +154,43 @@ class AzureRMArtifactFacts(AzureRMModuleBase):
                                                     base_url=self._cloud_environment.endpoints.resource_manager)
 
         if self.name:
-            self.results['artifacts'] = self.get()
+            self.results['armtemplates'] = self.get()
         else:
-            self.results['artifacts'] = self.list()
+            self.results['armtemplates'] = self.list()
 
         return self.results
-
-    def get(self):
-        response = None
-        results = []
-        try:
-            response = self.mgmt_client.artifacts.get(resource_group_name=self.resource_group,
-                                                      lab_name=self.lab_name,
-                                                      artifact_source_name=self.artifact_source_name,
-                                                      name=self.name)
-            self.log("Response : {0}".format(response))
-        except CloudError as e:
-            self.log('Could not get facts for Artifact.')
-
-        if response:
-            results.append(self.format_response(response))
-
-        return results
 
     def list(self):
         response = None
         results = []
         try:
-            response = self.mgmt_client.artifacts.list(resource_group_name=self.resource_group,
-                                                       lab_name=self.lab_name,
-                                                       artifact_source_name=self.artifact_source_name)
+            response = self.mgmt_client.arm_templates.list(resource_group_name=self.resource_group,
+                                                           lab_name=self.lab_name,
+                                                           artifact_source_name=self.artifact_source_name)
             self.log("Response : {0}".format(response))
         except CloudError as e:
-            self.log('Could not get facts for Artifact.')
+            self.fail('Could not get facts for DTL ARM Template.')
 
         if response is not None:
             for item in response:
                 results.append(self.format_response(item))
+
+        return results
+
+    def get(self):
+        response = None
+        results = []
+        try:
+            response = self.mgmt_client.arm_templates.get(resource_group_name=self.resource_group,
+                                                          lab_name=self.lab_name,
+                                                          artifact_source_name=self.artifact_source_name,
+                                                          name=self.name)
+            self.log("Response : {0}".format(response))
+        except CloudError as e:
+            self.fail('Could not get facts for DTL ARM Template.')
+
+        if response:
+            results.append(self.format_response(response))
 
         return results
 
@@ -225,20 +200,17 @@ class AzureRMArtifactFacts(AzureRMModuleBase):
             'resource_group': self.parse_resource_to_dict(d.get('id')).get('resource_group'),
             'lab_name': self.parse_resource_to_dict(d.get('id')).get('name'),
             'artifact_source_name': self.parse_resource_to_dict(d.get('id')).get('child_name_1'),
-            'id': d.get('id'),
-            'description': d.get('description'),
-            'file_path': d.get('file_path'),
+            'id': d.get('id', None),
             'name': d.get('name'),
-            'parameters': d.get('parameters'),
-            'publisher': d.get('publisher'),
-            'target_os_type': d.get('target_os_type'),
-            'title': d.get('title')
+            'display_name': d.get('display_name'),
+            'description': d.get('description'),
+            'publisher': d.get('publisher')
         }
         return d
 
 
 def main():
-    AzureRMArtifactFacts()
+    AzureRMDtlArmTemplateFacts()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_devtestlabartifact_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_devtestlabartifact_info.py
@@ -15,11 +15,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_devtestlabarmtemplate_facts
+module: azure_rm_devtestlabartifact_info
 version_added: "2.8"
-short_description: Get Azure DevTest Lab ARM Template facts.
+short_description: Get Azure DevTest Lab Artifact facts.
 description:
-    - Get facts of Azure DevTest Lab ARM Template.
+    - Get facts of Azure DevTest Lab Artifact.
 
 options:
     resource_group:
@@ -36,7 +36,7 @@ options:
         required: True
     name:
         description:
-            - The name of the ARM template.
+            - The name of the artifact.
 
 extends_documentation_fragment:
     - azure
@@ -47,62 +47,87 @@ author:
 '''
 
 EXAMPLES = '''
-  - name: Get information on DevTest Lab ARM Template
-    azure_rm_devtestlabarmtemplate_facts:
+  - name: Get instance of DevTest Lab Artifact
+    azure_rm_devtestlabartifact_info:
       resource_group: myResourceGroup
       lab_name: myLab
-      artifact_source_name: public environment repo
-      name: WebApp
+      artifact_source_name: myArtifactSource
+      name: myArtifact
 '''
 
 RETURN = '''
-arm_templates:
-    description: A list of dictionaries containing facts for DevTest Lab ARM Template.
+artifacts:
+    description: A list of dictionaries containing facts for DevTest Lab Artifact.
     returned: always
     type: complex
     contains:
         id:
             description:
-                - The identifier of the resource.
+                - The identifier of the artifact.
             returned: always
             type: str
-            sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.DevTestLab/labs/myLab/art
-                     ifactSources/public environment repo/armTemplates/WebApp"
+            sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.DevTestLab/labs/myLab/ar
+                     tifactSources/myArtifactSource/artifacts/myArtifact"
         resource_group:
             description:
-                - Resource group name.
+                - Name of the resource group.
             returned: always
+            type: str
             sample: myResourceGroup
         lab_name:
             description:
-                - DevTest Lab name.
+                - Name of the lab.
             returned: always
+            type: str
             sample: myLab
         artifact_source_name:
             description:
-                - Artifact source name.
+                - The name of the artifact source.
             returned: always
-            sample: public environment repo
+            type: str
+            sample: myArtifactSource
         name:
             description:
-                - ARM Template name.
+                - The name of the artifact.
             returned: always
-            sample: WebApp
-        display_name:
-            description:
-                - The tags of the resource.
-            returned: always
-            sample: Web App
+            type: str
+            sample: myArtifact
         description:
             description:
-                - The tags of the resource.
+                - Description of the artifact.
             returned: always
-            sample: This template creates an Azure Web App without a data store.
+            type: str
+            sample: Installs My Software
+        file_path:
+            description:
+                - "Artifact's path in the repo."
+            returned: always
+            type: str
+            sample: Artifacts/myArtifact
         publisher:
             description:
-                - The tags of the resource.
+                - Publisher name.
             returned: always
-            sample: Microsoft
+            type: str
+            sample: MyPublisher
+        target_os_type:
+            description:
+                - Target OS type.
+            returned: always
+            type: str
+            sample: Linux
+        title:
+            description:
+                - Title of the artifact.
+            returned: always
+            type: str
+            sample: My Software
+        parameters:
+            description:
+                - A dictionary containing parameters definition of the artifact.
+            returned: always
+            type: complex
+            sample: {}
 '''
 
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase
@@ -116,7 +141,7 @@ except ImportError:
     pass
 
 
-class AzureRMDtlArmTemplateFacts(AzureRMModuleBase):
+class AzureRMArtifactFacts(AzureRMModuleBase):
     def __init__(self):
         # define user inputs into argument
         self.module_arg_spec = dict(
@@ -145,7 +170,7 @@ class AzureRMDtlArmTemplateFacts(AzureRMModuleBase):
         self.lab_name = None
         self.artifact_source_name = None
         self.name = None
-        super(AzureRMDtlArmTemplateFacts, self).__init__(self.module_arg_spec, supports_tags=False)
+        super(AzureRMArtifactFacts, self).__init__(self.module_arg_spec, supports_tags=False)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:
@@ -154,43 +179,43 @@ class AzureRMDtlArmTemplateFacts(AzureRMModuleBase):
                                                     base_url=self._cloud_environment.endpoints.resource_manager)
 
         if self.name:
-            self.results['armtemplates'] = self.get()
+            self.results['artifacts'] = self.get()
         else:
-            self.results['armtemplates'] = self.list()
+            self.results['artifacts'] = self.list()
 
         return self.results
-
-    def list(self):
-        response = None
-        results = []
-        try:
-            response = self.mgmt_client.arm_templates.list(resource_group_name=self.resource_group,
-                                                           lab_name=self.lab_name,
-                                                           artifact_source_name=self.artifact_source_name)
-            self.log("Response : {0}".format(response))
-        except CloudError as e:
-            self.fail('Could not get facts for DTL ARM Template.')
-
-        if response is not None:
-            for item in response:
-                results.append(self.format_response(item))
-
-        return results
 
     def get(self):
         response = None
         results = []
         try:
-            response = self.mgmt_client.arm_templates.get(resource_group_name=self.resource_group,
-                                                          lab_name=self.lab_name,
-                                                          artifact_source_name=self.artifact_source_name,
-                                                          name=self.name)
+            response = self.mgmt_client.artifacts.get(resource_group_name=self.resource_group,
+                                                      lab_name=self.lab_name,
+                                                      artifact_source_name=self.artifact_source_name,
+                                                      name=self.name)
             self.log("Response : {0}".format(response))
         except CloudError as e:
-            self.fail('Could not get facts for DTL ARM Template.')
+            self.log('Could not get facts for Artifact.')
 
         if response:
             results.append(self.format_response(response))
+
+        return results
+
+    def list(self):
+        response = None
+        results = []
+        try:
+            response = self.mgmt_client.artifacts.list(resource_group_name=self.resource_group,
+                                                       lab_name=self.lab_name,
+                                                       artifact_source_name=self.artifact_source_name)
+            self.log("Response : {0}".format(response))
+        except CloudError as e:
+            self.log('Could not get facts for Artifact.')
+
+        if response is not None:
+            for item in response:
+                results.append(self.format_response(item))
 
         return results
 
@@ -200,17 +225,20 @@ class AzureRMDtlArmTemplateFacts(AzureRMModuleBase):
             'resource_group': self.parse_resource_to_dict(d.get('id')).get('resource_group'),
             'lab_name': self.parse_resource_to_dict(d.get('id')).get('name'),
             'artifact_source_name': self.parse_resource_to_dict(d.get('id')).get('child_name_1'),
-            'id': d.get('id', None),
-            'name': d.get('name'),
-            'display_name': d.get('display_name'),
+            'id': d.get('id'),
             'description': d.get('description'),
-            'publisher': d.get('publisher')
+            'file_path': d.get('file_path'),
+            'name': d.get('name'),
+            'parameters': d.get('parameters'),
+            'publisher': d.get('publisher'),
+            'target_os_type': d.get('target_os_type'),
+            'title': d.get('title')
         }
         return d
 
 
 def main():
-    AzureRMDtlArmTemplateFacts()
+    AzureRMArtifactFacts()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_devtestlabartifactsource_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_devtestlabartifactsource_info.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_devtestlabartifactsource_facts
+module: azure_rm_devtestlabartifactsource_info
 version_added: "2.8"
 short_description: Get Azure DevTest Lab Artifact Source facts.
 description:
@@ -47,7 +47,7 @@ author:
 
 EXAMPLES = '''
   - name: Get instance of DevTest Lab Artifact Source
-    azure_rm_devtestlabartifactsource_facts:
+    azure_rm_devtestlabartifactsource_info:
       resource_group: myResourceGroup
       lab_name: myLab
       name: myArtifactSource

--- a/lib/ansible/modules/cloud/azure/azure_rm_devtestlabvirtualmachine_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_devtestlabvirtualmachine_info.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_devtestlabvirtualmachine_facts
+module: azure_rm_devtestlabvirtualmachine_info
 version_added: "2.8"
 short_description: Get Azure DevTest Lab Virtual Machine facts.
 description:
@@ -47,7 +47,7 @@ author:
 
 EXAMPLES = '''
   - name: Get instance of DTL Virtual Machine
-    azure_rm_devtestlabvirtualmachine_facts:
+    azure_rm_devtestlabvirtualmachine_info:
       resource_group: myResourceGroup
       lab_name: myLab
       name: myVm

--- a/lib/ansible/modules/cloud/azure/azure_rm_devtestlabvirtualnetwork_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_devtestlabvirtualnetwork_info.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_devtestlabvirtualnetwork_facts
+module: azure_rm_devtestlabvirtualnetwork_info
 version_added: "2.8"
 short_description: Get Azure DevTest Lab Virtual Network facts.
 description:
@@ -44,13 +44,13 @@ author:
 
 EXAMPLES = '''
   - name: Get instance of DevTest Lab Virtual Network
-    azure_rm_devtestlabvirtualnetwork_facts:
+    azure_rm_devtestlabvirtualnetwork_info:
       resource_group: myResourceGroup
       lab_name: myLab
       name: myVirtualNetwork
 
   - name: List all Virtual Networks in DevTest Lab
-    azure_rm_devtestlabvirtualnetwork_facts:
+    azure_rm_devtestlabvirtualnetwork_info:
       resource_group: myResourceGroup
       lab_name: myLab
       name: myVirtualNetwork

--- a/test/integration/targets/azure_rm_devtestlab/tasks/main.yml
+++ b/test/integration/targets/azure_rm_devtestlab/tasks/main.yml
@@ -61,7 +61,7 @@
       - output.changed
 
 - name: List DevTest Lab in a resource group
-  azure_rm_devtestlab_facts:
+  azure_rm_devtestlab_info:
     resource_group: "{{ resource_group }}"
   register: output_lab
 - name: Assert that facts are returned
@@ -78,7 +78,7 @@
       - output_lab.labs[0]['vault_name'] != None
 
 - name: Get DevTest Lab facts
-  azure_rm_devtestlab_facts:
+  azure_rm_devtestlab_info:
     resource_group: "{{ resource_group }}"
     name: "{{ lab_name }}"
   register: output_lab
@@ -263,7 +263,7 @@
       - output.changed
 
 - name: Get DevTest Lab Virtual Network facts
-  azure_rm_devtestlabvirtualnetwork_facts:
+  azure_rm_devtestlabvirtualnetwork_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
     name: "{{ vn_name }}"
@@ -281,7 +281,7 @@
       - output.virtualnetworks[0]['provisioning_state'] != None
 
 - name: List all Virtual Networks in DevTest Lab
-  azure_rm_devtestlabvirtualnetwork_facts:
+  azure_rm_devtestlabvirtualnetwork_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
   register: output
@@ -458,7 +458,7 @@
   when: "github_token | length > 0"
 
 - name: Get Facts of DTL Virtual Machine
-  azure_rm_devtestlabvirtualmachine_facts:
+  azure_rm_devtestlabvirtualmachine_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
     name: "{{ vm_name }}"
@@ -488,7 +488,7 @@
   when: "github_token | length > 0"
 
 - name: List Facts of DTL Virtual Machine
-  azure_rm_devtestlabvirtualmachine_facts:
+  azure_rm_devtestlabvirtualmachine_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
   register: output_vm
@@ -516,7 +516,7 @@
 
 
 - name: List all artifact sources
-  azure_rm_devtestlabartifactsource_facts:
+  azure_rm_devtestlabartifactsource_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
   register: output
@@ -537,7 +537,7 @@
       - output.artifactsources | length >= 2
 
 - name: Get artifacts source facts
-  azure_rm_devtestlabartifactsource_facts:
+  azure_rm_devtestlabartifactsource_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
     name: public repo
@@ -572,7 +572,7 @@
   when: "github_token | length > 0"
 
 - name: List ARM Template facts
-  azure_rm_devtestlabarmtemplate_facts:
+  azure_rm_devtestlabarmtemplate_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
     artifact_source_name: "public environment repo"
@@ -591,7 +591,7 @@
       - "output.armtemplates | length > 1"
 
 - name: Get ARM Template facts
-  azure_rm_devtestlabarmtemplate_facts:
+  azure_rm_devtestlabarmtemplate_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
     artifact_source_name: "public environment repo"
@@ -613,7 +613,7 @@
 
 
 - name: Get Artifact facts
-  azure_rm_devtestlabartifact_facts:
+  azure_rm_devtestlabartifact_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
     artifact_source_name: "public repo"
@@ -635,7 +635,7 @@
       - "output.artifacts | length > 1"
 
 - name: Get Artifact facts
-  azure_rm_devtestlabartifact_facts:
+  azure_rm_devtestlabartifact_info:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
     artifact_source_name: "public repo"


### PR DESCRIPTION
These modules are just introduced in devel, so they were not released yet.
We can safely rename them.

This follows the discussion here:

https://github.com/ansible/ansible/issues/54280#issuecomment-475876315

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
multiple dtl info modules

##### ADDITIONAL INFORMATION
