### PR TITLE
docker_swarm: Return UnlockKey

### DIFF
--- a/changelogs/fragments/54490-docker_swarm-return-unlock-key.yaml
+++ b/changelogs/fragments/54490-docker_swarm-return-unlock-key.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_swarm - ``UnlockKey`` will now be returned when ``autolock_managers`` is ``true``."

--- a/changelogs/fragments/54490-docker_swarm-return-unlock-key.yaml
+++ b/changelogs/fragments/54490-docker_swarm-return-unlock-key.yaml
@@ -1,2 +1,3 @@
 minor_changes:
   - "docker_swarm - ``UnlockKey`` will now be returned when ``autolock_managers`` is ``true``."
+  - "docker_swarm_info - Add option ``unlock_key`` to retrieve the swarm unlock key."

--- a/changelogs/fragments/54490-docker_swarm-return-unlock-key.yaml
+++ b/changelogs/fragments/54490-docker_swarm-return-unlock-key.yaml
@@ -1,3 +1,2 @@
 minor_changes:
   - "docker_swarm - ``UnlockKey`` will now be returned when ``autolock_managers`` is ``true``."
-  - "docker_swarm_info - Add option ``unlock_key`` to retrieve the swarm unlock key."

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -846,6 +846,14 @@ class DifferenceTracker(object):
             after[item['name']] = item['parameter']
         return before, after
 
+    def exists(self, name):
+        '''
+        Returns a boolean if a difference exists for name
+        '''
+        return any([
+            diff for diff in self._diff if diff['name'] == name
+        ])
+
     def get_legacy_docker_container_diffs(self):
         '''
         Return differences in the docker_container legacy format.

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -846,7 +846,7 @@ class DifferenceTracker(object):
             after[item['name']] = item['parameter']
         return before, after
 
-    def exists(self, name):
+    def has_difference_for(self, name):
         '''
         Returns a boolean if a difference exists for name
         '''

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -850,9 +850,7 @@ class DifferenceTracker(object):
         '''
         Returns a boolean if a difference exists for name
         '''
-        return any([
-            diff for diff in self._diff if diff['name'] == name
-        ])
+        return any(diff for diff in self._diff if diff['name'] == name)
 
     def get_legacy_docker_container_diffs(self):
         '''

--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -248,7 +248,4 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
     def get_unlock_key(self):
         if self.docker_py_version < LooseVersion('2.7.0'):
             return None
-        try:
-            return super(AnsibleDockerSwarmClient, self).get_unlock_key()
-        except APIError:
-            return None
+        return super(AnsibleDockerSwarmClient, self).get_unlock_key()

--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -13,7 +13,10 @@ except ImportError:
     pass
 
 from ansible.module_utils._text import to_native
-from ansible.module_utils.docker.common import AnsibleDockerClient
+from ansible.module_utils.docker.common import (
+    AnsibleDockerClient,
+    LooseVersion,
+)
 
 
 class AnsibleDockerSwarmClient(AnsibleDockerClient):
@@ -241,3 +244,11 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
 
     def get_node_name_by_id(self, nodeid):
         return self.get_node_inspect(nodeid)['Description']['Hostname']
+
+    def get_unlock_key(self):
+        if self.docker_py_version < LooseVersion('2.7.0'):
+            return None
+        try:
+            return super(AnsibleDockerSwarmClient, self).get_unlock_key()
+        except APIError:
+            return None

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -233,7 +233,7 @@ swarm_facts:
       UnlockKey:
           description: The swarm unlock-key if I(autolock_managers) is C(true).
           returned: on success if I(autolock_managers) is C(true)
-            and swarm is initialised or autolock_managers is changed.
+            and swarm is initialised, or if I(autolock_managers) has changed.
           type: str
           example: SWMKEY-1-xxx
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -232,7 +232,8 @@ swarm_facts:
                   example: SWMTKN-1--xxxxx
       UnlockKey:
           description: The swarm unlock-key if I(autolock_managers) is C(true).
