### PR TITLE
Revert "more 2.8 facts modules renamed to info"

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_applicationsecuritygroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_applicationsecuritygroup_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_applicationsecuritygroup_info
+module: azure_rm_applicationsecuritygroup_facts
 version_added: "2.8"
 short_description: Get Azure Application Security Group facts.
 description:
@@ -42,14 +42,14 @@ author:
 
 EXAMPLES = '''
   - name: List application security groups in specific resource group
-    azure_rm_applicationsecuritygroup_info:
+    azure_rm_applicationsecuritygroup_facts:
       resource_group: myResourceGroup
 
   - name: List application security groups in specific subscription
-    azure_rm_applicationsecuritygroup_info:
+    azure_rm_applicationsecuritygroup_facts:
 
   - name: Get application security group by name
-    azure_rm_applicationsecuritygroup_info:
+    azure_rm_applicationsecuritygroup_facts:
         resource_group: myResourceGroup
         name: myApplicationSecurityGroup
         tags:

--- a/lib/ansible/modules/cloud/azure/azure_rm_cdnendpoint_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_cdnendpoint_facts.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_cdnendpoint_info
+module: azure_rm_cdnendpoint_facts
 
 version_added: "2.8"
 
@@ -49,12 +49,12 @@ author:
 
 EXAMPLES = '''
   - name: Get facts for all endpoints in CDN profile
-    azure_rm_cdnendpoint_info:
+    azure_rm_cdnendpoint_facts:
       resource_group: myResourceGroup
       profile_name: myCDNProfile
 
   - name: Get facts of specific CDN endpoint
-    azure_rm_cdnendpoint_info:
+    azure_rm_cdnendpoint_facts:
       resource_group: myResourceGroup
       profile_name: myCDNProfile
       name: myEndpoint1

--- a/lib/ansible/modules/cloud/azure/azure_rm_cdnprofile_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_cdnprofile_facts.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_cdnprofile_info
+module: azure_rm_cdnprofile_facts
 
 version_added: "2.8"
 
@@ -44,15 +44,15 @@ author:
 
 EXAMPLES = '''
     - name: Get facts for one CDN profile
-      azure_rm_cdnprofile_info:
+      azure_rm_cdnprofile_facts:
         name: Testing
         resource_group: myResourceGroup
 
     - name: Get facts for all CDN profiles
-      azure_rm_cdnprofile_info:
+      azure_rm_cdnprofile_facts:
 
     - name: Get facts by tags
-      azure_rm_cdnprofile_info:
+      azure_rm_cdnprofile_facts:
         tags:
           - Environment:Test
 '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_containerinstance_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_containerinstance_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_containerinstance_info
+module: azure_rm_containerinstance_facts
 version_added: "2.8"
 short_description: Get Azure Container Instance facts.
 description:
@@ -43,12 +43,12 @@ author:
 
 EXAMPLES = '''
   - name: Get specific Container Instance facts
-    azure_rm_containerinstance_info:
+    azure_rm_containerinstance_facts:
       resource_group: myResourceGroup
       name: container_group_name
 
   - name: List Container Instances in a specified resource group name
-    azure_rm_containerinstance_info:
+    azure_rm_containerinstance_facts:
       resource_group: myResourceGroup
 '''
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_cosmosdbaccount_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_cosmosdbaccount_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_cosmosdbaccount_info
+module: azure_rm_cosmosdbaccount_facts
 version_added: "2.8"
 short_description: Get Azure Cosmos DB Account facts.
 description:
@@ -53,7 +53,7 @@ author:
 
 EXAMPLES = '''
   - name: Get instance of Database Account
-    azure_rm_cosmosdbaccount_info:
+    azure_rm_cosmosdbaccount_facts:
       resource_group: myResourceGroup
       name: testaccount
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_deployment_info
+module: azure_rm_deployment_facts
 version_added: "2.8"
 short_description: Get Azure Deployment facts.
 description:
@@ -40,7 +40,7 @@ author:
 
 EXAMPLES = '''
   - name: Get instance of Deployment
-    azure_rm_deployment_info:
+    azure_rm_deployment_facts:
       resource_group: myResourceGroup
       name: myDeployment
 '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_image_info
+module: azure_rm_image_facts
 
 version_added: "2.8"
 
@@ -42,19 +42,19 @@ author:
 
 EXAMPLES = '''
 - name: List images with name
-  azure_rm_image_info:
+  azure_rm_image_facts:
     name: test-image
     resource_group: myResourceGroup
 
 - name: List images by resource group
-  azure_rm_image_info:
+  azure_rm_image_facts:
     resource_group: myResourceGroup
     tags:
       - testing
       - foo:bar
 
 - name: List all available images under current subscription
