### PR TITLE
Add Cloud/Amazon SSM Send-Command Module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_send_command.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ssm_send_command
+module: aws_ssm_send_command
 short_description: Execute commands through Simple System Manager (SSM) a.k.a. Run Command
 description:
   - This module allows you to execute commands through SSM/Run Command.
@@ -72,7 +72,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- ssm_send_command:
+- aws_ssm_send_command:
     name: AWS-UpdateSSMAgent
     comment: "SSM agent update check"
     instance_ids:

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_send_command.py
@@ -12,8 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# Based on https://github.com/ansible/ansible/pull/19868
-
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_send_command.py
@@ -26,8 +26,8 @@ module: aws_ssm_send_command
 short_description: Execute commands through Simple System Manager (SSM) a.k.a. Run Command
 description:
   - This module allows you to execute commands through SSM/Run Command.
-version_added: "2.8"
-author: "Joe Wozniak (woznij)"
+version_added: "2.9"
+author: "Joe Wozniak (@woznij)"
 requirements:
   - python >= 2.6
   - boto3
@@ -69,6 +69,7 @@ options:
     default: {}
 extends_documentation_fragment:
     - aws
+    - ec2
 '''
 
 EXAMPLES = '''
@@ -87,10 +88,10 @@ EXAMPLES = '''
 
 RETURN = '''
 output:
-    description: If wait=true, will return the output of the executed command.
+    description: If wait=true, will return the output of the executed command. Sample truncated for brevity.
     returned: success
     type: str
-    sample: "Updating amazon-ssm-agent from 2.3.539.0 to latest\nSuccessfully downloaded https://s3.us-west-2.amazonaws.com/amazon-ssm-us-west-2/ssm-agent-manifest.json\namazon-ssm-agent 2.3.539.0 has already been installed, update skipped\n"
+    sample: "Updating amazon-ssm-agent from 2.3.539.0 to latest\nSuccessfully downloaded https://s3.us-west-2.amazonaws.com/amazon-ssm-us-west-2/ssm-agent..."
 status:
     description: Status of the run command.
     returned: success

