### PR TITLE
Added the 'show commit config diff' output available from the IOSXR

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -471,6 +471,11 @@ def load_config(module, command_filter, commit=False, replace=False,
             response = conn.edit_config(candidate=command_filter, commit=commit, admin=admin, replace=replace, comment=comment, label=label)
             if module._diff:
                 diff = response.get('diff')
+
+            # Overwrite the default diff by the IOS XR commit diff.
+            # See plugins/cliconf/iosxr.py for this key set: show_commit_config_diff
+            diff = response.get('show_commit_config_diff')
+
         except ConnectionError as exc:
             module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
 

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -117,6 +117,11 @@ class Cliconf(CliconfBase):
             results.append(self.send_command(**line))
             requests.append(cmd)
 
+        # Before any commit happend, we can get a real configuration
+        # diff from the device and make it available by the iosxr_config module.
+        # This information can be usefull either in check mode or normal mode.
+        resp['show_commit_config_diff'] = self.get('show commit changes diff')
+
         if commit:
             self.commit(comment=comment, label=label, replace=replace)
         else:


### PR DESCRIPTION
##### SUMMARY
When running iosxr_config module in both check and diff mode, the module only returns
the commands that needs to be applied on the device. The diff is never displayed in check mode
because the module cannot anticipate the result of the changes on the cisco device. This is
valid for IOS, NXOS and IOSXR.

IOS XR architecture is very different from IOS and now provides candidates configurations
with commit feature. In addition, the IOS XR can now calculate the diff between the
candidate and the running configurations using the "show commit changes diff" command.

This proposal is to leverage the "show commit changes diff" functionality in network_cli mode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
/lib/module_utils/network/iosxr/iosxr.py
/lib/plugins/cliconf/iosxr.py

##### ADDITIONAL INFORMATION
Use case for testing: prefix-set

When configuring any routing policy in IOS XR, the command replaces the block of configuration and there is no way to see the result of this kind of modification.

Configuration from the IOS-XR device:

```
prefix-set testmo
  3.3.3.3/32,
  4.4.4.4/32
end-set
```

Playbook task example:

```
- name: Edit config EVPN bridge domain
  iosxr_config:
    parents:
      - prefix-set testmo
    lines:
      - 1.1.1.1/32 , 2.2.2.2/32
    after:
      - end-set
```
##### ACTUAL RESULTS

The dry run does not show that 3.3.3.3/32 and 4.4.4.4/32 will be gone after the configuration is applied.

```
changed: [tor50] => {"changed": true, "commands": ["prefix-set testmo", "1.1.1.1/32 , 2.2.2.2/32", "end-set"]}
```

##### PROPOSED CHANGE - EXPECTED RESULTS

With the proposal applied, the output is now:

```
TASK [debug] *************************************************************************************************************************************************************************************************************************************************
ok: [tor50] => {
    "output": {
        "changed": true,
        "commands": [
            "prefix-set testmo",
            "1.1.1.1/32 , 2.2.2.2/32",
            "end-set"
        ],
        "diff": {
            "prepared": "Building configuration...\n!! IOS XR Configuration version = 6.3.2\n   !\n   prefix-set testmo\n-    3.3.3.3/32,\n-    4.4.4.4/32\n+    1.1.1.1/32,\n+    2.2.2.2/32\n   end-set\nend"
        },
        "failed": false
    }
}
TASK [debug] *************************************************************************************************************************************************************************************************************************************************
ok: [tor50] => {
    "msg": [
        "Building configuration...",
        "!! IOS XR Configuration version = 6.3.2",
        "   !",
        "   prefix-set testmo",
        "-    3.3.3.3/32,",
        "-    4.4.4.4/32",
        "+    1.1.1.1/32,",
        "+    2.2.2.2/32",
        "   end-set",
        "end"
    ]
}
```