-  azure_rm_image_info:
+  azure_rm_image_facts:
 '''
 
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_rediscache_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_rediscache_facts.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_rediscache_info
+module: azure_rm_rediscache_facts
 
 version_added: "2.8"
 
@@ -49,18 +49,18 @@ author:
 
 EXAMPLES = '''
     - name: Get Redis Cache by name
-      azure_rm_rediscache_info:
+      azure_rm_rediscache_facts:
         resource_group: myResourceGroup
         name: myRedis
 
     - name: Get Redis Cache with access keys by name
-      azure_rm_rediscache_info:
+      azure_rm_rediscache_facts:
         resource_group: myResourceGroup
         name: myRedis
         return_access_keys: true
 
     - name: Get Redis Cache in specific resource group
-      azure_rm_rediscache_info:
+      azure_rm_rediscache_facts:
         resource_group: myResourceGroup
 '''
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_roleassignment_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_roleassignment_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_roleassignment_info
+module: azure_rm_roleassignment_facts
 version_added: "2.8"
 short_description: Gets Azure Role Assignment facts.
 description:
@@ -47,11 +47,11 @@ author:
 
 EXAMPLES = '''
     - name: Get role assignments for specific service principal
-      azure_rm_roleassignment_info:
+      azure_rm_roleassignment_facts:
         assignee: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
     - name: Get role assignments for specific scope
-      azure_rm_roleassignment_info:
+      azure_rm_roleassignment_facts:
         scope: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 '''
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_roledefinition_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_roledefinition_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_roledefinition_info
+module: azure_rm_roledefinition_facts
 version_added: "2.8"
 short_description: Get Azure Role Definition facts.
 description:
@@ -47,11 +47,11 @@ author:
 
 EXAMPLES = '''
     - name: List Role Definitions in scope
-      azure_rm_roledefinition_info:
+      azure_rm_roledefinition_facts:
         scope: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup
 
     - name: Get Role Definition by name
-      azure_rm_roledefinition_info:
+      azure_rm_roledefinition_facts:
         scope: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup
         name: myRoleDefinition
 '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_subnet_info
+module: azure_rm_subnet_facts
 version_added: "2.8"
 short_description: Get Azure Subnet facts.
 description:
