### PR TITLE
cloudstack: fix E326

### DIFF
--- a/changelogs/fragments/cloudstack_minors.yaml
+++ b/changelogs/fragments/cloudstack_minors.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - cs_zone - The option network_type uses capitalized values for the types e.g. 'Advanced' and 'Basic' to match the return from the API.
+  - cloudstack - The choice list for the param 'hypervisor' had been removed to allow the API to validate depending on your setup directly.

--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -22,17 +22,6 @@ except ImportError:
     CS_IMP_ERR = traceback.format_exc()
     HAS_LIB_CS = False
 
-CS_HYPERVISORS = [
-    'KVM', 'kvm',
-    'VMware', 'vmware',
-    'BareMetal', 'baremetal',
-    'XenServer', 'xenserver',
-    'LXC', 'lxc',
-    'HyperV', 'hyperv',
-    'UCS', 'ucs',
-    'OVM', 'ovm',
-    'Simulator', 'simulator',
-]
 
 if sys.version_info > (3,):
     long = int

--- a/lib/ansible/modules/cloud/cloudstack/cs_cluster.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_cluster.py
@@ -42,8 +42,8 @@ options:
     description:
       - Name the hypervisor to be used.
       - Required if I(state=present).
+      - Possible values are C(KVM), C(VMware), C(BareMetal), C(XenServer), C(LXC), C(HyperV), C(UCS), C(OVM), C(Simulator).
     type: str
-    choices: [ KVM, VMware, BareMetal, XenServer, LXC, HyperV, UCS, OVM ]
   url:
     description:
       - URL for the cluster
@@ -206,8 +206,7 @@ from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
     cs_argument_spec,
     cs_required_together,
-    CS_HYPERVISORS
-)
+  )
 
 
 class AnsibleCloudStackCluster(AnsibleCloudStack):
@@ -350,7 +349,7 @@ def main():
         zone=dict(),
         pod=dict(),
         cluster_type=dict(choices=['CloudManaged', 'ExternalManaged']),
-        hypervisor=dict(choices=CS_HYPERVISORS),
+        hypervisor=dict(),
         state=dict(choices=['present', 'enabled', 'disabled', 'absent'], default='present'),
         url=dict(),
         username=dict(),

--- a/lib/ansible/modules/cloud/cloudstack/cs_cluster.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_cluster.py
@@ -206,7 +206,7 @@ from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
     cs_argument_spec,
     cs_required_together,
-  )
+)
 
 
 class AnsibleCloudStackCluster(AnsibleCloudStack):

--- a/lib/ansible/modules/cloud/cloudstack/cs_host.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_host.py
@@ -53,8 +53,8 @@ options:
     description:
       - Name of the cluster.
       - Required if I(state=present) and host does not yet exist.
+      - Possible values are C(KVM), C(VMware), C(BareMetal), C(XenServer), C(LXC), C(HyperV), C(UCS), C(OVM), C(Simulator).
     type: str
-    choices: [ KVM, VMware, BareMetal, XenServer, LXC, HyperV, UCS, OVM, Simulator ]
   allocation_state:
     description:
       - Allocation state of the host.
@@ -330,7 +330,6 @@ from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
     cs_argument_spec,
     cs_required_together,
-    CS_HYPERVISORS
 )
 import time
 
@@ -592,7 +591,7 @@ def main():
         url=dict(),
         password=dict(no_log=True),
         username=dict(),
-        hypervisor=dict(choices=CS_HYPERVISORS),
+        hypervisor=dict(),
         allocation_state=dict(choices=['enabled', 'disabled', 'maintenance']),
         pod=dict(),
         cluster=dict(),

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -88,8 +88,8 @@ options:
       - Name the hypervisor to be used for creating the new instance.
       - Relevant when using I(state=present), but only considered if not set on ISO/template.
       - If not set or found on ISO/template, first found hypervisor will be used.
