### PR TITLE
ec2_eni: refresh local view of eni after adding secondary IPs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -343,6 +343,7 @@ def create_eni(connection, vpc_id, module):
         if secondary_private_ip_address_count is not None:
             try:
                 connection.assign_private_ip_addresses(network_interface_id=eni.id, secondary_private_ip_address_count=secondary_private_ip_address_count)
+                eni.update()
             except BotoServerError:
                 eni.delete()
                 raise
@@ -350,6 +351,7 @@ def create_eni(connection, vpc_id, module):
         if secondary_private_ip_addresses is not None:
             try:
                 connection.assign_private_ip_addresses(network_interface_id=eni.id, private_ip_addresses=secondary_private_ip_addresses)
+                eni.update()
             except BotoServerError:
                 eni.delete()
                 raise

--- a/test/integration/targets/ec2_eni/aliases
+++ b/test/integration/targets/ec2_eni/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_eni/tasks/main.yml
+++ b/test/integration/targets/ec2_eni/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+- block:
+  - name: set up aws connection info
+    set_fact:
+      aws_connection_info: &aws_connection_info
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        region: "{{ aws_region }}"
+    no_log: yes
+
+  # ============================================================
+  - name: create a VPC
+    ec2_vpc_net:
+      name: "{{ resource_prefix }}-vpc"
+      state: present
+      cidr_block: "10.232.232.128/26"
+      <<: *aws_connection_info
+      tags:
+        Name: "{{ resource_prefix }}-vpc"
+        Description: "Created by ansible-test"
+    register: vpc_result
+
+  # ============================================================
+  - name: create a subnet
+    ec2_vpc_subnet:
+      cidr: "10.232.232.128/28"
+      az: "{{ aws_region }}a"
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      <<: *aws_connection_info
+      tags:
+        Name: "{{ resource_prefix }}-vpc"
+        Description: "Created by ansible-test"
+      state: present
+    register: vpc_subnet_result
+
+  # ============================================================
+  - name: create an ENI with 1 primary and 3 secondary IP addresses
+    ec2_eni:
+      region: "{{ aws_region }}"
+      secondary_private_ip_address_count: 3
+      subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+      <<: *aws_connection_info
+      state: present
+    register: eni_result
+
+  - debug:
+      var: eni_result
+      verbosity: 2
+
+  - name: ensure we can retrieve all of the IP addresses
+    assert:
+      that:
+        - eni_result.interface.private_ip_addresses | length == 4
+        - eni_result.interface.private_ip_addresses[0].primary_address
+        - not eni_result.interface.private_ip_addresses[1].primary_address
+        - not eni_result.interface.private_ip_addresses[2].primary_address
+        - not eni_result.interface.private_ip_addresses[3].primary_address
+
+  always:
+    # ============================================================
+    - name: tidy up ENI
+      ec2_eni:
+        eni_id: "{{ eni_result.interface.id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up subnet
+      ec2_vpc_subnet:
+        cidr: "10.232.232.128/28"
+        az: "{{ aws_region }}a"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: "10.232.232.128/26"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
- added integration test to prove the error no longer exists

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When specifying `secondary_private_ip_address_count` the results would only have the primary address.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_eni

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Asking for 4 IPs:
before
<!--- Paste verbatim command output below, e.g. before and after your change -->
```before
            "private_ip_addresses": [
                {
                    "primary_address": true,
                    "private_ip_address": "10.232.232.133"
                }
            ],
```
after
```after
            "private_ip_addresses": [
                {
                    "primary_address": true,
                    "private_ip_address": "10.232.232.133"
                },
                {
                    "primary_address": false,
                    "private_ip_address": "10.232.232.137"
                },
                {
                    "primary_address": false,
                    "private_ip_address": "10.232.232.142"
                },
                {
                    "primary_address": false,
                    "private_ip_address": "10.232.232.134"
                }
            ],
```
