### PR TITLE
openssl_certificate: fix ACME provider

### DIFF
--- a/changelogs/fragments/54656-openssl_certificate-acme-chain.yml
+++ b/changelogs/fragments/54656-openssl_certificate-acme-chain.yml
@@ -1,5 +1,5 @@
 minor_changes:
 - "openssl_certificate - change default value for ``acme_chain`` from ``yes`` to ``no``. Current versions
-   of `acme-tiny <https://github.com/diafygi/acme-tiny/>`_ do not support the ``--chain`` command anymore,
-   whether this default setting causes the module not to work with such versions of acme-tiny until
-   ``acme_chain: no`` is explicitly set."
+   of `acme-tiny <https://github.com/diafygi/acme-tiny/>`_ do not support the ``--chain`` command anymore.
+   This default setting caused the module not to work with such versions of acme-tiny until
+   ``acme_chain: no`` was explicitly set."

--- a/changelogs/fragments/54656-openssl_certificate-acme-chain.yml
+++ b/changelogs/fragments/54656-openssl_certificate-acme-chain.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- "openssl_certificate - change default value for ``acme_chain`` from ``yes`` to ``no``. Current versions
+   of `acme-tiny <https://github.com/diafygi/acme-tiny/>`_ do not support the ``--chain`` command anymore,
+   whether this default setting causes the module not to work with such versions of acme-tiny until
+   ``acme_chain: no`` is explicitly set."

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1648,17 +1648,15 @@ class AcmeCertificate(Certificate):
 
         if not self.check(module, perms_required=False) or self.force:
             acme_tiny_path = self.module.get_bin_path('acme-tiny', required=True)
-            chain = ''
+            command = [acme_tiny_path]
             if self.use_chain:
-                chain = '--chain'
+                command.append('--chain')
+            command.extend(['--account-key', self.accountkey_path])
+            command.extend(['--csr', self.csr_path])
+            command.extend(['--acme-dir', self.challenge_path])
 
             try:
-                crt = module.run_command("%s %s --account-key %s --csr %s "
-                                         "--acme-dir %s" % (acme_tiny_path, chain,
-                                                            self.accountkey_path,
-                                                            self.csr_path,
-                                                            self.challenge_path),
-                                         check_rc=True)[1]
+                crt = module.run_command(command, check_rc=True)[1]
                 if self.backup:
                     self.backup_file = module.backup_local(self.path)
                 crypto_utils.write_file(module, to_bytes(crt))

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -211,8 +211,10 @@ options:
         description:
             - Include the intermediate certificate to the generated certificate
             - This is only used by the C(acme) provider.
+            - Note that this is only available for older versions of C(acme-tiny).
+              New versions include the chain automatically, and setting I(acme_chain) to C(yes) results in an error.
         type: bool
-        default: yes
+        default: no
         version_added: "2.5"
 
     signature_algorithms:
@@ -1736,7 +1738,7 @@ def main():
             # provider: acme
             acme_accountkey_path=dict(type='path'),
             acme_challenge_path=dict(type='path'),
-            acme_chain=dict(type='bool', default=True),
+            acme_chain=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
         add_file_common_args=True,


### PR DESCRIPTION
##### SUMMARY
Fixes #41396.

The fix changes the default value of `acme_chain` from `yes` to `no`, since the resulting command line argument to `acme-tiny` hasn't been available for some time.

I'm not sure whether this qualifies for a backport, since it changes behavior, but I'll try (so the RM can decide) once this is merged.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
