### PR TITLE
 Don't swallow exceptions when processing included files

### DIFF
--- a/changelogs/fragments/include-no-swallow-error.yaml
+++ b/changelogs/fragments/include-no-swallow-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- include_role - Don't swallow errors when processing included files/roles (https://github.com/ansible/ansible/issues/54786)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -893,15 +893,12 @@ class StrategyBase:
         # collect the results from the handler run
         host_results = self._wait_on_handler_results(iterator, handler, notified_hosts)
 
-        try:
-            included_files = IncludedFile.process_include_results(
-                host_results,
-                iterator=iterator,
-                loader=self._loader,
-                variable_manager=self._variable_manager
-            )
-        except AnsibleError:
-            return False
+        included_files = IncludedFile.process_include_results(
+            host_results,
+            iterator=iterator,
+            loader=self._loader,
+            variable_manager=self._variable_manager
+        )
 
         result = True
         if len(included_files) > 0:

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -202,15 +202,12 @@ class StrategyModule(StrategyBase):
 
             self.update_active_connections(results)
 
-            try:
-                included_files = IncludedFile.process_include_results(
-                    host_results,
-                    iterator=iterator,
-                    loader=self._loader,
-                    variable_manager=self._variable_manager
-                )
-            except AnsibleError as e:
-                return self._tqm.RUN_ERROR
+            included_files = IncludedFile.process_include_results(
+                host_results,
+                iterator=iterator,
+                loader=self._loader,
+                variable_manager=self._variable_manager
+            )
 
             if len(included_files) > 0:
                 all_blocks = dict((host, []) for host in hosts_left)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -324,16 +324,12 @@ class StrategyModule(StrategyBase):
 
                 self.update_active_connections(results)
 
-                try:
-                    included_files = IncludedFile.process_include_results(
-                        host_results,
-                        iterator=iterator,
-                        loader=self._loader,
-                        variable_manager=self._variable_manager
-                    )
-                except AnsibleError as e:
-                    # this is a fatal error, so we abort here regardless of block state
-                    return self._tqm.RUN_ERROR
+                included_files = IncludedFile.process_include_results(
+                    host_results,
+                    iterator=iterator,
+                    loader=self._loader,
+                    variable_manager=self._variable_manager
+                )
 
                 include_failure = False
                 if len(included_files) > 0:


### PR DESCRIPTION
##### SUMMARY

Don't swallow exceptions when processing included files. Fixes #54786

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/strategy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```