### PR TITLE
nxos_interface:DI: delay only when operation state check is requested

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -590,14 +590,15 @@ def check_declarative_intent_params(module, want):
     failed_conditions = []
     have_neighbors = None
     for w in want:
+        if w['interface_type']:
+            return
         want_tx_rate = w.get('tx_rate')
         want_rx_rate = w.get('rx_rate')
         want_neighbors = w.get('neighbors')
+        if not (want_tx_rate or want_rx_rate or want_neighbors):
+            continue
 
         time.sleep(module.params['delay'])
-
-        if w['interface_type']:
-            return
 
         cmd = [{'command': 'show interface {0}'.format(w['name']), 'output': 'text'}]
 

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -591,7 +591,7 @@ def check_declarative_intent_params(module, want):
     have_neighbors = None
     for w in want:
         if w['interface_type']:
-            return
+            continue
         want_tx_rate = w.get('tx_rate')
         want_rx_rate = w.get('rx_rate')
         want_neighbors = w.get('neighbors')


### PR DESCRIPTION
##### SUMMARY
There is a 10 second delay that occurs for every interface that is changed.
This delay should only occur when a task sets one of the `want` vars. I added a guard clause to skip the delay.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`modules/networks/nxos/nxos_interface`