@@ -44,13 +44,13 @@ author:
 
 EXAMPLES = '''
   - name: Get facts of specific subnet
-    azure_rm_subnet_info:
+    azure_rm_subnet_facts:
       resource_group: myResourceGroup
       virtual_network_name: myVirtualNetwork
       name: mySubnet
 
   - name: List facts for all subnets in virtual network
-    azure_rm_subnet_info:
+    azure_rm_subnet_facts:
       resource_group: myResourceGroup
       virtual_network_name: myVirtualNetwork
       name: mySubnet

--- a/test/integration/targets/azure_rm_cdnprofile/tasks/main.yml
+++ b/test/integration/targets/azure_rm_cdnprofile/tasks/main.yml
@@ -17,7 +17,7 @@
   check_mode: yes
 
 - name: Check there is no CDN profile created
-  azure_rm_cdnprofile_info:
+  azure_rm_cdnprofile_facts:
       resource_group: "{{ resource_group }}"
       name: "{{ cdnprofilename }}"
   register: fact
@@ -43,7 +43,7 @@
       - output.id != ''
 
 - name: Gather CDN profile facts
-  azure_rm_cdnprofile_info:
+  azure_rm_cdnprofile_facts:
       resource_group: "{{ resource_group }}"
       name: "{{ cdnprofilename }}"
   register: fact
@@ -96,7 +96,7 @@
   check_mode: yes
 
 - name: Gather CDN profile facts
-  azure_rm_cdnprofile_info:
+  azure_rm_cdnprofile_facts:
       resource_group: "{{ resource_group }}"
       name: "{{ cdnprofilename }}"
   register: fact
@@ -144,7 +144,7 @@
       - output.id
 
 - name: Get facts of a Azure CDN endpoint
-  azure_rm_cdnendpoint_info:
+  azure_rm_cdnendpoint_facts:
       resource_group: "{{ resource_group }}"
       name: "{{ endpointname }}"
       profile_name: "{{ cdnprofilename }}"
@@ -265,7 +265,7 @@
       - output.changed
 
 - name: Get CDN profile fact
-  azure_rm_cdnprofile_info:
+  azure_rm_cdnprofile_facts:
       resource_group: "{{ resource_group }}"
       name: "{{ cdnprofilename }}"
   register: fact

--- a/test/integration/targets/azure_rm_containerinstance/tasks/main.yml
+++ b/test/integration/targets/azure_rm_containerinstance/tasks/main.yml
@@ -100,7 +100,7 @@
   register: output
 
 - name: Gather facts for single Container Instance
-  azure_rm_containerinstance_info:
+  azure_rm_containerinstance_facts:
     resource_group: "{{ resource_group }}"
     name: "aci{{ resource_group | hash('md5') | truncate(7, True, '') }}sec"
   register: output 
@@ -124,7 +124,7 @@
       - output.containerinstances[0]['restart_policy'] == 'on_failure'
 
 - name: Gather facts for all Container Instances in the resource group
-  azure_rm_containerinstance_info:
+  azure_rm_containerinstance_facts:
     resource_group: "{{ resource_group }}"
   register: output
 

--- a/test/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
+++ b/test/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
@@ -116,7 +116,7 @@
       - output.changed
 
 - name: Get facts of single account
-  azure_rm_cosmosdbaccount_info:
+  azure_rm_cosmosdbaccount_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
   register: output
@@ -148,7 +148,7 @@
       - output.accounts[0]['tags'] != None
 
 - name: Get facts with keys
-  azure_rm_cosmosdbaccount_info:
+  azure_rm_cosmosdbaccount_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
     retrieve_keys: all
@@ -164,7 +164,7 @@
       - output.accounts[0]['secondary_readonly_master_key'] != None
 
 - name: Get facts with readonly keys
-  azure_rm_cosmosdbaccount_info:
+  azure_rm_cosmosdbaccount_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
     retrieve_keys: readonly
@@ -182,7 +182,7 @@
       - output.accounts[0]['connection_strings'] | length > 0
 
 - name: List acounts by resource group
-  azure_rm_cosmosdbaccount_info:
+  azure_rm_cosmosdbaccount_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
   register: output

--- a/test/integration/targets/azure_rm_deployment/tasks/main.yml
+++ b/test/integration/targets/azure_rm_deployment/tasks/main.yml
@@ -29,7 +29,7 @@
   with_items: "{{ output.deployment.instances }}"
 
 - name: Get Deployment Facts
-  azure_rm_deployment_info:
+  azure_rm_deployment_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ dns_label }}"
   register: output

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -106,7 +106,7 @@
           - output.id
 
 - name: Gather information about image created
-  azure_rm_image_info:
+  azure_rm_image_facts:
     resource_group: "{{ resource_group }}"
     name: testimage001
   register: output

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -351,7 +351,7 @@
       - output.id != ''
 
 - name: Get Application security group
-  azure_rm_applicationsecuritygroup_info:
+  azure_rm_applicationsecuritygroup_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ applicationsecuritygroup_name1 }}"
   register: facts

--- a/test/integration/targets/azure_rm_rediscache/tasks/main.yml
+++ b/test/integration/targets/azure_rm_rediscache/tasks/main.yml
@@ -36,7 +36,7 @@
       - output.id
 
 - name: Get facts
-  azure_rm_rediscache_info:
+  azure_rm_rediscache_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ redis_name }}"
   register: facts
@@ -177,7 +177,7 @@
       - output.id
 
 - name: Get facts
-  azure_rm_rediscache_info:
+  azure_rm_rediscache_facts:
     resource_group: "{{ resource_group }}"
     name: "{{ redis_name }}2"
     return_access_keys: True

--- a/test/integration/targets/azure_rm_roledefinition/tasks/main.yml
+++ b/test/integration/targets/azure_rm_roledefinition/tasks/main.yml
@@ -51,7 +51,7 @@
       - output.changed
 
 - name: Get facts by name
-  azure_rm_roledefinition_info:
+  azure_rm_roledefinition_facts:
     scope: "/subscriptions/{{ subscription_id }}/resourceGroups/{{ resource_group }}"
     type: custom
   register: facts
@@ -61,7 +61,7 @@
     - facts['roledefinitions'] | length > 1
 
 - name: Get facts
-  azure_rm_roledefinition_info:
+  azure_rm_roledefinition_facts:
     scope: "/subscriptions/{{ subscription_id }}/resourceGroups/{{ resource_group }}"
     role_name: "{{ role_name }}"
   register: facts
@@ -119,7 +119,7 @@
       - output.changed
 
 - name: Get role definition facts
-  azure_rm_roledefinition_info:
+  azure_rm_roledefinition_facts:
     role_name: "{{ role_name }}"
     scope: "/subscriptions/{{ subscription_id }}/resourceGroups/{{ resource_group }}"
     type: custom
@@ -157,7 +157,7 @@
       - output.changed
 
 - name: Get facts
-  azure_rm_roleassignment_info:
+  azure_rm_roleassignment_facts:
     scope: "/subscriptions/{{ subscription_id }}/resourceGroups/{{ resource_group }}"
     assignee: "{{ principal_id }}"
   register: facts

--- a/test/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/test/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -142,7 +142,7 @@
     that: not output.changed
 
 - name: Get subnet facts
-  azure_rm_subnet_info:
+  azure_rm_subnet_facts:
     name: foobar
     virtual_network_name: My_Virtual_Network
     resource_group: "{{ resource_group }}"


### PR DESCRIPTION
Reverts ansible/ansible#54313

@bcoca i think we still need to keep it in the old way in Ansible 2.8.