### PR TITLE
cloudscale_server: implement param server_groups

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -400,7 +400,7 @@ class AnsibleCloudscaleServer(AnsibleCloudscaleBase):
         if not server_group_params:
             return None
 
-        matchin_group_names = []
+        matching_group_names = []
         results = []
         server_groups = self._get('server-groups')
         for server_group in server_groups:
@@ -412,10 +412,10 @@ class AnsibleCloudscaleServer(AnsibleCloudscaleBase):
                 results.append(server_group['uuid'])
                 server_group_params.remove(server_group['name'])
                 # Remember the names found
-                matchin_group_names.append(server_group['name'])
+                matching_group_names.append(server_group['name'])
 
             # Names are not unique, verify if name already found in previous iterations
-            elif server_group['name'] in matchin_group_names:
+            elif server_group['name'] in matching_group_names:
                 self._module.fail_json(msg="More than one server group with name exists: '%s'. "
                                        "Use the 'uuid' parameter to identify the server group." % server_group['name'])
 

--- a/test/integration/targets/cloudscale_server/tasks/failures.yml
+++ b/test/integration/targets/cloudscale_server/tasks/failures.yml
@@ -1,0 +1,24 @@
+---
+- name: Fail missing params
+  cloudscale_server:
+  register: srv
+  ignore_errors: True
+- name: 'VERIFY: Fail name and UUID'
+  assert:
+    that:
+      - srv is failed
+
+- name: Fail unexisting server group
+  cloudscale_server:
+    name: '{{ cloudscale_resource_prefix }}-test-group'
+    flavor: '{{ cloudscale_test_flavor }}'
+    image: '{{ cloudscale_test_image }}'
+    password: '{{ cloudscale_test_password }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-unexist-group'
+  ignore_errors: True
+  register: srv
+- name: 'VERIFY: Fail unexisting server group'
+  assert:
+    that:
+      - srv is failed
+      - srv.msg.startswith('Server group name or UUID not found')

--- a/test/integration/targets/cloudscale_server/tasks/failures.yml
+++ b/test/integration/targets/cloudscale_server/tasks/failures.yml
@@ -22,3 +22,32 @@
     that:
       - srv is failed
       - srv.msg.startswith('Server group name or UUID not found')
+
+- name: Create two server groups with the same name
+  uri:
+    url: https://api.cloudscale.ch/v1/server-groups
+    method: POST
+    headers:
+      Authorization: 'Bearer {{ cloudscale_api_token }}'
+    body:
+      name: '{{ cloudscale_resource_prefix }}-duplicate'
+      type: anti-affinity
+    body_format: json
+    status_code: 201
+  register: duplicate
+  with_sequence: count=2
+
+- name: Try to use server groups with identical name
+  cloudscale_server:
+    name: '{{ cloudscale_resource_prefix }}-test-group'
+    flavor: '{{ cloudscale_test_flavor }}'
+    image: '{{ cloudscale_test_image }}'
+    password: '{{ cloudscale_test_password }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-duplicate'
+  ignore_errors: True
+  register: srv
+- name: 'VERIFY: Fail unexisting server group'
+  assert:
+    that:
+      - srv is failed
+      - srv.msg.startswith('More than one server group with name exists')

--- a/test/integration/targets/cloudscale_server/tasks/main.yml
+++ b/test/integration/targets/cloudscale_server/tasks/main.yml
@@ -6,3 +6,6 @@
     - import_role:
         name: cloudscale_common
         tasks_from: cleanup_servers
+    - import_role:
+        name: cloudscale_common
+        tasks_from: cleanup_server_groups

--- a/test/integration/targets/cloudscale_server/tasks/main.yml
+++ b/test/integration/targets/cloudscale_server/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - block:
+    - import_tasks: failures.yml
     - import_tasks: tests.yml
   always:
     - import_role:

--- a/test/integration/targets/cloudscale_server/tasks/tests.yml
+++ b/test/integration/targets/cloudscale_server/tasks/tests.yml
@@ -1,10 +1,24 @@
 ---
+- name: Setup server groups
+  uri:
+    url: https://api.cloudscale.ch/v1/server-groups
+    method: POST
+    headers:
+      Authorization: 'Bearer {{ cloudscale_api_token }}'
+    body:
+      name: '{{ cloudscale_resource_prefix }}-group-{{ item }}'
+      type: anti-affinity
+    body_format: json
+    status_code: 201
+  with_sequence: count=2
+
 - name: Test create a running server in check mode
   cloudscale_server:
     name: '{{ cloudscale_resource_prefix }}-test'
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-group-1'
   register: server
   check_mode: yes
 - name: Verify create a running server in check mode
