### PR TITLE
Remove paramiko as a hard dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@
 # be suitable)
 jinja2
 PyYAML
-paramiko
 cryptography


### PR DESCRIPTION
We operate just fine without paramiko.  So remove paramiko from the
requirements.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt

##### ADDITIONAL INFORMATION
Note that this means that pip install ansible will no longer pull in paramiko as well.