### PR TITLE
[WIP] nxos_file_copy parameter deprecation notice

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -251,9 +251,9 @@ def transfer_file_to_device(module, dest):
     if not enough_space(module):
         module.fail_json(msg='Could not transfer file. Not enough space on device.')
 
-    hostname = module.params['host']
-    username = module.params['username']
-    password = module.params['password']
+    hostname = module.params['nxos_host']
+    username = module.params['nxos_username']
+    password = module.params['nxos_password']
     port = module.params['connect_ssh_port']
 
     ssh = paramiko.SSHClient()
@@ -285,9 +285,9 @@ def transfer_file_to_device(module, dest):
 
 
 def copy_file_from_remote(module, local, local_file_directory, file_system='bootflash:'):
-    hostname = module.params['host']
-    username = module.params['username']
-    password = module.params['password']
+    hostname = module.params['nxos_host']
+    username = module.params['nxos_username']
+    password = module.params['nxos_password']
     port = module.params['connect_ssh_port']
 
     try:
@@ -368,7 +368,14 @@ def main():
         remote_scp_server_password=dict(no_log=True),
     )
 
+    nxos_file_copy_spec = {
+        'nxos_host': dict(type='str'),
+        'nxos_username': dict(type='str'),
+        'nxos_password': dict(no_log=True),
+    }
+
     argument_spec.update(nxos_argument_spec)
+    argument_spec.update(nxos_file_copy_spec)
 
     required_if = [("file_pull", True, ["remote_file", "remote_scp_server"]),
                    ("file_pull", False, ["local_file"])]
@@ -383,6 +390,7 @@ def main():
                            supports_check_mode=True)
 
     file_pull = module.params['file_pull']
+
 
     if file_pull:
         if not HAS_PEXPECT:

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -47,12 +47,12 @@ class ActionModule(ActionNetworkModule):
             return {'failed': True, 'msg': "Transport type 'nxapi' is not valid for '%s' module." % (self._task.action)}
 
         if self._task.action == 'nxos_file_copy':
-            self._task.args['host'] = self._play_context.remote_addr
-            self._task.args['password'] = self._play_context.password
+            self._task.args['nxos_host'] = self._play_context.remote_addr
+            self._task.args['nxos_password'] = self._play_context.password
             if self._play_context.connection == 'network_cli':
-                self._task.args['username'] = self._play_context.remote_user
+                self._task.args['nxos_username'] = self._play_context.remote_user
             elif self._play_context.connection == 'local':
-                self._task.args['username'] = self._play_context.connection_user
+                self._task.args['nxos_username'] = self._play_context.connection_user
 
         if self._task.action == 'nxos_install_os':
             persistent_command_timeout = 0


### PR DESCRIPTION
##### SUMMARY
Handle the following deprecation notices for `nxos_file_copy` module.

```
TASK [Copy NX-OS image] *****************************************************************************
[DEPRECATION WARNING]: Param 'username' is deprecated. See the module docs for more information.
This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information. This
feature will be removed in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information.
This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_file_copy`

##### ADDITIONAL INFORMATION
The `nxos_file_copy` uses parameters from the `nxos_argument_spec` that gets added to every nxos module that are being deprecated in the `2.9` release.

See: https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/network/nxos/nxos.py#L69

The `nxos_file_copy` module still needs credential information to copy files to the device so this update creates new parameters `nxos_host`, `nxos_username` and `nxos_password` that are specific to the `nxos_file_copy` module but they are not set in the playbook task but instead use the existing logic in the action plugin to get these from the controller environment.

Not sure if there is a better way to solve this problem but we can use this as a starting point.

**Update:** It appears that `validate-modules` check wants me to document the parameters.  I would prefer not to expose these as user configurable parameters in the module since the information is being provided in `group_vars` or ansible env.  Is there any way around this problem?