### PR TITLE
win_domain_user: add retry logic for null user principal group

### DIFF
--- a/changelogs/fragments/win_domain_user-group-missing.yaml
+++ b/changelogs/fragments/win_domain_user-group-missing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_user - Better handle cases when getting a new user's groups fail - https://github.com/ansible/ansible/issues/54331

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -128,7 +128,7 @@ if ($null -ne $domain_server) {
 Function Get-PrincipalGroups {
     Param (identity, $args_extra)
     try{
-        $groups = Get-ADPrincipalGroupMembership -Identity $identity @args_extra -ErrorAction SilentlyContinue
+        $groups = Get-ADPrincipalGroupMembership -Identity $identity @args_extra -ErrorAction Stop
     } catch {
         Add-Warning -obj $result -message "Failed to enumerate user groups but continuing on.: $($_.Exception.Message)"
         return @()

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -126,7 +126,7 @@ if ($null -ne $domain_server) {
 }
 
 Function Get-PrincipalGroups {
-    Param (identity, $args_extra)
+    Param ($identity, $args_extra)
     try{
         $groups = Get-ADPrincipalGroupMembership -Identity $identity @args_extra -ErrorAction Stop
     } catch {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Active Directory Principal Group could be read null when created  while AD global catalogue is replicated. This patch adds retry logic to avoid raising a exception inside `win_domain_user` module when retrieving information with `Get-ADPrincipalGroupMembership`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #54331 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change 
```paste below

```
-->
Just works.