### PR TITLE
Temporarily skip failing Docker tests on RHEL 7.6.

### DIFF
--- a/test/integration/targets/docker_config/aliases
+++ b/test/integration/targets/docker_config/aliases
@@ -5,3 +5,4 @@ destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.
+skip/rhel7.6

--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -2,3 +2,4 @@ shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_container_info/aliases
+++ b/test/integration/targets/docker_container_info/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_host_info/aliases
+++ b/test/integration/targets/docker_host_info/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_image/aliases
+++ b/test/integration/targets/docker_image/aliases
@@ -2,3 +2,4 @@ shippable/posix/group3
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_image_info/aliases
+++ b/test/integration/targets/docker_image_info/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_network/aliases
+++ b/test/integration/targets/docker_network/aliases
@@ -2,3 +2,4 @@ shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_network_info/aliases
+++ b/test/integration/targets/docker_network_info/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_node/aliases
+++ b/test/integration/targets/docker_node/aliases
@@ -8,3 +8,4 @@ skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # after finishing the tests to minimize potential effects
              # on other tests.
 needs/root
+skip/rhel7.6

--- a/test/integration/targets/docker_node_info/aliases
+++ b/test/integration/targets/docker_node_info/aliases
@@ -5,3 +5,4 @@ destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.
+skip/rhel7.6

--- a/test/integration/targets/docker_prune/aliases
+++ b/test/integration/targets/docker_prune/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_secret/aliases
+++ b/test/integration/targets/docker_secret/aliases
@@ -5,3 +5,4 @@ destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.
+skip/rhel7.6

--- a/test/integration/targets/docker_stack/aliases
+++ b/test/integration/targets/docker_stack/aliases
@@ -5,3 +5,4 @@ destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.
+skip/rhel7.6

--- a/test/integration/targets/docker_swarm/aliases
+++ b/test/integration/targets/docker_swarm/aliases
@@ -8,3 +8,4 @@ skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # after finishing the tests to minimize potential effects
              # on other tests.
 needs/root
+skip/rhel7.6

--- a/test/integration/targets/docker_swarm_info/aliases
+++ b/test/integration/targets/docker_swarm_info/aliases
@@ -5,3 +5,4 @@ destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.
+skip/rhel7.6

--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -5,3 +5,4 @@ destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting
              # the whole CI system.
+skip/rhel7.6

--- a/test/integration/targets/docker_volume/aliases
+++ b/test/integration/targets/docker_volume/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/docker_volume_info/aliases
+++ b/test/integration/targets/docker_volume_info/aliases
@@ -2,3 +2,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 destructive
+skip/rhel7.6

--- a/test/integration/targets/inventory_docker_swarm/aliases
+++ b/test/integration/targets/inventory_docker_swarm/aliases
@@ -8,3 +8,4 @@ skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # after finishing the tests to minimize potential effects
              # on other tests.
 needs/root
+skip/rhel7.6


### PR DESCRIPTION
##### SUMMARY

Temporarily skip failing Docker tests on RHEL 7.6.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker integration tests
