### PR TITLE
docker_swarm_service: Remove configs and secrets defaults

### DIFF
--- a/changelogs/fragments/54361-docker_swarm_service-remove-secrets-configs-defaults.yaml
+++ b/changelogs/fragments/54361-docker_swarm_service-remove-secrets-configs-defaults.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_swarm_service - Removed redundant defaults for ``uid``, ``gid``, and ``mode`` from ``configs`` and ``secrets``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1990,14 +1990,14 @@ class DockerService(DockerBaseClass):
             ports = {}
             for port in self.publish:
                 if port.get('mode'):
-                    ports[int(port['published_port'])] = (
-                        int(port['target_port']),
+                    ports[port['published_port']] = (
+                        port['target_port'],
                         port['protocol'],
                         port['mode'],
                     )
                 else:
-                    ports[int(port['published_port'])] = (
-                        int(port['target_port']),
+                    ports[port['published_port']] = (
+                        port['target_port'],
                         port['protocol'],
                     )
             endpoint_spec_args['ports'] = ports

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -59,17 +59,14 @@ options:
         description:
           - UID of the config file's owner.
         type: int
-        default: 0
       gid:
         description:
           - GID of the config file's group.
         type: int
-        default: 0
       mode:
         description:
           - File access mode inside the container.
         type: str
-        default: "0o444"
   constraints:
     description:
       - List of the service constraints.
@@ -614,17 +611,14 @@ options:
         description:
           - UID of the secret file's owner.
         type: int
-        default: 0
       gid:
         description:
           - GID of the secret file's group.
         type: int
-        default: 0
       mode:
         description:
           - File access mode inside the container.
         type: int
-        default: 0o444
   state:
     description:
       - Service state.
@@ -2467,17 +2461,17 @@ def main():
             config_id=dict(type='str', required=True),
             config_name=dict(type='str', required=True),
             filename=dict(type='str'),
-            uid=dict(type='int', default=0),
-            gid=dict(type='int', default=0),
-            mode=dict(type='int', default=0o444),
+            uid=dict(type='int'),
+            gid=dict(type='int'),
+            mode=dict(type='int'),
         )),
         secrets=dict(type='list', elements='dict', options=dict(
             secret_id=dict(type='str', required=True),
             secret_name=dict(type='str', required=True),
             filename=dict(type='str'),
-            uid=dict(type='int', default=0),
-            gid=dict(type='int', default=0),
-            mode=dict(type='int', default=0o444),
+            uid=dict(type='int'),
+            gid=dict(type='int'),
+            mode=dict(type='int'),
         )),
         networks=dict(type='list', elements='str'),
         command=dict(type='raw'),

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1062,7 +1062,7 @@
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
       test:
-      - NONE
+        - NONE
   register: healthcheck_5
   ignore_errors: yes
 

--- a/test/units/modules/cloud/docker/test_docker_swarm_service.py
+++ b/test/units/modules/cloud/docker/test_docker_swarm_service.py
@@ -112,3 +112,163 @@ def test_get_nanoseconds_from_raw_option(docker_swarm_service):
 
     with pytest.raises(ValueError):
         docker_swarm_service.get_nanoseconds_from_raw_option('test', [])
