### PR TITLE
openssh_cert: add serial_number param

### DIFF
--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -111,10 +111,10 @@ options:
     serial_number:
         description:
             - "Specify the certificate serial number when signing a public key.
-               The serial number that is logged by the server when the certificate is used for authentication.
-               The certificate serial number may be used in a KeyRevocationList."
+               The serial number is logged by the server when the certificate is used for authentication.
+               The certificate serial number may be used in a KeyRevocationList.
+               Note: The default value set by ssh-keygen is 0."
         type: int
-        default: 0
 
 extends_documentation_fragment: files
 '''
@@ -298,7 +298,7 @@ class Certificate(object):
             else:
                 args.extend(['-I', ""])
 
-            if self.serial_number:
+            if self.serial_number is not None:
                 args.extend(['-z', str(self.serial_number)])
 
             if self.principals:
@@ -526,7 +526,7 @@ def main():
             public_key=dict(type='path'),
             path=dict(type='path', required=True),
             identifier=dict(type='str'),
-            serial_number=dict(type='int', default=0),
+            serial_number=dict(type='int'),
             valid_from=dict(type='str'),
             valid_to=dict(type='str'),
             valid_at=dict(type='str'),

--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -113,6 +113,7 @@ options:
             - "Specify the certificate serial number.
                The serial number is logged by the server when the certificate is used for authentication.
                The certificate serial number may be used in a KeyRevocationList.
+               The serial number may be omitted for checks, but must be specified again for a new certificate.
                Note: The default value set by ssh-keygen is 0."
         type: int
 
@@ -416,8 +417,7 @@ class Certificate(object):
 
         def _check_serial_number():
             if self.serial_number is None:
-                # the default serial number set by ssh-keygen is 0
-                return serial_number == '0'
+                return True
             return self.serial_number == int(serial_number)
 
         def _check_type():

--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -456,9 +456,12 @@ class Certificate(object):
             for word in arr:
                 if word in keywords:
                     concated.append(string)
-                    string = ""
-                string += " " + word
+                    string = word
+                else:
+                    string += " " + word
             concated.append(string)
+            # drop the certificate path
+            concated.pop(0)
             return concated
 
         def format_cert_info():

--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -108,6 +108,12 @@ options:
         description:
             - Specify the key identity when signing a public key. The identifier that is logged by the server when the certificate is used for authentication.
         type: str
+    serial_number:
+        description:
+            - "Specify the certificate serial number when signing a public key. The serial number that is logged by the server when the certificate is used for authentication.
+               The certificate serial number may be used in a KeyRevocationList."
+        type: int
+        default: 0
 
 extends_documentation_fragment: files
 '''
@@ -216,6 +222,7 @@ class Certificate(object):
         self.public_key = module.params['public_key']
         self.path = module.params['path']
         self.identifier = module.params['identifier']
+        self.serial_number = module.params['serial_number']
         self.valid_from = module.params['valid_from']
         self.valid_to = module.params['valid_to']
         self.valid_at = module.params['valid_at']
@@ -289,6 +296,9 @@ class Certificate(object):
                 args.extend(['-I', self.identifier])
             else:
                 args.extend(['-I', ""])
+
+            if self.serial_number:
+                args.extend(['-z', str(self.serial_number)])
 
             if self.principals:
                 args.extend(['-n', ','.join(self.principals)])
@@ -515,6 +525,7 @@ def main():
             public_key=dict(type='path'),
             path=dict(type='path', required=True),
             identifier=dict(type='str'),
+            serial_number=dict(type='int', default=0),
             valid_from=dict(type='str'),
             valid_to=dict(type='str'),
             valid_at=dict(type='str'),

--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -110,7 +110,8 @@ options:
         type: str
     serial_number:
         description:
-            - "Specify the certificate serial number when signing a public key. The serial number that is logged by the server when the certificate is used for authentication.
+            - "Specify the certificate serial number when signing a public key.
+               The serial number that is logged by the server when the certificate is used for authentication.
                The certificate serial number may be used in a KeyRevocationList."
         type: int
         default: 0

--- a/test/integration/targets/openssh_cert/tasks/main.yml
+++ b/test/integration/targets/openssh_cert/tasks/main.yml
@@ -320,12 +320,36 @@
       path: '{{ output_dir }}/id_cert_serial_42'
       valid_from: always
       valid_to: forever
+      serial_number: 0
     register: rc_serial_number_removed
   - name: check changed
     assert:
       that:
         - rc_serial_number_removed is changed
       msg: OpenSSH certificate regenerated upon serial number removal.
+  - name: Generate a new cert with serial number
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_serial_ignore'
+      valid_from: always
+      valid_to: forever
+      serial_number: 42
+  - name: Generate cert again, omitting the parameter serial_number (idempotent)
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_serial_ignore'
+      valid_from: always
+      valid_to: forever
+    register: rc_serial_number_ignored
+  - name: check idempotent
+    assert:
+      that:
+        - rc_serial_number_ignored is not changed
+      msg: OpenSSH certificate generation with omitted serial number is idempotent.
   - name: Remove certificate (check mode)
     openssh_cert:
       state: absent

