### PR TITLE
Fix file path encoding bugs on Python 3.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2069,9 +2069,11 @@ class AnsibleModule(object):
 
     def digest_from_file(self, filename, algorithm):
         ''' Return hex digest of local file for a digest_method specified by name, or None if file is not present. '''
-        if not os.path.exists(filename):
+        b_filename = to_bytes(filename, errors='surrogate_or_strict')
+
+        if not os.path.exists(b_filename):
             return None
-        if os.path.isdir(filename):
+        if os.path.isdir(b_filename):
             self.fail_json(msg="attempted to take checksum of directory: %s" % filename)
 
         # preserve old behaviour where the third parameter was a hash algorithm object
@@ -2085,7 +2087,7 @@ class AnsibleModule(object):
                                    (filename, algorithm, ', '.join(AVAILABLE_HASH_ALGORITHMS)))
 
         blocksize = 64 * 1024
-        infile = open(os.path.realpath(filename), 'rb')
+        infile = open(os.path.realpath(b_filename), 'rb')
         block = infile.read(blocksize)
         while block:
             digest_method.update(block)

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -576,7 +576,7 @@ def main():
             dest = to_native(b_dest, errors='surrogate_or_strict')
         if not force:
             module.exit_json(msg="file already exists", src=src, dest=dest, changed=False)
-        if os.access(b_dest, os.R_OK) and os.path.isfile(dest):
+        if os.access(b_dest, os.R_OK) and os.path.isfile(b_dest):
             checksum_dest = module.sha1(dest)
     else:
         if not os.path.exists(os.path.dirname(b_dest)):

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -374,6 +374,8 @@ def get_timestamp_for_time(formatted_time, time_format):
 
 
 def update_timestamp_for_file(path, mtime, atime, diff=None):
+    b_path = to_bytes(path, errors='surrogate_or_strict')
+
     try:
         # When mtime and atime are set to 'now', rely on utime(path, None) which does not require ownership of the file
         # https://github.com/ansible/ansible/issues/50943
@@ -382,8 +384,8 @@ def update_timestamp_for_file(path, mtime, atime, diff=None):
             # not be updated. Just use the current time for the diff values
             mtime = atime = time.time()
 
-            previous_mtime = os.stat(path).st_mtime
-            previous_atime = os.stat(path).st_atime
+            previous_mtime = os.stat(b_path).st_mtime
+            previous_atime = os.stat(b_path).st_atime
 
             set_time = None
         else:
@@ -391,8 +393,8 @@ def update_timestamp_for_file(path, mtime, atime, diff=None):
             if mtime is None and atime is None:
                 return False
 
-            previous_mtime = os.stat(path).st_mtime
-            previous_atime = os.stat(path).st_atime
+            previous_mtime = os.stat(b_path).st_mtime
+            previous_atime = os.stat(b_path).st_atime
 
             if mtime is None:
                 mtime = previous_mtime
@@ -410,7 +412,7 @@ def update_timestamp_for_file(path, mtime, atime, diff=None):
 
             set_time = (atime, mtime)
 
-        os.utime(path, set_time)
+        os.utime(b_path, set_time)
 
         if diff is not None:
             if 'before' not in diff:


### PR DESCRIPTION
##### SUMMARY

Fix file path encoding bugs on Python 3.

Discovered while testing FreeBSD with Python 3.x.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

basic module_utils
copy module
file module
