### PR TITLE
Backport: Catch all request timeouts for winrm connection

### DIFF
--- a/changelogs/fragments/winrm-all-timeout-exceptions.yaml
+++ b/changelogs/fragments/winrm-all-timeout-exceptions.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Catch all connection timeout related exceptions and raise
+    AnsibleConnectionError instead

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -491,7 +491,7 @@ class Connection(ConnectionBase):
                                        % (to_native(response.std_out), to_native(stderr)))
 
             return response
-        except requests.exceptions.ConnectionError as exc:
+        except requests.exceptions.Timeout as exc:
             raise AnsibleConnectionFailure('winrm connection error: %s' % to_native(exc))
         finally:
             if command_id:


### PR DESCRIPTION
##### SUMMARY
The current implementation only catches `ConnectTimeout` exceptions.
Instead we should catch `Timout` which also catches `ReadTimeout`
exceptions.

Backport of: #54104 
Improves on: #51744

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
winrm

##### ADDITIONAL INFORMATION
```
fatal: [win-node]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout": ""}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='xxx.xxx.xxx.xxx', port=5986): Read timed out. (read timeout=120)

Traceback (most recent call last):
  File "/opt/zuul/lib/python3.6/site-packages/urllib3/connectionpool.py", line 384, in _make_request
    six.raise_from(e, None)
  File "<string>", line 2, in raise_from
  File "/opt/zuul/lib/python3.6/site-packages/urllib3/connectionpool.py", line 380, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/lib/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/lib/python3.6/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.6/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib/python3.6/ssl.py", line 1012, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib/python3.6/ssl.py", line 874, in read
    return self._sslobj.read(len, buffer)
  File "/usr/lib/python3....ib/python3.6/site-packages/winrm/protocol.py", line 417, in _raw_get_command_output
    res = self.send_message(xmltodict.unparse(req))
  File "/opt/zuul/lib/python3.6/site-packages/winrm/protocol.py", line 234, in send_message
    resp = self.transport.send_message(message)
  File "/opt/zuul/lib/python3.6/site-packages/winrm/transport.py", line 256, in send_message
    response = self._send_message_request(prepared_request, message)
  File "/opt/zuul/lib/python3.6/site-packages/winrm/transport.py", line 261, in _send_message_request
    response = self.session.send(prepared_request, timeout=self.read_timeout_sec)
  File "/opt/zuul/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/opt/zuul/lib/python3.6/site-packages/requests/adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host="xxx.xxx.xxx.xxx", port=5986): Read timed out. (read timeout=120)
```