### PR TITLE
azure_rm_virtualmachine module to handle concatenated strings for the image type

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -158,11 +158,11 @@ def managed_disk_to_dict(managed_disk):
         name=managed_disk.name,
         location=managed_disk.location,
         tags=managed_disk.tags,
-        zones=managed_disk.zones,
         disk_size_gb=managed_disk.disk_size_gb,
         os_type=os_type,
         storage_account_type=managed_disk.sku.name.value,
-        managed_by=managed_disk.managed_by
+        managed_by=managed_disk.managed_by,
+        zones=managed_disk.zones
     )
 
 

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -2,6 +2,7 @@
    set_fact:
        managed_disk1: "{{ resource_group | hash('md5') | truncate(24, True, '') }}"
        managed_disk2: "{{ resource_group | hash('md5') | truncate(18, True, '') }}"
+       managed_disk3: "{{ resource_group | hash('md5') | truncate(16, True, '') }}"
 
  - name: Clearing (if) previous disks were created
    azure_rm_managed_disk:
@@ -369,6 +370,29 @@
 
  - name: Assert delete failed since disk is attached to VM
    assert: { that: "output['failed'] == True" }
+
+ - name: create new managed disk with zones
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk3 }}"
+       disk_size_gb: 1
+       storage_account_type: "Standard_LRS"
+       zones: 1
+       tags:
+           testing: testing
+           delete: never
+   register: output
+
+ - assert:
+     that:
+       - output.changed
+       - output.state.zones == ["1"]
+
+ - name: Delete managed disk with zones
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk3 }}"
+       state: absent
 
  - name: Delete managed disk (Check Mode)
    azure_rm_managed_disk:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Would like the azure_rm_virtualmachine module to handle concatenated strings for the image type, eg OpenLogic:CentOS:7.4:latest
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
