### PR TITLE
fix poller for some resources

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
@@ -209,6 +209,7 @@ from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError
+    from msrest.polling import LROPoller
     from msrestazure.azure_operation import AzureOperationPoller
     from msrest.serialization import Model
     from azure.mgmt.redis import RedisManagementClient
@@ -561,7 +562,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
             response = self._client.redis.create(resource_group_name=self.resource_group,
                                                  name=self.name,
                                                  parameters=params)
-            if isinstance(response, AzureOperationPoller):
+            if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
                 response = self.get_poller_result(response)
 
         except CloudError as exc:
@@ -597,7 +598,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
             response = self._client.redis.update(resource_group_name=self.resource_group,
                                                  name=self.name,
                                                  parameters=params)
-            if isinstance(response, AzureOperationPoller):
+            if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
                 response = self.get_poller_result(response)
 
         except CloudError as exc:

--- a/lib/ansible/modules/cloud/azure/azure_rm_rediscachefirewallrule.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_rediscachefirewallrule.py
@@ -90,6 +90,7 @@ from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError
+    from msrest.polling import LROPoller
     from msrestazure.azure_operation import AzureOperationPoller
     from msrest.serialization import Model
     from azure.mgmt.redis import RedisManagementClient
@@ -258,7 +259,7 @@ class AzureRMRedisCacheFirewallRule(AzureRMModuleBase):
                                                                     rule_name=self.name,
                                                                     start_ip=self.start_ip_address,
                                                                     end_ip=self.end_ip_address)
-            if isinstance(response, AzureOperationPoller):
+            if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
                 response = self.get_poller_result(response)
 
         except CloudError as exc:

--- a/lib/ansible/modules/cloud/azure/azure_rm_roledefinition.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_roledefinition.py
@@ -331,7 +331,7 @@ class AzureRMRoleDefinition(AzureRMModuleBase):
             response = self._client.role_definitions.create_or_update(role_definition_id=self.role['name'] if self.role else str(uuid.uuid4()),
                                                                       scope=self.scope,
                                                                       role_definition=role_definition)
-            if isinstance(response, AzureOperationPoller):
+            if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
                 response = self.get_poller_result(response)
 
         except CloudError as exc:


### PR DESCRIPTION
##### SUMMARY
Some resources were still using old AzureOperationPoller.
This may cause failure, or they may start failing if the version of underlying Python SDK is updated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
several

##### ADDITIONAL INFORMATION
