### PR TITLE
Support using importlib on py>=3 to avoid imp deprecation

### DIFF
--- a/changelogs/fragments/ansiballz-imp-deprecation.yaml
+++ b/changelogs/fragments/ansiballz-imp-deprecation.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- AnsiballZ - Use ``importlib`` to load the module instead of ``imp`` on Python3+

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -394,7 +394,8 @@ ANSIBALLZ_COVERAGE_TEMPLATE = '''
 ANSIBALLZ_COVERAGE_CHECK_TEMPLATE = '''
         try:
             if PY3:
-                importlib.util.find_spec('coverage')
+                if importlib.util.find_spec('coverage') is None:
+                    raise ImportError
             else:
                 imp.find_module('coverage')
         except ImportError:

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -587,7 +587,7 @@ class ModuleInfo:
     def get_source(self):
         if imp and self.py_src:
             try:
-                return self._info[0].read
+                return self._info[0].read()
             finally:
                 self._info[0].close()
         return _slurp(self.path)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -379,7 +379,10 @@ ANSIBALLZ_COVERAGE_TEMPLATE = '''
 
 ANSIBALLZ_COVERAGE_CHECK_TEMPLATE = '''
         try:
-            imp.find_module('coverage')
+            if PY3:
+                importlib.util.find_spec('coverage')
+            else:
+                imp.find_module('coverage')
         except ImportError:
             print('{"msg": "Could not find `coverage` module.", "failed": true}')
             sys.exit(1)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -298,9 +298,15 @@ def _ansiballz_main():
             basic._ANSIBLE_ARGS = json_params
 
             # Run the module!  By importing it as '__main__', it thinks it is executing as a script
-            import imp
-            with open(script_path, 'r') as f:
-                importer = imp.load_module('__main__', f, script_path, ('.py', 'r', imp.PY_SOURCE))
+            if PY3:
+                import importlib.util
+                spec = importlib.util.spec_from_file_location('__main__', script_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+            else:
+                import imp
+                with open(script_path, 'r') as f:
+                    imp.load_module('__main__', f, script_path, ('.py', 'r', imp.PY_SOURCE))
 
             # Ansible modules must exit themselves
             print('{"msg": "New-style module did not handle its own exit", "failed": true}')

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -540,6 +540,7 @@ class PluginLoader:
                 spec = importlib.util.spec_from_file_location(to_native(full_name), to_native(path))
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
+                sys.modules[full_name] = module
         return module
 
     def _update_object(self, obj, name, path):

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -532,15 +532,15 @@ class PluginLoader:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
-            if imp:
-                with open(to_bytes(path), 'rb') as module_file:
-                    # to_native is used here because imp.load_source's path is for tracebacks and python's traceback formatting uses native strings
-                    module = imp.load_source(to_native(full_name), to_native(path), module_file)
-            else:
+            if imp is None:
                 spec = importlib.util.spec_from_file_location(to_native(full_name), to_native(path))
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
                 sys.modules[full_name] = module
+            else:
+                with open(to_bytes(path), 'rb') as module_file:
+                    # to_native is used here because imp.load_source's path is for tracebacks and python's traceback formatting uses native strings
+                    module = imp.load_source(to_native(full_name), to_native(path), module_file)
         return module
 
     def _update_object(self, obj, name, path):

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import glob
-import imp
 import os
 import os.path
 import pkgutil
@@ -27,6 +26,12 @@ from ansible.plugins import get_plugin_class, MODULE_CACHE, PATH_CACHE, PLUGIN_P
 from ansible.utils.collection_loader import AnsibleCollectionLoader, AnsibleFlatMapLoader, is_collection_ref
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import add_fragments
+
+try:
+    import importlib.util
+    imp = None
+except ImportError:
+    import imp
 
 # HACK: keep Python 2.6 controller tests happy in CI until they're properly split
 try:
@@ -527,9 +532,14 @@ class PluginLoader:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
-            with open(to_bytes(path), 'rb') as module_file:
-                # to_native is used here because imp.load_source's path is for tracebacks and python's traceback formatting uses native strings
-                module = imp.load_source(to_native(full_name), to_native(path), module_file)
+            if imp:
+                with open(to_bytes(path), 'rb') as module_file:
+                    # to_native is used here because imp.load_source's path is for tracebacks and python's traceback formatting uses native strings
+                    module = imp.load_source(to_native(full_name), to_native(path), module_file)
+            else:
+                spec = importlib.util.spec_from_file_location(to_native(full_name), to_native(path))
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
         return module
 
     def _update_object(self, obj, name, path):

--- a/test/units/executor/module_common/test_recursive_finder.py
+++ b/test/units/executor/module_common/test_recursive_finder.py
@@ -19,22 +19,17 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import imp
 import pytest
 import zipfile
 
 from collections import namedtuple
-from functools import partial
-from io import BytesIO, StringIO
+from io import BytesIO
 
 import ansible.errors
 
 from ansible.executor.module_common import recursive_finder
 from ansible.module_utils.six import PY2
-from ansible.module_utils.six.moves import builtins
 
-
-original_find_module = imp.find_module
 
 # These are the modules that are brought in by module_utils/basic.py  This may need to be updated
 # when basic.py gains new imports
@@ -106,18 +101,6 @@ def finder_containers():
     # zf.writestr('ansible/__init__.py', b'')
 
     return FinderContainers(py_module_names, py_module_cache, zf)
-
-
-def find_module_foo(module_utils_data, *args, **kwargs):
-    if args[0] == 'foo':
-        return (module_utils_data, '/usr/lib/python2.7/site-packages/ansible/module_utils/foo.py', ('.py', 'r', imp.PY_SOURCE))
-    return original_find_module(*args, **kwargs)
-
-
-def find_package_foo(module_utils_data, *args, **kwargs):
-    if args[0] == 'foo':
-        return (module_utils_data, '/usr/lib/python2.7/site-packages/ansible/module_utils/foo', ('', '', imp.PKG_DIRECTORY))
-    return original_find_module(*args, **kwargs)
 
 
 class TestRecursiveFinder(object):


### PR DESCRIPTION
##### SUMMARY
Support using importlib on py>=3 to avoid imp deprecation

In Python 3.7+ importing `imp` results in a deprecation warning.

Implement functionality to utilize `importlib` in Py3+

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/module_common.py

##### ADDITIONAL INFORMATION

When a module fails, this `imp` deprecation can be printed, and it has been confusing users, potentially obscuring the real problem from them.