### PR TITLE
Fix netconf plugin dispatch response

### DIFF
--- a/changelogs/fragments/netconf_plugin_dispatch_fix.yaml
+++ b/changelogs/fragments/netconf_plugin_dispatch_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fix netconf plugin dispatch response (https://github.com/ansible/ansible/issues/53236)

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -208,7 +208,7 @@ class NetconfBase(AnsiblePlugin):
             raise ValueError('rpc_command value must be provided')
         req = fromstring(rpc_command)
         resp = self.m.dispatch(req, source=source, filter=filter)
-        return resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+        return resp.data_xml if resp.data_ele else resp.xml
 
     @ensure_connected
     def lock(self, target="candidate"):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #53236

*  If dispatch() rpc response has data element
   return the xml string from `<data>` element
   else return the complete xml string from
   `<rpc-reply>`.

(cherry picked from commit aac5ef5e13e692c09bfd30772311733878b01035)

Merged to devel https://github.com/ansible/ansible/pull/54326

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_rpc
plugins/netconf/init.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
