### PR TITLE
Backport/2.7/54105 pamd: fix idempotence issue when removing rules

### DIFF
--- a/changelogs/fragments/pamd-make-idempotence-fix.yaml
+++ b/changelogs/fragments/pamd-make-idempotence-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Backport of https://github.com/ansible/ansible/pull/54105, pamd - fix idempotence issue when removing rules

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -480,7 +480,7 @@ class PamdService(object):
                 else:
                     self._head = current_line.next
                     current_line.next.prev = None
-            changed += 1
+                changed += 1
 
             current_line = current_line.next
         return changed

--- a/test/units/modules/system/test_pamd.py
+++ b/test/units/modules/system/test_pamd.py
@@ -349,5 +349,7 @@ session    required pam_unix.so"""
 
     def test_remove_rule(self):
         self.assertTrue(self.pamd.remove('account', 'required', 'pam_unix.so'))
+        # Second run should not change anything
+        self.assertFalse(self.pamd.remove('account', 'required', 'pam_unix.so'))
         test_rule = PamdRule('account', 'required', 'pam_unix.so')
         self.assertNotIn(str(test_rule), str(self.pamd))


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/54105

###### COMPONENT NAME

`pamd`