+      - Possible values are C(KVM), C(VMware), C(BareMetal), C(XenServer), C(LXC), C(HyperV), C(UCS), C(OVM), C(Simulator).
     type: str
-    choices: [ KVM, kvm, VMware, vmware, BareMetal, baremetal, XenServer, xenserver, LXC, lxc, HyperV, hyperv, UCS, ucs, OVM, ovm, Simulator, simulator ]
   keyboard:
     description:
       - Keyboard device type for the instance.
@@ -424,7 +424,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
-    CS_HYPERVISORS,
     cs_argument_spec,
     cs_required_together
 )
@@ -1041,7 +1040,7 @@ def main():
         disk_size=dict(type='int'),
         root_disk_size=dict(type='int'),
         keyboard=dict(type='str', choices=['de', 'de-ch', 'es', 'fi', 'fr', 'fr-be', 'fr-ch', 'is', 'it', 'jp', 'nl-be', 'no', 'pt', 'uk', 'us']),
-        hypervisor=dict(choices=CS_HYPERVISORS),
+        hypervisor=dict(),
         host=dict(),
         security_groups=dict(type='list', aliases=['security_group']),
         affinity_groups=dict(type='list', aliases=['affinity_group']),

--- a/lib/ansible/modules/cloud/cloudstack/cs_storage_pool.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_storage_pool.py
@@ -58,8 +58,8 @@ options:
   hypervisor:
     description:
       - Required when creating a zone scoped pool.
+      - Possible values are C(KVM), C(VMware), C(BareMetal), C(XenServer), C(LXC), C(HyperV), C(UCS), C(OVM), C(Simulator).
     type: str
-    choices: [ KVM, VMware, BareMetal, XenServer, LXC, HyperV, UCS, OVM, Simulator ]
   storage_tags:
     description:
       - Tags associated with this storage pool.
@@ -234,7 +234,6 @@ from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
     cs_argument_spec,
     cs_required_together,
-    CS_HYPERVISORS,
 )
 
 
@@ -468,7 +467,7 @@ def main():
         pod=dict(),
         cluster=dict(),
         scope=dict(choices=['zone', 'cluster']),
-        hypervisor=dict(choices=CS_HYPERVISORS),
+        hypervisor=dict(),
         provider=dict(default='DefaultPrimary'),
         capacity_bytes=dict(type='int'),
         capacity_iops=dict(type='int'),

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -121,26 +121,8 @@ options:
     description:
       - Name the hypervisor to be used for creating the new template.
       - Relevant when using I(state=present).
+      - Possible values are C(KVM), C(VMware), C(BareMetal), C(XenServer), C(LXC), C(HyperV), C(UCS), C(OVM), C(Simulator).
     type: str
-    choices:
-    - KVM
-    - kvm
-    - VMware
-    - vmware
-    - BareMetal
-    - baremetal
-    - XenServer
-    - xenserver
-    - LXC
-    - lxc
-    - HyperV
-    - hyperv
-    - UCS
-    - ucs
-    - OVM
-    - ovm
-    - Simulator
-    - simulator
   requires_hvm:
     description:
       - Whether the template requires HVM or not.
@@ -400,7 +382,6 @@ from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
     cs_argument_spec,
     cs_required_together,
-    CS_HYPERVISORS
 )
 
 
@@ -712,7 +693,7 @@ def main():
         checksum=dict(),
         template_filter=dict(default='self', choices=['all', 'featured', 'self', 'selfexecutable', 'sharedexecutable', 'executable', 'community']),
         template_find_options=dict(type='list', choices=['display_text', 'checksum', 'cross_zones'], aliases=['template_find_option'], default=[]),
-        hypervisor=dict(choices=CS_HYPERVISORS),
+        hypervisor=dict(),
         requires_hvm=dict(type='bool'),
         password_enabled=dict(type='bool'),
         template_tag=dict(),

