### PR TITLE
hostname: Add GNUCoreutilsStrategy and VoidHostname

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -557,6 +557,43 @@ class FreeBSDStrategy(GenericStrategy):
             f.close()
 
 
+class GNUCoreutilsStrategy(GenericStrategy):
+    """
+    This is a GNU coreutils Hostname manipulation strategy class - it
+    edits the /etc/hostname file, then runs hostname.
+    """
+
+    HOSTNAME_FILE = '/etc/hostname'
+
+    def get_permanent_hostname(self):
+        if not os.path.isfile(self.HOSTNAME_FILE):
+            try:
+                open(self.HOSTNAME_FILE, "a").write("")
+            except IOError as e:
+                self.module.fail_json(msg="failed to write file: %s" %
+                                          to_native(e), exception=traceback.format_exc())
+        try:
+            f = open(self.HOSTNAME_FILE)
+            try:
+                return f.read().strip()
+            finally:
+                f.close()
+        except Exception as e:
+            self.module.fail_json(msg="failed to read hostname: %s" %
+                                      to_native(e), exception=traceback.format_exc())
+
+    def set_permanent_hostname(self, name):
+        try:
+            f = open(self.HOSTNAME_FILE, 'w+')
+            try:
+                f.write("%s\n" % name)
+            finally:
+                f.close()
+        except Exception as e:
+            self.module.fail_json(msg="failed to update hostname: %s" %
+                                      to_native(e), exception=traceback.format_exc())
+
+
 class FedoraHostname(Hostname):
     platform = 'Linux'
     distribution = 'Fedora'
@@ -719,6 +756,12 @@ class NeonHostname(Hostname):
     platform = 'Linux'
     distribution = 'Neon'
     strategy_class = DebianStrategy
+
+
+class VoidHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Void'
+    strategy_class = GNUCoreutilsStrategy
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
- Add a GNUCoreutilsStrategy to update the host's /etc/hostname file
  and then invoke the hostname command with the new hostname. This is
  mostly the same as the AlpineStrategy, except the hostname command
  line differs.

- Add a VoidHostname implementation to support Void Linux's use of GNU
  coreutils.

This is done entirely to support Void Linux on managed nodes, though the
GNUCoreutilsStrategy likely has applications outside just Void.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hostname

##### ADDITIONAL INFORMATION
This likely won't work on Ansible 2.7 -- I've only used this on the devel branch. This is because 2.7 and earlier use platform.linux_distribution to get the managed node's distribution, which will produce an empty string on Void and likely other unsupported distributions. Since devel / 2.8 doesn't use this anymore, it's now possible to implement this.

###### Before
```
$ ansible -b -m hostname -a name=new-hostname test-host

test-host | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "msg": "hostname module cannot be used on platform Linux (Void)"
}
```

###### After
```
$ ansible -b -m hostname -a name=new-hostname test-host

test-host | CHANGED => {
    "ansible_facts": {
        "ansible_domain": "",
        "ansible_fqdn": "new-hostname",
        "ansible_hostname": "new-hostname",
        "ansible_nodename": "new-hostname",
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "name": "new-hostname"
}
```