### PR TITLE
correct openssl rsa to genrsa in acme doc fragment

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -266,6 +266,7 @@ EXAMPLES = r'''
 #     type: TXT
 #     ttl: 60
 #     state: present
+#     wait: yes
 #     # Note: route53 requires TXT entries to be enclosed in quotes
 #     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
 #     when: sample_com_challenge is changed
@@ -278,6 +279,7 @@ EXAMPLES = r'''
 #     type: TXT
 #     ttl: 60
 #     state: present
+#     wait: yes
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
 #     value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"

--- a/lib/ansible/plugins/doc_fragments/acme.py
+++ b/lib/ansible/plugins/doc_fragments/acme.py
@@ -27,7 +27,7 @@ options:
     description:
       - "Path to a file containing the ACME account RSA or Elliptic Curve
          key."
-      - "RSA keys can be created with C(openssl rsa ...). Elliptic curve keys can
+      - "RSA keys can be created with C(openssl genrsa ...). Elliptic curve keys can
          be created with C(openssl ecparam -genkey ...). Any other tool creating
          private keys in PEM format can be used as well."
       - "Mutually exclusive with C(account_key_content)."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ACME references "openssl rsa" for generating account key.  Should be genrsa.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
acme
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
