### PR TITLE
[WIP]vmware: move get_folder() in module_utils

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1382,3 +1382,33 @@ class PyVmomi(object):
         else:
             result = self._jsonify(obj)
         return result
+
+    def get_folder_type_obj(self, type):
+        return {
+            'vm': self.datacenter_obj.vmFolder,
+            'host': self.datacenter_obj.hostFolder,
+            'datastore': self.datacenter_obj.datastoreFolder,
+            'network': self.datacenter_obj.networkFolder,
+        }[type]
+
+
+    def get_folder(self, datacenter_name, folder_name, folder_type, parent_folder=None):
+        """
+        Get managed object of folder by name
+        Returns: Managed object of folder by name
+
+        """
+        # TODO(Gonéri): use self.datacenter_obj instead of datacenter_name
+        folder_objs = get_all_objs(self.content, [vim.Folder], parent_folder)
+        expected_type = self.get_folder_type_obj(folder_type).childType
+        for folder in folder_objs:
+            if parent_folder:
+                if folder.name == folder_name and expected_type == folder.childType:
+                    return folder
+            else:
+                if folder.name == folder_name and \
+                   self.get_folder_type_obj(folder_type).childType == folder.childType and \
+                   folder.parent.parent.name == datacenter_name:    # e.g. folder.parent.parent.name == /DC01/host/folder
+                    return folder
+
+        return None

--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -280,25 +280,6 @@ class VmwareFolderManager(PyVmomi):
                                               " exception %s " % to_native(gen_exec))
             self.module.exit_json(**results)
 
-    def get_folder(self, datacenter_name, folder_name, folder_type, parent_folder=None):
-        """
-        Get managed object of folder by name
-        Returns: Managed object of folder by name
-
-        """
-        folder_objs = get_all_objs(self.content, [vim.Folder], parent_folder)
-        for folder in folder_objs:
-            if parent_folder:
-                if folder.name == folder_name and \
-                   self.datacenter_folder_type[folder_type].childType == folder.childType:
-                    return folder
-            else:
-                if folder.name == folder_name and \
-                   self.datacenter_folder_type[folder_type].childType == folder.childType and \
-                   folder.parent.parent.name == datacenter_name:    # e.g. folder.parent.parent.name == /DC01/host/folder
-                    return folder
-
-        return None
 
 
 def main():

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1993,39 +1993,6 @@ class PyVmomiHelper(PyVmomi):
                     self.module.fail_json(msg="hardware.scsi attribute should be 'paravirtual' or 'lsilogic'")
         return disk_controller_type
 
-    def find_folder(self, searchpath):
-        """ Walk inventory objects one position of the searchpath at a time """
-
-        # split the searchpath so we can iterate through it
-        paths = [x.replace('/', '') for x in searchpath.split('/')]
-        paths_total = len(paths) - 1
-        position = 0
-
-        # recursive walk while looking for next element in searchpath
-        root = self.content.rootFolder
-        while root and position <= paths_total:
-            change = False
-            if hasattr(root, 'childEntity'):
-                for child in root.childEntity:
-                    if child.name == paths[position]:
-                        root = child
-                        position += 1
-                        change = True
-                        break
-            elif isinstance(root, vim.Datacenter):
-                if hasattr(root, 'vmFolder'):
-                    if root.vmFolder.name == paths[position]:
-                        root = root.vmFolder
-                        position += 1
-                        change = True
-            else:
-                root = None
-
-            if not change:
-                root = None
-
-        return root
-
     def get_resource_pool(self, cluster=None, host=None, resource_pool=None):
         """ Get a resource pool, filter on cluster, esxi_hostname or resource_pool if given """
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host.py
@@ -319,17 +319,6 @@ class VMwareHost(PyVmomi):
             state = 'absent'
         return state
 
-    def search_folder(self, folder_name):
-        """
-            Search folder in vCenter
-            Returns: folder object
-        """
-        search_index = self.content.searchIndex
-        folder_obj = search_index.FindByInventoryPath(folder_name)
-        if not (folder_obj and isinstance(folder_obj, vim.Folder)):
-            self.module.fail_json(msg="Folder '%s' not found" % folder_name)
-        return folder_obj
-
     def search_cluster(self, datacenter_name, cluster_name, esxi_hostname):
         """
             Search cluster in vCenter
@@ -363,8 +352,9 @@ class VMwareHost(PyVmomi):
             esxi_license = None
             resource_pool = None
             task = None
+            self.datacenter_obj = self.find_datacenter_by_name(self.datacenter_name)
             if self.folder_name:
-                self.folder = self.search_folder(self.folder_name)
+                self.folder = self.get_folder(self.datacenter_name, self.folder_name, folder_type='host')
                 try:
                     task = self.folder.AddStandaloneHost(
                         spec=host_connect_spec, compResSpec=resource_pool,


### PR DESCRIPTION
- Move `get_folder()` from `vcenter_folder.py` in the module_utils module.
- Reuse it in `vmware_guest.py` and `vmware_host.py`

##### SUMMARY

Minor re-factoring of the code base used to find the folders.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- vmware

##### ADDITIONAL INFORMATION

WIP because the patch has not been tested enough.