--- a/lib/ansible/modules/cloud/amazon/ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/ssm_send_command.py
@@ -1,0 +1,216 @@
+#!/usr/bin/python
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ssm_send_command
+short_description: Execute commands through Simple System Manager (SSM) a.k.a. Run Command
+description:
+  - This module allows you to execute commands through SSM/Run Command.
+version_added: "2.2"
+extends_documentation_fragment:
+  - aws
+author: "Joe Wozniak <woznij@amazon.com>"
+requirements:
+  - python >= 2.6
+  - boto3
+notes:
+  - Async invocation will always return an empty C(output) key.
+  - Synchronous invocation may result in a function timeout, resulting in an
+    empty C(output) key.
+options:
+  name:
+    description:
+      - This should match the name of the SSM document to be invoked.
+    required: true
+    default: NONE
+  comment:
+    description:
+      - A comment about this particular invocation.
+    required: false
+    default: NONE
+  instanceIds:
+    description:
+      - This should contain an array of instance IDs for the instances you
+        wish to run this command document against.
+    required: true
+    default: NONE
+  wait:
+    description:
+      - Whether to wait for the function results or not. If I(wait) is false,
+        the task will not return any results. To wait for the command to
+        complete, set C(wait=true) and the result will be available in the
+        I(output) key.
+    required: false
+    default: true
+  parameters:
+    description:
+      - A dictionary to be provided as the parameters for the SSM document
+        you're invoking.
+    required: false
+    default: {}
+'''
+
+EXAMPLES = '''
+- ssm_send_command:
+    name: AWS-RunPowerShellScript
+    comment: "Run inventory script"
+    instanceIds:
+      - i-123987193812
+      - i-289189288278
+    parameters:
+      commands:
+        - "c:\scripts\get-inventory.ps1"
+        - "c:\scripts\cleanup.ps1"
+      workingDirectory:
+        - "c:\scripts"
+      executionTimeout:
+        - "600"
+    wait: true
+  register: response
+'''
+
+RETURN = '''
+output:
+    description: If wait=true, will return the status of sent command.
+    returned: success
+    type: dict
+    sample: "{ 'output': 'something' }"
+status:
+    description: C(Status) of AWS SSM API call
+    type: str
+    sample: Success
+'''
+
+# import base64
+# import json
+import traceback
+from time import sleep
+
+try:
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        name                 = dict(),
+        wait                 = dict(choices=BOOLEANS, default=True, type='bool'),
+        comment              = dict(),
+        instanceIds          = dict(default=[], type='list'),
+        parameters           = dict(default={}, type='dict')
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False
+    )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    document_name = module.params.get('name')  # Needs to be an existing SSM document name
+    comment = module.params.get('comment')
+    await_return = module.params.get('wait')
+    instance_ids = module.params.get('instanceIds')
+    parameters = module.params.get('parameters')
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='Python module "boto3" is missing, please install it')
+
+    if not (document_name and instance_ids):
+        module.fail_json(msg="Must provide SSM document name and at least one instance id.")
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=HAS_BOTO3)
+    if not region:
+        module.fail_json(msg="The AWS region must be specified as an "
+                         "environment variable or in the AWS credentials "
+                         "profile.")
+
+    try:
+        client = boto3_conn(module, conn_type='client', resource='ssm',
+                            region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
+        module.fail_json(msg="Failure connecting boto3 to AWS", exception=traceback.format_exc(e))
+
+    invoke_params = {}
+
+    if document_name:
+        invoke_params['DocumentName'] = document_name
+    if comment:
+        invoke_params['Comment'] = comment
+    if instance_ids:
+        invoke_params['InstanceIds'] = instance_ids
+    if parameters:
+        invoke_params['Parameters'] = parameters
+
+    try:
+        response = client.send_command(**invoke_params)
+    except botocore.exceptions.ClientError as ce:
+        if ce.response['Error']['Code'] == 'ResourceNotFoundException':
+            module.fail_json(msg="Could not find the SSM doc to execute. Make sure "
+                             "the document name is correct and your profile has "
+                             "permissions to execute SSM.",
+                             exception=traceback.format_exc(ce))
+        module.fail_json(msg="Client-side error when invoking SSM, check inputs and specific error",
+                         exception=traceback.format_exc(ce))
+    except botocore.exceptions.ParamValidationError as ve:
+        module.fail_json(msg="Parameters to `invoke` failed to validate",
+                         exception=traceback.format_exc(ve))
+    except Exception as e:
+        module.fail_json(msg="Unexpected failure while invoking SSM send command.",
+                         exception=traceback.format_exc(e))
+
+    if await_return:
+        command_id = response['Command']['CommandId']
+        list_params = {}
+        if command_id:
+            list_params['CommandId'] = command_id
+            list_params['Details'] = True
+            checking = True
+            while checking:
+                try:
+                    invoke_response = client.list_command_invocations(**list_params)
+                except Exception as e:
+                    module.fail_json(msg="Error in checking on execution status",
+                                     exception=traceback.format_exc(e))
+                if invoke_response['CommandInvocations'][0]['Status'] == 'Success':
+                    checking = False
+                if invoke_response['CommandInvocations'][0]['Status'] == 'Failed':
+                    checking = False
+                    module.fail_json(msg="SSM Command failed", exception=invoke_response)
+                sleep(5)
+        else:
+            module.fail_json(msg='A valid command invocation ID was not returned.'
+                                 'Check the EC2 console command history')
+        results ={
+            'status': invoke_response['CommandInvocations'][0]['Status'],
+            'output': invoke_response['CommandInvocations'][0]['CommandPlugins'][0]['Output'],
+        }
+    else:
+        results ={
+            'status': response['Command']['Status'],
+            'output': '',
+        }
+
+    module.exit_json(changed=True, result=results)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/ssm_send_command.py
@@ -18,7 +18,7 @@ module: ssm_send_command
 short_description: Execute commands through Simple System Manager (SSM) a.k.a. Run Command
 description:
   - This module allows you to execute commands through SSM/Run Command.
-version_added: "2.2"
+version_added: "2.3"
 extends_documentation_fragment:
   - aws
 author: "Joe Wozniak <woznij@amazon.com>"

--- a/lib/ansible/modules/cloud/amazon/ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/ssm_send_command.py
@@ -14,16 +14,22 @@
 
 # Based on https://github.com/ansible/ansible/pull/19868
 
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
 DOCUMENTATION = '''
 ---
 module: ssm_send_command
 short_description: Execute commands through Simple System Manager (SSM) a.k.a. Run Command
 description:
   - This module allows you to execute commands through SSM/Run Command.
