### PR TITLE
Update guide_azure.rst

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -109,6 +109,8 @@ for credentials in ``$HOME/.azure/credentials``. This file is an ini style file.
     secret=xxxxxxxxxxxxxxxxx
     tenant=xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
+.. note:: The secret value should be UrlEncoded! Otherwise you might get login errors.
+
 It is possible to store multiple sets of credentials within the credentials file by creating multiple sections. Each
 section is considered a profile. The modules look for the [default] profile automatically. Define AZURE_PROFILE in the
 environment or pass a profile parameter to specify a specific profile.

--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -109,7 +109,7 @@ for credentials in ``$HOME/.azure/credentials``. This file is an ini style file.
     secret=xxxxxxxxxxxxxxxxx
     tenant=xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
-.. note:: The secret value should be UrlEncoded! Otherwise you might get login errors.
+.. note:: If your secret values contain non-ASCII characters, you must `URL Encode<https://www.w3schools.com/tags/ref_urlencode.asp>`_ them to avoid login errors.
 
 It is possible to store multiple sets of credentials within the credentials file by creating multiple sections. Each
 section is considered a profile. The modules look for the [default] profile automatically. Define AZURE_PROFILE in the

--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -109,7 +109,7 @@ for credentials in ``$HOME/.azure/credentials``. This file is an ini style file.
     secret=xxxxxxxxxxxxxxxxx
     tenant=xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
-.. note:: If your secret values contain non-ASCII characters, you must `URL Encode<https://www.w3schools.com/tags/ref_urlencode.asp>`_ them to avoid login errors.
+.. note:: If your secret values contain non-ASCII characters, you must `URL Encode <https://www.w3schools.com/tags/ref_urlencode.asp>`_ them to avoid login errors.
 
 It is possible to store multiple sets of credentials within the credentials file by creating multiple sections. Each
 section is considered a profile. The modules look for the [default] profile automatically. Define AZURE_PROFILE in the


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a note to the 'Storing in a file' section, that the secret value of the ini file should be UrlEncoded.
Otherwise the user might get login errors (depends on the characters used in the secret).


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
guide_azure.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

If the secret of the azure service principal contains unusual characters, the login will fail.
The secret must be urlencoded() to avoid this login error.

See also this discussion, wich got me to the solution:
https://stackoverflow.com/questions/42477266/aadsts50012-invalid-client-secret-is-provided-when-moving-from-a-test-app-to-pr

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
