### PR TITLE
vsphere_guest failed to create vm with "vm not present" message 

### DIFF
--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1904,9 +1904,8 @@ def main():
             module.exit_json(changed=False, msg="vm %s not present" % guest)
 
         # check if user is trying to perform state operation on a vm which doesn't exists
-        elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_extra_config,
-                                                                            vm_hardware, vm_disk, vm_nic, esxi)):
-            module.exit_json(changed=False, msg="vm %s not present" % guest)
+        elif state in ['present', 'powered_off', 'powered_on'] and not all(vm_hardware, vm_disk, vm_nic, esxi)):
+            module.fail_json(msg="vm %s not present and options neccessary to create not provided" % guest)
 
         # Create the VM
         elif state in ['present', 'powered_off', 'powered_on']:

--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1905,7 +1905,7 @@ def main():
 
         # check if user is trying to perform state operation on a vm which doesn't exists
         elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_hardware, vm_disk, vm_nic, esxi)):
-            module.fail_json(msg="vm %s not present and options neccessary to create not provided" % guest)
+            module.fail_json(msg="vm %s not present and not all options neccessary to create are provided" % guest)
 
         # Create the VM
         elif state in ['present', 'powered_off', 'powered_on']:

--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1904,7 +1904,7 @@ def main():
             module.exit_json(changed=False, msg="vm %s not present" % guest)
 
         # check if user is trying to perform state operation on a vm which doesn't exists
-        elif state in ['present', 'powered_off', 'powered_on'] and not all(vm_hardware, vm_disk, vm_nic, esxi)):
+        elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_hardware, vm_disk, vm_nic, esxi)):
             module.fail_json(msg="vm %s not present and options neccessary to create not provided" % guest)
 
         # Create the VM


### PR DESCRIPTION
vsphere_guest: corrected fix #19716 misbehavior
* creating machines without vm_extra_config
* not failing when trying to change power state of non-existing machine

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix #19716 behaved in most unfortunate way when trying to create virtual machine without vm_extra_config parameter (which is not necessary anyway). Instead of failing the task, it returned success with "vm not present" message. Also it seems that setting power state of absent machine wouldn't fail the module either.

This fix changes this behavior to:
* fail module instead of exit
* continue even when vm_extra_config is not provided
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
