### PR TITLE
Fix example in iptables module

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -399,6 +399,7 @@ EXAMPLES = r'''
     protocol: tcp
     destination_port: 8080
     jump: ACCEPT
+    action: insert
     rule_num: 5
 
 - name: Set the policy for the INPUT chain to DROP


### PR DESCRIPTION
##### SUMMARY
In the documentation the rule_num parameter works only in conjunction with action set to insert but in the example action is not defined so the default append value is used.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
iptables

##### ADDITIONAL INFORMATION
N/A