### PR TITLE
fix regex in plugins/terminal/iosxr.py

### DIFF
--- a/lib/ansible/plugins/terminal/iosxr.py
+++ b/lib/ansible/plugins/terminal/iosxr.py
@@ -29,7 +29,7 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n][\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(br"[\r\n]*[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
         re.compile(br']]>]]>[\r\n]?')
     ]
 


### PR DESCRIPTION
Fixes a bug where in some situations you can get a timeout on iosxr devices due to bad regexp. 

##### SUMMARY

Fixes situations where iosxr terminals that do not contain new line "/r/n" at the beginning of CLI timeouts due to regex error. Just make "/r/n" optional including "*" character in the regex

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
 terminal/iosxr.py

##### ADDITIONAL INFORMATION

The current regexp require that the router returns new line (/r/n) after authentication. Not every router returns this, which causes timeout while waiting for this regex.

You should either make newline as optional or add another regexp in the code without the newline.

Ex: re.compile(br"[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),

Router examples that works on current regexp:
```
ssh 127.0.0.1
liviozanol@127.0.0.1's password:
Last switch-over Wed Mar 28 17:49:02 2018: 1 year, 5 days, 22 hours, 48 minutes ago

RP/0/RSP0/CPU0:ROUTER#

-------

ssh 127.0.0.1
liviozanol@127.0.0.1's password:

RP/0/RSP0/CPU0:ROUTER#
```


Router example that **DO NOT** works on current regexp:

```
ssh 127.0.0.1
liviozanol@127.0.0.1's password:
RP/0/RSP0/CPU0:ROUTER#
```
Can be verified at: https://pythex.org/

[kind off-topic below]
Also, I really don't understand why the regexp's needs to be so complicated. I've read a some issues regarding regexp on ios, iosxr and nxos. Can't it be more simple? If we could know the reason why its so complicated maybe we could sugest some change.

This kind of error (regex not matched) should really raise an specific message to the user, since its VERY difficult to troubleshoot with a simple timeout error. Maybe you should raise a message in network_cli.py near `if errored_response` or at socket timeout on ansible_connection