### PR TITLE
support caching options (#51387)

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -95,7 +95,9 @@ options:
         version_added: 2.5
     attach_caching:
         description:
-            - "Disk caching policy controlled by VM."
+            - "Disk caching policy controlled by VM. Will be used when attached to the VM defined by C(managed_by)"
+            - "If this option is different from the current caching policy,"
+            - "the managed disk will be deattached from the VM and attached with current caching option again"
             - "Allowed values: '', read_only, read_write."
         choices:
             - ''
@@ -457,12 +459,13 @@ class AzureRMManagedDisk(AzureRMModuleBase):
 
     def is_attach_caching_option_different(self, vm_name, disk):
         resp = False
-        vm = self._get_vm(vm_name)
-        correspondence = next((d for d in vm.storage_profile.data_disks if d.name.lower() == disk.get('name').lower()), None)
-        if correspondence and correspondence.caching.name != self.attach_caching:
-            resp = True
-            if correspondence.caching.name == 'none' and self.attach_caching == '':
-                resp = False
+        if vm_name:
+            vm = self._get_vm(vm_name)
+            correspondence = next((d for d in vm.storage_profile.data_disks if d.name.lower() == disk.get('name').lower()), None)
+            if correspondence and correspondence.caching.name != self.attach_caching:
+                resp = True
+                if correspondence.caching.name == 'none' and self.attach_caching == '':
+                    resp = False
         return resp
 
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -93,9 +93,9 @@ options:
             - To detach a disk from a vm, explicitly set to ''.
             - If this option is unset, the value will not be changed.
         version_added: 2.5
-    caching:
+    attach_caching:
         description:
-            - "Disk caching policy."
+            - "Disk caching policy controlled by VM."
             - "Allowed values: '', read_only, read_write."
         choices:
             - ''
@@ -147,7 +147,7 @@ EXAMPLES = '''
         resource_group: myResourceGroup
         disk_size_gb: 4
         managed_by: testvm001
-        caching: read_only
+        attach_caching: read_only
 
     - name: Unmount the managed disk to VM
       azure_rm_manageddisk:
@@ -256,7 +256,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
                 type='str',
                 choices=['', '1', '2', '3']
             ),
-            caching=dict(
+            attach_caching=dict(
                 type='str',
                 choices=['', 'read_only', 'read_write']
             )
@@ -281,7 +281,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         self.tags = None
         self.zone = None
         self.managed_by = None
-        self.caching = None
+        self.attach_caching = None
         super(AzureRMManagedDisk, self).__init__(
             derived_arg_spec=self.module_arg_spec,
             required_if=required_if,
@@ -317,7 +317,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         if self.managed_by or self.managed_by == '':
             vm_name = parse_resource_id(disk_instance.get('managed_by', '')).get('name') if disk_instance else None
             vm_name = vm_name or ''
-            if self.managed_by != vm_name:
+            if self.managed_by != vm_name or self.is_attach_caching_option_different(vm_name, result):
                 changed = True
                 if not self.check_mode:
                     if vm_name:
@@ -345,9 +345,11 @@ class AzureRMManagedDisk(AzureRMModuleBase):
 
         # prepare the data disk
         params = self.compute_models.ManagedDiskParameters(id=disk.get('id'), storage_account_type=disk.get('storage_account_type'))
-        caching_options = self.compute_models.CachingTypes[self.caching] if self.caching and self.caching != '' else None
-        data_disk = self.compute_models.DataDisk(lun=lun, create_option=self.compute_models.DiskCreateOptionTypes.attach,
-                                                 managed_disk=params, caching=caching_options)
+        caching_options = self.compute_models.CachingTypes[self.attach_caching] if self.attach_caching and self.attach_caching != '' else None
+        data_disk = self.compute_models.DataDisk(lun=lun,
+                                                 create_option=self.compute_models.DiskCreateOptionTypes.attach,
+                                                 managed_disk=params,
+                                                 caching=caching_options)
         vm.storage_profile.data_disks.append(data_disk)
         self._update_vm(vm_name, vm)
 
@@ -452,6 +454,16 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             return managed_disk_to_dict(resp)
         except CloudError as e:
             self.log('Did not find managed disk')
+
+    def is_attach_caching_option_different(self, vm_name, disk):
+        resp = False
+        vm = self._get_vm(vm_name)
+        correspondence = next((d for d in vm.storage_profile.data_disks if d.name.lower() == disk.get('name').lower()), None)
+        if correspondence and correspondence.caching.name != self.attach_caching:
+            resp = True
+            if correspondence.caching.name == 'none' and self.attach_caching == '':
+                resp = False
+        return resp
 
 
 def main():

--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -95,9 +95,9 @@ options:
         version_added: 2.5
     attach_caching:
         description:
-            - "Disk caching policy controlled by VM. Will be used when attached to the VM defined by C(managed_by)"
-            - "If this option is different from the current caching policy,"
-            - "the managed disk will be deattached from the VM and attached with current caching option again"
+            - "Disk caching policy controlled by VM. Will be used when attached to the VM defined by C(managed_by)."
+            - "If this option is different from the current caching policy,
+               the managed disk will be deattached from the VM and attached with current caching option again."
             - "Allowed values: '', read_only, read_write."
         choices:
             - ''


### PR DESCRIPTION
* add related information into the documentation and examples

* add variables and options in the init

* add caching params when creating DataDisk

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modify the content of the documentation and example to fit caching options feature. Add a new variable "caching" into the  AzureRMManagedDisk class. The attach method of AzureRMManagedDisk class can pass caching parameter now. Fixes #51387 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_managed_disk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
