### PR TITLE
Show terraform plan output in with --diff option

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -389,11 +389,11 @@ def main():
         select_workspace(command[0], project_path, workspace_ctx["current"])
     if state == 'absent' and workspace != 'default' and purge_workspace is True:
         remove_workspace(command[0], project_path, workspace)
-    
+
     if module.check_mode:
         changed = needs_application
     diff = dict(before='', after=out)
-    
+
     module.exit_json(changed=changed, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
 
 

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -106,6 +106,7 @@ options:
     version_added: 2.7
 notes:
    - To just run a `terraform plan`, use check mode.
+   - To show terraform plan output use diff mode
 requirements: [ "terraform" ]
 author: "Ryan Scott Brown (@ryansb)"
 '''
@@ -388,7 +389,11 @@ def main():
         select_workspace(command[0], project_path, workspace_ctx["current"])
     if state == 'absent' and workspace != 'default' and purge_workspace is True:
         remove_workspace(command[0], project_path, workspace)
-
+    
+    if module.check_mode:
+        changed = needs_application
+    diff=dict(before= '', after= out)
+    
     module.exit_json(changed=changed, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
 
 

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -394,7 +394,7 @@ def main():
         changed = needs_application
     diff = dict(before='', after=out)
 
-    module.exit_json(changed=changed, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
+    module.exit_json(changed=changed, diff=diff, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -392,7 +392,7 @@ def main():
     
     if module.check_mode:
         changed = needs_application
-    diff=dict(before= '', after= out)
+    diff = dict(before='', after=out)
     
     module.exit_json(changed=changed, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Currently there is no easy way to display the plan generated by terraform. This PR will display the plan when --diff option is used. This kind of makes sense because the terraform plan will show what changes are about to be applied to the infrastructure. Also it is critical in many situations to review the plan before applying it (this can be achieved with a combination of --check and --diff options)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
cloud/misc/terraform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
