### PR TITLE
Optionally get service account file path from env var

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -53,6 +53,9 @@ DOCUMENTATION = '''
                 - The path of a Service Account JSON file if serviceaccount is selected as type.
             required: True
             type: path
+            env:
+                - name: GCE_CREDENTIALS_FILE_PATH
+                  version_added: "2.8"
         service_account_email:
             description:
                 - An optional service account email address if machineaccount is selected


### PR DESCRIPTION
##### SUMMARY
Addresses https://github.com/ansible/ansible/issues/54406

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gcp_compute inventory plugin

##### ADDITIONAL INFORMATION
Tested with

```
GCE_CREDENTIALS_FILE_PATH="/Users/alancoding/Documents/repos/ansible-inventory-file-examples/private/gce/creds.json" ansible-inventory -i min.gcp_compute.yml --list --export
```

Where `min.gcp_compute.yml` has

```yaml
auth_kind: serviceaccount
filters: null
strict: true
plugin: gcp_compute
projects:
- alans_project
zones:
  - us-east1-d
```

This will allow users to check their inventory config into source control.