### PR TITLE
openssl_pkcs12: Add idempotency checks

### DIFF
--- a/changelogs/fragments/54633-openssl_pkcs12_idempotency_fixes.yaml
+++ b/changelogs/fragments/54633-openssl_pkcs12_idempotency_fixes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "openssl_pkcs12 - Fixed idempotency checks, the module will regenerate the pkcs12 file if any of the parameters differ from the ones in the file. The ``ca_certificates`` parameter has been renamed to ``other_certificates``. "

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -333,6 +333,12 @@ Noteworthy module changes
 * The ``win_dsc`` module will now validate the input options for a DSC resource. In previous versions invalid options
   would be ignored but are now not.
 
+* The ``win_domain_membership`` module will no longer automatically join a host in a domain that already has an account
+  with the same name. Set ``allow_existing_computer_account=yes`` to override this check and go back to the original
+  behaviour.
+
+* The ``openssl_pkcs12`` module will now regenerate the pkcs12 file if there are differences between the file on disk and the parameters passed to the module.
+
 Plugins
 =======
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -333,10 +333,6 @@ Noteworthy module changes
 * The ``win_dsc`` module will now validate the input options for a DSC resource. In previous versions invalid options
   would be ignored but are now not.
 
-* The ``win_domain_membership`` module will no longer automatically join a host in a domain that already has an account
-  with the same name. Set ``allow_existing_computer_account=yes`` to override this check and go back to the original
-  behaviour.
-
 * The ``openssl_pkcs12`` module will now regenerate the pkcs12 file if there are differences between the file on disk and the parameters passed to the module.
 
 Plugins

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -276,7 +276,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
             elif bool(pkcs12_other_certificates) != bool(self.ca_certificates):
                 return False
 
-            if pkcs12_other_certificates is None:
+            if not pkcs12_other_certificates:
                 if ((self.pkcs12.get_friendlyname() is not None) and (pkcs12_friendly_name is not None)):
                     return self.pkcs12.get_friendlyname() == pkcs12_friendly_name
                 elif bool(self.pkcs12.get_friendlyname()) != bool(pkcs12_friendly_name):

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -29,10 +29,11 @@ options:
         type: str
         default: export
         choices: [ export, parse ]
-    ca_certificates:
+    other_certificates:
         description:
-            - List of CA certificate to include.
+            - List of other certificates to include.
         type: list
+        aliases: [ ca_certificates ]
     certificate_path:
         description:
             - The path to read certificates and private keys from.

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -242,7 +242,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
             self.src = self.path
             try:
                 pkcs12_privatekey, pkcs12_certificate, pkcs12_other_certificates, pkcs12_friendly_name = self.parse()
-            except crypto.Error as ex:
+            except crypto.Error:
                 return False
             if (pkcs12_privatekey is not None) and (self.privatekey_path is not None):
                 expected_pkey = crypto.dump_privatekey(crypto.FILETYPE_PEM,

--- a/test/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/test/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -1,21 +1,37 @@
 ---
 - block:
-  - name: 'Generate privatekey with'
+  - name: 'Generate privatekey'
     openssl_privatekey:
       path: "{{ output_dir }}/ansible_pkey.pem"
 
-  - name: 'Generate CSR with'
+  - name: 'Generate CSR'
     openssl_csr:
       path: "{{ output_dir }}/ansible.csr"
       privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
       commonName: 'www.ansible.com'
 
+  - name: 'Generate CSR 2'
+    openssl_csr:
+      path: "{{ output_dir }}/ansible2.csr"
+      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
+      commonName: 'www2.ansible.com'
+
+  - name: 'Generate CSR 3'
+    openssl_csr:
+      path: "{{ output_dir }}/ansible3.csr"
+      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
+      commonName: 'www3.ansible.com'
+
   - name: 'Generate certificate'
     openssl_certificate:
-      path: "{{ output_dir }}/ansible.crt"
+      path: "{{ output_dir }}/{{ item }}.crt"
       privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
-      csr_path: "{{ output_dir }}/ansible.csr"
+      csr_path: "{{ output_dir }}/{{ item }}.csr"
       provider: selfsigned
+    loop:
+      - ansible
+      - ansible2
+      - ansible3
 
   - name: 'Generate PKCS#12 file'
     openssl_pkcs12:
@@ -25,6 +41,15 @@
       certificate_path: "{{ output_dir }}/ansible.crt"
       state: present
     register: p12_standard
+
+  - name: 'Generate PKCS#12 file again, idempotency'
+    openssl_pkcs12:
+      path: "{{ output_dir }}/ansible.p12"
+      friendly_name: 'abracadabra'
+      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
+      certificate_path: "{{ output_dir }}/ansible.crt"
+      state: present
+    register: p12_standard_idempotency
 
   - name: 'Generate PKCS#12 file (force)'
     openssl_pkcs12:
@@ -51,6 +76,37 @@
     openssl_pkcs12:
       src: "{{ output_dir }}/ansible.p12"
       path: "{{ output_dir }}/ansible_parse.pem"
+      action: 'parse'
+      state: 'present'
+
+  - name: 'Generate PKCS#12 file with multiple certs'
+    openssl_pkcs12:
+      path: "{{ output_dir }}/ansible_multi_certs.p12"
+      friendly_name: 'abracadabra'
+      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
+      certificate_path: "{{ output_dir }}/ansible.crt"
+      ca_certificates:
+        - "{{ output_dir }}/ansible2.crt"
+        - "{{ output_dir }}/ansible3.crt"
+      state: present
+    register: p12_multiple_certs
+
+  - name: 'Generate PKCS#12 file with multiple certs, again (idempotency)'
+    openssl_pkcs12:
+      path: "{{ output_dir }}/ansible_multi_certs.p12"
+      friendly_name: 'abracadabra'
+      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
+      certificate_path: "{{ output_dir }}/ansible.crt"
+      ca_certificates:
+        - "{{ output_dir }}/ansible2.crt"
+        - "{{ output_dir }}/ansible3.crt"
+      state: present
+    register: p12_multiple_certs_idempotency
+
+  - name: 'Dump PKCS#12 with multiple certs'
+    openssl_pkcs12:
+      src: "{{ output_dir }}/ansible_multi_certs.p12"
+      path: "{{ output_dir }}/ansible_parse_multi_certs.pem"
       action: 'parse'
       state: 'present'
 
@@ -163,10 +219,11 @@
   - name: 'Delete PKCS#12 file'
     openssl_pkcs12:
       state: absent
-      path: '{{ output_dir }}/ansible.p12'
+      path: '{{ output_dir }}/{{ item }}.p12'
     loop:
       - 'ansible'
       - 'ansible_no_pkey'
+      - 'ansible_multi_certs'
       - 'ansible_pw1'
       - 'ansible_pw2'
       - 'ansible_pw3'

--- a/test/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/test/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -4,6 +4,14 @@
     openssl_privatekey:
       path: "{{ output_dir }}/ansible_pkey.pem"
 
+  - name: 'Generate privatekey2'
+    openssl_privatekey:
+      path: "{{ output_dir }}/ansible_pkey2.pem"
+
+  - name: 'Generate privatekey3'
+    openssl_privatekey:
+      path: "{{ output_dir }}/ansible_pkey3.pem"
+
   - name: 'Generate CSR'
     openssl_csr:
       path: "{{ output_dir }}/ansible.csr"
@@ -13,25 +21,28 @@
   - name: 'Generate CSR 2'
     openssl_csr:
       path: "{{ output_dir }}/ansible2.csr"
-      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
+      privatekey_path: "{{ output_dir }}/ansible_pkey2.pem"
       commonName: 'www2.ansible.com'
 
   - name: 'Generate CSR 3'
     openssl_csr:
       path: "{{ output_dir }}/ansible3.csr"
-      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
+      privatekey_path: "{{ output_dir }}/ansible_pkey3.pem"
       commonName: 'www3.ansible.com'
 
   - name: 'Generate certificate'
     openssl_certificate:
-      path: "{{ output_dir }}/{{ item }}.crt"
-      privatekey_path: "{{ output_dir }}/ansible_pkey.pem"
-      csr_path: "{{ output_dir }}/{{ item }}.csr"
+      path: "{{ output_dir }}/{{ item.name }}.crt"
+      privatekey_path: "{{ output_dir }}/{{ item.pkey }}"
+      csr_path: "{{ output_dir }}/{{ item.name }}.csr"
       provider: selfsigned
     loop:
-      - ansible
-      - ansible2
-      - ansible3
+      - name: ansible
+        pkey: ansible_pkey.pem
+      - name: ansible2
+        pkey: ansible_pkey2.pem
+      - name: ansible3
+        pkey: ansible_pkey3.pem
 
   - name: 'Generate PKCS#12 file'
     openssl_pkcs12:

--- a/test/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/test/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -1,9 +1,3 @@
----
-- name: 'Install pexpect'
-  pip:
-    name: 'pexpect'
-    state: 'present'
-
 - name: 'Validate PKCS#12'
   command: "openssl pkcs12 -info -in {{ output_dir }}/ansible.p12 -nodes -passin pass:''"
   register: p12
@@ -11,6 +5,10 @@
 - name: 'Validate PKCS#12 with no private key'
   command: "openssl pkcs12 -info -in {{ output_dir }}/ansible_no_pkey.p12 -nodes -passin pass:''"
   register: p12_validate_no_pkey
+
+- name: 'Validate PKCS#12 with multiple certs'
+  shell: "openssl pkcs12 -info -in {{ output_dir }}/ansible_multi_certs.p12 -nodes -passin pass:'' | grep subject"
+  register: p12_validate_multi_certs
 
 - name: 'Validate PKCS#12 (assert)'
   assert:
@@ -21,6 +19,11 @@
       - p12_validate_no_pkey.stdout_lines[-1] == '-----END CERTIFICATE-----'
       - p12_force.changed
       - p12_force_and_mode.mode == '0644' and p12_force_and_mode.changed
+      - not p12_standard_idempotency.changed
+      - not p12_multiple_certs_idempotency.changed
+      - "'www.' in p12_validate_multi_certs.stdout"
+      - "'www2.' in p12_validate_multi_certs.stdout"
+      - "'www3.' in p12_validate_multi_certs.stdout"
 
 - name: Check passphrase on private key
   assert:


### PR DESCRIPTION
##### SUMMARY
Adds idempotency checks to the openssl_pkcs12 module and related tests. 
Also decoupled `parse` and `generate` from the file write, as they are now used for multiple stuff that don't require the file to be written to disk.
Fixes #53221

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12

