### PR TITLE
vyos_config support comment lines

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -221,10 +221,13 @@ def diff_config(commands, config):
     for line in commands:
         item = str(line).replace("'", '')
 
-        if not item.startswith('set') and not item.startswith('delete'):
-            raise ValueError('line must start with either `set` or `delete`')
+        if not item.startswith('set') and not item.startswith('delete') and not item.startswith('comment'):
+            raise ValueError('line must start with either `set`, `delete` or `comment`')
 
         elif item.startswith('set') and item not in config:
+            updates.append(line)
+
+        elif item.startswith('comment'):
             updates.append(line)
 
         elif item.startswith('delete'):


### PR DESCRIPTION
##### SUMMARY
- Fixes #53920 
- Support passing `comment` lines through `vyos_config`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vyos_config.py