### PR TITLE
Added a new integer property - 'mtu' - to the os_network module.

### DIFF
--- a/changelogs/fragments/55881-os-network-mtu-support-on-create-update.yml
+++ b/changelogs/fragments/55881-os-network-mtu-support-on-create-update.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - os_network - added MTU support when creating/updating a network

--- a/lib/ansible/modules/cloud/openstack/os_network.py
+++ b/lib/ansible/modules/cloud/openstack/os_network.py
@@ -76,6 +76,13 @@ options:
            not utilised.
      type: bool
      version_added: "2.8"
+   mtu:
+     description:
+       -  The maximum transmission unit (MTU) value to address fragmentation.
+          Network will use OpenStack defaults if this option is
+          not provided.
+     type: int
+     version_added: "2.9"
 requirements:
      - "openstacksdk"
 '''
@@ -164,7 +171,8 @@ def main():
         provider_segmentation_id=dict(required=False, type='int'),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None),
-        port_security_enabled=dict(type='bool')
+        port_security_enabled=dict(type='bool'),
+        mtu=dict(required=False, type='int')
     )
 
     module_kwargs = openstack_module_kwargs()
@@ -180,6 +188,7 @@ def main():
     provider_segmentation_id = module.params['provider_segmentation_id']
     project = module.params.get('project')
     port_security_enabled = module.params.get('port_security_enabled')
+    mtu = module.params.get('mtu')
 
     sdk, cloud = openstack_cloud_from_module(module)
     try:
@@ -207,11 +216,13 @@ def main():
                 if project_id is not None:
                     net = cloud.create_network(name, shared, admin_state_up,
                                                external, provider, project_id,
-                                               port_security_enabled=port_security_enabled)
+                                               port_security_enabled=port_security_enabled,
+                                               mtu_size=mtu)
                 else:
                     net = cloud.create_network(name, shared, admin_state_up,
                                                external, provider,
-                                               port_security_enabled=port_security_enabled)
+                                               port_security_enabled=port_security_enabled,
+                                               mtu_size=mtu)
                 changed = True
             else:
                 changed = False


### PR DESCRIPTION
##### SUMMARY
The networking API v2 specification, which is implemented
by openstack neutron, features an optional MTU parameter that
allows operators to specify the value for the maximum
transmission unit value.

Fixes #55881

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloud / openstack / os_network

##### ADDITIONAL INFORMATION

```
- os_network:
    cloud: mycloud
    state: present
    name: priv_network
    mtu: 9000
```
