### PR TITLE
standardize TLS connection properties

### DIFF
--- a/changelogs/fragments/standardize-tls-params.yml
+++ b/changelogs/fragments/standardize-tls-params.yml
@@ -1,0 +1,13 @@
+---
+minor_changes:
+- |
+  Modules and plugins have been standardized on a well-defined set of
+  TLS-related parameters.  The old names remain as aliases for compatibility.
+  In general, the new names will override the old names if both are specified.
+
+  The standard names are:
+
+  - ``client_cert``: certificate for client identity, might also include the private key
+  - ``client_key``: private key for ``client_cert``
+  - ``ca_cert``: public key to validate server's identity, usually a root certificate
+  - ``validate_certs``: boolean to enable or disable certificate validity checking

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -70,7 +70,7 @@ def tower_auth_config(module):
         password = module.params.pop('tower_password', None)
         if password:
             auth_config['password'] = password
-        verify_ssl = module.params.pop('tower_verify_ssl', None)
+        verify_ssl = module.params.pop('validate_certs', None)
         if verify_ssl is not None:
             auth_config['verify_ssl'] = verify_ssl
         return auth_config
@@ -92,7 +92,7 @@ class TowerModule(AnsibleModule):
             tower_host=dict(),
             tower_username=dict(),
             tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool'),
+            validate_certs=dict(type='bool', aliases=['tower_verify_ssl']),
             tower_config_file=dict(type='path'),
         )
         args.update(argument_spec)
@@ -102,7 +102,7 @@ class TowerModule(AnsibleModule):
             ('tower_config_file', 'tower_host'),
             ('tower_config_file', 'tower_username'),
             ('tower_config_file', 'tower_password'),
-            ('tower_config_file', 'tower_verify_ssl'),
+            ('tower_config_file', 'validate_certs'),
         ))
 
         super(TowerModule, self).__init__(argument_spec=args, **kwargs)

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -84,19 +84,19 @@ DOCKER_COMMON_ARGS = dict(
     tls_hostname=dict(type='str', default=DEFAULT_TLS_HOSTNAME, fallback=(env_fallback, ['DOCKER_TLS_HOSTNAME'])),
     api_version=dict(type='str', default='auto', fallback=(env_fallback, ['DOCKER_API_VERSION']), aliases=['docker_api_version']),
     timeout=dict(type='int', default=DEFAULT_TIMEOUT_SECONDS, fallback=(env_fallback, ['DOCKER_TIMEOUT'])),
-    cacert_path=dict(type='path', aliases=['tls_ca_cert']),
-    cert_path=dict(type='path', aliases=['tls_client_cert']),
-    key_path=dict(type='path', aliases=['tls_client_key']),
+    ca_cert=dict(type='path', aliases=['tls_ca_cert', 'cacert_path']),
+    client_cert=dict(type='path', aliases=['tls_client_cert', 'cert_path']),
+    client_key=dict(type='path', aliases=['tls_client_key', 'key_path']),
     ssl_version=dict(type='str', fallback=(env_fallback, ['DOCKER_SSL_VERSION'])),
     tls=dict(type='bool', default=DEFAULT_TLS, fallback=(env_fallback, ['DOCKER_TLS'])),
-    tls_verify=dict(type='bool', default=DEFAULT_TLS_VERIFY, fallback=(env_fallback, ['DOCKER_TLS_VERIFY'])),
+    validate_certs=dict(type='bool', default=DEFAULT_TLS_VERIFY, fallback=(env_fallback, ['DOCKER_TLS_VERIFY']), aliases=['tls_verify']),
     debug=dict(type='bool', default=False)
 )
 
 DOCKER_MUTUALLY_EXCLUSIVE = []
 
 DOCKER_REQUIRED_TOGETHER = [
-    ['cert_path', 'key_path']
+    ['client_cert', 'client_key']
 ]
 
 DEFAULT_DOCKER_REGISTRY = 'https://index.docker.io/v1/'
@@ -406,7 +406,7 @@ class AnsibleDockerClient(Client):
             if use_tls == 'encrypt':
                 params['tls'] = True
             if use_tls == 'verify':