@@ -19,12 +33,14 @@
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-group-1'
   register: server
 - name: Verify create a running server
   assert:
     that:
       - server is changed
       - server.state == 'running'
+      - server.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
 
 - name: Test create a running server idempotence
   cloudscale_server:
@@ -32,12 +48,14 @@
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-group-1'
   register: server
 - name: Verify create a running server idempotence
   assert:
     that:
       - server is not changed
       - server.state == 'running'
+      - server.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
 
 - name: Test update flavor of a running server without force in check mode
   cloudscale_server:
@@ -54,6 +72,7 @@
       - server is not changed
       - server.state == 'running'
       - server.flavor.slug == '{{ cloudscale_test_flavor }}'
+      - server.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
 
 - name: Test update flavor of a running server without force
   cloudscale_server:
@@ -69,6 +88,7 @@
       - server is not changed
       - server.state == 'running'
       - server.flavor.slug == '{{ cloudscale_test_flavor }}'
+      - server.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
 
 - name: Test update flavor of a running server without force idempotence
   cloudscale_server:
@@ -84,6 +104,7 @@
       - server is not changed
       - server.state == 'running'
       - server.flavor.slug == '{{ cloudscale_test_flavor }}'
+      - server.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
 
 - name: Test update flavor and name of a running server without force in check mode
   cloudscale_server:
@@ -196,7 +217,7 @@
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
-    anti_affinity_with: '{{ running_server_uuid }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-group-1'
     use_public_network: no
     use_private_network: yes
     state: stopped
@@ -214,7 +235,7 @@
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
-    anti_affinity_with: '{{ running_server_uuid }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-group-1'
     use_public_network: no
     use_private_network: yes
     state: stopped
@@ -226,6 +247,7 @@
       - server_stopped.state == 'stopped'
       - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
       - server_stopped.interfaces.0.type == 'private'
+      - server_stopped.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
 
 - name: Test create server stopped in anti affinity and private network only idempotence
   cloudscale_server:
@@ -233,7 +255,7 @@
     flavor: '{{ cloudscale_test_flavor }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
-    anti_affinity_with: '{{ running_server_uuid }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-group-1'
     use_public_network: no
     use_private_network: yes
     state: stopped
@@ -245,6 +267,27 @@
       - server_stopped.state == 'stopped'
       - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
       - server_stopped.interfaces.0.type == 'private'
+      - server_stopped.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
+
+- name: Test change server group not changed
+  cloudscale_server:
+    name: '{{ cloudscale_resource_prefix }}-test-stopped'
+    flavor: '{{ cloudscale_test_flavor }}'
+    image: '{{ cloudscale_test_image }}'
+    ssh_keys: '{{ cloudscale_test_ssh_key }}'
+    server_groups: '{{ cloudscale_resource_prefix }}-group-2'
+    use_public_network: no
+    use_private_network: yes
+    state: stopped
+  register: server_stopped
+- name: Verify Test update server group not changed
+  assert:
+    that:
+      - server_stopped is not changed
+      - server_stopped.state == 'stopped'
+      - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
+      - server_stopped.interfaces.0.type == 'private'
+      - server_stopped.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
 
 - name: Test create server with password in check mode
   cloudscale_server:
@@ -370,7 +413,6 @@
       - server.state == 'stopped'
       - server.flavor.slug == '{{ cloudscale_test_flavor }}'
       - server.name == '{{ cloudscale_resource_prefix }}-test'
-
 
 - name: Test update a stopped server idempotence
   cloudscale_server:

--- a/test/integration/targets/cloudscale_server/tasks/tests.yml
+++ b/test/integration/targets/cloudscale_server/tasks/tests.yml
@@ -1,15 +1,8 @@
 ---
 - name: Setup server groups
-  uri:
-    url: https://api.cloudscale.ch/v1/server-groups
-    method: POST
-    headers:
-      Authorization: 'Bearer {{ cloudscale_api_token }}'
-    body:
-      name: '{{ cloudscale_resource_prefix }}-group-{{ item }}'
-      type: anti-affinity
-    body_format: json
-    status_code: 201
+  cloudscale_server_group:
+    name: '{{ cloudscale_resource_prefix }}-group-{{ item }}'
+    type: anti-affinity
   with_sequence: count=2
 
 - name: Test create a running server in check mode


### PR DESCRIPTION
##### SUMMARY
Implement new param server_groups, deprecates anti_affinity_with
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudscale_server

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
