### PR TITLE
Fix for Bug#54050

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 |PyPI version| |Docs badge| |Chat badge| |Build Status| |Code Of Conduct| |Mailing Lists| |License|
 
+
 *******
 Ansible
 *******

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
 |PyPI version| |Docs badge| |Chat badge| |Build Status| |Code Of Conduct| |Mailing Lists| |License|
 
-
 *******
 Ansible
 *******

--- a/lib/ansible/modules/network/eos/eos_l2_interface.py
+++ b/lib/ansible/modules/network/eos/eos_l2_interface.py
@@ -213,16 +213,20 @@ def map_config_to_obj(module):
     for item in set(match):
         command = {'command': 'show interfaces {0} switchport | include Switchport'.format(item),
                    'output': 'text'}
-        switchport_cfg = run_commands(module, command)[0].split(':')[1].strip()
-        if switchport_cfg == 'Enabled':
-            state = 'present'
-        else:
-            state = 'absent'
+        command_result = run_commands(module, command)
+        print ("command_result = %s" % (len(command_result)))
+        if command_result[0] != "": 
+            switchport_cfg = command_result[0].split(':')[1].strip()
+        
+            if switchport_cfg == 'Enabled':
+                state = 'present'
+            else:
+                state = 'absent'
 
-        obj = {
-            'name': item.lower(),
-            'state': state,
-        }
+            obj = {
+                'name': item.lower(),
+                'state': state,
+            }
 
         obj['access_vlan'] = parse_config_argument(configobj, item, 'switchport access vlan')
         obj['native_vlan'] = parse_config_argument(configobj, item, 'switchport trunk native vlan')

--- a/lib/ansible/modules/network/eos/eos_l2_interface.py
+++ b/lib/ansible/modules/network/eos/eos_l2_interface.py
@@ -214,10 +214,9 @@ def map_config_to_obj(module):
         command = {'command': 'show interfaces {0} switchport | include Switchport'.format(item),
                    'output': 'text'}
         command_result = run_commands(module, command)
-        print ("command_result = %s" % (len(command_result)))
-        if command_result[0] != "": 
+        if command_result[0] != "":
             switchport_cfg = command_result[0].split(':')[1].strip()
-        
+
             if switchport_cfg == 'Enabled':
                 state = 'present'
             else:


### PR DESCRIPTION
##### SUMMARY
Fixes #54050.

This does a silent ignore on interfaces that don't exist.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
eos_l2_interface


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Playbook for testing:
```
- hosts: tb7280-1 
  gather_facts: false

  vars:
    l2_interfaces:
        - {name: Ethernet1/1, mode: trunk, state: present}
        - {name: Ethernet2/1, mode: trunk, state: present}

  tasks:
    - name: l2 interfaces
      eos_l2_interface:
         aggregate: "{{l2_interfaces}}"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before Changes
```
PLAY [tb7280-1] *********************************************************************************************************************

TASK [l2 interfaces] ****************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: IndexError: list index out of range
fatal: [tb7280-1]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/aws_svcs/.ansible/tmp/ansible-local-879416tgl33/ansible-tmp-1554388404.83-267013644925932/AnsiballZ_eos_l2_interface.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/home/aws_svcs/.ansible/tmp/ansible-local-879416tgl33/ansible-tmp-1554388404.83-267013644925932/AnsiballZ_eos_l2_interface.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/aws_svcs/.ansible/tmp/ansible-local-879416tgl33/ansible-tmp-1554388404.83-267013644925932/AnsiballZ_eos_l2_interface.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_eos_l2_interface_payload_t2G3ET/__main__.py\", line 314, in <module>\n  File \"/tmp/ansible_eos_l2_interface_payload_t2G3ET/__main__.py\", line 298, in main\n  File \"/tmp/ansible_eos_l2_interface_payload_t2G3ET/__main__.py\", line 212, in map_config_to_obj\nIndexError: list index out of range\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
	to retry, use: --limit @/home/aws_svcs/ansible-datacenter/eos_l2_test.retry

PLAY RECAP **************************************************************************************************************************
tb7280-1                   : ok=0    changed=0    unreachable=0    failed=1
```

After Changes
```
PLAY [tb7280-1] ******************************************************************************************************************************************************************

TASK [l2 interfaces] *************************************************************************************************************************************************************
ok: [tb7280-1]

PLAY RECAP ***********************************************************************************************************************************************************************
tb7280-1                   : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```
