### PR TITLE
Fetching a test file, not the motd file

### DIFF
--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: create a file that we can use to fetch
   copy: content="test" dest={{ remote_tmp_dir }}/orig
 
-- name: fetch the motd
+- name: fetch the test file
   fetch: src={{ remote_tmp_dir }}/orig dest={{ output_dir }}/fetched
   register: fetched
 


### PR DESCRIPTION
##### SUMMARY

The description "fetch the motd" is not accurate since `/etc/motd` is not the file fetched.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
fetch

##### ADDITIONAL INFORMATION

I release any copyright claim on this trivial and obvious improvement.