-version_added: "2.3"
+version_added: "2.8"
 extends_documentation_fragment:
   - aws
-author: "Joe Wozniak <woznij@amazon.com>"
+author: "Joe Wozniak (woznij@amazon.com)"
 requirements:
   - python >= 2.6
   - boto3
@@ -35,19 +41,19 @@ options:
   name:
     description:
       - This should match the name of the SSM document to be invoked.
+    type: string
     required: true
-    default: NONE
   comment:
     description:
       - A comment about this particular invocation.
     required: false
-    default: NONE
+    type: str
   instance_ids:
     description:
-      - This should contain an array of instance IDs for the instances you
-        wish to run this command document against.
+      - A list of instance IDs for the instances you wish to run this command
+        document against.
     required: true
-    default: NONE
+    type: list
   wait:
     description:
       - Whether to wait for the function results or not. If I(wait) is false,
@@ -55,6 +61,7 @@ options:
         complete, set C(wait=true) and the result will be available in the
         I(output) key.
     required: false
+    type: bool
     default: true
   parameters:
     description:
@@ -62,6 +69,9 @@ options:
         you're invoking.
     required: false
     default: {}
+extends_documentation_fragment:
+    - aws
+    - ec2
 '''
 
 EXAMPLES = '''
@@ -85,17 +95,17 @@ EXAMPLES = '''
 
 RETURN = '''
 output:
-    description: If wait=true, will return the status of sent command.
+    description: If wait=true, will return the output of the executed command.
     returned: success
-    type: dict
-    sample: "{ 'output': 'something' }"
+    type: str
+    sample: "Updating amazon-ssm-agent from 2.3.372.0 to latest"
 status:
-    description: C(Status) of AWS SSM API call
+    description: Status of the run command.
+    returned: always
     type: str
     sample: Success
 '''
 
-from ansible.module_utils.basic import BOOLEANS
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info, AWSRetry
 import traceback
@@ -123,7 +133,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         name=dict(required=True),
-        wait=dict(choices=BOOLEANS, default=True, type='bool'),
+        wait=dict(default=True, type='bool'),
         comment=dict(),
         instance_ids=dict(required=True, type='list'),
         parameters=dict(default={}, type='dict')

--- a/lib/ansible/modules/cloud/amazon/ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/ssm_send_command.py
@@ -27,9 +27,7 @@ short_description: Execute commands through Simple System Manager (SSM) a.k.a. R
 description:
   - This module allows you to execute commands through SSM/Run Command.
 version_added: "2.8"
-extends_documentation_fragment:
-  - aws
-author: "Joe Wozniak (woznij@amazon.com)"
+author: "Joe Wozniak (woznij)"
 requirements:
   - python >= 2.6
   - boto3
@@ -41,7 +39,7 @@ options:
   name:
     description:
       - This should match the name of the SSM document to be invoked.
-    type: string
+    type: str
     required: true
   comment:
     description:
@@ -71,24 +69,18 @@ options:
     default: {}
 extends_documentation_fragment:
     - aws
-    - ec2
 '''
 
 EXAMPLES = '''
 - ssm_send_command:
-    name: AWS-RunPowerShellScript
-    comment: "Run inventory script"
+    name: AWS-UpdateSSMAgent
+    comment: "SSM agent update check"
     instance_ids:
       - i-123987193812
       - i-289189288278
     parameters:
-      commands:
-        - "c:\\scripts\\get-inventory.ps1"
-        - "c:\\scripts\\cleanup.ps1"
-      workingDirectory:
-        - "c:\\scripts"
-      executionTimeout:
-        - "600"
+      version: latest
+      allowDowngrade: 'false'
     wait: true
   register: response
 '''
