### PR TITLE
Test that file ownership and permissions prevent file fetch

### DIFF
--- a/test/integration/targets/fetch/defaults/main.yml
+++ b/test/integration/targets/fetch/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+remote_unprivileged_user: tmp_ansible_test_user

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: create a file that we can use to fetch
   copy: content="test" dest={{ remote_tmp_dir }}/orig
 
-- name: fetch the motd
+- name: fetch the test file
   fetch: src={{ remote_tmp_dir }}/orig dest={{ output_dir }}/fetched
   register: fetched
 

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -143,24 +143,32 @@
 # Set up for some 'become' tests. Like the 'copy' module tests
 # we first need to have an unprivileged user with the same 
 # ssh key as our regular user allowed for login.
+- name: note the home directory for the Ansible user
+  set_fact: 
+    remote_user_home: "{{ ansible_env.HOME }}"
+
 - name: create a file that we can use to fetch using become
-  copy: content="test" owner=root mode=0600 dest={{ remote_tmp_dir }}/orig.root
   become: true
+  copy: content="test" owner=root mode=0600 dest={{ remote_tmp_dir }}/orig.root
 
 - name: Create remote unprivileged remote user
+  become: true
   user:
     name: '{{ remote_unprivileged_user }}'
   register: user
 
-- file:
+- name: create an `.ssh` directory for holding `authorized_keys`
+  become: true
+  file:
     path: "{{ user.home }}/.ssh"
     owner: '{{ remote_unprivileged_user }}'
     state: directory
     mode: 0700
 
 - name: Duplicate authorized_keys
+  become: true
   copy:
-    src: $HOME/.ssh/authorized_keys
+    src: '{{ remote_user_home }}/.ssh/authorized_keys'
     dest: '{{ user.home }}/.ssh/authorized_keys'
     owner: '{{ remote_unprivileged_user }}'
     mode: 0600
@@ -191,9 +199,9 @@
       - "failed_fetch_root_owned_file.msg"
 
 - name: fetch the root-readable test file using 'become'
+  become: true
   fetch: src={{ remote_tmp_dir }}/orig.root dest={{ output_dir }}/fetched
   remote_user: '{{ remote_unprivileged_user }}'
-  become: true
   register: fetched
 
 - debug: var=fetched

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -145,6 +145,7 @@
 # ssh key as our regular user allowed for login.
 - name: create a file that we can use to fetch using become
   copy: content="test" owner=root mode=0600 dest={{ remote_tmp_dir }}/orig.root
+  become: true
 
 - name: Create remote unprivileged remote user
   user:

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -171,6 +171,9 @@
     state: directory
   remote_user: '{{ remote_unprivileged_user }}'
 
+# Pulling a root-only file as a non-root user should fail, but it succeeds.
+# This appears to be related to the closed issue #13388.
+#
 # Based on https://github.com/ansible/ansible/pull/13424 it appears that overriding
 # remote_user on a per-task basis with Docker doesn't work. That matches the observed
 #   <testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
@@ -178,6 +181,20 @@
 #
 # https://github.com/ansible/ansible/pull/15556 had a good conversation about the
 # Docker-specific challenges of the "become" process.
+- name: attempt to fetch the only-root-readable test file using a non-root user, should fail
+  fetch: src={{ remote_tmp_dir }}/orig.root dest={{ output_dir }}/fetched
+  remote_user: '{{ remote_unprivileged_user }}'
+  register: failed_fetch_root_owned_file
+  ignore_errors: true
+
+- debug: var=failed_fetch_root_owned_file
+
+- name: check that fetching a root-owned non-readable file indeed failed
+  assert:
+    that:
+      - "failed_fetch_root_owned_file is failed"
+      - "failed_fetch_root_owned_file.msg"
+
 - name: fetch the root-readable test file using 'become'
   fetch: src={{ remote_tmp_dir }}/orig.root dest={{ output_dir }}/fetched
   remote_user: '{{ remote_unprivileged_user }}'

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -163,6 +163,7 @@
     remote_src: yes
 
 - file:
