### PR TITLE
Clarify how to use variables with handlers

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -415,7 +415,6 @@ If the variable used in the handler name is not available, the entire play fails
 
 Instead, place variables in the task parameters of your handler. You can load the values using ``include_vars`` like this:
 
-
   .. code-block:: yaml+jinja
 
     tasks:

--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -407,9 +407,9 @@ Here's an example handlers section::
 
 You may want your Ansible handlers to use variables. For example, if the name of a service varies slightly by distribution, you want your output to show the exact name of the restarted service for each target machine. Avoid placing variables in the name of the handler. Since handler names are templated early on, Ansible may not have a value available for a handler name like this::
 
-   handlers:
-   # this handler name may cause your play to fail!
-   - name: restart "{{ web_service_name }}"
+    handlers:
+    # this handler name may cause your play to fail!
+    - name: restart "{{ web_service_name }}"
 
 If the variable used in the handler name is not available, the entire play fails. Changing that variable mid-play **will not** result in newly created handler.
 

--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -415,7 +415,6 @@ If the variable used in the handler name is not available, the entire play fails
 
 Instead, place variables in the task parameters of your handler. You can load the values using ``include_vars`` like this:
 
-Here is an example using ``include_vars``:
 
   .. code-block:: yaml+jinja
 

--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -405,6 +405,23 @@ Here's an example handlers section::
             name: apache
             state: restarted
 
+Avoid using variables in handler names. Since handler names are templated early on, all variables may not be available, resulting in play failure. It is possible to use variables in handler task parameters. For example, if the name of a service varies slightly by distribution, the service name can be set using ``include_vars`` (or any place where variables can be set).
+
+Here is an example using ``include_vars``:
+
+  .. code-block:: yaml+jinja
+
+    tasks:
+      - name: Set variables based on distribution
+        include_vars: "{{ ansible_facts.distributon }}.yml"
+
+    handlers:
+      - name: restart web service
+        service:
+          name: "{{ web_service_name | default('httpd') }}"
+          state: restarted
+
+
 As of Ansible 2.2, handlers can also "listen" to generic topics, and tasks can notify those topics as follows::
 
     handlers:

--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -405,14 +405,16 @@ Here's an example handlers section::
             name: apache
             state: restarted
 
-Avoid using variables in handler names. Since handler names are templated early on, all variables may not be available, resulting in play failure. It is possible to use variables in handler task parameters. For example, if the name of a service varies slightly by distribution, the service name can be set using ``include_vars`` (or any place where variables can be set).
+Avoid using variables in handler names. Since handler names are templated early on, all variables may not be available, resulting in play failure. If a handler name does contain a variable, changing that variables mid-play **will not** result in newly created handler.
+
+It is possible to use variables in handler *task parameters*. For example, if the name of a service varies slightly by distribution, the service name can be set using ``include_vars``.
 
 Here is an example using ``include_vars``:
 
   .. code-block:: yaml+jinja
 
     tasks:
-      - name: Set variables based on distribution
+      - name: Set host variables based on distribution
         include_vars: "{{ ansible_facts.distribution }}.yml"
 
     handlers:

--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -413,7 +413,7 @@ You may want your Ansible handlers to use variables. For example, if the name of
 
 If the variable used in the handler name is not available, the entire play fails. Changing that variable mid-play **will not** result in newly created handler.
 
-It is possible to use variables in handler *task parameters*. For example, if the name of a service varies slightly by distribution, the service name can be set using ``include_vars``.
+Instead, place variables in the task parameters of your handler. You can load the values using ``include_vars`` like this:
 
 Here is an example using ``include_vars``:
 

--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -413,7 +413,7 @@ Here is an example using ``include_vars``:
 
     tasks:
       - name: Set variables based on distribution
-        include_vars: "{{ ansible_facts.distributon }}.yml"
+        include_vars: "{{ ansible_facts.distribution }}.yml"
 
     handlers:
       - name: restart web service

--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -405,7 +405,13 @@ Here's an example handlers section::
             name: apache
             state: restarted
 
-Avoid using variables in handler names. Since handler names are templated early on, all variables may not be available, resulting in play failure. If a handler name does contain a variable, changing that variables mid-play **will not** result in newly created handler.
+You may want your Ansible handlers to use variables. For example, if the name of a service varies slightly by distribution, you want your output to show the exact name of the restarted service for each target machine. Avoid placing variables in the name of the handler. Since handler names are templated early on, Ansible may not have a value available for a handler name like this::
+
+   handlers:
+   # this handler name may cause your play to fail!
+   - name: restart "{{ web_service_name }}"
+
+If the variable used in the handler name is not available, the entire play fails. Changing that variable mid-play **will not** result in newly created handler.
 
 It is possible to use variables in handler *task parameters*. For example, if the name of a service varies slightly by distribution, the service name can be set using ``include_vars``.
 


### PR DESCRIPTION
##### SUMMARY
Fixes #19050 

Handler names cannot use variables. Clarify this in the docs and add an example on where and how to user variables appropriately in handlers.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
`/docs/docsite/rst/user_guide/playbooks_intro.rst`