### PR TITLE
Separate state from config, update ucspe link, ensure description idempotence

### DIFF
--- a/lib/ansible/modules/remote_management/ucs/ucs_org.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_org.py
@@ -18,7 +18,7 @@ short_description: Manages UCS Organizations for UCS Manager
 
 description:
   - Manages UCS Organizations for UCS Manager.
-  - Examples can be used with the L(UCS Platform Emulator, http://cs.co/ucspe).
+  - Examples can be used with the L(UCS Platform Emulator, https://community.cisco.com/t5/unified-computing-system/ucs-platform-emulator-downloads-ucspe-3-2-3epe1-ucspe-3-0-2cpe1/ta-p/3648177).
 
 extends_documentation_fragment: ucs
 
@@ -171,7 +171,7 @@ def main():
 
     kwargs = dict()
 
-    if module.params['description'] != None:
+    if module.params['description'] is not None:
         kwargs['descr'] = module.params['description']
 
     try:
@@ -179,7 +179,7 @@ def main():
         dn = parent_org_dn + '/org-' + module.params['org_name']
 
         mo = ucs.login_handle.query_dn(dn)
-        
+
         # Determine state change
         if mo:
             # Object exists, if it should exist has anything changed?
@@ -195,7 +195,7 @@ def main():
 
         # Object exists but should not, that is a change
         if mo and requested_state == 'absent':
-                changed = True
+            changed = True
 
         # Apply state if not check_mode
         if changed and not module.check_mode:
@@ -204,7 +204,7 @@ def main():
             else:
                 kwargs['parent_mo_or_dn'] = parent_org_dn
                 kwargs['name'] = module.params['org_name']
-                if module.params['description'] != None:
+                if module.params['description'] is not None:
                     kwargs['descr'] = module.params['description']
 
                 mo = OrgOrg(**kwargs)

--- a/lib/ansible/modules/remote_management/ucs/ucs_org.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_org.py
@@ -18,7 +18,7 @@ short_description: Manages UCS Organizations for UCS Manager
 
 description:
   - Manages UCS Organizations for UCS Manager.
-  - Examples can be used with the L(UCS Platform Emulator, https://cs.co/ucspe).
+  - Examples can be used with the UCS Platform Emulator U(https://cs.co/ucspe).
 
 extends_documentation_fragment: ucs
 

--- a/lib/ansible/modules/remote_management/ucs/ucs_org.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_org.py
@@ -18,7 +18,7 @@ short_description: Manages UCS Organizations for UCS Manager
 
 description:
   - Manages UCS Organizations for UCS Manager.
-  - Examples can be used with the L(UCS Platform Emulator, https://community.cisco.com/t5/unified-computing-system/ucs-platform-emulator-downloads-ucspe-3-2-3epe1-ucspe-3-0-2cpe1/ta-p/3648177).
+  - Examples can be used with the L(UCS Platform Emulator, https://cs.co/ucspe).
 
 extends_documentation_fragment: ucs
 


### PR DESCRIPTION
##### SUMMARY
Module remote_management/ucs_org bug fixes
- Mixes state determination with configuration, those operations were separated
- Not setting a description resulting in the removal of an existing description for an existing Org
- UCSPE link in documentation was invalid

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
ucs_org

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 2.8.0.dev0
  config file = /Users/jomcdono/Documents/src/ucs/ansible-envs/ucs/ansible.cfg
  configured module search path = ['/Users/jomcdono/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jomcdono/Documents/src/ucs/ansible/lib/ansible
  executable location = /Users/jomcdono/Documents/src/ucs/ansible/bin/ansible
  python version = 3.7.2 (default, Feb 12 2019, 08:15:36) [Clang 10.0.0 (clang-1000.11.45.5)]
```
