### PR TITLE
[2.7] openssl_*: proper mode support

### DIFF
--- a/changelogs/fragments/54085-openssl-mode-writing.yaml
+++ b/changelogs/fragments/54085-openssl-mode-writing.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+- "openssl_pkcs12, openssl_privatekey, openssl_publickey - These modules no longer delete the output file before starting to regenerate the output, or when generating the output failed."
+bugfixes:
+- "openssl_pkcs12, openssl_privatekey - These modules now accept the output file mode in symbolic form or as a octal string (https://github.com/ansible/ansible/issues/53476)."
+- "openssl_certificate, openssl_csr, openssl_pkcs12, openssl_privatekey, openssl_publickey - The modules are now able to overwrite write-protected files (https://github.com/ansible/ansible/issues/48656)."

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -579,12 +579,7 @@ class SelfSignedCertificate(Certificate):
             cert.sign(self.privatekey, self.digest)
             self.cert = cert
 
-            try:
-                with open(self.path, 'wb') as cert_file:
-                    cert_file.write(crypto.dump_certificate(crypto.FILETYPE_PEM, self.cert))
-            except EnvironmentError as exc:
-                raise CertificateError(exc)
-
+            crypto_utils.write_file(module, crypto.dump_certificate(crypto.FILETYPE_PEM, self.cert))
             self.changed = True
 
         file_args = module.load_file_common_arguments(module.params)
@@ -676,12 +671,7 @@ class OwnCACertificate(Certificate):
             cert.sign(self.ca_privatekey, self.digest)
             self.cert = cert
 
-            try:
-                with open(self.path, 'wb') as cert_file:
-                    cert_file.write(crypto.dump_certificate(crypto.FILETYPE_PEM, self.cert))
-            except EnvironmentError as exc:
-                raise CertificateError(exc)
-
+            crypto_utils.write_file(module, crypto.dump_certificate(crypto.FILETYPE_PEM, self.cert))
             self.changed = True
 
         file_args = module.load_file_common_arguments(module.params)
@@ -1011,8 +1001,7 @@ class AcmeCertificate(Certificate):
                                                             self.csr_path,
                                                             self.challenge_path),
                                          check_rc=True)[1]
-                with open(self.path, 'wb') as certfile:
-                    certfile.write(to_bytes(crt))
+                crypto_utils.write_file(module, to_bytes(crt))
                 self.changed = True
             except OSError as exc:
                 raise CertificateError(exc)

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -414,13 +414,8 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
             req.sign(self.privatekey, self.digest)
             self.request = req
 
-            try:
-                csr_file = open(self.path, 'wb')
-                csr_file.write(crypto.dump_certificate_request(crypto.FILETYPE_PEM, self.request))
-                csr_file.close()
-            except (IOError, OSError) as exc:
-                raise CertificateSigningRequestError(exc)
-
+            result = crypto.dump_certificate_request(crypto.FILETYPE_PEM, self.request)
+            crypto_utils.write_file(module, result)
             self.changed = True
 
         file_args = module.load_file_common_arguments(module.params)

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -177,9 +177,9 @@ class Pkcs(crypto_utils.OpenSSLObject):
         self.privatekey_passphrase = module.params['privatekey_passphrase']
         self.privatekey_path = module.params['privatekey_path']
         self.src = module.params['src']
-        self.mode = module.params['mode']
-        if not self.mode:
-            self.mode = 0o400
+
+        if module.params['mode'] is None:
+            module.params['mode'] = '0400'
 
     def check(self, module, perms_required=True):
         """Ensure the resource is in its desired state."""
@@ -216,11 +216,6 @@ class Pkcs(crypto_utils.OpenSSLObject):
 
         self.pkcs12 = crypto.PKCS12()
 
-        try:
-            self.remove()
-        except PkcsError as exc:
-            module.fail_json(msg=to_native(exc))
-
         if self.ca_certificates:
             ca_certs = [crypto_utils.load_certificate(os.path.expanduser(os.path.expandvars(ca_cert))) for ca_cert
                         in self.ca_certificates]
@@ -239,38 +234,28 @@ class Pkcs(crypto_utils.OpenSSLObject):
                                        self.privatekey_passphrase)
                                        )
 
