### PR TITLE
from typing import Tuple for line 265

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -126,7 +126,7 @@ repository:
 
 import json
 import traceback
-from typing import Tuple
+from typing import Tuple  # pylint: disable=unused-import
 
 try:
     from botocore.exceptions import ClientError

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -126,6 +126,7 @@ repository:
 
 import json
 import traceback
+from typing import Tuple
 
 try:
     from botocore.exceptions import ClientError

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 # packages.  Thus, this should be the loosest set possible (only required
 # packages, not optional ones, and with the widest range of versions that could
 # be suitable)
-jinja2
-PyYAML
-paramiko
 cryptography
+jinja2
+paramiko
+PyYAML
+typing


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/ansible/ansible on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./lib/ansible/modules/storage/netapp/na_ontap_firewall_policy.py:169:27: F821 undefined name 'unicode'
                ip_addr = unicode(ip)  # pylint: disable=undefined-variable
                          ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:379:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:399:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:403:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:418:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/ironware/ironware_facts.py:273:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/ironware/ironware_facts.py:513:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py:555:33: F821 undefined name 'azure'
        self.nsg_models = None  # type: azure.mgmt.network.models
                                ^
./lib/ansible/modules/cloud/amazon/ecs_ecr.py:264:5: F821 undefined name 'Tuple'
    # type: (EcsEcr, dict, int) -> Tuple[bool, dict]
    ^
./lib/ansible/module_utils/api.py:114:21: F823 local variable 'retry_count' defined in enclosing scope on line 107 referenced before assignment
                    retry_count += 1  # pylint: disable=undefined-variable
                    ^

1     F632 use ==/!= to compare str, bytes, and int literals
1     F723 syntax error in type comment 'dict [str, tuple[tuple[int, int]]'
21    F821 undefined name 'basestring'
1     F823 local variable 'retry_count' defined in enclosing scope on line 107 referenced before assignment
24
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
