### PR TITLE
fix: kinesis stream tag deletion

### DIFF
--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -477,7 +477,7 @@ def tags_action(client, stream_name, tags, action='create', check_mode=False):
                 client.add_tags_to_stream(**params)
                 success = True
             elif action == 'delete':
-                params['TagKeys'] = tags.keys()
+                params['TagKeys'] = list(tags)
                 client.remove_tags_from_stream(**params)
                 success = True
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
tags.keys() returns a list of the keys, sure. But in Python 3 it's a 
"dict_keys" class, and BOTO is expecting a list. So let's make this work 
in Python 3 _and_ 2.

list(tags) returns a list of the keys in Python 2 and Python3. That 
seems to be what we want.

Fixes https://github.com/ansible/ansible/issues/54534
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kinesis_stream

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
