### PR TITLE
meraki_admin - Enable check mode

### DIFF
--- a/changelogs/fragments/53597-meraki_admin_check.yml
+++ b/changelogs/fragments/53597-meraki_admin_check.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "meraki_admin - Add support for check mode."

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -337,9 +337,11 @@ def create_admin(meraki, org_id, name, email):
     if meraki.params['networks'] is not None:
         nets = meraki.get_nets(org_id=org_id)
         networks = network_factory(meraki, meraki.params['networks'], nets)
-        # meraki.fail_json(msg=str(type(networks)), data=networks)
         payload['networks'] = networks
     if is_admin_existing is None:  # Create new admin
+        if meraki.module.check_mode is True:
+            meraki.result['data'] = payload
+            meraki.exit_json(**meraki.result)
         path = meraki.construct_path('create', function='admin', org_id=org_id)
         r = meraki.request(path,
                            method='POST',
@@ -354,6 +356,10 @@ def create_admin(meraki, org_id, name, email):
         if not meraki.params['networks']:
             payload['networks'] = []
         if meraki.is_update_required(is_admin_existing, payload) is True:
+            if meraki.module.check_mode is True:
+                is_admin_existing.update(payload)
+                meraki.result['data'] = payload
+                meraki.exit_json(**meraki.result)
             path = meraki.construct_path('update', function='admin', org_id=org_id) + is_admin_existing['id']
             r = meraki.request(path,
                                method='PUT',
@@ -364,6 +370,9 @@ def create_admin(meraki, org_id, name, email):
                 return r
         else:
             meraki.result['data'] = is_admin_existing
+            if meraki.module.check_mode is True:
+                meraki.result['data'] = payload
+                meraki.exit_json(**meraki.result)
             return -1
 
 
@@ -395,7 +404,7 @@ def main():
     # args/params passed to the execution, as well as if the module
     # supports check mode
     module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=False,
+                           supports_check_mode=True,
                            )
     meraki = MerakiModule(module, function='admin')
 
@@ -429,8 +438,6 @@ def main():
     # if the user is working with this module in only check mode we do not
     # want to make any changes to the environment, just return the current
     # state with no modifications
-    if module.check_mode:
-        return result
 
     # execute checks for argument completeness
     if meraki.params['state'] == 'query':
@@ -468,6 +475,9 @@ def main():
         if r != -1:
             meraki.result['data'] = r
     elif meraki.params['state'] == 'absent':
+        if meraki.module.check_mode is True:
+            meraki.result['data'] = {}
+            meraki.exit_json(**meraki.result)
         admin_id = get_admin_id(meraki,
                                 get_admins(meraki, org_id),
                                 email=meraki.params['email']

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -4,6 +4,24 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
+  - name: Create new administrator in check mode
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jane Doe
+      email: '{{email_prefix}}+janedoe@{{email_domain}}'
+      org_access: read-only
+    delegate_to: localhost
+    check_mode: yes
+    register: create_org_check
+
+  - name: Create new admin check mode assertion
+    assert:
+      that:
+        - create_org_check is not changed
+        - 'create_org_check.data.name == "Jane Doe"'
+
   - name: Create new administrator
     meraki_admin:
       auth_key: '{{auth_key}}'
@@ -20,6 +38,20 @@
       that:
         - create_orgaccess.changed == true
         - 'create_orgaccess.data.name == "Jane Doe"'
+
+  - name: Delete recently created administrator with check mode
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      email: '{{email_prefix}}+janedoe@{{email_domain}}'
+    delegate_to: localhost
+    register: delete_one_check
+    check_mode: yes
+
+  - assert:
+      that:
+        - delete_one_check is not changed
 
   - name: Delete recently created administrator
     meraki_admin:
@@ -46,6 +78,31 @@
       that:
         - create_orgaccess_id.changed == true
         - 'create_orgaccess_id.data.name == "Jane Doe"'
+
+  - name: Create administrator with tags with check mode
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: John Doe
+      email: '{{email_prefix}}+johndoe@{{email_domain}}'
+      orgAccess: none
+      tags:
+        - { "tag": "production", "access": "read-only" }
+        - tag: beta
+          access: full
+    delegate_to: localhost
+    register: create_tags_check
+    check_mode: yes
+
+  - debug:
+      var: create_tags_check
+
+  - assert:
+      that:
+        - create_tags_check is not changed
+        - create_tags_check.data.name == "John Doe"
+        - create_tags_check.data.tags | length == 2
 
   - name: Create administrator with tags
     meraki_admin:
@@ -119,6 +176,27 @@
       - TestNet
       - TestNet2
 
+  - name: Create administrator with networks with check mode
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jim Doe
+      email: '{{email_prefix}}+jimdoe@{{email_domain}}'
+      orgAccess: none
+      networks:
+        - { "network": "TestNet", "access": "read-only" }
+        - { "network": "TestNet2", "access": "full" }
+    delegate_to: localhost
+    register: create_network_check
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_network_check is not changed
+        - create_network_check.data.name == "Jim Doe"
+        - create_network_check.data.networks | length == 2
+
   - name: Create administrator with networks
     meraki_admin:
       auth_key: '{{auth_key}}'
@@ -139,6 +217,29 @@
         - create_network.data.name == "Jim Doe"
         - create_network.data.networks | length == 2
 
+  - name: Update administrator with check mode
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jim Doe
+      email: '{{email_prefix}}+jimdoe@{{email_domain}}'
+      orgAccess: none
+      networks:
+        - { "network": "TestNet", "access": "full" }
+    delegate_to: localhost
+    register: update_network_check
+    check_mode: yes
+
+  - debug:
+      var: update_network_check
+
+  - assert:
+      that:
+        - update_network_check is not changed
+        - update_network_check.data.networks.0.access == "full"
+        - update_network_check.data.networks | length == 1
+
   - name: Update administrator
     meraki_admin:
       auth_key: '{{auth_key}}'
@@ -157,6 +258,27 @@
         - update_network.changed == true
         - update_network.data.networks.0.access == "full"
         - update_network.data.networks | length == 1
+
+  - name: Update administrator for idempotency check with check mode
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jim Doe
+      email: '{{email_prefix}}+jimdoe@{{email_domain}}'
+      orgAccess: none
+      networks:
+        - { "network": "TestNet", "access": "full" }
+    delegate_to: localhost
+    register: update_network_idempotent_check
+    check_mode: yes
+
+  - debug:
+      var: update_network_idempotent_check
+
+  - assert:
+      that:
+        - update_network_idempotent_check is not changed
 
   - name: Update administrator for idempotency check
     meraki_admin:

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -19,7 +19,7 @@
   - name: Create new admin check mode assertion
     assert:
       that:
-        - create_org_check is not changed
+        - create_org_check is changed
         - 'create_org_check.data.name == "Jane Doe"'
 
   - name: Create new administrator
@@ -51,7 +51,7 @@
 
   - assert:
       that:
-        - delete_one_check is not changed
+        - delete_one_check is changed
 
   - name: Delete recently created administrator
     meraki_admin:
@@ -100,7 +100,7 @@
 
   - assert:
       that:
-        - create_tags_check is not changed
+        - create_tags_check is changed
         - create_tags_check.data.name == "John Doe"
         - create_tags_check.data.tags | length == 2
 
@@ -193,7 +193,7 @@
 
   - assert:
       that:
-        - create_network_check is not changed
+        - create_network_check is changed
         - create_network_check.data.name == "Jim Doe"
         - create_network_check.data.networks | length == 2
 
@@ -236,7 +236,7 @@
 
   - assert:
       that:
-        - update_network_check is not changed
+        - update_network_check is changed
         - update_network_check.data.networks.0.access == "full"
         - update_network_check.data.networks | length == 1
 
@@ -280,7 +280,7 @@
       that:
         - update_network_idempotent_check is not changed
 
-  - name: Update administrator for idempotency check
+  - name: Update administrator for idempotency
     meraki_admin:
       auth_key: '{{auth_key}}'
       state: present


### PR DESCRIPTION
##### SUMMARY
Enables check mode support for meraki_admin module.

Related to bug #53597.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meraki_admin

##### ADDITIONAL INFORMATION
```paste below
  - name: Create administrator with tags with check mode
    meraki_admin:
      auth_key: '{{auth_key}}'
      state: present
      org_name: '{{test_org_name}}'
      name: John Doe
      email: '{{email_prefix}}+johndoe@{{email_domain}}'
      orgAccess: none
      tags:
        - { "tag": "production", "access": "read-only" }
        - tag: beta
          access: full
    delegate_to: localhost
    register: create_tags_check
    check_mode: yes

ok: [localhost] => {
    "create_tags_check": {
        "changed": false,
        "data": {
            "email": "meraki+johndoe@kevinbreit.net",
            "name": "John Doe",
            "orgAccess": "none",
            "tags": [
                {
                    "access": "read-only",
                    "tag": "production"
                },
                {
                    "access": "full",
                    "tag": "beta"
                }
            ]
        },
        "failed": false,
        "response": "OK (unknown bytes)",
        "status": 200
    }
}
```
