### PR TITLE
[WIP] Check if modules should be _facts or not

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -141,6 +141,9 @@ Errors
             modules or a ``.ps1`` for powershell modules
   502       Ansible module subdirectories must contain an ``__init__.py``
   503       Missing python documentation file
+  504       Module contains ansible_facts but is not named with _facts suffix
+  505       Module does not contain ansible_facts but is named using the _facts suffix.
+            This module should instead use the _info suffix
 =========   ===================
 
 Warnings

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1,5 +1,7 @@
 lib/ansible/modules/cloud/amazon/_ec2_ami_find.py E322
 lib/ansible/modules/cloud/amazon/_ec2_ami_find.py E323
+lib/ansible/modules/cloud/amazon/_ec2_facts.py E505
+lib/ansible/modules/cloud/amazon/_ec2_remote_facts.py E505
 lib/ansible/modules/cloud/amazon/aws_api_gateway.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E326
@@ -816,6 +818,8 @@ lib/ansible/modules/storage/zfs/zfs.py E322
 lib/ansible/modules/storage/zfs/zfs.py E323
 lib/ansible/modules/storage/zfs/zfs_facts.py E323
 lib/ansible/modules/storage/zfs/zpool_facts.py E323
+lib/ansible/modules/system/gather_facts.py E505
+lib/ansible/modules/system/hostname.py E505
 lib/ansible/modules/system/known_hosts.py E324
 lib/ansible/modules/system/puppet.py E322
 lib/ansible/modules/system/puppet.py E336
@@ -823,10 +827,14 @@ lib/ansible/modules/system/runit.py E322
 lib/ansible/modules/system/runit.py E324
 lib/ansible/modules/system/service.py E210
 lib/ansible/modules/system/service.py E323
+lib/ansible/modules/system/setup.py E504
 lib/ansible/modules/system/systemd.py E336
 lib/ansible/modules/system/user.py E210
 lib/ansible/modules/system/user.py E324
 lib/ansible/modules/system/user.py E327
+lib/ansible/modules/utilities/logic/include_vars.py E504
+lib/ansible/modules/utilities/logic/set_fact.py E504
+lib/ansible/modules/utilities/logic/set_stats.py E504
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py E326
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py E324
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py E323
@@ -842,3 +850,4 @@ lib/ansible/modules/web_infrastructure/htpasswd.py E326
 lib/ansible/modules/web_infrastructure/jenkins_plugin.py E322
 lib/ansible/modules/web_infrastructure/jenkins_plugin.py E324
 lib/ansible/modules/web_infrastructure/jira.py E322
+lib/ansible/modules/windows/setup.ps1 E504

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1,7 +1,7 @@
 lib/ansible/modules/cloud/amazon/_ec2_ami_find.py E322
 lib/ansible/modules/cloud/amazon/_ec2_ami_find.py E323
-lib/ansible/modules/cloud/amazon/_ec2_facts.py E505
-lib/ansible/modules/cloud/amazon/_ec2_remote_facts.py E505
+lib/ansible/modules/cloud/amazon/_ec2_facts.py E505  # Removed module, without any real functionality
+lib/ansible/modules/cloud/amazon/_ec2_remote_facts.py E505  # Removed module, without any real functionality
 lib/ansible/modules/cloud/amazon/aws_api_gateway.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E326
@@ -818,8 +818,8 @@ lib/ansible/modules/storage/zfs/zfs.py E322
 lib/ansible/modules/storage/zfs/zfs.py E323
 lib/ansible/modules/storage/zfs/zfs_facts.py E323
 lib/ansible/modules/storage/zfs/zpool_facts.py E323
-lib/ansible/modules/system/gather_facts.py E505
-lib/ansible/modules/system/hostname.py E505
+lib/ansible/modules/system/gather_facts.py E505  # This is a docs only file for an action plugin
+lib/ansible/modules/system/hostname.py E505  # This module updates the remote hostname, and updates ansible_hostname, and should not be renamed
 lib/ansible/modules/system/known_hosts.py E324
 lib/ansible/modules/system/puppet.py E322
 lib/ansible/modules/system/puppet.py E336
@@ -827,14 +827,14 @@ lib/ansible/modules/system/runit.py E322
 lib/ansible/modules/system/runit.py E324
 lib/ansible/modules/system/service.py E210
 lib/ansible/modules/system/service.py E323
-lib/ansible/modules/system/setup.py E504
+lib/ansible/modules/system/setup.py E504  # This module returns ansible_facts, but should not be renamed
 lib/ansible/modules/system/systemd.py E336
 lib/ansible/modules/system/user.py E210
 lib/ansible/modules/system/user.py E324
 lib/ansible/modules/system/user.py E327
-lib/ansible/modules/utilities/logic/include_vars.py E504
-lib/ansible/modules/utilities/logic/set_fact.py E504
-lib/ansible/modules/utilities/logic/set_stats.py E504
+lib/ansible/modules/utilities/logic/include_vars.py E504  # This module returns ansible_facts, but should not be renamed
+lib/ansible/modules/utilities/logic/set_fact.py E504  # This module returns ansible_facts, but should not be renamed
+lib/ansible/modules/utilities/logic/set_stats.py E504  # This module returns ansible_facts, but should not be renamed
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py E326
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py E324
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py E323
@@ -850,4 +850,4 @@ lib/ansible/modules/web_infrastructure/htpasswd.py E326
 lib/ansible/modules/web_infrastructure/jenkins_plugin.py E322
 lib/ansible/modules/web_infrastructure/jenkins_plugin.py E324
 lib/ansible/modules/web_infrastructure/jira.py E322
-lib/ansible/modules/windows/setup.ps1 E504
+lib/ansible/modules/windows/setup.ps1 E504  # This module returns ansible_facts, but should not be renamed


### PR DESCRIPTION
##### SUMMARY
Check if modules should be _facts or not

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/sanity/validate-modules/main.py

##### ADDITIONAL INFORMATION
There will be cases where a module should return `ansible_facts` but not have the `_facts` suffix, such as `setup` and `hostname` (where `hostname` updates the remote hostname and the fact). Ignores will need to be added for those cases.