### PR TITLE
ACI CDP Interface Policy Module Creation

### DIFF
--- a/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: my_sample_module
+
+short_description: This is my sample module
+
+version_added: "2.4"
+
+description:
+    - "This is my longer description explaining my sample module"
+
+options:
+    name:
+        description:
+            - This is the message to send to the sample module
+        required: true
+    new:
+        description:
+            - Control to demo if the result of this module is changed or not
+        required: false
+
+extends_documentation_fragment:
+    - azure
+
+author:
+    - Your Name (@yourhandle)
+'''
+
+EXAMPLES = '''
+# Pass in a message
+- name: Test with a message
+  my_new_test_module:
+    name: hello world
+
+# pass in a message and have changed true
+- name: Test with a message and changed output
+  my_new_test_module:
+    name: hello world
+    new: true
+
+# fail the module
+- name: Test failure of the module
+  my_new_test_module:
+    name: fail me
+'''
+
+RETURN = '''
+original_message:
+    description: The original name param that was passed in
+    type: str
+message:
+    description: The output message that the sample module generates
+'''
+from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+#    run_module()
+    argument_spec = aci_argument_spec()
+    argument_spec.update(
+        cdp_policy=dict(type='str', required=False, aliases=['cdp_interface', 'name']),  # Not required for querying all objects
+        description=dict(type='str', aliases=['descr']),
+        admin_state=dict(type='bool'),  
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'absent', ['cdp_policy']],
+            ['state', 'present', ['cdp_policy']],
+        ],
+    )
+
+    aci = ACIModule(module)
+
+    cdp_policy = module.params['cdp_policy']
+    description = module.params['description']
+    admin_state = aci.boolean(module.params['admin_state'], 'enabled', 'disabled')
+    state = module.params['state']
+
+
+    aci.construct_url(
+        root_class=dict(
+            aci_class='cdpIfPol',
+            aci_rn='infra/cdpIfP-{0}'.format(cdp_policy),
+            module_object=cdp_policy,
+            target_filter={'name': cdp_policy},
+        ),
+    )
+
+    aci.get_existing()
+
+    if state == 'present':
+        aci.payload(
+            aci_class='cdpIfPol',
+            class_config=dict(
+                name=cdp_policy,
+                descr=description,
+                adminSt=admin_state,
+            ),
+        )
+
+        aci.get_diff(aci_class='cdpIfPol')
+
+        aci.post_config()
+
+    elif state == 'absent':
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
@@ -9,58 +9,163 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
-module: my_sample_module
-
-short_description: This is my sample module
-
-version_added: "2.4"
-
+module: aci_interface_policy_cdp
+short_description: Manage CDP interface policies (cdp:IfPol)
 description:
-    - "This is my longer description explaining my sample module"
-
+- Manage CDP interface policies on Cisco ACI fabrics.
+version_added: '2.9'
 options:
-    name:
-        description:
-            - This is the message to send to the sample module
-        required: true
-    new:
-        description:
-            - Control to demo if the result of this module is changed or not
-        required: false
-
-extends_documentation_fragment:
-    - azure
-
-author:
-    - Your Name (@yourhandle)
-'''
-
-EXAMPLES = '''
-# Pass in a message
-- name: Test with a message
-  my_new_test_module:
-    name: hello world
-
-# pass in a message and have changed true
-- name: Test with a message and changed output
-  my_new_test_module:
-    name: hello world
-    new: true
-
-# fail the module
-- name: Test failure of the module
-  my_new_test_module:
-    name: fail me
-'''
-
-RETURN = '''
-original_message:
-    description: The original name param that was passed in
+  cdp_policy:
+    description:
+    - The CDP interface policy name.
     type: str
-message:
-    description: The output message that the sample module generates
+    required: yes
+    aliases: [ name ]
+  description:
+    description:
+    - The description for the CDP interface policy name.
+    type: str
+    aliases: [ descr ]
+  admin_state:
+    description:
+    - Enable or Disable CDP state.
+    - The APIC defaults to C(yes) when unset during creation.
+    type: bool
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+extends_documentation_fragment: aci
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(cdp:IfPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Tim Knipper (@tknipper11)
+'''
+
+# FIXME: Add more, better examples
+EXAMPLES = r'''
+- aci_interface_policy_cdp:
+    host: '{{ hostname }}'
+    username: '{{ username }}'
+    password: '{{ password }}'
+    cdp_policy: '{{ cdp_policy }}'
+    description: '{{ description }}'
+    admin_state: '{{ admin_state }}'
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "cdpIfPol": {
+                "attributes": {
+                    "adminSt": "disabled",
+                    "annotation": "",
+                    "descr": "Ansible Created CDP Test Policy",
+                    "dn": "uni/infra/cdpIfP-Ansible_CDP_Test_Policy",
+                    "name": "Ansible_CDP_Test_Policy",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: str
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous:
+  description: The original configuration from the APIC before the module has started
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: str
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: POST
+response:
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: str
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# Copyright: (c) 2019, Tim Knipper <tim.knipper@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',

--- a/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
@@ -22,7 +22,7 @@ options:
     - The CDP interface policy name.
     type: str
     required: yes
-    aliases: [ name ]
+    aliases: [ cdp_interface, name ]
   description:
     description:
     - The description for the CDP interface policy name.
@@ -173,12 +173,11 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def main():
-#    run_module()
     argument_spec = aci_argument_spec()
     argument_spec.update(
         cdp_policy=dict(type='str', required=False, aliases=['cdp_interface', 'name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
-        admin_state=dict(type='bool'),  
+        admin_state=dict(type='bool'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
 
@@ -197,7 +196,6 @@ def main():
     description = module.params['description']
     admin_state = aci.boolean(module.params['admin_state'], 'enabled', 'disabled')
     state = module.params['state']
-
 
     aci.construct_url(
         root_class=dict(

--- a/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_cdp.py
@@ -15,7 +15,7 @@ module: aci_interface_policy_cdp
 short_description: Manage CDP interface policies (cdp:IfPol)
 description:
 - Manage CDP interface policies on Cisco ACI fabrics.
-version_added: '2.9'
+version_added: '2.8'
 options:
   cdp_policy:
     description:

--- a/test/integration/targets/aci_interface_policy_cdp/aliases
+++ b/test/integration/targets/aci_interface_policy_cdp/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/aci_interface_policy_cdp/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_cdp/tasks/main.yml
@@ -79,7 +79,6 @@
 - debug: 
     var: cdp_disable
 
-
 - assert: 
     that:
-      - 'cdp_disable.current.0.cdpifPol.attributes.adminSt == "disabled"'
+      - 'cdp_disable.current.0.cdpIfPol.attributes.adminSt == "disabled"'

--- a/test/integration/targets/aci_interface_policy_cdp/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_cdp/tasks/main.yml
@@ -1,0 +1,85 @@
+# Test code for the ACI modules
+# Copyright: (c) 2019, Tim Knipper (tknipper11) <tim.knipper@gmail.com>
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+# CLEAN ENVIRONMENT
+- name: Remove CDP Test Policy
+  aci_interface_policy_cdp:
+    name: Ansible_CDP_Test_Policy
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(false) }}'
+    output_level: debug
+    state: absent
+  register: cdp_delete
+
+
+
+- name: Create CDP Test Policy
+  aci_interface_policy_cdp:
+    name: Ansible_CDP_Test_Policy
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(false) }}'
+#    output_level: debug
+    state: present
+  register: cdp_create
+- debug: 
+    var: cdp_create
+
+- assert: 
+    that: 
+      - cdp_create is changed
+
+
+- name: test for idempotency
+  aci_interface_policy_cdp:
+    name: Ansible_CDP_Test_Policy
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(false) }}'
+#    output_level: debug
+    state: present
+  register: cdp_idem
+
+- assert:
+    that: 
+      - cdp_idem is not changed
+
+
+
+- name: Create CDP Disable Test Policy
+  aci_interface_policy_cdp:
+    name: Ansible_CDP_Test_Policy
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(false) }}'
+#    output_level: debug
+    state: present
+    admin_state: no
+  register: cdp_disable
+- debug: 
+    var: cdp_disable
+
+
+- assert: 
+    that:
+      - 'cdp_disable.current.0.cdpifPol.attributes.adminSt == "disabled"'

--- a/test/integration/targets/aci_interface_policy_cdp/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_cdp/tasks/main.yml
@@ -57,7 +57,8 @@
     state: present
   register: cdp_idem
 
-- assert:
+- name: Assert that idempotency is not changed
+  assert:
     that: 
       - cdp_idem is not changed
 
@@ -79,6 +80,27 @@
 - debug: 
     var: cdp_disable
 
-- assert: 
+- name: Assert that CDP is Disabled
+  assert:
     that:
       - 'cdp_disable.current.0.cdpIfPol.attributes.adminSt == "disabled"'
+
+
+- name: Query CDP Policy
+  aci_interface_policy_cdp:
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(false) }}'
+#    output_level: debug
+    state: query
+  register: cdp_query
+- debug: 
+    var: cdp_query
+
+- name: CDP Query Assertion
+  assert: 
+    that: 
+      - cdp_query is not changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module creates a fabric interface policy for CDP enable and CDP disable.  This is based on the aci_interface_policy_lldp module already in version 2.7.  cc @kbreit 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aci_interface_policy_cdp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [aci_interface_policy_cdp : debug] ************************************************************************************************************************
ok: [localhost] => {
    "cdp_disable": {
        "changed": true,
        "current": [
            {
                "cdpIfPol": {
                    "attributes": {
                        "adminSt": "disabled",
                        "annotation": "",
                        "descr": "",
                        "dn": "uni/infra/cdpIfP-Ansible_CDP_Test_Policy",
                        "name": "Ansible_CDP_Test_Policy",
                        "nameAlias": "",
                        "ownerKey": "",
                        "ownerTag": ""
                    }
                }
            }
        ],
        "failed": false
    }
}


```
