### PR TITLE
fix remove_orphans using APIs exposed via AnsibleDockerClient

### DIFF
--- a/changelogs/fragments/26937-fix-remove-orphans.yml
+++ b/changelogs/fragments/26937-fix-remove-orphans.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_compose - fixed an issue where remove_orphans doesn't work reliably

--- a/changelogs/fragments/26937-fix-remove-orphans.yml
+++ b/changelogs/fragments/26937-fix-remove-orphans.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - docker_compose - fixed an issue where remove_orphans doesn't work reliably
+  - docker_compose - fixed an issue where ``remove_orphans`` doesn't work reliably.

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -732,7 +732,7 @@ class ContainerManager(DockerBaseClass):
             def _findOrphans():
                 for container in containers:
                     # service_name = ctnr.labels.get(LABEL_SERVICE)
-                    service_name = container['Labels'][LABEL_SERVICE]
+                    service_name = container.get('Labels', {}).get(LABEL_SERVICE)
                     if service_name not in self.project.service_names:
                         yield container
 

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -463,7 +463,7 @@ try:
     from compose.cli.command import project_from_options
     from compose.service import NoSuchImageError
     from compose.cli.main import convergence_strategy_from_opts, build_action_from_opts, image_type_from_opt
-    from compose.const import DEFAULT_TIMEOUT
+    from compose.const import DEFAULT_TIMEOUT, LABEL_SERVICE, LABEL_PROJECT, LABEL_ONE_OFF
     HAS_COMPOSE = True
     HAS_COMPOSE_EXC = None
     MINIMUM_COMPOSE_VERSION = '1.7.0'
@@ -716,6 +716,29 @@ class ContainerManager(DockerBaseClass):
             build_output = self.cmd_build()
             result['changed'] = build_output['changed']
             result['actions'] += build_output['actions']
+
+        if self.remove_orphans:
+            # containers = list(filter(None, [
+            #     Container.from_ps(self.project.client, container)
+            #     for container in self.project.client.containers(
+            #         all=False,
+            #         filters={'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name), '{0}={1}'.format(LABEL_ONE_OFF, "False")]})])
+            # )
+
+            containers = self.client.containers(
+                filters={'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name), '{0}={1}'.format(LABEL_ONE_OFF, "False")]}
+            )
+            
+            def _findOrphans():
+                for container in containers:
+                    # service_name = ctnr.labels.get(LABEL_SERVICE)
+                    service_name = container['Labels'][LABEL_SERVICE]
+                    if service_name not in self.project.service_names:
+                        yield container
+                    
+            orphans = list(_findOrphans())
+            if orphans:
+              result['changed'] = True
 
         for service in self.project.services:
             if not service_names or service.name in service_names:

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -718,20 +718,12 @@ class ContainerManager(DockerBaseClass):
             result['actions'] += build_output['actions']
 
         if self.remove_orphans:
-            # containers = list(filter(None, [
-            #     Container.from_ps(self.project.client, container)
-            #     for container in self.project.client.containers(
-            #         all=False,
-            #         filters={'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name), '{0}={1}'.format(LABEL_ONE_OFF, "False")]})])
-            # )
-
             containers = self.client.containers(
                 filters={'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name), '{0}={1}'.format(LABEL_ONE_OFF, "False")]}
             )
 
             def _findOrphans():
                 for container in containers:
-                    # service_name = ctnr.labels.get(LABEL_SERVICE)
                     service_name = container.get('Labels', {}).get(LABEL_SERVICE)
                     if service_name not in self.project.service_names:
                         yield container

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -735,11 +735,11 @@ class ContainerManager(DockerBaseClass):
                     service_name = container['Labels'][LABEL_SERVICE]
                     if service_name not in self.project.service_names:
                         yield container
-                    
+
             orphans = list(_findOrphans())
             if orphans:
-              result['changed'] = True
-
+                result['changed'] = True
+        
         for service in self.project.services:
             if not service_names or service.name in service_names:
                 plan = service.convergence_plan(strategy=converge)

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -728,7 +728,7 @@ class ContainerManager(DockerBaseClass):
             containers = self.client.containers(
                 filters={'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name), '{0}={1}'.format(LABEL_ONE_OFF, "False")]}
             )
-            
+
             def _findOrphans():
                 for container in containers:
                     # service_name = ctnr.labels.get(LABEL_SERVICE)
@@ -739,7 +739,7 @@ class ContainerManager(DockerBaseClass):
             orphans = list(_findOrphans())
             if orphans:
                 result['changed'] = True
-        
+
         for service in self.project.services:
             if not service_names or service.name in service_names:
                 plan = service.convergence_plan(strategy=converge)

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -720,8 +720,10 @@ class ContainerManager(DockerBaseClass):
         if self.remove_orphans:
             containers = self.client.containers(
                 filters={
-                    'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name),
-                    '{0}={1}'.format(LABEL_ONE_OFF, "False")],
+                    'label': [
+                        '{0}={1}'.format(LABEL_PROJECT, self.project.name),
+                        '{0}={1}'.format(LABEL_ONE_OFF, "False")
+                    ],
                 }
             )
 

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -719,7 +719,10 @@ class ContainerManager(DockerBaseClass):
 
         if self.remove_orphans:
             containers = self.client.containers(
-                filters={'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name), '{0}={1}'.format(LABEL_ONE_OFF, "False")]}
+                filters={
+                    'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name),
+                    '{0}={1}'.format(LABEL_ONE_OFF, "False")],
+                }
             )
 
             def _findOrphans():

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -727,13 +727,12 @@ class ContainerManager(DockerBaseClass):
                 }
             )
 
-            def _findOrphans():
-                for container in containers:
-                    service_name = container.get('Labels', {}).get(LABEL_SERVICE)
-                    if service_name not in self.project.service_names:
-                        yield container
+            orphans = []
+            for container in containers:
+                service_name = container.get('Labels', {}).get(LABEL_SERVICE)
+                if service_name not in self.project.service_names:
+                    orphans.append(service_name)
 
-            orphans = list(_findOrphans())
             if orphans:
                 result['changed'] = True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix remove_orphans by using the low-level API exposed by the AnsibleDockerClient to determine if there are any orphaned containers. If there are, `result['changed']` is set to `True`. This causes self.project.up() to run, which successfully removes the orphan containers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #26937
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_compose

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
