### PR TITLE
Meraki - Create use_config_templates parameter

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -45,6 +45,7 @@ def meraki_argument_spec():
                 timeout=dict(type='int', default=30),
                 org_name=dict(type='str', aliases=['organization']),
                 org_id=dict(type='str'),
+                use_config_templates=dict(type='bool', default=True),
                 )
 
 
@@ -206,9 +207,10 @@ class MerakiModule(object):
         if self.status != 200:
             self.fail_json(msg='Network lookup failed')
         self.nets = r
-        templates = self.get_config_templates(org_id)
-        for t in templates:
-            self.nets.append(t)
+        if self.params['use_config_templates'] is True:
+            templates = self.get_config_templates(org_id)
+            for t in templates:
+                self.nets.append(t)
         return self.nets
 
     # def get_net(self, org_name, net_name, data=None):

--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -24,6 +24,7 @@ notes:
 - Module is not idempotent as the Meraki API is limited in what information it provides about configuration templates.
 - Meraki's API does not support creating new configuration templates.
 - To use the configuration template, simply pass its ID via C(net_id) parameters in Meraki modules.
+- Do not set the C(use_config_template) value to C(no).
 options:
     state:
         description:
@@ -222,6 +223,9 @@ def main():
         meraki.exit_json(**meraki.result)
 
     # execute checks for argument completeness
+
+    if meraki.params['use_config_template'] is False:
+        meraki.fail_json(msg="Do not use use_config_template parameter with meraki_config_template module.")
 
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)

--- a/lib/ansible/plugins/doc_fragments/meraki.py
+++ b/lib/ansible/plugins/doc_fragments/meraki.py
@@ -31,6 +31,13 @@ options:
         - Only useful for internal Meraki developers.
         type: bool
         default: yes
+    use_config_templates:
+        description:
+        - Specifies whether configuration templates should be considered when looking for networks.
+        - Only specify C(no) when organization does not use any configuration templates.
+        - Specifying C(no) may improve performance.
+        type: bool
+        default: yes
     output_level:
         description:
         - Set amount of debug output during module execution.

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -33,6 +33,7 @@
       net_name: IntTestNetworkSwitch
       type: switch
       timezone: America/Chicago
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_switch
     
@@ -44,6 +45,7 @@
       net_name: IntTestNetworkSwitchOrgID
       type: switch
       timezone: America/Chicago
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_switch_org_id  
     
@@ -54,6 +56,7 @@
       org_name: '{{test_org_name}}'
       net_name: IntTestNetworkAppliance
       type: appliance
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_appliance_no_tz
     
@@ -65,6 +68,7 @@
       net_name: IntTestNetworkWireless
       type: wireless
       timezone: America/Chicago
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_wireless
 
@@ -76,6 +80,7 @@
       net_name: IntTestNetworkWireless
       type: wireless
       timezone: America/Chicago
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_wireless_idempotent
 
@@ -90,6 +95,7 @@
         - switch
       timezone: America/Chicago
       disable_my_meraki: yes
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_combined
 
@@ -100,6 +106,7 @@
       org_name: '{{test_org_name}}'
       net_name: IntTestNetworkCombined
       disable_my_meraki: no
+      use_config_templates: false
     delegate_to: localhost
     register: enable_meraki_com
     
@@ -112,6 +119,7 @@
       type: switch
       timezone: America/Chicago
       tags: first_tag
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_tag
 
@@ -129,6 +137,7 @@
       tags: 
         - first_tag
         - second_tag
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_tags
 
@@ -147,6 +156,7 @@
         - first_tag
         - second_tag
         - third_tag
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_modified
 
@@ -162,6 +172,7 @@
         - first_tag
         - second_tag
         - third_tag
+      use_config_templates: false
     delegate_to: localhost
     register: create_net_modified_idempotent
 
@@ -190,6 +201,7 @@
       auth_key: '{{ auth_key }}'
       state: query
       org_name: '{{test_org_name}}'
+      use_config_templates: false
     delegate_to: localhost
     register: net_query_all
       
@@ -199,6 +211,7 @@
       state: query
       org_name: '{{test_org_name}}'
       net_name: '{{test_template_name}}'
+      use_config_templates: yes
     delegate_to: localhost
     register: query_config_template
 
@@ -208,6 +221,7 @@
       state: query
       org_name: '{{test_org_name}}'
       net_name: IntTestNetworkSwitch
+      use_config_templates: false
     delegate_to: localhost
     register: net_query_one
 
@@ -227,6 +241,7 @@
       auth_key: '{{ auth_key }}'
       state: absent
       net_name: IntTestNetworkSwitch
+      use_config_templates: false
     delegate_to: localhost
     register: delete_all_no_org
     ignore_errors: yes
@@ -237,6 +252,7 @@
       state: absent
       org_id: '{{test_org_id}}'
       net_name: IntTestNetworkSwitchOrgID
+      use_config_templates: false
     delegate_to: localhost
     register: delete_net_org_id
 
@@ -245,6 +261,7 @@
       auth_key: '{{ auth_key }}'
       state: query
       org_name: '{{test_org_name}}'
+      use_config_templates: false
     delegate_to: localhost
     register: query_deleted_org_id
 
@@ -254,6 +271,7 @@
       state: absent
       org_name: '{{test_org_name}}'
       net_name: '{{ item }}'
+      use_config_templates: false
     delegate_to: localhost
     register: delete_all
     ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
The Meraki module utility has a function to lookup all networks (`get_nets()`). Prior to this pull request, it would look up networks and configuration templates. Unfortunately, this requires 2 API calls and at ~1 second per call, the configuration template lookup call is relatively expensive. This pull request adds a `use_config_templates` parameter which, if disabled, will prevent `get_nets()` from querying configuration templates. This is only for improved performance.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meraki
