### PR TITLE
Use six.moves to import configparser in cloudforms script

### DIFF
--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -22,7 +22,7 @@
 
 from __future__ import print_function
 import argparse
-import ConfigParser
+from ansible.module_utils.six.moves import configparser as ConfigParser
 import os
 import re
 from time import time


### PR DESCRIPTION
##### SUMMARY
Addresses https://github.com/ansible/awx/issues/3511

(will be Ansible bug soon, ping @kdelee)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/cloudforms.py

##### ADDITIONAL INFORMATION
I haven't done full functional testing yet.

I did run in a python3 environment and get a connection error.

I did test this example:

```
CLOUDFORMS_INI_PATH=~/Documents/tower/awx/main/tests/data/inventory/scripts/cloudforms/files/CLOUDFORMS_INI_PATH python3 contrib/inventory/cloudforms.py 
Traceback (most recent call last):
  File "contrib/inventory/cloudforms.py", line 483, in <module>
    CloudFormsInventory()
  File "contrib/inventory/cloudforms.py", line 49, in __init__
    self.read_settings()
  File "contrib/inventory/cloudforms.py", line 161, in read_settings
    self.cloudforms_purge_actions = config.getboolean('cloudforms', 'purge_actions')
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/configparser.py", line 829, in getboolean
    raw=raw, vars=vars, fallback=fallback, **kwargs)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/configparser.py", line 809, in _get_conv
    **kwargs)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/configparser.py", line 803, in _get
    return conv(self.get(section, option, **kwargs))
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/configparser.py", line 1155, in _convert_to_boolean
    raise ValueError('Not a boolean: %s' % value)
ValueError: Not a boolean: maybe
```

That looks promising, config parser had its wits about itself somewhat (the config file there is not intended to be correct).

And now, if I use this:

```
[cloudforms]
url = https://foo.invalid
username = fooo
password = fooo
ssl_verify = false
version = 2.4
purge_actions = yes
clean_group_keys = yes
nest_tags = yes
suffix = .ppt
prefer_ipv4 = yes

[cache]
max_age = 0
path = {{ cache_dir }}
```

I can get:

```
CLOUDFORMS_INI_PATH=~/Documents/tower/awx/main/tests/data/inventory/scripts/cloudforms/files/CLOUDFORMS_INI_PATH python3 contrib/inventory/cloudforms.py 
Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/connection.py", line 159, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/util/connection.py", line 57, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/socket.py", line 745, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/connectionpool.py", line 343, in _make_request
    self._validate_conn(conn)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/connectionpool.py", line 839, in _validate_conn
    conn.connect()
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/connection.py", line 301, in connect
    conn = self._new_conn()
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/connection.py", line 168, in _new_conn
    self, "Failed to establish a new connection: %s" % e)
urllib3.exceptions.NewConnectionError: <urllib3.connection.VerifiedHTTPSConnection object at 0x109faceb8>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/connectionpool.py", line 638, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/urllib3/util/retry.py", line 398, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='foo.invalid', port=443): Max retries exceeded with url: /api/vms?offset=0&limit=100&expand=resources,tags,hosts,&attributes=ipaddresses (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x109faceb8>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "contrib/inventory/cloudforms.py", line 483, in <module>
    CloudFormsInventory()
  File "contrib/inventory/cloudforms.py", line 53, in __init__
    self.update_cache()
  File "contrib/inventory/cloudforms.py", line 292, in update_cache
    for host in self._get_hosts():
  File "contrib/inventory/cloudforms.py", line 274, in _get_hosts
    ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses" % (self.cloudforms_url, offset, limit))
  File "contrib/inventory/cloudforms.py", line 240, in _get_json
    verify=self.cloudforms_ssl_verify)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/Users/alancoding/.virtualenvs/ansible3/lib/python3.6/site-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='foo.invalid', port=443): Max retries exceeded with url: /api/vms?offset=0&limit=100&expand=resources,tags,hosts,&attributes=ipaddresses (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x109faceb8>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',))
```

Still needs full testing, but this shouldn't be a bad start.

Also see:

https://github.com/ansible/ansible/commit/50932ce556d87606d417c6c042f653ab4f64be5e