### PR TITLE
Adding support for memcached1.5 and redis5.0 parameter group families.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -37,7 +37,7 @@ options:
     description:
       - The name of the cache parameter group family that the cache parameter group can be used with.
         Required when creating a cache parameter group.
-    choices: ['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0']
+    choices: ['memcached1.4', 'memcached1.5', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0', 'redis5.0']
   name:
     description:
      - A user-specified name for the cache parameter group.
@@ -285,7 +285,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            group_family=dict(type='str', choices=['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0']),
+            group_family=dict(type='str', choices=['memcached1.4', 'memcached1.5', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0', 'redis5.0']),
             name=dict(required=True, type='str'),
             description=dict(default='', type='str'),
             state=dict(required=True),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding support for [memcached1.5](https://aws.amazon.com/about-aws/whats-new/2018/11/memcached_15_now_available_on_amazon_elasticache/) and [redis5.0](https://aws.amazon.com/about-aws/whats-new/2018/11/redis_50_now_available_on_amazon_elasticache_for_redis/) parameter group families.
Fixes #53543
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The original issue was for `redis5.0` only, this adds `memcached1.5` as well.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elasticache_parameter_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

###### STEPS TO TEST
```
- name: Create Elasticache Parameter Group
  elasticache_parameter_group:
    state: present
    name: "{{ item | regex_replace('\\.', '') }}-testing-group"
    group_family: "{{ item }}"
    description: 'testing-group'
  register: parameter_groups
  with_items:
    - memcached1.5
    - redis5.0

- debug: var=parameter_groups.results
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
###### TEST RESULTS
```paste below
ok: [control-mine] => {
    "parameter_groups.results": [
        {
            "_ansible_ignore_errors": null,
            "_ansible_item_label": "memcached1.5",
            "_ansible_item_result": true,
            "_ansible_no_log": false,
            "_ansible_parsed": true,
            "changed": true,
            "elasticache": {
                "cache_parameter_group": {
                    "cache_parameter_group_family": "memcached1.5",
                    "cache_parameter_group_name": "memcached15-testing-group",
                    "description": "testing-group"
                },
                "response_metadata": {
                    "http_headers": {
                        "content-length": "567",
                        "content-type": "text/xml",
                        "date": "Fri, 29 Mar 2019 01:35:28 GMT",
                        "x-amzn-requestid": "ef3e6601-51c2-11e9-a9f9-05153ba79039"
                    },
                    "http_status_code": 200,
                    "request_id": "ef3e6601-51c2-11e9-a9f9-05153ba79039",
                    "retry_attempts": 0
                }
            },
            "failed": false,
            "invocation": {
                "module_args": {
                    "aws_access_key": null,
                    "aws_region": "eu-west-1",
                    "aws_secret_key": null,
                    "description": "testing-group",
                    "ec2_url": null,
                    "group_family": "memcached1.5",
                    "name": "memcached15-testing-group",
                    "profile": null,
                    "region": "eu-west-1",
                    "security_token": null,
                    "state": "present",
                    "validate_certs": true,
                    "values": null
                }
            },
            "item": "memcached1.5"
        },
        {
            "_ansible_ignore_errors": null,
            "_ansible_item_label": "redis5.0",
            "_ansible_item_result": true,
            "_ansible_no_log": false,
            "_ansible_parsed": true,
            "changed": true,
            "elasticache": {
                "cache_parameter_group": {
                    "cache_parameter_group_family": "redis5.0",
                    "cache_parameter_group_name": "redis50-testing-group",
                    "description": "testing-group"
                },
                "response_metadata": {
                    "http_headers": {
                        "content-length": "559",
                        "content-type": "text/xml",
                        "date": "Fri, 29 Mar 2019 01:35:29 GMT",
                        "x-amzn-requestid": "efca2ba3-51c2-11e9-8a00-4989f9e453b7"
                    },
                    "http_status_code": 200,
                    "request_id": "efca2ba3-51c2-11e9-8a00-4989f9e453b7",
                    "retry_attempts": 0
                }
            },
            "failed": false,
            "invocation": {
                "module_args": {
                    "aws_access_key": null,
                    "aws_region": "eu-west-1",
                    "aws_secret_key": null,
                    "description": "testing-group",
                    "ec2_url": null,
                    "group_family": "redis5.0",
                    "name": "redis50-testing-group",
                    "profile": null,
                    "region": "eu-west-1",
                    "security_token": null,
                    "state": "present",
                    "validate_certs": true,
                    "values": null
                }
            },
            "item": "redis5.0"
        }
    ]
}
```
