### PR TITLE
Add BusyBox support to group module

### DIFF
--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -11,7 +11,7 @@
   check_mode: True
 
 - name: get result of create group (check mode)
-  script: grouplist.sh "{{ ansible_distribution }}"
+  script: 'grouplist.sh "{{ ansible_distribution }}"'
   register: create_group_actual_check
 
 - name: assert create group (check mode)
@@ -27,7 +27,7 @@
   register: create_group
 
 - name: get result of create group
-  script: grouplist.sh "{{ ansible_distribution }}"
+  script: 'grouplist.sh "{{ ansible_distribution }}"'
   register: create_group_actual
 
 - name: assert create group
@@ -89,7 +89,7 @@
   check_mode: True
 
 - name: get result of create a group with a gid (check mode)
-  script: grouplist.sh "{{ ansible_distribution }}"
+  script: 'grouplist.sh "{{ ansible_distribution }}"'
   register: create_group_gid_actual_check
 
 - name: assert create group with a gid (check mode)
@@ -143,7 +143,7 @@
           that:
           - create_group_gid_non_unique is changed
           - create_group_gid_non_unique.gid | int == gid.stdout_lines[0] | int
-  when: ansible_facts.system != 'Darwin'
+  when: ansible_facts.distribution not in ['MacOSX', 'Alpine']
 
 ##
 ## group remove


### PR DESCRIPTION
##### SUMMARY

Fixes #29808

Use `addgroup` and `delgroup` for modifying groups on BusyBox based distributions.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`/lib/ansible/modules/system/group.py`

##### ADDITIONAL INFORMATION

Since there is no command for easily modifying groups, I modify `/etc/groups` directly when changing the GID of a group. Not sure if that is ok or not.