### PR TITLE
Added parsing of LLDP remote port description

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -280,6 +280,7 @@ class Interfaces(FactsBase):
                 facts[intf] = list()
             fact = dict()
             fact['host'] = self.parse_lldp_host(entry)
+            fact['remote_description'] = self.parse_lldp_remote_desc(entry)
             fact['port'] = self.parse_lldp_port(entry)
             facts[intf].append(fact)
         return facts
@@ -351,6 +352,11 @@ class Interfaces(FactsBase):
         if match:
             return match.group(1)
 
+    def parse_lldp_remote_desc(self, data):
+        match = re.search(r'Port Description: (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+    
     def parse_lldp_host(self, data):
         match = re.search(r'System Name: (.+)$', data, re.M)
         if match:

--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -356,7 +356,7 @@ class Interfaces(FactsBase):
         match = re.search(r'Port Description: (.+)$', data, re.M)
         if match:
             return match.group(1)
-    
+
     def parse_lldp_host(self, data):
         match = re.search(r'System Name: (.+)$', data, re.M)
         if match:


### PR DESCRIPTION
##### SUMMARY
Cisco IOS-XR show lldp neighbors command returns the port description from the remote device it is connected to. This information is not actually parsed by the iosxr_facts module. This patch add the parsing of the remote port description from LLDP output. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
/lib/modules/network/iosxr/iosxr_facts.py

##### ADDITIONAL INFORMATION
The command "show lldp neighbors detail" returns several useful informations that can be used from a script for inventory or other tasks. 

This pull request is a proposal to make the remote port description available in the ansible_net_neighbors object. 

```
RP/0/RP0/CPU0:tor-15.tenlab-cloud#show lldp neighbors detail

[ ... output ommited ... ]
------------------------------------------------
Local Interface: TenGigE0/0/0/47
Chassis id: XX
Port id: XX
Port Description: Interface  12 as sriov-1-1
```
