### PR TITLE
Add macOS support to hostname module

### DIFF
--- a/changelogs/fragments/322214-hostname-macos-support.yml
+++ b/changelogs/fragments/322214-hostname-macos-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - add macOS support (https://github.com/ansible/ansible/pull/54439)

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -18,9 +18,12 @@ version_added: "1.4"
 short_description: Manage hostname
 requirements: [ hostname ]
 description:
-    - Set system's hostname, supports most OSs/Distributions, including those using systemd.
+    - Set system's hostname. Supports most OSs/Distributions including those using C(systemd).
     - Note, this module does *NOT* modify C(/etc/hosts). You need to modify it yourself using other modules like template or replace.
     - Windows, HP-UX, and AIX are not currently supported.
+notes:
+    - On macOS, this module uses C(scutil) to set C(HostName), C(ComputerName), and C(LocalHostName). Since C(LocalHostName)
+      cannot contain spaces or most special characters, this module will replace characters when setting C(LocalHostName).
 options:
     name:
         description:
@@ -583,17 +586,21 @@ class FreeBSDStrategy(GenericStrategy):
 
 class DarwinStrategy(GenericStrategy):
     """
-    This is a macOS hostname manipulation strategy class - it uses
+    This is a macOS hostname manipulation strategy class. It uses
     /usr/sbin/scutil to set ComputerName, HostName, and LocalHostName.
 
-    HostName corresponds to what most platforms consider to be hostname;
-    it controls the name used on the commandline and SSH.
+    HostName corresponds to what most platforms consider to be hostname.
+    It controls the name used on the commandline and SSH.
 
     However, macOS also has LocalHostName and ComputerName settings.
     LocalHostName controls the Bonjour/ZeroConf name, used by services
-    like AirDrop. ComputerName is the name used for user-facing GUI
-    services, like the System Preferences/Sharing pane and when users
-    connect to the Mac over the network.
+    like AirDrop. This class implements a method, _scrub_hostname(), that mimics
+    the transformations macOS makes on hostnames when enterened in the Sharing
+    preference pane. It replaces spaces with dashes and removes all special
+    characters.
+
+    ComputerName is the name used for user-facing GUI services, like the
+    System Preferences/Sharing pane and when users connect to the Mac over the network.
     """
 
     def __init__(self, module):

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -704,7 +704,7 @@ class DarwinStrategy(GenericStrategy):
         # Get all the current host name values in the order of self.name_types
         all_names = tuple(self.module.run_command([self.scutil, '--get', name_type])[1].strip() for name_type in self.name_types)
 
-        # Get the expeceted hostname valuse based on the order in self.name_types
+        # Get the expected host name values based on the order in self.name_types
         expected_names = tuple(self.scrubbed_name if n == 'LocalHostName' else name for n in self.name_types)
 
         # Ensure all three names are updated

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -36,7 +36,7 @@ options:
         description:
             - Which strategy to use to update the hostname.
             - If not set we try to autodetect, but this can be problematic, particularly with containers as they can present misleading information.
-        choices: ['alpine', 'debian', 'freebsd', 'generic', 'macos', 'openbsd', 'openrc', 'redhat', 'sles', 'solaris', 'systemd']
+        choices: ['alpine', 'debian', 'freebsd', 'generic', 'macos', 'macosx', 'darwin', 'openbsd', 'openrc', 'redhat', 'sles', 'solaris', 'systemd']
         type: str
         version_added: '2.9'
 '''

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -590,7 +590,7 @@ class DarwinStrategy(GenericStrategy):
     /usr/sbin/scutil to set ComputerName, HostName, and LocalHostName.
 
     HostName corresponds to what most platforms consider to be hostname.
-    It controls the name used on the commandline and SSH.
+    It controls the name used on the command line and SSH.
 
     However, macOS also has LocalHostName and ComputerName settings.
     LocalHostName controls the Bonjour/ZeroConf name, used by services
@@ -609,7 +609,7 @@ class DarwinStrategy(GenericStrategy):
         self.name_types = ('HostName', 'ComputerName', 'LocalHostName')
         self.scrubbed_name = self._scrub_hostname(self.module.params['name'])
 
-    def _maketrans(self, replace_chars, replacement_chars, delete_chars):
+    def _make_translation(self, replace_chars, replacement_chars, delete_chars):
         if PY3:
             return str.maketrans(replace_chars, replacement_chars, delete_chars)
 
@@ -625,7 +625,8 @@ class DarwinStrategy(GenericStrategy):
         return table
 
     def _scrub_hostname(self, name):
-        """LocalHostName only accepts valid DNS characters while HostName and ComputerName
+        """
+        LocalHostName only accepts valid DNS characters while HostName and ComputerName
         accept a much wider range of characters. This function aims to mimic how macOS
         translates a friendly name to the LocalHostName.
         """
@@ -634,7 +635,7 @@ class DarwinStrategy(GenericStrategy):
         name = to_text(name)
         replace_chars = u'\'"~`!@#$%^&*(){}[]/=?+\\|-_ '
         delete_chars = u".'"
-        table = self._maketrans(replace_chars, u'-' * len(replace_chars), delete_chars)
+        table = self._make_translation(replace_chars, u'-' * len(replace_chars), delete_chars)
         name = name.translate(table)
 
         # Replace multiple dashes with a single dash

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -626,7 +626,7 @@ class DarwinStrategy(GenericStrategy):
 
     def _scrub_hostname(self, name):
         """LocalHostName only accepts valid DNS characters while HostName and ComputerName
-        accept a much wider range of characters. This functions aims to mimic how macOS
+        accept a much wider range of characters. This function aims to mimic how macOS
         translates a friendly name to the LocalHostName.
         """
 
@@ -648,8 +648,8 @@ class DarwinStrategy(GenericStrategy):
         cmd = [self.scutil, '--get', 'HostName']
         rc, out, err = self.module.run_command(cmd)
         if rc != 0 and 'HostName: not set' not in err:
-
             self.module.fail_json(msg="Failed to get current hostname rc=%d, out=%s, err=%s" % (rc, out, err))
+
         return to_native(out).strip()
 
     def get_permanent_hostname(self):
@@ -657,6 +657,7 @@ class DarwinStrategy(GenericStrategy):
         rc, out, err = self.module.run_command(cmd)
         if rc != 0:
             self.module.fail_json(msg="Failed to get permanent hostname rc=%d, out=%s, err=%s" % (rc, out, err))
+
         return to_native(out).strip()
 
     def set_permanent_hostname(self, name):

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -20,7 +20,7 @@ requirements: [ hostname ]
 description:
     - Set system's hostname, supports most OSs/Distributions, including those using systemd.
     - Note, this module does *NOT* modify C(/etc/hosts). You need to modify it yourself using other modules like template or replace.
-    - Windows, macOS, HP-UX and AIX are not currently supported.
+    - Windows, HP-UX, and AIX are not currently supported.
 options:
     name:
         description:
@@ -54,7 +54,8 @@ from ansible.module_utils.basic import (
 )
 from ansible.module_utils.common.sys_info import get_platform_subclass
 from ansible.module_utils.facts.system.service_mgr import ServiceMgrFactCollector
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.six import PY3, text_type
 
 STRATS = {'generic': 'Generic', 'debian': 'Debian', 'sles': 'SLES', 'redhat': 'RedHat', 'alpine': 'Alpine',
           'systemd': 'Systemd', 'openrc': 'OpenRC', 'openbsd': 'OpenBSD', 'solaris': 'Solaris', 'freebsd': 'FreeBSD'}
@@ -580,6 +581,104 @@ class FreeBSDStrategy(GenericStrategy):
             f.close()
 
 
+class DarwinStrategy(GenericStrategy):
+    """
+    This is a macOS hostname manipulation strategy class - it uses
+    /usr/sbin/scutil to set ComputerName, HostName, and LocalHostName.
+
+    HostName corresponds to what most platforms consider to be hostname;
+    it controls the name used on the commandline and SSH.
+
+    However, macOS also has LocalHostName and ComputerName settings.
+    LocalHostName controls the Bonjour/ZeroConf name, used by services
+    like AirDrop. ComputerName is the name used for user-facing GUI
+    services, like the System Preferences/Sharing pane and when users
+    connect to the Mac over the network.
+    """
+
+    def __init__(self, module):
+        super(DarwinStrategy, self).__init__(module)
+        self.scutil = self.module.get_bin_path('scutil', True)
+        self.name_types = ('HostName', 'ComputerName', 'LocalHostName')
+        self.scrubbed_name = self._scrub_hostname(self.module.params['name'])
+
+    def _maketrans(self, replace_chars, replacement_chars, delete_chars):
+        if PY3:
+            return str.maketrans(replace_chars, replacement_chars, delete_chars)
+
+        if not isinstance(replace_chars, text_type) or not isinstance(replacement_chars, text_type):
+            raise ValueError('replace_chars and replacement_chars must both be strings')
+        if len(replace_chars) != len(replacement_chars):
+            raise ValueError('replacement_chars must be the same length as replace_chars')
+
+        table = dict(zip((ord(c) for c in replace_chars), replacement_chars))
+        for char in delete_chars:
+            table[ord(char)] = None
+
+        return table
+
+    def _scrub_hostname(self, name):
+        """LocalHostName only accepts valid DNS characters while HostName and ComputerName
+        accept a much wider range of characters. This functions aims to mimic how macOS
+        translates a friendly name to the LocalHostName.
+        """
+
+        # Replace all these characters with a single dash
+        name = to_text(name)
+        replace_chars = u'\'"~`!@#$%^&*(){}[]/=?+\\|-_ '
+        delete_chars = u".'"
+        table = self._maketrans(replace_chars, u'-' * len(replace_chars), delete_chars)
+        name = name.translate(table)
+
+        # Replace multiple dashes with a single dash
+        while '-' * 2 in name:
+            name = name.replace('-' * 2, '')
+
+        name = name.rstrip('-')
+        return name
+
+    def get_current_hostname(self):
+        cmd = [self.scutil, '--get', 'HostName']
+        rc, out, err = self.module.run_command(cmd)
+        if rc != 0 and 'HostName: not set' not in err:
+
+            self.module.fail_json(msg="Failed to get current hostname rc=%d, out=%s, err=%s" % (rc, out, err))
+        return to_native(out).strip()
+
+    def get_permanent_hostname(self):
+        cmd = [self.scutil, '--get', 'ComputerName']
+        rc, out, err = self.module.run_command(cmd)
+        if rc != 0:
+            self.module.fail_json(msg="Failed to get permanent hostname rc=%d, out=%s, err=%s" % (rc, out, err))
+        return to_native(out).strip()
+
+    def set_permanent_hostname(self, name):
+        for hostname_type in self.name_types:
+            if hostname_type == 'LocalHostName':
+                name = self.scrubbed_name
+            cmd = [self.scutil, '--set', hostname_type, to_native(name)]
+            rc, out, err = self.module.run_command(cmd)
+            if rc != 0:
+                self.module.fail_json(msg="Failed to set {3} to '{2}': {0} {1}".format(to_native(out), to_native(err), to_native(name), hostname_type))
+
+    def set_current_hostname(self, name):
+        pass
+
+    def update_current_hostname(self):
+        pass
+
+    def update_permanent_hostname(self):
+        name = self.module.params['name']
+
+        # Ensure all three names were updated
+        all_names = tuple((self.module.run_command([self.scutil, '--get', name_type])[1].strip() for name_type in self.name_types))
+
+        if all_names != (name, name, self.scrubbed_name):
+            if not self.module.check_mode:
+                self.set_permanent_hostname(name)
+            self.changed = True
+
+
 class FedoraHostname(Hostname):
     platform = 'Linux'
     distribution = 'Fedora'
@@ -822,6 +921,12 @@ class NeonHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class DarwinHostname(Hostname):
+    platform = 'Darwin'
+    distribution = None
+    strategy_class = DarwinStrategy
+
+
 class OsmcHostname(Hostname):
     platform = 'Linux'
     distribution = 'Osmc'
@@ -866,6 +971,8 @@ def main():
     if name != current_hostname:
         name_before = current_hostname
     elif name != permanent_hostname:
+        name_before = permanent_hostname
+    else:
         name_before = permanent_hostname
 
     kw = dict(changed=changed, name=name,

--- a/test/integration/targets/hostname/aliases
+++ b/test/integration/targets/hostname/aliases
@@ -1,5 +1,3 @@
 shippable/posix/group1
 destructive
 skip/aix  # currently unsupported by hostname module
-skip/osx  # same, see #54439, #32214
-skip/macos

--- a/test/integration/targets/hostname/tasks/MacOSX.yml
+++ b/test/integration/targets/hostname/tasks/MacOSX.yml
@@ -1,0 +1,43 @@
+- name: macOS | Get macOS hostname values
+  command: scutil --get {{ item }}
+  loop:
+    - HostName
+    - ComputerName
+    - LocalHostName
+  register: macos_scutil
+  ignore_errors: yes
+
+- name: macOS | Ensure all hostname values were set correctly
+  assert:
+    that:
+      - "['bugs.acme.com', 'bugs.acme.com', 'bugsacmecom'] == macos_scutil.results | map(attribute='stdout') | list"
+
+- name: macOS | Set to a hostname using spaces and punctuation
+  hostname:
+    name: The Dude's Computer
+
+- name: macOS | Get macOS hostname values
+  command: scutil --get {{ item }}
+  loop:
+    - HostName
+    - ComputerName
+    - LocalHostName
+  register: macos_scutil_complex
+  ignore_errors: yes
+
+- name: macOS | Ensure all hostname values were set correctly
+  assert:
+    that:
+      - "['The Dude\\'s Computer', 'The Dude\\'s Computer', 'The-Dudes-Computer'] == (macos_scutil_complex.results | map(attribute='stdout') | list)"
+
+- name: macOS | Set all hostname values to the default
+  command: scutil --set {{ item }} ''
+  loop:
+    - HostName
+    - ComputerName
+    - LocalHostName
+  register: macos_scutil_complex
+
+- name: macOS | Set hostname after being reset to defaults
+  hostname:
+    name: Macintosh

--- a/test/integration/targets/hostname/tasks/MacOSX.yml
+++ b/test/integration/targets/hostname/tasks/MacOSX.yml
@@ -9,12 +9,12 @@
     name: bugs.acme.example.com
     use: macos
 
-- name: macOS | Set hostname specifiying macos strategy
+- name: macOS | Set hostname specifiying macosx strategy
   hostname:
     name: bugs.acme.example.com
     use: macosx
 
-- name: macOS | Set hostname specifiying macos strategy
+- name: macOS | Set hostname specifiying darwin strategy
   hostname:
     name: bugs.acme.example.com
     use: darwin

--- a/test/integration/targets/hostname/tasks/MacOSX.yml
+++ b/test/integration/targets/hostname/tasks/MacOSX.yml
@@ -1,3 +1,7 @@
+- name: Set hostname
+  hostname:
+    name: bugs.acme.notld
+
 - name: macOS | Get macOS hostname values
   command: scutil --get {{ item }}
   loop:
@@ -10,7 +14,7 @@
 - name: macOS | Ensure all hostname values were set correctly
   assert:
     that:
-      - "['bugs.acme.com', 'bugs.acme.com', 'bugsacmecom'] == macos_scutil.results | map(attribute='stdout') | list"
+      - "['bugs.acme.notld', 'bugs.acme.notld', 'bugsacmecom'] == macos_scutil.results | map(attribute='stdout') | list"
 
 - name: macOS | Set to a hostname using spaces and punctuation
   hostname:
@@ -29,15 +33,3 @@
   assert:
     that:
       - "['The Dude\\'s Computer', 'The Dude\\'s Computer', 'The-Dudes-Computer'] == (macos_scutil_complex.results | map(attribute='stdout') | list)"
-
-- name: macOS | Set all hostname values to the default
-  command: scutil --set {{ item }} ''
-  loop:
-    - HostName
-    - ComputerName
-    - LocalHostName
-  register: macos_scutil_complex
-
-- name: macOS | Set hostname after being reset to defaults
-  hostname:
-    name: Macintosh

--- a/test/integration/targets/hostname/tasks/MacOSX.yml
+++ b/test/integration/targets/hostname/tasks/MacOSX.yml
@@ -1,6 +1,23 @@
-- name: Set hostname
+- name: macOS | Set hostname
   hostname:
-    name: bugs.acme.notld
+    name: bugs.acme.example.com
+
+# These tasks can be changed to a loop once https://github.com/ansible/ansible/issues/71031
+# is fixed
+- name: macOS | Set hostname specifiying macos strategy
+  hostname:
+    name: bugs.acme.example.com
+    use: macos
+
+- name: macOS | Set hostname specifiying macos strategy
+  hostname:
+    name: bugs.acme.example.com
+    use: macosx
+
+- name: macOS | Set hostname specifiying macos strategy
+  hostname:
+    name: bugs.acme.example.com
+    use: darwin
 
 - name: macOS | Get macOS hostname values
   command: scutil --get {{ item }}
@@ -14,7 +31,7 @@
 - name: macOS | Ensure all hostname values were set correctly
   assert:
     that:
-      - "['bugs.acme.notld', 'bugs.acme.notld', 'bugsacmecom'] == macos_scutil.results | map(attribute='stdout') | list"
+      - "['bugs.acme.example.com', 'bugs.acme.example.com', 'bugsacmeexamplecom'] == macos_scutil.results | map(attribute='stdout') | list"
 
 - name: macOS | Set to a hostname using spaces and punctuation
   hostname:

--- a/test/integration/targets/hostname/tasks/main.yml
+++ b/test/integration/targets/hostname/tasks/main.yml
@@ -1,5 +1,5 @@
 # Setting the hostname in our test containers doesn't work currently
-- when: ansible_facts.virtualization_type not in ('docker', 'container')
+- when: ansible_facts.virtualization_type not in ('docker', 'container', 'containerd')
   block:
     - name: Include distribution specific variables
       include_vars: "{{ lookup('first_found', params) }}"

--- a/test/integration/targets/hostname/tasks/main.yml
+++ b/test/integration/targets/hostname/tasks/main.yml
@@ -16,84 +16,8 @@
       command: hostname
       register: original
 
-    - name: Run hostname module in check_mode
-      hostname:
-        name: crocodile.ansible.test.doesthiswork.net.example.com
-      check_mode: true
-      register: hn1
-
-    - name: Get current hostname again
-      command: hostname
-        name: bugs.acme.com
-      register: after_hn
-
-    - name: Ensure hostname changed properly
-    - assert:
-        that:
-          - hn1 is changed
-          - hnchange2 is not changed
-          - original.stdout == after_hn.stdout
-          - ansible_facts.nodename == 'bugs.acme.com'
-
-    - when: _hostname_file is defined and _hostname_file
-      block:
-        - name: See if current hostname file exists
-          stat:
-            path: "{{ _hostname_file }}"
-          register: hn_stat
-
-        - name: Move the current hostname file if it exists
-          command: mv {{ _hostname_file }} {{ _hostname_file }}.orig
-          when: hn_stat.stat.exists
-
-        - name: Run hostname module in check_mode
-          hostname:
-            name: crocodile.ansible.test.doesthiswork.net.example.com
-          check_mode: true
-          register: hn
-
-        - stat:
-            path: /etc/rc.conf.d/hostname
-          register: hn_stat_checkmode
-
-        - assert:
-            that:
-              # TODO: This is a legitimate bug and will be fixed in another PR.
-              # - not hn_stat_checkmode.stat.exists
-              - hn is changed
-
-        - name: Get hostname again
-          command: hostname
-          register: current_after_cm
-
-        - assert:
-            that:
-              - original.stdout == current_after_cm.stdout
-
-    - name: Run hostname module for real now
-      hostname:
-        name: crocodile.ansible.test.doesthiswork.net.example.com
-      register: hn2
-
-    - name: Get hostname
-      command: hostname
-      register: current_after_hn2
-
-    - name: Run hostname again to ensure it is idempotent
-      hostname:
-        name: crocodile.ansible.test.doesthiswork.net.example.com
-      register: hnidem
-
-    - name: Get hostname
-      command: hostname
-      register: current_after_hnidem
-
-    - assert:
-        that:
-          - hn2 is changed
-          - hnidem is not changed
-          - current_after_hn2.stdout == 'crocodile.ansible.test.doesthiswork.net.example.com'
-          - current_after_hn2.stdout == current_after_hnidem.stdout
+    - import_tasks: test_check_mode.yml
+    - import_tasks: test_normal.yml
 
     - name: Include distribution specific tasks
       include_tasks:
@@ -107,20 +31,20 @@
     # Reset back to original hostname
     - name: Move back original file if it existed
       command: mv -f {{ _hostname_file }}.orig {{ _hostname_file }}
-      when: hn_stat is defined and hn_stat.stat.exists
+      when: hn_stat.stat.exists | default(False)
 
     - name: Delete the file if it never existed
       file:
         path: "{{ _hostname_file }}"
         state: absent
-      when: hn_stat is defined and not hn_stat.stat.exists
+      when: not hn_stat.stat.exists | default(True)
 
-    # Reset back to original hostname
-    - hostname:
+    - name: Reset back to original hostname
+      hostname:
         name: "{{ original.stdout }}"
       register: revert
 
-    # And make sure we really do
-    - assert:
+    - name: Ensure original hostname was reset
+      assert:
         that:
           - revert is changed

--- a/test/integration/targets/hostname/tasks/main.yml
+++ b/test/integration/targets/hostname/tasks/main.yml
@@ -102,8 +102,6 @@
         files:
           - "{{ ansible_facts.distribution }}.yml"
           - default.yml
-  # Setting the hostname in our test containers doesn't work currently
-  when: ansible_facts.virtualization_type != 'docker'
 
   always:
     # Reset back to original hostname

--- a/test/integration/targets/hostname/tasks/main.yml
+++ b/test/integration/targets/hostname/tasks/main.yml
@@ -24,12 +24,16 @@
 
     - name: Get current hostname again
       command: hostname
+        name: bugs.acme.com
       register: after_hn
 
+    - name: Ensure hostname changed properly
     - assert:
         that:
           - hn1 is changed
+          - hnchange2 is not changed
           - original.stdout == after_hn.stdout
+          - ansible_facts.nodename == 'bugs.acme.com'
 
     - when: _hostname_file is defined and _hostname_file
       block:
@@ -98,6 +102,9 @@
         files:
           - "{{ ansible_facts.distribution }}.yml"
           - default.yml
+  # Setting the hostname in our test containers doesn't work currently
+  when: ansible_facts.virtualization_type != 'docker'
+
   always:
     # Reset back to original hostname
     - name: Move back original file if it existed

--- a/test/integration/targets/hostname/tasks/test_check_mode.yml
+++ b/test/integration/targets/hostname/tasks/test_check_mode.yml
@@ -1,0 +1,50 @@
+- name: Run hostname module in check_mode
+  hostname:
+    name: crocodile.ansible.test.doesthiswork.net.example.com
+  check_mode: true
+  register: hn1
+
+- name: Get current hostname again
+  command: hostname
+  register: after_hn
+
+- name: Ensure hostname changed properly
+  assert:
+    that:
+      - hn1 is changed
+      - original.stdout == after_hn.stdout
+
+- when: _hostname_file is defined and _hostname_file
+  block:
+    - name: See if current hostname file exists
+      stat:
+        path: "{{ _hostname_file }}"
+      register: hn_stat
+
+    - name: Move the current hostname file if it exists
+      command: mv {{ _hostname_file }} {{ _hostname_file }}.orig
+      when: hn_stat.stat.exists
+
+    - name: Run hostname module in check_mode
+      hostname:
+        name: crocodile.ansible.test.doesthiswork.net.example.com
+      check_mode: true
+      register: hn
+
+    - stat:
+        path: /etc/rc.conf.d/hostname
+      register: hn_stat_checkmode
+
+    - assert:
+        that:
+          # TODO: This is a legitimate bug and will be fixed in another PR.
+          # - not hn_stat_checkmode.stat.exists
+          - hn is changed
+
+    - name: Get hostname again
+      command: hostname
+      register: current_after_cm
+
+    - assert:
+        that:
+          - original.stdout == current_after_cm.stdout

--- a/test/integration/targets/hostname/tasks/test_normal.yml
+++ b/test/integration/targets/hostname/tasks/test_normal.yml
@@ -1,0 +1,24 @@
+- name: Run hostname module for real now
+  hostname:
+    name: crocodile.ansible.test.doesthiswork.net.example.com
+  register: hn2
+
+- name: Get hostname
+  command: hostname
+  register: current_after_hn2
+
+- name: Run hostname again to ensure it does not change
+  hostname:
+    name: crocodile.ansible.test.doesthiswork.net.example.com
+  register: hn3
+
+- name: Get hostname
+  command: hostname
+  register: current_after_hn3
+
+- assert:
+    that:
+      - hn2 is changed
+      - hn3 is not changed
+      - current_after_hn2.stdout == 'crocodile.ansible.test.doesthiswork.net.example.com'
+      - current_after_hn2.stdout == current_after_hn2.stdout


### PR DESCRIPTION
##### SUMMARY
macOS has three seprate hostname params that need to be set: `HostName`, `ComputerName`, and `LocalHostName`. One of those params, `LocalHostName`, has more stringent requirements than the other two, which accept special characters and spaces. I created a method to scrub the hostname to ensure it works well with the system requirements

Closes #32214 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/system/hostname.py`

##### ADDITIONAL INFORMATION
It's still up for debate if we should be setting all there of these values, as discussed in #32214. I think it seems to make the most sense to set at least `ComputerName` and `LocalHostName`. I found some Mac admins that reported setting `HostName` is not a good idea. We can omit that if needed.

I still need to write some docs on this.