### PR TITLE
doc: properly format the Jinja2 of the vmware example

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -80,7 +80,7 @@ EXAMPLES = r'''
     datacenter: datacenter
     validate_certs: no
     name: testvm-1
-    dest_folder: /"{{ datacenter }}"/vm
+    dest_folder: "/{{ datacenter }}/vm"
   delegate_to: localhost
 
 - name: Get VM UUID
@@ -90,7 +90,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ datacenter }}"
-    folder: /"{{datacenter}}"/vm
+    folder: "/{{datacenter}}/vm"
     name: "{{ vm_name }}"
   delegate_to: localhost
   register: vm_facts

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -94,7 +94,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
-    folder: /"{{ datacenter_name }}"/vm/my_folder
+    folder: "/{{ datacenter_name }}/vm/my_folder"
     name: "{{ guest_name }}"
     state: powered-off
   delegate_to: localhost
@@ -105,7 +105,7 @@ EXAMPLES = r'''
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: /"{{ datacenter_name }}"/vm/my_folder
+    folder: "/{{ datacenter_name }}/vm/my_folder"
     name: "{{ guest_name }}"
     state: powered-off
     scheduled_at: "09/01/2018 10:18"

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
     password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ datacenter }}"
-    folder: /"{{datacenter}}"/vm
+    folder: "/{{datacenter}}/vm"
     name: "{{ vm_name }}"
   delegate_to: localhost
   register: vm_facts
@@ -96,7 +96,7 @@ EXAMPLES = '''
     password: "{{ vcenter_password }}"
     validate_certs: no
     name: test-vm
-    folder: /"{{datacenter}}"/vm
+    folder: "/{{datacenter}}/vm"
   delegate_to: localhost
   register: facts
 '''

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -109,7 +109,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter }}"
-    folder: /"{{datacenter}}"/vm
+    folder: "/{{datacenter}}/vm"
     vm_id: "{{ vm_name }}"
     vm_username: root
     vm_password: superSecret
@@ -128,7 +128,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter }}"
-    folder: /"{{datacenter}}"/vm
+    folder: "/{{datacenter}}/vm"
     vm_id: NameOfVM
     vm_username: root
     vm_password: superSecret
@@ -145,7 +145,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter }}"
-    folder: /"{{datacenter}}"/vm
+    folder: "/{{datacenter}}/vm"
     vm_id: "{{ vm_name }}"
     vm_username: sample
     vm_password: old_password
@@ -160,7 +160,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ datacenter }}"
-    folder: /"{{datacenter}}"/vm
+    folder: "/{{datacenter}}/vm"
     vm_id: "{{ vm_name }}"
     vm_username: testUser
     vm_password: SuperSecretPassword


### PR DESCRIPTION
##### SUMMARY

Fix the syntax of the VMWare example. This patch is similar to
8aec69dd89fd23b7a63bb6ba488d9f11a77a4b91.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

vmware