### PR TITLE
BIGIP: deprecates TMOS v11.x support for GTM modules

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_gtm_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool.py
@@ -910,7 +910,7 @@ class BaseManager(object):
         result.append(
             dict(
                 msg='The support for this TMOS version is deprecated.',
-                version='2.8'
+                version='2.12'
             )
         )
 

--- a/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
@@ -667,7 +667,7 @@ class BaseManager(object):
         result.append(
             dict(
                 msg='The support for this TMOS version is deprecated.',
-                version='2.8'
+                version='2.12'
             )
         )
 

--- a/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
@@ -123,6 +123,8 @@ options:
         module.
     type: str
     version_added: 2.8
+notes:
+  - Support for TMOS versions below v12.x has been deprecated for this module, and will be removed in Ansible 2.12.
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -646,11 +648,28 @@ class BaseManager(object):
 
     def _announce_deprecations(self, result):
         warnings = result.pop('__warnings', [])
+        if self.version_is_less_than_12():
+            self._deprecate_v11(warnings)
         for warning in warnings:
             self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
+
+    def version_is_less_than_12(self):
+        version = tmos_version(self.client)
+        if LooseVersion(version) < LooseVersion('12.0.0'):
+            return True
+        else:
+            return False
+
+    def _deprecate_v11(self, result):
+        result.append(
+            dict(
+                msg='The support for this TMOS version is deprecated.',
+                version='2.8'
+            )
+        )
 
     def present(self):
         if self.exists():

--- a/test/units/modules/network/f5/test_bigip_gtm_pool.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_pool.py
@@ -162,6 +162,7 @@ class TestUntypedManager(unittest.TestCase):
         tm = UntypedManager(module=module)
         tm.exists = Mock(side_effect=[False, True])
         tm.create_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -200,6 +201,7 @@ class TestUntypedManager(unittest.TestCase):
         tm = UntypedManager(module=module)
         tm.exists = Mock(side_effect=[True, True])
         tm.update_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=True)
         tm.read_current_from_device = Mock(return_value=current)
 
         # Override methods to force specific logic in the module to happen
@@ -236,6 +238,7 @@ class TestUntypedManager(unittest.TestCase):
         # Override methods in the specific type of manager
         tm = UntypedManager(module=module)
         tm.exists = Mock(side_effect=[True, False])
+        tm.version_is_less_than_12 = Mock(return_value=True)
         tm.remove_from_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
@@ -289,6 +292,7 @@ class TestTypedManager(unittest.TestCase):
         tm = TypedManager(module=module)
         tm.exists = Mock(side_effect=[False, True])
         tm.create_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -328,6 +332,7 @@ class TestTypedManager(unittest.TestCase):
         tm = TypedManager(module=module)
         tm.exists = Mock(side_effect=[True, True])
         tm.update_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=False)
         tm.read_current_from_device = Mock(return_value=current)
 
         # Override methods to force specific logic in the module to happen
@@ -365,6 +370,7 @@ class TestTypedManager(unittest.TestCase):
         # Override methods in the specific type of manager
         tm = TypedManager(module=module)
         tm.exists = Mock(side_effect=[True, False])
+        tm.version_is_less_than_12 = Mock(return_value=False)
         tm.remove_from_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen

--- a/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
@@ -159,6 +159,7 @@ class TestUntypedManager(unittest.TestCase):
         tm = UntypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -210,6 +211,7 @@ class TestTypedManager(unittest.TestCase):
         tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -244,6 +246,7 @@ class TestTypedManager(unittest.TestCase):
         tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -278,6 +281,7 @@ class TestTypedManager(unittest.TestCase):
         tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -318,6 +322,7 @@ class TestTypedManager(unittest.TestCase):
         tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -359,6 +364,7 @@ class TestTypedManager(unittest.TestCase):
         tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=True)
         tm.read_current_from_device = Mock(return_value=current)
+        tm.version_is_less_than_12 = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -402,6 +408,7 @@ class TestTypedManager(unittest.TestCase):
         tm.exists = Mock(return_value=True)
         tm.read_current_from_device = Mock(return_value=current)
         tm.update_on_device = Mock(return_value=True)
+        tm.version_is_less_than_12 = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)


### PR DESCRIPTION
##### SUMMARY
deprecates TMOS v11 support for GTM modules

We are moving away from v11.x in favor of 12.x and above, the v11.x version of TMOS was never meant to be a long term supported solution, as it puts some limitation on the changes we can
make on the GTM modules

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

lib/ansible/modules/network/f5/bigip_gtm_pool.py
lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
test/units/modules/network/f5/test_bigip_gtm_pool.py
test/units/modules/network/f5/test_bigip_gtm_wide_ip.py


