### PR TITLE
[2.7] acme_certficate: allow to write files to CWD

### DIFF
--- a/changelogs/fragments/54754-acme_certificate-cwd.yml
+++ b/changelogs/fragments/54754-acme_certificate-cwd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_certificate - writing result failed when no path was specified (i.e. destination in current working directory)."

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -133,9 +133,10 @@ def write_file(module, dest, content):
             raise ModuleFailException("Destination %s not readable" % (dest))
         checksum_dest = module.sha1(dest)
     else:
-        if not os.access(os.path.dirname(dest), os.W_OK):
+        dirname = os.path.dirname(dest) or '.'
+        if not os.access(dirname, os.W_OK):
             os.remove(tmpsrc)
-            raise ModuleFailException("Destination dir %s not writable" % (os.path.dirname(dest)))
+            raise ModuleFailException("Destination dir %s not writable" % (dirname))
     if checksum_src != checksum_dest:
         try:
             shutil.copyfile(tmpsrc, dest)


### PR DESCRIPTION
##### SUMMARY
Backport of #54754 to stable-2.7. Prevents unnecessary module failure when certificate has no path component (i.e. is in CWD).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
