### PR TITLE
[stable-2.6] Reduce testing of Ubuntu versions.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -58,9 +58,7 @@ matrix:
     - env: T=linux/fedora29/1
     - env: T=linux/opensuse15py2/1
     - env: T=linux/opensuse15/1
-    - env: T=linux/ubuntu1404/1
     - env: T=linux/ubuntu1604/1
-    - env: T=linux/ubuntu1604py3/1
     - env: T=linux/ubuntu1804/1
 
     - env: T=osx/10.11/2
@@ -72,9 +70,7 @@ matrix:
     - env: T=linux/fedora29/2
     - env: T=linux/opensuse15py2/2
     - env: T=linux/opensuse15/2
-    - env: T=linux/ubuntu1404/2
     - env: T=linux/ubuntu1604/2
-    - env: T=linux/ubuntu1604py3/2
     - env: T=linux/ubuntu1804/2
 
     - env: T=osx/10.11/3
@@ -86,9 +82,7 @@ matrix:
     - env: T=linux/fedora29/3
     - env: T=linux/opensuse15py2/3
     - env: T=linux/opensuse15/3
-    - env: T=linux/ubuntu1404/3
     - env: T=linux/ubuntu1604/3
-    - env: T=linux/ubuntu1604py3/3
     - env: T=linux/ubuntu1804/3
 
     - env: T=aws/2.7/1

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -5,7 +5,5 @@ fedora28 name=quay.io/ansible/fedora28-test-container:1.5.0
 fedora29 name=quay.io/ansible/fedora29-test-container:1.5.0 python=3
 opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.7.0
 opensuse15 name=quay.io/ansible/opensuse15-test-container:1.7.0 python=3
-ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0 seccomp=unconfined
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0 seccomp=unconfined
-ubuntu1604py3 name=quay.io/ansible/ubuntu1604py3-test-container:1.4.0 seccomp=unconfined python=3
 ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:1.6.0 seccomp=unconfined python=3


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Reduce testing of Ubuntu versions.

Removing:

- Ubuntu 14.04 with Python 2.7
- Ubuntu 16.04 with Python 3.5

Keeping:

- Ubuntu 16.04 with Python 2.7
- Ubuntu 18.04 with Python 3.6.

Backport of https://github.com/ansible/ansible/pull/54747

(cherry picked from commit c8f2becb7a3d15b6c8dd8aa29eb8d0e6b7d7a9ae)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml
