### PR TITLE
Allow all of yum version compare operators

### DIFF
--- a/changelogs/fragments/yum-select-version.yml
+++ b/changelogs/fragments/yum-select-version.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "yum allows comparison operators like '>=' for selecting package version"

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -101,12 +101,13 @@ class YumDnf(with_metaclass(ABCMeta, object)):
 
         # Fail if someone passed a space separated string
         # https://github.com/ansible/ansible/issues/46301
-        if any((' ' in name and '@' not in name and '==' not in name for name in self.names)):
-            module.fail_json(
-                msg='It appears that a space separated string of packages was passed in '
-                    'as an argument. To operate on several packages, pass a comma separated '
-                    'string of packages or a list of packages.'
-            )
+        for name in self.names:
+            if ' ' in name and not any(spec in name for spec in ['@', '>', '<', '=']):
+                module.fail_json(
+                    msg='It appears that a space separated string of packages was passed in '
+                        'as an argument. To operate on several packages, pass a comma separated '
+                        'string of packages or a list of packages.'
+                )
 
         # Sanity checking for autoremove
         if self.state is None:

--- a/test/integration/targets/yum/tasks/repo.yml
+++ b/test/integration/targets/yum/tasks/repo.yml
@@ -589,6 +589,56 @@
 
   when: ansible_pkg_mgr == 'yum'
 
+
+# https://github.com/ansible/ansible/pull/54603
+- block:
+    - name: Install foo < 1.1
+      yum:
+        name: "foo < 1.1"
+        state: present
+      register: yum_result
+
+    - name: Check foo with rpm
+      shell: rpm -q foo
+      register: rpm_result
+
+    - name: Verify installation
+      assert:
+        that:
+            - "yum_result.changed"
+            - "rpm_result.stdout.startswith('foo-1.0')"
+
+    - name: Install foo >= 1.1
+      yum:
+        name: "foo >= 1.1"
+        state: present
+      register: yum_result
+
+    - name: Check foo with rpm
+      shell: rpm -q foo
+      register: rpm_result
+
+    - name: Verify installation
+      assert:
+        that:
+            - "yum_result.changed"
+            - "rpm_result.stdout.startswith('foo-1.1')"
+
+    - name: Verify yum module outputs
+      assert:
+        that:
+            - "'msg' in yum_result"
+            - "'rc' in yum_result"
+            - "'results' in yum_result"
+
+  always:
+    - name: Clean up
+      yum:
+        name: foo
+        state: absent
+
+  when: ansible_pkg_mgr == 'yum'
+
 # https://github.com/ansible/ansible/issues/45250
 - block:
     - name: Install foo-1.0, foo-bar-1.0, bar-1.0


### PR DESCRIPTION
##### SUMMARY
Improved fix for #47689, which allows all version comparison operators (not only '==').

Fixes: #47744

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yum

##### ADDITIONAL INFORMATION
 In our playbooks we often use yum: name= 'package >= VERSION' and we'd like ansible-2.7 to support it. Instead of listing all possible operators like '<=' '>=' yum module allows spaces when other special sign (@<>=) appers.