### PR TITLE
Clarify source of the host name

### DIFF
--- a/lib/ansible/modules/files/fetch.py
+++ b/lib/ansible/modules/files/fetch.py
@@ -34,6 +34,7 @@ options:
     - A directory to save the file into.
     - For example, if the I(dest) directory is C(/backup) a I(src) file named C(/etc/profile) on host
       C(host.example.com), would be saved into C(/backup/host.example.com/etc/profile).
+      The host name is based on the inventory name.
     required: yes
   fail_on_missing:
     version_added: '1.1'


### PR DESCRIPTION
##### SUMMARY

The documentation of `fetch.py` seemed ambiguous about which hostname would be chosen from several possibilities within Ansible.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Clarifies `fetch.py` documentation.

##### ADDITIONAL INFORMATION

The host could have been either the inventory name (`inventory_hostname`) or the discovered hostname (`ansible_hostname`)

Inspecting the source code of `fetch.py` shows that the inventory name is preferred.

```
if 'inventory_hostname' in task_vars:
                    target_name = task_vars['inventory_hostname']
```

I consider this a trivial improvement and release any copyright on this change.
