### PR TITLE
docker_swarm tests: openssl_certificate now has cryptography backend, i.e. enable more tests!

### DIFF
--- a/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
@@ -150,5 +150,4 @@
       - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
     when: docker_py_version is version('2.6.0', '<')
 
-  # https://github.com/ansible/ansible/issues/34054: openssl_certificate unusable on RHEL 7
-  when: pyopenssl_version.stdout is version('0.15', '>=')
+  when: pyopenssl_version.stdout is version('0.15', '>=') or cryptography_version.stdout is version('1.6', '>=')


### PR DESCRIPTION
##### SUMMARY
This means that openssl_certificate now also works under RHEL7.6, which is the only/last of the two CI nodes the `docker_swarm` tests run on which didn't support `openssl_certificate` because pyOpenSSL is too old on that platform.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
