### PR TITLE
Don't require datacenter with uuid in vmware_guest_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -70,7 +70,7 @@ options:
    datacenter:
      description:
      - Destination datacenter for the deploy operation
-     required: True
+     required: False
    tags:
      description:
      - Whether to show tags or not.
@@ -223,7 +223,7 @@ def main():
         uuid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
-        datacenter=dict(type='str', required=True),
+        datacenter=dict(type='str', required=False),
         tags=dict(type='bool', default=False),
         schema=dict(type='str', choices=['summary', 'vsphere'], default='summary'),
         properties=dict(type='list')
@@ -235,6 +235,9 @@ def main():
         # FindByInventoryPath() does not require an absolute path
         # so we should leave the input folder path unmodified
         module.params['folder'] = module.params['folder'].rstrip('/')
+
+    if module.params.get('name') and not module.params.get('datacenter'):
+        module.fail_json(msg="The option 'datacenter' is required when the option 'name'")
 
     if module.params['schema'] != 'vsphere' and module.params.get('properties'):
         module.fail_json(msg="The option 'properties' is only valid when the schema is 'vsphere'")


### PR DESCRIPTION
##### SUMMARY
It is possible to get the facts for a VMware guest when using the uuid of the VM without setting a datacenter.  Datacenter is only necessary when you are looking up by name.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_facts

##### ADDITIONAL INFORMATION
You can test this by specifying a uuid and an invalid datacenter.  The fact gathering will still be successful.
