### PR TITLE
Add administrative up/down option.

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -51,6 +51,8 @@ options:
     description:
       - The administrative state of the Layer-3 interface. It sets the state to be either Up
         or Down.
+    default: up
+    choices: ['up', 'down']
 extends_documentation_fragment: ios
 """
 
@@ -182,7 +184,7 @@ def map_obj_to_commands(updates, module):
         ipv6 = w['ipv6']
         state = w['state']
         updown = w['updown']
-        
+
         interface = 'interface ' + name
         commands.append(interface)
 
@@ -209,7 +211,7 @@ def map_obj_to_commands(updates, module):
                 commands.append('no shutdown')
             elif updown == 'down':
                 commands.append('shutdown')
-                
+
             if ipv4:
                 if obj_in_have is None or obj_in_have.get('ipv4') is None or ipv4 != obj_in_have['ipv4']:
                     address = ipv4.split('/')
@@ -292,8 +294,7 @@ def main():
         ipv6=dict(),
         state=dict(default='present',
                    choices=['present', 'absent']),
-        updown=dict(default='up',
-                   choices=['up', 'down'])
+        updown=dict(default='up', choices=['up', 'down'])
     )
 
     aggregate_spec = deepcopy(element_spec)

--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -252,8 +252,7 @@ def map_config_to_obj(module):
             'name': item,
             'ipv4': ipv4,
             'ipv6': parse_config_argument(configobj, item, 'ipv6 address'),
-            'state': 'present',
-            'updown': updown
+            'state': 'present'
         }
         instances.append(obj)
 

--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -53,6 +53,7 @@ options:
         or Down.
     default: up
     choices: ['up', 'down']
+    version_added: "2.8"
 extends_documentation_fragment: ios
 """
 


### PR DESCRIPTION
Adding an option to control the administrative state of a layer 3 interface. Up/Down represent "no shutdown" and "shutdown" respectively.
