### PR TITLE
Fix elasticache documentation of security_group_ids

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache.py
@@ -59,7 +59,7 @@ options:
     version_added: "2.0"
   security_group_ids:
     description:
-      - A list of vpc security group names to associate with this cache cluster. Only use if inside a vpc
+      - A list of vpc security group IDs to associate with this cache cluster. Only use if inside a vpc
     version_added: "1.6"
   cache_security_groups:
     description:


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
When creating an ElastiCache redis cluster/instance via this module using a list of security group names (i.e. "FooSG") with `security_group_ids`, the module will fail to create the redis cluster/instance.

When using the security group ID (i.e. "sg-XXXXXXXX"), the cluster is created successfully. Tested with Ansible v2.7.8.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
elasticache.py