### PR TITLE
[WIP] Some getent databases allow for duplicate records

### DIFF
--- a/changelogs/fragments/getent-append.yaml
+++ b/changelogs/fragments/getent-append.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- getent - append values if duplicates are returned by getent (https://github.com/ansible/ansible/issues/54488)

--- a/lib/ansible/modules/system/getent.py
+++ b/lib/ansible/modules/system/getent.py
@@ -129,7 +129,13 @@ def main():
     if rc == 0:
         for line in out.splitlines():
             record = line.split(split)
-            results[dbtree][record[0]] = record[1:]
+            if record[0] in results[dbtree]:
+                results[dbtree][record[0]].update(record[1:])
+            else:
+                results[dbtree][record[0]] = set(record[1:])
+
+        for k, v in results[dbtree].items():
+            results[dbtree][k] = list(v)
 
         module.exit_json(ansible_facts=results)
 

--- a/lib/ansible/modules/system/getent.py
+++ b/lib/ansible/modules/system/getent.py
@@ -130,9 +130,12 @@ def main():
         for line in out.splitlines():
             record = line.split(split)
             if record[0] in results[dbtree]:
-                results[dbtree][record[0]].update(record[1:])
+                current = results[dbtree][record[0]]
+                for r in record[1:]:
+                    if r not in current:
+                        current.append(r)
             else:
-                results[dbtree][record[0]] = set(record[1:])
+                results[dbtree][record[0]] = record[1:]
 
         for k, v in results[dbtree].items():
             results[dbtree][k] = list(v)


### PR DESCRIPTION
##### SUMMARY
 Some getent databases allow for duplicate records, ensure we combine, rather than overwrite

Fixes #54488 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/getent.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```