-        try:
-            pkcs12_file = os.open(self.path,
-                                  os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                                  self.mode)
-            os.write(pkcs12_file, self.pkcs12.export(self.passphrase,
-                                                     self.iter_size, self.maciter_size))
-            os.close(pkcs12_file)
-        except (IOError, OSError) as exc:
-            self.remove()
-            raise PkcsError(exc)
+        crypto_utils.write_file(
+            module,
+            self.pkcs12.export(self.passphrase, self.iter_size, self.maciter_size),
+            0o600
+        )
 
     def parse(self, module):
         """Read PKCS#12 file."""
 
         try:
-            self.remove()
-
-            p12 = crypto.load_pkcs12(open(self.src, 'rb').read(),
+            with open(self.src, 'rb') as pkcs12_fh:
+                pkcs12_content = pkcs12_fh.read()
+            p12 = crypto.load_pkcs12(pkcs12_content,
                                      self.passphrase)
             pkey = crypto.dump_privatekey(crypto.FILETYPE_PEM,
                                           p12.get_privatekey())
             crt = crypto.dump_certificate(crypto.FILETYPE_PEM,
                                           p12.get_certificate())
 
-            pkcs12_file = os.open(self.path,
-                                  os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                                  self.mode)
-            os.write(pkcs12_file, b'%s%s' % (pkey, crt))
-            os.close(pkcs12_file)
+            crypto_utils.write_file(module, b'%s%s' % (pkey, crt))
 
         except IOError as exc:
-            self.remove()
             raise PkcsError(exc)
 
 

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -186,14 +186,12 @@ class PublicKey(crypto_utils.OpenSSLObject):
                     )
                     publickey_content = crypto.dump_publickey(crypto.FILETYPE_PEM, self.privatekey)
 
-                with open(self.path, 'wb') as publickey_file:
-                    publickey_file.write(publickey_content)
+                crypto_utils.write_file(module, publickey_content)
 
                 self.changed = True
             except (IOError, OSError) as exc:
                 raise PublicKeyError(exc)
             except AttributeError as exc:
-                self.remove()
                 raise PublicKeyError('You need to have PyOpenSSL>=16.0.0 to generate public keys')
 
         self.fingerprint = crypto_utils.get_fingerprint(

--- a/test/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/main.yml
@@ -40,4 +40,31 @@
     passphrase: ànsïblé
     cipher: aes256
 
+- name: Generate privatekey_mode (mode 0400)
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey_mode.pem'
+    mode: '0400'
+  register: privatekey_mode_1
+- name: Stat for privatekey_mode
+  stat:
+    path: '{{ output_dir }}/privatekey_mode.pem'
+  register: privatekey_mode_1_stat
+
+- name: Generate privatekey_mode (mode 0400, idempotency)
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey_mode.pem'
+    mode: '0400'
+  register: privatekey_mode_2
+
+- name: Generate privatekey_mode (mode 0400, force)
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey_mode.pem'
+    mode: '0400'
+    force: yes
+  register: privatekey_mode_3
+- name: Stat for privatekey_mode
+  stat:
+    path: '{{ output_dir }}/privatekey_mode.pem'
+  register: privatekey_mode_3_stat
+
 - import_tasks: ../tests/validate.yml

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -68,3 +68,13 @@
     that:
       - privatekey6.stdout == '4096'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
+
+- name: Validate mode
+  assert:
+    that:
+      - privatekey_mode_1 is changed
+      - privatekey_mode_1_stat.stat.mode == '0400'
+      - privatekey_mode_2 is not changed
+      - privatekey_mode_3 is changed
+      - privatekey_mode_3_stat.stat.mode == '0400'
+      - privatekey_mode_1_stat.stat.mtime != privatekey_mode_3_stat.stat.mtime


### PR DESCRIPTION
##### SUMMARY
Backport of #54085 to stable-2.7.

This PR also contains a behavior change: some of the modules no longer delete the output before trying to regenerate it. For me this is more like a bug, that's why I want to backport this change as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/crypto.py
openssl_certificate
openssl_csr
openssl_privatekey
openssl_publickey
openssl_pks12
