### PR TITLE
VMware: Securize the index lookup of dict.keys() item

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
@@ -114,7 +114,7 @@ class VMwareConfigurationBackup(PyVmomi):
                 self.module.fail_json(msg="Failed to find ESXi %s" % self.esxi_hostname)
 
         host_system = get_all_objs(self.content, [vim.HostSystem])
-        return host_system.keys()[0]
+        return list(host_system)[0]
 
     def process_state(self):
         if self.state == 'saved':

--- a/lib/ansible/modules/cloud/vmware/vmware_dns_config.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dns_config.py
@@ -108,7 +108,7 @@ def main():
         host = get_all_objs(content, [vim.HostSystem])
         if not host:
             module.fail_json(msg="Unable to locate Physical Host.")
-        host_system = host.keys()[0]
+        host_system = list(host)[0]
         changed = configure_dns(host_system, change_hostname_to, domainname, dns_servers)
         module.exit_json(changed=changed)
     except vmodl.RuntimeFault as runtime_fault:

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel_ip_config.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel_ip_config.py
@@ -104,7 +104,7 @@ def main():
         host = get_all_objs(content, [vim.HostSystem])
         if not host:
             module.fail_json(msg="Unable to locate Physical Host.")
-        host_system = host.keys()[0]
+        host_system = list(host)[0]
         changed = configure_vmkernel_ip_address(host_system, vmk_name, ip_address, subnet_mask)
         module.exit_json(changed=changed)
     except vmodl.RuntimeFault as runtime_fault:

--- a/lib/ansible/modules/cloud/vmware/vmware_vsan_cluster.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vsan_cluster.py
@@ -108,7 +108,7 @@ def main():
         host = get_all_objs(content, [vim.HostSystem])
         if not host:
             module.fail_json(msg="Unable to locate Physical Host.")
-        host_system = host.keys()[0]
+        host_system = list(host)[0]
         changed, result, cluster_uuid = create_vsan_cluster(host_system, new_cluster_uuid)
         module.exit_json(changed=changed, result=result, cluster_uuid=cluster_uuid)
 


### PR DESCRIPTION
##### SUMMARY
Since python3, dict.keys() returns a dict_keys object instead of a list (python behavior). This PR transform some `dict.keys()[index]` found in VMware modules to a `list(dict)[item]` that should returns a list type element in both py2 and py3.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cfg_backup,vmware_dns_config.vmware_vmkernel_ip_config,vmware_vsan_cluster

##### ADDITIONAL INFORMATION
Before, using py3 and `vmware_dns_config` :

```
fatal: [srv-lab-os-2.*******]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "change_hostname_to": "srv-lab-os-2.*******",
            "dns_servers": [
                "9.9.9.9",
                "8.8.8.8"
            ],
            "domainname": "*******",
            "hostname": "srv-lab-os-2.*******",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "username": "root",
            "validate_certs": false
        }
    },
    "msg": "'dict_keys' object does not support indexing"
}
The full traceback is:
  File "/tmp/ansible_vmware_dns_config_payload_wvcv8erz/__main__.py", line 111, in main
    host_system = host.keys()[0]
```

After change, with both python2.7 and 3, change is successful.