### PR TITLE
Add GetChassisThermals command to Chassis category of redfish_facts

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -928,7 +928,7 @@ class RedfishUtils(object):
 
         if sensors is None:
             return {'ret': False, 'msg': 'Key Temperatures was not found.'}
-            
+
         result['entries'] = sensors
         return result
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -900,9 +900,9 @@ class RedfishUtils(object):
 
         # Get these entries, but does not fail if not found
         properties = ['Name', 'PhysicalContext', 'UpperThresholdCritical',
-                      'UpperThresholdFatal', 'UpperThresholdNonCritical', 
-                      'LowerThresholdCritical', 'LowerThresholdFatal', 
-                      'LowerThresholdNonCritical', 'MaxReadingRangeTemp', 
+                      'UpperThresholdFatal', 'UpperThresholdNonCritical',
+                      'LowerThresholdCritical', 'LowerThresholdFatal',
+                      'LowerThresholdNonCritical', 'MaxReadingRangeTemp',
                       'MinReadingRangeTemp', 'ReadingCelsius', 'RelatedItem',
                       'SensorNumber']
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -900,8 +900,11 @@ class RedfishUtils(object):
 
         # Get these entries, but does not fail if not found
         properties = ['Name', 'PhysicalContext', 'UpperThresholdCritical',
-                      'UpperThresholdFatal', 'LowerThresholdCritical',
-                      'ReadingCelsius']
+                      'UpperThresholdFatal', 'UpperThresholdNonCritical', 
+                      'LowerThresholdCritical', 'LowerThresholdFatal', 
+                      'LowerThresholdNonCritical', 'MaxReadingRangeTemp', 
+                      'MinReadingRangeTemp', 'ReadingCelsius', 'RelatedItem',
+                      'SensorNumber']
 
         # Go through list
         for chassis_uri in self.chassis_uri_list:

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -893,6 +893,45 @@ class RedfishUtils(object):
         result["entries"] = fan_results
         return result
 
+    def get_chassis_thermals(self):
+        result = {}
+        sensors = []
+        key = "Thermal"
+
+        # Get these entries, but does not fail if not found
+        properties = ['Name', 'PhysicalContext', 'UpperThresholdCritical',
+                      'UpperThresholdFatal', 'LowerThresholdCritical',
+                      'ReadingCelsius']
+
+        # Go through list
+        for chassis_uri in self.chassis_uri_list:
+            response = self.get_request(self.root_uri + chassis_uri)
+            if response['ret'] is False:
+                return response
+            result['ret'] = True
+            data = response['data']
+            if key in data:
+                thermal_uri = data[key]["@odata.id"]
+                response = self.get_request(self.root_uri + thermal_uri)
+                if response['ret'] is False:
+                    return response
+                result['ret'] = True
+                data = response['data']
+                if "Temperatures" in data:
+                    for sensor in data[u'Temperatures']:
+                        sensor_result = {}
+                        for property in properties:
+                            if property in sensor:
+                                if sensor[property] is not None:
+                                    sensor_result[property] = sensor[property]
+                        sensors.append(sensor_result)
+
+        if sensors is None:
+            return {'ret': False, 'msg': 'Key Temperatures was not found.'}
+            
+        result['entries'] = sensors
+        return result
+
     def get_cpu_inventory(self, systems_uri):
         result = {}
         cpu_list = []

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -271,6 +271,8 @@ def main():
                     result["fan"] = rf_utils.get_fan_inventory()
                 elif command == "GetPsuInventory":
                     result["psu"] = rf_utils.get_psu_inventory()
+                elif command == "GetChassisThermals":
+                    result["thermals"] = rf_utils.get_chassis_thermals()
 
         elif category == "Accounts":
             # execute only if we find an Account service resource

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -162,7 +162,7 @@ CATEGORY_COMMANDS_ALL = {
                 "GetMemoryInventory", "GetNicInventory",
                 "GetStorageControllerInventory", "GetDiskInventory",
                 "GetBiosAttributes", "GetBootOrder"],
