### PR TITLE
docs(lineinfile): fix typo inserbefore -> insertbefore

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -116,7 +116,7 @@ options:
   firstmatch:
     description:
       - Used with C(insertafter) or C(insertbefore).
-      - If set, C(insertafter) and C(inserbefore) find a first line has regular expression matches.
+      - If set, C(insertafter) and C(insertbefore) find a first line has regular expression matches.
     type: bool
     default: no
     version_added: "2.5"
@@ -285,7 +285,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         bre_ins = None
 
     # index[0] is the line num where regexp has been found
-    # index[1] is the line num where insertafter/inserbefore has been found
+    # index[1] is the line num where insertafter/insertbefore has been found
     index = [-1, -1]
     m = None
     b_line = to_bytes(line, errors='surrogate_or_strict')

--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -116,7 +116,7 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 	}
 
 	# index[0] is the line num where regexp has been found
-	# index[1] is the line num where insertafter/inserbefore has been found
+	# index[1] is the line num where insertafter/insertbefore has been found
 	$index = -1, -1;
 	$lineno = 0;
 


### PR DESCRIPTION
##### SUMMARY
Corrects typo in `lineinfile`'s documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`lineinfile`