### PR TITLE
ovirt_disk: really add new content types

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -630,7 +630,10 @@ def main():
         profile=dict(default=None),
         quota_id=dict(default=None),
         format=dict(default='cow', choices=['raw', 'cow']),
-        content_type=dict(default='data', choices=['data', 'iso']),
+        content_type=dict(
+            default='data',
+            choices=['data', 'iso', 'hosted_engine', 'hosted_engine_sanlock', 'hosted_engine_metadata', 'hosted_engine_configuration']
+        ),
         sparse=dict(default=None, type='bool'),
         bootable=dict(default=None, type='bool'),
         shareable=dict(default=None, type='bool'),


### PR DESCRIPTION
##### SUMMARY
really add new content types to ovirt_disk module
Fixes: https://github.com/ansible/ansible/issues/54719

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ovirt_disk

##### ADDITIONAL INFORMATION
https://github.com/ansible/ansible/pull/54328 simply add them to the documentation:
```
    content_type:
        description:
            - Specify if the disk is a data disk or ISO image or a one of a the Hosted Engine disk types
            - The Hosted Engine disk content types are available with Engine 4.3+ and Ansible 2.8
        choices: ['data', 'iso', 'hosted_engine', 'hosted_engine_sanlock', 'hosted_engine_metadata', 'hosted_engine_configuration']

```
