### PR TITLE
Fix netconf plugin dispatch response

### DIFF
--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -211,7 +211,7 @@ class NetconfBase(AnsiblePlugin):
             raise ValueError('rpc_command value must be provided')
         req = fromstring(rpc_command)
         resp = self.m.dispatch(req, source=source, filter=filter)
-        return resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+        return resp.data_xml if resp.data_ele else resp.xml
 
     @ensure_connected
     def lock(self, target="candidate"):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #53236

*  If dispatch() rpc response has data element
   return the xml string from `<data>` element
   else return the complete xml string from
   `<rpc-reply>`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_rpc
plugins/netconf/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
