### PR TITLE
Fix pip test on FreeBSD with Python 3.x.

### DIFF
--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -10,7 +10,28 @@
   set_fact:
     virtualenv: "{{ command.stdout_lines[0] }}"
 
-- include: 'pip.yml'
+- block:
+    - name: install git, needed for repo installs
+      package:
+        name: git
+        state: present
+      when: ansible_distribution != "MacOSX"
+      register: git_install
+
+    - include_tasks: pip.yml
+  always:
+    - name: remove unwanted packages
+      package:
+        name: git
+        state: absent
+      when: git_install.changed
+
+    - name: remove auto-installed packages from FreeBSD
+      pkgng:
+        name: git
+        state: absent
+        autoremove: yes
+      when: git_install.changed
   when: ansible_fips|bool != True
   module_defaults:
     pip:

--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -31,7 +31,7 @@
         name: git
         state: absent
         autoremove: yes
-      when: git_install.changed
+      when: git_install.changed and ansible_distribution == "FreeBSD"
   when: ansible_fips|bool != True
   module_defaults:
     pip:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -18,12 +18,6 @@
 
 # FIXME: replace the python test package
 
-- name: install git, needed for repo installs
-  package:
-    name: git
-    state: present
-  when: ansible_distribution != "MacOSX"
-
 # first some tests installed system-wide
 # verify things were not installed to start with
 
@@ -139,7 +133,7 @@
       - "not (req_installed is changed)"
 
 - name: install the same module from url
-  pip: 
+  pip:
     name: "git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
     virtualenv: "{{ output_dir }}/pipenv"
     editable: True


### PR DESCRIPTION
##### SUMMARY

Fix pip test on FreeBSD with Python 3.x.

On FreeBSD the git package depends on Python 2.7. To allow the tests to run on Python 3.x we need to make sure that Python 2.7 is uninstalled before the test finishes.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip integration test
