### PR TITLE
network, eos_config: when the config session show no diff, set 'changed' to False

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -435,13 +435,16 @@ def main():
 
             response = load_config(module, commands, replace=replace, commit=commit)
 
-            if 'diff' in response and module.params['diff_against'] == 'session':
-                result['diff'] = {'prepared': response['diff']}
+            result['changed'] = True
+
+            if module.params['diff_against'] == 'session':
+                if 'diff' in response:
+                    result['diff'] = {'prepared': response['diff']}
+                else:
+                    result['changed'] = False
 
             if 'session' in response:
                 result['session'] = response['session']
-
-            result['changed'] = True
 
     running_config = module.params['running_config']
     startup_config = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Sometimes, config lines pushed to an Arista switch thanks to the `eos_config` module do not result in any change to the running config, at the end. That is the case when deleting a config line and re-inserting the same, for instance.

If we are using the EOS's "session" system there is even no change to the running config *during* the task, hence no risk of service disruption.

Also, there is no diff returned by the Arista switch. My change use this absence of diff to re-set `changed` to False in that particular case, which seems logical to me.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

My particular use-case is the following : before inserting a config block, I *negate* or *default* it (network equivalent to deleting the whole block). The goal is to make sure that no rogue (i.e. non-managed) config line remains. In other words, the goal is to replicate the `template` module where any manually added content would be removed.

I know I should use a combination of the `before` parameter (where I would put the negation/defaulting) and rely on the module to detect when the `before` + `src` needs to be pushed. However, every mode of the parameter `match` either always trigger the  push, or never does. It may be interesting to try and fix this, but at first glance this seemed above my skills. This PR seemed like a quick win instead.

Personally, I think it is better to rely on the switch OS to define whether the config changed or not (especially since that when a config line has the default parameters, it may not be displayed in the running config. I know, network vendors are weird...).

To reproduce : 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
spine-1.lab#show running-config interfaces Management1
interface Management1
   ip address 198.51.100.101/24
spine-1.lab#

$ cat inventories/lab/gns3/host_vars/spine-1.lab.yaml 
mgmt_ip: 198.51.100.101/24

$ cat test.yaml 
---
- hosts: inband_switches
  roles:
      - arista_switch

$ cat roles/arista_switch/tasks/main.yaml 
- name: Gathering EOS Facts
  action: eos_facts

- name: Management interface configuration
  eos_config:
      match: none
      src: templates/management-interface2.j2
      save_when: changed

  register: output
- name: output
  debug: msg="{{ output.commands }}"

$ cat roles/arista_switch/templates/management-interface2.j2 
default interface Management1
interface Management1
   ip address {{ mgmt_ip }}

$ ansible-playbook -i inventories/lab/gns3/inventory --limit spine-1.lab test.yaml 

PLAY [inband_switches] *****************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************
ok: [spine-1.lab]

TASK [arista_switch : Gathering EOS Facts] *********************************************************************************************************************************************************
ok: [spine-1.lab]

TASK [arista_switch : Management interface configuration] ******************************************************************************************************************************************
changed: [spine-1.lab]

TASK [arista_switch : output] **********************************************************************************************************************************************************************
ok: [spine-1.lab] => {
    "msg": [
        "default interface Management1",
        "interface Management1",
        "ip address 198.51.100.101/24"
    ]
}

PLAY RECAP *****************************************************************************************************************************************************************************************
spine-1.lab                : ok=4    changed=1    unreachable=0    failed=0   

```

After my changes : 
```
$ ansible-playbook -i inventories/lab/gns3/inventory --limit spine-1.lab test.yaml 

PLAY [inband_switches] *****************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************
ok: [spine-1.lab]

TASK [arista_switch : Gathering EOS Facts] *********************************************************************************************************************************************************
ok: [spine-1.lab]

TASK [arista_switch : Management interface configuration] ******************************************************************************************************************************************
ok: [spine-1.lab]

TASK [arista_switch : output] **********************************************************************************************************************************************************************
ok: [spine-1.lab] => {
    "msg": [
        "default interface Management1",
        "interface Management1",
        "ip address 198.51.100.101/24"
    ]
}

PLAY RECAP *****************************************************************************************************************************************************************************************
spine-1.lab                : ok=4    changed=0    unreachable=0    failed=0   
```

Here is an example of behavior when a rogue line should be deleted : 
```
spine-1.lab#show running-config interfaces Management1
interface Management1
   description This should not be here since there is no description in the Jinja2 template
   ip address 198.51.100.101/24

$ ansible-playbook -i inventories/lab/gns3/inventory --limit spine-1.lab test.yaml 

PLAY [inband_switches] *****************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************
ok: [spine-1.lab]

TASK [arista_switch : Gathering EOS Facts] *********************************************************************************************************************************************************
ok: [spine-1.lab]

TASK [arista_switch : Management interface configuration] ******************************************************************************************************************************************
--- system:/running-config
+++ session:/ansible_1554127545-session-config
@@ -43,7 +43,6 @@
 interface Ethernet12
 !
 interface Management1
-   description This should not be here since there is no description in the Jinja2 template
    ip address 198.51.100.101/24
 !
 ip route 0.0.0.0/0 198.51.100.1
changed: [spine-1.lab]

TASK [arista_switch : output] **********************************************************************************************************************************************************************
ok: [spine-1.lab] => {
    "msg": [
        "default interface Management1",
        "interface Management1",
        "ip address 198.51.100.101/24"
    ]
}

PLAY RECAP *****************************************************************************************************************************************************************************************
spine-1.lab                : ok=4    changed=1    unreachable=0    failed=0   

```