### PR TITLE
WIP: vmware_guest_facts: Add lookup based on Manage Object ID (MoID)

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vcenter_extension.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_extension.py
@@ -160,7 +160,7 @@ def main():
     visible = module.params['visible']
     thumbprint = module.params['ssl_thumbprint']
 
-    content = connect_to_api(module, False)
+    content = connect_to_api(module, False).RetrieveContent()
     em = content.extensionManager
     key_check = em.FindExtension(extension_key)
     results = dict(changed=False, installed=dict())

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -292,7 +292,7 @@ class VMDKUploader(Thread):
 
 class VMwareDeployOvf:
     def __init__(self, module):
-        self.si = connect_to_api(module)
+        self.content = connect_to_api(module).RetrieveContent()
         self.module = module
         self.params = module.params
 
@@ -309,27 +309,27 @@ class VMwareDeployOvf:
         self.entity = None
 
     def get_objects(self):
-        self.datastore = find_datastore_by_name(self.si, self.params['datastore'])
+        self.datastore = find_datastore_by_name(self.content, self.params['datastore'])
         if not self.datastore:
             self.module.fail_json(msg='%(datastore)s could not be located' % self.params)
 
-        self.datacenter = find_datacenter_by_name(self.si, self.params['datacenter'])
+        self.datacenter = find_datacenter_by_name(self.content, self.params['datacenter'])
         if not self.datacenter:
             self.module.fail_json(msg='%(datacenter)s could not be located' % self.params)
 
         if self.params['cluster']:
-            cluster = find_cluster_by_name(self.si, self.params['cluster'])
+            cluster = find_cluster_by_name(self.content, self.params['cluster'])
             if cluster is None:
                 self.module.fail_json(msg="Unable to find cluster '%(cluster)s'" % self.params)
             else:
                 self.resource_pool = cluster.resourcePool
         else:
-            self.resource_pool = find_resource_pool_by_name(self.si, self.params['resource_pool'])
+            self.resource_pool = find_resource_pool_by_name(self.content, self.params['resource_pool'])
             if not self.resource_pool:
                 self.module.fail_json(msg='%(resource_pool)s could not be located' % self.params)
 
         for key, value in self.params['networks'].items():
-            network = find_network_by_name(self.si, value)
+            network = find_network_by_name(self.content, value)
             if not network:
                 self.module.fail_json(msg='%(network)s could not be located' % self.params)
             network_mapping = vim.OvfManager.NetworkMapping()
@@ -379,7 +379,7 @@ class VMwareDeployOvf:
                 params['propertyMapping'].append(property_mapping)
 
         if self.params['folder']:
-            folder = self.si.searchIndex.FindByInventoryPath(self.params['folder'])
+            folder = self.content.searchIndex.FindByInventoryPath(self.params['folder'])
             if not folder:
                 self.module.fail_json(msg="Unable to find the specified folder %(folder)s" % self.params)
         else:
@@ -389,7 +389,7 @@ class VMwareDeployOvf:
 
         ovf_descriptor = self.get_ovf_descriptor()
 
