### PR TITLE
postgresql_privs: Include partioned tables

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -460,7 +460,7 @@ class Connection(object):
         query = """SELECT relname
                    FROM pg_catalog.pg_class c
                    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                   WHERE nspname = %s AND relkind in ('r', 'v', 'm')"""
+                   WHERE nspname = %s AND relkind in ('r', 'v', 'm', 'p')"""
         self.cursor.execute(query, (schema,))
         return [t[0] for t in self.cursor.fetchall()]
 


### PR DESCRIPTION
Include partioned tables in ALL_IN_SCHEMA list.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes  #54516 by adding the partioned tables into the selection of tables in the schema
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_privs
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Grant access to all tables in a schema. Be sure it includes partioned tables.
After this fix the db user can perform the requested actions (or not after a revoke)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
