### PR TITLE
[aws_s3] fix deleting versioned objects before deleting bucket

### DIFF
--- a/changelogs/fragments/54435_aws_s3_fix_removing_versioned_buckets.yaml
+++ b/changelogs/fragments/54435_aws_s3_fix_removing_versioned_buckets.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_s3 - Delete objects and delete markers so versioned buckets can be removed.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -122,7 +122,7 @@ Noteworthy module changes
 * :ref:`docker_container <docker_container_module>`'s support for port ranges was adjusted to be more compatible to the ``docker`` command line utility: a one-port container range combined with a multiple-port host range will no longer result in only the first host port be used, but the whole range being passed to Docker so that a free port in that range will be used.
 * :ref:`purefb_fs <purefb_fs_module>` no longer supports the deprecated ``nfs`` option. This has been superceeded by ``nfsv3``.
 * :ref:`nxos_igmp_interface <nxos_igmp_interface_module>` no longer supports the deprecated ``oif_prefix`` and ``oif_source`` options. These have been superceeded by ``oif_ps``.
-* :ref:`aws_s3 <aws_s3_module>` is now able to delete buckets (and their contents) that have versioning enabled when ``mode`` is set to ``delete``.
+* :ref:`aws_s3 <aws_s3_module>` can now delete versioned buckets even when they are not empty - set mode to delete to delete a versioned bucket and everything in it.
 
 
 Plugins

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -122,6 +122,7 @@ Noteworthy module changes
 * :ref:`docker_container <docker_container_module>`'s support for port ranges was adjusted to be more compatible to the ``docker`` command line utility: a one-port container range combined with a multiple-port host range will no longer result in only the first host port be used, but the whole range being passed to Docker so that a free port in that range will be used.
 * :ref:`purefb_fs <purefb_fs_module>` no longer supports the deprecated ``nfs`` option. This has been superceeded by ``nfsv3``.
 * :ref:`nxos_igmp_interface <nxos_igmp_interface_module>` no longer supports the deprecated ``oif_prefix`` and ``oif_source`` options. These have been superceeded by ``oif_ps``.
+* :ref:`aws_s3 <aws_s3_module>` is now able to delete buckets (and their contents) that have versioning enabled when ``mode`` is set to ``delete``.
 
 
 Plugins


### PR DESCRIPTION
##### SUMMARY
Prior to this fix the latest objects are deleted from a bucket but the versioned markers are left behind, causing a traceback when deleting the bucket.

Generating the list of keys and deleted version markers from `list_object_versions` works both for versioned and non-versioned buckets. I kept the original attempt via `list_objects_v2` in case of permissions errors or S3 drop-ins without versioning support.

Fixes #53536

@willthames Do you mind taking a look at this? It seems like a foot gun that people could delete a bucket containing versioned objects accidentally. But since [object locks](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) can prevent that I'm not sure. Thoughts?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_s3