### PR TITLE
win basic - do not warn on case insensitive matches

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -217,10 +217,6 @@ add ``$ErrorActionPreference = "Continue"`` to the top of the module. This chang
 of the EAP that was accidentally removed in a previous release and ensure that modules are more resiliant to errors
 that may occur in execution.
 
-PowerShell module options and option choices are currently case insensitive to what is defined in the module
-specification. This behaviour is deprecated and a warning displayed to the user if a case insensitive match was found.
-A future release of Ansible will make these checks case sensitive.
-
 The ``win_dsc`` module will now validate the input options for a DSC resource. In previous versions invalid options would be ignored but are now not.
 
 Modules removed

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -777,6 +777,8 @@ namespace Ansible.Basic
                                                        k, choiceMsg, String.Join(", ", choices), String.Join(", ", diffList));
                             FailJson(FormatOptionsContext(msg));
                         }
+                        /*
+                        For now we will just silently accept case insensitive choices, uncomment this if we want to add it back in
                         else if (caseDiffList.Count > 0)
                         {
                             // For backwards compatibility with Legacy.psm1 we need to be matching choices that are not case sensitive.
@@ -786,7 +788,7 @@ namespace Ansible.Basic
                                 k, choiceMsg, String.Join(", ", choices), String.Join(", ", caseDiffList.Select(x => RemoveNoLogValues(x, noLogValues)))
                             );
                             Warn(FormatOptionsContext(msg));
-                        }
+                        }*/
                     }
                 }
             }
@@ -861,6 +863,8 @@ namespace Ansible.Basic
                 FailJson(msg);
             }
 
+            /*
+            // Uncomment when we want to start warning users around options that are not a case sensitive match to the spec
             if (caseUnsupportedParameters.Count > 0)
             {
                 legalInputs.RemoveAll(x => passVars.Keys.Contains(x.Replace("_ansible_", "")));
@@ -868,7 +872,7 @@ namespace Ansible.Basic
                 msg = String.Format("{0}. Module options will become case sensitive in a future Ansible release. Supported parameters include: {1}",
                     FormatOptionsContext(msg), String.Join(", ", legalInputs));
                 Warn(msg);
-            }
+            }*/
 
             // Make sure we convert all the incorrect case params to the ones set by the module spec
             foreach (string key in caseUnsupportedParameters)

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -584,7 +584,8 @@ $tests = @{
                     option1 = 1
                 }
             }
-            warnings = @($expected_warnings)
+            # We have disabled the warning for now
+            #warnings = @($expected_warnings)
         }
         $actual | Assert-DictionaryEquals -Expected $expected
     }
@@ -1779,8 +1780,9 @@ test_no_log - Invoked with:
         $expected_warning += "Case insensitive matches were: ABC"
 
         $output.invocation | Assert-DictionaryEquals -Expected @{module_args = @{option_key = "ABC"}}
-        $output.warnings.Count | Assert-Equals -Expected 1
-        $output.warnings[0] | Assert-Equals -Expected $expected_warning
+        # We have disabled the warnings for now
+        #$output.warnings.Count | Assert-Equals -Expected 1
+        #$output.warnings[0] | Assert-Equals -Expected $expected_warning
     }
 
     "Case insensitive choice no_log" = {
@@ -1807,8 +1809,9 @@ test_no_log - Invoked with:
         $expected_warning += "Case insensitive matches were: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
 
         $output.invocation | Assert-DictionaryEquals -Expected @{module_args = @{option_key = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}}
-        $output.warnings.Count | Assert-Equals -Expected 1
-        $output.warnings[0] | Assert-Equals -Expected $expected_warning
+        # We have disabled the warnings for now
+        #$output.warnings.Count | Assert-Equals -Expected 1
+        #$output.warnings[0] | Assert-Equals -Expected $expected_warning
     }
 
     "Case insentitive choice as list" = {
@@ -1836,8 +1839,9 @@ test_no_log - Invoked with:
         $expected_warning += "Case insensitive matches were: AbC, jkl"
 
         $output.invocation | Assert-DictionaryEquals -Expected @{module_args = $complex_args}
-        $output.warnings.Count | Assert-Equals -Expected 1
-        $output.warnings[0] | Assert-Equals -Expected $expected_warning
+        # We have disabled the warnings for now
+        #$output.warnings.Count | Assert-Equals -Expected 1
+        #$output.warnings[0] | Assert-Equals -Expected $expected_warning
     }
 
     "Invalid choice" = {


### PR DESCRIPTION
##### SUMMARY
The meeting based on https://github.com/ansible/community/issues/436#issuecomment-465655663 has stated that a special case insensitive option should be added instead of a blanket deprecation. This PR removes the warnings until we can fully finalise how we want to approach it.

It still keeps the support for case insensitive option name and choice matching for backwards compatibility with PowerShell.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Ansible.Basic.cs