### PR TITLE
meraki_config_template - Enable check mode

### DIFF
--- a/changelogs/fragments/53597-meraki_config_template_check_mode.yml
+++ b/changelogs/fragments/53597-meraki_config_template_check_mode.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "meraki_config_template - Enable check mode."

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -61,6 +61,7 @@ class MerakiModule(object):
         self.nets = None
         self.org_id = None
         self.net_id = None
+        self.check_mode = module.check_mode
 
         # normal output
         self.existing = None

--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -156,7 +156,7 @@ def delete_template(meraki, org_id, name, data):
     path = meraki.construct_path('delete', org_id=org_id)
     path = path + '/' + template_id
     response = meraki.request(path, 'DELETE')
-    if meraki.status != 200:
+    if meraki.status != 204:
         meraki.fail_json(msg='Unable to remove configuration template')
     return response
 
@@ -283,7 +283,8 @@ def main():
                                                         org_id,
                                                         meraki.params['config_template'],
                                                         get_config_templates(meraki, org_id))
-                if meraki.status == 200:
+                if meraki.status == 204:
+                    meraki.result['data'] = {}
                     meraki.result['changed'] = True
             else:
                 meraki.fail_json(msg="No template named {0} found.".format(meraki.params['config_template']))

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -53,14 +53,6 @@
       net_name: '{{ test_net_name }}'
       type: appliance
     delegate_to: localhost
-
-# TODO: Get the network ID from the previous task
-  - name: Get network id
-    meraki_network:
-      auth_key: '{{auth_key}}'
-      state: query
-      org_name: '{{test_org_name}}'
-      net_name: '{{test_net_name}}'
     register: net_info
 
   - set_fact:

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -54,6 +54,7 @@
       type: appliance
     delegate_to: localhost
 
+# TODO: Get the network ID from the previous task
   - name: Get network id
     meraki_network:
       auth_key: '{{auth_key}}'
@@ -77,6 +78,19 @@
   - assert:
       that:
         bind.changed == True
+
+  - name: Bind a template to a network with check mode
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+      config_template: '{{test_template_name}}'
+    register: bind_check
+
+  - assert:
+      that:
+        bind_check is not changed
 
   - name: Bind a template to a network when it's already bound
     meraki_config_template:
@@ -157,6 +171,19 @@
   - assert:
       that:
         unbind_id.changed == True
+
+  - name: Unbind a template to a network via id with check mode
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_id: '{{net_id}}'
+      config_template: '{{test_template_name}}'
+    register: unbind_id_check
+
+  - assert:
+      that:
+        unbind_id_check is not changed
 
   always:
   - name: Delete network

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -66,6 +66,16 @@
   - set_fact:
       net_id: '{{net_info.data.id}}'
 
+  - name: Bind a template to a network with check mode
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+      config_template: '{{test_template_name}}'
+    check_mode: yes
+    register: bind_check
+
   - name: Bind a template to a network
     meraki_config_template:
       auth_key: '{{auth_key}}'
@@ -79,18 +89,9 @@
       that:
         bind.changed == True
 
-  - name: Bind a template to a network with check mode
-    meraki_config_template:
-      auth_key: '{{auth_key}}'
-      state: present
-      org_name: '{{ test_org_name }}'
-      net_name: '{{ test_net_name }}'
-      config_template: '{{test_template_name}}'
-    register: bind_check
-
   - assert:
       that:
-        bind_check is not changed
+        bind_check is changed
 
   - name: Bind a template to a network when it's already bound
     meraki_config_template:
@@ -159,7 +160,21 @@
         - bind_id_idempotent.changed == False
         - bind_id_idempotent.data is defined
 
-  - name: Unbind a template to a network via id
+  - name: Unbind a template from a network via id with check mode
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_id: '{{net_id}}'
+      config_template: '{{test_template_name}}'
+    check_mode: yes
+    register: unbind_id_check
+
+  - assert:
+      that:
+        unbind_id_check is changed
+
+  - name: Unbind a template from a network via id
     meraki_config_template:
       auth_key: '{{auth_key}}'
       state: absent
@@ -172,18 +187,28 @@
       that:
         unbind_id.changed == True
 
-  - name: Unbind a template to a network via id with check mode
+  # This is disabled by default since they can't be created via API
+  - name: Delete sacrificial template with check mode
     meraki_config_template:
       auth_key: '{{auth_key}}'
       state: absent
       org_name: '{{test_org_name}}'
-      net_id: '{{net_id}}'
-      config_template: '{{test_template_name}}'
-    register: unbind_id_check
+      config_template: sacrificial_template
+    check_mode: yes
+    register: delete_template_check
 
-  - assert:
-      that:
-        unbind_id_check is not changed
+  # This is disabled by default since they can't be created via API
+  - name: Delete sacrificial template
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      config_template: sacrificial_template
+      output_level: debug
+    register: delete_template
+
+  - debug:
+      var: delete_template
 
   always:
   - name: Delete network


### PR DESCRIPTION
##### SUMMARY
Enables check mode support for meraki_admin module. This particular PR adds a `check_mode` property in the Meraki module utility.

This PR should come before my other PRs for check mode because it includes a property in `MerakiModule` which exposes check mode status from the module.

Note, the configuration template API does not return any data so check mode was very easy.

Related to bug #53597.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meraki_config_template
