### PR TITLE
[stable-2.7] - Meraki - remove redundant API calls

### DIFF
--- a/changelogs/fragments/meraki_orgnet_fix.yml
+++ b/changelogs/fragments/meraki_orgnet_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Meraki - Lookups using org_name or net_name no longer query Meraki twice, only once. Major performance improvements.

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -157,7 +157,7 @@ class MerakiModule(object):
         response = self.request('/organizations', method='GET')
         if self.status != 200:
             self.fail_json(msg='Organization lookup failed')
-        self.orgs = self.request('/organizations', method='GET')
+        self.orgs = response
         return self.orgs
 
     def is_org_valid(self, data, org_name=None, org_id=None):
@@ -205,7 +205,7 @@ class MerakiModule(object):
         r = self.request(path, method='GET')
         if self.status != 200:
             self.fail_json(msg='Network lookup failed')
-        self.nets = self.request(path, method='GET')
+        self.nets = r
         templates = self.get_config_templates(org_id)
         for t in templates:
             self.nets.append(t)


### PR DESCRIPTION
##### SUMMARY
* Performance fixes for net and org lookups
- Both methods had duplicate lookups
- This should significantly improve performance
- Currently untested

* Add ChangeLog file

* Change from bugfix to bugfixes and change indent

(cherry picked from commit c254b93796ef81a98d01b28e421360a741b5e8c4)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki
