### PR TITLE
docker_swarm inventory: fix tests, and make sure that they fail if no host is found

### DIFF
--- a/test/integration/targets/inventory_docker_swarm/inventory_1.docker_swarm.yml
+++ b/test/integration/targets/inventory_docker_swarm/inventory_1.docker_swarm.yml
@@ -1,3 +1,3 @@
 ---
 plugin: docker_swarm
-host: unix://var/run/docker.sock
+docker_host: unix://var/run/docker.sock

--- a/test/integration/targets/inventory_docker_swarm/inventory_2.docker_swarm.yml
+++ b/test/integration/targets/inventory_docker_swarm/inventory_2.docker_swarm.yml
@@ -1,5 +1,5 @@
 ---
 plugin: docker_swarm
-host: unix://var/run/docker.sock
+docker_host: unix://var/run/docker.sock
 verbose_output: no
 include_host_uri: yes

--- a/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_1.yml
@@ -17,6 +17,10 @@
 
 - hosts: all
   connection: local  # otherwise Ansible will complain that it cannot connect via ssh to 127.0.0.1:22
+  vars:
+    # for some reason, Ansible can't find the Python interpreter when connecting to the nodes,
+    # which is in fact just localhost in disguise. That's why we use ansible_playbook_python.
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   tasks:
     - name: Check for groups
       assert:

--- a/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_1.yml
@@ -1,4 +1,20 @@
 ---
+- hosts: 127.0.0.1
+  connection: local  # otherwise Ansible will complain that it cannot connect via ssh to 127.0.0.1:22
+  gather_facts: no
+  tasks:
+    - name: Show all groups
+      debug:
+        var: groups
+    - name: Make sure docker_swarm groups are there
+      assert:
+        that:
+          - groups.all | length > 0
+          - groups.leader | length == 1
+          - groups.manager | length > 0
+          - groups.worker | length >= 0
+          - groups.nonleaders | length >= 0
+
 - hosts: all
   connection: local  # otherwise Ansible will complain that it cannot connect via ssh to 127.0.0.1:22
   tasks:

--- a/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_2.yml
+++ b/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_2.yml
@@ -17,6 +17,10 @@
 
 - hosts: all
   connection: local  # otherwise Ansible will complain that it cannot connect via ssh to 127.0.0.1:22
+  vars:
+    # for some reason, Ansible can't find the Python interpreter when connecting to the nodes,
+    # which is in fact just localhost in disguise. That's why we use ansible_playbook_python.
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   tasks:
     - name: Make sure docker_swarm_node_attributes is not available
       assert:

--- a/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_2.yml
+++ b/test/integration/targets/inventory_docker_swarm/playbooks/test_inventory_2.yml
@@ -1,4 +1,20 @@
 ---
+- hosts: 127.0.0.1
+  connection: local  # otherwise Ansible will complain that it cannot connect via ssh to 127.0.0.1:22
+  gather_facts: no
+  tasks:
+    - name: Show all groups
+      debug:
+        var: groups
+    - name: Make sure docker_swarm groups are there
+      assert:
+        that:
+          - groups.all | length > 0
+          - groups.leader | length == 1
+          - groups.manager | length > 0
+          - groups.worker | length >= 0
+          - groups.nonleaders | length >= 0
+
 - hosts: all
   connection: local  # otherwise Ansible will complain that it cannot connect via ssh to 127.0.0.1:22
   tasks:


### PR DESCRIPTION
##### SUMMARY
Currently, the tests didn't really work since the key variable was misspelled. Unfortunately, this didn't cause an error, but simply caused the tests to not be run (since no host was found). This fixes the spelling, and adds more tests which make sure that the groups added by the plugin are actually around and have hosts in them (for the ones that have in a one-element cluster).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/docker_swarm.py
