### PR TITLE
Backport/2.7/53496: fix azure_rm.py not showing nic info for vmss #53496

### DIFF
--- a/changelogs/fragments/53496-azure_rm_inventory_vmss_nic.yaml
+++ b/changelogs/fragments/53496-azure_rm_inventory_vmss_nic.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- azure_rm inventory plugin - fix no nic type in vmss nic. (https://github.com/ansible/ansible/pull/53496)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backport PR https://github.com/ansible/ansible/pull/53496 to stable-2.7 branch.
