### PR TITLE
Test FreeBSD 12.0 with Python 3.x by default.

### DIFF
--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,5 +1,5 @@
 freebsd/11.1 python=2.7,3.6 python_dir=/usr/local/bin
-freebsd/12.0 python=2.7,3.6 python_dir=/usr/local/bin
+freebsd/12.0 python=3.6,2.7 python_dir=/usr/local/bin
 osx/10.11 python=2.7 python_dir=/usr/local/bin
 rhel/7.6 python=2.7
 rhel/8.0 python=3.6


### PR DESCRIPTION
##### SUMMARY

Test FreeBSD 12.0 with Python 3.x by default.

Resolves https://github.com/ansible/ansible/issues/52203

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
