### PR TITLE
gitlab: use config file & refactoring

### DIFF
--- a/lib/ansible/module_utils/gitlab.py
+++ b/lib/ansible/module_utils/gitlab.py
@@ -110,7 +110,7 @@ def request(module, api_url, project, path, access_token, private_token, rawdata
 def deprecation_warning(module):
     deprecated_aliases = ['login_token', 'private_token', 'access_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), '2.10')
 
 
 def gitlab_auth_argument_spec():

--- a/lib/ansible/module_utils/gitlab.py
+++ b/lib/ansible/module_utils/gitlab.py
@@ -69,7 +69,7 @@ class GitlabApiConnection(object):
         try:
             # if none of the connection details were provided, try using
             # configuration file on the host
-            if {self.user, self.password, self.token} == {None}:
+            if set([self.user, self.password, self.token]) == set([None]):
                 self.instance = gitlab.Gitlab.from_config(self.url, self.config_files)
             else:
                 self.instance = gitlab.Gitlab(url=self.url, ssl_verify=self.validate_certs, email=self.user,
@@ -107,13 +107,19 @@ def request(module, api_url, project, path, access_token, private_token, rawdata
         return False, str(status) + ": " + content
 
 
+def deprecation_warning(module):
+    deprecated_aliases = ['login_token', 'private_token', 'access_token']
+
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+
+
 def gitlab_auth_argument_spec():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         server_url=dict(type='str', no_log=True, removed_in_version=2.10),
         login_user=dict(type='str', no_log=True, removed_in_version=2.10),
         login_password=dict(type='str', no_log=True, removed_in_version=2.10),
-        api_token=dict(type='str', no_log=True, aliases=["login_token"]),
+        api_token=dict(type='str', no_log=True, aliases=["login_token", 'access_token', 'private_token']),
         config_files=dict(type='list', no_log=True, default=['/etc/python-gitlab.cfg', '~/.python-gitlab.cfg']),
     ))
     return argument_spec

--- a/lib/ansible/module_utils/gitlab.py
+++ b/lib/ansible/module_utils/gitlab.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import json
 
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.api import basic_auth_argument_spec
 
 try:
     from urllib import quote_plus  # Python 2.X
@@ -37,6 +38,39 @@ def request(module, api_url, project, path, access_token, private_token, rawdata
         return True, json.loads(content)
     else:
         return False, str(status) + ": " + content
+
+
+def gitlab_auth_argument_spec():
+    argument_spec = basic_auth_argument_spec()
+    argument_spec.update(dict(
+        server_url=dict(type='str', no_log=True, removed_in_version=2.10),
+        login_user=dict(type='str', no_log=True, removed_in_version=2.10),
+        login_password=dict(type='str', no_log=True, removed_in_version=2.10),
+        api_token=dict(type='str', no_log=True, aliases=["login_token"]),
+        config_files=dict(type='list', no_log=True, default=['/etc/python-gitlab.cfg', '~/.python-gitlab.cfg']),
+    ))
+    return argument_spec
+
+
+gitlab_module_kwargs = dict(
+    mutually_exclusive=[
+        ['api_url', 'server_url'],
+        ['api_username', 'login_user'],
+        ['api_password', 'login_password'],
+        ['api_username', 'api_token'],
+        ['api_password', 'api_token'],
+        ['login_user', 'login_token'],
+        ['login_password', 'login_token']
+    ],
+    required_together=[
+        ['api_username', 'api_password'],
+        ['login_user', 'login_password'],
+    ],
+    required_one_of=[
+        ['api_username', 'api_token', 'login_user', 'login_token', 'config_files']
+    ],
+    supports_check_mode=True,
+)
 
 
 def findProject(gitlab_instance, identifier):

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -120,9 +120,6 @@ deploy_key:
   type: dict
 '''
 
-import os
-import re
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -117,7 +117,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible.module_utils.gitlab import (findProject, gitlab_auth_argument_spec,
-                                         gitlab_module_kwargs, gitlab, GitlabApiConnection)
+                                         gitlab_module_kwargs, deprecation_warning, gitlab,
+                                         GitlabApiConnection)
 
 
 class GitLabDeployKey(object):
@@ -217,12 +218,6 @@ class GitLabDeployKey(object):
             return True
 
         return self.deployKeyObject.delete()
-
-
-def deprecation_warning(module):
-    deprecated_aliases = ['private_token', 'access_token']
-
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -132,11 +132,10 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
-from ansible.module_utils.gitlab import findProject
+from ansible.module_utils.gitlab import findProject, gitlab_auth_argument_spec, gitlab_module_kwargs
 
 
 class GitLabDeployKey(object):
@@ -245,9 +244,8 @@ def deprecation_warning(module):
 
 
 def main():
-    argument_spec = basic_auth_argument_spec()
+    argument_spec = gitlab_auth_argument_spec()
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True, aliases=["private_token", "access_token"]),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         project=dict(type='str', required=True),
         key=dict(type='str', required=True),
@@ -255,21 +253,7 @@ def main():
         title=dict(type='str', required=True)
     ))
 
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        mutually_exclusive=[
-            ['api_username', 'api_token'],
-            ['api_password', 'api_token']
-        ],
-        required_together=[
-            ['api_username', 'api_password']
-        ],
-        required_one_of=[
-            ['api_username', 'api_token']
-        ],
-        supports_check_mode=True,
-    )
-
+    module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
     gitlab_url = re.sub('/api.*', '', module.params['api_url'])

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -28,15 +28,8 @@ requirements:
   - python-gitlab python module
 extends_documentation_fragment:
     - auth_basic
+    - gitlab
 options:
-  api_token:
-    description:
-      - Gitlab token for logging in.
-    version_added: "2.8"
-    type: str
-    aliases:
-      - private_token
-      - access_token
   project:
     description:
       - Id or Full path of project in the form of group/name

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -28,6 +28,7 @@ requirements:
   - python-gitlab python module
 extends_documentation_fragment:
     - auth_basic
+    - gitlab
 options:
   server_url:
     description:
@@ -42,12 +43,6 @@ options:
     description:
       - Gitlab password for login_user
     type: str
-  api_token:
-    description:
-      - Gitlab token for logging in.
-    type: str
-    aliases:
-      - login_token
   name:
     description:
       - Name of the group you want to create.

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -152,11 +152,10 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
-from ansible.module_utils.gitlab import findGroup
+from ansible.module_utils.gitlab import findGroup, gitlab_auth_argument_spec, gitlab_module_kwargs
 
 
 class GitLabGroup(object):
@@ -273,12 +272,8 @@ def deprecation_warning(module):
 
 
 def main():
-    argument_spec = basic_auth_argument_spec()
+    argument_spec = gitlab_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version=2.10),
-        login_user=dict(type='str', no_log=True, removed_in_version=2.10),
-        login_password=dict(type='str', no_log=True, removed_in_version=2.10),
-        api_token=dict(type='str', no_log=True, aliases=["login_token"]),
         name=dict(type='str', required=True),
         path=dict(type='str'),
         description=dict(type='str'),
@@ -287,27 +282,7 @@ def main():
         visibility=dict(type='str', default="private", choices=["internal", "private", "public"]),
     ))
 
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        mutually_exclusive=[
-            ['api_url', 'server_url'],
-            ['api_username', 'login_user'],
-            ['api_password', 'login_password'],
-            ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
-            ['login_user', 'login_token'],
-            ['login_password', 'login_token']
-        ],
-        required_together=[
-            ['api_username', 'api_password'],
-            ['login_user', 'login_password'],
-        ],
-        required_one_of=[
-            ['api_username', 'api_token', 'login_user', 'login_token']
-        ],
-        supports_check_mode=True,
-    )
-
+    module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
     server_url = module.params['server_url']

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -141,21 +141,11 @@ group:
   type: dict
 '''
 
-import os
-import traceback
-
-GITLAB_IMP_ERR = None
-try:
-    import gitlab
-    HAS_GITLAB_PACKAGE = True
-except Exception:
-    GITLAB_IMP_ERR = traceback.format_exc()
-    HAS_GITLAB_PACKAGE = False
-
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
-from ansible.module_utils.gitlab import findGroup, gitlab_auth_argument_spec, gitlab_module_kwargs
+from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
+                                         gitlab, GitlabApiConnection, findGroup)
 
 
 class GitLabGroup(object):
@@ -285,19 +275,8 @@ def main():
     module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
-    server_url = module.params['server_url']
-    login_user = module.params['login_user']
-    login_password = module.params['login_password']
-
-    api_url = module.params['api_url']
-    validate_certs = module.params['validate_certs']
-    api_user = module.params['api_username']
-    api_password = module.params['api_password']
-
-    gitlab_url = server_url if api_url is None else api_url
-    gitlab_user = login_user if api_user is None else api_user
-    gitlab_password = login_password if api_password is None else api_password
-    gitlab_token = module.params['api_token']
+    api = GitlabApiConnection(module)
+    gitlab_instance = api.auth()
 
     group_name = module.params['name']
     group_path = module.params['path']
@@ -305,19 +284,6 @@ def main():
     state = module.params['state']
     parent_identifier = module.params['parent']
     group_visibility = module.params['visibility']
-
-    if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
-
-    try:
-        gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=validate_certs, email=gitlab_user, password=gitlab_password,
-                                        private_token=gitlab_token, api_version=4)
-        gitlab_instance.auth()
-    except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:
-        module.fail_json(msg="Failed to connect to Gitlab server: %s" % to_native(e))
-    except (gitlab.exceptions.GitlabHttpError) as e:
-        module.fail_json(msg="Failed to connect to Gitlab server: %s. \
-            Gitlab remove Session API now that private tokens are removed from user API endpoints since version 10.2" % to_native(e))
 
     # Define default group_path based on group_name
     if group_path is None:

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -32,15 +32,18 @@ extends_documentation_fragment:
 options:
   server_url:
     description:
+      - B(Deprecated)
       - The URL of the Gitlab server, with protocol (i.e. http or https).
     required: true
     type: str
   login_user:
     description:
+      - B(Deprecated)
       - Gitlab user name.
     type: str
   login_password:
     description:
+      - B(Deprecated)
       - Gitlab password for login_user
     type: str
   name:

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -143,7 +143,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
-                                         gitlab, GitlabApiConnection, findGroup)
+                                         gitlab, deprecation_warning, GitlabApiConnection, findGroup)
 
 
 class GitLabGroup(object):
@@ -251,12 +251,6 @@ class GitLabGroup(object):
             self.groupObject = group
             return True
         return False
-
-
-def deprecation_warning(module):
-    deprecated_aliases = ['login_token']
-
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -164,22 +164,10 @@ hook:
   type: dict
 '''
 
-import os
-import re
-import traceback
+from ansible.module_utils.basic import AnsibleModule
 
-GITLAB_IMP_ERR = None
-try:
-    import gitlab
-    HAS_GITLAB_PACKAGE = True
-except Exception:
-    GITLAB_IMP_ERR = traceback.format_exc()
-    HAS_GITLAB_PACKAGE = False
-
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
-
-from ansible.module_utils.gitlab import findProject, gitlab_auth_argument_spec, gitlab_module_kwargs
+from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
+                                         GitlabApiConnection, findProject)
 
 
 class GitLabHook(object):
@@ -321,11 +309,8 @@ def main():
     module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
-    gitlab_url = re.sub('/api.*', '', module.params['api_url'])
-    validate_certs = module.params['validate_certs']
-    gitlab_user = module.params['api_username']
-    gitlab_password = module.params['api_password']
-    gitlab_token = module.params['api_token']
+    api = GitlabApiConnection(module)
+    gitlab_instance = api.auth()
 
     state = module.params['state']
     project_identifier = module.params['project']
@@ -341,21 +326,7 @@ def main():
     enable_ssl_verification = module.params['hook_validate_certs']
     hook_token = module.params['token']
 
-    if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
-
-    try:
-        gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=validate_certs, email=gitlab_user, password=gitlab_password,
-                                        private_token=gitlab_token, api_version=4)
-        gitlab_instance.auth()
-    except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:
-        module.fail_json(msg="Failed to connect to Gitlab server: %s" % to_native(e))
-    except (gitlab.exceptions.GitlabHttpError) as e:
-        module.fail_json(msg="Failed to connect to Gitlab server: %s. \
-            Gitlab remove Session API now that private tokens are removed from user API endpoints since version 10.2." % to_native(e))
-
     gitlab_hook = GitLabHook(module, gitlab_instance)
-
     project = findProject(gitlab_instance, project_identifier)
 
     if project is None:

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -29,15 +29,8 @@ requirements:
   - python-gitlab python module
 extends_documentation_fragment:
     - auth_basic
+    - gitlab
 options:
-  api_token:
-    description:
-      - Gitlab token for logging in.
-    version_added: "2.8"
-    type: str
-    aliases:
-      - private_token
-      - access_token
   project:
     description:
       - Id or Full path of the project in the form of group/name

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -160,7 +160,7 @@ hook:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
-                                         GitlabApiConnection, findProject)
+                                         GitlabApiConnection, deprecation_warning, findProject)
 
 
 class GitLabHook(object):
@@ -273,12 +273,6 @@ class GitLabHook(object):
             return True
 
         return self.hookObject.delete()
-
-
-def deprecation_warning(module):
-    deprecated_aliases = ['private_token', 'access_token']
-
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -176,11 +176,10 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
-from ansible.module_utils.gitlab import findProject
+from ansible.module_utils.gitlab import findProject, gitlab_auth_argument_spec, gitlab_module_kwargs
 
 
 class GitLabHook(object):
@@ -302,9 +301,8 @@ def deprecation_warning(module):
 
 
 def main():
-    argument_spec = basic_auth_argument_spec()
+    argument_spec = gitlab_auth_argument_spec()
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True, aliases=["private_token", "access_token"]),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         project=dict(type='str', required=True),
         hook_url=dict(type='str', required=True),
@@ -320,21 +318,7 @@ def main():
         token=dict(type='str', no_log=True),
     ))
 
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        mutually_exclusive=[
-            ['api_username', 'api_token'],
-            ['api_password', 'api_token']
-        ],
-        required_together=[
-            ['api_username', 'api_password']
-        ],
-        required_one_of=[
-            ['api_username', 'api_token']
-        ],
-        supports_check_mode=True,
-    )
-
+    module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
     gitlab_url = re.sub('/api.*', '', module.params['api_url'])

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -33,15 +33,18 @@ extends_documentation_fragment:
 options:
   server_url:
     description:
+      - B(Deprecated)
       - The URL of the Gitlab server, with protocol (i.e. http or https).
     required: true
     type: str
   login_user:
     description:
+      - B(Deprecated)
       - Gitlab user name.
     type: str
   login_password:
     description:
+      - B(Deprecated)
       - Gitlab password for login_user
     type: str
   group:

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -177,11 +177,10 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
-from ansible.module_utils.gitlab import findGroup, findProject
+from ansible.module_utils.gitlab import findGroup, findProject, gitlab_auth_argument_spec, gitlab_module_kwargs
 
 
 class GitLabProject(object):
@@ -293,12 +292,8 @@ def deprecation_warning(module):
 
 
 def main():
-    argument_spec = basic_auth_argument_spec()
+    argument_spec = gitlab_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version=2.10),
-        login_user=dict(type='str', no_log=True, removed_in_version=2.10),
-        login_password=dict(type='str', no_log=True, removed_in_version=2.10),
-        api_token=dict(type='str', no_log=True, aliases=["login_token"]),
         group=dict(type='str'),
         name=dict(type='str', required=True),
         path=dict(type='str'),
@@ -312,27 +307,7 @@ def main():
         state=dict(type='str', default="present", choices=["absent", "present"]),
     ))
 
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        mutually_exclusive=[
-            ['api_url', 'server_url'],
-            ['api_username', 'login_user'],
-            ['api_password', 'login_password'],
-            ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
-            ['login_user', 'login_token'],
-            ['login_password', 'login_token']
-        ],
-        required_together=[
-            ['api_username', 'api_password'],
-            ['login_user', 'login_password'],
-        ],
-        required_one_of=[
-            ['api_username', 'api_token', 'login_user', 'login_token']
-        ],
-        supports_check_mode=True,
-    )
-
+    module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
     server_url = module.params['server_url']

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -29,6 +29,7 @@ requirements:
   - python-gitlab python module
 extends_documentation_fragment:
     - auth_basic
+    - gitlab
 options:
   server_url:
     description:
@@ -43,12 +44,6 @@ options:
     description:
       - Gitlab password for login_user
     type: str
-  api_token:
-    description:
-      - Gitlab token for logging in.
-    type: str
-    aliases:
-      - login_token
   group:
     description:
       - Id or The full path of the group of which this projects belongs to.

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -168,7 +168,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
-                                         gitlab, GitlabApiConnection, findGroup, findProject)
+                                         gitlab, deprecation_warning, GitlabApiConnection, findGroup,
+                                         findProject)
 
 
 class GitLabProject(object):
@@ -271,12 +272,6 @@ class GitLabProject(object):
             self.projectObject = project
             return True
         return False
-
-
-def deprecation_warning(module):
-    deprecated_aliases = ['login_token']
-
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -151,7 +151,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
-                                         gitlab, GitlabApiConnection)
+                                         gitlab, deprecation_warning, GitlabApiConnection)
 
 
 try:
@@ -271,16 +271,10 @@ class GitLabRunner(object):
         return runner.delete()
 
 
-def deprecation_warning(module):
-    deprecated_aliases = ['login_token']
-
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
-
-
 def main():
     argument_spec = gitlab_auth_argument_spec()
     argument_spec.update(dict(
-        url=dict(type='str', required=True, removed_in_version=2.10),
+        url=dict(type='str', removed_in_version=2.10),
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),
         tag_list=dict(type='list', default=[]),

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -164,9 +164,10 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
+
+from ansible.module_utils.gitlab import gitlab_auth_argument_spec, gitlab_module_kwargs
 
 try:
     cmp
@@ -292,10 +293,9 @@ def deprecation_warning(module):
 
 
 def main():
-    argument_spec = basic_auth_argument_spec()
+    argument_spec = gitlab_auth_argument_spec()
     argument_spec.update(dict(
         url=dict(type='str', required=True, removed_in_version=2.10),
-        api_token=dict(type='str', no_log=True, aliases=["private_token"]),
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),
         tag_list=dict(type='list', default=[]),
@@ -307,23 +307,7 @@ def main():
         state=dict(type='str', default="present", choices=["absent", "present"]),
     ))
 
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        mutually_exclusive=[
-            ['api_url', 'url'],
-            ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
-        ],
-        required_together=[
-            ['api_username', 'api_password'],
-            ['login_user', 'login_password'],
-        ],
-        required_one_of=[
-            ['api_username', 'api_token']
-        ],
-        supports_check_mode=True,
-    )
-
+    module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
     url = re.sub('/api.*', '', module.params['url'])

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -37,19 +37,13 @@ requirements:
   - python-gitlab python module
 extends_documentation_fragment:
     - auth_basic
+    - gitlab
 options:
   url:
     description:
       - The URL of the Gitlab server, with protocol (i.e. http or https).
     required: true
     type: str
-  api_token:
-    description:
-      - Your private token to interact with the GitLab API.
-    required: True
-    type: str
-    aliases:
-      - private_token
   description:
     description:
       - The unique name of the runner.

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -41,6 +41,7 @@ extends_documentation_fragment:
 options:
   url:
     description:
+      - B(Deprecated)
       - The URL of the Gitlab server, with protocol (i.e. http or https).
     required: true
     type: str

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -180,22 +180,11 @@ user:
   type: dict
 '''
 
