### PR TITLE
VMware: vmware_datastore_facts: don't nodify dict in iter (#54869)

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
@@ -214,10 +214,12 @@ class PyVmomiCache(object):
         if confine_to_datacenter:
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary
+                tmpobjs = objects.copy()
                 for k, v in objects.items():
                     parent_dc = get_parent_datacenter(k)
                     if parent_dc.name != self.dc_name:
-                        objects.pop(k, None)
+                        tmpobjs.pop(k, None)
+                objects = tmpobjs
             else:
                 # everything else should be a list
                 objects = [x for x in objects if get_parent_datacenter(x).name == self.dc_name]


### PR DESCRIPTION
##### SUMMARY

With Python3, we cannot iterate on a dict and modify it at the same time.

Fixes ##54869

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

vmware_datastore_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```