### PR TITLE
Clarify poll value behaviour in playbook async doc

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -15,7 +15,7 @@ The behaviour of asynchronous mode depends on the value of `poll`.
 Avoid connection timeouts: poll > 0
 -----------------------------------
 
-When `poll` is a positive value, the playbook will *still* block on the task until it either completes, fails or times out.
+When ``poll`` is a positive value, the playbook will *still* block on the task until it either completes, fails or times out.
 
 In this case, however, `async` explicitly sets the timeout you wish to apply to this task rather than being limited by the connection method timeout.
 

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -21,7 +21,7 @@ In this case, however, `async` explicitly sets the timeout you wish to apply to 
 
 To launch a task asynchronously, specify its maximum runtime
 and how frequently you would like to poll for status.  The default
-poll value is 10 seconds if you do not specify a value for `poll`::
+poll value is 15 seconds if you do not specify a value for `poll`::
 
     ---
 

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -9,6 +9,16 @@ be running operations that take longer than the SSH timeout.
 
 To avoid blocking or timeout issues, you can use asynchronous mode to run all of your tasks at once and then poll until they are done.
 
+The behaviour of asynchronous mode depends on the value of `poll`.
+
+
+Avoid connection timeouts: poll > 0
+-----------------------------------
+
+When `poll` is a positive value, the playbook will *still* block on the task until it either completes, fails or times out.
+
+In this case, however, `async` explicitly sets the timeout you wish to apply to this task rather than being limited by the connection method timeout.
+
 To launch a task asynchronously, specify its maximum runtime
 and how frequently you would like to poll for status.  The default
 poll value is 10 seconds if you do not specify a value for `poll`::
@@ -35,8 +45,21 @@ poll value is 10 seconds if you do not specify a value for `poll`::
   task when run in check mode. See :doc:`playbooks_checkmode` on how to
   skip a task in check mode.
 
-Alternatively, if you do not need to wait on the task to complete, you may
-run the task asynchronously by specifying a poll value of 0::
+
+Concurrent tasks: poll = 0
+--------------------------
+
+When `poll` is 0, Ansible will start the task and immediately move on to the next one without waiting for a result.
+
+From the point of view of sequencing this is asynchronous programming: tasks may now run concurrently.
+
+The playbook run will end without checking back on async tasks.
+
+The async tasks will run until they either complete, fail or timeout according to their `async` value.
+
+If you need a synchronization point with a task, register it to obtain its job ID and use the `async_status` module to observe it.
+
+You may run a task asynchronously by specifying a poll value of 0::
 
     ---
 

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -49,7 +49,7 @@ poll value is 10 seconds if you do not specify a value for `poll`::
 Concurrent tasks: poll = 0
 --------------------------
 
-When `poll` is 0, Ansible will start the task and immediately move on to the next one without waiting for a result.
+When ``poll`` is 0, Ansible will start the task and immediately move on to the next one without waiting for a result.
 
 From the point of view of sequencing this is asynchronous programming: tasks may now run concurrently.
 

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -57,7 +57,7 @@ The playbook run will end without checking back on async tasks.
 
 The async tasks will run until they either complete, fail or timeout according to their `async` value.
 
-If you need a synchronization point with a task, register it to obtain its job ID and use the `async_status` module to observe it.
+If you need a synchronization point with a task, register it to obtain its job ID and use the :ref:`async_status <async_status_module>` module to observe it.
 
 You may run a task asynchronously by specifying a poll value of 0::
 


### PR DESCRIPTION
##### SUMMARY

The documentation for `async` and `poll` is ambiguous and does not make
the playbook behaviour obvious. The word "asynchronous" is applied to
the host connection and to task ordering.

For example lines 12 and 39 both explain how to run a task
"asynchronously", but don't describe the difference very well.

This commit tries to clarify the difference in behaviour that hinges on
whether `poll` = 0 or not.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

playbooks_async.rst