-          returned: success
+          returned: on success if I(autolock_managers) is C(true)
+            and swarm is initialised or autolock_managers is changed.
           type: str
           example: SWMKEY-1-xxx
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -449,7 +449,10 @@ class SwarmManager(DockerBaseClass):
         default = {'UnlockKey': None}
         if not self.has_swarm_lock_changed():
             return default
-        return self.client.get_unlock_key() or default
+        try:
+            return self.client.get_unlock_key() or default
+        except APIError:
+            return default
 
     def has_swarm_lock_changed(self):
         return self.parameters.autolock_managers and (

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -457,7 +457,7 @@ class SwarmManager(DockerBaseClass):
 
     def has_swarm_lock_changed(self):
         return self.parameters.autolock_managers and (
-                self.created or self.differences.has_difference_for('autolock_managers')
+            self.created or self.differences.has_difference_for('autolock_managers')
         )
 
     def init_swarm(self):

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -452,9 +452,9 @@ class SwarmManager(DockerBaseClass):
         return self.client.get_unlock_key() or default
 
     def has_swarm_lock_changed(self):
-        return self.parameters.autolock_managers and (self.created or self.differences.exists(
-            'autolock_managers'
-        ))
+        return self.parameters.autolock_managers and (
+                self.created or self.differences.has_difference_for('autolock_managers')
+        )
 
     def init_swarm(self):
         if not self.force and self.client.check_if_swarm_manager():

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -151,6 +151,7 @@ options:
     description:
       - If set, generate a key and use it to lock data stored on the managers.
       - Docker default value is C(no).
+      - M(docker_swarm_info) can be used to retrieve the unlock key.
     type: bool
   rotate_worker_token:
     description: Rotate the worker join token.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_info.py
@@ -29,7 +29,7 @@ description:
 version_added: "2.8"
 
 author:
-    - Piotr Wojciechowski (@wojciechowskipiotr)
+    - Piotr Wojciechowski (@WojciechowskiPiotr)
 
 options:
   nodes:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_info.py
@@ -68,6 +68,11 @@ options:
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/service_ps/#filtering)
         for more information on possible filters.
     type: dict
+  unlock_key:
+    description:
+      - Whether to retrieve the swarm unlock key.
+    type: bool
+    default: no
   verbose_output:
     description:
       - When set to C(yes) and I(nodes), I(services) or I(tasks) is set to C(yes)
@@ -119,6 +124,11 @@ EXAMPLES = '''
       name: mynode
   register: result
 
+- name: Get the swarm unlock key
+  docker_swarm_info:
+    unlock_key: yes
+  register: result
+
 - debug:
     var: result.swarm_facts
 '''
@@ -143,13 +153,17 @@ docker_swarm_manager:
       - Only if this one is C(true), the module will not fail.
     returned: both on success and on error
     type: bool
-
 swarm_facts:
     description:
       - Facts representing the basic state of the docker Swarm cluster.
       - Contains tokens to connect to the Swarm
     returned: always
     type: dict
+swarm_unlock_key:
+    description:
+      - Contains the key needed to unlock the swarm.
+    returned: When I(unlock_key) is C(true).
+    type: str
 nodes:
     description:
       - List of dict objects containing the basic information about each volume.
@@ -208,6 +222,8 @@ class DockerSwarmManager(DockerBaseClass):
                 filter_name = docker_object + "_filters"
                 filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name))
                 self.results[returned_name] = self.get_docker_items_list(docker_object, filters)
+        if self.client.module.params['unlock_key']:
+            self.results['swarm_unlock_key'] = self.get_docker_swarm_unlock_key()
 
     def get_docker_swarm_facts(self):
         try:
@@ -305,6 +321,10 @@ class DockerSwarmManager(DockerBaseClass):
 
         return object_essentials
 
