### PR TITLE
[WIP] Don't use task args/params to pass loop info for includes

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -316,8 +316,8 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_include(self, included_file):
         msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        if 'item' in included_file._args:
-            msg += " => (item=%s)" % (self._get_item_label(included_file._args),)
+        if 'item' in included_file._task.vars:
+            msg += " => (item=%s)" % (self._get_item_label(included_file._task.vars),)
         self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -762,7 +762,6 @@ class StrategyBase:
         ti_copy._parent = included_file._task._parent
 
         temp_vars = ti_copy.vars.copy()
-        temp_vars.update(included_file._args)
 
         ti_copy.vars = temp_vars
 

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -51,11 +51,10 @@ def mock_variable_manager():
 def test_included_file_instantiation():
     filename = 'somefile.yml'
 
-    inc_file = IncludedFile(filename=filename, args=[], task=None)
+    inc_file = IncludedFile(filename=filename, task=None)
 
     assert isinstance(inc_file, IncludedFile)
     assert inc_file._filename == filename
-    assert inc_file._args == []
     assert inc_file._task is None
 
 
@@ -83,7 +82,6 @@ def test_process_include_results(mock_iterator, mock_variable_manager):
     assert len(res) == 1
     assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')
     assert res[0]._hosts == ['testhost1', 'testhost2']
-    assert res[0]._args == {}
 
 
 def test_process_include_diff_files(mock_iterator, mock_variable_manager):
@@ -121,9 +119,6 @@ def test_process_include_diff_files(mock_iterator, mock_variable_manager):
     assert res[0]._hosts == ['testhost1']
     assert res[1]._hosts == ['testhost2']
 
-    assert res[0]._args == {}
-    assert res[1]._args == {}
-
 
 def test_process_include_simulate_free(mock_iterator, mock_variable_manager):
     hostname = "testhost1"
@@ -156,6 +151,3 @@ def test_process_include_simulate_free(mock_iterator, mock_variable_manager):
 
     assert res[0]._hosts == ['testhost1']
     assert res[1]._hosts == ['testhost2']
-
-    assert res[0]._args == {}
-    assert res[1]._args == {}


### PR DESCRIPTION
##### SUMMARY
Don't use task args/params to pass loop info for includes

See #54618 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```