### PR TITLE
VMware: vmware_datastore_facts: empty list if none found

### DIFF
--- a/changelogs/fragments/vmware_datastore_facts.yaml
+++ b/changelogs/fragments/vmware_datastore_facts.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - vmware_datastore_facts - When no datastore was found, returns an empty list.

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
@@ -275,15 +275,7 @@ def main():
 
     result['datastores'] = datastores
 
-    # found a datastore
-    if datastores:
-        module.exit_json(**result)
-    else:
-        msg = "Unable to gather datastore facts"
-        if module.params['name']:
-            msg += " for %(name)s" % module.params
-        msg += " in datacenter %(datacenter)s" % module.params
-        module.fail_json(msg=msg)
+    module.exit_json(**result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY

When `vmware_datastore_facts` does not fine any datastore, it raises an error.
This is not consistent with the other _facts modules. It should just return
an empty list instead.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_datastore_facts