### PR TITLE
porting guide - move win_dsc changes to proper section

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -217,8 +217,6 @@ add ``$ErrorActionPreference = "Continue"`` to the top of the module. This chang
 of the EAP that was accidentally removed in a previous release and ensure that modules are more resiliant to errors
 that may occur in execution.
 
-The ``win_dsc`` module will now validate the input options for a DSC resource. In previous versions invalid options would be ignored but are now not.
-
 Modules removed
 ---------------
 
@@ -313,6 +311,9 @@ Noteworthy module changes
 * The ``ipa_user`` module originally always sent ``password`` to FreeIPA regardless of whether the password changed. Now the module only sends ``password`` if ``update_password`` is set to ``always``, which is the default.
 
 * The ``win_psexec`` has deprecated the undocumented ``extra_opts`` module option. This will be removed in Ansible 2.10.
+
+* The ``win_dsc`` module will now validate the input options for a DSC resource. In previous versions invalid options
+  would be ignored but are now not.
 
 Plugins
 =======


### PR DESCRIPTION
##### SUMMARY
Moves the `win_dsc` entry to the proper section of the porting guide.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
win_dsc
porting guide