### PR TITLE
win_user_right - fix non json output issue

### DIFF
--- a/changelogs/fragments/win_user_right-output.yaml
+++ b/changelogs/fragments/win_user_right-output.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_user_right - Fix output containing non json data - https://github.com/ansible/ansible/issues/54413

--- a/lib/ansible/modules/windows/win_user_right.ps1
+++ b/lib/ansible/modules/windows/win_user_right.ps1
@@ -68,7 +68,7 @@ namespace Ansible
                 } catch
                 {
                     throw new ArgumentException(String.Format("SID string {0} could not be converted to SecurityIdentifier", sidString));
-                }                    
+                }
 
                 Byte[] buffer = new Byte[sid.BinaryLength];
                 sid.GetBinaryForm(buffer, 0);
@@ -271,7 +271,7 @@ $env:TMP = $_remote_tmp
 Add-Type -TypeDefinition $sec_helper_util
 $env:TMP = $original_tmp
 
-Function Compare-UserList($existing_users, $new_users) {  
+Function Compare-UserList($existing_users, $new_users) {
     $added_users = [String[]]@()
     $removed_users = [String[]]@()
     if ($action -eq "add") {
@@ -296,7 +296,8 @@ $lsa_helper = New-Object -TypeName Ansible.LsaRightHelper
 
 $new_users = [System.Collections.ArrayList]@()
 foreach ($user in $users) {
-    $new_users.Add((Convert-ToSID -account_name $user))
+    $user_sid = Convert-ToSID -account_name $user
+    $new_users.Add($user_sid) > $null
 }
 $new_users = [String[]]$new_users.ToArray()
 try {
@@ -321,7 +322,7 @@ if (($change_result.added.Length -gt 0) -or ($change_result.removed.Length -gt 0
         $user_name = Convert-FromSID -sid $user
         $result.removed += $user_name
         $diff_text += "-$user_name`n"
-        $new_user_list.Remove($user)
+        $new_user_list.Remove($user) > $null
     }
     foreach ($user in $change_result.added) {
         if (-not $check_mode) {
@@ -330,9 +331,9 @@ if (($change_result.added.Length -gt 0) -or ($change_result.removed.Length -gt 0
         $user_name = Convert-FromSID -sid $user
         $result.added += $user_name
         $diff_text += "+$user_name`n"
-        $new_user_list.Add($user)
+        $new_user_list.Add($user) > $null
     }
-    
+
     if ($diff_mode) {
         if ($new_user_list.Count -eq 0) {
             $diff_text = "-$diff_text"

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -153,7 +153,6 @@ lib/ansible/modules/windows/win_uri.ps1 PSAvoidUsingEmptyCatchBlock
 lib/ansible/modules/windows/win_user.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_user.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_user_profile.ps1 PSCustomUseLiteralPath
-lib/ansible/modules/windows/win_user_right.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_wait_for.ps1 PSAvoidUsingEmptyCatchBlock
 lib/ansible/modules/windows/win_wait_for.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_webpicmd.ps1 PSAvoidUsingInvokeExpression


### PR DESCRIPTION
##### SUMMARY
The `.Add()` method for an ArrayList returns the index which is being sent to the output confusing the JSON parser on the controller. This change makes sure we pipe the output to `$null` so only the return json is received by the controller.

Fixes https://github.com/ansible/ansible/issues/54413

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_user_right