### PR TITLE
asa: Not all modules will have 'passwords' and 'context' keys

### DIFF
--- a/lib/ansible/module_utils/network/asa/asa.py
+++ b/lib/ansible/module_utils/network/asa/asa.py
@@ -86,7 +86,8 @@ def get_connection(module):
         return _CONNECTION
     _CONNECTION = Connection(module._socket_path)
 
-    context = module.params['context']
+    # For new modules that will not have the provider dict
+    context = module.params.get('context')
 
     if context:
         if context == 'system':
@@ -130,6 +131,7 @@ def run_commands(module, commands, check_rc=True):
 def get_config(module, flags=None):
     flags = [] if flags is None else flags
 
+    # For new modules that will not have the provider dict
     passwords = module.params.get('passwords', False)
     if passwords:
         cmd = 'more system:running-config'

--- a/lib/ansible/module_utils/network/asa/asa.py
+++ b/lib/ansible/module_utils/network/asa/asa.py
@@ -130,7 +130,7 @@ def run_commands(module, commands, check_rc=True):
 def get_config(module, flags=None):
     flags = [] if flags is None else flags
 
-    passwords = module.params['passwords']
+    passwords = module.params.get('passwords', False)
     if passwords:
         cmd = 'more system:running-config'
     else:

--- a/lib/ansible/module_utils/network/asa/asa.py
+++ b/lib/ansible/module_utils/network/asa/asa.py
@@ -131,7 +131,7 @@ def run_commands(module, commands, check_rc=True):
 def get_config(module, flags=None):
     flags = [] if flags is None else flags
 
-    # For new modules that will not have the provider dict
+    # Not all modules include the 'passwords' key.
     passwords = module.params.get('passwords', False)
     if passwords:
         cmd = 'more system:running-config'

--- a/lib/ansible/module_utils/network/asa/asa.py
+++ b/lib/ansible/module_utils/network/asa/asa.py
@@ -86,7 +86,7 @@ def get_connection(module):
         return _CONNECTION
     _CONNECTION = Connection(module._socket_path)
 
-    # For new modules that will not have the provider dict
+    # Not all modules include the 'context' key.
     context = module.params.get('context')
 
     if context:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- New modules shouldn't have provider dict but 
   module_utils/get_config assumes that `passwords` key is already there.
- This is a quick fix to mitigate that (for now).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/asa.py