### PR TITLE
get_certificate: stop using ca_certs alias

### DIFF
--- a/lib/ansible/modules/crypto/get_certificate.py
+++ b/lib/ansible/modules/crypto/get_certificate.py
@@ -29,7 +29,6 @@ options:
         - A PEM file containing one or more root certificates; if present, the cert will be validated against these root certs.
         - Note that this only validates the certificate is signed by the chain; not that the cert is valid for the host presenting it.
       type: path
-      aliases: [ ca_certs ]
     port:
       description:
         - The port to connect to
@@ -131,14 +130,14 @@ else:
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            ca_cert=dict(type='path', aliases=['ca_certs']),
+            ca_cert=dict(type='path'),
             host=dict(type='str', required=True),
             port=dict(type='int', required=True),
             timeout=dict(type='int', default=10),
         ),
     )
 
-    ca_certs = module.params.get('ca_cert')
+    ca_cert = module.params.get('ca_cert')
     host = module.params.get('host')
     port = module.params.get('port')
     timeout = module.params.get('timeout')
@@ -153,12 +152,12 @@ def main():
     if timeout:
         setdefaulttimeout(timeout)
 
-    if ca_certs:
-        if not isfile(ca_certs):
+    if ca_cert:
+        if not isfile(ca_cert):
             module.fail_json(msg="ca_cert file does not exist")
 
     try:
-        cert = get_server_certificate((host, port), ca_certs=ca_certs)
+        cert = get_server_certificate((host, port), ca_certs=ca_cert)
         x509 = crypto.load_certificate(crypto.FILETYPE_PEM, cert)
     except Exception as e:
         module.fail_json(msg="Failed to get cert from port with error: {0}".format(e))

--- a/test/integration/targets/get_certificate/tests/validate.yml
+++ b/test/integration/targets/get_certificate/tests/validate.yml
@@ -43,11 +43,11 @@
       # We got the expected error message
       - "'Failed to get cert from port with error: timed out' == result.msg or 'Connection refused' in result.msg"
 
-- name: Test failure if ca_certs is not a valid file
+- name: Test failure if ca_cert is not a valid file
   get_certificate:
     host: "{{ httpbin_host }}"
     port: 443
-    ca_certs: dn.e
+    ca_cert: dn.e
   register: result
   ignore_errors: true
 
@@ -65,7 +65,7 @@
 
 - name: Get servers certificate comparing it to its own ca_cert file
   get_certificate:
-    ca_certs: '{{ output_dir }}/temp.pem'
+    ca_cert: '{{ output_dir }}/temp.pem'
     host: "{{ httpbin_host }}"
     port: 443
   register: result
@@ -87,7 +87,7 @@
 
 - name: Get servers certificate comparing it to an invalid ca_cert file
   get_certificate:
-    ca_certs: '{{ my_temp_dir.path }}/bogus_ca.pem'
+    ca_cert: '{{ my_temp_dir.path }}/bogus_ca.pem'
     host: "{{ httpbin_host }}"
     port: 443
   register: result


### PR DESCRIPTION
##### SUMMARY
Follow-up to #54315: remove the old name `ca_certs` for the `ca_cert` option. After all, this module is new for Ansible 2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
get_certificate
