### PR TITLE
Use --mode=script always while running gluster commands (#54843)

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_peer.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_peer.py
@@ -104,7 +104,7 @@ class Peer(object):
         self.call_peer_commands()
 
     def get_to_be_probed_hosts(self, hosts):
-        peercmd = [self.glustercmd, 'pool', 'list']
+        peercmd = [self.glustercmd, 'pool', 'list', '--mode=script']
         rc, output, err = self.module.run_command(peercmd,
                                                   environ_update=self.lang)
         peers_in_cluster = [line.split('\t')[1].strip() for
@@ -124,7 +124,7 @@ class Peer(object):
         result['changed'] = False
 
         for node in self.nodes:
-            peercmd = [self.glustercmd, 'peer', self.action, node]
+            peercmd = [self.glustercmd, 'peer', self.action, node, '--mode=script']
             if self.force:
                 peercmd.append(self.force)
             rc, out, err = self.module.run_command(peercmd,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added --mode=script for all gluster commands. Recently gluster added a (y/n) prompt for peer detach.
Which we will have to override with mode=script.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes issue #54843 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gluster_peer 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Install a older version of gluster for example: glusterfs 3.12.2 or higher.
And run the playbook:
```
[sac@dhcp35-44 peer]$ cat peer.yml
---
- name: Attach and detach a peer
  remote_user: root
  hosts: all
  gather_facts: no
  tasks:
     - name: Peer probe a node
       gluster_peer:
           state: present
           nodes:
               - node1

     - name: Peer detach a node
       gluster_peer:
           state: absent
           nodes:
               - node1
           force: true
```
The task will be stuck since glusterd is waiting forever for user input.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the change, ansible task would appear to have been stuck since it is waiting for user input.
After the change:
```paste below
[sac@dhcp35-44 peer]$ time ansible-playbook -i peer.inv peer.yml                                                                 

PLAY [Attach and detach a peer] **************************************************************************************************

TASK [Peer probe a node] *********************************************************************************************************
changed: [10.70.42.25]

TASK [Peer detach a node] ********************************************************************************************************
changed: [10.70.42.25]

PLAY RECAP ***********************************************************************************************************************
10.70.42.25                : ok=2    changed=2    unreachable=0    failed=0                
```
