### PR TITLE
win_domain_membership: Pass domain and credentials to Get-ADObject

### DIFF
--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -119,9 +119,9 @@ Function Join-Domain {
     Write-DebugLog "adding hostname set arg to Add-Computer args"
     If($new_hostname) {
         $add_args["NewName"] = $new_hostname
-        $hostname_in_domain = Get-ADObject -LDAPFilter "(&(CN=$new_hostname)(ObjectClass=Computer))"
+        $hostname_in_domain = Get-ADObject -LDAPFilter "(&(CN=$new_hostname)(ObjectClass=Computer))" -Server $dns_domain_name -Credential $domain_cred
     } else {
-        $hostname_in_domain = Get-ADObject -LDAPFilter "(&(CN=$env:COMPUTERNAME)(ObjectClass=Computer))"
+        $hostname_in_domain = Get-ADObject -LDAPFilter "(&(CN=$env:COMPUTERNAME)(ObjectClass=Computer))" -Server $dns_domain_name -Credential $domain_cred
     }
 
     if($domain_ou_path){


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since commit 85d836171b6cd5a07ff49955335444680c110ea3 trying to join a computer to a domain results in:
```
Unhandled exception while executing module: Unable to find a default server with Active Directory Web Services running.
```

The new check for whether the computer name already exists in the domain using `Get-ADObject` doesn't actually specify which domain to check or which credentials to use, so if the machine is not already in the domain, this code predictably fails.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_membership

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

