### PR TITLE
fix empty import of defaults variables in role

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -263,7 +263,7 @@ class Role(Base, Become, Conditional, Taggable):
                     new_data = self._loader.load_from_file(found)
                     if new_data and allow_dir:
                         data = combine_vars(data, new_data)
-                    else:
+                    elif new_data:
                         data = new_data
                 return data
             elif main is not None:

--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -464,7 +464,8 @@ class AzureHost(object):
         self.nics = []
 
         # Azure often doesn't provide a globally-unique filename, so use resource name + a chunk of ID hash
-        self.default_inventory_hostname = '{0}_{1}'.format(vm_model['name'], hashlib.sha1(vm_model['id']).hexdigest()[0:4])
+        utf8_vm_model = vm_model['id'].encode('utf-8')
+        self.default_inventory_hostname = '{0}_{1}'.format(vm_model['name'], hashlib.sha1(utf8_vm_model).hexdigest()[0:4])
 
         self._hostvars = {}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #54915 and #46608
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
#54915: role/__init__.py
#46608: azure_rm.py

##### ADDITIONAL INFORMATION

Fixes #54915 : We ensure, that we can have empty default vars files in a role default vars directory, such as <role>/defaults/main/{a,b,c}_vars.yml. 

Fixes  #46608 : On python 3.6 the azure_rm.py dynamic inventory plugin breaks because of encoding issues. It's already fixed in ansible 2.8, but 2.7 needs a backport.