### PR TITLE
Fix ovirt4.py inventory file for oVirt 4.3

### DIFF
--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -176,7 +176,7 @@ def get_dict_of_struct(connection, vm):
             if vm.name in [vm.name for vm in connection.follow_link(group.vms)]
         ],
         'statistics': dict(
-            (stat.name, stat.values[0].datum) for stat in stats
+            (stat.name, stat.values[0].datum) for stat in stats if stat.values
         ),
         'devices': dict(
             (device.name, [ip.address for ip in device.ips]) for device in devices if device.ips


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

ovirt4.py inventory file fails with oVirt 4.3 with the following error:
~~~
Traceback (most recent call last):
  File "inventory/ovirt", line 259, in <module>
    main()
  File "inventory/ovirt", line 250, in main
    vm_name=args.host,
  File "inventory/ovirt", line 209, in get_data
    vms[name] = get_dict_of_struct(connection, vm)
  File "inventory/ovirt", line 178, in get_dict_of_struct
    (stat.name, stat.values[0].datum) for stat in stats
  File "inventory/ovirt", line 178, in <genexpr>
    (stat.name, stat.values[0].datum) for stat in stats
IndexError: list index out of range
~~~
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ovirt4.py

