### PR TITLE
Fix example on address | ipsubnet(20) usage

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -479,7 +479,7 @@ the first argument, the ``ipsubnet()`` filter will instead return the biggest su
 contains that given IP address::
 
     # {{ address | ipsubnet(20) }}
-    192.168.128.0/20
+    192.168.144.0/20
 
 By specifying an index number as a second argument, you can select smaller and
 smaller subnets::


### PR DESCRIPTION
<!--- Your description here -->
+label: docsite_pr

`192.168.128.0/20` does not contain `192.168.144.5`, the correct subnet is `192.168.144.0/20` (which is what is rendered on my test template).

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix example error in the documentation of the ipaddr/ipsubnet filter.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipaddr

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ cat templates/test.j2
{{ address | ipsubnet(20) }}

$ ansible-playbook test.yaml --check
[...]
TASK [Test ipsubnet] *********************************************************************************************************************************************************
--- before
+++ after: /home/benjamin/.ansible/tmp/ansible-local-1087sb_d47ul/tmpm7a89e79/test.j2
@@ -0,0 +1 @@
+192.168.144.0/20
[...]
```
