### PR TITLE
Add support for querying IPMI power status

### DIFF
--- a/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
@@ -19,7 +19,7 @@ module: ipmi_facts
 short_description: Facts collection for ipmi BMC devices
 description:
   - Use this module for querying ipmi informations
-version_added: "2.8"
+version_added: "2.9"
 notes:
     - "This module creates a new top-level C(ipmi_facts) fact,
       which contains IPMI powerstate and boot informations"

--- a/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
@@ -52,17 +52,17 @@ author: "Luca Lorenzetto (@remixtj) <lorenzetto.luca@gmail.com>"
 
 RETURN = '''
 bootdev:
-    description: The boot device name which will be used beyond next boot.
+    description: The boot device name which will be used for the next boot (and beyond if persistent).
     returned: success
     type: str
     sample: default
 bootdev_persistent:
-    description: If True, system firmware will use this device beyond next boot.
+    description: If True, system firmware will use the specified device beyond next boot.
     returned: success
     type: bool
     sample: false
 uefimode:
-    description: If True, system firmware will use UEFI boot explicitly beyond next boot.
+    description: If True, system firmware will use UEFI boot explicitly.
     returned: success
     type: bool
     sample: false
@@ -100,7 +100,7 @@ def main():
         argument_spec=dict(
             name=dict(required=True),
             port=dict(default=623, type='int'),
-            user=dict(required=True, no_log=True),
+            user=dict(required=True),
             password=dict(required=True, no_log=True),
             timeout=dict(default=300, type='int'),
         ),

--- a/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
@@ -1,0 +1,142 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ipmi_facts
+short_description: Power management for machine
+description:
+  - Use this module for querying ipmi informations
+version_added: "2.8"
+notes:
+    - "This module creates a new top-level C(ipmi_facts) fact,
+      which contains IPMI powerstate and boot informations"
+options:
+  name:
+    description:
+      - Hostname or ip address of the BMC.
+    required: true
+  port:
+    description:
+      - Remote RMCP port.
+    default: 623
+  user:
+    description:
+      - Username to use to connect to the BMC.
+    required: true
+  password:
+    description:
+      - Password to connect to the BMC.
+    required: true
+  timeout:
+    description:
+      - Maximum number of seconds before interrupt request.
+    default: 300
+requirements:
+  - "python >= 2.6"
+  - pyghmi
+author: "Luca Lorenzetto (@remixtj) <lorenzetto.luca@gmail.com>"
+'''
+
+RETURN = '''
+bootdev:
+    description: The boot device name which will be used beyond next boot.
+    returned: success
+    type: str
+    sample: default
+persistent:
+    description: If True, system firmware will use this device beyond next boot.
+    returned: success
+    type: bool
+    sample: false
+uefimode:
+    description: If True, system firmware will use UEFI boot explicitly beyond next boot.
+    returned: success
+    type: bool
+    sample: false
+powerstate:
+    description: The current power state of the machine.
+    returned: success
+    type: str
+    sample: on
+'''
+
+EXAMPLES = '''
+# Ensure machine is powered on.
+- ipmi_power:
+    name: test.testdomain.com
+    user: admin
+    password: password
+    state: on
+'''
+
+import traceback
+
+PYGHMI_IMP_ERR = None
+try:
+    from pyghmi.ipmi import command
+except ImportError:
+    PYGHMI_IMP_ERR = traceback.format_exc()
+    command = None
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True),
+            port=dict(default=623, type='int'),
+            user=dict(required=True, no_log=True),
+            password=dict(required=True, no_log=True),
+            timeout=dict(default=300, type='int'),
+        ),
+        supports_check_mode=True,
+    )
+
+    if command is None:
+        module.fail_json(msg=missing_required_lib('pyghmi'), exception=PYGHMI_IMP_ERR)
+
+    name = module.params['name']
+    port = module.params['port']
+    user = module.params['user']
+    password = module.params['password']
+    timeout = module.params['timeout']
+
+    # --- run command ---
+    try:
+        ipmi_cmd = command.Command(
+            bmc=name, userid=user, password=password, port=port
+        )
+        module.debug('ipmi instantiated - name: "%s"' % name)
+
+        current_powerstate = ipmi_cmd.get_power() 
+        current_bootdev = ipmi_cmd.get_bootdev()
+        current_bootdev['bootdev_persistent'] = current_bootdev.pop('persistent')
+        response = current_powerstate.copy()
+        response.update(current_bootdev)
+        changed = False
+
+        if 'error' in response:
+            module.fail_json(msg=response['error'])
+
+        module.exit_json(changed=changed, 
+                         ansible_facts=dict(ipmi_facts=response))
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
@@ -56,7 +56,7 @@ bootdev:
     returned: success
     type: str
     sample: default
