### PR TITLE
Fix inventory_aws_conformance tests

### DIFF
--- a/test/integration/targets/inventory_aws_conformance/lib/boto/mocks/instances.py
+++ b/test/integration/targets/inventory_aws_conformance/lib/boto/mocks/instances.py
@@ -179,7 +179,7 @@ class InstanceBase(object):
     def __init__(self, stopped=False):
         # set common ignored attribute to make sure instances have identical tags and security groups
         self._ignore_security_groups = {
-            'sg-0e1d2bd02b45b712e': 'sgname-with-hyphens',
+            'sg-0e1d2bd02b45b712e': 'a-sgname-with-hyphens',
             'sg-ae5c262eb5c4d712e': 'name@with?invalid!chars'
         }
         self._ignore_tags = {

--- a/test/integration/targets/inventory_aws_conformance/runme.sh
+++ b/test/integration/targets/inventory_aws_conformance/runme.sh
@@ -87,8 +87,8 @@ compose:
   ec2_placement: placement['availability_zone']
   ec2_ramdisk: ramdisk_id | default("")
   ec2_reason: state_transition_reason
-  ec2_security_group_ids: security_groups | map(attribute='group_id') | list |  join(',')
-  ec2_security_group_names: security_groups | map(attribute='group_name') | list |  join(',')
+  ec2_security_group_ids: security_groups | map(attribute='group_id') | list | sort | join(',')
+  ec2_security_group_names: security_groups | map(attribute='group_name') | list | sort | join(',')
   ec2_state: state['name']
   ec2_state_code: state['code']
   ec2_state_reason: state_reason['message'] if state_reason is defined else ""


### PR DESCRIPTION
##### SUMMARY
Fix the order of list variables created in config since it varies
Modify mock for boto to reflect the new fixed order for the config

Fixing instabilities like https://app.shippable.com/github/ansible/ansible/runs/115865/70/console

I modified the config and mock rather than inventory_diff.py, since by that time the list has been joined by commas and group names themselves can contain commas, so splitting/sorting at that point seems misleading. But I'm not sure this is the right solution.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/inventory_aws_conformance
