### PR TITLE
systemd: Allow standalone 'daemon_reexec' option without using 'name'

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -80,7 +80,8 @@ options:
         default: no
         version_added: "2.3"
 notes:
-    - Since 2.4, one of the following options is required 'state', 'enabled', 'masked', 'daemon_reload', and all except 'daemon_reload' also require 'name'.
+    - Since 2.4, one of the following options is required 'state', 'enabled', 'masked', 'daemon_reload', ('daemon_reexec' since 2.8),
+      and all except 'daemon_reload' (and 'daemon_reexec' since 2.8) also require 'name'.
     - Before 2.4 you always required 'name'.
 requirements:
     - A system managed by systemd.
@@ -123,6 +124,10 @@ EXAMPLES = '''
 - name: just force systemd to reread configs (2.4 and above)
   systemd:
     daemon_reload: yes
+
+- name: just force systemd to re-execute itself (2.8 and above)
+  systemd:
+    daemon_reexec: yes
 '''
 
 RETURN = '''
@@ -325,7 +330,7 @@ def main():
             no_block=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
-        required_one_of=[['state', 'enabled', 'masked', 'daemon_reload']],
+        required_one_of=[['state', 'enabled', 'masked', 'daemon_reload', 'daemon_reexec']],
         required_by=dict(
             state=('name', ),
             enabled=('name', ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Since `systemctl daemon-reexec` is a legitimate command, Ansible should honor that as well.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Ref: #46032

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
systemd

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: reexecute systemd manager
  service:
    daemon_reexec: true
```
