### PR TITLE
ufw: fix default, direction is not necessary for it

### DIFF
--- a/changelogs/fragments/54799-ufw-default-direction.yml
+++ b/changelogs/fragments/54799-ufw-default-direction.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ufw - when ``default`` is specified, ``direction`` does not needs to be specified. This was accidentally introduced in Ansible 2.7.8."

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -472,10 +472,11 @@ def main():
                     current_default_values["outgoing"] = extract.group(2)
                     current_default_values["routed"] = extract.group(3)
                     if params['direction'] is None:
-                        if any(v != value for v in current_default_values.values()):
+                        if any(v not in (value, 'disabled') for v in current_default_values.values()):
                             changed = True
                     else:
-                        if current_default_values[params['direction']] != value:
+                        v = current_default_values[params['direction']]
+                        if v not in (value, 'disabled'):
                             changed = True
                 else:
                     changed = True

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -461,7 +461,7 @@ def main():
                 execute(cmd + [[command], [value]])
 
         elif command == 'default':
-            if params['direction'] not in ['outgoing', 'incoming', 'routed']:
+            if params['direction'] not in ['outgoing', 'incoming', 'routed', None]:
                 module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed".')
             if module.check_mode:
                 regexp = r'Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)'
@@ -471,8 +471,12 @@ def main():
                     current_default_values["incoming"] = extract.group(1)
                     current_default_values["outgoing"] = extract.group(2)
                     current_default_values["routed"] = extract.group(3)
-                    if current_default_values[params['direction']] != value:
-                        changed = True
+                    if params['direction'] is None:
+                        if any(v != value for v in current_default_values.values()):
+                            changed = True
+                    else:
+                        if current_default_values[params['direction']] != value:
+                            changed = True
                 else:
                     changed = True
             else:

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -462,7 +462,7 @@ def main():
 
         elif command == 'default':
             if params['direction'] not in ['outgoing', 'incoming', 'routed', None]:
-                module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed".')
+                module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed", or direction must not be specified.')
             if module.check_mode:
                 regexp = r'Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)'
                 extract = re.search(regexp, pre_state)
@@ -486,7 +486,7 @@ def main():
 
         elif command == 'rule':
             if params['direction'] not in ['in', 'out', None]:
-                module.fail_json(msg='For rules, direction must be one of "in" and "out".')
+                module.fail_json(msg='For rules, direction must be one of "in" and "out", or direction must not be specified.')
             # Rules are constructed according to the long format
             #
             # ufw [--dry-run] [route] [delete] [insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -472,8 +472,9 @@ def main():
                     current_default_values["outgoing"] = extract.group(2)
                     current_default_values["routed"] = extract.group(3)
                     if params['direction'] is None:
-                        if any(v not in (value, 'disabled') for v in current_default_values.values()):
-                            changed = True
+                        for v in current_default_values.values():
+                            if v not in (value, 'disabled'):
+                                changed = True
                     else:
                         v = current_default_values[params['direction']]
                         if v not in (value, 'disabled'):

--- a/test/integration/targets/ufw/tasks/tests/global-state.yml
+++ b/test/integration/targets/ufw/tasks/tests/global-state.yml
@@ -103,6 +103,35 @@
   register: ufw_defaults_change
   environment:
     LC_ALL: C
+- name: Default (change again)
+  ufw:
+    default: deny
+    direction: incoming
+  register: default_change_2
+- name: Default (change all, check mode)
+  ufw:
+    default: allow
+  check_mode: yes
+  register: default_change_all_check
+- name: Default (change all)
+  ufw:
+    default: allow
+  register: default_change_all
+- name: Get defaults
+  shell: |
+    ufw status verbose | grep "^Default:"
+  register: ufw_defaults_change_all
+  environment:
+    LC_ALL: C
+- name: Default (change all, idempotent, check mode)
+  ufw:
+    default: allow
+  check_mode: yes
+  register: default_change_all_idem_check
+- name: Default (change all, idempotent)
+  ufw:
+    default: allow
+  register: default_change_all_idem
 - assert:
     that:
     - default_check is changed
@@ -113,3 +142,10 @@
     - default_change_check is changed
     - default_change is changed
     - "'allow (incoming)' in ufw_defaults_change.stdout"
+    - default_change_2 is changed
+    - default_change_all_check is changed
+    - default_change_all is changed
+    - default_change_all_idem_check is not changed
+    - default_change_all_idem is not changed
+    - "'allow (incoming)' in ufw_defaults_change_all.stdout"
+    - "'allow (outgoing)' in ufw_defaults_change_all.stdout"


### PR DESCRIPTION
##### SUMMARY
While implementing #49948 and #50402, we forgot to consider that `direction` is not required for `default`. This re-allows not specifying `direction` when `default` is used.

Fixes #53854.

CC @jbarotin

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
