### PR TITLE
Fixes solaris (sunos) uptime in ansible facts module

### DIFF
--- a/changelogs/fragments/solaris_uptime_boot_time.yaml
+++ b/changelogs/fragments/solaris_uptime_boot_time.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+        - facts - change to use boot_time on a solaris OS to report correct uptime (https://github.com/ansible/ansible/issues/53635)

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -17,6 +17,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+import time
 
 from ansible.module_utils.six.moves import reduce
 
@@ -266,18 +267,13 @@ class SunOSHardware(Hardware):
 
     def get_uptime_facts(self):
         uptime_facts = {}
-        # On Solaris, unix:0:system_misc:snaptime is created shortly after machine boots up
-        # and displays tiem in seconds. This is much easier than using uptime as we would
-        # need to have a parsing procedure for translating from human-readable to machine-readable
-        # format.
-        # Example output:
-        # unix:0:system_misc:snaptime     1175.410463590
-        rc, out, err = self.module.run_command('/usr/bin/kstat -p unix:0:system_misc:snaptime')
+        rc, out, err = self.module.run_command('/usr/bin/kstat -p unix:0:system_misc:boot_time')
 
         if rc != 0:
             return
 
-        uptime_facts['uptime_seconds'] = int(float(out.split('\t')[1]))
+        # uptime = $current_time - $boot_time
+        uptime_facts['uptime_seconds'] = int(time.time() - int(out.split('\t')[1]))
 
         return uptime_facts
 

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -267,6 +267,8 @@ class SunOSHardware(Hardware):
 
     def get_uptime_facts(self):
         uptime_facts = {}
+        # sample kstat output:
+        # unix:0:system_misc:boot_time    1548249689
         rc, out, err = self.module.run_command('/usr/bin/kstat -p unix:0:system_misc:boot_time')
 
         if rc != 0:

--- a/test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py
+++ b/test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py
@@ -1,0 +1,16 @@
+import time
+from ansible.module_utils.facts.hardware import sunos
+
+
+def test_sunos_get_uptime_facts(mocker):
+    kstat_output = '\nunix:0:system_misc:boot_time\t1548249689\n'
+
+    module_mock = mocker.patch('ansible.module_utils.basic.AnsibleModule')
+    module = module_mock()
+    module.run_command.return_value = (0, kstat_output, '')
+
+    inst = sunos.SunOSHardware(module)
+
+    expected = int(time.time()) - 1548249689
+    result = inst.get_uptime_facts()
+    assert expected == result['uptime_seconds']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Reported #53635 incorrect uptime on solaris hosts. 
Use boot_time instead of snaptime (snapshot time - but why?!?) to calculate uptime.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #53635 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
facts module

##### ADDITIONAL INFORMATION
```
mator@solaris11sparc:~$ uptime
  4:20am  up 65 day(s), 11:59,  1 user,  load average: 0.01, 0.00, 0.00  
  
$ ansible -m setup solaris11sparc -a 'filter=ansible_uptime*'
solaris11sparc | SUCCESS => {
    "ansible_facts": {
        "ansible_uptime_seconds": 5659064, 
    }, 
    "changed": false
}
```
compare to uptime command days:
ansible_uptime_seconds divided by 86400 seconds (in a day = 24h * 60m * 60s)
```
$ echo $[5659064/24/60/60]
65
```
result is 65 days




solaris 10 host:
```
solaris10 ~$ uptime
  7:15pm  up 232 day(s),  4:31,  2 users,  load average: 0.01, 0.00, 0.00

$ ansible -m setup solaris10 -a 'filter=ansible_uptime*'
solaris10 | SUCCESS => {
    "ansible_facts": {
        "ansible_uptime_seconds": 20057533, 
    }, 
    "changed": false
}

$ echo $[20057533/86400]
232
```