### PR TITLE
Pin rabbitmq tests to pika < 1.0.0 to fix tests.

### DIFF
--- a/test/integration/targets/rabbitmq_lookup/tasks/ubuntu.yml
+++ b/test/integration/targets/rabbitmq_lookup/tasks/ubuntu.yml
@@ -10,7 +10,7 @@
 
 - name: Install pika and requests
   pip:
-    name: pika,requests
+    name: pika<1.0.0,requests
     state: latest
 
 - name: Test that giving an incorrect amqp protocol in URL will error
@@ -29,29 +29,29 @@
     rabbitmq_test_protocol: "{{ lookup('rabbitmq', url='amqp://guest:guest@xxxxx192.112312368.250.1:5672/%2F', queue='hello', count=3) }}"
   ignore_errors: yes
   register: rabbitmq_ip_error
- 
+
 - assert:
     that:
       - "rabbitmq_ip_error is failed"
       - "'Connection issue' in rabbitmq_ip_error.msg"
- 
+
 - name: Test missing parameters will error
   set_fact:
     rabbitmq_test_protocol: "{{ lookup('rabbitmq') }}"
   ignore_errors: yes
   register: rabbitmq_params_error
- 
+
 - assert:
     that:
       - "rabbitmq_params_error is failed"
       - "'URL is required for rabbitmq lookup.' in rabbitmq_params_error.msg"
- 
+
 - name: Test missing queue will error
   set_fact:
     rabbitmq_queue_protocol: "{{ lookup('rabbitmq', url='amqp://guest:guest@192.168.250.1:5672/%2F') }}"
   ignore_errors: yes
   register: rabbitmq_queue_error
- 
+
 - assert:
     that:
       - "rabbitmq_queue_error is failed"

--- a/test/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
+++ b/test/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
@@ -1,6 +1,6 @@
 - name: Install requests and pika
   pip:
-    name: requests,pika
+    name: requests,pika<1.0.0
     state: present
 
 - name: RabbitMQ basic publish test


### PR DESCRIPTION
##### SUMMARY

Pin rabbitmq tests to pika < 1.0.0 to fix tests.

Tests are failing with the release of pika 1.0.0.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

rabbitmq_lookup and rabbitmq_publish integration tests
