### PR TITLE
psrp - auth options

### DIFF
--- a/changelogs/fragments/psrp-options.yaml
+++ b/changelogs/fragments/psrp-options.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- psrp - Explicitly documented the extra auth options that could have been passed in - https://github.com/ansible/ansible/issues/54664

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -157,6 +157,87 @@ options:
     type: bool
     default: 'no'
 
+  # auth options
+  certificate_key_pem:
+    description:
+    - The local path to an X509 certificate key to use with certificate auth.
+    vars:
+    - name: ansible_psrp_certificate_key_pem
+  certificate_pem:
+    description:
+    - The local path to an X509 certificate to use with certificate auth.
+    vars:
+    - name: ansible_psrp_certificate_pem
+  credssp_auth_mechanism:
+    description:
+    - The sub authentication mechanism to use with CredSSP auth.
+    - When C(auto), both Kerberos and NTLM is attempted with kerberos being
+      preferred.
+    choices:
+    - auto
+    - kerberos
+    - ntlm
+    default: auto
+    vars:
+    - name: ansible_psrp_credssp_auth_mechanism
+  credssp_disable_tlsv1_2:
+    description:
+    - Disables the use of TLSv1.2 on the CredSSP authentication channel.
+    - This should not be set to C(yes) unless dealing with a host that does not
+      have TLSv1.2.
+    default: no
+    type: bool
+    vars:
+    - name: ansible_psrp_credssp_disable_tlsv1_2
+  credssp_minimum_version:
+    description:
+    - The minimum CredSSP server authentication version that will be accepted.
+    - Set to C(5) to ensure the server has been patched and is not vulnerable
+      to CVE 2018-0886.
+    default: 2
+    type: int
+    vars:
+    - name: ansible_psrp_credssp_minimum_version
+  negotiate_delegate:
+    description:
+    - Allow the remote user the ability to delegate it's credentials to another
+      server, i.e. credential delegation.
+    - Only valid when Kerberos was the negotiated auth or was explicitly set as
+      the authentication.
+    - Ignored when NTLM was the negotiated auth.
+    vars:
+    - name: ansible_psrp_negotiate_delegate
+  negotiate_hostname_override:
+    description:
+    - Override the remote hostname when searching for the host in the Kerberos
+      lookup.
+    - This allows Ansible to connect over IP but authenticate with the remote
+      server using it's DNS name.
+    - Only valid when Kerberos was the negotiated auth or was explicitly set as
+      the authentication.
+    - Ignored when NTLM was the negotiated auth.
+    vars:
+    - name: ansible_psrp_negotiate_hostname_override
+  negotiate_send_cbt:
+    description:
+    - Send the Channel Binding Token (CBT) structure when authenticating.
+    - CBT is used to provide extra protection against Man in the Middle C(MitM)
+      attacks by binding the outer transport channel to the auth channel.
+    - CBT is not used when using just C(HTTP), only C(HTTPS).
+    default: yes
+    type: bool
+    vars:
+    - name: ansible_psrp_negotiate_send_cbt
+  negotiate_service:
+    description:
+    - Override the service part of the SPN used during Kerberos authentication.
+    - Only valid when Kerberos was the negotiated auth or was explicitly set as
+      the authentication.
+    - Ignored when NTLM was the negotiated auth.
+    default: WSMAN
+    vars:
+    - name: ansible_psrp_negotiate_service
+
   # protocol options
   operation_timeout:
     description:
@@ -537,6 +618,16 @@ if ($bytes_read -gt 0) {
         self._psrp_reconnection_retries = int(self.get_option('reconnection_retries'))
         self._psrp_reconnection_backoff = float(self.get_option('reconnection_backoff'))
 
+        self._psrp_certificate_key_pem = self.get_option('certificate_key_pem')
+        self._psrp_certificate_pem = self.get_option('certificate_pem')
+        self._psrp_credssp_auth_mechanism = self.get_option('credssp_auth_mechanism')
+        self._psrp_credssp_disable_tlsv1_2 = self.get_option('credssp_disable_tlsv1_2')
+        self._psrp_credssp_minimum_version = self.get_option('credssp_minimum_version')
+        self._psrp_negotiate_send_cbt = self.get_option('negotiate_send_cbt')
+        self._psrp_negotiate_delegate = self.get_option('negotiate_delegate')
+        self._psrp_negotiate_hostname_override = self.get_option('negotiate_hostname_override')
+        self._psrp_negotiate_service = self.get_option('negotiate_service')
+
         supported_args = []
         for auth_kwarg in AUTH_KWARGS.values():
             supported_args.extend(auth_kwarg)
@@ -558,6 +649,15 @@ if ($bytes_read -gt 0) {
             no_proxy=self._psrp_ignore_proxy,
             max_envelope_size=self._psrp_max_envelope_size,
             operation_timeout=self._psrp_operation_timeout,
+            certificate_key_pem=self._psrp_certificate_key_pem,
+            certificate_pem=self._psrp_certificate_pem,
+            credssp_auth_mechanism=self._psrp_credssp_auth_mechanism,
+            credssp_disable_tlsv1_2=self._psrp_credssp_disable_tlsv1_2,
+            credssp_minimum_version=self._psrp_credssp_minimum_version,
+            negotiate_send_cbt=self._psrp_negotiate_send_cbt,
+            negotiate_delegate=self._psrp_negotiate_delegate,
+            negotiate_hostname_override=self._psrp_negotiate_hostname_override,
+            negotiate_service=self._psrp_negotiate_service,
         )
 
         # Check if PSRP version supports newer read_timeout argument (needs pypsrp 0.3.0+)


### PR DESCRIPTION
##### SUMMARY
Explicitly document each extra auth option that was allowed to be used but not documented. CI will fail due to `version_added` not being set but these options have been valid since this connection plugin was first created.

Fixes https://github.com/ansible/ansible/issues/54664.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
psrp