-    path: "{{ remote_dir }}"
-    state: directory
+  # output_dir is hardcoded in test/runner/lib/executor.py and created there
+  path: "{{ output_dir }}"
+  state: directory
   remote_user: '{{ remote_unprivileged_user }}'

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -165,12 +165,6 @@
     mode: 0600
     remote_src: yes
 
-- file:
-    # output_dir is hardcoded in test/runner/lib/executor.py and created there
-    path: "{{ output_dir }}"
-    state: directory
-  remote_user: '{{ remote_unprivileged_user }}'
-
 # Pulling a root-only file as a non-root user should fail, but it succeeds.
 # This appears to be related to the closed issue #13388.
 #

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -139,3 +139,30 @@
     that:
       - "failed_fetch_dest_dir is failed"
       - "failed_fetch_dest_dir.msg"
+
+# Set up for some 'become' tests. Like the 'copy' module tests
+# we first need to have an unprivileged user with the same 
+# ssh key as our regular user allowed for login.
+- name: Create remote unprivileged remote user
+  user:
+    name: '{{ remote_unprivileged_user }}'
+  register: user
+
+- file:
+    path: "{{ user.home }}/.ssh"
+    owner: '{{ remote_unprivileged_user }}'
+    state: directory
+    mode: 0700
+
+- name: Duplicate authorized_keys
+  copy:
+    src: $HOME/.ssh/authorized_keys
+    dest: '{{ user.home }}/.ssh/authorized_keys'
+    owner: '{{ remote_unprivileged_user }}'
+    mode: 0600
+    remote_src: yes
+
+- file:
+    path: "{{ remote_dir }}"
+    state: directory
+  remote_user: '{{ remote_unprivileged_user }}'

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -171,6 +171,13 @@
     state: directory
   remote_user: '{{ remote_unprivileged_user }}'
 
+# Based on https://github.com/ansible/ansible/pull/13424 it appears that overriding
+# remote_user on a per-task basis with Docker doesn't work. That matches the observed
+#   <testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
+# entries in -vvv output.
+#
+# https://github.com/ansible/ansible/pull/15556 had a good conversation about the
+# Docker-specific challenges of the "become" process.
 - name: fetch the root-readable test file using 'become'
   fetch: src={{ remote_tmp_dir }}/orig.root dest={{ output_dir }}/fetched
   remote_user: '{{ remote_unprivileged_user }}'

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -143,6 +143,9 @@
 # Set up for some 'become' tests. Like the 'copy' module tests
 # we first need to have an unprivileged user with the same 
 # ssh key as our regular user allowed for login.
+- name: create a file that we can use to fetch using become
+  copy: content="test" owner=root mode=0600 dest={{ remote_tmp_dir }}/orig.root
+
 - name: Create remote unprivileged remote user
   user:
     name: '{{ remote_unprivileged_user }}'
@@ -163,7 +166,23 @@
     remote_src: yes
 
 - file:
-  # output_dir is hardcoded in test/runner/lib/executor.py and created there
-  path: "{{ output_dir }}"
-  state: directory
+    # output_dir is hardcoded in test/runner/lib/executor.py and created there
+    path: "{{ output_dir }}"
+    state: directory
   remote_user: '{{ remote_unprivileged_user }}'
+
+- name: fetch the root-readable test file using 'become'
+  fetch: src={{ remote_tmp_dir }}/orig.root dest={{ output_dir }}/fetched
+  remote_user: '{{ remote_unprivileged_user }}'
+  become: true
+  register: fetched
+
+- debug: var=fetched
+
+- name: Assert that we fetched correctly
+  assert:
+    that:
+      - 'fetched["changed"] == True'
+      - 'fetched["checksum"] == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"'
+      - 'fetched["remote_checksum"] == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"'
+      - 'lookup("file", output_dir + "/fetched/" + inventory_hostname + remote_tmp_dir + "/orig.root") == "test"'


