### PR TITLE
Update lineinfile description

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -82,6 +82,8 @@ options:
       - If the first match is required, use(firstmatch=yes).
       - A special value is available; C(EOF) for inserting the line at the end of the file.
       - If specified regular expression has no matches, EOF will be used instead.
+      - Cannot set with C(insertbefore).
+      - If C(insertbefore) is set, default value C(EOF) will be ignored.
       - If regular expressions are passed to both C(regexp) and C(insertafter), C(insertafter) is only honored if no match for C(regexp) is found.
       - May not be used with C(backrefs).
     type: str
@@ -94,6 +96,7 @@ options:
       - If the first match is required, use C(firstmatch=yes).
       - A value is available; C(BOF) for inserting the line at the beginning of the file.
       - If specified regular expression has no matches, the line will be inserted at the end of the file.
+      - Cannot set with C(insertafter).      
       - If regular expressions are passed to both C(regexp) and C(insertbefore), C(insertbefore) is only honored if no match for C(regexp) is found.
       - May not be used with C(backrefs).
     type: str

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -96,7 +96,7 @@ options:
       - If the first match is required, use C(firstmatch=yes).
       - A value is available; C(BOF) for inserting the line at the beginning of the file.
       - If specified regular expression has no matches, the line will be inserted at the end of the file.
-      - Cannot set with C(insertafter).      
+      - Cannot set with C(insertafter).
       - If regular expressions are passed to both C(regexp) and C(insertbefore), C(insertbefore) is only honored if no match for C(regexp) is found.
       - May not be used with C(backrefs).
     type: str

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -82,10 +82,9 @@ options:
       - If the first match is required, use(firstmatch=yes).
       - A special value is available; C(EOF) for inserting the line at the end of the file.
       - If specified regular expression has no matches, EOF will be used instead.
-      - Cannot set with C(insertbefore).
       - If C(insertbefore) is set, default value C(EOF) will be ignored.
       - If regular expressions are passed to both C(regexp) and C(insertafter), C(insertafter) is only honored if no match for C(regexp) is found.
-      - May not be used with C(backrefs).
+      - May not be used with C(backrefs) or C(insertbefore).
     type: str
     choices: [ EOF, '*regex*' ]
     default: EOF
@@ -96,9 +95,8 @@ options:
       - If the first match is required, use C(firstmatch=yes).
       - A value is available; C(BOF) for inserting the line at the beginning of the file.
       - If specified regular expression has no matches, the line will be inserted at the end of the file.
-      - Cannot set with C(insertafter).
       - If regular expressions are passed to both C(regexp) and C(insertbefore), C(insertbefore) is only honored if no match for C(regexp) is found.
-      - May not be used with C(backrefs).
+      - May not be used with C(backrefs) or C(insertafter).
     type: str
     choices: [ BOF, '*regex*' ]
     version_added: "1.1"


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Add document which says `insertbefore` and `insertafter` are mutually exclusive in lineinfile module.
2. Add document which says if `insertbefore` is set, default value of `insertafter` `EOF` will be ignored.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lineinfile
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
1. If set `insertbefore` and  `insertafter` simultaneously, I got error message `parameters are mutually exclusive: insertbefore, insertafter`. Because  I could not find document to explain that behavior in our doc, I added No.1 document.

2. Original document could not explain behavior below. So, I added No.2 document.

###### playbook
```yaml
lineinfile:              
  path: /path/to/file
  regexp: '^11111'       
  insertbefore: '^222'   
  line: 'newline'
```
###### before
```
111
111
222
222
333
111
```

###### result
```
111
111
222
newline
222
333
111
```
###### expected result according to document
The line "newline" should be inserted at the end of the file because default value `EOF` of `insertafter` is still valid according to original document.
```
111
111
222
newline
222
333
111
newline
```
