### PR TITLE
cs_instance_facts: add a "nic" fact to return VM networking information

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -184,6 +184,72 @@ volumes:
   returned: success
   type: list
   sample: '[ { name: "ROOT-1369", type: "ROOT", size: 10737418240 }, { name: "data01, type: "DATADISK", size: 10737418240 } ]'
+nic:
+  description: List of dictionaries of the instance nics
+  returned: success
+  type: complex
+  version_added: '2.8'
+  contains:
+    broadcasturi:
+      description: The broadcast uri of the nic
+      returned: success
+      type: str
+      sample: vlan://2250
+    gateway:
+      description: The gateway of the nic
+      returned: success
+      type: str
+      sample: 10.1.2.1
+    id:
+      description: The ID of the nic
+      returned: success
+      type: str
+      sample: 5dc74fa3-2ec3-48a0-9e0d-6f43365336a9
+    ipaddress:
+      description: The ip address of the nic
+      returned: success
+      type: str
+      sample: 10.1.2.3
+    isdefault:
+      description: True if nic is default, false otherwise
+      returned: success
+      type: bool
+      sample: true
+    isolationuri:
+      description: The isolation uri of the nic
+      returned: success
+      type: str
+      sample: vlan://2250
+    macaddress:
+      description: The mac address of the nic
+      returned: success
+      type: str
+      sample: 06:a2:03:00:08:12
+    netmask:
+      description: The netmask of the nic
+      returned: success
+      type: str
+      sample: 255.255.255.0
+    networkid:
+      description: The ID of the corresponding network
+      returned: success
+      type: str
+      sample: 432ce27b-c2bb-4e12-a88c-a919cd3a3017
+    networkname:
+      description: The name of the corresponding network
+      returned: success
+      type: str
+      sample: network1
+    traffictype:
+      description: The traffic type of the nic
+      returned: success
+      type: str
+      sample: Guest
+    type:
+      description: The type of the network
+      returned: success
+      type: str
+      sample: Shared
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -272,6 +338,7 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
                 for nic in instance['nic']:
                     if nic['isdefault'] and 'ipaddress' in nic:
                         self.result['default_ip'] = nic['ipaddress']
+                self.result['nic'] = instance['nic']
             volumes = self.get_volumes(instance)
             if volumes:
                 self.result['volumes'] = volumes

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -185,68 +185,68 @@ volumes:
   type: list
   sample: '[ { name: "ROOT-1369", type: "ROOT", size: 10737418240 }, { name: "data01, type: "DATADISK", size: 10737418240 } ]'
 nic:
-  description: List of dictionaries of the instance nics
+  description: List of dictionaries of the instance nics.
   returned: success
   type: complex
   version_added: '2.8'
   contains:
     broadcasturi:
-      description: The broadcast uri of the nic
+      description: The broadcast uri of the nic.
       returned: success
       type: str
       sample: vlan://2250
     gateway:
-      description: The gateway of the nic
+      description: The gateway of the nic.
       returned: success
       type: str
       sample: 10.1.2.1
     id:
-      description: The ID of the nic
+      description: The ID of the nic.
       returned: success
       type: str
       sample: 5dc74fa3-2ec3-48a0-9e0d-6f43365336a9
     ipaddress:
-      description: The ip address of the nic
+      description: The ip address of the nic.
       returned: success
       type: str
       sample: 10.1.2.3
     isdefault:
-      description: True if nic is default, false otherwise
+      description: True if nic is default, false otherwise.
       returned: success
       type: bool
       sample: true
     isolationuri:
-      description: The isolation uri of the nic
+      description: The isolation uri of the nic.
       returned: success
       type: str
       sample: vlan://2250
     macaddress:
-      description: The mac address of the nic
+      description: The mac address of the nic.
       returned: success
       type: str
       sample: 06:a2:03:00:08:12
     netmask:
-      description: The netmask of the nic
+      description: The netmask of the nic.
       returned: success
       type: str
       sample: 255.255.255.0
     networkid:
-      description: The ID of the corresponding network
+      description: The ID of the corresponding network.
       returned: success
       type: str
       sample: 432ce27b-c2bb-4e12-a88c-a919cd3a3017
     networkname:
-      description: The name of the corresponding network
+      description: The name of the corresponding network.
       returned: success
       type: str
       sample: network1
     traffictype:
-      description: The traffic type of the nic
+      description: The traffic type of the nic.
       returned: success
       type: str
       sample: Guest
     type:
-      description: The type of the network
+      description: The type of the network.
       returned: success
       type: str
       sample: Shared


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a "nic" fact to `cs_instance_facts` that returns detailed VM networking information.

It could be useful on cross-cluster or cross-zone migration scenarios and to help setup advanced network on VMs using offers without DHCP such as "QuickCloudNoServices".
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cs_instance_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example of additional information returned with this change below.

This is the raw return of the Cloudstack API, the parameters could also be rewritten to conform with the usual module nomenclature.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
            "nic": [
                {
                    "broadcasturi": "vlan://1234",
                    "gateway": "10.1.2.1",
                    "id": "6d33dcf8-3c56-4106-8e70-512531afc596",
                    "ipaddress": "10.1.2.11",
                    "isdefault": true,
                    "isolationuri": "vlan://1234",
                    "macaddress": "01:02:03:04:05:06",
                    "netmask": "255.255.255.0",
                    "networkid": "1a750364-13d3-49ff-8c85-d219d989aa70",
                    "networkname": "network-1234",
                    "traffictype": "Guest",
                    "type": "Shared"
                },
                {
                    "broadcasturi": "vlan://2345",
                    "gateway": "10.1.3.1",
                    "id": "6d33dcf8-3c56-4106-8e70-512531afc597",
                    "ipaddress": "10.1.3.11",
                    "isdefault": false,
                    "isolationuri": "vlan://2345",
                    "macaddress": "11:12:13:14:15:16",
                    "netmask": "255.255.255.0",
                    "networkid": "1a750364-13d3-49ff-8c85-d219d989aa71",
                    "networkname": "network-2345",
                    "traffictype": "Guest",
                    "type": "Shared"
                }
            ],
```