### PR TITLE
tower: modify tower_credential module to support custom cred types (ansible#54493)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -59,6 +59,7 @@ options:
     credential_type:
       description:
         - Non built-in custom credential type name.
+      version_added: "2.8"
       type: str
     host:
       description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In addition to built-in credential types, Tower also supports creation of custom credential types.

Existing tower_credential module does not allow us to reference and create credential of custom type.

This change will allow for management of credentials of custom credential type.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tower_credential module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Existing tower_credential module only supports built-in credential types specified using the 'kind' module param. These are built-in cred types (valid choices) supported -
 
  ["ssh", "vault", "net", "scm", "aws", "vmware", "satellite6", "cloudforms", "gce", "azure_rm", "openstack", "rhv", "insights", "tower"]

This change will allow for an extra 'kind' param choice value - 'cloud' (as in Tower, custom credentials types can only be defined as 'cloud' kind). If credential kind param has value of 'cloud', the new param 'credential_type' will be required (used to specify custom credential type name). See below for example.

This change is back-compatible - i.e. when any other built-in 'kind' is specified, credential_type param is not needed and logic is unchanged.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    - name: Credential
      tower_credential:
        name: "ACME Cred"
        organization: Foo
        kind: cloud
        credential_type: ACME
        ...

```
