### PR TITLE
fix: allow kinesis stream shard count updates

### DIFF
--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -1030,11 +1030,6 @@ def create_stream(client, stream_name, number_of_shards=1, retention_period=None
             )
         )
 
-    if stream_found and not check_mode:
-        if current_stream['ShardsCount'] != number_of_shards:
-            err_msg = 'Can not change the number of shards in a Kinesis Stream'
-            return success, changed, err_msg, results
-
     if stream_found and current_stream.get('StreamStatus') != 'DELETING':
         success, changed, err_msg = update(
             client, current_stream, stream_name, number_of_shards,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/54529

Support had been added (by a prior PR 24805) for updating the shard count of a Kinesis stream but the logic that errors out if you _try_ to was not removed. This just removes the "If the stream exists and we've specified a different shard count" logic so that we can actually make use of the feature added in https://github.com/ansible/ansible/pull/24805.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kinesis_stream

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```