### PR TITLE
[wip]test: vcenter provider static config

### DIFF
--- a/test/integration/cloud-config-vcenter.ini.template
+++ b/test/integration/cloud-config-vcenter.ini.template
@@ -1,0 +1,4 @@
+[default]
+vcenter_hostname=@HOSTNAME
+vcenter_username=@USERNAME
+vcenter_password=@PASSWORD


### PR DESCRIPTION
##### SUMMARY

The vcenter provider can now use a static configuration file, this give
a way to run the test-suite on a regular environment.
The configuration file is located here:

  test/integration/cloud-config-vcenter.ini

Note: This commit also generalizes the use of `vcenter_hostname` instead
of `vcenter_host`. This to be consistent with what is done in the
documentation.


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

vmware