+    def get_docker_swarm_unlock_key(self):
+        unlock_key = self.client.get_unlock_key()
+        return unlock_key.get('UnlockKey')
+
 
 def main():
     argument_spec = dict(
@@ -314,7 +334,11 @@ def main():
         tasks_filters=dict(type='dict'),
         services=dict(type='bool', default=False),
         services_filters=dict(type='dict'),
+        unlock_key=dict(type='bool', default=False),
         verbose_output=dict(type='bool', default=False),
+    )
+    option_minimal_versions = dict(
+        unlock_key=dict(docker_py_version='2.7.0', docker_api_version='1.25'),
     )
 
     client = AnsibleDockerSwarmClient(
@@ -322,6 +346,7 @@ def main():
         supports_check_mode=True,
         min_docker_version='1.10.0',
         min_docker_api_version='1.24',
+        option_minimal_versions=option_minimal_versions,
         fail_results=dict(
             can_talk_to_docker=False,
             docker_swarm_active=False,

--- a/lib/ansible/modules/cloud/docker/docker_swarm_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_info.py
@@ -326,7 +326,7 @@ class DockerSwarmManager(DockerBaseClass):
         return object_essentials
 
     def get_docker_swarm_unlock_key(self):
-        unlock_key = self.client.get_unlock_key()
+        unlock_key = self.client.get_unlock_key() or {}
         return unlock_key.get('UnlockKey')
 
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_info.py
@@ -124,13 +124,17 @@ EXAMPLES = '''
       name: mynode
   register: result
 
+- debug:
+    var: result.swarm_facts
+
 - name: Get the swarm unlock key
   docker_swarm_info:
     unlock_key: yes
   register: result
 
 - debug:
-    var: result.swarm_facts
+    var: result.swarm_unlock_key
+
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/docker/docker_swarm_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_info.py
@@ -327,7 +327,7 @@ class DockerSwarmManager(DockerBaseClass):
 
     def get_docker_swarm_unlock_key(self):
         unlock_key = self.client.get_unlock_key() or {}
-        return unlock_key.get('UnlockKey')
+        return unlock_key.get('UnlockKey') or None
 
 
 def main():

--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -14,7 +14,7 @@
     ignore_errors: yes
 
   - name: Kill docker daemon
-    command: systemctl stop -s 9 docker
+    command: systemctl kill -s 9 docker
     become: yes
 
   - name: Restart docker daemon

--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -13,11 +13,16 @@
     diff: no
     ignore_errors: yes
 
+  - name: Kill docker daemon
+    command: systemctl stop -s 9 docker
+    become: yes
+
   - name: Restart docker daemon
     service:
       name: docker
-      state: restarted
+      state: started
     become: yes
+
   - name: Wait for docker daemon to be fully restarted
     command: docker ps
 

--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -20,7 +20,7 @@
   - name: Restart docker daemon
     service:
       name: docker
-      state: started
+      state: restarted
     become: yes
 
   - name: Wait for docker daemon to be fully restarted

--- a/test/integration/targets/docker_swarm/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options.yml
@@ -61,6 +61,15 @@
   register: output_6
   ignore_errors: yes
 
+- name: autolock_managers (force new swarm)
+  docker_swarm:
+    state: present
+    force: yes
+    autolock_managers: yes
+  diff: yes
+  register: output_7
+  ignore_errors: yes
+
 - name: assert autolock_managers changes
   assert:
     that:
@@ -94,8 +103,9 @@
   assert:
     that:
       - 'output_2.swarm_facts.UnlockKey'
-      - 'output_3.swarm_facts.UnlockKey'
+      - 'output_3.swarm_facts.UnlockKey is none'
       - 'output_6.swarm_facts.UnlockKey is none'
+      - 'output_7.swarm_facts.UnlockKey'
   when: docker_py_version is version('2.7.0', '>=')
 
 - assert:

--- a/test/integration/targets/docker_swarm/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options.yml
@@ -89,6 +89,15 @@
        - 'output_6.diff.before is defined'
        - 'output_6.diff.after is defined'
   when: docker_py_version is version('2.6.0', '>=')
+
+- name: assert UnlockKey in swarm_facts
+  assert:
+    that:
+      - 'output_2.swarm_facts.UnlockKey'
+      - 'output_3.swarm_facts.UnlockKey'
+      - 'output_6.swarm_facts.UnlockKey is none'
+  when: docker_py_version is version('2.7.0', '>=')
+
 - assert:
     that:
     - output_1 is failed

--- a/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
+++ b/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
@@ -18,6 +18,7 @@
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == false'
          - 'output.docker_swarm_manager == false'
+         - 'output.swarm_unlock_key is not defined'
 
   - name: Create a Swarm cluster
     docker_swarm:
@@ -45,6 +46,7 @@
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
+         - 'output.swarm_unlock_key is not defined'
 
   - name: Try to get docker_swarm_info and list of nodes when docker is running in swarm mode and as manager
     docker_swarm_info:
@@ -61,6 +63,7 @@
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
+         - 'output.swarm_unlock_key is not defined'
 
   - name: Get local docker node name
     set_fact:
@@ -84,6 +87,7 @@
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
+         - 'output.swarm_unlock_key is not defined'
 
   - name: Try to get docker_swarm_info and list of nodes with filters providing existing node name
     docker_swarm_info:
@@ -102,6 +106,7 @@
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
+         - 'output.swarm_unlock_key is not defined'
 
   - name: Create random name
     set_fact:
@@ -124,6 +129,7 @@
          - 'output.can_talk_to_docker == true'
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
+         - 'output.swarm_unlock_key is not defined'
 
   - name: Try to get docker_swarm_info and swarm_unlock_key on non a unlocked swarm
     docker_swarm_info:

--- a/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
+++ b/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
@@ -133,7 +133,7 @@
   - name: assert reading swarm facts and non existing swarm unlock key
     assert:
       that:
-        - 'not output.swarm_unlock_key'
+        - 'output.swarm_unlock_key is none'
         - 'output.can_talk_to_docker == true'
         - 'output.docker_swarm_active == true'
         - 'output.docker_swarm_manager == true'

--- a/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
+++ b/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
@@ -139,7 +139,7 @@
   - name: assert reading swarm facts and swarm unlock key
     assert:
       that:
-        - 'output.swarm_unlock_key'
+        - 'output.swarm_unlock_key is string'
         - 'output.swarm_unlock_key == autolock_managers_update_output.swarm_facts.UnlockKey'
         - 'output.can_talk_to_docker == true'
         - 'output.docker_swarm_active == true'

--- a/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
+++ b/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
@@ -125,6 +125,19 @@
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
 
+  - name: Try to get docker_swarm_info and swarm_unlock_key on non a unlocked swarm
+    docker_swarm_info:
+      unlock_key: yes
+    register: output
+
+  - name: assert reading swarm facts and non existing swarm unlock key
+    assert:
+      that:
+        - 'not output.swarm_unlock_key'
+        - 'output.can_talk_to_docker == true'
+        - 'output.docker_swarm_active == true'
+        - 'output.docker_swarm_manager == true'
+
   - name: Update swarm cluster to be locked
     docker_swarm:
       state: present

--- a/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
+++ b/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
@@ -125,6 +125,26 @@
          - 'output.docker_swarm_active == true'
          - 'output.docker_swarm_manager == true'
 
+  - name: Update swarm cluster to be locked
+    docker_swarm:
+      state: present
+      autolock_managers: true
+    register: autolock_managers_update_output
+
+  - name: Try to get docker_swarm_info and swarm_unlock_key
+    docker_swarm_info:
+      unlock_key: yes
+    register: output
+
+  - name: assert reading swarm facts and swarm unlock key
+    assert:
+      that:
+        - 'output.swarm_unlock_key'
+        - 'output.swarm_unlock_key == autolock_managers_update_output.swarm_facts.UnlockKey'
+        - 'output.can_talk_to_docker == true'
+        - 'output.docker_swarm_active == true'
+        - 'output.docker_swarm_manager == true'
+
   always:
   - name: Cleanup
     docker_swarm:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Return `UnlockKey` when `autolock_managers` is ``true``. It should be returned so it can be retrieved and stored in a safe place to be used if the swarm needs to be restarted.

https://docs.docker.com/engine/swarm/swarm_manager_locking/ 

Returning this parameter could be pretty sensitive if Ansible logs are stored somewhere insecure but I guess the same could be said about the join-tokens.

One alternative could be to create a new module to handle swarm locking / unlocking.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm