### PR TITLE
azure_rm_managed_disk additional disk types

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -45,10 +45,18 @@ options:
             - Valid Azure location. Defaults to location of the resource group.
     storage_account_type:
         description:
-            - "Type of storage for the managed disk: C(Standard_LRS)  or C(Premium_LRS). If not specified the disk is created C(Standard_LRS)."
+            - "Type of storage for the managed disk."
+            - "If not specified, the disk is created as C(Standard_LRS)."
+            - "C(Standard_LRS) is for Standard HDD."
+            - "C(StandardSSD_LRS) (added in 2.8) is for Standard SSD."
+            - "C(Premium_LRS) is for Premium SSD."
+            - "C(UltraSSD_LRS) (added in 2.8) is for Ultra SSD, which is in preview mode, and only available on select instance types."
+            - "See https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-types for more information about disk types."
         choices:
             - Standard_LRS
+            - StandardSSD_LRS
             - Premium_LRS
+            - UltraSSD_LRS
     create_option:
         description:
             - "Allowed values: empty, import, copy.
@@ -201,7 +209,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             ),
             storage_account_type=dict(
                 type='str',
-                choices=['Standard_LRS', 'Premium_LRS']
+                choices=['Standard_LRS', 'StandardSSD_LRS', 'Premium_LRS', 'UltraSSD_LRS']
             ),
             create_option=dict(
                 type='str',

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
@@ -81,7 +81,8 @@ azure_managed_disk:
             type: str
         storage_account_type:
             description:
-                - Type of storage for the managed disk
+                - Type of storage for the managed disk.
+                - See https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-types for more information about this type.
             type: str
             sample: Standard_LRS
         create_option:

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -59,8 +59,10 @@
    assert:
      that:
        - output.changed
+       - output.state.disk_size_gb == 1
        - output.state.id is defined
        - output.state.os_type == None
+       - output.state.storage_account_type == "Standard_LRS"
 
  - name: Change the operating system type of the managed disk to linux
    azure_rm_managed_disk:
@@ -145,11 +147,11 @@
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "md{{ rpfx }}1"
-       disk_size_gb: 30000
+       disk_size_gb: 3000000
    register: output
    ignore_errors: yes
 
- - name: Assert disk size change to incompatible size (>4095)  failure
+ - name: Assert disk size change to incompatible size failure
    assert: { that: "output['failed'] == True" }
 
  - name: Change disk to bigger size
@@ -163,8 +165,33 @@
    assert:
      that:
        - output.changed
+       - output.state.disk_size_gb == 2
 
- - name: Change disk to Premium
+ - name: Change disk to Standard SSD
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "md{{ rpfx }}1"
+       storage_account_type: "StandardSSD_LRS"
+       disk_size_gb: 2
+   register: output
+
+ - name: Assert status succeeded
+   assert:
+     that:
+       - output.changed
+       - output.state.storage_account_type == "StandardSSD_LRS"
+
+ - name: Gather facts to one specific disk
+   azure_rm_managed_disk_facts:
+       resource_group: "{{ resource_group }}"
+       name: "md{{ rpfx }}1"
+
+ - assert:
+     that:
+       - "azure_managed_disk | length == 1"
+       - azure_managed_disk[0].storage_account_type == "StandardSSD_LRS"
+
+ - name: Change disk to Premium (SSD)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "md{{ rpfx }}1"
@@ -176,6 +203,7 @@
    assert:
      that:
        - output.changed
+       - output.state.storage_account_type == "Premium_LRS"
 
  - name: Update disk tags
    azure_rm_managed_disk:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are a couple disk type options not represented in Ansible.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_managed_disk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
See this link:  https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.models.disksku?view=azure-dotnet

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Added the new types to the allowed list and updated the integration test.
```
