### PR TITLE
[2.7] correct openssl rsa to genrsa in acme doc fragment

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -234,6 +234,7 @@ EXAMPLES = R'''
 #     type: TXT
 #     ttl: 60
 #     state: present
+#     wait: yes
 #     # Note: route53 requires TXT entries to be enclosed in quotes
 #     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
 #     when: sample_com_challenge is changed
@@ -246,6 +247,7 @@ EXAMPLES = R'''
 #     type: TXT
 #     ttl: 60
 #     state: present
+#     wait: yes
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
 #     value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"

--- a/lib/ansible/utils/module_docs_fragments/acme.py
+++ b/lib/ansible/utils/module_docs_fragments/acme.py
@@ -28,7 +28,7 @@ options:
     description:
       - "Path to a file containing the ACME account RSA or Elliptic Curve
          key."
-      - "RSA keys can be created with C(openssl rsa ...). Elliptic curve keys can
+      - "RSA keys can be created with C(openssl genrsa ...). Elliptic curve keys can
          be created with C(openssl ecparam -genkey ...). Any other tool creating
          private keys in PEM format can be used as well."
       - "Mutually exclusive with C(account_key_content)."


### PR DESCRIPTION
##### SUMMARY
Backport of #54744 to stable-2.7. Fixes some docs issues.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_certificate
