### PR TITLE
VMware: vmware_host: ensure idempotency when state is absent

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host.py
@@ -341,7 +341,9 @@ class VMwareHost(PyVmomi):
 
     def state_exit_unchanged(self):
         """Exit with status message"""
-        if self.reconnect_disconnected and self.host_update.runtime.connectionState == 'disconnected':
+        if not self.host_update:
+            result = "Host already disconnected"
+        elif self.reconnect_disconnected and self.host_update.runtime.connectionState == 'disconnected':
             self.state_reconnect_host()
         else:
             if self.folder_name:


### PR DESCRIPTION
If a host is already missing, `self.host_update` is `None`. With
this change,`state_exit_unchanged()` won't try anymore to access
`self.host_update.runtime`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_host