-import os
-import re
-import traceback
-
-GITLAB_IMP_ERR = None
-try:
-    import gitlab
-    HAS_GITLAB_PACKAGE = True
-except Exception:
-    GITLAB_IMP_ERR = traceback.format_exc()
-    HAS_GITLAB_PACKAGE = False
-
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
-from ansible.module_utils.gitlab import findGroup, gitlab_auth_argument_spec, gitlab_module_kwargs
+from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
+                                         gitlab, GitlabApiConnection, findGroup)
 
 
 class GitLabUser(object):
@@ -438,20 +427,8 @@ def main():
     module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
-    server_url = module.params['server_url']
-    login_user = module.params['login_user']
-    login_password = module.params['login_password']
-
-    api_url = module.params['api_url']
-    validate_certs = module.params['validate_certs']
-    api_user = module.params['api_username']
-    api_password = module.params['api_password']
-
-    gitlab_url = server_url if api_url is None else api_url
-    gitlab_user = login_user if api_user is None else api_user
-    gitlab_password = login_password if api_password is None else api_password
-    gitlab_token = module.params['api_token']
-    config_files = map(os.path.expanduser, module.params['config_files'])
+    api = GitlabApiConnection(module)
+    gitlab_instance = api.auth()
 
     user_name = module.params['name']
     state = module.params['state']
