### PR TITLE
auto inventory: allow yaml files with header instead of extension

### DIFF
--- a/changelogs/fragments/auto_no_extension.yml
+++ b/changelogs/fragments/auto_no_extension.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+- |
+  Custom inventory plugins can now be auto-loaded as long as they are yaml-based
+  and the inventory file starts with the "---" yaml header.

--- a/lib/ansible/plugins/inventory/auto.py
+++ b/lib/ansible/plugins/inventory/auto.py
@@ -32,7 +32,7 @@ class InventoryModule(BaseInventoryPlugin):
     NAME = 'auto'
 
     def verify_file(self, path):
-        if not path.endswith('.yml') and not path.endswith('.yaml'):
+        if not path.endswith('.yml') and not path.endswith('.yaml') and not self.verify_yaml_header(path):
             return False
         return super(InventoryModule, self).verify_file(path)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow folks to have custom inventory plugins that auto-load despite also accepting arbitrary file names.  Prevents having to ship an ansible.cfg file in the repo that white lists the custom inventory plugin.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
auto

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
