### PR TITLE
win_acl - fix support for registry paths

### DIFF
--- a/test/integration/targets/win_acl/defaults/main.yml
+++ b/test/integration/targets/win_acl/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 test_acl_path: '{{ win_output_dir }}\win_acl .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+# Use HKU as that path is not automatically loaded in the PSProvider making our test more complex
+test_acl_reg_path: HKU:\.DEFAULT\Ansible Test .ÅÑŚÌβŁÈ [$!@^&test(;)]

--- a/test/integration/targets/win_acl/tasks/main.yml
+++ b/test/integration/targets/win_acl/tasks/main.yml
@@ -7,6 +7,15 @@
   - absent
   - directory
 
+- name: ensure we start with a clean reg path
+  win_regedit:
+    path: '{{ test_acl_reg_path }}'
+    delete_key: yes
+    state: '{{ item }}'
+  with_items:
+  - absent
+  - present
+
 - block:
   - name: run tests
     include_tasks: tests.yml
@@ -15,4 +24,10 @@
   - name: cleanup testing dir
     win_file:
       path: '{{ test_acl_path }}'
+      state: absent
+
+  - name: cleanup testing reg path
+    win_regedit:
+      path: '{{ test_acl_reg_path }}'
+      delete_key: yes
       state: absent

--- a/test/integration/targets/win_acl/tasks/tests.yml
+++ b/test/integration/targets/win_acl/tasks/tests.yml
@@ -3,15 +3,24 @@
 - name: get register cmd that will get ace info
   set_fact:
     test_ace_cmd: |
+      # Overcome bug in Set-Acl/Get-Acl for registry paths and -LiteralPath
+      New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
+      Push-Location -LiteralPath (Split-Path -Path $path -Qualifier)
+      $rights_key = if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Registry") {
+          "RegistryRights"
+      } else {
+          "FileSystemRights"
+      }
       $ace_list = (Get-Acl -LiteralPath $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
           @{
-              rights = $_.FileSystemRights.ToString()
+              rights = $_."$rights_key".ToString()
               type = $_.AccessControlType.ToString()
               identity = $_.IdentityReference.Value.ToString()
               inheritance_flags = $_.InheritanceFlags.ToString()
               propagation_flags = $_.PropagationFlags.ToString()
           }
       }
+      Pop-Location
       ConvertTo-Json -InputObject @($ace_list)
 
 - name: add write rights to Guest
@@ -161,3 +170,151 @@
   assert:
     that:
     - not remove_deny_right_again is changed
+
+- name: add write rights to Guest - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: allow
+    user: Guests
+    rights: WriteKey
+  register: allow_right_reg
+
+- name: get result of add write rights to Guest - registry
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ test_ace_cmd }}'
+  register: allow_right_reg_actual
+
+- name: assert add write rights to Guest - registry
+  assert:
+    that:
+    - allow_right_reg is changed
+    - (allow_right_reg_actual.stdout|from_json)|count == 1
+    - (allow_right_reg_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (allow_right_reg_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (allow_right_reg_actual.stdout|from_json)[0].propagation_flags == 'None'
+    - (allow_right_reg_actual.stdout|from_json)[0].rights == 'WriteKey'
+    - (allow_right_reg_actual.stdout|from_json)[0].type == 'Allow'
+
+- name: add write rights to Guest (idempotent) - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: allow
+    user: Guests
+    rights: WriteKey
+  register: allow_right_reg_again
+
+- name: assert add write rights to Guest (idempotent) - registry
+  assert:
+    that:
+    - not allow_right_reg_again is changed
+
+- name: remove write rights from Guest - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: allow
+    user: Guests
+    rights: WriteKey
+    state: absent
+  register: remove_right_reg
+
+- name: get result of remove write rights from Guest - registry
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ test_ace_cmd }}'
+  register: remove_right_reg_actual
+
+- name: assert remove write rights from Guest - registry
+  assert:
+    that:
+    - remove_right_reg is changed
+    - remove_right_reg_actual.stdout_lines == ["[", "", "]"]
+
+- name: remove write rights from Guest (idempotent) - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: allow
+    user: Guests
+    rights: WriteKey
+    state: absent
+  register: remove_right_reg_again
+
+- name: assert remote write rights from Guest (idempotent) - registry
+  assert:
+    that:
+    - not remove_right_reg_again is changed
+
+- name: add deny write rights to Guest - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: deny
+    user: Guests
+    rights: WriteKey
+    inherit: ContainerInherit
+    propagation: NoPropagateInherit
+    state: present
+  register: add_deny_right_reg
+
+- name: get result of add deny write rights to Guest - registry
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ test_ace_cmd }}'
+  register: add_deny_right_reg_actual
+
+- name: assert add deny write rights to Guest - registry
+  assert:
+    that:
+    - add_deny_right_reg is changed
+    - (add_deny_right_reg_actual.stdout|from_json)|count == 1
+    - (add_deny_right_reg_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (add_deny_right_reg_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit'
+    - (add_deny_right_reg_actual.stdout|from_json)[0].propagation_flags == 'NoPropagateInherit'
+    - (add_deny_right_reg_actual.stdout|from_json)[0].rights == 'WriteKey'
+    - (add_deny_right_reg_actual.stdout|from_json)[0].type == 'Deny'
+
+- name: add deny write rights to Guest (idempotent) - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: deny
+    user: Guests
+    rights: WriteKey
+    inherit: ContainerInherit
+    propagation: NoPropagateInherit
+    state: present
+  register: add_deny_right_reg_again
+
+- name: assert add deny write rights to Guest (idempotent) - registry
+  assert:
+    that:
+    - not add_deny_right_reg_again is changed
+
+- name: remove deny write rights from Guest - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: deny
+    user: Guests
+    rights: WriteKey
+    inherit: ContainerInherit
+    propagation: NoPropagateInherit
+    state: absent
+  register: remove_deny_right_reg
+
+- name: get result of remove deny write rights from Guest - registry
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ test_ace_cmd }}'
+  register: remove_deny_right_reg_actual
+
+- name: assert remove deny write rights from Guest - registry
+  assert:
+    that:
+    - remove_deny_right_reg is changed
+    - remove_deny_right_reg_actual.stdout_lines == ["[", "", "]"]
+
+- name: remove deny write rights from Guest (idempotent) - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: deny
+    user: Guests
+    rights: WriteKey
+    inherit: ContainerInherit
+    propagation: NoPropagateInherit
+    state: absent
+  register: remove_deny_right_reg_again
+
+- name: assert remove deny write rights from Guest (idempotent) - registry
+  assert:
+    that:
+    - not remove_deny_right_reg_again is changed


### PR DESCRIPTION
##### SUMMARY
Fixes an issue where win_acl is no longer able to set registry path DACLs due to a but when using `-LiteralPath` with the `Get/Set-Acl` cmdlets. This also adds tests for this scenario so this shouldn't happen again.

Fixes https://github.com/ansible/ansible/issues/54357. No changelog is needed because the breaking change has not made it into a release yet.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_acl