-    "Chassis": ["GetFanInventory", "GetPsuInventory"],
+    "Chassis": ["GetFanInventory", "GetPsuInventory", "GetChassisThermals"],
     "Accounts": ["ListUsers"],
     "Update": ["GetFirmwareInventory"],
     "Manager": ["GetManagerNicInventory", "GetLogs"],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request adds a GetChassisThermals command to the Chassis category of redfish_facts. It retrieves from the Thermal/Temperatures field various temperature-related data for each sensor populated therein.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #54231 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```yaml
- name: Test Redfish modules
  hosts: localhost
  gather_facts: false
  vars:
    baseuri: 10.243.5.31
    user: USERID
    password: PASSW0RD

  tasks:
    - name: Get Chassis Thermals
      redfish_facts:
        category: Chassis
        command: GetChassisThermals
        baseuri: "{{ baseuri }}"
        username: "{{ user }}"
        password: "{{ password }}"
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/home/xander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible
  executable location = /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
No config file found; using defaults
host_list declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass it's verify_file() method
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'


PLAYBOOK: test_redfish_facts.1.yml **********************************************************************************1 plays in ../test_redfish_facts.1.yml

PLAY [Test Redfish modules] *****************************************************************************************META: ran handlers

TASK [Get Chassis Thermals] *****************************************************************************************task path: /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/test_redfish_facts.1.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: xander
<127.0.0.1> EXEC /bin/sh -c 'echo ~xander && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/xander/.ansible/tmp/ansible-tmp-1553609768.02-132527517191880 `" && echo ansible-tmp-1553609768.02-132527517191880="` echo /home/xander/.ansible/tmp/ansible-tmp-1553609768.02-132527517191880 `" ) && sleep 0'
Using module file /mnt/c/Users/amadsen/Coding/lenovo-redfish-automated-testing/ansible/lib/ansible/modules/remote_management/redfish/redfish_facts.py
<127.0.0.1> PUT /home/xander/.ansible/tmp/ansible-local-8740sZYjwN/tmpESZy_z TO /home/xander/.ansible/tmp/ansible-tmp-1553609768.02-132527517191880/AnsiballZ_redfish_facts.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/xander/.ansible/tmp/ansible-tmp-1553609768.02-132527517191880/ /home/xander/.ansible/tmp/ansible-tmp-1553609768.02-132527517191880/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/xander/.ansible/tmp/ansible-tmp-1553609768.02-132527517191880/AnsiballZ_redfish_facts.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/xander/.ansible/tmp/ansible-tmp-1553609768.02-132527517191880/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "redfish_facts": {
            "thermals": {
                "entries": [
                    {
                        "Name": "Ambient Temp", 
                        "PhysicalContext": "Intake", 
                        "ReadingCelsius": 24, 
                        "UpperThresholdCritical": 47, 
                        "UpperThresholdFatal": 50
                    }, 
                    {
                        "Name": "Exhaust Temp", 
                        "PhysicalContext": "Exhaust", 
                        "ReadingCelsius": 27
                    }, 
                    {
                        "Name": "CPU1 Temp", 
                        "PhysicalContext": "CPU", 
                        "ReadingCelsius": 26
                    }, 
                    {
                        "Name": "CPU2 Temp", 
                        "PhysicalContext": "CPU", 
                        "ReadingCelsius": 24
                    }, 
                    {
                        "Name": "CPU1 DTS", 
                        "PhysicalContext": "CPU", 
                        "ReadingCelsius": -510, 
                        "UpperThresholdCritical": -2, 
                        "UpperThresholdFatal": 0
                    }, 
                    {
                        "Name": "CPU2 DTS", 
                        "PhysicalContext": "CPU", 
                        "ReadingCelsius": -510, 
                        "UpperThresholdCritical": -2, 
                        "UpperThresholdFatal": 0
                    }, 
                    {
                        "Name": "DIMM 5 Temp", 
                        "PhysicalContext": "Memory", 
                        "ReadingCelsius": 27
                    }, 
                    {
                        "Name": "DIMM 17 Temp", 
                        "PhysicalContext": "Memory", 
                        "ReadingCelsius": 27
                    }, 
                    {
                        "Name": "PCH Temp", 
                        "PhysicalContext": "ComputeBay", 
                        "ReadingCelsius": 49
                    }
                ], 
                "ret": true
            }
        }
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "baseuri": "10.243.5.31", 
            "category": [
                "Chassis"
            ], 
            "command": [
                "GetChassisThermals"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "USERID"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************************************localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
