### PR TITLE
redhat_subscription: Fix usage of ConfigParser

### DIFF
--- a/changelogs/fragments/redhat_subscription_use_strings_for_yum_plugin_configs.yaml
+++ b/changelogs/fragments/redhat_subscription_use_strings_for_yum_plugin_configs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- redhat_subscription - For compatibility using the redhat_subscription module on hosts set to use a python 3 interpreter, use string values when updating yum plugin configuration files.

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -260,9 +260,9 @@ class RegistrationBase(object):
             cfg.read([tmpfile])
 
             if enabled:
-                cfg.set('main', 'enabled', 1)
+                cfg.set('main', 'enabled', '1')
             else:
-                cfg.set('main', 'enabled', 0)
+                cfg.set('main', 'enabled', '0')
 
             fd = open(tmpfile, 'w+')
             cfg.write(fd)


### PR DESCRIPTION
##### SUMMARY
This PR fixes an issue in the usage of configparser in the redhat_subscription module. The configparser module is imported from ansible.module_utils.six.moves as of f75ffe46db3. After that change was made, any attempt to use the redhat_subscription module with an ansible_python_interpreter of python 3+ fail with the following: 
```
FAILED! => {"changed": false, "msg": "Failed to register with 'https://subscription.rhsm.stage.redhat.com/subscription': option values must be strings"}
```

The error ultimately comes from passing integers to ConfigParser.set where strings were expected when updating the rhsm and rhn yum plugin configurations (under /etc/yum/pluginconf.d/).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription

##### ADDITIONAL INFORMATION
This issue seems only to surface when a python 3 interpreter is used on the target machine(s).
Here's a sample inventory file for my reproducer (named inv):
```
[all:vars]
ansible_connection=ssh
ansible_user=root
ansible_ssh_pass=redhat

[local]
192.168.121.179 ansible_python_interpreter="/usr/bin/env python3"
```

The playbook used is as follows (named test.yml):
```
---
- hosts: "local"
  become: yes
  tasks:
    - name: Register the machine
      redhat_subscription:
        state: present
        server_hostname: https://candlepin.example.com:8443/candlepin
        username: admin
        password: admin
        auto_attach: true
```

With these files in place execute: ```ansible-playbook test.yml -i ./inv```
Output:
```
TASK [Register with stage] *******************************************************************************************************************************************************************
fatal: [192.168.121.179]: FAILED! => {"changed": false, "msg": "Failed to register with 'https://candlepin.example.com:8443/candlepin': option values must be strings"}
```