--- a/test/integration/targets/openssh_cert/tasks/main.yml
+++ b/test/integration/targets/openssh_cert/tasks/main.yml
@@ -253,6 +253,20 @@
       that:
         - "'Serial: 0' in rc_no_serial_number.info"
       msg: OpenSSH user certificate contains the default serial number.
+  - name: Generate cert without serial (idempotent)
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_no_serial'
+      valid_from: always
+      valid_to: forever
+    register: rc_no_serial_number_idempotent
+  - name: check idempotent
+    assert:
+      that:
+        - rc_no_serial_number_idempotent is not changed
+      msg: OpenSSH certificate generation without serial number is idempotent.
   - name: Generate cert with serial 42
     openssh_cert:
       type: user
@@ -268,6 +282,50 @@
       that:
         - "'Serial: 42' in rc_serial_number.info"
       msg: OpenSSH user certificate contains the serial number from the params.
+  - name: Generate cert with serial 42 (idempotent)
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_serial_42'
+      valid_from: always
+      valid_to: forever
+      serial_number: 42
+    register: rc_serial_number_idempotent
+  - name: check idempotent
+    assert:
+      that:
+        - rc_serial_number_idempotent is not changed
+      msg: OpenSSH certificate generation with serial number is idempotent.
+  - name: Generate cert with changed serial number
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_serial_42'
+      valid_from: always
+      valid_to: forever
+      serial_number: 1337
+    register: rc_serial_number_changed
+  - name: check changed
+    assert:
+      that:
+        - rc_serial_number_changed is changed
+      msg: OpenSSH certificate regenerated upon serial number change.
+  - name: Generate cert with removed serial number
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_serial_42'
+      valid_from: always
+      valid_to: forever
+    register: rc_serial_number_removed
+  - name: check changed
+    assert:
+      that:
+        - rc_serial_number_removed is changed
+      msg: OpenSSH certificate regenerated upon serial number removal.
   - name: Remove certificate (check mode)
     openssh_cert:
       state: absent

--- a/test/integration/targets/openssh_cert/tasks/main.yml
+++ b/test/integration/targets/openssh_cert/tasks/main.yml
@@ -239,6 +239,35 @@
           - "clear"
       valid_from: "2001-01-21"
       valid_to: "2019-01-21"
+  - name: Generate cert without serial
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_no_serial'
+      valid_from: always
+      valid_to: forever
+    register: rc_no_serial_number
+  - name: check default serial
+    assert:
+      that:
+        - "'Serial: 0' in rc_no_serial_number.info"
+      msg: OpenSSH user certificate contains the default serial number.
+  - name: Generate cert with serial 42
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_serial_42'
+      valid_from: always
+      valid_to: forever
+      serial_number: 42
+    register: rc_serial_number
+  - name: check serial 42
+    assert:
+      that:
+        - "'Serial: 42' in rc_serial_number.info"
+      msg: OpenSSH user certificate contains the serial number from the params.
   - name: Remove certificate (check mode)
     openssh_cert:
       state: absent


### PR DESCRIPTION
##### SUMMARY
The new `openssh_cert` module is almost complete. One critical param used to identify a certificate, the `serial_number`, is missing currently.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssh_cert

##### ADDITIONAL INFORMATION
The returned certificate information has been cleaned up slightly:

- I dropped the certificate path from the output, it is already present in `rc.filename`
- I removed the leading white space.

<details>
 <summary>before</summary>
    <pre>
{
  "filename": "/tmp/abc/id_cert", 
  "info": [
    " /tmp/abc/id_cert:", 
    " Type: ssh-rsa-cert-v01@openssh.com user certificate", 
    " Public key: RSA-CERT SHA256:WhldnJ13G402y2uonuAJatycQYuLVGT6M5pLtE1jgYs", 
    " Signing CA: RSA SHA256:WhldnJ13G402y2uonuAJatycQYuLVGT6M5pLtE1jgYs", 
    " Key ID: \"\"", 
    " Serial: 42", 
    " Valid: forever", 
    " Principals: (none)", 
    " Critical Options: (none)", 
    " Extensions: permit-X11-forwarding permit-agent-forwarding permit-port-forwarding permit-pty permit-user-rc"
  ], 
  "type": "user"
}
    </pre>
</details>
<details>
 <summary>after</summary>
    <pre>
{
  "filename": "/tmp/abc/id_cert", 
  "info": [
    "Type: ssh-rsa-cert-v01@openssh.com user certificate", 
    "Public key: RSA-CERT SHA256:WhldnJ13G402y2uonuAJatycQYuLVGT6M5pLtE1jgYs", 
    "Signing CA: RSA SHA256:WhldnJ13G402y2uonuAJatycQYuLVGT6M5pLtE1jgYs", 
    "Key ID: \"\"", 
    "Serial: 42", 
    "Valid: forever", 
    "Principals: (none)", 
    "Critical Options: (none)", 
    "Extensions: permit-X11-forwarding permit-agent-forwarding permit-port-forwarding permit-pty permit-user-rc"
  ], 
  "type": "user"
}
    </pre>
</details>