### PR TITLE
fix remove_orphans using compose.container API

### DIFF
--- a/changelogs/fragments/26937-fix-remove-orphans.yml
+++ b/changelogs/fragments/26937-fix-remove-orphans.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_compose - fixed an issue where remove_orphans doesn't work reliably

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -731,10 +731,10 @@ class ContainerManager(DockerBaseClass):
                     service_name = container.labels.get(LABEL_SERVICE)
                     if service_name not in self.project.service_names:
                         yield container
-                    
+
             orphans = list(_findOrphans())
             if orphans:
-              result['changed'] = True
+                result['changed'] = True
 
         for service in self.project.services:
             if not service_names or service.name in service_names:

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -723,8 +723,12 @@ class ContainerManager(DockerBaseClass):
                 Container.from_ps(self.project.client, container)
                 for container in self.project.client.containers(
                     all=False,
-                    filters={'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name), '{0}={1}'.format(LABEL_ONE_OFF, "False")]})])
-            )
+                    filters={
+                        'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name),
+                        '{0}={1}'.format(LABEL_ONE_OFF, "False")],
+                    }
+                )
+            ]))
 
             def _findOrphans():
                 for container in containers:

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -724,8 +724,10 @@ class ContainerManager(DockerBaseClass):
                 for container in self.project.client.containers(
                     all=False,
                     filters={
-                        'label': ['{0}={1}'.format(LABEL_PROJECT, self.project.name),
-                        '{0}={1}'.format(LABEL_ONE_OFF, "False")],
+                        'label': [
+                            '{0}={1}'.format(LABEL_PROJECT, self.project.name),
+                            '{0}={1}'.format(LABEL_ONE_OFF, "False")
+                        ],
                     }
                 )
             ]))

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -732,13 +732,12 @@ class ContainerManager(DockerBaseClass):
                 )
             ]))
 
-            def _findOrphans():
-                for container in containers:
-                    service_name = container.labels.get(LABEL_SERVICE)
-                    if service_name not in self.project.service_names:
-                        yield container
+            orphans = []
+            for container in containers:
+                service_name = container.labels.get(LABEL_SERVICE)
+                if service_name not in self.project.service_names:
+                    orphans.append(service_name)
 
-            orphans = list(_findOrphans())
             if orphans:
                 result['changed'] = True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix remove_orphans by using the high-level API exposed by `compose.container` to determine if there are any orphaned containers. If there are, `result['changed']` is set to `True`. This causes `self.project.up()` to run, which successfully removes the orphan containers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #26937
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_compose

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