-                params['tls_verify'] = True
+                params['validate_certs'] = True
 
         result = dict(
             docker_host=self._get_value('docker_host', params['docker_host'], 'DOCKER_HOST',
@@ -415,12 +415,12 @@ class AnsibleDockerClient(Client):
                                          'DOCKER_TLS_HOSTNAME', DEFAULT_TLS_HOSTNAME),
             api_version=self._get_value('api_version', params['api_version'], 'DOCKER_API_VERSION',
                                         'auto'),
-            cacert_path=self._get_value('cacert_path', params['cacert_path'], 'DOCKER_CERT_PATH', None),
-            cert_path=self._get_value('cert_path', params['cert_path'], 'DOCKER_CERT_PATH', None),
-            key_path=self._get_value('key_path', params['key_path'], 'DOCKER_CERT_PATH', None),
+            cacert_path=self._get_value('cacert_path', params['ca_cert'], 'DOCKER_CERT_PATH', None),
+            cert_path=self._get_value('cert_path', params['client_cert'], 'DOCKER_CERT_PATH', None),
+            key_path=self._get_value('key_path', params['client_key'], 'DOCKER_CERT_PATH', None),
             ssl_version=self._get_value('ssl_version', params['ssl_version'], 'DOCKER_SSL_VERSION', None),
             tls=self._get_value('tls', params['tls'], 'DOCKER_TLS', DEFAULT_TLS),
-            tls_verify=self._get_value('tls_verfy', params['tls_verify'], 'DOCKER_TLS_VERIFY',
+            tls_verify=self._get_value('tls_verfy', params['validate_certs'], 'DOCKER_TLS_VERIFY',
                                        DEFAULT_TLS_VERIFY),
             timeout=self._get_value('timeout', params['timeout'], 'DOCKER_TIMEOUT',
                                     DEFAULT_TIMEOUT_SECONDS),

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -106,17 +106,21 @@ AUTH_ARG_SPEC = {
     'password': {
         'no_log': True,
     },
-    'verify_ssl': {
+    'validate_certs': {
         'type': 'bool',
+        'aliases': ['verify_ssl'],
     },
-    'ssl_ca_cert': {
+    'ca_cert': {
         'type': 'path',
+        'aliases': ['ssl_ca_cert'],
     },
-    'cert_file': {
+    'client_cert': {
         'type': 'path',
+        'aliases': ['cert_file'],
     },
-    'key_file': {
+    'client_key': {
         'type': 'path',
+        'aliases': ['key_file'],
     },
 }
 

--- a/lib/ansible/module_utils/manageiq.py
+++ b/lib/ansible/module_utils/manageiq.py
@@ -47,8 +47,8 @@ def manageiq_argument_spec():
         username=dict(default=os.environ.get('MIQ_USERNAME', None)),
         password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),
         token=dict(default=os.environ.get('MIQ_TOKEN', None), no_log=True),
-        verify_ssl=dict(default=True, type='bool'),
-        ca_bundle_path=dict(required=False, default=None),
+        validate_certs=dict(default=True, type='bool', aliases=['verify_ssl']),
+        ca_cert=dict(required=False, default=None, aliases=['ca_bundle_path']),
     )
 
     return dict(
@@ -103,8 +103,8 @@ class ManageIQ(object):
         username = params['username']
         password = params['password']
         token = params['token']
-        verify_ssl = params['verify_ssl']
-        ca_bundle_path = params['ca_bundle_path']
+        verify_ssl = params['validate_certs']
+        ca_bundle_path = params['ca_cert']
 
         self._module = module
         self._api_url = url + '/api'

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -67,7 +67,7 @@ NIOS_PROVIDER_SPEC = {
     'host': dict(fallback=(env_fallback, ['INFOBLOX_HOST'])),
     'username': dict(fallback=(env_fallback, ['INFOBLOX_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['INFOBLOX_PASSWORD']), no_log=True),
-    'ssl_verify': dict(type='bool', default=False, fallback=(env_fallback, ['INFOBLOX_SSL_VERIFY'])),
+    'validate_certs': dict(type='bool', default=False, fallback=(env_fallback, ['INFOBLOX_SSL_VERIFY']), aliases=['ssl_verify']),
     'silent_ssl_warnings': dict(type='bool', default=True),
     'http_request_timeout': dict(type='int', default=10, fallback=(env_fallback, ['INFOBLOX_HTTP_REQUEST_TIMEOUT'])),
     'http_pool_connections': dict(type='int', default=10),
@@ -89,7 +89,7 @@ def get_connector(*args, **kwargs):
                         'to be installed.  It can be installed using the '
                         'command `pip install infoblox-client`')
 
-    if not set(kwargs.keys()).issubset(NIOS_PROVIDER_SPEC.keys()):
+    if not set(kwargs.keys()).issubset(list(NIOS_PROVIDER_SPEC.keys()) + ['ssl_verify']):
         raise Exception('invalid or unsupported keyword argument for connector')
     for key, value in iteritems(NIOS_PROVIDER_SPEC):
         if key not in kwargs:
@@ -103,6 +103,10 @@ def get_connector(*args, **kwargs):
             env = ('INFOBLOX_%s' % key).upper()
             if env in os.environ:
                 kwargs[key] = os.environ.get(env)
+
+    if 'validate_certs' in kwargs.keys():
+        kwargs['ssl_verify'] = kwargs['validate_certs']
+        kwargs.pop('validate_certs', None)
 
     return Connector(kwargs)
 

--- a/lib/ansible/module_utils/network/ingate/common.py
+++ b/lib/ansible/module_utils/network/ingate/common.py
@@ -23,7 +23,7 @@ def ingate_argument_spec(**kwargs):
         password=dict(type='str', required=True, no_log=True),
         port=dict(type='int'),
         timeout=dict(type='int'),
-        verify_ssl=dict(default=True, type='bool'),
+        validate_certs=dict(default=True, type='bool', aliases=['verify_ssl']),
     )
     argument_spec = dict(
         client=dict(type='dict', required=True,
@@ -56,7 +56,7 @@ def ingate_create_client_noauth(**kwargs):
                                   timeout=client_params['timeout'])
 
     # Check if we should skip SSL Certificate verification.
-    verify_ssl = client_params.get('verify_ssl')
+    verify_ssl = client_params.get('validate_certs')
     if not verify_ssl:
         api_client.skip_verify_certificate()
 

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -81,10 +81,10 @@ def openstack_full_argument_spec(**kwargs):
         auth=dict(default=None, type='dict', no_log=True),
         region_name=dict(default=None),
         availability_zone=dict(default=None),
-        verify=dict(default=None, type='bool', aliases=['validate_certs']),
-        cacert=dict(default=None),
-        cert=dict(default=None),
-        key=dict(default=None, no_log=True),
+        validate_certs=dict(default=None, type='bool', aliases=['verify']),
+        ca_cert=dict(default=None, aliases=['cacert']),
+        client_cert=dict(default=None, aliases=['cert']),
+        client_key=dict(default=None, no_log=True, aliases=['key']),
         wait=dict(default=True, type='bool'),
         timeout=dict(default=180, type='int'),
         api_timeout=dict(default=None, type='int'),
@@ -133,8 +133,8 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
                 " config dict is provided, {param} should be"
                 " excluded.")
             for param in (
-                    'auth', 'region_name', 'verify',
-                    'cacert', 'key', 'api_timeout', 'auth_type'):
+                    'auth', 'region_name', 'validate_certs',
+                    'ca_cert', 'client_key', 'api_timeout', 'auth_type'):
                 if module.params[param] is not None:
                     module.fail_json(msg=fail_message.format(param=param))
             # For 'interface' parameter, fail if we receive a non-default value
@@ -147,9 +147,9 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
                 auth_type=module.params['auth_type'],
                 auth=module.params['auth'],
                 region_name=module.params['region_name'],
-                verify=module.params['verify'],
-                cacert=module.params['cacert'],
-                key=module.params['key'],
+                verify=module.params['validate_certs'],
+                cacert=module.params['ca_cert'],
+                key=module.params['client_key'],
                 api_timeout=module.params['api_timeout'],
                 interface=module.params['interface'],
             )

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -43,7 +43,7 @@ def ensure_libs(sslrootcert=None):
     if not HAS_PSYCOPG2:
         raise LibraryError('psycopg2 is not installed. we need psycopg2.')
     if sslrootcert and psycopg2.__version__ < '2.4.3':
-        raise LibraryError('psycopg2 must be at least 2.4.3 in order to use the ssl_rootcert parameter')
+        raise LibraryError('psycopg2 must be at least 2.4.3 in order to use the ca_cert parameter')
 
     # no problems
     return None
@@ -57,5 +57,5 @@ def postgres_common_argument_spec():
         login_unix_socket=dict(default=''),
         port=dict(type='int', default=5432),
         ssl_mode=dict(default='prefer', choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(),
+        ca_cert=dict(aliases=['ssl_rootcert']),
     )

--- a/lib/ansible/module_utils/rabbitmq.py
+++ b/lib/ansible/module_utils/rabbitmq.py
@@ -32,9 +32,9 @@ def rabbitmq_argument_spec():
         login_host=dict(type='str', default='localhost'),
         login_port=dict(type='str', default='15672'),
         login_protocol=dict(type='str', default='http', choices=['http', 'https']),
-        cacert=dict(type='path'),
-        cert=dict(type='path'),
-        key=dict(type='path'),
+        ca_cert=dict(type='path', aliases=['cacert']),
+        client_cert=dict(type='path', aliases=['cert']),
+        client_key=dict(type='path', aliases=['key']),
         vhost=dict(type='str', default='/'),
     )
 

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -251,7 +251,7 @@ def rax_argument_spec():
         tenant_id=dict(type='str'),
         tenant_name=dict(type='str'),
         username=dict(type='str'),
-        verify_ssl=dict(type='bool'),
+        validate_certs=dict(type='bool', aliases=['verify_ssl']),
     )
 
 
@@ -275,7 +275,7 @@ def setup_rax_module(module, rax_module, region_required=True):
     tenant_id = module.params.get('tenant_id')
     tenant_name = module.params.get('tenant_name')
     username = module.params.get('username')
-    verify_ssl = module.params.get('verify_ssl')
+    verify_ssl = module.params.get('validate_certs')
 
     if env is not None:
         rax_module.set_environment(env)

--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -53,7 +53,7 @@ def vca_argument_spec():
         service_type=dict(default=DEFAULT_SERVICE_TYPE, choices=SERVICE_MAP.keys()),
         vdc_name=dict(),
         gateway_name=dict(default='gateway'),
-        verify_certs=dict(type='bool', default=True)
+        validate_certs=dict(type='bool', default=True, aliases=['verify_certs'])
     )
 
 
@@ -130,7 +130,7 @@ class VcaAnsibleModule(AnsibleModule):
         if service_type == 'vchs':
             version = '5.6'
 
-        verify = self.params.get('verify_certs')
+        verify = self.params.get('validate_certs')
 
         return VCA(host=host, username=username,
                    service_type=SERVICE_MAP[service_type],
@@ -293,7 +293,7 @@ def vca_login(module):
     vdc_name = module.params.get('vdc_name')
     service = module.params.get('service_id')
     version = module.params.get('api_version')
-    verify = module.params.get('verify_certs')
+    verify = module.params.get('validate_certs')
 
     _validate_module(module)
 

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_cdi_upload.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_cdi_upload.py
@@ -41,11 +41,12 @@ options:
     description:
       - URL containing the host and port on which the CDI Upload Proxy is available.
       - "More info: U(https://github.com/kubevirt/containerized-data-importer/blob/master/doc/upload.md#expose-cdi-uploadproxy-service)"
-  upload_host_verify_ssl:
+  upload_host_validate_certs:
     description:
       - Whether or not to verify the CDI Upload Proxy's SSL certificates against your system's CA trust store.
     default: true
     type: bool
+    aliases: [ upload_host_verify_ssl ]
   path:
     description:
       - Path of local image file to transfer.
@@ -71,7 +72,7 @@ EXAMPLES = '''
     pvc_namespace: default
     pvc_name: pvc-vm1
     upload_host: https://localhost:8443
-    upload_host_verify_ssl: false
+    upload_host_validate_certs: false
     path: /tmp/cirros-0.4.0-x86_64-disk.img
 '''
 
@@ -97,9 +98,10 @@ SERVICE_ARG_SPEC = {
     'pvc_name': {'required': True},
     'pvc_namespace': {'required': True},
     'upload_host': {'required': True},
-    'upload_host_verify_ssl': {
+    'upload_host_validate_certs': {
         'type': 'bool',
-        'default': True
+        'default': True,
+        'aliases': ['upload_host_verify_ssl']
     },
     'path': {'required': True},
     'merge_type': {
@@ -135,7 +137,7 @@ class KubeVirtCDIUpload(KubernetesRawModule):
         pvc_name = self.params.get('pvc_name')
         pvc_namespace = self.params.get('pvc_namespace')
         upload_host = self.params.get('upload_host')
-        upload_host_verify_ssl = self.params.get('upload_host_verify_ssl')
+        upload_host_verify_ssl = self.params.get('upload_host_validate_certs')
         path = self.params.get('path')
 
         definition = defaultdict(defaultdict)

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -112,16 +112,18 @@ options:
         required: false
         default: unix:/var/snap/lxd/common/lxd/unix.socket
         version_added: '2.8'
-    key_file:
+    client_key:
         description:
           - The client certificate key file path.
         required: false
         default: '"{}/.config/lxc/client.key" .format(os.environ["HOME"])'
-    cert_file:
+        aliases: [ key_file ]
+    client_cert:
         description:
           - The client certificate file path.
         required: false
         default: '"{}/.config/lxc/client.crt" .format(os.environ["HOME"])'
+        aliases: [ cert_file ]
     trust_password:
         description:
           - The client trusted password.
@@ -204,9 +206,9 @@ EXAMPLES = '''
     - name: Restart a container
       lxd_container:
         url: https://127.0.0.1:8443
-        # These cert_file and key_file values are equal to the default values.
-        #cert_file: "{{ lookup('env', 'HOME') }}/.config/lxc/client.crt"
-        #key_file: "{{ lookup('env', 'HOME') }}/.config/lxc/client.key"
+        # These client_cert and client_key values are equal to the default values.
+        #client_cert: "{{ lookup('env', 'HOME') }}/.config/lxc/client.crt"
+        #client_key: "{{ lookup('env', 'HOME') }}/.config/lxc/client.key"
         trust_password: mypassword
         name: mycontainer
         state: restarted
@@ -298,8 +300,8 @@ class LXDContainerManagement(object):
         self.force_stop = self.module.params['force_stop']
         self.addresses = None
 
-        self.key_file = self.module.params.get('key_file', None)
-        self.cert_file = self.module.params.get('cert_file', None)
+        self.key_file = self.module.params.get('client_key', None)
+        self.cert_file = self.module.params.get('client_cert', None)
         self.debug = self.module._verbosity >= 4
 
         try:
@@ -601,13 +603,15 @@ def main():
                 type='str',
                 default='unix:/var/snap/lxd/common/lxd/unix.socket'
             ),
-            key_file=dict(
+            client_key=dict(
                 type='str',
-                default='{0}/.config/lxc/client.key'.format(os.environ['HOME'])
+                default='{0}/.config/lxc/client.key'.format(os.environ['HOME']),
+                aliases=['key_file']
             ),
-            cert_file=dict(
+            client_cert=dict(
                 type='str',
-                default='{0}/.config/lxc/client.crt'.format(os.environ['HOME'])
+                default='{0}/.config/lxc/client.crt'.format(os.environ['HOME']),
+                aliases=['cert_file']
             ),
             trust_password=dict(type='str', no_log=True)
         ),

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -73,16 +73,18 @@ options:
         required: false
         default: unix:/var/snap/lxd/common/lxd/unix.socket
         version_added: '2.8'
-    key_file:
+    client_key:
         description:
           - The client certificate key file path.
         required: false
         default: '"{}/.config/lxc/client.key" .format(os.environ["HOME"])'
-    cert_file:
+        aliases: [ key_file ]
+    client_cert:
         description:
           - The client certificate file path.
         required: false
         default: '"{}/.config/lxc/client.crt" .format(os.environ["HOME"])'
+        aliases: [ cert_file ]
     trust_password:
         description:
           - The client trusted password.
@@ -123,9 +125,9 @@ EXAMPLES = '''
   - name: create macvlan profile
     lxd_profile:
       url: https://127.0.0.1:8443
-      # These cert_file and key_file values are equal to the default values.
-      #cert_file: "{{ lookup('env', 'HOME') }}/.config/lxc/client.crt"
-      #key_file: "{{ lookup('env', 'HOME') }}/.config/lxc/client.key"
+      # These client_cert and client_key values are equal to the default values.
+      #client_cert: "{{ lookup('env', 'HOME') }}/.config/lxc/client.crt"
+      #client_key: "{{ lookup('env', 'HOME') }}/.config/lxc/client.key"
       trust_password: mypassword
       name: macvlan
       state: present
@@ -205,8 +207,8 @@ class LXDProfileManagement(object):
         self.state = self.module.params['state']
         self.new_name = self.module.params.get('new_name', None)
 
-        self.key_file = self.module.params.get('key_file', None)
-        self.cert_file = self.module.params.get('cert_file', None)
+        self.key_file = self.module.params.get('client_key', None)
+        self.cert_file = self.module.params.get('client_cert', None)
         self.debug = self.module._verbosity >= 4
 
         try:
@@ -370,13 +372,15 @@ def main():
                 type='str',
                 default='unix:/var/snap/lxd/common/lxd/unix.socket'
             ),
-            key_file=dict(
+            client_key=dict(
                 type='str',
-                default='{0}/.config/lxc/client.key'.format(os.environ['HOME'])
+                default='{0}/.config/lxc/client.key'.format(os.environ['HOME']),
+                aliases=['key_file']
             ),
-            cert_file=dict(
+            client_cert=dict(
                 type='str',
-                default='{0}/.config/lxc/client.crt'.format(os.environ['HOME'])
+                default='{0}/.config/lxc/client.crt'.format(os.environ['HOME']),
+                aliases=['cert_file']
             ),
             trust_password=dict(type='str', no_log=True)
         ),

--- a/lib/ansible/modules/clustering/k8s/k8s_auth.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_auth.py
@@ -53,15 +53,17 @@ options:
   password:
     description:
     - Provide a password for authenticating with the API server.
-  ssl_ca_cert:
+  ca_cert:
     description:
     - "Path to a CA certificate file used to verify connection to the API server. The full certificate chain
       must be provided to avoid certificate validation errors."
-  verify_ssl:
+    aliases: [ ssl_ca_cert ]
+  validate_certs:
     description:
     - "Whether or not to verify the API server's SSL certificates."
     type: bool
     default: true
+    aliases: [ verify_ssl ]
   api_key:
     description:
     - When C(state) is set to I(absent), this specifies the token to revoke.
@@ -78,7 +80,7 @@ EXAMPLES = '''
   module_defaults:
     group/k8s:
       host: https://k8s.example.com/
-      ssl_ca_cert: ca.pem
+      ca_cert: ca.pem
   tasks:
   - block:
     # It's good practice to store login credentials in a secure vault and not
@@ -124,11 +126,11 @@ k8s_auth:
       description: URL for accessing the API server.
       returned: success
       type: str
-    ssl_ca_cert:
+    ca_cert:
       description: Path to a CA certificate file used to verify connection to the API server.
       returned: success
       type: str
-    verify_ssl:
+    validate_certs:
       description: "Whether or not to verify the API server's SSL certificates."
       returned: success
       type: bool
@@ -172,10 +174,11 @@ K8S_AUTH_ARG_SPEC = {
     'host': {'required': True},
     'username': {},
     'password': {'no_log': True},
-    'ssl_ca_cert': {'type': 'path'},
-    'verify_ssl': {
+    'ca_cert': {'type': 'path', 'aliases': ['ssl_ca_cert']},
+    'validate_certs': {
         'type': 'bool',
-        'default': True
+        'default': True,
+        'aliases': ['verify_ssl']
     },
     'api_key': {'no_log': True},
 }
@@ -203,8 +206,8 @@ class KubernetesAuthModule(AnsibleModule):
 
     def execute_module(self):
         state = self.params.get('state')
-        verify_ssl = self.params.get('verify_ssl')
-        ssl_ca_cert = self.params.get('ssl_ca_cert')
+        verify_ssl = self.params.get('validate_certs')
+        ssl_ca_cert = self.params.get('ca_cert')
 
         self.auth_username = self.params.get('username')
         self.auth_password = self.params.get('password')
@@ -224,8 +227,8 @@ class KubernetesAuthModule(AnsibleModule):
             new_api_key = self.openshift_login()
             result = dict(
                 host=self.con_host,
-                verify_ssl=verify_ssl,
-                ssl_ca_cert=ssl_ca_cert,
+                validate_certs=verify_ssl,
+                ca_cert=ssl_ca_cert,
                 api_key=new_api_key,
                 username=self.auth_username,
             )

--- a/lib/ansible/modules/crypto/get_certificate.py
+++ b/lib/ansible/modules/crypto/get_certificate.py
@@ -26,7 +26,7 @@ options:
       required: true
     ca_cert:
       description:
-        - A PEM file containing a list of root certificates; if present, the cert will be validated against these root certs.
+        - A PEM file containing one or more root certificates; if present, the cert will be validated against these root certs.
         - Note that this only validates the certificate is signed by the chain; not that the cert is valid for the host presenting it.
       type: path
       aliases: [ ca_certs ]

--- a/lib/ansible/modules/crypto/get_certificate.py
+++ b/lib/ansible/modules/crypto/get_certificate.py
@@ -24,11 +24,12 @@ options:
         - The host to get the cert for (IP is fine)
       type: str
       required: true
-    ca_certs:
+    ca_cert:
       description:
         - A PEM file containing a list of root certificates; if present, the cert will be validated against these root certs.
         - Note that this only validates the certificate is signed by the chain; not that the cert is valid for the host presenting it.
       type: path
+      aliases: [ ca_certs ]
     port:
       description:
         - The port to connect to
@@ -41,7 +42,7 @@ options:
       default: 10
 
 notes:
-  - When using ca_certs on OS X it has been reported that in some conditions the validate will always succeed.
+  - When using ca_cert on OS X it has been reported that in some conditions the validate will always succeed.
 
 requirements:
   - "python >= 2.6"
@@ -130,14 +131,14 @@ else:
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            ca_certs=dict(type='path'),
+            ca_cert=dict(type='path', aliases=['ca_certs']),
             host=dict(type='str', required=True),
             port=dict(type='int', required=True),
             timeout=dict(type='int', default=10),
         ),
     )
 
-    ca_certs = module.params.get('ca_certs')
+    ca_certs = module.params.get('ca_cert')
     host = module.params.get('host')
     port = module.params.get('port')
     timeout = module.params.get('timeout')
@@ -154,7 +155,7 @@ def main():
 
     if ca_certs:
         if not isfile(ca_certs):
-            module.fail_json(msg="ca_certs file does not exist")
+            module.fail_json(msg="ca_cert file does not exist")
 
     try:
         cert = get_server_certificate((host, port), ca_certs=ca_certs)

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -258,9 +258,9 @@ def main():
             collation=dict(type='str', default=''),
             target=dict(type='path'),
             state=dict(type='str', default='present', choices=['absent', 'dump', 'import', 'present']),
-            ssl_cert=dict(type='path'),
-            ssl_key=dict(type='path'),
-            ssl_ca=dict(type='path'),
+            client_cert=dict(type='path', aliases=['ssl_cert']),
+            client_key=dict(type='path', aliases=['ssl_key']),
+            ca_cert=dict(type='path', aliases=['ssl_ca']),
             connect_timeout=dict(type='int', default=30),
             config_file=dict(type='path', default='~/.my.cnf'),
             single_transaction=dict(type='bool', default=False),
@@ -282,9 +282,9 @@ def main():
     login_port = module.params["login_port"]
     if login_port < 0 or login_port > 65535:
         module.fail_json(msg="login_port must be a valid unix port number (0-65535)")
-    ssl_cert = module.params["ssl_cert"]
-    ssl_key = module.params["ssl_key"]
-    ssl_ca = module.params["ssl_ca"]
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
     connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
     login_password = module.params["login_password"]

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -220,9 +220,9 @@ def main():
             master_ssl_cipher=dict(type='str'),
             connect_timeout=dict(type='int', default=30),
             config_file=dict(type='path', default='~/.my.cnf'),
-            ssl_cert=dict(type='path'),
-            ssl_key=dict(type='path'),
-            ssl_ca=dict(type='path'),
+            client_cert=dict(type='path', aliases=['ssl_cert']),
+            client_key=dict(type='path', aliases=['ssl_key']),
+            ca_cert=dict(type='path', aliases=['ssl_ca']),
         )
     )
     mode = module.params["mode"]
@@ -242,9 +242,9 @@ def main():
     master_ssl_key = module.params["master_ssl_key"]
     master_ssl_cipher = module.params["master_ssl_cipher"]
     master_auto_position = module.params["master_auto_position"]
-    ssl_cert = module.params["ssl_cert"]
-    ssl_key = module.params["ssl_key"]
-    ssl_ca = module.params["ssl_ca"]
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
     connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
 

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -570,9 +570,9 @@ def main():
             connect_timeout=dict(type='int', default=30),
             config_file=dict(type='path', default='~/.my.cnf'),
             sql_log_bin=dict(type='bool', default=True),
-            ssl_cert=dict(type='path'),
-            ssl_key=dict(type='path'),
-            ssl_ca=dict(type='path'),
+            client_cert=dict(type='path', aliases=['ssl_cert']),
+            client_key=dict(type='path', aliases=['ssl_key']),
+            ca_cert=dict(type='path', aliases=['ssl_ca']),
         ),
         supports_check_mode=True,
     )
@@ -590,9 +590,9 @@ def main():
     config_file = module.params['config_file']
     append_privs = module.boolean(module.params["append_privs"])
     update_password = module.params['update_password']
-    ssl_cert = module.params["ssl_cert"]
-    ssl_key = module.params["ssl_key"]
-    ssl_ca = module.params["ssl_ca"]
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
     db = 'mysql'
     sql_log_bin = module.params["sql_log_bin"]
 

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -119,19 +119,19 @@ def main():
             login_unix_socket=dict(type='str'),
             variable=dict(type='str'),
             value=dict(type='str'),
-            ssl_cert=dict(type='path'),
-            ssl_key=dict(type='path'),
-            ssl_ca=dict(type='path'),
+            client_cert=dict(type='path', aliases=['ssl_cert']),
+            client_key=dict(type='path', aliases=['ssl_key']),
+            ca_cert=dict(type='path', aliases=['ssl_ca']),
             connect_timeout=dict(type='int', default=30),
             config_file=dict(type='path', default='~/.my.cnf'),
         ),
     )
     user = module.params["login_user"]
     password = module.params["login_password"]
-    ssl_cert = module.params["ssl_cert"]
-    ssl_key = module.params["ssl_key"]
-    ssl_ca = module.params["ssl_ca"]
     connect_timeout = module.params['connect_timeout']
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
     config_file = module.params['config_file']
     db = 'mysql'
 

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -462,7 +462,7 @@ def main():
         "login_password": "password",
         "port": "port",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != '' and v is not None)
@@ -479,7 +479,7 @@ def main():
 
     if not raw_connection:
         try:
-            pgutils.ensure_libs(sslrootcert=module.params.get('ssl_rootcert'))
+            pgutils.ensure_libs(sslrootcert=module.params.get('ca_cert'))
             db_connection = psycopg2.connect(database=maintenance_db, **kw)
 
             # Enable autocommit so we can create databases

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -65,13 +65,14 @@ options:
     choices: [allow, disable, prefer, require, verify-ca, verify-full]
     type: str
     version_added: '2.8'
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
       certificate(s). If the file exists, the server's certificate will be
       verified to be signed by one of these authorities.
     type: path
     version_added: '2.8'
+    aliases: [ ssl_rootcert ]
   port:
     description:
     - Database port to connect to.
@@ -225,7 +226,7 @@ def main():
         cascade=dict(type='bool', default=False),
         ssl_mode=dict(type='str', default='prefer', choices=[
                       'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type="path", default=None),
+        ca_cert=dict(type="path", default=None, aliases=['ssl_rootcert']),
         session_role=dict(type="str"),
     )
 
@@ -242,7 +243,7 @@ def main():
     schema = module.params["schema"]
     state = module.params["state"]
     cascade = module.params["cascade"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     session_role = module.params["session_role"]
     changed = False
 
@@ -256,7 +257,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" and v is not None)
@@ -267,7 +268,7 @@ def main():
         kw["host"] = module.params["login_unix_socket"]
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
-        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ca_cert parameter')
 
     try:
         db_connection = psycopg2.connect(**kw)

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -75,12 +75,13 @@ options:
     type: str
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
       certificate(s). If the file exists, the server's certificate will be
       verified to be signed by one of these authorities.
     type: str
+    aliases: [ ssl_rootcert ]
   state:
     description:
     - Index state.
@@ -433,7 +434,7 @@ def main():
         idxname=dict(type='str', required=True, aliases=['name']),
         db=dict(type='str'),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type='str'),
+        ca_cert=dict(type='str', aliases=['ssl_rootcert']),
         state=dict(type='str', default='present', choices=['absent', 'present']),
         concurrent=dict(type='bool', default=True),
         table=dict(type='str'),
@@ -458,7 +459,7 @@ def main():
     idxtype = module.params["idxtype"]
     columns = module.params["columns"]
     cond = module.params["cond"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     session_role = module.params["session_role"]
     tablespace = module.params["tablespace"]
     storage_params = module.params["storage_params"]
@@ -495,7 +496,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" and v is not None)
@@ -506,7 +507,7 @@ def main():
         kw["host"] = module.params["login_unix_socket"]
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
-        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ca_cert parameter')
 
     if module.check_mode and concurrent:
         module.fail_json(msg="Cannot concurrently create or drop index %s "

--- a/lib/ansible/modules/database/postgresql/postgresql_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_info.py
@@ -80,13 +80,14 @@ options:
     type: str
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     default: prefer
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
       certificate(s).
     - If the file exists, the server's certificate will be
       verified to be signed by one of these authorities.
     type: str
+    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -965,7 +966,7 @@ def main():
         port=dict(type='int', default=5432, aliases=['login_port']),
         filter=dict(type='list'),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type='str'),
+        ca_cert=dict(type='str', aliases=['ssl_rootcert']),
         session_role=dict(type='str'),
     )
     module = AnsibleModule(
@@ -977,7 +978,7 @@ def main():
         module.fail_json(msg="The python psycopg2 module is required")
 
     filter_ = module.params["filter"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     session_role = module.params["session_role"]
 
     # To use defaults values, keyword arguments must be absent, so
@@ -990,7 +991,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" and v is not None)
@@ -1002,7 +1003,7 @@ def main():
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert:
         module.fail_json(msg='psycopg2 must be at least 2.4.3 in order '
-                             'to user the ssl_rootcert parameter')
+                             'to user the ca_cert parameter')
 
     db_conn_obj = PgDbConn(module, kw, session_role)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_lang.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_lang.py
@@ -101,12 +101,13 @@ options:
     default: prefer
     choices: ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
     version_added: '2.8'
-  ssl_rootcert:
+  ca_cert:
     description:
       - Specifies the name of a file containing SSL certificate authority (CA)
         certificate(s). If the file exists, the server's certificate will be
         verified to be signed by one of these authorities.
     version_added: '2.8'
+    aliases: [ ssl_rootcert ]
 notes:
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
@@ -237,7 +238,7 @@ def main():
             fail_on_drop=dict(type='bool', default='yes'),
             ssl_mode=dict(default='prefer', choices=[
                           'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-            ssl_rootcert=dict(default=None),
+            ca_cert=dict(default=None, aliases=['ssl_rootcert']),
             session_role=dict(),
         ),
         supports_check_mode=True
@@ -250,7 +251,7 @@ def main():
     force_trust = module.params["force_trust"]
     cascade = module.params["cascade"]
     fail_on_drop = module.params["fail_on_drop"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     session_role = module.params["session_role"]
 
     if not postgresqldb_found:
@@ -266,7 +267,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" and v is not None)
@@ -277,7 +278,7 @@ def main():
         kw["host"] = module.params["login_unix_socket"]
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
-        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ca_cert parameter')
 
     try:
         db_connection = psycopg2.connect(**kw)

--- a/lib/ansible/modules/database/postgresql/postgresql_ping.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ping.py
@@ -57,13 +57,14 @@ options:
     type: str
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     default: prefer
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
       certificate(s).
     - If the file exists, the server's certificate will be
       verified to be signed by one of these authorities.
     type: str
+    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -90,7 +91,7 @@ EXAMPLES = r'''
     login_host: dbsrv
     login_user: secret
     login_password: secret_pass
-    ssl_rootcert: /root/root.crt
+    ca_cert: /root/root.crt
     ssl_mode: verify-full
 '''
 
@@ -172,7 +173,7 @@ def main():
     argument_spec.update(
         db=dict(type='str'),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type='str'),
+        ca_cert=dict(type='str', aliases=['ssl_rootcert']),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -182,7 +183,7 @@ def main():
     if not HAS_PSYCOPG2:
         module.fail_json(msg="The python psycopg2 module is required")
 
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
 
     # To use defaults values, keyword arguments must be absent, so
     # check which values are empty and don't include in the **kw
@@ -194,7 +195,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" and v is not None)
@@ -206,7 +207,7 @@ def main():
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
         module.fail_json(msg='psycopg2 must be at least 2.4.3 in order '
-                             'to user the ssl_rootcert parameter')
+                             'to user the ca_cert parameter')
 
     # Set some default values:
     cursor = False

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -86,13 +86,14 @@ options:
     type: str
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
       certificate(s).
     - If the file exists, the server's certificate will be
       verified to be signed by one of these authorities.
     type: str
+    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -220,7 +221,7 @@ def main():
         query=dict(type='str'),
         db=dict(type='str'),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type='str'),
+        ca_cert=dict(type='str', aliases=['ssl_rootcert']),
         positional_args=dict(type='list'),
         named_args=dict(type='dict'),
         session_role=dict(type='str'),
@@ -239,7 +240,7 @@ def main():
     query = module.params["query"]
     positional_args = module.params["positional_args"]
     named_args = module.params["named_args"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     session_role = module.params["session_role"]
     path_to_script = module.params["path_to_script"]
 
@@ -265,7 +266,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != '' and v is not None)
@@ -277,7 +278,7 @@ def main():
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert:
         module.fail_json(msg='psycopg2 must be at least 2.4.3 '
-                             'in order to user the ssl_rootcert parameter')
+                             'in order to user the ca_cert parameter')
 
     db_connection = connect_to_db(module, kw)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -91,12 +91,13 @@ options:
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     version_added: '2.8'
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
     - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     type: str
     version_added: '2.8'
+    aliases: [ ssl_rootcert ]
 notes:
 - This module uses I(psycopg2), a Python PostgreSQL database adapter.
 - You must ensure that psycopg2 is installed on the host before using this module.
@@ -252,7 +253,7 @@ def main():
         state=dict(type="str", default="present", choices=["absent", "present"]),
         ssl_mode=dict(type="str", default='prefer', choices=[
                       'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type="str", default=None),
+        ca_cert=dict(type="str", default=None, aliases=['ssl_rootcert']),
         session_role=dict(type="str"),
     )
 
@@ -267,7 +268,7 @@ def main():
     schema = module.params["schema"]
     owner = module.params["owner"]
     state = module.params["state"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     cascade_drop = module.params["cascade_drop"]
     session_role = module.params["session_role"]
     changed = False
@@ -282,7 +283,7 @@ def main():
         "port": "port",
         "database": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" and v is not None)
@@ -294,7 +295,7 @@ def main():
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
         module.fail_json(
-            msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+            msg='psycopg2 must be at least 2.4.3 in order to user the ca_cert parameter')
 
     try:
         db_connection = psycopg2.connect(**kw)

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -96,13 +96,14 @@ options:
     type: str
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     default: prefer
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
       certificate(s).
     - If the file exists, the server's certificate will be
       verified to be signed by one of these authorities.
     type: str
+    aliases: [ ssl_rootcert ]
 notes:
 - Supported version of PostgreSQL is 9.4 and later.
 - Pay attention, change setting with 'postmaster' context can return changed is true
@@ -338,7 +339,7 @@ def main():
         db=dict(type='str', aliases=['login_db']),
         port=dict(type='int', default=5432, aliases=['login_port']),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type='str'),
+        ca_cert=dict(type='str', aliases=['ssl_rootcert']),
         value=dict(type='str'),
         reset=dict(type='bool'),
         session_role=dict(type='str'),
@@ -354,7 +355,7 @@ def main():
     name = module.params["name"]
     value = module.params["value"]
     reset = module.params["reset"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     session_role = module.params["session_role"]
 
     # Allow to pass values like 1mb instead of 1MB, etc:
@@ -379,7 +380,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != '' and v is not None)
@@ -394,7 +395,7 @@ def main():
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert:
         module.fail_json(msg='psycopg2 must be at least 2.4.3 '
-                             'in order to user the ssl_rootcert parameter')
+                             'in order to user the ca_cert parameter')
 
     db_connection = connect_to_db(module, kw, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)

--- a/lib/ansible/modules/database/postgresql/postgresql_tablespace.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_tablespace.py
@@ -112,13 +112,14 @@ options:
     type: str
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ssl_rootcert:
+  ca_cert:
     description:
     - Specifies the name of a file containing SSL certificate authority (CA)
       certificate(s).
     - If the file exists, the server's certificate will be
       verified to be signed by one of these authorities.
     type: str
+    aliases: [ ssl_rootcert ]
 notes:
 - I(state=absent) and I(state=present) (the second one if the tablespace doesn't exist) do not
   support check mode because the corresponding PostgreSQL DROP and CREATE TABLESPACE commands
@@ -389,7 +390,7 @@ def main():
         db=dict(type='str', aliases=['login_db']),
         port=dict(type='int', default=5432, aliases=['login_port']),
         ssl_mode=dict(type='str', default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(type='str'),
+        ca_cert=dict(type='str', aliases=['ssl_rootcert']),
         session_role=dict(type='str'),
     )
 
@@ -408,7 +409,7 @@ def main():
     owner = module.params["owner"]
     rename_to = module.params["rename_to"]
     settings = module.params["set"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     session_role = module.params["session_role"]
 
     if state == 'absent' and (location or owner or rename_to or settings):
@@ -425,7 +426,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != '' and v is not None)
@@ -437,7 +438,7 @@ def main():
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert:
         module.fail_json(msg='psycopg2 must be at least 2.4.3 '
-                             'in order to user the ssl_rootcert parameter')
+                             'in order to user the ca_cert parameter')
 
     db_connection = connect_to_db(module, kw, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -138,12 +138,13 @@ options:
     default: prefer
     choices: ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
     version_added: '2.3'
-  ssl_rootcert:
+  ca_cert:
     description:
       - Specifies the name of a file containing SSL certificate authority (CA)
         certificate(s). If the file exists, the server's certificate will be
         verified to be signed by one of these authorities.
     version_added: '2.3'
+    aliases: [ ssl_rootcert ]
   conn_limit:
     description:
       - Specifies the user (role) connection limit.
@@ -163,7 +164,7 @@ notes:
    - If you specify PUBLIC as the user (role), then the privilege changes will apply
      to all users (roles). You may not specify password or role_attr_flags when the
      PUBLIC user is specified.
-   - The ssl_rootcert parameter requires at least Postgres version 8.4 and
+   - The ca_cert parameter requires at least Postgres version 8.4 and
      I(psycopg2) version 2.4.3.
 requirements: [ psycopg2 ]
 author: "Ansible Core Team"
@@ -759,7 +760,7 @@ def main():
         expires=dict(default=None),
         ssl_mode=dict(default='prefer', choices=[
             'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(default=None),
+        ca_cert=dict(default=None, aliases=['ssl_rootcert']),
         conn_limit=dict(type='int', default=None),
         session_role=dict(),
     ))
@@ -783,7 +784,7 @@ def main():
     else:
         encrypted = "UNENCRYPTED"
     expires = module.params["expires"]
-    sslrootcert = module.params["ssl_rootcert"]
+    sslrootcert = module.params["ca_cert"]
     conn_limit = module.params["conn_limit"]
 
     if not postgresqldb_found:
@@ -799,7 +800,7 @@ def main():
         "port": "port",
         "db": "database",
         "ssl_mode": "sslmode",
-        "ssl_rootcert": "sslrootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" and v is not None)
@@ -811,7 +812,7 @@ def main():
 
     if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
         module.fail_json(
-            msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+            msg='psycopg2 must be at least 2.4.3 in order to user the ca_cert parameter')
 
     try:
         db_connection = psycopg2.connect(**kw)

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_binding.py
@@ -107,9 +107,9 @@ class RabbitMqBinding(object):
         self.destination_type = 'q' if self.module.params['destination_type'] == 'queue' else 'e'
         self.routing_key = self.module.params['routing_key']
         self.arguments = self.module.params['arguments']
-        self.verify = self.module.params['cacert']
-        self.cert = self.module.params['cert']
-        self.key = self.module.params['key']
+        self.verify = self.module.params['ca_cert']
+        self.cert = self.module.params['client_cert']
+        self.key = self.module.params['client_key']
         self.props = urllib_parse.quote(self.routing_key) if self.routing_key != '' else '~'
         self.base_url = '{0}://{1}:{2}/api/bindings'.format(self.login_protocol,
                                                             self.login_host,

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_exchange.py
@@ -127,7 +127,7 @@ def main():
 
     # Check if exchange already exists
     r = requests.get(url, auth=(module.params['login_user'], module.params['login_password']),
-                     verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
+                     verify=module.params['ca_cert'], cert=(module.params['client_cert'], module.params['client_key']))
 
     if r.status_code == 200:
         exchange_exists = True
@@ -179,12 +179,12 @@ def main():
                     "type": module.params['exchange_type'],
                     "arguments": module.params['arguments']
                 }),
-                verify=module.params['cacert'],
-                cert=(module.params['cert'], module.params['key'])
+                verify=module.params['ca_cert'],
+                cert=(module.params['client_cert'], module.params['client_key'])
             )
         elif module.params['state'] == 'absent':
             r = requests.delete(url, auth=(module.params['login_user'], module.params['login_password']),
-                                verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
+                                verify=module.params['ca_cert'], cert=(module.params['client_cert'], module.params['client_key']))
 
         # RabbitMQ 3.6.7 changed this response code from 204 to 201
         if r.status_code == 204 or r.status_code == 201:

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_queue.py
@@ -141,7 +141,7 @@ def main():
 
     # Check if queue already exists
     r = requests.get(url, auth=(module.params['login_user'], module.params['login_password']),
-                     verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
+                     verify=module.params['ca_cert'], cert=(module.params['client_cert'], module.params['client_key']))
 
     if r.status_code == 200:
         queue_exists = True
@@ -228,12 +228,12 @@ def main():
                     "auto_delete": module.params['auto_delete'],
                     "arguments": module.params['arguments']
                 }),
-                verify=module.params['cacert'],
-                cert=(module.params['cert'], module.params['key'])
+                verify=module.params['ca_cert'],
+                cert=(module.params['client_cert'], module.params['client_key'])
             )
         elif module.params['state'] == 'absent':
             r = requests.delete(url, auth=(module.params['login_user'], module.params['login_password']),
-                                verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
+                                verify=module.params['ca_cert'], cert=(module.params['client_cert'], module.params['client_key']))
 
         # RabbitMQ 3.6.7 changed this response code from 204 to 201
         if r.status_code == 204 or r.status_code == 201:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -112,11 +112,12 @@ options:
             - The preshared key, at least 32 hex digits. Required if either tls_connect or tls_accept has PSK enabled.
             - Works only with >= Zabbix 3.0
         version_added: '2.5'
-    tls_issuer:
+    ca_cert:
         description:
             - Required certificate issuer.
             - Works only with >= Zabbix 3.0
         version_added: '2.5'
+        aliases: [ tls_issuer ]
     tls_subject:
         description:
             - Required certificate subject.
@@ -642,7 +643,7 @@ def main():
             tls_accept=dict(type='int', default=1),
             tls_psk_identity=dict(type='str', required=False),
             tls_psk=dict(type='str', required=False),
-            tls_issuer=dict(type='str', required=False),
+            ca_cert=dict(type='str', required=False, aliases=['tls_issuer']),
             tls_subject=dict(type='str', required=False),
             inventory_zabbix=dict(required=False, type='dict'),
             timeout=dict(type='int', default=10),
@@ -678,7 +679,7 @@ def main():
     tls_accept = module.params['tls_accept']
     tls_psk_identity = module.params['tls_psk_identity']
     tls_psk = module.params['tls_psk']
-    tls_issuer = module.params['tls_issuer']
+    tls_issuer = module.params['ca_cert']
     tls_subject = module.params['tls_subject']
     inventory_zabbix = module.params['inventory_zabbix']
     status = module.params['status']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
@@ -64,10 +64,11 @@ options:
         required: false
         choices: ['no_encryption','PSK','certificate']
         default: 'no_encryption'
-    tls_issuer:
+    ca_cert:
         description:
             - Certificate issuer.
         required: false
+        aliases: [ tls_issuer ]
     tls_subject:
         description:
             - Certificate subject.
@@ -248,7 +249,7 @@ def main():
                              choices=['no_encryption', 'PSK', 'certificate']),
             tls_accept=dict(default='no_encryption',
                             choices=['no_encryption', 'PSK', 'certificate']),
-            tls_issuer=dict(type='str', required=False, default=None),
+            ca_cert=dict(type='str', required=False, default=None, aliases=['tls_issuer']),
             tls_subject=dict(type='str', required=False, default=None),
             tls_psk_identity=dict(type='str', required=False, default=None),
             tls_psk=dict(type='str', required=False, default=None),
@@ -274,7 +275,7 @@ def main():
     status = module.params['status']
     tls_connect = module.params['tls_connect']
     tls_accept = module.params['tls_accept']
-    tls_issuer = module.params['tls_issuer']
+    tls_issuer = module.params['ca_cert']
     tls_subject = module.params['tls_subject']
     tls_psk_identity = module.params['tls_psk_identity']
     tls_psk = module.params['tls_psk']

--- a/lib/ansible/modules/network/f5/bigip_device_auth_ldap.py
+++ b/lib/ansible/modules/network/f5/bigip_device_auth_ldap.py
@@ -87,26 +87,30 @@ options:
       - "yes"
       - "no"
       - start-tls
-  ssl_ca_cert:
+  ca_cert:
     description:
       - Specifies the name of an SSL certificate from a certificate authority (CA).
       - To remove this value, use the reserved value C(none).
     type: str
-  ssl_client_key:
+    aliases: [ ssl_ca_cert ]
+  client_key:
     description:
       - Specifies the name of an SSL client key.
       - To remove this value, use the reserved value C(none).
     type: str
-  ssl_client_cert:
+    aliases: [ ssl_client_key ]
+  client_cert:
     description:
       - Specifies the name of an SSL client certificate.
       - To remove this value, use the reserved value C(none).
     type: str
-  ssl_check_peer:
+    aliases: [ ssl_client_cert ]
+  validate_certs:
     description:
       - Specifies whether the system checks an SSL peer, as a result of which the
         system requires and verifies the server certificate.
     type: bool
+    aliases: [ ssl_check_peer ]
   login_ldap_attr:
     description:
       - Specifies the LDAP directory attribute containing the local user name that is
@@ -196,22 +200,22 @@ ssl:
   returned: changed
   type: str
   sample: start-tls
-ssl_ca_cert:
+ca_cert:
   description: The name of an SSL certificate from a certificate authority.
   returned: changed
   type: str
   sample: My-Trusted-CA-Bundle.crt
-ssl_client_key:
+client_key:
   description: The name of an SSL client key.
   returned: changed
   type: str
   sample: MyKey.key
-ssl_client_cert:
+client_cert:
   description: The name of an SSL client certificate.
   returned: changed
   type: str
   sample: MyCert.crt
-ssl_check_peer:
+validate_certs:
   description: Indicates if the system checks an SSL peer.
   returned: changed
   type: bool
@@ -257,10 +261,10 @@ class Parameters(AnsibleF5Parameters):
         'userTemplate': 'user_template',
         'fallback': 'fallback_to_local',
         'loginAttribute': 'login_ldap_attr',
-        'sslCheckPeer': 'ssl_check_peer',
-        'sslClientCert': 'ssl_client_cert',
-        'sslClientKey': 'ssl_client_key',
-        'sslCaCertFile': 'ssl_ca_cert',
+        'sslCheckPeer': 'validate_certs',
+        'sslClientCert': 'client_cert',
+        'sslClientKey': 'client_key',
+        'sslCaCertFile': 'ca_cert',
         'checkRolesGroup': 'check_member_attr',
         'searchBaseDn': 'remote_directory_tree',
     }
@@ -293,10 +297,10 @@ class Parameters(AnsibleF5Parameters):
         'scope',
         'servers',
         'ssl',
-        'ssl_ca_cert',
-        'ssl_check_peer',
-        'ssl_client_cert',
-        'ssl_client_key',
+        'ca_cert',
+        'validate_certs',
+        'client_cert',
+        'client_key',
         'user_template',
     ]
 
@@ -803,10 +807,10 @@ class ArgumentSpec(object):
             ssl=dict(
                 choices=['yes', 'no', 'start-tls']
             ),
-            ssl_ca_cert=dict(),
-            ssl_client_key=dict(),
-            ssl_client_cert=dict(),
-            ssl_check_peer=dict(type='bool'),
+            ca_cert=dict(aliases=['ssl_ca_cert']),
+            client_key=dict(aliases=['ssl_client_key']),
+            client_cert=dict(aliases=['ssl_client_cert']),
+            validate_certs=dict(type='bool', aliases=['ssl_check_peer']),
             login_ldap_attr=dict(),
             fallback_to_local=dict(type='bool'),
             update_password=dict(

--- a/lib/ansible/modules/network/radware/vdirect_commit.py
+++ b/lib/ansible/modules/network/radware/vdirect_commit.py
@@ -82,13 +82,14 @@ options:
      - may be set as C(VDIRECT_HTTPS) or C(VDIRECT_USE_SSL) environment variable.
     type: bool
     default: 'yes'
-  vdirect_validate_certs:
+  validate_certs:
     description:
      - If C(no), SSL certificates will not be validated,
      - may be set as C(VDIRECT_VALIDATE_CERTS) or C(VDIRECT_VERIFY) environment variable.
      - This should only set to C(no) used on personally controlled sites using self-signed certificates.
     type: bool
     default: 'yes'
+    aliases: [ vdirect_validate_certs ]
   devices:
     description:
      - List of Radware Alteon device names for commit operations.
@@ -172,9 +173,9 @@ meta_args = dict(
     vdirect_timeout=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_TIMEOUT']),
         default=60, type='int'),
-    vdirect_validate_certs=dict(
+    validate_certs=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_VERIFY', 'VDIRECT_VALIDATE_CERTS']),
-        default=True, type='bool'),
+        default=True, type='bool', aliases=['vdirect_validate_certs']),
     vdirect_https_port=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_HTTPS_PORT']),
         default=2189, type='int'),
@@ -219,7 +220,7 @@ class VdirectCommit(object):
                                              http_port=params['vdirect_http_port'],
                                              timeout=params['vdirect_timeout'],
                                              https=params['vdirect_use_ssl'],
-                                             verify=params['vdirect_validate_certs'])
+                                             verify=params['validate_certs'])
         self.devices = params['devices']
         self.apply = params['apply']
         self.save = params['save']

--- a/lib/ansible/modules/network/radware/vdirect_file.py
+++ b/lib/ansible/modules/network/radware/vdirect_file.py
@@ -76,13 +76,14 @@ options:
      - may be set as VDIRECT_HTTPS or VDIRECT_USE_SSL environment variable.
     type: bool
     default: 'yes'
-  vdirect_validate_certs:
+  validate_certs:
     description:
      - If C(no), SSL certificates will not be validated,
      - may be set as VDIRECT_VALIDATE_CERTS or VDIRECT_VERIFY environment variable.
      - This should only set to C(no) used on personally controlled sites using self-signed certificates.
     type: bool
     default: 'yes'
+    aliases: [ vdirect_validate_certs ]
   file_name:
     description:
      - vDirect runnable file name to be uploaded.
@@ -148,9 +149,9 @@ meta_args = dict(
     vdirect_timeout=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_TIMEOUT']),
         default=60, type='int'),
-    vdirect_validate_certs=dict(
+    validate_certs=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_VERIFY', 'VDIRECT_VALIDATE_CERTS']),
-        default=True, type='bool'),
+        default=True, type='bool', aliases=['vdirect_validate_certs']),
     vdirect_https_port=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_HTTPS_PORT']),
         default=2189, type='int'),
@@ -187,7 +188,7 @@ class VdirectFile(object):
                                              http_port=params['vdirect_http_port'],
                                              timeout=params['vdirect_timeout'],
                                              https=params['vdirect_use_ssl'],
-                                             verify=params['vdirect_validate_certs'])
+                                             verify=params['validate_certs'])
 
     def upload(self, fqn):
         if fqn.endswith(TEMPLATE_EXTENSION):

--- a/lib/ansible/modules/network/radware/vdirect_runnable.py
+++ b/lib/ansible/modules/network/radware/vdirect_runnable.py
@@ -76,13 +76,14 @@ options:
      - may be set as C(VDIRECT_HTTPS) or C(VDIRECT_USE_SSL) environment variable.
     type: bool
     default: 'yes'
-  vdirect_validate_certs:
+  validate_certs:
     description:
      - If C(no), SSL certificates will not be validated,
      - may be set as C(VDIRECT_VALIDATE_CERTS) or C(VDIRECT_VERIFY) environment variable.
      - This should only set to C(no) used on personally controlled sites using self-signed certificates.
     type: bool
     default: 'yes'
+    aliases: [ vdirect_validate_certs ]
   runnable_type:
     description:
      - vDirect runnable type.
@@ -160,9 +161,9 @@ meta_args = dict(
     vdirect_timeout=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_TIMEOUT']),
         default=60, type='int'),
-    vdirect_validate_certs=dict(
+    validate_certs=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_VERIFY', 'VDIRECT_VALIDATE_CERTS']),
-        default=True, type='bool'),
+        default=True, type='bool', aliases=['vdirect_validate_certs']),
     vdirect_https_port=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_HTTPS_PORT']),
         default=2189, type='int'),
@@ -222,7 +223,7 @@ class VdirectRunnable(object):
                                              http_port=params['vdirect_http_port'],
                                              timeout=params['vdirect_timeout'],
                                              https=params['vdirect_use_ssl'],
-                                             verify=params['vdirect_validate_certs'])
+                                             verify=params['validate_certs'])
         self.params = params
         self.type = self.params['runnable_type']
         self.name = self.params['runnable_name']

--- a/lib/ansible/modules/notification/mqtt.py
+++ b/lib/ansible/modules/notification/mqtt.py
@@ -61,7 +61,7 @@ options:
         retained message immediately.
     type: bool
     default: 'no'
-  ca_certs:
+  ca_cert:
     description:
       - The path to the Certificate Authority certificate files that are to be
         treated as trusted by this client. If this is the only option given
@@ -72,18 +72,21 @@ options:
         network encryption but may not be sufficient depending on how the broker
         is configured.
     version_added: 2.3
-  certfile:
+    aliases: [ ca_certs ]
+  client_cert:
     description:
       - The path pointing to the PEM encoded client certificate. If this is not
         None it will be used as client information for TLS based
         authentication. Support for this feature is broker dependent.
     version_added: 2.3
-  keyfile:
+    aliases: [ certfile ]
+  client_key:
     description:
       - The path pointing to the PEM encoded client private key. If this is not
         None it will be used as client information for TLS based
         authentication. Support for this feature is broker dependent.
     version_added: 2.3
+    aliases: [ keyfile ]
 
 
 # informational: requirements for nodes
@@ -141,9 +144,9 @@ def main():
             retain=dict(default=False, type='bool'),
             username=dict(default=None),
             password=dict(default=None, no_log=True),
-            ca_certs=dict(default=None, type='path'),
-            certfile=dict(default=None, type='path'),
-            keyfile=dict(default=None, type='path'),
+            ca_cert=dict(default=None, type='path', aliases=['ca_certs']),
+            client_cert=dict(default=None, type='path', aliases=['certfile']),
+            client_key=dict(default=None, type='path', aliases=['keyfile']),
         ),
         supports_check_mode=True
     )
@@ -160,9 +163,9 @@ def main():
     retain = module.params.get("retain")
     username = module.params.get("username", None)
     password = module.params.get("password", None)
-    ca_certs = module.params.get("ca_certs", None)
-    certfile = module.params.get("certfile", None)
-    keyfile = module.params.get("keyfile", None)
+    ca_certs = module.params.get("ca_cert", None)
+    certfile = module.params.get("client_cert", None)
+    keyfile = module.params.get("client_key", None)
 
     if client_id is None:
         client_id = "%s_%s" % (socket.getfqdn(), os.getpid())

--- a/lib/ansible/modules/packaging/os/pulp_repo.py
+++ b/lib/ansible/modules/packaging/os/pulp_repo.py
@@ -48,11 +48,13 @@ options:
     type: bool
     default: 'no'
     version_added: "2.8"
-  importer_ssl_ca_cert:
+  ca_cert:
     description:
       - CA certificate string used to validate the feed source SSL certificate.
         This can be the file content or the path to the file.
-  importer_ssl_client_cert:
+    type: str
+    aliases: [ importer_ssl_ca_cert ]
+  client_cert:
     description:
       - Certificate used as the client certificate when synchronizing the
         repository. This is used to communicate authentication information to
@@ -60,11 +62,15 @@ options:
         certificate. The specified file may be the certificate itself or a
         single file containing both the certificate and private key. This can be
         the file content or the path to the file.
-  importer_ssl_client_key:
+    type: str
+    aliases: [ importer_ssl_client_cert ]
+  client_key:
     description:
       - Private key to the certificate specified in I(importer_ssl_client_cert),
         assuming it is not included in the certificate file itself. This can be
         the file content or the path to the file.
+    type: str
+    aliases: [ importer_ssl_client_key ]
   name:
     description:
       - Name of the repo to add or remove. This correlates to repo-id in Pulp.
@@ -529,9 +535,9 @@ def main():
         add_export_distributor=dict(default=False, type='bool'),
         feed=dict(),
         generate_sqlite=dict(default=False, type='bool'),
-        importer_ssl_ca_cert=dict(),
-        importer_ssl_client_cert=dict(),
-        importer_ssl_client_key=dict(),
+        ca_cert=dict(aliases=['importer_ssl_ca_cert']),
+        client_cert=dict(aliases=['importer_ssl_client_cert']),
+        client_key=dict(aliases=['importer_ssl_client_key']),
         name=dict(required=True, aliases=['repo']),
         proxy_host=dict(),
         proxy_port=dict(),
@@ -555,9 +561,9 @@ def main():
     add_export_distributor = module.params['add_export_distributor']
     feed = module.params['feed']
     generate_sqlite = module.params['generate_sqlite']
-    importer_ssl_ca_cert = module.params['importer_ssl_ca_cert']
-    importer_ssl_client_cert = module.params['importer_ssl_client_cert']
-    importer_ssl_client_key = module.params['importer_ssl_client_key']
+    importer_ssl_ca_cert = module.params['ca_cert']
+    importer_ssl_client_cert = module.params['client_cert']
+    importer_ssl_client_key = module.params['client_key']
     proxy_host = module.params['proxy_host']
     proxy_port = module.params['proxy_port']
     proxy_username = module.params['proxy_username']

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -55,11 +55,12 @@ options:
             - Supply an profilename for use with registration.
         type: str
         version_added: "2.0"
-    sslcacert:
+    ca_cert:
         description:
             - Supply a custom ssl CA certificate file for use with registration.
         type: path
         version_added: "2.1"
+        aliases: [ sslcacert ]
     systemorgid:
         description:
             - Supply an organizational id for use with registration.
@@ -350,7 +351,7 @@ def main():
             server_url=dict(type='str'),
             activationkey=dict(type='str', no_log=True),
             profilename=dict(type='str'),
-            sslcacert=dict(type='path'),
+            ca_cert=dict(type='path', aliases=['sslcacert']),
             systemorgid=dict(type='str'),
             enable_eus=dict(type='bool', default=False),
             nopackages=dict(type='bool', default=False),
@@ -374,7 +375,7 @@ def main():
     state = module.params['state']
     activationkey = module.params['activationkey']
     profilename = module.params['profilename']
-    sslcacert = module.params['sslcacert']
+    sslcacert = module.params['ca_cert']
     systemorgid = module.params['systemorgid']
     channels = module.params['channels']
     enable_eus = module.params['enable_eus']

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -273,19 +273,23 @@ options:
     description:
       - Path to the directory containing the databases of the certificate
         authorities yum should use to verify SSL certificates.
+    aliases: [ ca_cert ]
   sslclientcert:
     description:
       - Path to the SSL client certificate yum should use to connect to
         repos/remote sites.
+    aliases: [ client_cert ]
   sslclientkey:
     description:
       - Path to the SSL client key yum should use to connect to repos/remote
         sites.
+    aliases: [ client_key ]
   sslverify:
     description:
       - Defines whether yum should verify SSL certificates/hosts at all.
     type: bool
     default: 'yes'
+    aliases: [ validate_certs ]
   state:
     description:
       - State of the repo file.
@@ -593,11 +597,11 @@ def main():
         retries=dict(),
         s3_enabled=dict(type='bool'),
         skip_if_unavailable=dict(type='bool'),
-        sslcacert=dict(),
+        sslcacert=dict(aliases=['ca_cert']),
         ssl_check_cert_permissions=dict(type='bool'),
-        sslclientcert=dict(),
-        sslclientkey=dict(),
-        sslverify=dict(type='bool'),
+        sslclientcert=dict(aliases=['client_cert']),
+        sslclientkey=dict(aliases=['client_key']),
+        sslverify=dict(type='bool', aliases=['validate_certs']),
         state=dict(choices=['present', 'absent'], default='present'),
         throttle=dict(),
         timeout=dict(),

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_alert_profiles.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_alert_profiles.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Delete an alert profile from ManageIQ
   manageiq_alert_profiles:
@@ -71,7 +71,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
@@ -80,7 +80,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Add an alert with a "miq expression" to ManageIQ
   manageiq_alerts:
@@ -107,7 +107,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Delete an alert from ManageIQ
   manageiq_alerts:
@@ -117,7 +117,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
@@ -104,7 +104,7 @@ EXAMPLES = '''
       url: 'https://manageiq_server'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Create a group in ManageIQ with the role EvmRole-user and tenant with tenant_id 4
   manageiq_group:
@@ -115,7 +115,7 @@ EXAMPLES = '''
       url: 'https://manageiq_server'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name:
   - Create or update a group in ManageIQ with the role EvmRole-user and tenant my_tenant.
@@ -141,7 +141,7 @@ EXAMPLES = '''
       url: 'https://manageiq_server'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Delete a group in ManageIQ
   manageiq_group:

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_policies.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_policies.py
@@ -62,7 +62,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Unassign a policy_profile for a provider in ManageIQ
   manageiq_policies:
@@ -75,7 +75,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: List current policy_profile and policies for a provider in ManageIQ
   manageiq_policies:
@@ -86,7 +86,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -82,7 +82,7 @@ options:
         description: Provider's api endpoint authentication password. defaults to None.
       auth_key:
         description: Provider's api endpoint authentication bearer token. defaults to None.
-      verify_ssl:
+      validate_certs:
         description: Whether SSL certificates should be verified for HTTPS requests (deprecated). defaults to True.
         type: bool
         default: 'yes'
@@ -106,7 +106,7 @@ options:
         description: Provider's api endpoint authentication password. defaults to None.
       auth_key:
         description: Provider's api endpoint authentication bearer token. defaults to None.
-      verify_ssl:
+      validate_certs:
         description: Whether SSL certificates should be verified for HTTPS requests (deprecated). defaults to True.
         type: bool
         default: 'yes'
@@ -133,7 +133,7 @@ options:
         description: Provider's api endpoint authentication password. defaults to None.
       auth_key:
         description: Provider's api endpoint authentication bearer token. defaults to None.
-      verify_ssl:
+      validate_certs:
         description: Whether SSL certificates should be verified for HTTPS requests (deprecated). defaults to True.
         default: true
       security_protocol:
@@ -165,7 +165,7 @@ EXAMPLES = '''
       auth_key: 'topSecret'
       hostname: 'example.com'
       port: 8443
-      verify_ssl: true
+      validate_certs: true
       security_protocol: 'ssl-with-validation-custom-ca'
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
@@ -191,7 +191,7 @@ EXAMPLES = '''
       role: 'hawkular'
       hostname: 'example.com'
       port: 443
-      verify_ssl: true
+      validate_certs: true
       security_protocol: 'ssl-with-validation-custom-ca'
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
@@ -216,7 +216,7 @@ EXAMPLES = '''
       url: 'https://127.0.0.1:80'
       username: 'admin'
       password: 'password'
-      verify_ssl: true
+      validate_certs: true
 
 
 - name: Update an existing provider named 'EngLab' (defaults to 'Prometheus' metrics)
@@ -228,7 +228,7 @@ EXAMPLES = '''
       auth_key: 'topSecret'
       hostname: 'next.example.com'
       port: 8443
-      verify_ssl: true
+      validate_certs: true
       security_protocol: 'ssl-with-validation-custom-ca'
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
@@ -253,7 +253,7 @@ EXAMPLES = '''
       auth_key: 'topSecret'
       hostname: 'next.example.com'
       port: 443
-      verify_ssl: true
+      validate_certs: true
       security_protocol: 'ssl-with-validation-custom-ca'
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
@@ -278,7 +278,7 @@ EXAMPLES = '''
       url: 'https://127.0.0.1'
       username: 'admin'
       password: 'password'
-      verify_ssl: true
+      validate_certs: true
 
 
 - name: Delete a provider in ManageIQ
@@ -290,7 +290,7 @@ EXAMPLES = '''
       url: 'https://127.0.0.1'
       username: 'admin'
       password: 'password'
-      verify_ssl: true
+      validate_certs: true
 
 
 - name: Create a new Amazon provider in ManageIQ using token authentication
@@ -305,7 +305,7 @@ EXAMPLES = '''
     manageiq_connection:
       url: 'https://127.0.0.1'
       token: 'VeryLongToken'
-      verify_ssl: true
+      validate_certs: true
 
 
 - name: Create a new oVirt provider in ManageIQ
@@ -317,7 +317,7 @@ EXAMPLES = '''
       hostname: 'rhev01.example.com'
       userid: 'admin@internal'
       password: 'password'
-      verify_ssl: true
+      validate_certs: true
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
         FAKECERTsdKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtvcGVu
@@ -342,7 +342,7 @@ EXAMPLES = '''
       path: 'ovirt_engine_history'
       userid: 'user_id_metrics'
       password: 'password_metrics'
-      verify_ssl: true
+      validate_certs: true
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
         FAKECERTsdKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtvcGVu
@@ -366,7 +366,7 @@ EXAMPLES = '''
       url: 'https://127.0.0.1'
       username: 'admin'
       password: 'password'
-      verify_ssl: true
+      validate_certs: true
 
 - name: Create a new VMware provider in ManageIQ
   manageiq_provider:
@@ -382,7 +382,7 @@ EXAMPLES = '''
     manageiq_connection:
       url: 'https://127.0.0.1'
       token: 'VeryLongToken'
-      verify_ssl: true
+      validate_certs: true
 
 - name: Create a new Azure provider in ManageIQ
   manageiq_provider:
@@ -400,7 +400,7 @@ EXAMPLES = '''
       url: 'https://cf-6af0.rhpds.opentlc.com'
       username: 'admin'
       password: 'password'
-      verify_ssl: false
+      validate_certs: false
 
 - name: Create a new OpenStack Director provider in ManageIQ with rsa keypair
   manageiq_provider:
@@ -413,7 +413,7 @@ EXAMPLES = '''
       userid: 'admin'
       password: 'password'
       security_protocol: 'ssl-with-validation'
-      verify_ssl: 'true'
+      validate_certs: 'true'
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
         FAKECERTsdKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtvcGVu
@@ -452,7 +452,7 @@ EXAMPLES = '''
       userid: 'admin'
       password: 'password'
       security_protocol: 'ssl-with-validation'
-      verify_ssl: 'true'
+      validate_certs: 'true'
       certificate_authority: |
         -----BEGIN CERTIFICATE-----
         FAKECERTsdKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtvcGVu
@@ -491,7 +491,7 @@ EXAMPLES = '''
     provider:
       hostname: 'gce.example.com'
       auth_key: 'google_json_key'
-      verify_ssl: 'false'
+      validate_certs: 'false'
 '''
 
 RETURN = '''
@@ -551,7 +551,7 @@ def endpoint_argument_spec():
         role=dict(),
         hostname=dict(required=True),
         port=dict(type='int'),
-        verify_ssl=dict(default=True, type='bool'),
+        validate_certs=dict(default=True, type='bool', aliases=['verify_ssl']),
         certificate_authority=dict(),
         security_protocol=dict(
             choices=[
@@ -662,7 +662,7 @@ class ManageIQProvider(object):
                         'role': role,
                         'hostname': endpoint.get('hostname'),
                         'port': endpoint.get('port'),
-                        'verify_ssl': [0, 1][endpoint.get('verify_ssl', True)],
+                        'verify_ssl': [0, 1][endpoint.get('validate_certs', True)],
                         'security_protocol': endpoint.get('security_protocol'),
                         'certificate_authority': endpoint.get('certificate_authority'),
                         'path': endpoint.get('path'),

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_tags.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_tags.py
@@ -65,7 +65,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Remove tags for a provider in ManageIQ
   manageiq_tags:
@@ -81,7 +81,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: List current tags for a provider in ManageIQ
   manageiq_tags:
@@ -92,7 +92,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_tenant.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_tenant.py
@@ -86,7 +86,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Create a tenant in ManageIQ
   manageiq_tenant:
@@ -97,7 +97,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Delete a tenant in ManageIQ
   manageiq_tenant:
@@ -108,7 +108,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Set tenant quota for cpu_allocated, mem_allocated, remove quota for vms_allocated
   manageiq_tenant:
@@ -122,7 +122,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 
 - name: Delete a tenant in ManageIQ using a token
@@ -133,7 +133,7 @@ EXAMPLES = '''
     manageiq_connection:
       url: 'http://127.0.0.1:3000'
       token: 'sometoken'
-      verify_ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -79,7 +79,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Create a new user in ManageIQ using a token
   manageiq_user:
@@ -91,7 +91,7 @@ EXAMPLES = '''
     manageiq_connection:
       url: 'http://127.0.0.1:3000'
       token: 'sometoken'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Delete a user in ManageIQ
   manageiq_user:
@@ -101,7 +101,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Delete a user in ManageIQ using a token
   manageiq_user:
@@ -110,7 +110,7 @@ EXAMPLES = '''
     manageiq_connection:
       url: 'http://127.0.0.1:3000'
       token: 'sometoken'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Update email of user in ManageIQ
   manageiq_user:
@@ -120,7 +120,7 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
-      verify_ssl: False
+      validate_certs: False
 
 - name: Update email of user in ManageIQ using a token
   manageiq_user:
@@ -129,7 +129,7 @@ EXAMPLES = '''
     manageiq_connection:
       url: 'http://127.0.0.1:3000'
       token: 'sometoken'
-      verify_ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -95,11 +95,12 @@ options:
       - Trigger hook on wiki events
     type: bool
     default: no
-  enable_ssl_verification:
+  hook_validate_certs:
     description:
       - Whether GitLab will do SSL verification when triggering the hook
     type: bool
     default: no
+    aliases: [ enable_ssl_verification ]
   token:
     description:
       - Secret token to validate hook messages at the receiver.
@@ -119,7 +120,7 @@ EXAMPLES = '''
     state: present
     push_events: yes
     tag_push_events: yes
-    enable_ssl_verification: no
+    hook_validate_certs: no
     token: "my-super-secret-token-that-my-ci-server-will-check"
 
 - name: "Delete the previous hook"
@@ -315,7 +316,7 @@ def main():
         job_events=dict(type='bool', default=False),
         pipeline_events=dict(type='bool', default=False),
         wiki_page_events=dict(type='bool', default=False),
-        enable_ssl_verification=dict(type='bool', default=False),
+        hook_validate_certs=dict(type='bool', default=False, aliases=['enable_ssl_verification']),
         token=dict(type='str', no_log=True),
     ))
 
@@ -353,7 +354,7 @@ def main():
     job_events = module.params['job_events']
     pipeline_events = module.params['pipeline_events']
     wiki_page_events = module.params['wiki_page_events']
-    enable_ssl_verification = module.params['enable_ssl_verification']
+    enable_ssl_verification = module.params['hook_validate_certs']
     hook_token = module.params['token']
 
     if not HAS_GITLAB_PACKAGE:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py
@@ -58,11 +58,12 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_verify_ssl:
+    validate_certs:
       description:
         - Tower option to avoid certificates check.
       required: False
       type: bool
+      aliases: [ tower_verify_ssl ]
 extends_documentation_fragment: tower
 '''
 
@@ -75,7 +76,7 @@ EXAMPLES = '''
     inputs: "{{ lookup('file', 'tower_credential_inputs_nexus.json') }}"
     injectors: {'extra_vars': {'nexus_credential': 'test' }}
     state: present
-    tower_verify_ssl: false
+    validate_certs: false
 
 - tower_credential_type:
     name: Nexus

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory_source.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory_source.py
@@ -138,10 +138,11 @@ options:
         - Desired state of the resource.
       default: "present"
       choices: ["present", "absent"]
-    tower_verify_ssl:
+    validate_certs:
       description:
         - Tower option to avoid certificates check.
       type: bool
+      aliases: [ tower_verify_ssl ]
 extends_documentation_fragment: tower
 '''
 
@@ -158,7 +159,7 @@ EXAMPLES = '''
     overwrite: true
     source_vars: '{ private: false }'
     state: present
-    tower_verify_ssl: false
+    validate_certs: false
 '''
 
 

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -29,7 +29,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_foreman
             key: url
-      ssl_cert:
+      client_cert:
         description: X509 certificate to authenticate to Foreman if https is used
         env:
             - name: FOREMAN_SSL_CERT
@@ -37,7 +37,10 @@ DOCUMENTATION = '''
         ini:
           - section: callback_foreman
             key: ssl_cert
-      ssl_key:
+          - section: callback_foreman
+            key: client_cert
+        aliases: [ ssl_cert ]
+      client_key:
         description: the corresponding private key
         env:
           - name: FOREMAN_SSL_KEY
@@ -45,6 +48,9 @@ DOCUMENTATION = '''
         ini:
           - section: callback_foreman
             key: ssl_key
+          - section: callback_foreman
+            key: client_key
+        aliases: [ ssl_key ]
       verify_certs:
         description:
           - Toggle to decide whether to verify the Foreman certificate.
@@ -96,7 +102,7 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
         self.FOREMAN_URL = self.get_option('url')
-        self.FOREMAN_SSL_CERT = (self.get_option('ssl_cert'), self.get_option('ssl_key'))
+        self.FOREMAN_SSL_CERT = (self.get_option('client_cert'), self.get_option('client_key'))
         self.FOREMAN_SSL_VERIFY = str(self.get_option('verify_certs'))
 
         self.ssl_verify = self._ssl_verify()

--- a/lib/ansible/plugins/callback/grafana_annotations.py
+++ b/lib/ansible/plugins/callback/grafana_annotations.py
@@ -48,15 +48,18 @@ DOCUMENTATION = """
         ini:
           - section: callback_grafana_annotations
             key: grafana_url
-      validate_grafana_certs:
+      validate_certs:
         description: validate the SSL certificate of the Grafana server. (For HTTPS url)
         env:
           - name: GRAFANA_VALIDATE_CERT
         ini:
           - section: callback_grafana_annotations
             key: validate_grafana_certs
+          - section: callback_grafana_annotations
+            key: validate_certs
         default: True
         type: bool
+        aliases: [ validate_grafana_certs ]
       http_agent:
         description: The HTTP 'User-agent' value to set in HTTP requets.
         env:
@@ -173,7 +176,7 @@ class CallbackModule(CallbackBase):
 
         self.grafana_api_key = self.get_option('grafana_api_key')
         self.grafana_url = self.get_option('grafana_url')
-        self.validate_grafana_certs = self.get_option('validate_grafana_certs')
+        self.validate_grafana_certs = self.get_option('validate_certs')
         self.http_agent = self.get_option('http_agent')
         self.grafana_user = self.get_option('grafana_user')
         self.grafana_password = self.get_option('grafana_password')

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -25,14 +25,17 @@ DOCUMENTATION = '''
             ini:
                 - section: callback_nrdp
                   key: url
-        validate_nrdp_certs:
+        validate_certs:
             description: (bool) validate the SSL certificate of the nrdp server. (For HTTPS url)
             env:
                 - name: NRDP_VALIDATE_CERTS
             ini:
                 - section: callback_nrdp
                   key: validate_nrdp_certs
+                - section: callback_nrdp
+                  key: validate_certs
             default: False
+            aliases: [ validate_nrdp_certs ]
         token:
             description: token to be allowed to push nrdp events
             required: True
@@ -99,7 +102,7 @@ class CallbackModule(CallbackBase):
         self.token = self.get_option('token')
         self.hostname = self.get_option('hostname')
         self.servicename = self.get_option('servicename')
-        self.validate_nrdp_certs = self.get_option('validate_nrdp_certs')
+        self.validate_nrdp_certs = self.get_option('validate_certs')
 
         if (self.url or self.token or self.hostname or
                 self.servicename) is None:

--- a/lib/ansible/plugins/connection/kubectl.py
+++ b/lib/ansible/plugins/connection/kubectl.py
@@ -123,38 +123,46 @@ DOCUMENTATION = """
         env:
           - name: K8S_AUTH_TOKEN
           - name: K8S_AUTH_API_KEY
-      kubectl_cert_file:
+      client_cert:
         description:
           - Path to a certificate used to authenticate with the API.
         default: ''
         vars:
           - name: ansible_kubectl_cert_file
+          - name: ansible_kubectl_client_cert
         env:
           - name: K8S_AUTH_CERT_FILE
-      kubectl_key_file:
+        aliases: [ kubectl_cert_file ]
+      client_key:
         description:
           - Path to a key file used to authenticate with the API.
         default: ''
         vars:
           - name: ansible_kubectl_key_file
+          - name: ansible_kubectl_client_key
         env:
           - name: K8S_AUTH_KEY_FILE
-      kubectl_ssl_ca_cert:
+        aliases: [ kubectl_key_file ]
+      ca_cert:
         description:
           - Path to a CA certificate used to authenticate with the API.
         default: ''
         vars:
           - name: ansible_kubectl_ssl_ca_cert
+          - name: ansible_kubectl_ca_cert
         env:
           - name: K8S_AUTH_SSL_CA_CERT
-      kubectl_verify_ssl:
+        aliases: [ kubectl_ssl_ca_cert ]
+      validate_certs:
         description:
           - Whether or not to verify the API server's SSL certificate. Defaults to I(true).
         default: ''
         vars:
           - name: ansible_kubectl_verify_ssl
+          - name: ansible_kubectl_validate_certs
         env:
           - name: K8S_AUTH_VERIFY_SSL
+        aliases: [ kubectl_verify_ssl ]
 """
 
 import distutils.spawn
@@ -183,10 +191,10 @@ CONNECTION_OPTIONS = {
     'kubectl_host': '--server',
     'kubectl_username': '--username',
     'kubectl_password': '--password',
-    'kubectl_cert_file': '--client-certificate',
-    'kubectl_key_file': '--client-key',
-    'kubectl_ssl_ca_cert': '--certificate-authority',
-    'kubectl_verify_ssl': '--insecure-skip-tls-verify',
+    'client_cert': '--client-certificate',
+    'client_key': '--client-key',
+    'ca_cert': '--certificate-authority',
+    'validate_certs': '--insecure-skip-tls-verify',
     'kubectl_token': '--token'
 }
 

--- a/lib/ansible/plugins/connection/oc.py
+++ b/lib/ansible/plugins/connection/oc.py
@@ -106,38 +106,46 @@ DOCUMENTATION = """
         env:
           - name: K8S_AUTH_TOKEN
           - name: K8S_AUTH_API_KEY
-      oc_cert_file:
+      client_cert:
         description:
           - Path to a certificate used to authenticate with the API.
         default: ''
         vars:
           - name: ansible_oc_cert_file
+          - name: ansible_oc_client_cert
         env:
           - name: K8S_AUTH_CERT_FILE
-      oc_key_file:
+        aliases: [ oc_cert_file ]
+      client_key:
         description:
           - Path to a key file used to authenticate with the API.
         default: ''
         vars:
           - name: ansible_oc_key_file
+          - name: ansible_oc_client_key
         env:
           - name: K8S_AUTH_KEY_FILE
-      oc_ssl_ca_cert:
+        aliases: [ oc_key_file ]
+      ca_cert:
         description:
           - Path to a CA certificate used to authenticate with the API.
         default: ''
         vars:
           - name: ansible_oc_ssl_ca_cert
+          - name: ansible_oc_ca_cert
         env:
           - name: K8S_AUTH_SSL_CA_CERT
-      oc_verify_ssl:
+        aliases: [ oc_ssl_ca_cert ]
+      validate_certs:
         description:
           - Whether or not to verify the API server's SSL certificate. Defaults to I(true).
         default: ''
         vars:
           - name: ansible_oc_verify_ssl
+          - name: ansible_oc_validate_certs
         env:
           - name: K8S_AUTH_VERIFY_SSL
+        aliases: [ oc_verify_ssl ]
 """
 
 from ansible.plugins.connection.kubectl import Connection as KubectlConnection
@@ -151,10 +159,10 @@ CONNECTION_OPTIONS = {
     'oc_kubeconfig': '--config',
     'oc_context': '--context',
     'oc_host': '--server',
-    'oc_cert_file': '--client-certificate',
-    'oc_key_file': '--client-key',
-    'oc_ssl_ca_cert': '--certificate-authority',
-    'oc_verify_ssl': '--insecure-skip-tls-verify',
+    'client_cert': '--client-certificate',
+    'client_key': '--client-key',
+    'ca_cert': '--certificate-authority',
+    'validate_certs': '--insecure-skip-tls-verify',
     'oc_token': '--token'
 }
 

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -72,7 +72,7 @@ options:
     description:
     - Whether to validate the remote server's certificate or not.
     - Set to C(ignore) to not validate any certificates.
-    - I(cert_trust_path) can be set to the path of a PEM certificate chain to
+    - I(ca_cert) can be set to the path of a PEM certificate chain to
       use in the validation.
     choices:
     - validate
@@ -80,13 +80,15 @@ options:
     default: validate
     vars:
     - name: ansible_psrp_cert_validation
-  cert_trust_path:
+  ca_cert:
     description:
     - The path to a PEM certificate chain to use when validating the server's
       certificate.
     - This value is ignored if I(cert_validation) is set to C(ignore).
     vars:
     - name: ansible_psrp_cert_trust_path
+    - name: ansible_psrp_ca_cert
+    aliases: [ cert_trust_path ]
   connection_timeout:
     description:
     - The connection timeout for making the request to the remote host.
@@ -516,7 +518,7 @@ if ($bytes_read -gt 0) {
         self._psrp_auth = self.get_option('auth')
         # cert validation can either be a bool or a path to the cert
         cert_validation = self.get_option('cert_validation')
-        cert_trust_path = self.get_option('cert_trust_path')
+        cert_trust_path = self.get_option('ca_cert')
         if cert_validation == 'ignore':
             self._psrp_cert_validation = False
         elif cert_trust_path is not None:

--- a/lib/ansible/plugins/doc_fragments/docker.py
+++ b/lib/ansible/plugins/doc_fragments/docker.py
@@ -42,27 +42,27 @@ options:
               instead. If the environment variable is not set, the default value will be used.
         type: int
         default: 60
-    cacert_path:
+    ca_cert:
         description:
             - Use a CA certificate when performing server verification by providing the path to a CA certificate file.
             - If the value is not specified in the task and the environment variable C(DOCKER_CERT_PATH) is set,
               the file C(ca.pem) from the directory specified in the environment variable C(DOCKER_CERT_PATH) will be used.
         type: path
-        aliases: [ tls_ca_cert ]
-    cert_path:
+        aliases: [ tls_ca_cert, cacert_path ]
+    client_cert:
         description:
             - Path to the client's TLS certificate file.
             - If the value is not specified in the task and the environment variable C(DOCKER_CERT_PATH) is set,
               the file C(cert.pem) from the directory specified in the environment variable C(DOCKER_CERT_PATH) will be used.
         type: path
-        aliases: [ tls_client_cert ]
-    key_path:
+        aliases: [ tls_client_cert, cert_path ]
+    client_key:
         description:
             - Path to the client's TLS key file.
             - If the value is not specified in the task and the environment variable C(DOCKER_CERT_PATH) is set,
               the file C(key.pem) from the directory specified in the environment variable C(DOCKER_CERT_PATH) will be used.
         type: path
-        aliases: [ tls_client_key ]
+        aliases: [ tls_client_key, key_path ]
     ssl_version:
         description:
             - Provide a valid SSL version number. Default value determined by ssl.py module.
@@ -77,13 +77,14 @@ options:
               instead. If the environment variable is not set, the default value will be used.
         type: bool
         default: no
-    tls_verify:
+    validate_certs:
         description:
             - Secure the connection to the API by using TLS and verifying the authenticity of the Docker host server.
             - If the value is not specified in the task, the value of environment variable C(DOCKER_TLS_VERIFY) will be
               used instead. If the environment variable is not set, the default value will be used.
         type: bool
         default: no
+        aliases: [ tls_verify ]
     debug:
         description:
             - Debug mode

--- a/lib/ansible/plugins/doc_fragments/ingate.py
+++ b/lib/ansible/plugins/doc_fragments/ingate.py
@@ -46,11 +46,12 @@ options:
         description:
           - The timeout (in seconds) for REST API requests.
         type: int
-      verify_ssl:
+      validate_certs:
         description:
           - Verify the unit's HTTPS certificate.
         type: bool
         default: yes
+        aliases: [ verify_ssl ]
 notes:
   - This module requires that the Ingate Python SDK is installed on the
     host. To install the SDK use the pip command from your shell

--- a/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
+++ b/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
@@ -43,31 +43,35 @@ options:
       variable.
     - Please read the description of the C(username) option for a discussion of when this option is applicable.
     type: str
-  cert_file:
+  client_cert:
     description:
     - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE environment
       variable.
     type: path
-  key_file:
+    aliases: [ cert_file ]
+  client_key:
     description:
     - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE environment
       variable.
     type: path
-  ssl_ca_cert:
+    aliases: [ key_file ]
+  ca_cert:
     description:
     - Path to a CA certificate used to authenticate with the API. The full certificate chain must be provided to
       avoid certificate validation errors. Can also be specified via K8S_AUTH_SSL_CA_CERT environment variable.
     type: path
-  verify_ssl:
+    aliases: [ ssl_ca_cert ]
+  validate_certs:
     description:
     - Whether or not to verify the API server's SSL certificates. Can also be specified via K8S_AUTH_VERIFY_SSL
       environment variable.
     type: bool
+    aliases: [ verify_ssl ]
 notes:
   - "The OpenShift Python client wraps the K8s Python client, providing full access to
     all of the APIS and models available on both platforms. For API version details and
     additional information visit https://github.com/openshift/openshift-restclient-python"
-  - "To avoid SSL certificate validation errors when C(verify_ssl) is I(True), the full
-    certificate chain for the API server must be provided via C(ssl_ca_cert) or in the
+  - "To avoid SSL certificate validation errors when C(validate_certs) is I(True), the full
+    certificate chain for the API server must be provided via C(ca_cert) or in the
     kubeconfig file."
 '''

--- a/lib/ansible/plugins/doc_fragments/manageiq.py
+++ b/lib/ansible/plugins/doc_fragments/manageiq.py
@@ -32,15 +32,17 @@ options:
         description:
           - ManageIQ token. C(MIQ_TOKEN) env var if set. otherwise, required if no username or password is passed in.
         type: str
-      verify_ssl:
+      validate_certs:
         description:
           - Whether SSL certificates should be verified for HTTPS requests. defaults to True.
         type: bool
         default: yes
-      ca_bundle_path:
+        aliases: [ verify_ssl ]
+      ca_cert:
         description:
           - The path to a CA bundle file or directory with certificates. defaults to None.
         type: path
+        aliases: [ ca_bundle_path ]
 
 requirements:
   - 'manageiq-client U(https://github.com/ManageIQ/manageiq-api-client-python/)'

--- a/lib/ansible/plugins/doc_fragments/mysql.py
+++ b/lib/ansible/plugins/doc_fragments/mysql.py
@@ -43,22 +43,25 @@ options:
     type: path
     default: '~/.my.cnf'
     version_added: "2.0"
-  ssl_ca:
+  ca_cert:
     description:
       - The path to a Certificate Authority (CA) certificate. This option, if used, must specify the same certificate
         as used by the server.
     type: path
     version_added: "2.0"
-  ssl_cert:
+    aliases: [ ssl_ca ]
+  client_cert:
     description:
       - The path to a client public key certificate.
     type: path
     version_added: "2.0"
-  ssl_key:
+    aliases: [ ssl_cert ]
+  client_key:
     description:
       - The path to the client private key.
     type: path
     version_added: "2.0"
+    aliases: [ ssl_key ]
 requirements:
    - PyMySQL (Python 2.7 and Python 3.X), or
    - MySQLdb (Python 2.x)

--- a/lib/ansible/plugins/doc_fragments/nios.py
+++ b/lib/ansible/plugins/doc_fragments/nios.py
@@ -36,13 +36,14 @@ options:
           - Value can also be specified using C(INFOBLOX_PASSWORD) environment
             variable.
         type: str
-      ssl_verify:
+      validate_certs:
         description:
           - Boolean value to enable or disable verifying SSL certificates
           - Value can also be specified using C(INFOBLOX_SSL_VERIFY) environment
             variable.
         type: bool
         default: no
+        aliases: [ ssl_verify ]
       http_request_timeout:
         description:
           - The amount of time before to wait before receiving a response

--- a/lib/ansible/plugins/doc_fragments/openstack.py
+++ b/lib/ansible/plugins/doc_fragments/openstack.py
@@ -54,26 +54,29 @@ options:
       - How long should the socket layer wait before timing out for API calls.
         If this is omitted, nothing will be passed to the requests library.
     type: int
-  verify:
+  validate_certs:
     description:
       - Whether or not SSL API requests should be verified.
       - Before Ansible 2.3 this defaulted to C(yes).
     type: bool
     default: no
-    aliases: [ validate_certs ]
-  cacert:
+    aliases: [ verify ]
+  ca_cert:
     description:
       - A path to a CA Cert bundle that can be used as part of verifying
         SSL API requests.
     type: str
-  cert:
+    aliases: [ cacert ]
+  client_cert:
     description:
       - A path to a client certificate to use as part of the SSL transaction.
     type: str
-  key:
+    aliases: [ cert ]
+  client_key:
     description:
       - A path to a client key to use as part of the SSL transaction.
     type: str
+    aliases: [ key ]
   interface:
     description:
         - Endpoint URL type to fetch from the service catalog.

--- a/lib/ansible/plugins/doc_fragments/postgres.py
+++ b/lib/ansible/plugins/doc_fragments/postgres.py
@@ -38,18 +38,19 @@ options:
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     version_added: '2.3'
-  ssl_rootcert:
+  ca_cert:
     description:
       - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
       - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     type: str
     version_added: '2.3'
+    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
 - This module uses I(psycopg2), a Python PostgreSQL database adapter. You must ensure that psycopg2 is installed on
   the host before using this module. If the remote host is the PostgreSQL server (which is the default case), then
   PostgreSQL must also be installed on the remote host. For Ubuntu-based systems, install the C(postgresql), C(libpq-dev),
   and C(python-psycopg2) packages on the remote host before using this module.
-- The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
+- The ca_cert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
 requirements: [ psycopg2 ]
 '''

--- a/lib/ansible/plugins/doc_fragments/rabbitmq.py
+++ b/lib/ansible/plugins/doc_fragments/rabbitmq.py
@@ -34,21 +34,24 @@ options:
         choices: [ http , https ]
         default: http
         version_added: "2.3"
-    cacert:
+    ca_cert:
         description:
             - CA certificate to verify SSL connection to management API.
         type: path
         version_added: "2.3"
-    cert:
+        aliases: [ cacert ]
+    client_cert:
         description:
             - Client certificate to send on SSL connections to management API.
         type: path
         version_added: "2.3"
-    key:
+        aliases: [ cert ]
+    client_key:
         description:
             - Private key matching the client certificate.
         type: path
         version_added: "2.3"
+        aliases: [ key ]
     vhost:
         description:
             - RabbitMQ virtual host.

--- a/lib/ansible/plugins/doc_fragments/rackspace.py
+++ b/lib/ansible/plugins/doc_fragments/rackspace.py
@@ -35,11 +35,12 @@ options:
     description:
       - Rackspace username, overrides I(credentials).
     type: str
-  verify_ssl:
+  validate_certs:
     description:
       - Whether or not to require SSL validation of API endpoints.
     type: bool
     version_added: '1.5'
+    aliases: [ verify_ssl ]
 requirements:
   - python >= 2.6
   - pyrax
@@ -95,11 +96,12 @@ options:
   username:
     description:
       - Rackspace username, overrides I(credentials).
-  verify_ssl:
+  validate_certs:
     description:
       - Whether or not to require SSL validation of API endpoints.
     version_added: '1.5'
     type: bool
+    aliases: [ verify_ssl ]
 requirements:
   - python >= 2.6
   - pyrax

--- a/lib/ansible/plugins/doc_fragments/tower.py
+++ b/lib/ansible/plugins/doc_fragments/tower.py
@@ -21,12 +21,13 @@ options:
     description:
     - Password for your Tower instance.
     type: str
-  tower_verify_ssl:
+  validate_certs:
     description:
     - Whether to allow insecure connections to Tower.
     - If C(no), SSL certificates will not be validated.
     - This should only be used on personally controlled sites using self-signed certificates.
     type: bool
+    aliases: [ tower_verify_ssl ]
   tower_config_file:
     description:
     - Path to the Tower config file.

--- a/lib/ansible/plugins/doc_fragments/vca.py
+++ b/lib/ansible/plugins/doc_fragments/vca.py
@@ -48,11 +48,12 @@ options:
       type: str
       choices: [ absent, present ]
       default: present
-    verify_certs:
+    validate_certs:
       description:
         - If the certificates of the authentication is to be verified.
       type: bool
       default: yes
+      aliases: [ verify_certs ]
     vdc_name:
       description:
         - The name of the vdc where the gateway is located.

--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -48,24 +48,25 @@ DOCUMENTATION = '''
             description: Connect using TLS without verifying the authenticity of the Docker host server.
             type: bool
             default: no
-        tls_verify:
+        validate_certs:
             description: Toggle if connecting using TLS with or without verifying the authenticity of the Docker
                          host server.
             type: bool
             default: no
-        key_path:
+            aliases: [ tls_verify ]
+        client_key:
             description: Path to the client's TLS key file.
             type: path
-            aliases: [ tls_client_key ]
-        cacert_path:
+            aliases: [ tls_client_key, key_path ]
+        ca_cert:
             description: Use a CA certificate when performing server verification by providing the path to a CA
                          certificate file.
             type: path
-            aliases: [ tls_ca_cert ]
-        cert_path:
+            aliases: [ tls_ca_cert, cacert_path ]
+        client_cert:
             description: Path to the client's TLS certificate file.
             type: path
-            aliases: [ tls_client_cert ]
+            aliases: [ tls_client_cert, cert_path ]
         tls_hostname:
             description: When verifying the authenticity of the Docker host server, provide the expected name of
                          the server.
@@ -116,10 +117,10 @@ tls: yes
 # Example using remote docker with verified TLS and client certificate verification
 plugin: docker_swarm
 docker_host: tcp://my-docker-host:2376
-tls_verify: yes
-cacert_path: /somewhere/ca.pem
-key_path: /somewhere/key.pem
-cert_path: /somewhere/cert.pem
+validate_certs: yes
+ca_cert: /somewhere/ca.pem
+client_key: /somewhere/key.pem
+client_cert: /somewhere/cert.pem
 
 # Example using constructed features to create groups and set ansible_host
 plugin: docker_swarm
@@ -164,10 +165,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         raw_params = dict(
             docker_host=self.get_option('docker_host'),
             tls=self.get_option('tls'),
-            tls_verify=self.get_option('tls_verify'),
-            key_path=self.get_option('key_path'),
-            cacert_path=self.get_option('cacert_path'),
-            cert_path=self.get_option('cert_path'),
+            tls_verify=self.get_option('validate_certs'),
+            key_path=self.get_option('client_key'),
+            cacert_path=self.get_option('ca_cert'),
+            cert_path=self.get_option('client_cert'),
             tls_hostname=self.get_option('tls_hostname'),
             api_version=self.get_option('api_version'),
             timeout=self.get_option('timeout'),
@@ -186,7 +187,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         if self.get_option('include_host_uri'):
             if self.get_option('include_host_uri_port'):
                 host_uri_port = str(self.get_option('include_host_uri_port'))
-            elif self.get_option('tls') or self.get_option('tls_verify'):
+            elif self.get_option('tls') or self.get_option('validate_certs'):
                 host_uri_port = '2376'
             else:
                 host_uri_port = '2375'

--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -57,23 +57,27 @@ DOCUMENTATION = '''
               description:
               - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD
                 environment variable.
-          cert_file:
+          client_cert:
               description:
               - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE
                 environment variable.
-          key_file:
+              aliases: [ cert_file ]
+          client_key:
               description:
               - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
                 environment variable.
-          ssl_ca_cert:
+              aliases: [ key_file ]
+          ca_cert:
               description:
               - Path to a CA certificate used to authenticate with the API. Can also be specified via
                 K8S_AUTH_SSL_CA_CERT environment variable.
-          verify_ssl:
+              aliases: [ ssl_ca_cert ]
+          validate_certs:
               description:
               - "Whether or not to verify the API server's SSL certificates. Can also be specified via
                 K8S_AUTH_VERIFY_SSL environment variable."
               type: bool
+              aliases: [ verify_ssl ]
           namespaces:
               description:
               - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized
@@ -93,7 +97,7 @@ plugin: k8s
 connections:
     host: https://192.168.64.4:8443
     token: xxxxxxxxxxxxxxxx
-    ssl_verify: false
+    validate_certs: false
 
 # Use default config (~/.kube/config) file and active context, and return objects for a specific namespace
 plugin: k8s

--- a/lib/ansible/plugins/inventory/openshift.py
+++ b/lib/ansible/plugins/inventory/openshift.py
@@ -57,23 +57,27 @@ DOCUMENTATION = '''
               description:
               - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD
                 environment variable.
-          cert_file:
+          client_cert:
               description:
               - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE
                 environment variable.
-          key_file:
+              aliases: [ cert_file ]
+          client_key:
               description:
               - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
                 environment variable.
-          ssl_ca_cert:
+              aliases: [ key_file ]
+          ca_cert:
               description:
               - Path to a CA certificate used to authenticate with the API. Can also be specified via
                 K8S_AUTH_SSL_CA_CERT environment variable.
-          verify_ssl:
+              aliases: [ ssl_ca_cert ]
+          validate_certs:
               description:
               - "Whether or not to verify the API server's SSL certificates. Can also be specified via
                 K8S_AUTH_VERIFY_SSL environment variable."
               type: bool
+              aliases: [ verify_ssl ]
           namespaces:
               description:
               - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized

--- a/lib/ansible/plugins/inventory/tower.py
+++ b/lib/ansible/plugins/inventory/tower.py
@@ -52,13 +52,14 @@ DOCUMENTATION = '''
             env:
                 - name: TOWER_INVENTORY
             required: True
-        verify_ssl:
+        validate_certs:
             description: Specify whether Ansible should verify the SSL certificate of Ansible Tower host.
             type: bool
             default: True
             env:
                 - name: TOWER_VERIFY_SSL
             required: False
+            aliases: [ verify_ssl ]
         include_metadata:
             description: Make extra requests to provide all group vars with metadata about the source Ansible Tower host.
             type: bool
@@ -156,7 +157,7 @@ class InventoryModule(BaseInventoryPlugin):
         request_handler = Request(url_username=self.get_option('username'),
                                   url_password=self.get_option('password'),
                                   force_basic_auth=True,
-                                  validate_certs=self.get_option('verify_ssl'))
+                                  validate_certs=self.get_option('validate_certs'))
 
         inventory_id = self.get_option('inventory_id').replace('/', '')
         inventory_url = '/api/v2/inventories/{inv_id}/script/?hostvars=1&towervars=1&all=1'.format(inv_id=inventory_id)

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -54,8 +54,9 @@ DOCUMENTATION = """
     mount_point:
       description: vault mount point, only required if you have a custom mount point.
       default: ldap
-    cacert:
+    ca_cert:
       description: path to certificate to use for authentication.
+      aliases: [ cacert ]
     validate_certs:
       description: controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
       type: boolean
@@ -266,6 +267,10 @@ class LookupModule(LookupBase):
             except ValueError:
                 raise AnsibleError("hashi_vault lookup plugin needs key=value pairs, but received %s" % terms)
             vault_dict[key] = value
+
+        if 'ca_cert' in vault_dict.keys():
+            vault_dict['cacert'] = vault_dict['ca_cert']
+            vault_dict.pop('ca_cert', None)
 
         vault_conn = HashiVault(**vault_dict)
 

--- a/lib/ansible/plugins/lookup/k8s.py
+++ b/lib/ansible/plugins/lookup/k8s.py
@@ -98,24 +98,28 @@ DOCUMENTATION = """
         description:
         - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD environment
           variable.
-      cert_file:
+      client_cert:
         description:
         - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE
           environment
           variable.
-      key_file:
+        aliases: [ cert_file ]
+      client_key:
         description:
         - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE environment
           variable.
-      ssl_ca_cert:
+        aliases: [ key_file ]
+      ca_cert:
         description:
         - Path to a CA certificate used to authenticate with the API. Can also be specified via K8S_AUTH_SSL_CA_CERT
           environment variable.
-      verify_ssl:
+        aliases: [ ssl_ca_cert ]
+      validate_certs:
         description:
         - Whether or not to verify the API server's SSL certificates. Can also be specified via K8S_AUTH_VERIFY_SSL
           environment variable.
         type: bool
+        aliases: [ verify_ssl ]
 
     requirements:
       - "python >= 2.7"

--- a/lib/ansible/plugins/lookup/laps_password.py
+++ b/lib/ansible/plugins/lookup/laps_password.py
@@ -40,13 +40,14 @@ options:
     - gssapi
     default: gssapi
     type: str
-  cacert_file:
+  ca_cert:
     description:
     - The path to a CA certificate PEM file to use for certificate validation.
     - Certificate validation is used when C(scheme=ldaps) or C(start_tls=yes).
     - This may fail on hosts with an older OpenLDAP install like MacOS, this will have to be updated before
       reinstalling python-ldap to get working again.
     type: str
+    aliases: [ cacert_file ]
   domain:
     description:
     - The domain to search in to retrieve the LAPS password.
@@ -173,7 +174,7 @@ EXAMPLES = """
     ansible_password: "{{ lookup('laps_password', 'windows-pc',
                                  domain='dc01.ansible.com',
                                  start_tls=True,
-                                 cacert_file='/usr/local/share/certs/ad.pem') }}"
+                                 ca_cert='/usr/local/share/certs/ad.pem') }}"
 """
 
 RETURN = """
@@ -243,7 +244,7 @@ class LookupModule(LookupBase):
         scheme = self.get_option('scheme')
         start_tls = self.get_option('start_tls')
         validate_certs = self.get_option('validate_certs')
-        cacert_file = self.get_option('cacert_file')
+        cacert_file = self.get_option('ca_cert')
         search_base = self.get_option('search_base')
         username = self.get_option('username')
         password = self.get_option('password')

--- a/test/integration/targets/get_certificate/tests/validate.yml
+++ b/test/integration/targets/get_certificate/tests/validate.yml
@@ -56,7 +56,7 @@
       - result is not changed
       - result is failed
       # We got the correct response from the module
-      - "'ca_certs file does not exist' == result.msg"
+      - "'ca_cert file does not exist' == result.msg"
 
 - name: Download CA Cert as pem from server
   get_url:

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -17,7 +17,7 @@
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'url=https://localhost:8201 cacert={{ local_temp_dir }}/cert.pem validate_certs=True '
+        conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True '
 
     - name: 'test {{ auth_type }} auth with certs (validation enabled, environment variables)'
       include_tasks: '{{ auth_type }}_test.yml'

--- a/test/integration/targets/tower_user/tasks/main.yml
+++ b/test/integration/targets/tower_user/tasks/main.yml
@@ -83,7 +83,7 @@
     password: "{{ 65535 | random | to_uuid }}"
     email: joe@example.org
     state: present
-    tower_verify_ssl: true
+    validate_certs: true
     tower_host: http://foo.invalid
   ignore_errors: true
   register: result

--- a/test/integration/targets/tower_workflow_launch/tests/validate.yml
+++ b/test/integration/targets/tower_workflow_launch/tests/validate.yml
@@ -1,6 +1,6 @@
 - name: Run a workflow with no parameters
   tower_workflow_launch:
-    tower_verify_ssl: False
+    validate_certs: False
   ignore_errors: true
   register: result1
 
@@ -12,7 +12,7 @@
 - name: Fail no connect to Tower server
   tower_workflow_launch:
     tower_host: 127.0.0.1:22
-    tower_verify_ssl: False
+    validate_certs: False
     workflow_template: "Here"
   ignore_errors: True
   register: result2
@@ -24,7 +24,7 @@
 
 - name: Connect to Tower server but request an invalid workflow
   tower_workflow_launch:
-    tower_verify_ssl: False
+    validate_certs: False
     workflow_template: "Does Not Exist"
   ignore_errors: true
   register: result3
@@ -36,7 +36,7 @@
 
 - name: Connect to Tower in check_mode with a valid workflow name
   tower_workflow_launch:
-    tower_verify_ssl: False
+    validate_certs: False
     workflow_template: "Success Workflow"
   check_mode: True
   ignore_errors: true
@@ -49,7 +49,7 @@
 
 - name: Connect to Tower in check_mode with a valid workflow id
   tower_workflow_launch:
-    tower_verify_ssl: False
+    validate_certs: False
     workflow_template: 9999999
   check_mode: True
   ignore_errors: true
@@ -62,7 +62,7 @@
 
 - name: Run the workflow without waiting (this should just give us back a job ID)
   tower_workflow_launch:
-    tower_verify_ssl: False
+    validate_certs: False
     workflow_template: "Success Workflow"
     wait: False
   ignore_errors: True
@@ -75,7 +75,7 @@
 
 - name: Kick off a workflow and wait for it
   tower_workflow_launch:
-    tower_verify_ssl: False
+    validate_certs: False
     workflow_template: "Success Workflow"
   ignore_errors: True
   register: result7
@@ -87,7 +87,7 @@
 
 - name: Kick off a workflow and wait for it, but only for a second
   tower_workflow_launch:
-    tower_verify_ssl: False
+    validate_certs: False
     workflow_template: "Success Workflow"
     timeout: 1
   ignore_errors: True

--- a/test/units/module_utils/net_tools/nios/test_api.py
+++ b/test/units/module_utils/net_tools/nios/test_api.py
@@ -30,7 +30,7 @@ class TestNiosApi(unittest.TestCase):
         self.mock_connector.stop()
 
     def test_get_provider_spec(self):
-        provider_options = ['host', 'username', 'password', 'ssl_verify', 'silent_ssl_warnings',
+        provider_options = ['host', 'username', 'password', 'validate_certs', 'silent_ssl_warnings',
                             'http_request_timeout', 'http_pool_connections',
                             'http_pool_maxsize', 'max_retries', 'wapi_version', 'max_results']
         res = api.WapiBase.provider_spec

--- a/test/units/modules/network/radware/test_vdirect_commit.py
+++ b/test/units/modules/network/radware/test_vdirect_commit.py
@@ -26,7 +26,7 @@ from units.compat.mock import patch
 BASE_PARAMS = {'vdirect_ip': None, 'vdirect_user': None, 'vdirect_password': None,
                'vdirect_wait': None, 'vdirect_secondary_ip': None,
                'vdirect_https_port': None, 'vdirect_http_port': None,
-               'vdirect_timeout': None, 'vdirect_use_ssl': None, 'vdirect_validate_certs': None}
+               'vdirect_timeout': None, 'vdirect_use_ssl': None, 'validate_certs': None}
 
 COMMIT_PARAMS = {'devices': ['adc', 'defensepro', 'vx', 'appwall'], 'apply': True, 'save': True, 'sync': True}
 

--- a/test/units/modules/network/radware/test_vdirect_file.py
+++ b/test/units/modules/network/radware/test_vdirect_file.py
@@ -31,7 +31,7 @@ RESP_DATA = 3
 NONE_PARAMS = {'vdirect_ip': None, 'vdirect_user': None, 'vdirect_password': None,
                'vdirect_wait': None, 'vdirect_secondary_ip': None,
                'vdirect_https_port': None, 'vdirect_http_port': None,
-               'vdirect_timeout': None, 'vdirect_use_ssl': None, 'vdirect_validate_certs': None}
+               'vdirect_timeout': None, 'vdirect_use_ssl': None, 'validate_certs': None}
 
 
 @patch('vdirect_client.rest_client.RestClient')

--- a/test/units/modules/network/radware/test_vdirect_runnable.py
+++ b/test/units/modules/network/radware/test_vdirect_runnable.py
@@ -26,7 +26,7 @@ from units.compat.mock import patch
 BASE_PARAMS = {'vdirect_ip': None, 'vdirect_user': None, 'vdirect_password': None,
                'vdirect_wait': None, 'vdirect_secondary_ip': None,
                'vdirect_https_port': None, 'vdirect_http_port': None,
-               'vdirect_timeout': None, 'vdirect_use_ssl': None, 'vdirect_validate_certs': None}
+               'vdirect_timeout': None, 'vdirect_use_ssl': None, 'validate_certs': None}
 
 RUNNABLE_PARAMS = {'runnable_type': 'ConfigurationTemplate', 'runnable_name': 'runnable',
                    'action_name': None, 'parameters': None}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There are are a variety of options for TLS connection options and settings.  These should be standardized:
- `client_cert`: certificate for client identity, might also include the private key
- `client_key`: private key for `client_cert`
- `ca_cert`: public key to validate server's identity, usually a root certificate
- `validate_certs`: boolean to enable or disable certificate validity checking

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes https://github.com/ansible/ansible/issues/52506

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
