### PR TITLE
win_credential - fix encoding for text based secrets

### DIFF
--- a/lib/ansible/modules/windows/win_credential.ps1
+++ b/lib/ansible/modules/windows/win_credential.ps1
@@ -555,7 +555,7 @@ if ($null -ne $secret) {
     if ($secret_format -eq "base64") {
         $secret = [System.Convert]::FromBase64String($secret)
     } else {
-        $secret = [System.Text.Encoding]::UTF8.GetBytes($secret)
+        $secret = [System.Text.Encoding]::Unicode.GetBytes($secret)
     }
 }
 

--- a/lib/ansible/modules/windows/win_credential.py
+++ b/lib/ansible/modules/windows/win_credential.py
@@ -45,7 +45,8 @@ options:
       data_format:
         description:
         - Controls the input type for I(data).
-        - If C(text), I(data) is a text string that is UTF-8 encoded to bytes.
+        - If C(text), I(data) is a text string that is UTF-16LE encoded to
+          bytes.
         - If C(base64), I(data) is a base64 string that is base64 decoded to
           bytes.
         type: str
@@ -88,7 +89,7 @@ options:
   secret_format:
     description:
     - Controls the input type for I(secret).
-    - If C(text), I(secret) is a text string that is UTF-8 encoded to bytes.
+    - If C(text), I(secret) is a text string that is UTF-16LE encoded to bytes.
     - If C(base64), I(secret) is a base64 string that is base64 decoded to
       bytes.
     type: str

--- a/test/integration/targets/win_credential/tasks/tests.yml
+++ b/test/integration/targets/win_credential/tasks/tests.yml
@@ -419,7 +419,7 @@
     - generic_password_actual.comment == None
     - generic_password_actual.name == test_hostname
     - generic_password_actual.persistence == "Enterprise"
-    - generic_password_actual.secret == "genericpass"|b64encode
+    - generic_password_actual.secret == "genericpass"|b64encode(encoding='utf-16-le')
     - generic_password_actual.type == "Generic"
     - generic_password_actual.username == "genericuser"
 

--- a/test/integration/targets/win_credential/tasks/tests.yml
+++ b/test/integration/targets/win_credential/tasks/tests.yml
@@ -409,6 +409,10 @@
   register: generic_password_actual
   vars: *become_vars
 
+- name: set encoded password result
+  set_fact:
+    encoded_pass: '{{ "genericpass" | string | b64encode(encoding="utf-16-le") }}'
+
 - name: assert create generic password
   assert:
     that:
@@ -419,7 +423,7 @@
     - generic_password_actual.comment == None
     - generic_password_actual.name == test_hostname
     - generic_password_actual.persistence == "Enterprise"
-    - generic_password_actual.secret == "genericpass"|b64encode(encoding='utf-16-le')
+    - generic_password_actual.secret == encoded_pass
     - generic_password_actual.type == "Generic"
     - generic_password_actual.username == "genericuser"
 


### PR DESCRIPTION
##### SUMMARY
I made a mistake when creating the module, the secrets should be UTF-16LE encoded bytes and not UTF-8. This PR fixes this issue to use the correct encoding so that interactive Windows users can use the stored credentials properly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_credential