### PR TITLE
Adding basic support for Azure MSI user-assigned identity

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -1149,8 +1149,9 @@ class AzureRMAuth(object):
 
         return None
 
-    def _get_msi_credentials(self, subscription_id_param=None):
-        credentials = MSIAuthentication()
+    def _get_msi_credentials(self, subscription_id_param=None, **kwargs):
+        client_id = kwargs.get('client_id', None)
+        credentials = MSIAuthentication(client_id=client_id)
         subscription_id = subscription_id_param or os.environ.get(AZURE_CREDENTIAL_ENV_MAPPING['subscription_id'], None)
         if not subscription_id:
             try:
@@ -1206,7 +1207,7 @@ class AzureRMAuth(object):
 
         if auth_source == 'msi':
             self.log('Retrieving credenitals from MSI')
-            return self._get_msi_credentials(arg_credentials['subscription_id'])
+            return self._get_msi_credentials(arg_credentials['subscription_id'], client_id=params.get('client_id', None))
 
         if auth_source == 'cli':
             if not HAS_AZURE_CLI_CORE:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If more than one user-assigned identity is assigned to a host, then an identifier is required to specify which credentials are retrieved.  This change uses the existing support for client_id to retrieve the user-assigned identity by client_id.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
A client_id is only required when two or more user-assigned identities are assigned to a host, and optional if only one user-assigned identity is assigned.

This is only "basic" support, because an object_id or full object identifier can be used instead, but there's no existing code to retrieve those from the yml.

To reproduce:
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
* Assign two or more user-assigned identities to a system.
* Try to use ansible on that system with the azure_rm plugin and MSI as the auth source.
* Witness a failure to retrieve credentials from MSI.

<!--- Paste verbatim command output below, e.g. before and after your change -->
