### PR TITLE
Add check to log jsonrpc request/response

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -136,13 +136,18 @@ class ConnectionProcess(object):
                     data = recv_data(s)
                     if not data:
                         break
-                    self.connection._log_messages("jsonrpc request: %s" % data)
+                    log_messages = self.connection.get_option('persistent_log_messages')
+
+                    if log_messages:
+                        display.display("jsonrpc request: %s" % data, log_only=True)
 
                     signal.alarm(self.connection.get_option('persistent_command_timeout'))
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
-                    self.connection._log_messages("jsonrpc response: %s" % resp)
+                    if log_messages:
+                        display.display("jsonrpc response: %s" % resp, log_only=True)
+
                     send_data(s, to_bytes(resp))
 
                 s.close()


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #54605

Add check in ansible-connection to check if persistent
the log message is enabled, if yes log the jsonrpc request
in the log file.

With the current approach the _messages queue in `NetworkConnectionBase`
is getting overwritten and response for `pop_message` api invocation from
ansible-connection is not received at the module side.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
