### PR TITLE
fix a bug for ce about action/ce.py

### DIFF
--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -36,13 +36,7 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-CLI_SUPPORTED_MODULES = ['ce_rollback', 'ce_mlag_interface', 'ce_startup', 'ce_config',
-                         'ce_command', 'ce_facts', 'ce_evpn_global', 'ce_evpn_bgp_rr',
-                         'ce_mtu', 'ce_evpn_bgp', 'ce_snmp_location', 'ce_snmp_contact',
-                         'ce_snmp_traps', 'ce_netstream_global', 'ce_netstream_aging',
-                         'ce_netstream_export', 'ce_netstream_template', 'ce_ntp_auth',
-                         'ce_stp', 'ce_vxlan_global', 'ce_vxlan_arp', 'ce_vxlan_gateway',
-                         'ce_acl_interface']
+CLI_SUPPORTED_MODULES = ['ce_config', 'ce_command']
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -36,7 +36,13 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-CLI_SUPPORTED_MODULES = ['ce_config', 'ce_command']
+CLI_SUPPORTED_MODULES = ['ce_rollback', 'ce_mlag_interface', 'ce_startup', 'ce_config',
+                         'ce_command', 'ce_facts', 'ce_evpn_global', 'ce_evpn_bgp_rr',
+                         'ce_mtu', 'ce_evpn_bgp', 'ce_snmp_location', 'ce_snmp_contact',
+                         'ce_snmp_traps', 'ce_netstream_global', 'ce_netstream_aging',
+                         'ce_netstream_export', 'ce_netstream_template', 'ce_ntp_auth',
+                         'ce_stp', 'ce_vxlan_global', 'ce_vxlan_arp', 'ce_vxlan_gateway',
+                         'ce_acl_interface']
 
 
 class ActionModule(_ActionModule):
@@ -105,7 +111,7 @@ class ActionModule(_ActionModule):
             out = conn.get_prompt()
             while to_text(out, errors='surrogate_then_replace').strip().endswith(']'):
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                conn.send_command('exit')
+                conn.exec_command('return')
                 out = conn.get_prompt()
 
         result = super(ActionModule, self).run(task_vars=task_vars)


### PR DESCRIPTION
##### SUMMARY
There is a bug in ce.py.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/ce.py

##### ADDITIONAL INFORMATION
ansible 2.7.0
  config file = /usr/xuyuandong/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.7.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]



PLAYBOOK like this :+1: 

---

- name: sample playbook
  gather_facts: yes
  connection: local
  hosts: switch4
  tasks:
  - name: "Step1.1 Test "
    ce_command:
      commands: 'system'
    ignore_errors: true
  - name: "Step1.2 Test"
    ce_command:
      commands: 'system'





Berfor fix bug

Task path: /usr/xuyuandong/test.yml:12
<10.130.200.118> attempting to start connection
<10.130.200.118> using connection plugin network_cli
<10.130.200.118> found existing local domain socket, using it!
<10.130.200.118> updating play_context for connection
<10.130.200.118>
<10.130.200.118> local domain socket path is /root/.ansible/pc/447fe5392c
<10.130.200.118> wrong context, sending exit to device
The full traceback is:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/ansible-2.7.0-py2.7.egg/ansible/executor/task_executor.py", line 139, in run
    res = self._execute()
  File "/usr/lib/python2.7/site-packages/ansible-2.7.0-py2.7.egg/ansible/executor/task_executor.py", line 598, in _execute
    result = self._handler.run(task_vars=variables)
  File "/usr/lib/python2.7/site-packages/ansible-2.7.0-py2.7.egg/ansible/plugins/action/ce.py", line 108, in run
    conn.send_command('exit')
  File "/usr/lib/python2.7/site-packages/ansible-2.7.0-py2.7.egg/ansible/module_utils/connection.py", line 173, in __rpc__
    raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)
ConnectionError: exit
              ^
Error: Unrecognized command found at '^' position.
[~6865_130.52]

fatal: [10.130.200.118]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
        to retry, use: --limit @/usr/xuyuandong/test.retry

PLAY RECAP **************************************************************************************************************************
10.130.200.118             : ok=2    changed=0    unreachable=0    failed=1



After fix bug

TASK [Step1.2 Test] *****************************************************************************************************************
task path: /usr/xuyuandong/test.yml:12
<10.130.200.118> attempting to start connection
<10.130.200.118> using connection plugin network_cli
<10.130.200.118> found existing local domain socket, using it!
<10.130.200.118> updating play_context for connection
<10.130.200.118>
<10.130.200.118> local domain socket path is /root/.ansible/pc/b100c1c7b6
<10.130.200.118> wrong context, sending exit to device
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-local-481oOQVrs/ansible-tmp-1554985909.58-247272148628680 `" && echo ansible-tmp-1554985909.58-247272148628680="` echo /root/.ansible/tmp/ansible-local-481oOQVrs/ansible-tmp-1554985909.58-247272148628680 `" ) && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible-2.7.0-py2.7.egg/ansible/modules/network/cloudengine/ce_command.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-481oOQVrs/tmp04DTHx TO /root/.ansible/tmp/ansible-local-481oOQVrs/ansible-tmp-1554985909.58-247272148628680/AnsiballZ_ce_command.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-local-481oOQVrs/ansible-tmp-1554985909.58-247272148628680/ /root/.ansible/tmp/ansible-local-481oOQVrs/ansible-tmp-1554985909.58-247272148628680/AnsiballZ_ce_command.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-local-481oOQVrs/ansible-tmp-1554985909.58-247272148628680/AnsiballZ_ce_command.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-local-481oOQVrs/ansible-tmp-1554985909.58-247272148628680/ > /dev/null 2>&1 && sleep 0'
ok: [10.130.200.118] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "commands": [
                "system"
            ],
            "host": null,
            "interval": 1,
            "match": "all",
            "password": null,
            "port": null,
            "provider": null,
            "retries": 10,
            "ssh_keyfile": null,
            "timeout": null,
            "transport": null,
            "use_ssl": null,
            "username": null,
            "validate_certs": null,
            "wait_for": null
        }
    },
    "stdout": [
        "Enter system view, return user view with return command."
    ],
    "stdout_lines": [
        [
            "Enter system view, return user view with return command."
        ]
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP **************************************************************************************************************************
10.130.200.118             : ok=3    changed=0    unreachable=0    failed=0

```paste below
code should be:


out = conn.get_prompt()
            while to_text(out, errors='surrogate_then_replace').strip().endswith(']'):
                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                conn.send_command('exit')
                out = conn.get_prompt()
```
I find that when connectin is network_cli there is a function named 'send_command', so when i run my playbook via 'ce_command ' one by one.An error happened!
so I  the code should be "conn.exec_command('return')",in which the context return to the user view!