### PR TITLE
Enable adding VLAN IP ranges for Physical Networks

### DIFF
--- a/test/integration/targets/cs_vlan_ip_range/tasks/main.yml
+++ b/test/integration/targets/cs_vlan_ip_range/tasks/main.yml
@@ -369,3 +369,67 @@
     that:
     - ipr_net is successful
     - ipr_net is changed
+
+# Create a new zone - the default one is enabled
+- name: assure zone for tests
+  cs_zone:
+    name: cs-test-zone
+    state: present
+    dns1: 8.8.8.8
+    network_type: advanced
+  register: cszone
+
+- name: ensure the zone is disabled
+  cs_zone:
+    name: "{{ cszone.name }}"
+    state: disabled
+
+- name: setup a network for tests
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    isolation_method: VLAN
+    broadcast_domain_range: ZONE
+    state: present
+  register: public_network
+
+- name: setup public network traffic
+  cs_traffic_type:
+    physical_network: "{{ public_network.name }}"
+    traffic_type: Public
+    kvm_networklabel: cloudbr1
+    zone: "{{ public_network.zone }}"
+
+- name: test adding a public IP range
+  cs_vlan_ip_range:
+    end_ip: 10.0.3.250
+    start_ip: 10.0.3.10
+    zone: "{{ cszone.name }}"
+    netmask: 255.255.255.0
+    for_virtual_network: 'yes'
+    gateway: 10.0.3.2
+    vlan: untagged
+  register: public_range
+- name: verify test adding a public IP range
+  assert:
+    that:
+      - public_range is successful
+      - public_range is changed
+      - public_range.physical_network == public_network.id
+      - public_range.vlan == 'vlan://untagged'
+      - public_range.gateway == '10.0.3.2'
+      - public_range.netmask == '255.255.255.0'
+      - public_range.zone == cszone.name
+      - public_range.start_ip == '10.0.3.10'
+      - public_range.end_ip == '10.0.3.250'
+
+- name: cleanup the network
+  cs_physical_network:
+    name: net01
+    zone: "{{ cszone.name }}"
+    state: absent
+
+- name: cleanup the zone
+  cs_zone:
+    name: "{{ cszone.name }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
Enable adding VLAN IP ranges for Physical Networks.

The use case for this change is a Public traffic type in a Physical network. Without this, there is no possibility to reserve a public IP range for a zone.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cs_vlan_ip_range

##### ADDITIONAL INFORMATION
