### PR TITLE
Clarify example for fileglob lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -24,8 +24,8 @@ DOCUMENTATION = """
 """
 
 EXAMPLES = """
-- name: display content of all .txt files in dir
-  debug: msg={{lookup('fileglob', '/my/path/*.txt')}}
+- name: Display paths of all .txt files in dir
+  debug: msg={{ lookup('fileglob', '/my/path/*.txt') }}
 
 - name: Copy each file over that matches the given pattern
   copy:


### PR DESCRIPTION
##### SUMMARY

fileglob returns a list of paths it does not return file contents, as explained in latest notes. The file lookup retrieves file contents. This change clarifies the first example to make it clear a paths, not contents, are returned. 

It also adds spaces around the lookup to avoid E206 from ansible-lint: "Variables should have spaces before and after: {{ var_name }}"

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

fileglob lookup plugin

+label: docsite_pr