### PR TITLE
Move example in coverage docs to code type

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -72,10 +72,11 @@ aren't using the ``--tox`` or ``--docker`` options which create an isolated pyth
 environment then you may have to use the ``--requirements`` option to ensure that the
 correct version of the coverage module is installed::
 
+```
    ansible-test units --coverage apt
    ansible-test integration --coverage aws_lambda --tox --requirements
    ansible-test coverage html
-
+```
 
 Reports can be generated in several different formats:
 


### PR DESCRIPTION
##### SUMMARY
The ansible-test lines should be in the code type for Markdown. This will make them appear on multiple lines and the dashes should look like two dashes instead of a single dash.

+label: docsite_pr


##### ISSUE TYPE
- Docs Pull Request