-        self.import_spec = self.si.ovfManager.CreateImportSpec(
+        self.import_spec = self.content.ovfManager.CreateImportSpec(
             ovf_descriptor,
             resource_pool,
             datastore,
@@ -411,9 +411,9 @@ class VMwareDeployOvf:
 
         if not self.params['allow_duplicates']:
             name = self.import_spec.importSpec.configSpec.name
-            match = find_vm_by_name(self.si, name, folder=folder)
+            match = find_vm_by_name(self.content, name, folder=folder)
             if match:
-                self.module.exit_json(instance=gather_vm_facts(self.si, match), changed=False)
+                self.module.exit_json(instance=gather_vm_facts(self.content, match), changed=False)
 
         if self.module.check_mode:
             self.module.exit_json(changed=True, instance={'hw_name': name})
@@ -540,9 +540,9 @@ class VMwareDeployOvf:
         env = ET.Element('Environment', **attrib)
 
         platform = ET.SubElement(env, 'PlatformSection')
-        ET.SubElement(platform, 'Kind').text = self.si.about.name
-        ET.SubElement(platform, 'Version').text = self.si.about.version
-        ET.SubElement(platform, 'Vendor').text = self.si.about.vendor
+        ET.SubElement(platform, 'Kind').text = self.content.about.name
+        ET.SubElement(platform, 'Version').text = self.content.about.version
+        ET.SubElement(platform, 'Vendor').text = self.content.about.vendor
         ET.SubElement(platform, 'Locale').text = 'US'
 
         prop_section = ET.SubElement(env, 'PropertySection')
@@ -574,13 +574,13 @@ class VMwareDeployOvf:
             if self.params['wait']:
                 wait_for_task(task)
                 if self.params['wait_for_ip_address']:
-                    _facts = wait_for_vm_ip(self.si, self.entity)
+                    _facts = wait_for_vm_ip(self.content, self.entity)
                     if not _facts:
                         self.module.fail_json(msg='Waiting for IP address timed out')
                     facts.update(_facts)
 
         if not facts:
-            facts.update(gather_vm_facts(self.si, self.entity))
+            facts.update(gather_vm_facts(self.content, self.entity))
 
         return facts
 

--- a/lib/ansible/modules/cloud/vmware/vmware_dns_config.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dns_config.py
@@ -104,7 +104,7 @@ def main():
     domainname = module.params['domainname']
     dns_servers = module.params['dns_servers']
     try:
-        content = connect_to_api(module)
+        content = connect_to_api(module).RetrieveContent()
         host = get_all_objs(content, [vim.HostSystem])
         if not host:
             module.fail_json(msg="Unable to locate Physical Host.")

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -34,7 +34,7 @@ options:
    name:
      description:
      - Name of the VM to work with
-     - This is required if UUID is not supplied.
+     - This is required if UUID or moid is not supplied.
    name_match:
      description:
      - If multiple VMs matching the name, use the first or last found
@@ -43,7 +43,12 @@ options:
    uuid:
      description:
      - UUID of the instance to manage if known, this is VMware's unique identifier.
-     - This is required if name is not supplied.
+     - This is required if name or moid is not supplied.
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - This is required if name or UUID is not supplied.
+     version_added: '2.9'
    use_instance_uuid:
      description:
      - Whether to use the VMware instance UUID rather than the BIOS UUID.
@@ -236,6 +241,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
@@ -244,7 +250,7 @@ def main():
         properties=dict(type='list')
     )
     module = AnsibleModule(argument_spec=argument_spec,
-                           required_one_of=[['name', 'uuid']],
+                           required_one_of=[['name', 'uuid', 'moid']],
                            supports_check_mode=True)
 
     if module.params.get('folder'):
@@ -283,7 +289,8 @@ def main():
             module.fail_json(msg="Fact gather failed with exception %s" % to_text(exc))
     else:
         module.fail_json(msg="Unable to gather facts for non-existing VM %s" % (module.params.get('uuid') or
-                                                                                module.params.get('name')))
+                                                                                module.params.get('name') or
+                                                                                module.params.get('moid')))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/vmware/vmware_migrate_vmk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_migrate_vmk.py
@@ -90,7 +90,7 @@ class VMwareMigrateVmk(object):
         self.esxi_hostname = self.module.params['esxi_hostname']
         self.current_portgroup_name = self.module.params['current_portgroup_name']
         self.current_switch_name = self.module.params['current_switch_name']
-        self.content = connect_to_api(module)
+        self.content = connect_to_api(module).RetrieveContent()
 
     def process_state(self):
         try:

--- a/lib/ansible/modules/cloud/vmware/vmware_resource_pool.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_resource_pool.py
@@ -159,7 +159,7 @@ class VMwareResourcePool(object):
         self.cluster_obj = None
         self.host_obj = None
         self.resource_pool_obj = None