-persistent:
+bootdev_persistent:
     description: If True, system firmware will use this device beyond next boot.
     returned: success
     type: bool
@@ -75,11 +75,12 @@ powerstate:
 
 EXAMPLES = '''
 # Ensure machine is powered on.
-- ipmi_power:
+- ipmi_facts:
     name: test.testdomain.com
     user: admin
     password: password
-    state: on
+- debug:
+    var: ipmi_facts
 '''
 
 import traceback

--- a/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
@@ -123,7 +123,7 @@ def main():
         )
         module.debug('ipmi instantiated - name: "%s"' % name)
 
-        current_powerstate = ipmi_cmd.get_power() 
+        current_powerstate = ipmi_cmd.get_power()
         current_bootdev = ipmi_cmd.get_bootdev()
         current_bootdev['bootdev_persistent'] = current_bootdev.pop('persistent')
         response = current_powerstate.copy()
@@ -133,7 +133,7 @@ def main():
         if 'error' in response:
             module.fail_json(msg=response['error'])
 
-        module.exit_json(changed=changed, 
+        module.exit_json(changed=changed,
                          ansible_facts=dict(ipmi_facts=response))
     except Exception as e:
         module.fail_json(msg=str(e))

--- a/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_facts.py
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: ipmi_facts
-short_description: Power management for machine
+short_description: Facts collection for ipmi BMC devices
 description:
   - Use this module for querying ipmi informations
 version_added: "2.8"

--- a/lib/ansible/modules/remote_management/ipmi/ipmi_power.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_power.py
@@ -47,7 +47,6 @@ options:
         - shutdown -- Have system request OS proper shutdown
         - reset -- Request system reset without waiting for OS
         - boot -- If system is off, then 'on', else 'reset'
-        - query -- Query for current power status
   timeout:
     description:
       - Maximum number of seconds before interrupt request.
@@ -73,17 +72,6 @@ EXAMPLES = '''
     user: admin
     password: password
     state: on
-
-# Query for current power status
-- ipmi_power:
-    name: test.testdomain.com
-    user: admin
-    password: password
-    state: query
-  register: ipmipowerstatus
-- debug:
-    var: ipmipowerstatus.powerstatus
-
 '''
 
 import traceback
@@ -103,7 +91,7 @@ def main():
         argument_spec=dict(
             name=dict(required=True),
             port=dict(default=623, type='int'),
-            state=dict(required=True, choices=['on', 'off', 'shutdown', 'reset', 'boot', 'query']),
+            state=dict(required=True, choices=['on', 'off', 'shutdown', 'reset', 'boot']),
             user=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
             timeout=dict(default=300, type='int'),
@@ -129,7 +117,7 @@ def main():
         module.debug('ipmi instantiated - name: "%s"' % name)
 
         current = ipmi_cmd.get_power()
-        if state != 'query' and current['powerstate'] != state:
+        if current['powerstate'] != state:
             response = {'powerstate': state} if module.check_mode else ipmi_cmd.set_power(state, wait=timeout)
             changed = True
         else:


### PR DESCRIPTION
##### SUMMARY

User may want to query for power status of an ipmi device
instead of changing it. With ipmi_facts, current state of the
ipmi status is returned and user may, as example, loop until a
desired power status is reached.
We developed this option because we have some tasks to
perform on storage side on some machines that boot from SAN.
These operations require to have machines powered off.

##### ISSUE TYPE
- New Module pull request

##### COMPONENT NAME
ipmi_facts

##### ADDITIONAL INFORMATION
Check docs included in the module for a sample of usage of the new parameter