### PR TITLE
[stable-2.6] Limit supervisor in tests to < 4.0.0.

### DIFF
--- a/test/integration/targets/supervisorctl/tasks/install_pip.yml
+++ b/test/integration/targets/supervisorctl/tasks/install_pip.yml
@@ -1,4 +1,4 @@
 - name: install supervisord
   pip:
-    name: supervisor
+    name: supervisor<4.0.0  # supervisor version 4.0.0 fails tests
     state: present


### PR DESCRIPTION
##### SUMMARY

Limit supervisor in tests to < 4.0.0.

Tests fail when using version 4.0.0.

Backport of https://github.com/ansible/ansible/pull/54935

(cherry picked from commit 4b3662605d7ac050f81512469391d1a0eb496e47)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

supervisorctl integration tests
