### PR TITLE
Allow 13 asterisk characters in password field without warning

### DIFF
--- a/changelogs/fragments/openbsd-disabled-account-no-warning-for-passwd.yaml
+++ b/changelogs/fragments/openbsd-disabled-account-no-warning-for-passwd.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - allow 13 asterisk characters in password field without warning

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -93,6 +93,7 @@ options:
             - Optionally set the user's password to this crypted value.
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create a disabled account on Linux systems, set this to C('!') or C('*').
+            - To create a disabled account on OpenBSD, set this to C('*************').
             - See U(https://docs.ansible.com/ansible/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate these password values.
         type: str
@@ -514,8 +515,8 @@ class User(object):
         if self.module.params['password'] and self.platform != 'Darwin':
             maybe_invalid = False
 
-            # Allow setting the password to * or ! in order to disable the account
-            if self.module.params['password'] in set(['*', '!']):
+            # Allow setting certain passwords in order to disable the account
+            if self.module.params['password'] in set(['*', '!', '*************']):
                 maybe_invalid = False
             else:
                 # : for delimiter, * for disable user, ! for lock user

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -105,11 +105,18 @@
         password: '*'
       register: test_user_encrypt4
 
-    - name: there should be no warnings when setting the password to '!' and '*'
+    - name: change password to '*************'
+      user:
+        name: ansibulluser
+        password: '*************'
+      register: test_user_encrypt5
+
+    - name: there should be no warnings when setting the password to '!',  '*' or '*************'
       assert:
         that:
           - "'warnings' not in test_user_encrypt3"
           - "'warnings' not in test_user_encrypt4"
+          - "'warnings' not in test_user_encrypt5"
   when: ansible_facts.system != 'Darwin'
 
 


### PR DESCRIPTION
##### SUMMARY

On OpenBSD, 13 asterisk characters as a password hash, marks the
account as disabled. Otherwise daily(8) script which executes
security(8) will email operator about not properly locked accounts.

Before the diff, we see following warning:

> [WARNING]: The input password appears not to have been hashed. The 'password' argument must be encrypted for this module to work properly.

After the diff, warning is gone.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
- modules/system/user.py

##### ADDITIONAL INFORMATION

I can provide more info, if needed.
