### PR TITLE
Fix for LaunchConfigName nor LaunchTemplate existing on ASG object

### DIFF
--- a/changelogs/fragments/54692-ec2_asg_fix_reading_properties.yml
+++ b/changelogs/fragments/54692-ec2_asg_fix_reading_properties.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_asg - Fix error where ASG dict has no launch config or launch template key

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -629,10 +629,13 @@ def get_properties(autoscaling_group):
                 instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
                                                    'lifecycle_state': i['LifecycleState'],
                                                    'launch_config_name': i['LaunchConfigurationName']}
-            else:
+            elif i.get('LaunchTemplate'):
                 instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
                                                    'lifecycle_state': i['LifecycleState'],
                                                    'launch_template': i['LaunchTemplate']}
+            else:
+                instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
+                                                   'lifecycle_state': i['LifecycleState']}
             if i['HealthStatus'] == 'Healthy' and i['LifecycleState'] == 'InService':
                 properties['viable_instances'] += 1
             if i['HealthStatus'] == 'Healthy':


### PR DESCRIPTION
##### SUMMARY
When attempting to use ec2_asg to make changes to an already existing autoscaling group, the module fails.

Fixes #50562

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_asg.py

##### ADDITIONAL INFORMATION
I was hiting an error when running my playbooks to modify auto-scaling groups and discovered the existing issue https://github.com/ansible/ansible/issues/50562.  Taking a further look I was able to get the following error message after adding a print debug line
```
The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 113, in <module>
  File "<stdin>", line 105, in _ansiballz_main
  File "<stdin>", line 48, in invoke_module
  File "/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py", line 1675, in <module>
  File "/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py", line 1661, in main
  File "/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py", line 1023, in create_autoscaling_group
  File "/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py", line 636, in get_properties
KeyError: 'LaunchTemplate'

failed: [localhost] (item=test-swarm-general-master-m5-large-master) => {
    "changed": false,
    "item": [
        {
            "associate_public_ip_address": false,
            "block_device_mappings": [],
            "classic_link_vpc_security_groups": [],
            "created_time": "2019-04-01 20:07:19.322000+00:00",
            "ebs_optimized": true,
            "iam_instance_profile": "test-swarm-general-role",
            "image_id": "ami-056d69b6d20f9f180",
            "instance_monitoring": false,
            "instance_type": "m5.large",
            "kernel_id": "",
            "key_name": "ansible-keypair",
            "launch_configuration_arn": "arn:aws:autoscaling:us-east-1:REDACTED:launchConfiguration:dd954e0f-8e3c-463c-b30b-41b1b698fbb0:launchConfigurationName/test-swarm-general-m5-large-master-20190401-1605",
            "launch_configuration_name": "test-swarm-general-m5-large-master-20190401-1605",
            "ramdisk_id": "",
            "security_groups": [
                "sg-02f86b76"
            ],
            "user_data": ""
        },
        {
            "alb_target_groups": [
                {
                    "alb_tg_health_check_interval": 120,
                    "alb_tg_health_check_path": "/v2/_catalog",
                    "alb_tg_health_check_port": 5000,
                    "alb_tg_health_check_protocol": "http",
                    "alb_tg_health_check_timeout": 15,
                    "alb_tg_healthy_threshold_count": 3,
                    "alb_tg_name": "us-east-1-test-dockerhub-5000",
                    "alb_tg_port": 5000,
                    "alb_tg_protocol": "http",
                    "alb_tg_return_code_matcher": 200,
                    "alb_tg_unhealthy_threshold_count": 3
                },
                {
                    "alb_tg_health_check_interval": 120,
                    "alb_tg_health_check_path": "/users/sign_in",
                    "alb_tg_health_check_port": "8085",
                    "alb_tg_health_check_protocol": "http",
                    "alb_tg_health_check_timeout": 15,
                    "alb_tg_healthy_threshold_count": 3,
                    "alb_tg_name": "test-swarm-general-gitlab",
                    "alb_tg_port": "8085",
                    "alb_tg_protocol": "http",
                    "alb_tg_return_code_matcher": 302,
                    "alb_tg_unhealthy_threshold_count": 3
                }
            ],
            "asg_alarm_arn": "arn:aws:sns:us-east-1:569557445448:loadbalancer_alarms",
            "asg_default_cooldown": 700,
            "asg_desired": 3,
            "asg_dimension": {
                "AutoScalingGroupName": "test-swarm-general-master"
            },
            "asg_evaluation_periods": 3,
            "asg_health_check_period": 300,
            "asg_max": 3,
            "asg_metric_namespace": "AWS/EC2",
            "asg_min": 3,
            "asg_period": 120,
            "asg_purpose": "master",
            "asg_scale_in_cooldown": 700,
            "asg_scale_metric": "CPUUtilization",
            "asg_scale_out_cooldown": 700,
            "asg_scalein_comparison": "<=",
            "asg_scalein_description": "This will alarm when CPU utilization is under 50% for 9 minutes",
            "asg_scalein_threshold": "30.0",
            "asg_scaleout_comparison": ">=",
            "asg_scaleout_description": "This will alarm when CPU utilization is over 80% for 9 minutes",
            "asg_scaleout_threshold": "80.0",
            "asg_statistic": "Average",
            "asg_unit": "Percent",
            "swarm_labels": [
                "swarm-general:true",
                "master:true"
            ],
            "type": "m5.large"
        }
    ],
    "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 113, in <module>\n  File \"<stdin>\", line 105, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module\n  File \"/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py\", line 1675, in <module>\n  File \"/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py\", line 1661, in main\n  File \"/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py\", line 1023, in create_autoscaling_group\n  File \"/tmp/ansible_ec2_asg_payload_6Npffj/__main__.py\", line 636, in get_properties\nKeyError: 'LaunchTemplate'\n",
    "module_stdout": "TESTING: {u'InstanceId': 'i-007caa4fef0eeb33f', u'ProtectedFromScaleIn': False, u'AvailabilityZone': 'us-east-1d', u'HealthStatus': 'Healthy', u'LifecycleState': 'InService'}\n",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

The print out was from the section where the error was hitting:
```
        for i in autoscaling_group_instances:
            print "TESTING: " + str(i)
            if i.get('LaunchConfigurationName'):
                instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
                                                   'lifecycle_state': i['LifecycleState'],
                                                   'launch_config_name': i['LaunchConfigurationName']}
            else:
                instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
                                                   'lifecycle_state': i['LifecycleState'],
                                                   'launch_template': i['LaunchTemplate']}
```
It turns out as evidenced by `"module_stdout": "TESTING: {u'InstanceId': 'i-007caa4fef0eeb33f', u'ProtectedFromScaleIn': False, u'AvailabilityZone': 'us-east-1d', u'HealthStatus': 'Healthy', u'LifecycleState': 'InService'}\n",` that there are in fact times where this will return without either `LaunchConfigurationName` or `LaunchTemplate` defined.  (The ASG in question has a LaunchConfig).

This PR adds a conditional to allow for neither to be defined and it does indeed seem to solve my issue without any unintended side-effects that I can tell.  