@@ -465,24 +442,6 @@ def main():
     confirm = module.params['confirm']
     user_isadmin = module.params['isadmin']
     user_external = module.params['external']
-
-    if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
-
-    try:
-        # if none of the connection details were provided, try using
-        # configuration file on the host
-        if {gitlab_user, gitlab_password, gitlab_token} == {None}:
-            gitlab_instance = gitlab.Gitlab.from_config(gitlab_url, config_files)
-        else:
-            gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=validate_certs, email=gitlab_user, password=gitlab_password,
-                                            private_token=gitlab_token, api_version=4)
-        gitlab_instance.auth()
-    except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:
-        module.fail_json(msg="Failed to connect to Gitlab server: %s" % to_native(e))
-    except (gitlab.exceptions.GitlabHttpError) as e:
-        module.fail_json(msg="Failed to connect to Gitlab server: %s. \
-            Gitlab remove Session API now that private tokens are removed from user API endpoints since version 10.2." % to_native(e))
 
     gitlab_user = GitLabUser(module, gitlab_instance)
     user_exists = gitlab_user.existsUser(user_username)

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -30,6 +30,7 @@ requirements:
   - administrator rights on the Gitlab server
 extends_documentation_fragment:
     - auth_basic
+    - gitlab
 options:
   server_url:
     description:
