### PR TITLE
PS AddType - Add the ability to supply custom compile symbols for C# code

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
@@ -33,6 +33,11 @@ Function Add-CSharpType {
     [Switch] Whether to include debug information in the compiled
     assembly. Cannot be used when AnsibleModule is set. This is a no-op
     when running on PSCore.
+
+    .PARAMETER CompileSymbols
+    [String[]] A list of symbols to be defined during compile time. These are
+    added to the existing symbols, 'CORECLR', 'WINDOWS', 'UNIX' that are set
+    conditionalls in this cmdlet.
     #>
     param(
         [Parameter(Mandatory=$true)][AllowEmptyCollection()][String[]]$References,
@@ -40,7 +45,8 @@ Function Add-CSharpType {
         [Switch]$PassThru,
         [Parameter(Mandatory=$true, ParameterSetName="Module")][Object]$AnsibleModule,
         [Parameter(ParameterSetName="Manual")][String]$TempPath = $env:TMP,
-        [Parameter(ParameterSetName="Manual")][Switch]$IncludeDebugInfo
+        [Parameter(ParameterSetName="Manual")][Switch]$IncludeDebugInfo,
+        [String[]]$CompileSymbols = @()
     )
     if ($null -eq $References -or $References.Length -eq 0) {
         return
@@ -49,7 +55,7 @@ Function Add-CSharpType {
     # define special symbols CORECLR, WINDOWS, UNIX if required
     # the Is* variables are defined on PSCore, if absent we assume an
     # older version of PowerShell under .NET Framework and Windows
-    $defined_symbols = [System.Collections.ArrayList]@()
+    $defined_symbols = [System.Collections.ArrayList]$CompileSymbols
     $is_coreclr = Get-Variable -Name IsCoreCLR -ErrorAction SilentlyContinue
     if ($null -ne $is_coreclr) {
         if ($is_coreclr.Value) {

--- a/test/integration/targets/win_module_utils/library/add_type_test.ps1
+++ b/test/integration/targets/win_module_utils/library/add_type_test.ps1
@@ -204,5 +204,28 @@ Add-CSharpType -References $ignored_warning
 $actual = [Namespace7.Class7]::GetString()
 Assert-Equals -actual $actual -expected "abc"
 
+$defined_symbol = @'
+using System;
+
+namespace Namespace8
+{
+    public class Class8
+    {
+        public static string GetString()
+        {
+#if SYMBOL1
+            string a = "symbol";
+#else
+            string a = "no symbol";
+#endif
+            return a;
+        }
+    }
+}
+'@
+Add-CSharpType -References $defined_symbol -CompileSymbols "SYMBOL1"
+$actual = [Namespace8.Class8]::GetString()
+Assert-Equals -actual $actual -expected "symbol"
+
 $result.res = "success"
 Exit-Json -obj $result


### PR DESCRIPTION
##### SUMMARY
I have the need to be able to compile C# code in PowerShell with custom compile symbols defined. Instead of trying to rewrite the code in the modules required it would be useful to just piggy back on top of `Add-CSharpType` which already has the ability to compile with custom symbols defined. This just exposes the option to end users.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.AddType.psm1