--- a/lib/ansible/modules/cloud/cloudstack/cs_zone.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_zone.py
@@ -46,8 +46,8 @@ options:
     description:
       - Network type of the zone.
     type: str
-    default: basic
-    choices: [ basic, advanced ]
+    default: Basic
+    choices: [ Basic, Advanced ]
   dns1:
     description:
       - First DNS for the zone.
@@ -348,7 +348,7 @@ def main():
         internal_dns2=dict(),
         dns1_ipv6=dict(),
         dns2_ipv6=dict(),
-        network_type=dict(default='basic', choices=['Basic', 'basic', 'Advanced', 'advanced']),
+        network_type=dict(default='Basic', choices=['Basic', 'Advanced']),
         network_domain=dict(),
         guest_cidr_address=dict(),
         dhcp_provider=dict(),

--- a/test/integration/targets/cs_cluster/tasks/main.yml
+++ b/test/integration/targets/cs_cluster/tasks/main.yml
@@ -14,7 +14,7 @@
     name: "{{ cs_resource_prefix }}-zone"
     dns1: 8.8.8.8
     dns2: 8.8.4.4
-    network_type: basic
+    network_type: Basic
   register: zone
 - name: verify setup zone is present
   assert:

--- a/test/integration/targets/cs_cluster/tasks/main.yml
+++ b/test/integration/targets/cs_cluster/tasks/main.yml
@@ -48,7 +48,7 @@
   cs_cluster:
     name: "{{ cs_resource_prefix }}-cluster"
     zone: "{{ cs_resource_prefix }}-zone"
-    hypervisor: simulator
+    hypervisor: Simulator
     cluster_type: CloudManaged
     pod: unexistent
   register: cluster
@@ -63,7 +63,7 @@
   cs_cluster:
     name: "{{ cs_resource_prefix }}-cluster"
     zone: "{{ cs_resource_prefix }}-zone"
-    hypervisor: simulator
+    hypervisor: Simulator
     cluster_type: CloudManaged
   register: cluster_origin
   check_mode: true
@@ -77,7 +77,7 @@
   cs_cluster:
     name: "{{ cs_resource_prefix }}-cluster"
     zone: "{{ cs_resource_prefix }}-zone"
-    hypervisor: simulator
+    hypervisor: Simulator
     cluster_type: CloudManaged
   register: cluster_origin
   tags: disable
@@ -113,7 +113,7 @@
   cs_cluster:
     name: "{{ cs_resource_prefix }}-cluster"
     zone: "{{ cs_resource_prefix }}-zone"
-    hypervisor: simulator
+    hypervisor: Simulator
     cluster_type: ExternalManaged
   register: cluster
   check_mode: true
@@ -132,7 +132,7 @@
   cs_cluster:
     name: "{{ cs_resource_prefix }}-cluster"
     zone: "{{ cs_resource_prefix }}-zone"
-    hypervisor: simulator
+    hypervisor: Simulator
     cluster_type: ExternalManaged
   register: cluster
 - name: verify test update cluster
@@ -150,7 +150,7 @@
   cs_cluster:
     name: "{{ cs_resource_prefix }}-cluster"
     zone: "{{ cs_resource_prefix }}-zone"
-    hypervisor: simulator
+    hypervisor: Simulator
     cluster_type: ExternalManaged
   register: cluster
 - name: verify test update cluster idempotence

--- a/test/integration/targets/cs_physical_network/tasks/main.yml
+++ b/test/integration/targets/cs_physical_network/tasks/main.yml
@@ -5,7 +5,7 @@
     name: cs-test-zone
     state: present
     dns1: 8.8.8.8
-    network_type: advanced
+    network_type: Advanced
   register: cszone
 
 - name: ensure the zone is disabled

--- a/test/integration/targets/cs_pod/tasks/main.yml
+++ b/test/integration/targets/cs_pod/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ cs_resource_prefix }}-zone"
     dns1: 8.8.8.8
     dns2: 8.8.4.4