### PR DESCRIPTION
##### SUMMARY
When permissions don't allow a file to be fetched, the attempt should fail.

The actual results suggest that when using a Docker container, Ansible always connects as `root` even when `remote_user: <other user>` is specified. This test demonstrates that observed behavior and currently fails.

This seems similar to the closed issue #13388. Pull #15556 also mentions some similar observations.

We probably do not want to merge this test enhancement until we identify what causes the `remote_user` to be ignored for Docker containers within the test suite. However, I thought you all could benefit from seeing a test that demonstrated the issue sooner rather than later.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fetch

##### ADDITIONAL INFORMATION
While reproducing an issue where `fetch` seemed to be ignoring the `become` directive, I created a test case using Docker. It appears that when run using 

```
$ ansible-test integration --docker -v fetch
```

even though the test requested a fetch using a new, nonprivileged user via `remote_user: '{{ remote_unprivileged_user }}'`, Ansible instead fetches it as root.

For example, here's what a triple-v log shows for this task (note the `ESTABLISH LOCAL CONNECTION FOR USER: root`):

```
TASK [fetch : attempt to fetch the only-root-readable test file using a non-root user, should fail] ***
task path: /root/.ansible/test/tmp/fetch-e6t19wo0-ÅÑŚÌβŁÈ/test/integration/targets/fetch/tasks/main.yml:187
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<testhost> EXEC /bin/sh -c 'echo ~root && sleep 0'
<testhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1554236816.4309068-133802087670756 `" && echo ansible-tmp-1554236816.4309068-133802087670756="` echo /root/.ansible/tmp/ansible-tmp-1554236816.4309068-133802087670756 `" ) && sleep 0'
Using module file /root/ansible/lib/ansible/modules/files/stat.py
<testhost> PUT /root/.ansible/tmp/ansible-local-12052xkzkq6/tmpp8mhdv_d TO /root/.ansible/tmp/ansible-tmp-1554236816.4309068-133802087670756/AnsiballZ_stat.py
<testhost> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1554236816.4309068-133802087670756/ /root/.ansible/tmp/ansible-tmp-1554236816.4309068-133802087670756/AnsiballZ_stat.py && sleep 0'
<testhost> EXEC /bin/sh -c '/tmp/python-lejid8t9-ansible/python /root/.ansible/tmp/ansible-tmp-1554236816.4309068-133802087670756/AnsiballZ_stat.py && sleep 0'
<testhost> FETCH /tmp/ansible.h2o14eo8.test/orig.root TO /root/ansible_testing/fetched/testhost/tmp/ansible.h2o14eo8.test/orig.root
<testhost> PUT /tmp/ansible.h2o14eo8.test/orig.root TO /root/ansible_testing/fetched/testhost/tmp/ansible.h2o14eo8.test/orig.root
<testhost> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1554236816.4309068-133802087670756/ > /dev/null 2>&1 && sleep 0'
changed: [testhost] => {
    "changed": true,
    "checksum": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
    "dest": "/root/ansible_testing/fetched/testhost/tmp/ansible.h2o14eo8.test/orig.root",
    "md5sum": "098f6bcd4621d373cade4e832627b4f6",
    "remote_checksum": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
    "remote_md5sum": null
}
Read vars_file 'integration_config.yml'

TASK [fetch : debug] ***********************************************************
task path: /root/.ansible/test/tmp/fetch-e6t19wo0-ÅÑŚÌβŁÈ/test/integration/targets/fetch/tasks/main.yml:193
ok: [testhost] => {
    "failed_fetch_root_owned_file": {
        "changed": true,
        "checksum": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
        "dest": "/root/ansible_testing/fetched/testhost/tmp/ansible.h2o14eo8.test/orig.root",
        "failed": false,
        "md5sum": "098f6bcd4621d373cade4e832627b4f6",
        "remote_checksum": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
        "remote_md5sum": null
    }
}
```

The file created by the test was mode `0600` owned by root. A non-root user should get a `permission denied` or `file not found` error attempting to retrieve it.