### PR TITLE
github_webhook: Fix create of new hook with existing hooks

### DIFF
--- a/lib/ansible/modules/source_control/github_webhook.py
+++ b/lib/ansible/modules/source_control/github_webhook.py
@@ -255,6 +255,8 @@ def main():
         for hook in repo.get_hooks():
             if hook.config.get("url") == module.params["url"]:
                 break
+        else:
+            hook = None
     except github.GithubException as err:
         module.fail_json(msg="Unable to get hooks from repository %s: %s" % (
             module.params["repository"], to_native(err)))


### PR DESCRIPTION
##### SUMMARY
When creating a new webhook with existing hooks already in place, the
module would erroneously select one of the existing hooks to update
instead of creating the hook anew. This fixes that bug.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

github_webhook
