### PR TITLE
Correct example since per_host default is false

### DIFF
--- a/lib/ansible/modules/utilities/logic/set_stats.py
+++ b/lib/ansible/modules/utilities/logic/set_stats.py
@@ -46,6 +46,7 @@ EXAMPLES = r'''
 - set_stats:
     data:
       packages_installed: 31
+    per_host: yes
 
 # Aggregating random stats for all hosts using complex arguments
 - set_stats:


### PR DESCRIPTION
##### SUMMARY
This example says "Aggregating packages_installed stat per host", but since the per_host default is "no", it does not do this per host.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
set_stats

##### ADDITIONAL INFORMATION
from reading https://docs.ansible.com/ansible/latest/modules/set_stats_module.html

After this change:

```
ANSIBLE_SHOW_CUSTOM_STATS=true ansible-playbook -i stats/hosts stats/stats_per_host.yml

PLAY [Set stats per host] ***************************************************************************************************************************************************

TASK [set_stats] ************************************************************************************************************************************************************
ok: [foo]
ok: [bar]

PLAY RECAP ******************************************************************************************************************************************************************
bar                        : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
foo                        : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


CUSTOM STATS: ***************************************************************************************************************************************************************
	foo: { "packages_installed": 31}
	bar: { "packages_installed": 31}
```
