### PR TITLE
Modified lvol.py to accept '+' on absolute values

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -250,9 +250,9 @@ def parse_vgs(data):
         parts = line.strip().split(';')
         vgs.append({
             'name': parts[0],
-            'size': int(decimal_point.match(parts[1]).group(1)),
-            'free': int(decimal_point.match(parts[2]).group(1)),
-            'ext_size': int(decimal_point.match(parts[3]).group(1))
+            'size': float(parts[1]),
+            'free': float(parts[2]),
+            'ext_size': float(parts[3])
         })
     return vgs
 

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -226,6 +226,7 @@ LVOL_ENV_VARS = dict(
     LC_CTYPE='C',
 )
 
+
 def mkversion(major, minor, patch):
     return (1000 * 1000 * int(major)) + (1000 * int(minor)) + int(patch)
 
@@ -348,24 +349,24 @@ def main():
             size_unit = ''
 
         if '%' not in size:
-            # LVCREATE(8) -L --size option unit
-	    if size[-1] in 'BSKMGTPE':
-		size_unit = size[-1].lower()
-		size = size[0:-1]
-		size_divisor = { 'B': 1.000, 'S': 1.000, 'K': 1.024, 'M': 1.048, 'G': 1.047, 'T': 1.099, 'P': 1.126, 'E': 1.153 }.get(size_unit.upper(), '1.000')
-		if '+' in size:
-		    size_operator = '+'
+        # LVCREATE(8) -L --size option unit
+            if size[-1] in 'BSKMGTPE':
+                size_unit = size[-1].lower()
+                size = size[0:-1]
+                size_divisor = { 'B': 1.000, 'S': 1.000, 'K': 1.024, 'M': 1.048, 'G': 1.047, 'T': 1.099, 'P': 1.126, 'E': 1.153 }.get(size_unit.upper(), '1.000')
+                if '+' in size:
+                    size_operator = '+'
                     size = str(float(size[1:]) / float(size_divisor))
-		else:
-		    size = str(float(size) / float(size_divisor))
+                else:
+                    size = str(float(size) / float(size_divisor))
             elif size[-1] in 'bskmgtpe':
                 size_unit = size[-1]
                 size = size[0:-1]
 
             try:
                 float(size)
-		if not size[0].isdigit():
-		    raise ValueError()
+                if not size[0].isdigit():
+                    raise ValueError()
             except ValueError:
                 module.fail_json(msg="Bad size specification of '%s'" % size)
 
@@ -545,10 +546,10 @@ def main():
             if tool:
                 if resizefs:
                     tool = '%s %s' % (tool, '--resizefs')
-		if size_operator:
-		    cmd = "%s %s -%s %s%s%s %s/%s %s" % (tool, test_opt, size_opt, size_operator, size, size_unit, vg, this_lv['name'], pvs)
-		else:
-		    cmd = "%s %s -%s %s%s %s/%s %s" % (tool, test_opt, size_opt, size, size_unit, vg, this_lv['name'], pvs)
+                if size_operator:
+                    cmd = "%s %s -%s %s%s%s %s/%s %s" % (tool, test_opt, size_opt, size_operator, size, size_unit, vg, this_lv['name'], pvs)
+                else:
+                    cmd = "%s %s -%s %s%s %s/%s %s" % (tool, test_opt, size_opt, size, size_unit, vg, this_lv['name'], pvs)
                 rc, out, err = module.run_command(cmd)
                 if "Reached maximum COW size" in out:
                     module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err, out=out)

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -347,12 +347,12 @@ def main():
             size_opt = 'l'
             size_unit = ''
 
-        if '%' not in size:
         # LVCREATE(8) -L --size option unit
+        if '%' not in size:
             if size[-1] in 'BSKMGTPE':
                 size_unit = size[-1].lower()
                 size = size[0:-1]
-                size_divisor = { 'B': 1.000, 'S': 1.000, 'K': 1.024, 'M': 1.048, 'G': 1.047, 'T': 1.099, 'P': 1.126, 'E': 1.153 }.get(size_unit.upper(), '1.000')
+                size_divisor = {'B': 1.000, 'S': 1.000, 'K': 1.024, 'M': 1.048, 'G': 1.047, 'T': 1.099, 'P': 1.126, 'E': 1.153}.get(size_unit.upper(), '1.000')
                 if '+' in size:
                     size_operator = '+'
                     size = str(float(size[1:]) / float(size_divisor))
@@ -582,4 +582,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -441,6 +441,8 @@ def main():
     if this_lv is None:
         if state == 'present':
             # Require size argument except for snapshot of thin volumes
+            if size_operator:
+                module.fail_json(msg="Bad size specification of '%s%s' for creating LV" % size_operator, size)
             if (lv or thinpool) and not size:
                 for test_lv in lvs:
                     if test_lv['name'] == lv and test_lv['thinvol'] and snapshot:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -441,7 +441,7 @@ def main():
     if this_lv is None:
         if state == 'present':
             # Require size argument except for snapshot of thin volumes
-            if size_operator:
+            if size_operator is not None:
                 module.fail_json(msg="Bad size specification of '%s%s' for creating LV" % size_operator, size)
             if (lv or thinpool) and not size:
                 for test_lv in lvs:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -16,7 +16,6 @@ DOCUMENTATION = '''
 author:
     - Jeroen Hoekx (@jhoekx)
     - Alexander Bulimov (@abulimov)
-    - Raoul Baudach (@unkaputtbar112)
 module: lvol
 short_description: Configure LVM logical volumes
 description:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -362,6 +362,9 @@ def main():
             elif size[-1] in 'bskmgtpe':
                 size_unit = size[-1]
                 size = size[0:-1]
+                if '+' in size:
+                    size_operator = '+'
+                    size = size[1:]
 
             try:
                 float(size)

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -442,7 +442,7 @@ def main():
         if state == 'present':
             # Require size argument except for snapshot of thin volumes
             if size_operator is not None:
-                module.fail_json(msg="Bad size specification of '%s%s' for creating LV" % size_operator, size)
+                module.fail_json(msg="Bad size specification of '%s%s' for creating LV" % (size_operator, size))
             if (lv or thinpool) and not size:
                 for test_lv in lvs:
                     if test_lv['name'] == lv and test_lv['thinvol'] and snapshot:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -16,6 +16,7 @@ DOCUMENTATION = '''
 author:
     - Jeroen Hoekx (@jhoekx)
     - Alexander Bulimov (@abulimov)
+    - Raoul Baudach (@unkaputtbar112)
 module: lvol
 short_description: Configure LVM logical volumes
 description:


### PR DESCRIPTION
... also added simple recalculations from e.g. MebiByte to MegaByte (for Kilo, Giga, Terra,...) to have consistency between lvs --units M/m and given Size M/m to lvextend (K/k, G/g, E/e, ...)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #54092 
"Fixes" #37599
Fixes #29313
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lvol

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
