### PR TITLE
Module validation: don't complain if type() is used in if

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -62,7 +62,7 @@ else:
 
 BLACKLIST_DIRS = frozenset(('.git', 'test', '.github', '.idea'))
 INDENT_REGEX = re.compile(r'([\t]*)')
-TYPE_REGEX = re.compile(r'.*(if|or)(\s+[^"\']*|\s+)(?<!_)(?<!str\()type\(.*')
+TYPE_REGEX = re.compile(r'.*(if|or)(\s+[^"\']*|\s+)(?<!_)(?<!str\()type\([^)].*')
 SYS_EXIT_REGEX = re.compile(r'[^#]*sys.exit\s*\(.*')
 BLACKLIST_IMPORTS = {
     'requests': {


### PR DESCRIPTION
##### SUMMARY
The `Type comparison using type() found. Use isinstance() instead` condition is too strict, it also has a problem with things like `if self.key.type() == crypto.TYPE_RSA:`, which has nothing to do with type comparisons. This improves the check by making sure that `check()` is ignored, only `check(` followed by something else than `)` is considered. This still can cause false negatives, but fewer of them.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/sanity/validate-modules/main.py
