### PR TITLE
Support ansible-galaxy test on FreeBSD Python 3.x.

### DIFF
--- a/test/integration/targets/ansible-galaxy/cleanup.yml
+++ b/test/integration/targets/ansible-galaxy/cleanup.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  vars:
+    git_install: '{{ lookup("file", lookup("env", "OUTPUT_DIR") + "/git_install.json") | from_json }}'
+  tasks:
+    - name: remove unwanted packages
+      package:
+        name: git
+        state: absent
+      when: git_install.changed
+
+    - name: remove auto-installed packages from FreeBSD
+      pkgng:
+        name: git
+        state: absent
+        autoremove: yes
+      when: git_install.changed and ansible_distribution == "FreeBSD"

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -4,6 +4,8 @@ set -eux -o pipefail
 
 ansible-playbook setup.yml
 
+trap 'ansible-playbook cleanup.yml' EXIT
+
 # Need a relative custom roles path for testing various scenarios of -p
 galaxy_relative_rolespath="my/custom/roles/path"
 

--- a/test/integration/targets/ansible-galaxy/setup.yml
+++ b/test/integration/targets/ansible-galaxy/setup.yml
@@ -4,3 +4,8 @@
       package:
         name: git
       when: ansible_distribution != "MacOSX"
+      register: git_install
+    - name: save install result
+      copy:
+        content: '{{ git_install }}'
+        dest: '{{ lookup("env", "OUTPUT_DIR") }}/git_install.json'


### PR DESCRIPTION
##### SUMMARY

Support ansible-galaxy test on FreeBSD Python 3.x.

On FreeBSD the git package depends on Python 2.7. To allow the tests to run on Python 3.x we need to make sure that Python 2.7 is uninstalled before the test finishes.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-galaxy integration test
