### PR TITLE
Fix OpenSSL tests on FreeBSD with Python 3.x.

### DIFF
--- a/test/integration/targets/setup_openssl/vars/FreeBSD.yml
+++ b/test/integration/targets/setup_openssl/vars/FreeBSD.yml
@@ -1,1 +1,2 @@
 pyopenssl_package_name: py27-openssl
+pyopenssl_package_name_python3: py36-openssl


### PR DESCRIPTION
##### SUMMARY

Fix OpenSSL tests on FreeBSD with Python 3.x.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

openssl integration tests
