### PR TITLE
Fix pull test on FreeBSD with Python 3.x.

### DIFF
--- a/test/integration/targets/pull/cleanup.yml
+++ b/test/integration/targets/pull/cleanup.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  vars:
+    git_install: '{{ lookup("file", lookup("env", "OUTPUT_DIR") + "/git_install.json") | from_json }}'
+  tasks:
+    - name: remove unwanted packages
+      package:
+        name: git
+        state: absent
+      when: git_install.changed
+
+    - name: remove auto-installed packages from FreeBSD
+      pkgng:
+        name: git
+        state: absent
+        autoremove: yes
+      when: git_install.changed and ansible_distribution == "FreeBSD"

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -13,6 +13,8 @@ temp_log="${temp_dir}/pull.log"
 
 ansible-playbook setup.yml
 
+trap "ansible-playbook '$(pwd)/cleanup.yml'" EXIT
+
 cp -av "pull-integration-test" "${repo_dir}"
 cd "${repo_dir}"
 (

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -13,7 +13,9 @@ temp_log="${temp_dir}/pull.log"
 
 ansible-playbook setup.yml
 
-trap "ansible-playbook '$(pwd)/cleanup.yml'" EXIT
+cleanup="$(pwd)/cleanup.yml"
+
+trap 'ansible-playbook "${cleanup}"' EXIT
 
 cp -av "pull-integration-test" "${repo_dir}"
 cd "${repo_dir}"

--- a/test/integration/targets/pull/setup.yml
+++ b/test/integration/targets/pull/setup.yml
@@ -4,3 +4,8 @@
       package:
         name: git
       when: ansible_distribution != "MacOSX"
+      register: git_install
+    - name: save install result
+      copy:
+        content: '{{ git_install }}'
+        dest: '{{ lookup("env", "OUTPUT_DIR") }}/git_install.json'


### PR DESCRIPTION
##### SUMMARY

Fix pull test on FreeBSD with Python 3.x.

On FreeBSD the git package depends on Python 2.7. To allow the tests to run on Python 3.x we need to make sure that Python 2.7 is uninstalled before the test finishes.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pull integration test