-    network_type: basic
+    network_type: Basic
   register: zone
 - name: verify setup zone is present
   assert:

--- a/test/integration/targets/cs_traffic_type/tasks/main.yml
+++ b/test/integration/targets/cs_traffic_type/tasks/main.yml
@@ -5,7 +5,7 @@
     name: cs-test-zone
     state: present
     dns1: 8.8.8.8
-    network_type: advanced
+    network_type: Advanced
   register: cszone
 
 - name: ensure the zone is disabled

--- a/test/integration/targets/cs_vlan_ip_range/tasks/main.yml
+++ b/test/integration/targets/cs_vlan_ip_range/tasks/main.yml
@@ -376,7 +376,7 @@
     name: cs-test-zone
     state: present
     dns1: 8.8.8.8
-    network_type: advanced
+    network_type: Advanced
   register: cszone
 
 - name: ensure the zone is disabled

--- a/test/integration/targets/cs_zone/tasks/main.yml
+++ b/test/integration/targets/cs_zone/tasks/main.yml
@@ -25,7 +25,7 @@
     name: "{{ cs_resource_prefix }}-zone"
     dns1: 8.8.8.8
     dns2: 8.8.4.4
-    network_type: basic
+    network_type: Basic
   register: zone
   check_mode: true
 - name: verify test create zone in check mode
@@ -39,7 +39,7 @@
     name: "{{ cs_resource_prefix }}-zone"
     dns1: 8.8.8.8
     dns2: 8.8.4.4
-    network_type: basic
+    network_type: Basic
   register: zone
 - name: verify test create zone
   assert:
@@ -61,7 +61,7 @@
     name: "{{ cs_resource_prefix }}-zone"
     dns1: 8.8.8.8
     dns2: 8.8.4.4
-    network_type: basic
+    network_type: Basic
   register: zone
 - name: verify test create zone idempotency
   assert:
@@ -86,7 +86,7 @@
     internal_dns1: 10.10.1.100
     internal_dns2: 10.10.1.101
     local_storage_enabled: true
-    network_type: basic
+    network_type: Basic
   register: zone
   check_mode: true
 - name: verify test update zone in check mode
@@ -112,7 +112,7 @@
     internal_dns1: 10.10.1.100
     internal_dns2: 10.10.1.101
     local_storage_enabled: true
-    network_type: basic
+    network_type: Basic
   register: zone
 - name: verify test update zone
   assert:
@@ -137,7 +137,7 @@
     internal_dns1: 10.10.1.100
     internal_dns2: 10.10.1.101
     local_storage_enabled: true
-    network_type: basic
+    network_type: Basic
   register: zone
 - name: verify test update zone idempotency
   assert:

--- a/test/integration/targets/cs_zone_facts/tasks/main.yml
+++ b/test/integration/targets/cs_zone_facts/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ cs_resource_prefix }}-zone"
     dns1: 8.8.8.8
     dns2: 8.8.4.4
-    network_type: basic
+    network_type: Basic
   register: zone
 - name: verify setup zone is present
   assert:

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -94,10 +94,6 @@ lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py E324
 lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py E326
 lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py E335
 lib/ansible/modules/cloud/centurylink/clc_server_snapshot.py E335
-lib/ansible/modules/cloud/cloudstack/cs_cluster.py E326
-lib/ansible/modules/cloud/cloudstack/cs_host.py E326
-lib/ansible/modules/cloud/cloudstack/cs_storage_pool.py E326
-lib/ansible/modules/cloud/cloudstack/cs_zone.py E326
 lib/ansible/modules/cloud/digital_ocean/_digital_ocean.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E324


### PR DESCRIPTION
##### SUMMARY
Fix E326s:
* The hypvervisor supported is depending on the setup anyway. Let's delegate the validation directly to the API. This should not break anything exisiting
* The network type should match the value of the API returned. However, this change will break existing playbooks, hence the minor change in changelog fragments

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudstack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