+
+
+def test_has_dict_changed(docker_swarm_service):
+    assert not docker_swarm_service.has_dict_changed(
+        {"a": 1},
+        {"a": 1},
+    )
+    assert not docker_swarm_service.has_dict_changed(
+        {"a": 1},
+        {"a": 1, "b": 2}
+    )
+    assert docker_swarm_service.has_dict_changed(
+        {"a": 1},
+        {"a": 2, "b": 2}
+    )
+    assert docker_swarm_service.has_dict_changed(
+        {"a": 1, "b": 1},
+        {"a": 1}
+    )
+    assert not docker_swarm_service.has_dict_changed(
+        None,
+        {"a": 2, "b": 2}
+    )
+    assert docker_swarm_service.has_dict_changed(
+        {},
+        {"a": 2, "b": 2}
+    )
+    assert docker_swarm_service.has_dict_changed(
+        {"a": 1},
+        {}
+    )
+    assert docker_swarm_service.has_dict_changed(
+        {"a": 1},
+        None
+    )
+    assert not docker_swarm_service.has_dict_changed(
+        {},
+        {}
+    )
+    assert not docker_swarm_service.has_dict_changed(
+        None,
+        None
+    )
+    assert not docker_swarm_service.has_dict_changed(
+        {},
+        None
+    )
+    assert not docker_swarm_service.has_dict_changed(
+        None,
+        {}
+    )
+
+
+def test_has_list_of_dicts_changed(docker_swarm_service):
+    assert docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"a": 1},
+            {"b": 1}
+        ],
+        [
+            {"a": 1}
+        ]
+    )
+    assert docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"a": 1},
+        ],
+        [
+            {"a": 1},
+            {"b": 1},
+        ]
+    )
+    assert not docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"a": 1},
+            {"b": 1},
+        ],
+        [
+            {"a": 1},
+            {"b": 1}
+        ]
+    )
+    assert not docker_swarm_service.has_list_of_dicts_changed(
+        None,
+        [
+            {"b": 1},
+            {"a": 1}
+        ]
+    )
+    assert docker_swarm_service.has_list_of_dicts_changed(
+        [],
+        [
+            {"b": 1},
+            {"a": 1}
+        ]
+    )
+    assert not docker_swarm_service.has_list_of_dicts_changed(
+        None,
+        None
+    )
+    assert not docker_swarm_service.has_list_of_dicts_changed(
+        [],
+        None
+    )
+    assert not docker_swarm_service.has_list_of_dicts_changed(
+        None,
+        []
+    )
+    assert not docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"src": 1, "dst": 2},
+            {"src": 1, "dst": 2, "protocol": "udp"},
+        ],
+        [
+            {"src": 1, "dst": 2,  "protocol": "tcp"},
+            {"src": 1, "dst": 2, "protocol": "udp"},
+        ]
+    )
+    assert not docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"src": 1, "dst": 2, "protocol": "udp"},
+            {"src": 1, "dst": 3, "protocol": "tcp"},
+        ],
+        [
+            {"src": 1, "dst": 2, "protocol": "udp"},
+            {"src": 1, "dst": 3,  "protocol": "tcp"},
+        ]
+    )
+    assert docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"src": 1, "dst": 2, "protocol": "udp"},
+            {"src": 1, "dst": 2},
+            {"src": 3, "dst": 4},
+        ],
+        [
+            {"src": 1, "dst": 3, "protocol": "udp"},
+            {"src": 1, "dst": 2, "protocol": "tcp"},
+            {"src": 3, "dst": 4, "protocol": "tcp"},
+        ]
+    )
+    assert docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"src": 1, "dst": 3, "protocol": "tcp"},
+            {"src": 1, "dst": 2, "protocol": "udp"},
+        ],
+        [
+            {"src": 1, "dst": 2, "protocol": "tcp"},
+            {"src": 1, "dst": 2, "protocol": "udp"},
+        ]
+    )
+    assert docker_swarm_service.has_list_of_dicts_changed(
+        [
+            {"src": 1, "dst": 2, "protocol": "udp"},
+            {"src": 1, "dst": 2, "protocol": "tcp", "extra": {"test": "foo"}},
+        ],
+        [
+            {"src": 1, "dst": 2, "protocol": "udp"},
+            {"src": 1, "dst": 2,  "protocol": "tcp"},
+        ]
+    )

--- a/test/units/modules/cloud/docker/test_docker_swarm_service.py
+++ b/test/units/modules/cloud/docker/test_docker_swarm_service.py
@@ -226,7 +226,7 @@ def test_has_list_of_dicts_changed(docker_swarm_service):
             {"src": 1, "dst": 2, "protocol": "udp"},
         ],
         [
-            {"src": 1, "dst": 2,  "protocol": "tcp"},
+            {"src": 1, "dst": 2, "protocol": "tcp"},
             {"src": 1, "dst": 2, "protocol": "udp"},
         ]
     )
@@ -237,7 +237,7 @@ def test_has_list_of_dicts_changed(docker_swarm_service):
         ],
         [
             {"src": 1, "dst": 2, "protocol": "udp"},
-            {"src": 1, "dst": 3,  "protocol": "tcp"},
+            {"src": 1, "dst": 3, "protocol": "tcp"},
         ]
     )
     assert docker_swarm_service.has_list_of_dicts_changed(
@@ -269,6 +269,6 @@ def test_has_list_of_dicts_changed(docker_swarm_service):
         ],
         [
             {"src": 1, "dst": 2, "protocol": "udp"},
-            {"src": 1, "dst": 2,  "protocol": "tcp"},
+            {"src": 1, "dst": 2, "protocol": "tcp"},
         ]
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR removes a couple of more defaults from the argument spec: 

`uid`, `gid` and `mode` have been removed from `configs` and `secrets`. They are already defaulted to the same values in docker-py.

I've added two generic compare functions to handle cases where default values are returned by the Docker API but is missing from the argument spec. In these cases they are ignored in the same manner as we do with `self.some_option is not None and self.some_option != some_old_option`.

Just some thoughts that might not be related to this PR:

This leaves us with two defaults left. `publish.protocol` which defaults to `tcp` and `mounts.type` which defaults to `bind`. 

`mounts.type` can't be changed since it is different from the docker-py default which is `volume`.

`publish.protocol` is a bit tricky to remove since it's passed to docker-py as a dictionary and thus we have no control of what order each element is sent to the Docker API. By some testing it looks like the docker engine does use `protocol` to sort the elements along with `target_port` and `published_port`. Just had a quick glance over the generic compare functions in `docker/common.py`, maybe `compare_generic(a, b, method="allow_more_present", type="set(dict)")`could work? 

In my opinion the best way forward would have been to implement the comparisons with the same logic and style as in `docker_container` and some other docker-modules but I don't think I have time to make such a big refactor before the deadline hits.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service