### PR TITLE
Document specifying openstack clouds path via env var

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -89,6 +89,8 @@ DOCUMENTATION = '''
                 /etc/ansible/openstack.yml to the regular locations documented
                 at https://docs.openstack.org/os-client-config/latest/user/configuration.html#config-files
             type: string
+            env:
+                - name: OS_CLIENT_CONFIG_FILE
         compose:
             description: Create vars from jinja2 expressions.
             type: dictionary


### PR DESCRIPTION
##### SUMMARY
This functionality has already existed.

This env var is how the `openstack.py` script consumed the file path. With the plugin, it was still picked up and parsed by the python library used.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
openstack inventory plugin

##### ADDITIONAL INFORMATION
Use case example:

```paste below
OS_CLIENT_CONFIG_FILE=private/clouds.yml ansible-inventory -i openstack.yml --list --export
```

Where `openstack.yml` has:

```yaml
plugin: openstack
fail_on_errors: true
inventory_hostname: uuid
```

Always has worked, always will. Tested before this change, tested after this change. Works and works.

This change just makes it so that:

https://docs.ansible.com/ansible/latest/plugins/inventory/openstack.html

will show this information to the public.