### PR TITLE
remove ansible_facts added by mistake

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan_facts.py
@@ -142,7 +142,6 @@ class AzureRMAppServicePlanFacts(AzureRMModuleBase):
         )
 
         self.results = dict(changed=False)
-        )
 
         self.name = None
         self.resource_group = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan_facts.py
@@ -141,9 +141,7 @@ class AzureRMAppServicePlanFacts(AzureRMModuleBase):
             tags=dict(type='list')
         )
 
-        self.results = dict(
-            changed=False,
-            ansible_facts=dict(azure_appserviceplans=[])
+        self.results = dict(changed=False)
         )
 
         self.name = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_mariadbconfiguration_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_mariadbconfiguration_facts.py
@@ -125,10 +125,7 @@ class AzureRMMariaDbConfigurationFacts(AzureRMModuleBase):
             )
         )
         # store the results of the module operation
-        self.results = dict(
-            changed=False,
-            ansible_facts=dict()
-        )
+        self.results = dict(changed=False)
         self.mgmt_client = None
         self.resource_group = None
         self.server_name = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_mysqlconfiguration_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_mysqlconfiguration_facts.py
@@ -123,10 +123,7 @@ class AzureRMMySqlConfigurationFacts(AzureRMModuleBase):
             )
         )
         # store the results of the module operation
-        self.results = dict(
-            changed=False,
-            ansible_facts=dict()
-        )
+        self.results = dict(changed=False)
         self.mgmt_client = None
         self.resource_group = None
         self.server_name = None


### PR DESCRIPTION
##### SUMMARY
Removed ansible_facts which is returned but not documented in these modules.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_appserviceplan_facts
azure_rm_mariadbconfiguration_facts
azure_rm_mysqlconfiguration_facts

##### ADDITIONAL INFORMATION