@@ -98,10 +90,10 @@ output:
     description: If wait=true, will return the output of the executed command.
     returned: success
     type: str
-    sample: "Updating amazon-ssm-agent from 2.3.372.0 to latest"
+    sample: "Updating amazon-ssm-agent from 2.3.539.0 to latest\nSuccessfully downloaded https://s3.us-west-2.amazonaws.com/amazon-ssm-us-west-2/ssm-agent-manifest.json\namazon-ssm-agent 2.3.539.0 has already been installed, update skipped\n"
 status:
     description: Status of the run command.
-    returned: always
+    returned: success
     type: str
     sample: Success
 '''

--- a/lib/ansible/modules/cloud/amazon/ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/ssm_send_command.py
@@ -73,10 +73,10 @@ EXAMPLES = '''
       - i-289189288278
     parameters:
       commands:
-        - "c:\scripts\get-inventory.ps1"
-        - "c:\scripts\cleanup.ps1"
+        - "c:\\scripts\\get-inventory.ps1"
+        - "c:\\scripts\\cleanup.ps1"
       workingDirectory:
-        - "c:\scripts"
+        - "c:\\scripts"
       executionTimeout:
         - "600"
     wait: true

--- a/lib/ansible/modules/cloud/amazon/ssm_send_command.py
+++ b/lib/ansible/modules/cloud/amazon/ssm_send_command.py
@@ -93,13 +93,14 @@ status:
     sample: Success
 '''
 
-# import base64
-# import json
+from ansible.module_utils.basic import AnsibleModule, BOOLEANS
+from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 import traceback
 from time import sleep
 
 try:
     import boto3
+    import botocore
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
@@ -108,19 +109,16 @@ except ImportError:
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        name                 = dict(),
+        name                 = dict(required=True),
         wait                 = dict(choices=BOOLEANS, default=True, type='bool'),
         comment              = dict(),
-        instanceIds          = dict(default=[], type='list'),
+        instanceIds          = dict(required=True, type='list'),
         parameters           = dict(default={}, type='dict')
     ))
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=False
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     document_name = module.params.get('name')  # Needs to be an existing SSM document name
     comment = module.params.get('comment')
@@ -187,11 +185,12 @@ def main():
                 except Exception as e:
                     module.fail_json(msg="Error in checking on execution status",
                                      exception=traceback.format_exc(e))
-                if invoke_response['CommandInvocations'][0]['Status'] == 'Success':
-                    checking = False
-                if invoke_response['CommandInvocations'][0]['Status'] == 'Failed':
-                    checking = False
-                    module.fail_json(msg="SSM Command failed", exception=invoke_response)
+                if not invoke_response['CommandInvocations'] == []:
+                    if invoke_response['CommandInvocations'][0]['Status'] == 'Success':
+                        checking = False
+                    if invoke_response['CommandInvocations'][0]['Status'] == 'Failed':
+                        checking = False
+                        module.fail_json(msg="SSM Command failed")
                 sleep(5)
         else:
             module.fail_json(msg='A valid command invocation ID was not returned.'
@@ -207,10 +206,6 @@ def main():
         }
 
     module.exit_json(changed=True, result=results)
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is an extension of PR #19868, addressing some of the feedback that was left on the PR but not addressed by the original author.

Usage of some best-practices for boto3 programming were also included, including usage of `AWSRetry`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ssm_send_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
AWS SSM is an AWS system that allows one to manage systems in AWS or on-premise using an Amazon agent and pre-made "documents", which define the commands which can be sent to an instance.

For example, the following runs the `AWS-UpdateSSMAgent` command document on the instance `i-0123456789abcde012`:
```sh
$ ansible localhost -m "ssm_send_command" -a "name=AWS-UpdateSSMAgent instance_ids=i-0123456789abcde012"
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
localhost | CHANGED => {
    "changed": true,
    "result": {
        "output": "Updating amazon-ssm-agent from 2.3.539.0 to latest\nSuccessfully downloaded https://s3.us-west-2.amazonaws.com/amazon-ssm-us-west-2/ssm-agent-manifest.json\namazon-ssm-agent 2.3.539.0 has already been installed, update skipped\n",
        "status": "Success"
    }
}
```
