### PR TITLE
Fix postgresql test on FreeBSD with Python 3.x.

### DIFF
--- a/test/integration/targets/setup_postgresql_db/vars/FreeBSD-py3.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/FreeBSD-py3.yml
@@ -1,0 +1,12 @@
+postgresql_packages:
+  - "postgresql95-server"
+  - "py36-psycopg2"
+
+pg_hba_location: "/usr/local/pgsql/data/pg_hba.conf"
+pg_dir: "/usr/local/pgsql/data"
+pg_ver: 9.5
+pg_user: pgsql
+pg_group: pgsql
+
+locale_latin_suffix: .ISO8859-1
+locale_utf8_suffix: .UTF-8


### PR DESCRIPTION
##### SUMMARY

Fix postgresql test on FreeBSD with Python 3.x.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

postgresql integration test
