### PR TITLE
make BECOME-SUCCESS check handle when there is additional output prefixes

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -672,8 +672,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         '''
         Removes the BECOME-SUCCESS message from the data.
         '''
-        if data.strip().startswith('BECOME-SUCCESS-'):
-            data = re.sub(r'^((\r)?\n)?BECOME-SUCCESS.*(\r)?\n', '', data)
+        pattern = re.compile(r'^(.*(\r)?\n)?BECOME-SUCCESS.*(\r)?\n')
+        if re.search(pattern, data[0:100].lstrip()):
+            data = re.sub(pattern, '', data.lstrip())
         return data
 
     def _update_module_args(self, module_name, module_args, task_vars):


### PR DESCRIPTION
##### SUMMARY
When executing the reboot module via sudo commands there are cases when text can be prepended before the `BECOME-SUCCESS` message. For example when using SSSD for authentication and your password is close to expiring the command output will be prefixed with something like `Your password will expire in 3 day(s)`. In my cause this caused the reboot module to incorrectly think that the node has rebooted even though it is still in the process of shutting down. 

This PR slightly modifies the `_strip_success_message` method to use the same regex pattern that is used during the substitution to see if it needs to remove `BECOME-SUCCESS`. This will only remove the first occurrence of `BECOME-SUCCESS` but will also match a string before it. The regex is greedy so it won't replace anything past the first match. I also limited the match to the first 100 characters of the string so that the entire string doesn't need to be parsed to determine if the substitution should occur. 

I didn't notice any existing unit tests for this but I will add some if requested. 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
action

##### ADDITIONAL INFORMATION

```python
>>> data='\r\nYour password will expire in 2 day(s).\r\nBECOME-SUCCESS-vemijwlktzishirbgrkygkhujthdmosf\r\n\r\n{"chang'
# current pattern
>>> pattern = re.compile(r'^((\r)?\n)?BECOME-SUCCESS.*(\r)?\n')
>>> data='\r\nYour password will expire in 2 day(s).\r\nBECOME-SUCCESS-vemijwlktzishirbgrkygkhujthdmosf\r\n\r\n{"chang'
# current pattern with strip
>>> re.sub(pattern, '', data.strip())
'Your password will expire in 2 day(s).\r\nBECOME-SUCCESS-vemijwlktzishirbgrkygkhujthdmosf\r\n\r\n{"chang'
# current pattern with lstrip
>>> re.sub(pattern, '', data.lstrip())
'Your password will expire in 2 day(s).\r\nBECOME-SUCCESS-vemijwlktzishirbgrkygkhujthdmosf\r\n\r\n{"chang'
# current pattern without strip
>>> re.sub(pattern, '', data)
'\r\nYour password will expire in 2 day(s).\r\nBECOME-SUCCESS-vemijwlktzishirbgrkygkhujthdmosf\r\n\r\n{"chang'

# new pattern
>>> pattern = re.compile(r'^(.*(\r)?\n)?BECOME-SUCCESS.*(\r)?\n')
# new pattern with lstrip
>>> re.sub(pattern, '', data.lstrip())
'\r\n{"chang'
# new pattern without strip
>>> re.sub(pattern, '', data)
'\r\nYour password will expire in 2 day(s).\r\nBECOME-SUCCESS-vemijwlktzishirbgrkygkhujthdmosf\r\n\r\n{"chang'
# new pattern with lstrip and multiple BECOME-SUCCESS strings
>>> re.sub(pattern, '', (data + data).lstrip())
'\r\n{"chang\r\nYour password will expire in 2 day(s).\r\nBECOME-SUCCESS-vemijwlktzishirbgrkygkhujthdmosf\r\n\r\n{"chang'
```

before: https://gist.github.com/spion06/3b358e20ae447d76a4489d7738bfc16b#file-broken-txt

after: https://gist.github.com/spion06/3b358e20ae447d76a4489d7738bfc16b#file-fixed-txt
