### PR TITLE
Canonicalize Gluster peer host names

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_volume.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_volume.py
@@ -180,6 +180,7 @@ import re
 import socket
 import time
 import traceback
+import socket
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -301,10 +302,15 @@ def get_quotas(name, nofail):
 
 
 def wait_for_peer(host):
+    def get_canon_name(h):
+        return socket.getaddrinfo(h, None, 0, 0, 0, socket.AI_CANONNAME)[0][3]
+
     for x in range(0, 4):
-        peers = get_peers()
-        if host in peers and peers[host][1].lower().find('peer in cluster') != -1:
-            return True
+        cn = get_canon_name(host)
+        for peer_name, peer_opts in get_peers().items():
+            peer_cn = get_canon_name(peer_name)
+            if cn == peer_cn and peer_opts[1].lower().find('peer in cluster') != -1:
+                return True
         time.sleep(1)
     return False
 


### PR DESCRIPTION
##### SUMMARY

By default, gluster_volume module checks hosts in arguments against hosts already in the cluster using simple string comparison. This doesn't work consistently when not using FQDNs (even then, this might be inconsistent when CNAMEs are used).

For example, `alpha.example.net` may or may not be printed in gluster(8) output as `alpha`. This patch ensures consistent behavior by using getaddrinfo(3) to canonicalize host names. Correct behavior confirmed under Python 2 and 3.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

gluster_volume
