### PR TITLE
Resolves handling of error and failure scenarios from Checkpoint module end

### DIFF
--- a/lib/ansible/modules/network/checkpoint/checkpoint_access_rule.py
+++ b/lib/ansible/modules/network/checkpoint/checkpoint_access_rule.py
@@ -228,6 +228,8 @@ def main():
         if code == 200:
             if needs_update(module, response):
                 code, response = update_access_rule(module, connection)
+                if code != 200:
+                    module.fail_json(msg=response)
                 if module.params['auto_publish_session']:
                     publish(connection)
 
@@ -240,7 +242,8 @@ def main():
                 pass
         elif code == 404:
             code, response = create_access_rule(module, connection)
-
+            if code != 200:
+                module.fail_json(msg=response)
             if module.params['auto_publish_session']:
                 publish(connection)
 
@@ -252,7 +255,8 @@ def main():
     else:
         if code == 200:
             code, response = delete_access_rule(module, connection)
-
+            if code != 200:
+                module.fail_json(msg=response)
             if module.params['auto_publish_session']:
                 publish(connection)
 
@@ -260,6 +264,7 @@ def main():
                     install_policy(connection, module.params['policy_package'], module.params['targets'])
 
             result['changed'] = True
+            result['checkpoint_access_rules'] = response
         elif code == 404:
             pass
 

--- a/lib/ansible/modules/network/checkpoint/checkpoint_host.py
+++ b/lib/ansible/modules/network/checkpoint/checkpoint_host.py
@@ -134,7 +134,6 @@ def update_host(module, connection):
 
 def delete_host(module, connection):
     name = module.params['name']
-    ip_address = module.params['ip_address']
 
     payload = {'name': name}
 
@@ -170,7 +169,8 @@ def main():
         if code == 200:
             if needs_update(module, response):
                 code, response = update_host(module, connection)
-
+                if code != 200:
+                    module.fail_json(msg=response)
                 if module.params['auto_publish_session']:
                     publish(connection)
 
@@ -183,7 +183,8 @@ def main():
                 pass
         elif code == 404:
             code, response = create_host(module, connection)
-
+            if code != 200:
+                module.fail_json(msg=response)
             if module.params['auto_publish_session']:
                 publish(connection)
 
@@ -196,7 +197,8 @@ def main():
         if code == 200:
             # Handle deletion
             code, response = delete_host(module, connection)
-
+            if code != 200:
+                module.fail_json(msg=response)
             if module.params['auto_publish_session']:
                 publish(connection)
 
@@ -204,6 +206,7 @@ def main():
                     install_policy(connection, module.params['policy_package'], module.params['targets'])
 
             result['changed'] = True
+            result['checkpoint_hosts'] = response
         elif code == 404:
             pass
 

--- a/lib/ansible/modules/network/checkpoint/checkpoint_session.py
+++ b/lib/ansible/modules/network/checkpoint/checkpoint_session.py
@@ -104,7 +104,8 @@ def main():
             code, response = connection.send_request('/web_api/publish', payload)
         else:
             code, response = connection.send_request('/web_api/discard', payload)
-
+        if code != 200:
+            module.fail_json(msg=response)
         result['checkpoint_session'] = response
     else:
         module.fail_json(msg='Check Point device returned error {0} with message {1}'.format(code, response))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CP PR modules were not handling the response for error scenarios as a result, respective CP modules were not handling and throwing the failure response correctly, e.g. if the user was trying to create `host` with incorrect IP address `checkpoint_host` module was not throwing the received response error and was just showing `changed = True` and exiting the play execution.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
checkpoint
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
