### PR TITLE
bug fix to na_ontap_interface

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_interface.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_interface.py
@@ -156,26 +156,27 @@ class NetAppOntapInterface(object):
     def __init__(self):
 
         self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
-        self.argument_spec.update(
-            state=dict(type='str', default='present', choices=['absent', 'present']),
-            interface_name=dict(type='str', required=True),
-            home_node=dict(type='str'),
-            home_port=dict(type='str'),
-            role=dict(type='str'),
-            address=dict(type='str'),
-            netmask=dict(type='str'),
-            vserver=dict(type='str', required=True),
-            firewall_policy=dict(type='str'),
-            failover_policy=dict(type='str'),
-            admin_status=dict(type='str', choices=['up', 'down']),
-            subnet_name=dict(type='str'),
-            is_auto_revert=dict(type='bool'),
-            protocols=dict(type='list'),
-        )
+        self.argument_spec.update(dict(
+            state=dict(required=False, choices=[
+                       'present', 'absent'], default='present'),
+            interface_name=dict(required=True, type='str'),
+            home_node=dict(required=False, type='str', default=None),
+            home_port=dict(required=False, type='str'),
+            role=dict(required=False, type='str'),
+            address=dict(required=False, type='str'),
+            netmask=dict(required=False, type='str'),
+            vserver=dict(required=True, type='str'),
+            firewall_policy=dict(required=False, type='str', default=None),
+            failover_policy=dict(required=False, type='str', default=None),
+            admin_status=dict(required=False, choices=['up', 'down']),
+            subnet_name=dict(required=False, type='str'),
+            is_auto_revert=dict(required=False, type=bool, default=None),
+            protocols=dict(required=False, type='list')
+        ))
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
-            supports_check_mode=True,
+            supports_check_mode=True
         )
         self.na_helper = NetAppModule()
         self.parameters = self.na_helper.set_parameters(self.module.params)
@@ -250,7 +251,7 @@ class NetAppOntapInterface(object):
         if self.parameters.get('protocols') is not None:
             data_protocols_obj = netapp_utils.zapi.NaElement('data-protocols')
             for protocol in self.parameters.get('protocols'):
-                if protocol.lower() == 'fc-nvme':
+                if protocol.lower() in ['fc-nvme', 'fcp']:
                     required_keys.remove('address')
                     required_keys.remove('home_port')
                     required_keys.remove('netmask')

--- a/lib/ansible/modules/storage/netapp/na_ontap_interface.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_interface.py
@@ -170,7 +170,7 @@ class NetAppOntapInterface(object):
             failover_policy=dict(required=False, type='str', default=None),
             admin_status=dict(required=False, choices=['up', 'down']),
             subnet_name=dict(required=False, type='str'),
-            is_auto_revert=dict(required=False, type=bool, default=None),
+            is_auto_revert=dict(required=False, type='bool', default=None),
             protocols=dict(required=False, type='list')
         ))
 


### PR DESCRIPTION
##### SUMMARY
The protocols for ontap interface can be fc-nvme or fcp, only fc-nvme was listed. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
-  na_ontap_interface.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
