### PR TITLE
Fix git test on FreeBSD with Python 3.x.

### DIFF
--- a/test/integration/targets/git/handlers/main.yml
+++ b/test/integration/targets/git/handlers/main.yml
@@ -1,0 +1,11 @@
+- name: remove git
+  package:
+    name: git
+    state: absent
+
+- name: remove git from FreeBSD
+  pkgng:
+    name: git
+    state: absent
+    autoremove: yes
+  when: ansible_distribution == "FreeBSD"

--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -12,6 +12,9 @@
   package:
     name: git
   when: ansible_distribution != "MacOSX"
+  notify:
+    - remove git
+    - remove git from FreeBSD
 
 - name: SETUP | verify that git is installed so this test can continue
   shell: which git


### PR DESCRIPTION
##### SUMMARY

Fix git test on FreeBSD with Python 3.x.

On FreeBSD the git package depends on Python 2.7. To allow the tests to run on Python 3.x we need to make sure that Python 2.7 is uninstalled before the test finishes.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

git integration test
