### PR TITLE
Add openssl_certificate_info module

### DIFF
--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -14,6 +14,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+# --------------------------------------------------------------
+# A clearly marked portion of this file is licensed under the BSD
+# Copyright (c) 2015, 2016 Paul Kehrer (@reaperhulk)
+# Copyright (c) 2017 Fraser Tweedale (@frasertweedale)
+# For more details, search for the function _obj2txt().
 
 
 try:
@@ -36,6 +42,7 @@ except ImportError:
 
 
 import abc
+import base64
 import binascii
 import datetime
 import errno
@@ -377,6 +384,103 @@ def pyopenssl_normalize_name(name):
         b_name = OpenSSL._util.lib.OBJ_nid2ln(nid)
         name = to_text(OpenSSL._util.ffi.string(b_name))
     return _NORMALIZE_NAMES.get(name, name)
+
+
+# #####################################################################################
+# #####################################################################################
+# # This excerpt is dual licensed under the terms of the Apache License, Version
+# # 2.0, and the BSD License. See the LICENSE file at
+# # https://github.com/pyca/cryptography/blob/master/LICENSE for complete details.
+# #
+# # Adapted from cryptography's hazmat/backends/openssl/decode_asn1.py
+# #
+# # Copyright (c) 2015, 2016 Paul Kehrer (@reaperhulk)
+# # Copyright (c) 2017 Fraser Tweedale (@frasertweedale)
+# #
+# # Relevant commits from cryptography project (https://github.com/pyca/cryptography):
+# #    pyca/cryptography@719d536dd691e84e208534798f2eb4f82aaa2e07
+# #    pyca/cryptography@5ab6d6a5c05572bd1c75f05baf264a2d0001894a
+# #    pyca/cryptography@2e776e20eb60378e0af9b7439000d0e80da7c7e3
+# #    pyca/cryptography@fb309ed24647d1be9e319b61b1f2aa8ebb87b90b
+# #    pyca/cryptography@2917e460993c475c72d7146c50dc3bbc2414280d
+# #    pyca/cryptography@3057f91ea9a05fb593825006d87a391286a4d828
+# #    pyca/cryptography@d607dd7e5bc5c08854ec0c9baff70ba4a35be36f
+def _obj2txt(openssl_lib, openssl_ffi, obj):
+    # Set to 80 on the recommendation of
+    # https://www.openssl.org/docs/crypto/OBJ_nid2ln.html#return_values
+    #
+    # But OIDs longer than this occur in real life (e.g. Active
+    # Directory makes some very long OIDs).  So we need to detect
+    # and properly handle the case where the default buffer is not
+    # big enough.
+    #
+    buf_len = 80
+    buf = openssl_ffi.new("char[]", buf_len)
+
+    # 'res' is the number of bytes that *would* be written if the
+    # buffer is large enough.  If 'res' > buf_len - 1, we need to
+    # alloc a big-enough buffer and go again.
+    res = openssl_lib.OBJ_obj2txt(buf, buf_len, obj, 1)
+    if res > buf_len - 1:  # account for terminating null byte
+        buf_len = res + 1
+        buf = openssl_ffi.new("char[]", buf_len)
+        res = openssl_lib.OBJ_obj2txt(buf, buf_len, obj, 1)
+    return openssl_ffi.buffer(buf, res)[:].decode()
+# #####################################################################################
+# #####################################################################################
+
+
+def cryptography_get_extensions_from_cert(cert):
+    # Since cryptography won't give us the DER value for an extension
+    # (that is only stored for unrecognized extensions), we have to re-do
+    # the extension parsing outselves.
+    result = dict()
+    backend = cert._backend
+    x509_obj = cert._x509
+
+    for i in range(backend._lib.X509_get_ext_count(x509_obj)):
+        ext = backend._lib.X509_get_ext(x509_obj, i)
+        if ext == backend._ffi.NULL:
+            continue
+        crit = backend._lib.X509_EXTENSION_get_critical(ext)
+        data = backend._lib.X509_EXTENSION_get_data(ext)
+        backend.openssl_assert(data != backend._ffi.NULL)
+        der = backend._ffi.buffer(data.data, data.length)[:]
+        entry = dict(
+            critical=(crit == 1),
+            value=base64.b64encode(der),
+        )
+        oid = _obj2txt(backend._lib, backend._ffi, backend._lib.X509_EXTENSION_get_object(ext))
+        result[oid] = entry
+    return result
+
+
+def pyopenssl_get_extensions_from_cert(cert):
+    # While pyOpenSSL allows us to get an extension's DER value, it won't
+    # give us the dotted string for an OID. So we have to do some magic to
+    # get hold of it.
+    result = dict()
+    ext_count = cert.get_extension_count()
+    for i in range(0, ext_count):
+        ext = cert.get_extension(i)
+        entry = dict(
+            critical=bool(ext.get_critical()),
+            value=base64.b64encode(ext.get_data()),
+        )
+        oid = _obj2txt(
+            OpenSSL._util.lib,
+            OpenSSL._util.ffi,
+            OpenSSL._util.lib.X509_EXTENSION_get_object(ext._extension)
+        )
+        # This could also be done a bit simpler:
+        #
+        #   oid = _obj2txt(OpenSSL._util.lib, OpenSSL._util.ffi, OpenSSL._util.lib.OBJ_nid2obj(ext._nid))
+        #
+        # Unfortunately this gives the wrong result in case the linked OpenSSL
+        # doesn't know the OID. That's why we have to get the OID dotted string
+        # similarly to how cryptography does it.
+        result[oid] = entry
+    return result
 
 
 def crpytography_name_to_oid(name):

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -343,6 +343,7 @@ class OpenSSLObject(object):
 
 _OID_MAP = {
     # First entry is 'canonical' name
+    "2.5.29.37.0": ('Any Extended Key Usage', 'anyExtendedKeyUsage'),
     "1.3.6.1.5.5.7.1.3": ('qcStatements', ),
     "1.3.6.1.5.5.7.3.10": ('DVCS', 'dvcs'),
     "1.3.6.1.5.5.7.3.7": ('IPSec User', 'ipsecUser'),
@@ -360,6 +361,7 @@ _NORMALIZE_NAMES = {
     'SN': 'surname',
     'GN': 'givenName',
     'UID': 'userId',
+    'userID': 'userId',
     'DC': 'domainComponent',
     'jurisdictionC': 'jurisdictionCountryName',
     'jurisdictionL': 'jurisdictionLocalityName',
@@ -370,7 +372,6 @@ _NORMALIZE_NAMES = {
     'emailProtection': 'E-mail Protection',
     'timeStamping': 'Time Stamping',
     'OCSPSigning': 'OCSP Signing',
-    'anyExtendedKeyUsage': 'Any Extended Key Usage',
 }
 
 for dotted, names in _OID_MAP.items():
@@ -514,7 +515,7 @@ def crpytography_name_to_oid(name):
         return x509.oid.NameOID.DN_QUALIFIER
     if name in ('pseudonym', ):
         return x509.oid.NameOID.PSEUDONYM
-    if name in ('UID', 'userId'):
+    if name in ('UID', 'userId', 'UserID'):
         return x509.oid.NameOID.USER_ID
     if name in ('DC', 'domainComponent'):
         return x509.oid.NameOID.DOMAIN_COMPONENT
@@ -555,9 +556,7 @@ def crpytography_name_to_oid(name):
 def crpytography_oid_to_name(oid):
     dotted_string = oid.dotted_string
     names = _OID_MAP.get(dotted_string)
-    if names:
-        return names[0]
-    name = oid._name
+    name = names[0] if names else oid._name
     return _NORMALIZE_NAMES.get(name, name)
 
 
@@ -596,7 +595,7 @@ def cryptography_get_name_oid(id):
         return x509.oid.NameOID.DN_QUALIFIER
     if id in ('pseudonym', ):
         return x509.oid.NameOID.PSEUDONYM
-    if id in ('UID', 'userId'):
+    if id in ('UID', 'userId', 'userID'):
         return x509.oid.NameOID.USER_ID
     if id in ('DC', 'domainComponent'):
         return x509.oid.NameOID.DOMAIN_COMPONENT
@@ -736,7 +735,7 @@ def cryptography_get_ext_keyusage(usage):
     if usage in ('OCSPSigning', 'OCSP Signing'):
         return x509.oid.ExtendedKeyUsageOID.OCSP_SIGNING
     if usage in ('anyExtendedKeyUsage', 'Any Extended Key Usage'):
-        return x509.oid.ExtendedKeyUsageOID.ANY_EXTENDED_KEY_USAGE
+        return x509.oid.ObjectIdentifier("2.5.29.37.0")
     if usage in ('qcStatements', ):
         return x509.oid.ObjectIdentifier("1.3.6.1.5.5.7.1.3")
     if usage in ('DVCS', 'dvcs'):

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -71,6 +71,9 @@ EXAMPLES = r'''
     csr_path: /etc/ssl/csr/ansible.com.csr
     provider: selfsigned
 
+
+# Get information on the certificate
+
 - name: Get information on generated certificate
   openssl_certificate_info:
     path: /etc/ssl/crt/ansible.com.crt
@@ -80,14 +83,22 @@ EXAMPLES = r'''
   debug:
     var: result
 
-- name: Check that certificate is valid tomorrow, but not in three weeks
+
+# Check whether the certificate is valid or not valid at certain times, fail
+# if this is not the case. The first task (openssl_certificate_info) collects
+# the information, and the second task (assert) validates the result and
+# makes the playbook fail in case something is not as expected.
+
+- name: Test whether that certificate is valid tomorrow and/or in three weeks
   openssl_certificate_info:
     path: /etc/ssl/crt/ansible.com.crt
     valid_at:
       point_1: "+1d"
       point_2: "+3w"
   register: result
-- assert:
+
+- name: Validate that certificate is valid tomorrow, but not in three weeks
+  assert:
     that:
       - result.valid_at.point_1      # valid in one day
       - not result.valid_at.point_2  # not valid in three weeks

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -665,7 +665,7 @@ def main():
 
             # Fail if no backend has been found
             if backend == 'auto':
-                module.fail_json(msg=("Can't detect none of the required Python libraries "
+                module.fail_json(msg=("Can't detect any of the required Python libraries "
                                       "cryptography (>= {0}) or PyOpenSSL (>= {1})").format(
                                           MINIMAL_CRYPTOGRAPHY_VERSION,
                                           MINIMAL_PYOPENSSL_VERSION))

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -663,10 +663,6 @@ def main():
             elif can_use_pyopenssl:
                 backend = 'pyopenssl'
 
-            if module.params['selfsigned_version'] == 2 or module.params['ownca_version'] == 2:
-                module.warn('crypto backend forced to pyopenssl. The cryptography library does not support v2 certificates')
-                backend = 'pyopenssl'
-
             # Fail if no backend has been found
             if backend == 'auto':
                 module.fail_json(msg=("Can't detect none of the required Python libraries "

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -1,0 +1,499 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2016-2017, Yanis Guenane <yanis+ansible@guenane.org>
+# Copyright: (c) 2017, Markus Teufelberger <mteufelberger+ansible@mgit.at>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: openssl_certificate_info
+version_added: '2.8'
+short_description: Provide information of OpenSSL X.509 certificates
+description:
+    - This module allows one to query information on OpenSSL certificates.
+    - It uses the pyOpenSSL or cryptography python library to interact with OpenSSL. If both the
+      cryptography and PyOpenSSL libraries are available (and meet the minimum version requirements)
+      cryptography will be preferred as a backend over PyOpenSSL (unless the backend is forced with
+      C(select_crypto_backend))
+requirements:
+    - PyOpenSSL >= 0.15 or cryptography >= 1.6
+author:
+  - Felix Fontein (@felixfontein)
+  - Yanis Guenane (@Spredzy)
+  - Markus Teufelberger (@MarkusTeufelberger)
+options:
+    path:
+        description:
+            - Remote absolute path where the certificate file is loaded from.
+        type: path
+        required: true
+    valid_at:
+        description:
+            - A dict of names mapping to time specifications. Every time specified here
+              will be checked whether the certificate is valid at this point. See the
+              C(valid_at) return value for informations on the result.
+            - Time can be specified either as relative time or as absolute timestamp.
+            - Time will always be interpreted as UTC.
+            - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
+              + C([w | d | h | m | s]) (e.g. C(+32w1d2h), and ASN.1 TIME (i.e. pattern C(YYYYMMDDHHMMSSZ)).
+              Note that all timestamps will be treated as being in UTC.
+
+    select_crypto_backend:
+        description:
+            - Determines which crypto backend to use.
+            - The default choice is C(auto), which tries to use C(cryptography) if available, and falls back to C(pyopenssl).
+            - If set to C(pyopenssl), will try to use the L(pyOpenSSL,https://pypi.org/project/pyOpenSSL/) library.
+            - If set to C(cryptography), will try to use the L(cryptography,https://cryptography.io/) library.
+        type: str
+        default: auto
+        choices: [ auto, cryptography, pyopenssl ]
+
+notes:
+    - All timestamp values are provided in ASN.1 TIME format, i.e. following the C(YYYYMMDDHHMMSSZ) pattern.
+      They are all in UTC.
+seealso:
+- module: openssl_certificate
+'''
+
+EXAMPLES = r'''
+- name: Generate a Self Signed OpenSSL certificate
+  openssl_certificate:
+    path: /etc/ssl/crt/ansible.com.crt
+    privatekey_path: /etc/ssl/private/ansible.com.pem
+    csr_path: /etc/ssl/csr/ansible.com.csr
+    provider: selfsigned
+
+- name: Get information on generated certificate
+  openssl_certificate_info:
+    path: /etc/ssl/crt/ansible.com.crt
+  register: result
+
+- name: Dump information
+  debug:
+    var: result
+
+- name: Check that certificate is valid tomorrow, but not in three weeks
+  openssl_certificate_info:
+    path: /etc/ssl/crt/ansible.com.crt
+    valid_at:
+      point_1: "+1d"
+      point_2: "+3w"
+  register: result
+- assert:
+    that:
+      - result.valid_at.point_1      # valid in one day
+      - not result.valid_at.point_2  # not valid in three weeks
+'''
+
+RETURN = r'''
+filename:
+    description: Path to the generated Certificate
+    returned: changed or success
+    type: str
+    sample: /etc/ssl/crt/www.ansible.com.crt
+'''
+
+
+import abc
+import datetime
+import os
+import traceback
+from distutils.version import LooseVersion
+
+from ansible.module_utils import crypto as crypto_utils
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native, to_bytes, to_text
+
+MINIMAL_CRYPTOGRAPHY_VERSION = '1.6'
+MINIMAL_PYOPENSSL_VERSION = '0.15'
+
+PYOPENSSL_IMP_ERR = None
+try:
+    import OpenSSL
+    from OpenSSL import crypto
+    PYOPENSSL_VERSION = LooseVersion(OpenSSL.__version__)
+except ImportError:
+    PYOPENSSL_IMP_ERR = traceback.format_exc()
+    PYOPENSSL_FOUND = False
+else:
+    PYOPENSSL_FOUND = True
+
+CRYPTOGRAPHY_IMP_ERR = None
+try:
+    import cryptography
+    from cryptography import x509
+    from cryptography.x509 import NameAttribute, Name
+    from cryptography.hazmat.primitives import serialization
+    CRYPTOGRAPHY_VERSION = LooseVersion(cryptography.__version__)
+except ImportError:
+    CRYPTOGRAPHY_IMP_ERR = traceback.format_exc()
+    CRYPTOGRAPHY_FOUND = False
+else:
+    CRYPTOGRAPHY_FOUND = True
+
+
+TIMESTAMP_FORMAT = "%Y%m%d%H%M%SZ"
+
+
+def get_relative_time_option(input_string, input_name):
+    """Return an ASN1 formatted string if a relative timespec
+       or an ASN1 formatted string is provided."""
+    result = input_string
+    if result.startswith("+") or result.startswith("-"):
+        return crypto_utils.convert_relative_to_datetime(result)
+    if result is None:
+        raise crypto_utils.CertificateError(
+            'The timespec "%s" for %s is not valid' %
+            input_string, input_name)
+    for date_fmt in ['%Y%m%d%H%M%SZ', '%Y%m%d%H%MZ', '%Y%m%d%H%M%S%z', '%Y%m%d%H%M%z']:
+        try:
+            result = datetime.datetime.strptime(input_string, date_fmt)
+            break
+        except ValueError:
+            pass
+
+    if not isinstance(result, datetime.datetime):
+        raise crypto_utils.CertificateError(
+            'The time spec "%s" for %s is invalid' %
+            (input_string, input_name)
+        )
+    return result
+
+
+class CertificateInfo(crypto_utils.OpenSSLObject):
+    def __init__(self, module, backend):
+        super(CertificateInfo, self).__init__(
+            module.params['path'],
+            'present',
+            False,
+            module.check_mode,
+        )
+        self.backend = backend
+        self.module = module
+
+        self.valid_at = module.params['valid_at']
+        if self.valid_at:
+            for k, v in self.valid_at.items():
+                if not isinstance(v, string_types):
+                    self.module.fail_json(
+                        msg='The value for valid_at.{0} must be of type string (got {1})'.format(k, type(v))
+                    )
+                self.valid_at[k] = get_relative_time_option(v, 'valid_at.{0}'.format(k))
+
+    def generate(self):
+        # Empty method because crypto_utils.OpenSSLObject wants this
+        pass
+
+    def dump(self):
+        # Empty method because crypto_utils.OpenSSLObject wants this
+        pass
+
+    @abc.abstractmethod
+    def _get_signature_algorithm(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_subject(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_issuer(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_version(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_key_usage(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_extended_key_usage(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_subject_alt_name(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_not_before(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_not_after(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_public_key(self, binary):
+        pass
+
+    def get_info(self):
+        result = dict()
+        self.cert = crypto_utils.load_certificate(self.path, backend=self.backend)
+
+        result['signature_algorithm'] = self._get_signature_algorithm()
+        result['subject'] = self._get_subject()
+        result['issuer'] = self._get_issuer()
+        result['version'] = self._get_version()
+        result['key_usage'], result['key_usage_critical'] = self._get_key_usage()
+        result['extended_key_usage'], result['extended_key_usage_critical'] = self._get_extended_key_usage()
+        result['subject_alt_name'], result['subject_alt_name_critical'] = self._get_subject_alt_name()
+
+        not_before = self._get_not_before()
+        not_after = self._get_not_after()
+        result['not_before'] = not_before.strftime(TIMESTAMP_FORMAT)
+        result['not_after'] = not_after.strftime(TIMESTAMP_FORMAT)
+        result['expired'] = not_after < datetime.datetime.utcnow()
+
+        result['valid_at'] = dict()
+        if self.valid_at:
+            for k, v in self.valid_at.items():
+                result['valid_at'][k] = not_before <= v <= not_after
+
+        result['public_key'] = self._get_public_key(binary=False)
+        result['public_key_fingerprints'] = crypto_utils.get_fingerprint_of_bytes(self._get_public_key(binary=True))
+
+        return result
+
+
+class CertificateInfoCryptography(CertificateInfo):
+    """Validate the supplied cert, using the cryptography backend"""
+    def __init__(self, module):
+        super(CertificateInfoCryptography, self).__init__(module, 'cryptography')
+
+    def _get_signature_algorithm(self):
+        return crypto_utils.crpytography_oid_to_name(self.cert.signature_algorithm_oid)
+
+    def _get_subject(self):
+        result = dict()
+        for attribute in self.cert.subject:
+            result[crypto_utils.crpytography_oid_to_name(attribute.oid)] = attribute.value
+        return result
+
+    def _get_issuer(self):
+        result = dict()
+        for attribute in self.cert.issuer:
+            result[crypto_utils.crpytography_oid_to_name(attribute.oid)] = attribute.value
+        return result
+
+    def _get_version(self):
+        if self.cert.version == x509.Version.v1:
+            return 1
+        if self.cert.version == x509.Version.v3:
+            return 3
+        return "unknown"
+
+    def _get_key_usage(self):
+        try:
+            current_key_ext = self.cert.extensions.get_extension_for_class(x509.KeyUsage)
+            current_key_usage = current_key_ext.value
+            key_usage = dict(
+                digital_signature=current_key_usage.digital_signature,
+                content_commitment=current_key_usage.content_commitment,
+                key_encipherment=current_key_usage.key_encipherment,
+                data_encipherment=current_key_usage.data_encipherment,
+                key_agreement=current_key_usage.key_agreement,
+                key_cert_sign=current_key_usage.key_cert_sign,
+                crl_sign=current_key_usage.crl_sign,
+                encipher_only=False,
+                decipher_only=False,
+            )
+            if key_usage['key_agreement']:
+                key_usage.update(dict(
+                    encipher_only=current_key_usage.encipher_only,
+                    decipher_only=current_key_usage.decipher_only
+                ))
+
+            key_usage_names = dict(
+                digital_signature='Digital Signature',
+                content_commitment='Non Repudiation',
+                key_encipherment='Key Encipherment',
+                data_encipherment='Data Encipherment',
+                key_agreement='Key Agreement',
+                key_cert_sign='Certificate Sign',
+                crl_sign='CRL Sign',
+                encipher_only='Encipher Only',
+                decipher_only='Decipher Only',
+            )
+            return sorted([
+                key_usage_names[name] for name, value in key_usage.items() if value
+            ]), current_key_ext.critical
+        except cryptography.x509.ExtensionNotFound:
+            return None, False
+
+    def _get_extended_key_usage(self):
+        try:
+            ext_keyusage_ext = self.cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+            return sorted([
+                crypto_utils.crpytography_oid_to_name(eku) for eku in ext_keyusage_ext.value
+            ]), ext_keyusage_ext.critical
+        except cryptography.x509.ExtensionNotFound:
+            return None, False
+
+    def _get_subject_alt_name(self):
+        try:
+            san_ext = self.cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+            result = [crypto_utils.cryptography_decode_name(san) for san in san_ext.value]
+            return result, san_ext.critical
+        except cryptography.x509.ExtensionNotFound:
+            return None, False
+
+    def _get_not_before(self):
+        return self.cert.not_valid_before
+
+    def _get_not_after(self):
+        return self.cert.not_valid_after
+
+    def _get_public_key(self, binary):
+        return self.cert.public_key().public_bytes(
+            serialization.Encoding.DER if binary else serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+
+
+class CertificateInfoPyOpenSSL(CertificateInfo):
+    """validate the supplied certificate."""
+
+    def __init__(self, module):
+        super(CertificateInfoPyOpenSSL, self).__init__(module, 'pyopenssl')
+
+    def _get_signature_algorithm(self):
+        return to_text(self.cert.get_signature_algorithm())
+
+    def __get_name(self, name):
+        result = dict()
+        for sub in name.get_components():
+            nid = OpenSSL._util.lib.OBJ_txt2nid(sub[0])
+            b_name = OpenSSL._util.lib.OBJ_nid2ln(nid)
+            name = to_text(OpenSSL._util.ffi.string(b_name))
+            result[name] = to_text(sub[1])
+        return result
+
+    def _get_subject(self):
+        return self.__get_name(self.cert.get_subject())
+
+    def _get_issuer(self):
+        return self.__get_name(self.cert.get_issuer())
+
+    def _get_version(self):
+        # Version numbers in certs are off by one:
+        # v1: 0, v2: 1, v3: 2 ...
+        return self.cert.get_version() + 1
+
+    def _get_key_usage(self):
+        for extension_idx in range(0, self.cert.get_extension_count()):
+            extension = self.cert.get_extension(extension_idx)
+            if extension.get_short_name() == b'keyUsage':
+                result = [usage.strip() for usage in to_text(extension, errors='surrogate_or_strict').split(',')]
+                return sorted(result), bool(extension.get_critical())
+        return None, False
+
+    def _get_extended_key_usage(self):
+        for extension_idx in range(0, self.cert.get_extension_count()):
+            extension = self.cert.get_extension(extension_idx)
+            if extension.get_short_name() == b'extendedKeyUsage':
+                result = [usage.strip() for usage in to_text(extension, errors='surrogate_or_strict').split(',')]
+                return sorted(result), bool(extension.get_critical())
+        return None, False
+
+    def _get_subject_alt_name(self):
+        for extension_idx in range(0, self.cert.get_extension_count()):
+            extension = self.cert.get_extension(extension_idx)
+            if extension.get_short_name() == b'subjectAltName':
+                result = [altname.replace('IP Address', 'IP').strip() for altname in
+                          to_text(extension, errors='surrogate_or_strict').split(', ')]
+                return result, bool(extension.get_critical())
+        return None, False
+
+    def _get_not_before(self):
+        time_string = to_native(self.cert.get_notBefore())
+        return datetime.datetime.strptime(time_string, "%Y%m%d%H%M%SZ")
+
+    def _get_not_after(self):
+        time_string = to_native(self.cert.get_notAfter())
+        return datetime.datetime.strptime(time_string, "%Y%m%d%H%M%SZ")
+
+    def _get_public_key(self, binary):
+        try:
+            return crypto.dump_publickey(
+                crypto.FILETYPE_ASN1 if binary else crypto.FILETYPE_PEM,
+                self.cert.get_pubkey()
+            )
+        except AttributeError:
+            self.module.warn('Your pyOpenSSL version does not support dumping public keys. '
+                             'Please upgrade to version 16.0 or newer, or use the cryptography backend.')
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(type='path', required=True),
+            valid_at=dict(type='dict'),
+            select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'cryptography', 'pyopenssl']),
+        ),
+        supports_check_mode=True,
+    )
+
+    try:
+        base_dir = os.path.dirname(module.params['path']) or '.'
+        if not os.path.isdir(base_dir):
+            module.fail_json(
+                name=base_dir,
+                msg='The directory %s does not exist or the file is not a directory' % base_dir
+            )
+
+        backend = module.params['select_crypto_backend']
+        if backend == 'auto':
+            # Detect what backend we can use
+            can_use_cryptography = CRYPTOGRAPHY_FOUND and CRYPTOGRAPHY_VERSION >= LooseVersion(MINIMAL_CRYPTOGRAPHY_VERSION)
+            can_use_pyopenssl = PYOPENSSL_FOUND and PYOPENSSL_VERSION >= LooseVersion(MINIMAL_PYOPENSSL_VERSION)
+
+            # If cryptography is available we'll use it
+            if can_use_cryptography:
+                backend = 'cryptography'
+            elif can_use_pyopenssl:
+                backend = 'pyopenssl'
+
+            if module.params['selfsigned_version'] == 2 or module.params['ownca_version'] == 2:
+                module.warn('crypto backend forced to pyopenssl. The cryptography library does not support v2 certificates')
+                backend = 'pyopenssl'
+
+            # Fail if no backend has been found
+            if backend == 'auto':
+                module.fail_json(msg=("Can't detect none of the required Python libraries "
+                                      "cryptography (>= {0}) or PyOpenSSL (>= {1})").format(
+                                          MINIMAL_CRYPTOGRAPHY_VERSION,
+                                          MINIMAL_PYOPENSSL_VERSION))
+
+        if backend == 'pyopenssl':
+            if not PYOPENSSL_FOUND:
+                module.fail_json(msg=missing_required_lib('pyOpenSSL'), exception=PYOPENSSL_IMP_ERR)
+            try:
+                getattr(crypto.X509Req, 'get_extensions')
+            except AttributeError:
+                module.fail_json(msg='You need to have PyOpenSSL>=0.15')
+
+            certificate = CertificateInfoPyOpenSSL(module)
+        elif backend == 'cryptography':
+            if not CRYPTOGRAPHY_FOUND:
+                module.fail_json(msg=missing_required_lib('cryptography'), exception=CRYPTOGRAPHY_IMP_ERR)
+            certificate = CertificateInfoCryptography(module)
+
+        result = certificate.get_info()
+        module.exit_json(**result)
+    except crypto_utils.OpenSSLObjectError as exc:
+        module.fail_json(msg=to_native(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -128,7 +128,7 @@ extended_key_usage_critical:
     returned: success
     type: bool
 extensions_by_oid:
-    description: Returns for every extension OID a dictionary
+    description: Returns a dictionary for every extension OID
     returned: success
     type: complex
     contains:
@@ -199,6 +199,8 @@ public_key_fingerprints:
         - For every hash algorithm available, the fingerprint is computed.
     returned: success
     type: dict
+    sample: "{'sha256': 'd4:b3:aa:6d:c8:04:ce:4e:ba:f6:29:4d:92:a3:94:b0:c2:ff:bd:bf:33:63:11:43:34:0f:51:b0:95:09:2f:63',
+              'sha512': 'f7:07:4a:f0:b0:f0:e6:8b:95:5f:f9:e6:61:0a:32:68:f1..."
 signature_algorithm:
     description: The signature algorithm used to sign the certificate.
     returned: success
@@ -213,7 +215,7 @@ version:
     description: The certificate version.
     returned: success
     type: int
-    sample: 1
+    sample: 3
 valid_at:
     description: For every time stamp provided in the I(valid_at) option, a
                  boolean whether the certificate is valid at that point in time

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -94,11 +94,116 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-filename:
-    description: Path to the generated Certificate
-    returned: changed or success
+expired:
+    description: Whether the certificate is expired (i.e. C(notAfter) is in the past)
+    returned: success
+    type: bool
+basic_constraints:
+    description: Entries in the C(basic_constraints) extension, or C(none) if extension is not present.
+    returned: success
+    type: list
+    sample: "[CA:TRUE, pathlen:1]"
+basic_constraints_critical:
+    description: Whether the C(basic_constraints) extension is critical.
+    returned: success
+    type: bool
+extended_key_usage:
+    description: Entries in the C(extended_key_usage) extension, or C(none) if extension is not present.
+    returned: success
+    type: list
+    sample: "[Biometric Info, DVCS, Time Stamping]"
+extended_key_usage_critical:
+    description: Whether the C(extended_key_usage) extension is critical.
+    returned: success
+    type: bool
+extensions_by_oid:
+    description: Returns for every extension OID a dictionary
+    returned: success
+    type: complex
+    contains:
+        critical:
+            description: Whether the extension is critical.
+            returned: success
+            type: bool
+        value:
+            description: The Base64 encoded value (in DER format) of the extension
+            returned: success
+            type: str
+            sample: "MAMCAQU="
+    sample: '{"1.3.6.1.5.5.7.1.24": { "critical": false, "value": "MAMCAQU="}}'
+key_usage:
+    description: Entries in the C(key_usage) extension, or C(none) if extension is not present.
+    returned: success
     type: str
-    sample: /etc/ssl/crt/www.ansible.com.crt
+    sample: "[Key Agreement, Data Encipherment]"
+key_usage_critical:
+    description: Whether the C(key_usage) extension is critical.
+    returned: success
+    type: bool
+subject_alt_name:
+    description: Entries in the C(subject_alt_name) extension, or C(none) if extension is not present.
+    returned: success
+    type: list
+    sample: "[DNS:www.ansible.com, IP:1.2.3.4]"
+subject_alt_name_critical:
+    description: Whether the C(subject_alt_name) extension is critical.
+    returned: success
+    type: bool
+ocsp_must_staple:
+    description: C(yes) if the OCSP Must Staple extension is present, C(none) otherwise.
+    returned: success
+    type: bool
+ocsp_must_staple_critical:
+    description: Whether the C(ocsp_must_staple) extension is critical.
+    returned: success
+    type: bool
+issuer:
+    description: The certificate's issuer.
+    returned: success
+    type: dict
+    sample: '{"organizationName": "Ansible"}'
+subject:
+    description: The certificate's subject.
+    returned: success
+    type: dict
+    sample: '{"commonName": "www.example.com", "emailAddress": "test@example.com"}'
+not_after:
+    description: C(notAfter) date as ASN.1 TIME
+    returned: success
+    type: str
+    sample: 20190413202428Z
+not_before:
+    description: C(notBefore) date as ASN.1 TIME
+    returned: success
+    type: str
+    sample: 20190331202428Z
+public_key:
+    description: Certificate's public key in PEM format
+    returned: success
+    type: str
+    sample: "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A..."
+public_key_fingerprints:
+    description:
+        - Fingerprints of certificate's public key.
+        - For every hash algorithm available, the fingerprint is computed.
+    returned: success
+    type: dict
+signature_algorithm:
+    description: The signature algorithm used to sign the certificate.
+    returned: success
+    type: str
+    sample: sha256WithRSAEncryption
+version:
+    description: The certificate version.
+    returned: success
+    type: int
+    sample: 1
+valid_at:
+    description: For every time stamp provided in the I(valid_at) option, a
+                 boolean whether the certificate is valid at that point in time
+                 or not.
+    returned: success
+    type: dict
 '''
 
 

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -410,7 +410,8 @@ class CertificateInfo(crypto_utils.OpenSSLObject):
                 result['valid_at'][k] = not_before <= v <= not_after
 
         result['public_key'] = self._get_public_key(binary=False)
-        result['public_key_fingerprints'] = crypto_utils.get_fingerprint_of_bytes(self._get_public_key(binary=True))
+        pk = self._get_public_key(binary=True)
+        result['public_key_fingerprints'] = crypto_utils.get_fingerprint_of_bytes(pk) if pk is not None else dict()
 
         result['serial_number'] = self._get_serial_number()
         result['extensions_by_oid'] = self._get_all_extensions()

--- a/test/integration/targets/openssl_certificate_info/aliases
+++ b/test/integration/targets/openssl_certificate_info/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+destructive

--- a/test/integration/targets/openssl_certificate_info/meta/main.yml
+++ b/test/integration/targets/openssl_certificate_info/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_openssl

--- a/test/integration/targets/openssl_certificate_info/tasks/impl.yml
+++ b/test/integration/targets/openssl_certificate_info/tasks/impl.yml
@@ -1,0 +1,52 @@
+---
+- debug:
+    msg: "Executing tests with backend {{ select_crypto_backend }}"
+
+- name: ({{select_crypto_backend}}) Get certificate info
+  openssl_certificate_info:
+    path: '{{ output_dir }}/cert_1.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: result
+
+- name: Update result list
+  set_fact:
+    info_results: "{{ info_results + [result] }}"
+
+- name: ({{select_crypto_backend}}) Get certificate info
+  openssl_certificate_info:
+    path: '{{ output_dir }}/cert_2.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+    valid_at:
+      today: "+0d"
+      past: "20190101235901Z"
+      twentydays: "+20d"
+  register: result
+- assert:
+    that:
+    - result.valid_at.today
+    - not result.valid_at.past
+    - not result.valid_at.twentydays
+
+- name: Update result list
+  set_fact:
+    info_results: "{{ info_results + [result] }}"
+
+- name: ({{select_crypto_backend}}) Get certificate info
+  openssl_certificate_info:
+    path: '{{ output_dir }}/cert_3.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: result
+
+- name: Update result list
+  set_fact:
+    info_results: "{{ info_results + [result] }}"
+
+- name: ({{select_crypto_backend}}) Get certificate info
+  openssl_certificate_info:
+    path: '{{ output_dir }}/cert_4.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: result
+
+- name: Update result list
+  set_fact:
+    info_results: "{{ info_results + [result] }}"

--- a/test/integration/targets/openssl_certificate_info/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate_info/tasks/main.yml
@@ -1,0 +1,151 @@
+---
+- name: Generate privatekey
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey.pem'
+
+- name: Generate privatekey with password
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekeypw.pem'
+    passphrase: hunter2
+    cipher: auto
+    select_crypto_backend: cryptography
+
+- name: Generate CSR 1
+  openssl_csr:
+    path: '{{ output_dir }}/csr_1.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    subject:
+      commonName: www.example.com
+      C: de
+      L: Somewhere
+      ST: Zurich
+      streetAddress: Welcome Street
+      O: Ansible
+      organizationalUnitName: Crypto Department
+      serialNumber: "1234"
+      SN: Last Name
+      GN: First Name
+      title: Chief
+      pseudonym: test
+      UID: asdf
+      emailAddress: test@example.com
+      postalAddress: 1234 Somewhere
+      postalCode: "1234"
+    useCommonNameForSAN: no
+    key_usage:
+      - digitalSignature
+      - keyAgreement
+      - Non Repudiation
+      - Key Encipherment
+      - dataEncipherment
+      - Certificate Sign
+      - cRLSign
+      - Encipher Only
+      - decipherOnly
+    key_usage_critical: yes
+    extended_key_usage:
+      - serverAuth  # the same as "TLS Web Server Authentication"
+      - TLS Web Server Authentication
+      - TLS Web Client Authentication
+      - Code Signing
+      - E-mail Protection
+      - timeStamping
+      - OCSPSigning
+      - Any Extended Key Usage
+      - qcStatements
+      - DVCS
+      - IPSec User
+      - biometricInfo
+    subject_alt_name:
+      - "DNS:www.ansible.com"
+      - "IP:1.2.3.4"
+      - "IP:::1"
+      - "email:test@example.org"
+      - "URI:https://example.org/test/index.html"
+    basic_constraints:
+      - "CA:TRUE"
+      - "pathlen:23"
+    basic_constraints_critical: yes
+    ocsp_must_staple: yes
+
+- name: Generate CSR 2
+  openssl_csr:
+    path: '{{ output_dir }}/csr_2.csr'
+    privatekey_path: '{{ output_dir }}/privatekeypw.pem'
+    privatekey_passphrase: hunter2
+    useCommonNameForSAN: no
+    basic_constraints:
+      - "CA:TRUE"
+
+- name: Generate CSR 3
+  openssl_csr:
+    path: '{{ output_dir }}/csr_3.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    useCommonNameForSAN: no
+    subject_alt_name:
+      - "DNS:*.ansible.com"
+      - "DNS:*.example.org"
+      - "IP:DEAD:BEEF::1"
+    basic_constraints:
+      - "CA:FALSE"
+
+- name: Generate CSR 4
+  openssl_csr:
+    path: '{{ output_dir }}/csr_4.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    useCommonNameForSAN: no
+
+- name: Generate selfsigned certificates
+  openssl_certificate:
+    path: '{{ output_dir }}/cert_{{ item }}.pem'
+    csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    provider: selfsigned
+    selfsigned_digest: sha256
+    selfsigned_not_after: "+10d"
+    selfsigned_not_before: "-3d"
+  loop:
+  - 1
+  - 2
+  - 3
+  - 4
+
+- name: Prepare result list
+  set_fact:
+    info_results: []
+
+- name: Running tests with pyOpenSSL backend
+  include_tasks: impl.yml
+  vars:
+    select_crypto_backend: pyopenssl
+  when: pyopenssl_version.stdout is version('0.15', '>=')
+
+- name: Prepare result list
+  set_fact:
+    pyopenssl_info_results: "{{ info_results }}"
+    info_results: []
+
+- name: Running tests with cryptography backend
+  include_tasks: impl.yml
+  vars:
+    select_crypto_backend: cryptography
+  when: cryptography_version.stdout is version('1.6', '>=')
+
+- name: Prepare result list
+  set_fact:
+    cryptography_info_results: "{{ info_results }}"
+
+- block:
+  - name: Dump pyOpenSSL results
+    debug:
+      var: pyopenssl_info_results
+  - name: Dump cryptography results
+    debug:
+      var: cryptography_info_results
+  - name: Compare results
+    assert:
+      that:
+      - item.0 == item.1
+      quiet: yes
+    loop: "{{ pyopenssl_info_results | zip(cryptography_info_results) | list }}"
+  when: pyopenssl_version.stdout is version('0.15', '>=') and cryptography_version.stdout is version('1.6', '>=')


### PR DESCRIPTION
##### SUMMARY
Adds a new module `openssl_certificate_info`. Useful for doing most checks from #54635 / `openssl_certificate`'s `assertonly` provider directly with in Ansible with `register`/`assert`.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
openssl_certificate_info
