### PR TITLE
Update documentation of filetree to mention limits of 'src' attribute

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -53,7 +53,8 @@ RETURN = """
     description: list of dictionaries with file information
     contains:
         src:
-          description: full path to file. This attribute is not present when filetree matches directories, and you may decide to skip directories using "when: item.state == 'file'" statement
+          description: full path to file. This attribute is not present when filetree matches directories, and you 
+          may decide to skip directories using `when: item.state == 'file'` statement
         root:
           description: allows filtering by original location
         path:

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -29,7 +29,7 @@ EXAMPLES = """
   with_filetree: web/
   when: item.state == 'directory'
 
-- name: Template files
+- name: Template files (explicitly skip directories in order to use the 'src' attribute)
   template:
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
@@ -53,7 +53,7 @@ RETURN = """
     description: list of dictionaries with file information
     contains:
         src:
-          description: TODO
+          description: full path to file. This attribute is not present when filetree matches directories, and you may decide to skip directories using "when: item.state == 'file'" statement
         root:
           description: allows filtering by original location
         path:

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -11,7 +11,7 @@ version_added: "2.4"
 short_description: recursively match all files in a directory tree
 description:
 - This lookup enables you to template a complete tree of files on a target system while retaining permissions and ownership.
-- Supports directories, files and symlinks, including SELinux and other file properties
+- Supports directories, files and symlinks, including SELinux and other file properties.
 - If you provide more than one path, it will implement a first_found logic, and will not process entries it already processed in previous paths.
   This enables merging different trees in order of importance, or add role_vars to specific paths to influence different instances of the same role.
 options:
@@ -53,8 +53,10 @@ RETURN = """
     description: list of dictionaries with file information
     contains:
         src:
-          description: full path to file. This attribute is not present when filetree matches directories, and you 
-          may decide to skip directories using `when: item.state == 'file'` statement
+          description:
+          - full path to file
+          - not returned when C(state) is set to C(directory)
+          - use `when: item.state == 'file'` or `when: item.state == 'link'` to skip directories and use this attribute
         root:
           description: allows filtering by original location
         path:

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -56,7 +56,7 @@ RETURN = """
           description:
           - full path to file
           - not returned when C(state) is set to C(directory)
-          - use `when: item.state == 'file'` or `when: item.state == 'link'` to skip directories and use this attribute
+          - use C(when: item.state == 'file') or C(when: item.state == 'link') to use this attribute
         root:
           description: allows filtering by original location
         path:

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -55,8 +55,7 @@ RETURN = """
         src:
           description:
           - full path to file
-          - not returned when C(state) is set to C(directory)
-          - use C(when: item.state == 'file') or C(when: item.state == 'link') to use this attribute
+          - not returned when C(item.state) is set to C(directory)
         root:
           description: allows filtering by original location
         path:


### PR DESCRIPTION
##### SUMMARY
I've spent about 40 minutes trying to understand why the example from documentation does not work and fails with `'dict object' has no attribute 'src'`. 

Finally came to this answer https://github.com/ansible/ansible/issues/51513#issuecomment-459150769 . That should be definitely mentioned at documentation

The workaround is to concatenate `item.root` and `item.path` and use that instead of `item.src` as mentioned at https://github.com/ellaqezi/dotfiles#known-issues

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
filetree

##### ADDITIONAL INFORMATION

