### PR TITLE
[WIP] Append header duplicate headers when http error

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -922,6 +922,8 @@ def normalize_headers(headers):
 
     # Don't be lossy, append header values for duplicate headers
     for name, value in headers.items():
+        # lower case keys to match py2 behavior, and create more consistent results
+        name = name.lower()
         if name in normalized:
             old = normalized[name]
             del normalized[name]

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1399,6 +1399,18 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         try:
             # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
             info.update(dict((k.lower(), v) for k, v in e.info().items()))
+            # Don't be lossy, append header values for duplicate headers
+            # In Py2 there is nothing that needs done, py2 does this for us
+            if PY3:
+                temp_headers = {}
+                for name, value in e.headers.items():
+                    # The same as above, lower case keys to match py2 behavior, and create more consistent results
+                    name = name.lower()
+                    if name in temp_headers:
+                        temp_headers[name] = ', '.join((temp_headers[name], value))
+                    else:
+                        temp_headers[name] = value
+                info.update(temp_headers)
         except Exception:
             pass
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -914,7 +914,7 @@ def rfc2822_date_string(timetuple, zone='-0000'):
         zone)
 
 
-def normalize_headers(headers):
+def normalize_headers(headers, force_lower_case=False):
     if PY3:
         normalized = httplib.HTTPMessage()
     else:
@@ -922,8 +922,11 @@ def normalize_headers(headers):
 
     # Don't be lossy, append header values for duplicate headers
     for name, value in headers.items():
-        # lower case keys to match py2 behavior, and create more consistent results
-        name = name.lower()
+
+        if force_lower_case:
+            # lower case keys to match py2 behavior, and create more consistent results
+            name = name.lower()
+
         if name in normalized:
             old = normalized[name]
             del normalized[name]
@@ -1374,7 +1377,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
         info.update(dict((k.lower(), v) for k, v in r.info().items()))
 
-        info.update(normalize_headers(r.headers))
+        info.update(normalize_headers(r.headers), force_lower_case=True)
 
         # parse the cookies into a nice dictionary
         cookie_list = []
@@ -1409,7 +1412,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
             # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
             info.update(dict((k.lower(), v) for k, v in e.info().items()))
 
-            info.update(normalize_headers(e.headers))
+            info.update(normalize_headers(e.headers), force_lower_case=True)
         except Exception:
             pass
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1371,6 +1371,9 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                      client_key=client_key, cookies=cookies, use_gssapi=use_gssapi,
                      unix_socket=unix_socket)
 
+        # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
+        info.update(dict((k.lower(), v) for k, v in r.info().items()))
+
         info.update(normalize_headers(r.headers))
 
         # parse the cookies into a nice dictionary
@@ -1403,6 +1406,9 @@ def fetch_url(module, url, data=None, headers=None, method=None,
 
         # Try to add exception info to the output but don't fail if we can't
         try:
+            # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
+            info.update(dict((k.lower(), v) for k, v in e.info().items()))
+
             info.update(normalize_headers(e.headers))
         except Exception:
             pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When http return error, headers are not concatenated when receiv multiple with the same name

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixe #54721 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/urls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
