### PR TITLE
openssl_certificate_info, openssl_csr: fix wrong exception, and little refactoring

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -282,7 +282,7 @@ def get_relative_time_option(input_string, input_name):
     if result.startswith("+") or result.startswith("-"):
         return crypto_utils.convert_relative_to_datetime(result)
     if result is None:
-        raise crypto_utils.CertificateError(
+        raise crypto_utils.OpenSSLObjectError(
             'The timespec "%s" for %s is not valid' %
             input_string, input_name)
     for date_fmt in ['%Y%m%d%H%M%SZ', '%Y%m%d%H%MZ', '%Y%m%d%H%M%S%z', '%Y%m%d%H%M%z']:
@@ -293,7 +293,7 @@ def get_relative_time_option(input_string, input_name):
             pass
 
     if not isinstance(result, datetime.datetime):
-        raise crypto_utils.CertificateError(
+        raise crypto_utils.OpenSSLObjectError(
             'The time spec "%s" for %s is invalid' %
             (input_string, input_name)
         )

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -632,7 +632,7 @@ class CertificateSigningRequestPyOpenSSL(CertificateSigningRequestBase):
                 return False
 
         try:
-            csr = crypto_utils.load_certificate_request(self.path)
+            csr = crypto_utils.load_certificate_request(self.path, backend='pyopenssl')
         except Exception as dummy:
             return False
 
@@ -819,8 +819,7 @@ class CertificateSigningRequestCryptography(CertificateSigningRequestBase):
             return key_a == key_b
 
         try:
-            with open(self.path, 'rb') as f:
-                csr = cryptography.x509.load_pem_x509_csr(f.read(), self.cryptography_backend)
+            csr = crypto_utils.load_certificate_request(self.path, backend='cryptography')
         except Exception as dummy:
             return False
 


### PR DESCRIPTION
##### SUMMARY
Fixes use of the wrong exception name in `openssl_certificate_info`, and makes `openssl_csr` always use `crypto_utils.load_certificate_request()`.

Both changes get no changelog since they affect code new for 2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate_info
openssl_csr