@@ -43,18 +44,6 @@ options:
     description:
       - Gitlab password for login_user
     type: str
-  api_token:
-    description:
-      - Gitlab token for logging in.
-    type: str
-    aliases:
-      - login_token
-  config_files:
-    description:
-      - Configuration file with Gitlab API connection details
-      - See python-gitlab documentation for syntax specification
-    type: list
-    default: ["/etc/python-gitlab.cfg", "~/.python-gitlab.cfg"]
   name:
     description:
       - Name of the user you want to create

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -192,11 +192,10 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
-from ansible.module_utils.gitlab import findGroup
+from ansible.module_utils.gitlab import findGroup, gitlab_auth_argument_spec, gitlab_module_kwargs
 
 
 class GitLabUser(object):
@@ -420,13 +419,8 @@ def deprecation_warning(module):
 
 
 def main():
-    argument_spec = basic_auth_argument_spec()
+    argument_spec = gitlab_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', removed_in_version=2.10),
-        login_user=dict(type='str', no_log=True, removed_in_version=2.10),
-        login_password=dict(type='str', no_log=True, removed_in_version=2.10),
-        api_token=dict(type='str', no_log=True, aliases=["login_token"]),
-        config_files=dict(type='list', no_log=True, default=['/etc/python-gitlab.cfg', '~/.python-gitlab.cfg']),
         name=dict(type='str', required=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         username=dict(type='str', required=True),
@@ -441,27 +435,7 @@ def main():
         external=dict(type='bool', default=False),
     ))
 
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        mutually_exclusive=[
-            ['api_url', 'server_url'],
-            ['api_username', 'login_user'],
-            ['api_password', 'login_password'],
-            ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
-            ['login_user', 'login_token'],
-            ['login_password', 'login_token']
-        ],
-        required_together=[
-            ['api_username', 'api_password'],
-            ['login_user', 'login_password'],
-        ],
-        required_one_of=[
-            ['api_username', 'api_token', 'login_user', 'login_token', 'config_files']
-        ],
-        supports_check_mode=True,
-    )
-
+    module = AnsibleModule(argument_spec, **gitlab_module_kwargs)
     deprecation_warning(module)
 
     server_url = module.params['server_url']

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -34,14 +34,17 @@ extends_documentation_fragment:
 options:
   server_url:
     description:
+      - B(Deprecated)
       - The URL of the Gitlab server, with protocol (i.e. http or https).
     type: str
   login_user:
     description:
+      - B(Deprecated)
       - Gitlab user name.
     type: str
   login_password:
     description:
+      - B(Deprecated)
       - Gitlab password for login_user
     type: str
   name:

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -176,7 +176,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible.module_utils.gitlab import (gitlab_auth_argument_spec, gitlab_module_kwargs,
-                                         gitlab, GitlabApiConnection, findGroup)
+                                         gitlab, deprecation_warning, GitlabApiConnection, findGroup)
 
 
 class GitLabUser(object):
@@ -391,12 +391,6 @@ class GitLabUser(object):
         user = self.userObject
 
         return user.delete()
-
-
-def deprecation_warning(module):
-    deprecated_aliases = ['login_token']
-
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
 
 
 def main():

--- a/lib/ansible/plugins/doc_fragments/gitlab.py
+++ b/lib/ansible/plugins/doc_fragments/gitlab.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+    # gitlab doc fragment.
+    DOCUMENTATION = r'''
+options:
+  api_token:
+    description:
+      - Gitlab token for logging in.
+    type: str
+    version_added: "2.8"
+    aliases:
+      - login_token
+      - private_token
+      - access_token
+  config_files:
+    description:
+      - Configuration file with Gitlab API connection details
+      - See python-gitlab documentation for syntax specification
+    type: list
+    version_added: "2.8"
+    default: ["/etc/python-gitlab.cfg", "~/.python-gitlab.cfg"]
+'''


### PR DESCRIPTION
##### SUMMARY

This adds support to [python-gitlab's configuration file](https://python-gitlab.readthedocs.io/en/stable/cli.html#files). Using it has following advantages:

- You save typing when describing a task,
- It might be more secure, than storing api token on the controller and passing it back and forth on each task execution
 
If this change gets approved, I'm willing to add same code to other *gitlab_** modules 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

gitlab_user

##### ADDITIONAL INFORMATION

before:

```- hosts: localhost
  tasks:
    - gitlab_user:
        api_url:  https://localhost:8443
        api_token: LUfFxzWWoYJqsY_W6JRk
        username: somebody
        validate_certs: no
        name: some body
        password: p@ssw0rd
        email: some@example.com
```

after:

```- hosts: localhost
  tasks:
    - gitlab_user:
        username: somebody
        name: somb body
        password: p@ssw0rd
        email: some@example.com
```
+ `~/.python-gitlab.cfg`:
```[global]
default = local
ssl_verify = false
[local]
url = https://localhost:8443
private_token = LUfFxzWWoYJqsY_W6JRk
api_version = 4
```