-        self.content = connect_to_api(module)
+        self.content = connect_to_api(module).RetrieveContent()
 
     def select_resource_pool(self, host):
         pool_obj = None

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_vss_dvs_migrate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_vss_dvs_migrate.py
@@ -62,7 +62,7 @@ from ansible.module_utils.vmware import (HAS_PYVMOMI, connect_to_api, get_all_ob
 class VMwareVmVssDvsMigrate(object):
     def __init__(self, module):
         self.module = module
-        self.content = connect_to_api(module)
+        self.content = connect_to_api(module).RetrieveContent()
         self.vm = None
         self.vm_name = module.params['vm_name']
         self.dvportgroup_name = module.params['dvportgroup_name']

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel_ip_config.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel_ip_config.py
@@ -100,7 +100,7 @@ def main():
     subnet_mask = module.params['subnet_mask']
 
     try:
-        content = connect_to_api(module, False)
+        content = connect_to_api(module, False).RetrieveContent()
         host = get_all_objs(content, [vim.HostSystem])
         if not host:
             module.fail_json(msg="Unable to locate Physical Host.")

--- a/lib/ansible/modules/cloud/vmware/vmware_vsan_cluster.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vsan_cluster.py
@@ -104,7 +104,7 @@ def main():
     new_cluster_uuid = module.params['cluster_uuid']
 
     try:
-        content = connect_to_api(module, False)
+        content = connect_to_api(module, False).RetrieveContent()
         host = get_all_objs(content, [vim.HostSystem])
         if not host:
             module.fail_json(msg="Unable to locate Physical Host.")

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -48,6 +48,8 @@
 
 - set_fact: vm1_instance_uuid="{{ guest_facts_0001['instance']['instance_uuid'] }}"
 
+- set_fact: vm1_moid="{{ guest_facts_0001['instance']['moid'] }}"
+
 - debug:
     var: vm1_uuid
 
@@ -186,5 +188,38 @@
       - "guest_facts_0005['instance']['guest_consolidation_needed'] is defined"
       - "guest_facts_0005['instance']['instance_uuid'] is defined"
       - "guest_facts_0005['instance']['instance_uuid'] == vm1_instance_uuid"
+      - "guest_facts_0001['instance']['moid'] is defined"
+      - "guest_facts_0001['instance']['vimref'] is defined"
+
+# Testcase 0005: Get details about virtual machines using MoID
+- name: get list of facts about virtual machines using the MoID
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    moid: "{{ vm1_moid }}"
+  register: guest_facts_0006
+
+- debug:
+    msg: "{{ guest_facts_0006 }}"
+
+- assert:
+    that:
+      - "guest_facts_0006['instance']['hw_name'] == infra.vm_list[0]"
+      - "guest_facts_0006['instance']['hw_product_uuid'] is defined"
+      - "guest_facts_0006['instance']['hw_product_uuid'] == vm1_uuid"
+      - "guest_facts_0006['instance']['hw_cores_per_socket'] is defined"
+      - "guest_facts_0006['instance']['hw_datastores'] is defined"
+      - "guest_facts_0006['instance']['hw_esxi_host'] is defined"
+      - "guest_facts_0006['instance']['hw_files'] is defined"
+      - "guest_facts_0006['instance']['hw_guest_ha_state'] is defined"
+      - "guest_facts_0006['instance']['hw_is_template'] is defined"
+      - "guest_facts_0006['instance']['hw_folder'] is defined"
+      - "guest_facts_0006['instance']['guest_question'] is defined"
+      - "guest_facts_0006['instance']['guest_consolidation_needed'] is defined"
+      - "guest_facts_0006['instance']['instance_uuid'] is defined"
+      - "guest_facts_0006['instance']['instance_uuid'] == vm1_instance_uuid"
       - "guest_facts_0001['instance']['moid'] is defined"
       - "guest_facts_0001['instance']['vimref'] is defined"


### PR DESCRIPTION
##### SUMMARY
Adds lookup based on Manage Object ID (moRef ID or moId) to vmware_guest_facts.
The moRef ID has been a unique identifier for years, see for example this good serie of @lamw about this:
https://www.virtuallyghetto.com/2017/07/uniquely-identifying-vms-in-vsphere-part-3-enhanced-linked-mode-cross-vc-vmotion.html

At Intermax all our tools are based on this identifier, I think we are not the only one with this 'problem'. This PR allows users to use this existing reference to gather the UUID or name/folder for future usage.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_facts

##### ADDITIONAL INFORMATION

Example of the usage in one of our roles:
```yaml
---
- hosts: localhost
  gather_facts: false
  tasks:
  - name: Gather facts for VMWare guest with Manage Object ID
    vmware_guest_facts:
      hostname: "{{ vmware_vcenter_hostname }}"
      username: "{{ vmware_vcenter_username }}"
      password: "{{ vmware_vcenter_password }}"
      datacenter: "{{ vmware_vcenter_datacenter }}"
      validate_certs: "{{ vmware_vcenter_validate_certs }}"
      moid: vm-31352
    register: facts

  - name: Use this new information to gather info again
    vmware_guest_facts:
      hostname: "{{ vmware_vcenter_hostname }}"
      username: "{{ vmware_vcenter_username }}"
      password: "{{ vmware_vcenter_password }}"
      datacenter: "{{ vmware_vcenter_datacenter }}"
      validate_certs: "{{ vmware_vcenter_validate_certs }}"
      name: "{{ facts.instance.hw_name }}"
      folder: "{{ facts.instance.hw_folder }}"
```
