### PR TITLE
Ansible.Basic - event log perm fix and no_log improv

### DIFF
--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -315,7 +315,11 @@ namespace Ansible.Basic
             using (EventLog eventLog = new EventLog("Application"))
             {
                 eventLog.Source = logSource;
-                eventLog.WriteEntry(message, logEntryType, 0);
+                try
+                {
+                    eventLog.WriteEntry(message, logEntryType, 0);
+                }
+                catch (System.InvalidOperationException) { }  // Ignore permission errors on the Application event log
             }
         }
 
@@ -1249,7 +1253,7 @@ namespace Ansible.Basic
                     return "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER";
                 foreach (string omitMe in noLogStrings)
                     if (stringValue.Contains(omitMe))
-                        return (stringValue).Replace(omitMe, new String('*', omitMe.Length));
+                        return (stringValue).Replace(omitMe, "********");
                 value = stringValue;
             }
             return value;

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -320,6 +320,11 @@ namespace Ansible.Basic
                     eventLog.WriteEntry(message, logEntryType, 0);
                 }
                 catch (System.InvalidOperationException) { }  // Ignore permission errors on the Application event log
+                catch (System.Exception e)
+                {
+                    // Cannot call Warn as that calls LogEvent and we get stuck in a loop
+                    warnings.Add(String.Format("Unknown error when creating event log entry: {0}", e.Message));
+                }
             }
         }
 

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -657,25 +657,25 @@ $tests = @{
                         dict = @{
                             pass = "plain"
                             hide = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-                            sub_hide = "****word"
+                            sub_hide = "********word"
                             int_hide = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
                         }
                         custom = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
                         list = @(
                             "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
-                            "****word",
+                            "********word",
                             "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                             "pa ss",
                             @{
                                 pass = "plain"
                                 hide = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-                                sub_hide = "****word"
+                                sub_hide = "********word"
                                 int_hide = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
                             }
                         )
-                        data = "Oops this is secret: ****"
+                        data = "Oops this is secret: ********"
                     }
-                    username = "user - **** - name"
+                    username = "user - ******** - name"
                     password = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
                 }
             }
@@ -686,21 +686,21 @@ $tests = @{
 
         $expected_event = @'
 test_no_log - Invoked with:
-  username: user - **** - name
+  username: user - ******** - name
   dict: dict: sub_hide: ****word
       pass: plain
-      int_hide: ****56
+      int_hide: ********56
       hide: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
-      data: Oops this is secret: ****
+      data: Oops this is secret: ********
       custom: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
       list: 
       - VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
-      - ****word
-      - ****567
+      - ********word
+      - ********567
       - pa ss
-      - sub_hide: ****word
+      - sub_hide: ********word
           pass: plain
-          int_hide: ****56
+          int_hide: ********56
           hide: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
   password2: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
   password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
@@ -1898,7 +1898,7 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equals -Expected $true
 
-        $expected_msg = "value of option_key must be one of: a, b. Got no match for: ***"
+        $expected_msg = "value of option_key must be one of: a, b. Got no match for: ********"
 
         $actual.Keys.Count | Assert-Equals -Expected 4
         $actual.changed | Assert-Equals -Expected $false


### PR DESCRIPTION
##### SUMMARY
Fixes 2 issues;

* The Application event log cannot be written to Network sourced logons that do not have admin permissions. We catch this error and just continue working as it isn't critical to the modules operations
* To better align with no_log in basic.py, we substitute found no_log values with a fixed length of `********` instead of `*` per replaced char

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs