### PR TITLE
Correcting documentation for sns_topic return types

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -164,13 +164,13 @@ sns_topic:
     subscriptions_confirmed:
       description: Count of confirmed subscriptions
       returned: when topic is owned by this AWS account
-      type: list
-      sample: []
+      type: str
+      sample: '0'
     subscriptions_deleted:
       description: Count of deleted subscriptions
       returned: when topic is owned by this AWS account
-      type: list
-      sample: []
+      type: str
+      sample: '0'
     subscriptions_existing:
       description: List of existing subscriptions
       returned: always


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The return types for `subscriptions_confirmed` and `subscriptions_deleted` should be numbers instead of lists. The [values are set](https://github.com/psharkey/ansible/blob/c461fe9a21fb7fc9f4ae59b408d5895e2830caac/lib/ansible/modules/cloud/amazon/sns_topic.py#L453) using  [`get_topic_attributes(**kwargs)`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#SNS.Client.get_topic_attributes) which return

- SubscriptionsConfirmed – the number of confirmed subscriptions on this topic
- SubscriptionsDeleted – the number of deleted subscriptions on this topic

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sns_topic

##### ADDITIONAL INFORMATION
N/A
