### PR TITLE
Fix error with get_manager_nic_inventory method

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -876,7 +876,7 @@ class RedfishUtils(object):
     def get_multi_cpu_inventory(self):
         return self.aggregate(self.get_cpu_inventory)
 
-    def get_nic_inventory(self, resource_type, systems_uri):
+    def get_nic_inventory(self, resource_uri):
         result = {}
         nic_list = []
         nic_results = []
@@ -885,12 +885,6 @@ class RedfishUtils(object):
         properties = ['Description', 'FQDN', 'IPv4Addresses', 'IPv6Addresses',
                       'NameServers', 'PermanentMACAddress', 'SpeedMbps', 'MTUSize',
                       'AutoNeg', 'Status']
-
-        #  Given resource_type, use the proper URI
-        if resource_type == 'Systems':
-            resource_uri = systems_uri
-        elif resource_type == 'Manager':
-            resource_uri = self.manager_uri
 
         response = self.get_request(self.root_uri + resource_uri)
         if response['ret'] is False:
@@ -932,11 +926,19 @@ class RedfishUtils(object):
     def get_multi_nic_inventory(self, resource_type):
         ret = True
         entries = []
-        for systems_uri in self.systems_uris:
-            inventory = self.get_nic_inventory(resource_type, systems_uri)
+
+        #  Given resource_type, use the proper URI
+        if resource_type == 'Systems':
+            resource_uris = self.systems_uris
+        elif resource_type == 'Manager':
+            # put in a list to match what we're doing with systems_uris
+            resource_uris = self.manager_uri.split()
+
+        for resource_uri in resource_uris:
+            inventory = self.get_nic_inventory(resource_uri)
             ret = inventory.pop('ret') and ret
             if 'entries' in inventory:
-                entries.append(({'systems_uri': systems_uri},
+                entries.append(({'resource_uri': resource_uri},
                                inventory['entries']))
         return dict(ret=ret, entries=entries)
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -932,7 +932,7 @@ class RedfishUtils(object):
             resource_uris = self.systems_uris
         elif resource_type == 'Manager':
             # put in a list to match what we're doing with systems_uris
-            resource_uris = self.manager_uri.split()
+            resource_uris = [self.manager_uri]
 
         for resource_uri in resource_uris:
             inventory = self.get_nic_inventory(resource_uri)

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -278,7 +278,7 @@ def main():
 
             for command in command_list:
                 if command == "GetManagerNicInventory":
-                    result["manager_nics"] = rf_utils.get_multi_nic_inventory(resource_type=category)
+                    result["manager_nics"] = rf_utils.get_multi_nic_inventory(category)
                 elif command == "GetLogs":
                     result["log"] = rf_utils.get_logs()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Method was not updated when code to handle multiple systems was added

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils
redfish_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Current:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
[root@ans1 inventory>cat get_nic_inventory.yml
---
- hosts: myhosts
  connection: local
  name: NIC Inventory
  gather_facts: False

  vars:
    datatype: NicInventory

  tasks:

  - name: Define output file
    include_tasks: create_output_file.yml

  - name: Get NIC Information
    redfish_facts:
      category: Systems
      command: GetNicInventory
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
    register: result

  - name: Copy results to output file
    copy:
      content: "{{ result | to_nice_json }}"
      dest: "{{ template }}.json"

[root@ans1 manager>ansible-playbook get_manager_nic_inventory.yml
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to
allow bad characters in group names by default, this will change, but still be
user configurable on deprecation. This feature will be removed in version 2.10.
 Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
 [WARNING]: Invalid characters were found in group names but not replaced, use
-vvvv to see details


PLAY [Get Manager NIC inventory] ***********************************************

TASK [Set output file] *********************************************************
Thursday 28 March 2019  13:19:23 -0500 (0:00:00.099)       0:00:00.100 ********
included: /share1/git/redfish-ansible-module/playbooks/manager/create_output_file.yml for red4

TASK [Define timestamp] ********************************************************
Thursday 28 March 2019  13:19:23 -0500 (0:00:00.026)       0:00:00.126 ********
ok: [red4]

TASK [Define file to place results] ********************************************
Thursday 28 March 2019  13:19:23 -0500 (0:00:00.034)       0:00:00.160 ********
ok: [red4]

TASK [Create dropoff directory for host] ***************************************
Thursday 28 March 2019  13:19:24 -0500 (0:00:00.020)       0:00:00.181 ********
ok: [red4]

TASK [Get Manager NIC inventory] ***********************************************
Thursday 28 March 2019  13:19:24 -0500 (0:00:00.423)       0:00:00.605 ********
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'RedfishUtils' object has no attribute 'systems_uris'
fatal: [red4]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1553797164.45-127524736762798/AnsiballZ_redfish_facts.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1553797164.45-127524736762798/AnsiballZ_redfish_facts.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1553797164.45-127524736762798/AnsiballZ_redfish_facts.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_redfish_facts_payload_0MFFKn/__main__.py\", line 290, in <module>\n  File \"/tmp/ansible_redfish_facts_payload_0MFFKn/__main__.py\", line 281, in main\n  File \"/tmp/ansible_redfish_facts_payload_0MFFKn/ansible_redfish_facts_payload.zip/ansible/module_utils/redfish_utils.py\", line 935, in get_multi_nic_inventory\nAttributeError: 'RedfishUtils' object has no attribute 'systems_uris'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP *********************************************************************
red4                       : ok=4    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

Thursday 28 March 2019  13:19:25 -0500 (0:00:01.295)       0:00:01.900 ********
===============================================================================
Get Manager NIC inventory ----------------------------------------------- 1.30s
Create dropoff directory for host --------------------------------------- 0.42s
Define timestamp -------------------------------------------------------- 0.03s
Set output file --------------------------------------------------------- 0.03s
Define file to place results -------------------------------------------- 0.02s
Playbook run took 0 days, 0 hours, 0 minutes, 1 seconds
```
After patch, Manager's NIC information is retrieved successfully:
```
[root@ans1 manager>ansible-playbook get_manager_nic_inventory.yml
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to
allow bad characters in group names by default, this will change, but still be
user configurable on deprecation. This feature will be removed in version 2.10.
 Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
 [WARNING]: Invalid characters were found in group names but not replaced, use
-vvvv to see details


PLAY [Get Manager NIC inventory] ***********************************************

TASK [Set output file] *********************************************************
Thursday 28 March 2019  13:22:11 -0500 (0:00:00.061)       0:00:00.061 ********
included: /share1/git/redfish-ansible-module/playbooks/manager/create_output_file.yml for red4

TASK [Define timestamp] ********************************************************
Thursday 28 March 2019  13:22:11 -0500 (0:00:00.025)       0:00:00.086 ********
ok: [red4]

TASK [Define file to place results] ********************************************
Thursday 28 March 2019  13:22:11 -0500 (0:00:00.035)       0:00:00.122 ********
ok: [red4]

TASK [Create dropoff directory for host] ***************************************
Thursday 28 March 2019  13:22:11 -0500 (0:00:00.023)       0:00:00.145 ********
ok: [red4]

TASK [Get Manager NIC inventory] ***********************************************
Thursday 28 March 2019  13:22:12 -0500 (0:00:00.491)       0:00:00.637 ********
ok: [red4]

TASK [Copy results to output file] *********************************************
Thursday 28 March 2019  13:22:14 -0500 (0:00:02.595)       0:00:03.232 ********
changed: [red4]

PLAY RECAP *********************************************************************
red4                       : ok=6    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

Thursday 28 March 2019  13:22:15 -0500 (0:00:00.783)       0:00:04.016 ********
===============================================================================
Get Manager NIC inventory ----------------------------------------------- 2.60s
Copy results to output file --------------------------------------------- 0.78s
Create dropoff directory for host --------------------------------------- 0.49s
Define timestamp -------------------------------------------------------- 0.04s
Set output file --------------------------------------------------------- 0.03s
Define file to place results -------------------------------------------- 0.02s
Playbook run took 0 days, 0 hours, 0 minutes, 4 seconds

```