### PR TITLE
Added a Docker Machine dynamic inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -91,9 +91,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     NAME = 'docker_machine'
 
-    DOCKER_MACHINE_PATH = get_bin_path('docker-machine')
+    DOCKER_MACHINE_PATH = None
 
     def _run_command(self, args):
+        if not self.DOCKER_MACHINE_PATH:
+            try:
+                self.DOCKER_MACHINE_PATH = get_bin_path('docker-machine', required=True)
+            except ValueError as e:
+                raise AnsibleError('Unable to locate the docker-machine binary.', orig_exc=e)
+
         command = [self.DOCKER_MACHINE_PATH]
         command.extend(args)
         display.debug('Executing command {0}'.format(command))

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -180,7 +180,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not env_var_tuples:
             warning_prefix = 'Unable to fetch Docker daemon env vars from Docker Machine for host {0}'.format(machine_name)
             if daemon_env in ('require', 'require-silently'):
-                if demon_env == 'require':
+                if daemon_env == 'require':
                     display.warning('{0}: host will be skipped'.format(warning_prefix))
                 return True
             else:  # 'optional', 'optional-silently'

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -165,11 +165,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _should_skip_host(self, machine_name, env_var_tuples):
         if not env_var_tuples:
+            warning_prefix = 'Unable to fetch Docker daemon env vars from Docker Machine for host {0}'.format(machine_name)
             if self.get_option('daemon_required'):
-                display.warning('Unable to fetch Docker daemon env vars from Docker Machine for host {0}: host will be skipped'.format(machine_name))
+                display.warning('{0}: host will be skipped'.format(warning_prefix))
                 return True
             else:
-                display.warning('Unable to fetch Docker daemon env vars from Docker Machine for host {0}: host will lack dm_DOCKER_xxx variables'.format(machine_name))
+                display.warning('{0}: host will lack dm_DOCKER_xxx variables'.format(warning_prefix))
         return False
 
     def _populate(self):

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -35,7 +35,7 @@ DOCUMENTATION = '''
             type: bool
             default: yes
         verbose_output:
-            description: when true, include all available nodes metadata (e.g. Image, Region, Size) as a JSON object.
+            description: when true, include all available nodes metadata (e.g. Image, Region, Size) as a JSON object named C(docker_machine_node_attributes).
             type: bool
             default: yes
 '''

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -13,7 +13,6 @@ DOCUMENTATION = '''
     requirements:
         - L(Docker Machine,https://docs.docker.com/machine/)
     extends_documentation_fragment:
-        - inventory_cache
         - constructed
     description:
         - Get inventory hosts from Docker Machine.

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -59,6 +59,10 @@ split_separator: ":"
 keyed_groups:
   - prefix: gantry_component
     key: 'dm_tag_gantry_component'
+
+# Example using compose to override the default SSH behaviour of asking the user to accept the remote host key
+compose:
+  ansible_ssh_common_args: '"-o StrictHostKeyChecking=accept-new"'
 '''
 
 from ansible.errors import AnsibleError
@@ -97,7 +101,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self.inventory.set_variable(id, 'ansible_host', self.node_attrs['Driver']['IPAddress'])
                 self.inventory.set_variable(id, 'ansible_port', self.node_attrs['Driver']['SSHPort'])
                 self.inventory.set_variable(id, 'ansible_user', self.node_attrs['Driver']['SSHUser'])
-                self.inventory.set_variable(id, 'ansible_ssh_common_args', '-o StrictHostKeyChecking=no')
                 self.inventory.set_variable(id, 'ansible_ssh_private_key_file', self.node_attrs['Driver']['SSHKeyPath'])
 
                 # pass '--shell=bash' to workaround 'Error: Unknown shell

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -40,8 +40,7 @@ DOCUMENTATION = '''
           description: for keyed_groups when splitting tags this is the separator to split the tag value on.
           required: False
           type: str
-          default: ":"
-        
+          default: ":"        
 '''
 
 EXAMPLES = '''
@@ -72,6 +71,7 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cachea
 import json
 import re
 import subprocess
+
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     ''' Host inventory parser for ansible using Docker machine as source. '''

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -172,5 +172,5 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path, cache)
-        config = self._read_config_data(path)
+        self._read_config_data(path)
         self._populate()

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -217,11 +217,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def verify_file(self, path):
         """Return the possibility of a file being consumable by this plugin."""
-        if super(InventoryModule, self).verify_file(path):
-            if path.endswith(('docker_machine.yml', 'docker_machine.yaml')):
-                return True
-        display.debug("docker_machine inventory filename must end with 'docker_machine.yml' or 'docker_machine.yaml'")
-        return False
+        return (
+            super(InventoryModule, self).verify_file(path) and
+            path.endswith((self.NAME + '.yaml', self.NAME + '.yml')))
 
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path, cache)

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -10,21 +10,21 @@ DOCUMENTATION = '''
     plugin_type: inventory
     short_description: Docker machine inventory source
     requirements:
-        - Docker Machine
+        - L(Docker Machine,https://docs.docker.com/machine/)
     extends_documentation_fragment:
         - inventory_cache
         - constructed
     description:
         - Get inventory hosts from Docker Machine.
         - Uses a YAML configuration file that ends with docker_machine.(yml|yaml).
-        - The plugin returns an C(all) group of nodes and one group per driver (e.g. digitalocean).
-        - The plugin sets standard host variables ansible_host, ansible_port, ansible_user and ansible_ssh_private_key.
-        - The plugin also sets standard host variable ansible_ssh_common_args to '-o StrictHostKeyChecking=no'.
-        - The plugin also stores the Docker Machine 'env' variables in dm_ prefixed host variables.
+        - The plugin returns an I(all) group of nodes and one group per driver (e.g. digitalocean).
+        - The plugin sets standard host variables I(ansible_host), I(ansible_port), I(ansible_user) and I(ansible_ssh_private_key).
+        - The plugin also sets standard host variable I(ansible_ssh_common_args) to '-o StrictHostKeyChecking=no'.
+        - The plugin also stores the Docker Machine 'env' variables in I(dm_) prefixed host variables.
 
     options:
         plugin:
-          description: token that ensures this is a source file for the 'docker_machine' plugin.
+          description: token that ensures this is a source file for the C(docker_machine) plugin.
           required: True
           choices: ['docker_machine']
         verbose_output:

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -47,14 +47,14 @@ plugin: docker_machine
 
 # Example using constructed features to create groups
 # keyed_groups may be used to create custom groups
-strict: False
+strict: no
 keyed_groups:
   - prefix: tag
     key: 'dm_tags'
 
 # Example using tag splitting where the tag is like 'dm_tag_gantry_component:routinator'
-strict: False
-split_tags: True
+strict: no
+split_tags: yes
 split_separator: ":"
 keyed_groups:
   - prefix: gantry_component

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -91,8 +91,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     NAME = 'docker_machine'
 
+    DOCKER_MACHINE_PATH = get_bin_path('docker-machine')
+
     def _run_command(self, args):
-        command = [(get_bin_path('docker-machine'))]
+        command = [self.DOCKER_MACHINE_PATH]
         command.extend(args)
         display.debug('Executing command {0}'.format(command))
         try:

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -174,4 +174,3 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).parse(inventory, loader, path, cache)
         config = self._read_config_data(path)
         self._populate()
-

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -17,10 +17,8 @@ DOCUMENTATION = '''
     description:
         - Get inventory hosts from Docker Machine.
         - Uses a YAML configuration file that ends with docker_machine.(yml|yaml).
-        - The plugin returns an I(all) group of nodes and one group per driver (e.g. digitalocean).
         - The plugin sets standard host variables C(ansible_host), C(ansible_port), C(ansible_user) and C(ansible_ssh_private_key).
-        - The plugin also sets standard host variable I(ansible_ssh_common_args) to C(-o StrictHostKeyChecking=no).
-        - The plugin also stores the Docker Machine 'env' variables in I(dm_) prefixed host variables.
+        - The plugin stores the Docker Machine 'env' output variables in I(dm_) prefixed host variables.
 
     options:
         plugin:
@@ -152,8 +150,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     self.inventory.set_variable(id, 'dm_tag_{0}'.format(kv_pair))
 
     def _populate(self):
-        self.inventory.add_group('all')
-
         try:
             self.nodes = self._run_command('ls', '-q').splitlines()
             for self.node in self.nodes:
@@ -161,7 +157,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
                 id = self.node_attrs['Driver']['MachineName']
                 self.inventory.add_host(id)
-                self.inventory.add_host(id, group='all')
 
                 # Find out more about the following variables at: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
                 self.inventory.set_variable(id, 'ansible_host', self.node_attrs['Driver']['IPAddress'])

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -75,12 +75,12 @@ compose:
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
+from ansible.module_utils.common.process import get_bin_path
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.utils.display import Display
 
 import json
 import re
-import shutil
 import subprocess
 
 display = Display()
@@ -92,7 +92,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = 'docker_machine'
 
     def _run_command(self, args):
-        command = [(shutil.which('docker-machine'))]
+        command = [(get_bin_path('docker-machine'))]
         command.extend(args)
         display.debug('Executing command {0}'.format(command))
         try:

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -40,7 +40,7 @@ DOCUMENTATION = '''
           description: for keyed_groups when splitting tags this is the separator to split the tag value on.
           required: False
           type: str
-          default: ":"        
+          default: ":"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -109,6 +109,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _set_tag_variables(self, id):
         tags = self.node_attrs['Driver'].get('Tags') or ''
+        self.inventory.set_variable(id, 'dm_tags', tags)
+
         if tags:
             split_tags = self.get_option('split_tags')
             split_separator = self.get_option('split_separator')

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -114,8 +114,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 #   # eval $(docker-machine env --shell=bash routinator)
 
                 for env_var_name in ['DOCKER_TLS_VERIFY', 'DOCKER_HOST', 'DOCKER_CERT_PATH', 'DOCKER_MACHINE_NAME']:
-                    env_var_value = re.search('{}="([^"]+)"'.format(env_var_name), env_out).group(1)
-                    self.inventory.set_variable(id, 'dm_{}'.format(env_var_name), env_var_value)
+                    env_var_value = re.search('{0}="([^"]+)"'.format(env_var_name), env_out).group(1)
+                    self.inventory.set_variable(id, 'dm_{0}'.format(env_var_name), env_var_value)
 
                 # Capture any tags
                 split_tags = self.get_option('split_tags')
@@ -124,9 +124,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 for kv_pair in tags.split(','):
                     if split_tags and split_separator in kv_pair:
                         k, v = kv_pair.split(split_separator)
-                        self.inventory.set_variable(id, 'dm_tag_{}'.format(k), v)
+                        self.inventory.set_variable(id, 'dm_tag_{0}'.format(k), v)
                     else:
-                        self.inventory.set_variable(id, 'dm_tag_{}'.format(kv_pair))
+                        self.inventory.set_variable(id, 'dm_tag_{0}'.format(kv_pair))
 
                 if self.get_option('verbose_output'):
                     self.inventory.set_variable(id, 'docker_machine_node_attributes', self.node_attrs)

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019, Ximon Eighteen <ximon.eighteen@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: docker_machine
+    plugin_type: inventory
+    short_description: Docker machine inventory source
+    requirements:
+        - Docker Machine
+    extends_documentation_fragment:
+        - inventory_cache
+        - constructed
+    description:
+        - Get inventory hosts from Docker Machine.
+        - Uses a YAML configuration file that ends with docker_machine.(yml|yaml).
+        - The plugin returns an C(all) group of nodes and one group per driver (e.g. digitalocean).
+        - The plugin sets standard host variables ansible_host, ansible_port, ansible_user and ansible_ssh_private_key.
+        - The plugin also sets standard host variable ansible_ssh_common_args to '-o StrictHostKeyChecking=no'.
+        - The plugin also stores the Docker Machine 'env' variables in dm_ prefixed host variables.
+
+    options:
+        plugin:
+          description: token that ensures this is a source file for the 'docker_machine' plugin.
+          required: True
+          choices: ['docker_machine']
+        verbose_output:
+            description: Toggle to (not) include all available nodes metadata (e.g. Image, Region, Size) as a JSON object.
+            type: bool
+            default: yes
+        split_tags:
+          description: for keyed_groups add two variables as if the tag were actually a key value pair separated by a colon, instead of just a single value.
+          required: False
+          type: bool
+          default: no
+        split_separator:
+          description: for keyed_groups when splitting tags this is the separator to split the tag value on.
+          required: False
+          type: str
+          default: ":"
+        
+'''
+
+EXAMPLES = '''
+# Minimal example
+plugin: docker_machine
+
+# Example using constructed features to create groups
+# keyed_groups may be used to create custom groups
+strict: False
+keyed_groups:
+  - prefix: tag
+    key: 'dm_tags'
+
+# Example using tag splitting where the tag is like 'dm_tag_gantry_component:routinator'
+strict: False
+split_tags: True
+split_separator: ":"
+keyed_groups:
+  - prefix: gantry_component
+    key: 'dm_tag_gantry_component'
+'''
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_text
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+
+import json
+import re
+import subprocess
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+    ''' Host inventory parser for ansible using Docker machine as source. '''
+
+    NAME = 'docker_machine'
+
+    def _run_command(self, *args):
+        return subprocess.check_output(["docker-machine"] + list(args)).decode('utf-8').strip()
+
+    def _populate(self):
+        self.inventory.add_group('all')
+
+        try:
+            self.nodes = self._run_command('ls', '-q').splitlines()
+            for self.node in self.nodes:
+                self.node_attrs = json.loads(self._run_command('inspect', self.node))
+
+                id = self.node_attrs['Driver']['MachineName']
+                self.inventory.add_host(id)
+                self.inventory.add_group(self.node_attrs['DriverName'])
+                self.inventory.add_host(id, group=self.node_attrs['DriverName'])
+                self.inventory.add_host(id, group='all')
+
+                # Find out more about the following variables at: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
+                self.inventory.set_variable(id, 'ansible_host', self.node_attrs['Driver']['IPAddress'])
+                self.inventory.set_variable(id, 'ansible_port', self.node_attrs['Driver']['SSHPort'])
+                self.inventory.set_variable(id, 'ansible_user', self.node_attrs['Driver']['SSHUser'])
+                self.inventory.set_variable(id, 'ansible_ssh_common_args', '-o StrictHostKeyChecking=no')
+                self.inventory.set_variable(id, 'ansible_ssh_private_key_file', self.node_attrs['Driver']['SSHKeyPath'])
+
+                # pass '--shell=bash' to workaround 'Error: Unknown shell
+                env_out = self._run_command('env', '--shell=bash', id)
+
+                # example output of docker-machine env
+                #   export DOCKER_TLS_VERIFY="1"
+                #   export DOCKER_HOST="tcp://134.209.204.160:2376"
+                #   export DOCKER_CERT_PATH="/root/.docker/machine/machines/routinator"
+                #   export DOCKER_MACHINE_NAME="routinator"
+                #   # Run this command to configure your shell:
+                #   # eval $(docker-machine env --shell=bash routinator)
+
+                for env_var_name in ['DOCKER_TLS_VERIFY', 'DOCKER_HOST', 'DOCKER_CERT_PATH', 'DOCKER_MACHINE_NAME']:
+                    env_var_value = re.search('{}="([^"]+)"'.format(env_var_name), env_out).group(1)
+                    self.inventory.set_variable(id, 'dm_{}'.format(env_var_name), env_var_value)
+
+                # Capture any tags
+                split_tags = self.get_option('split_tags')
+                split_separator = self.get_option('split_separator')
+                tags = self.node_attrs['Driver']['Tags']
+                for kv_pair in tags.split(','):
+                    if split_tags and split_separator in kv_pair:
+                        k, v = kv_pair.split(split_separator)
+                        self.inventory.set_variable(id, 'dm_tag_{}'.format(k), v)
+                    else:
+                        self.inventory.set_variable(id, 'dm_tag_{}'.format(kv_pair))
+
+                if self.get_option('verbose_output'):
+                    self.inventory.set_variable(id, 'docker_machine_node_attributes', self.node_attrs)
+
+                # Use constructed if applicable
+                strict = self.get_option('strict')
+
+                # Composed variables
+                self._set_composite_vars(self.get_option('compose'), self.node_attrs, id, strict=strict)
+
+                # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
+                self._add_host_to_composed_groups(self.get_option('groups'), self.node_attrs, id, strict=strict)
+
+                # Create groups based on variable values and add the corresponding hosts to it
+                self._add_host_to_keyed_groups(self.get_option('keyed_groups'), self.node_attrs, id, strict=strict)
+
+        except Exception as e:
+            raise AnsibleError('Unable to fetch hosts from Docker machine, this was the original exception: %s' %
+                               to_native(e))
+
+    def verify_file(self, path):
+        """Return the possibility of a file being consumable by this plugin."""
+        return (
+            super(InventoryModule, self).verify_file(path) and
+            path.endswith((self.NAME + '.yaml', self.NAME + '.yml')))
+
+    def parse(self, inventory, loader, path, cache=True):
+        super(InventoryModule, self).parse(inventory, loader, path, cache)
+        config = self._read_config_data(path)
+        self._populate()

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -143,7 +143,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         try:
             ls_lines = self._run_command(ls_command)
-        except Exception:
+        except subprocess.CalledProcessError:
             return []
 
         return ls_lines.splitlines()
@@ -151,7 +151,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _inspect_docker_machine_host(self, node):
         try:
             inspect_lines = self._run_command(['inspect', self.node])
-        except Exception as e:
+        except subprocess.CalledProcessError:
             return None
 
         return json.loads(inspect_lines)

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -51,7 +51,8 @@ EXAMPLES = '''
 # Minimal example
 plugin: docker_machine
 
-# Example using constructed features to create a group per Docker Machine L(driver,https://docs.docker.com/machine/drivers/), e.g.:
+# Example using constructed features to create a group per Docker Machine driver
+# (https://docs.docker.com/machine/drivers/), e.g.:
 #   $ docker-machine create --driver digitalocean ... mymachine
 #   $ ansible-inventory -i ./path/to/docker-machine.yml --host=mymachine
 #   {
@@ -120,7 +121,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _run_command(self, args):
         command = ['docker-machine']
         command.extend(args)
-        display.debug('Executing command {}'.format(command))
+        display.debug('Executing command {0}'.format(command))
         try:
             result = subprocess.check_output(command)
         except Exception as e:

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -99,7 +99,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         #   # eval $(docker-machine env --shell=bash routinator)
 
         # capture any of the DOCKER_xxx variables that were output and create Ansible host vars
-        # with the asme name and value but with a dm_ name prefix.
+        # with the same name and value but with a dm_ name prefix.
         for line in env_out.splitlines():
             match = re.search('(DOCKER_[^=]+)="([^"]+)"', line)
             if match:

--- a/lib/ansible/plugins/inventory/docker_machine.py
+++ b/lib/ansible/plugins/inventory/docker_machine.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: docker_machine
     plugin_type: inventory
-    short_description: Docker machine inventory source
+    short_description: Docker Machine inventory source
     requirements:
         - L(Docker Machine,https://docs.docker.com/machine/)
     extends_documentation_fragment:
@@ -144,7 +144,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self._add_host_to_keyed_groups(self.get_option('keyed_groups'), self.node_attrs, id, strict=strict)
 
         except Exception as e:
-            raise AnsibleError('Unable to fetch hosts from Docker machine, this was the original exception: %s' %
+            raise AnsibleError('Unable to fetch hosts from Docker Machine, this was the original exception: %s' %
                                to_native(e))
 
     def verify_file(self, path):

--- a/test/integration/targets/inventory_docker_machine/aliases
+++ b/test/integration/targets/inventory_docker_machine/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/inventory_docker_machine/aliases
+++ b/test/integration/targets/inventory_docker_machine/aliases
@@ -1,1 +1,8 @@
-unsupported
+shippable/posix/group2
+skip/osx
+skip/freebsd
+destructive
+skip/docker  # We need SSH access to the VM and need to be able to let
+             # docker-machine install docker in the VM. This won't work
+             # with tests running in docker containers.
+needs/root

--- a/test/integration/targets/inventory_docker_machine/docker-machine
+++ b/test/integration/targets/inventory_docker_machine/docker-machine
@@ -15,7 +15,6 @@ EOF
         ;;
 
     *)
-        # Hmm, this is quite possibly wrong on the Ansible shippable infra... :-(
-        /usr/local/bin/docker-machine $*
+        /usr/bin/docker-machine $*
         ;;
 esac

--- a/test/integration/targets/inventory_docker_machine/docker-machine
+++ b/test/integration/targets/inventory_docker_machine/docker-machine
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock Docker Machine wrapper for testing purposes
 
 [ "$MOCK_ERROR_IN" == "$1" ] && echo >&2 "Mock Docker Machine error" && exit 1
@@ -15,6 +15,7 @@ EOF
         ;;
 
     *)
+        # Hmm, this is quite possibly wrong on the Ansible shippable infra... :-(
         /usr/local/bin/docker-machine $*
         ;;
 esac

--- a/test/integration/targets/inventory_docker_machine/docker-machine
+++ b/test/integration/targets/inventory_docker_machine/docker-machine
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Mock Docker Machine wrapper for testing purposes
+
+[ "$MOCK_ERROR_IN" == "$1" ] && echo >&2 "Mock Docker Machine error" && exit 1
+case $1 in
+    env)        
+        cat <<'EOF'
+export DOCKER_TLS_VERIFY="1"
+export DOCKER_HOST="tcp://134.209.204.160:2376"
+export DOCKER_CERT_PATH="/root/.docker/machine/machines/routinator"
+export DOCKER_MACHINE_NAME="routinator"
+# Run this command to configure your shell:
+# eval $(docker-machine env --shell=bash routinator)
+EOF
+        ;;
+
+    *)
+        /usr/local/bin/docker-machine $*
+        ;;
+esac

--- a/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
@@ -1,3 +1,1 @@
 plugin: docker_machine
-compose:
-  ansible_ssh_common_args: '"-o StrictHostKeyChecking=accept-new"'

--- a/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
@@ -1,4 +1,3 @@
 plugin: docker_machine
-split_tags: yes
 compose:
   ansible_ssh_common_args: '"-o StrictHostKeyChecking=accept-new"'

--- a/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
@@ -1,9 +1,4 @@
----
 plugin: docker_machine
-strict: no
 split_tags: yes
-keyed_groups:
-  - prefix: dm_test_name
-    key: 'dm_DOCKER_MACHINE_NAME'
 compose:
   ansible_ssh_common_args: '"-o StrictHostKeyChecking=accept-new"'

--- a/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_1.docker_machine.yml
@@ -1,0 +1,9 @@
+---
+plugin: docker_machine
+strict: no
+split_tags: yes
+keyed_groups:
+  - prefix: dm_test_name
+    key: 'dm_DOCKER_MACHINE_NAME'
+compose:
+  ansible_ssh_common_args: '"-o StrictHostKeyChecking=accept-new"'

--- a/test/integration/targets/inventory_docker_machine/inventory_2.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_2.docker_machine.yml
@@ -1,2 +1,2 @@
 plugin: docker_machine
-daemon_required: yes
+daemon_env: require

--- a/test/integration/targets/inventory_docker_machine/inventory_2.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_2.docker_machine.yml
@@ -1,0 +1,2 @@
+plugin: docker_machine
+daemon_required: yes

--- a/test/integration/targets/inventory_docker_machine/inventory_3.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_3.docker_machine.yml
@@ -1,2 +1,2 @@
 plugin: docker_machine
-daemon_required: no
+daemon_env: optional

--- a/test/integration/targets/inventory_docker_machine/inventory_3.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/inventory_3.docker_machine.yml
@@ -1,0 +1,2 @@
+plugin: docker_machine
+daemon_required: no

--- a/test/integration/targets/inventory_docker_machine/meta/main.yml
+++ b/test/integration/targets/inventory_docker_machine/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/inventory_docker_machine/playbooks/pre-setup.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/pre-setup.yml
@@ -1,0 +1,18 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  tasks:
+    - name: Setup docker
+      include_role:
+        name: setup_docker
+
+    # There seems to be no better way to install docker-machine. At least I couldn't find any packages for RHEL7/8.
+    - name: Download docker-machine binary
+      vars:
+        docker_machine_version: "0.16.1"
+      get_url:
+        url: "https://github.com/docker/machine/releases/download/v{{ docker_machine_version }}/docker-machine-{{ ansible_system }}-{{ ansible_userspace_architecture }}"
+        dest: /tmp/docker-machine
+    - name: Install docker-machine binary
+      command: install /tmp/docker-machine /usr/bin/docker-machine
+      become: yes

--- a/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
@@ -1,28 +1,11 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  vars:
-    do_api_token: "{{ lookup('env', 'DIGITALOCEAN_TOKEN') }}"
-    do_region: "{{ lookup('env', 'DIGITALOCEAN_REGION') }}"
-    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   tasks:
-    - name: Check that Ansible variable do_api_token is set
-      assert:
-        that:
-          - do_api_token != ''
-
-    - name: Check that Ansible variable do_region is set
-      assert: { that: do_region != '' }
-
-    - name: Check that Ansible variable dm_machine_name is set
-      assert: { that: dm_machine_name != '' }
-
-    - name: Request Docker Machine to create a provisioned Digital Ocean droplet
-      command: "docker-machine create \
-        --driver digitalocean \
-        --digitalocean-access-token {{ do_api_token }} \
-        --digitalocean-region {{ do_region }} \
-        --digitalocean-image ubuntu-18-04-x64 \
-        --digitalocean-size s-1vcpu-1gb \
-        --digitalocean-tags sometag:somevalue,othertag:othervalue \
-        {{ dm_machine_name }}"
+    - name: Request Docker Machine to use this machine as a generic VM
+      command: "docker-machine --debug create \
+        --driver generic \
+        --generic-ip-address=localhost \
+        --generic-ssh-key {{ lookup('env', 'HOME') }}/.ssh/id_rsa \
+        --generic-ssh-user root \
+        vm"

--- a/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
@@ -7,7 +7,9 @@
     dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   tasks:
     - name: Check that Ansible variable do_api_token is set
-      assert: { that: do_api_token != '' }
+      assert:
+        that:
+          - do_api_token != ''
 
     - name: Check that Ansible variable do_region is set
       assert: { that: do_region != '' }
@@ -16,7 +18,7 @@
       assert: { that: dm_machine_name != '' }
 
     - name: Request Docker Machine to create a provisioned Digital Ocean droplet
-      shell: "docker-machine create \
+      command: "docker-machine create \
         --driver digitalocean \
         --digitalocean-access-token {{ do_api_token }} \
         --digitalocean-region {{ do_region }} \

--- a/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
@@ -1,0 +1,17 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  vars:
+    do_api_token: "{{ lookup('env', 'DIGITALOCEAN_TOKEN') }}"
+    do_region: "{{ lookup('env', 'DIGITALOCEAN_REGION) }}"
+    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
+  tasks:
+    - name: Request Docker Machine to create a provisioned Digital Ocean droplet
+      shell: "docker-machine create \
+        --driver digitalocean \
+        --digitalocean-access-token {{ do_api_token }} \
+        --digitalocean-region {{ do_region }} \
+        --digitalocean-image ubuntu-18-04-x64 \
+        --digitalocean-size s-1vcpu-1gb \
+        --digitalocean-tags sometag:somevalue,othertag:othervalue \
+        {{ dm_machine_name }}"

--- a/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/setup.yml
@@ -3,9 +3,18 @@
   connection: local
   vars:
     do_api_token: "{{ lookup('env', 'DIGITALOCEAN_TOKEN') }}"
-    do_region: "{{ lookup('env', 'DIGITALOCEAN_REGION) }}"
+    do_region: "{{ lookup('env', 'DIGITALOCEAN_REGION') }}"
     dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   tasks:
+    - name: Check that Ansible variable do_api_token is set
+      assert: { that: do_api_token != '' }
+
+    - name: Check that Ansible variable do_region is set
+      assert: { that: do_region != '' }
+
+    - name: Check that Ansible variable dm_machine_name is set
+      assert: { that: dm_machine_name != '' }
+
     - name: Request Docker Machine to create a provisioned Digital Ocean droplet
       shell: "docker-machine create \
         --driver digitalocean \

--- a/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
@@ -1,8 +1,6 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  vars:
-    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   tasks:
-    - name: Request Docker Machine to terminate the Digital Ocean droplet
-      command: "docker-machine rm {{ dm_machine_name }} -f"
+    - name: Request Docker Machine to remove this machine as a generic VM
+      command: "docker-machine rm vm -f"

--- a/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
@@ -1,0 +1,8 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  vars:
+    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
+  tasks:
+    - name: Request Docker Machine to terminate the Digital Ocean droplet
+      shell: "docker-machine rm {{ dm_machine_name }}"

--- a/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
@@ -5,4 +5,4 @@
     dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   tasks:
     - name: Request Docker Machine to terminate the Digital Ocean droplet
-      shell: "docker-machine rm {{ dm_machine_name }} -f"
+      command: "docker-machine rm {{ dm_machine_name }} -f"

--- a/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/teardown.yml
@@ -5,4 +5,4 @@
     dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   tasks:
     - name: Request Docker Machine to terminate the Digital Ocean droplet
-      shell: "docker-machine rm {{ dm_machine_name }}"
+      shell: "docker-machine rm {{ dm_machine_name }} -f"

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -1,35 +1,33 @@
 - hosts: 127.0.0.1
   gather_facts: no
-  vars:
-    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   tasks:
   - name: sanity check Docker Machine output
     vars:
       dm_ls_format: !unsafe '{{.Name}} | {{.DriverName}} | {{.State}} | {{.URL}} | {{.Error}}'
-      success_regex: "^{{ dm_machine_name }} | [^|]+ | Running | tcp://.+ |$"
+      success_regex: "^vm | [^|]+ | Running | tcp://.+ |$"
     command: docker-machine ls --format '{{ dm_ls_format }}'
     register: result
     failed_when: result.rc != 0 or result.stdout is not match(success_regex)
 
   - name: verify Docker Machine ip
-    command: docker-machine ip {{ dm_machine_name }}
+    command: docker-machine ip vm
     register: result
-    failed_when: result.rc != 0 or result.stdout != hostvars[dm_machine_name].ansible_host
+    failed_when: result.rc != 0 or result.stdout != hostvars['vm'].ansible_host
 
   - name: verify Docker Machine env
-    command: docker-machine env --shell=sh {{ dm_machine_name }}
+    command: docker-machine env --shell=sh vm
     register: result
 
   - debug: var=result.stdout
 
   - assert:
       that:
-        - "'DOCKER_TLS_VERIFY=\"{{ hostvars[dm_machine_name].dm_DOCKER_TLS_VERIFY }}\"' in result.stdout"
-        - "'DOCKER_HOST=\"{{ hostvars[dm_machine_name].dm_DOCKER_HOST }}\"' in result.stdout"
-        - "'DOCKER_CERT_PATH=\"{{ hostvars[dm_machine_name].dm_DOCKER_CERT_PATH }}\"' in result.stdout"
-        - "'DOCKER_MACHINE_NAME=\"{{ hostvars[dm_machine_name].dm_DOCKER_MACHINE_NAME }}\"' in result.stdout"
+        - "'DOCKER_TLS_VERIFY=\"{{ hostvars['vm'].dm_DOCKER_TLS_VERIFY }}\"' in result.stdout"
+        - "'DOCKER_HOST=\"{{ hostvars['vm'].dm_DOCKER_HOST }}\"' in result.stdout"
+        - "'DOCKER_CERT_PATH=\"{{ hostvars['vm'].dm_DOCKER_CERT_PATH }}\"' in result.stdout"
+        - "'DOCKER_MACHINE_NAME=\"{{ hostvars['vm'].dm_DOCKER_MACHINE_NAME }}\"' in result.stdout"
 
-- hosts: dm-test-machine
+- hosts: vm
   gather_facts: no
   tasks:
   - name: do something to verify that accept-new ssh setting was applied by the docker-machine inventory plugin
@@ -40,13 +38,11 @@
 
 - hosts: 127.0.0.1
   gather_facts: no
-  vars:
-    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   environment:
-    DOCKER_CERT_PATH: "{{ hostvars[dm_machine_name].dm_DOCKER_CERT_PATH }}"
-    DOCKER_HOST: "{{ hostvars[dm_machine_name].dm_DOCKER_HOST }}"
-    DOCKER_MACHINE_NAME: "{{ hostvars[dm_machine_name].dm_DOCKER_MACHINE_NAME }}"
-    DOCKER_TLS_VERIFY: "{{ hostvars[dm_machine_name].dm_DOCKER_TLS_VERIFY }}"
+    DOCKER_CERT_PATH: "{{ hostvars['vm'].dm_DOCKER_CERT_PATH }}"
+    DOCKER_HOST: "{{ hostvars['vm'].dm_DOCKER_HOST }}"
+    DOCKER_MACHINE_NAME: "{{ hostvars['vm'].dm_DOCKER_MACHINE_NAME }}"
+    DOCKER_TLS_VERIFY: "{{ hostvars['vm'].dm_DOCKER_TLS_VERIFY }}"
   tasks:
   - name: run a Docker container on the target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
     docker_container:

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -2,7 +2,7 @@
 - hosts: dm-inventory-test
   gather_facts: no
   tasks:
-  - name: do something
+  - name: do something to verify that accept-new ssh setting was applied by the docker-machine inventory plugin
     file:
       path: /tmp/deleteme
       state: directory
@@ -14,7 +14,7 @@
     DOCKER_MACHINE_NAME: "{{ hostvars['dm-inventory-test'].dm_DOCKER_MACHINE_NAME }}"
     DOCKER_TLS_VERIFY: "{{ hostvars['dm-inventory-test'].dm_DOCKER_TLS_VERIFY }}"
   tasks:
-  - name: docker-compose up on target Docker Machine host
+  - name: docker-compose up on target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
     docker_service:
       project_name: test
       definition:

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -1,5 +1,34 @@
----
-- hosts: dm-inventory-test
+- hosts: 127.0.0.1
+  gather_facts: no
+  vars:
+    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
+  tasks:
+  - name: sanity check Docker Machine output
+    vars:
+      dm_ls_format: !unsafe '{{.Name}} | {{.DriverName}} | {{.State}} | {{.URL}} | {{.Error}}'
+      success_regex: "^{{ dm_machine_name }} | digitalocean | Running | tcp://.+ |$"
+    shell: docker-machine ls --format '{{ dm_ls_format }}'
+    register: result
+    failed_when: result.rc != 0 or result.stdout is not match(success_regex)
+
+  - name: verify Docker Machine ip
+    shell: docker-machine ip {{ dm_machine_name }}
+    register: result
+    failed_when: result.rc != 0 or result.stdout != hostvars[dm_machine_name].ansible_host
+
+  - name: verify Docker Machine env
+    shell: docker-machine env --shell=sh {{ dm_machine_name }}
+    register: result
+
+  - assert:
+      that:
+        - "'DOCKER_TLS_VERIFY=\"{{ hostvars[dm_machine_name].dm_DOCKER_TLS_VERIFY }}\"' in result.stdout"
+        - "'DOCKER_HOST=\"{{ hostvars[dm_machine_name].dm_DOCKER_HOST }}\"' in result.stdout"
+        - "'DOCKER_CERT_PATH=\"{{ hostvars[dm_machine_name].dm_DOCKER_CERT_PATH }}\"' in result.stdout"
+        - "'DOCKER_MACHINE_NAME=\"{{ hostvars[dm_machine_name].dm_DOCKER_MACHINE_NAME }}\"' in result.stdout"
+      fail_msg: "Got: {{ result.stdout }}"
+
+- hosts: dm-test-machine
   gather_facts: no
   tasks:
   - name: do something to verify that accept-new ssh setting was applied by the docker-machine inventory plugin
@@ -7,7 +36,7 @@
       path: /tmp/deleteme
       state: directory
 
-- hosts: localhost
+- hosts: 127.0.0.1
   environment:
     DOCKER_CERT_PATH: "{{ hostvars['dm-inventory-test'].dm_DOCKER_CERT_PATH }}"
     DOCKER_HOST: "{{ hostvars['dm-inventory-test'].dm_DOCKER_HOST }}"

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -1,0 +1,25 @@
+---
+- hosts: dm-inventory-test
+  gather_facts: no
+  tasks:
+  - name: do something
+    file:
+      path: /tmp/deleteme
+      state: directory
+
+- hosts: localhost
+  environment:
+    DOCKER_CERT_PATH: "{{ hostvars['dm-inventory-test'].dm_DOCKER_CERT_PATH }}"
+    DOCKER_HOST: "{{ hostvars['dm-inventory-test'].dm_DOCKER_HOST }}"
+    DOCKER_MACHINE_NAME: "{{ hostvars['dm-inventory-test'].dm_DOCKER_MACHINE_NAME }}"
+    DOCKER_TLS_VERIFY: "{{ hostvars['dm-inventory-test'].dm_DOCKER_TLS_VERIFY }}"
+  tasks:
+  - name: docker-compose up on target Docker Machine host
+    docker_service:
+      project_name: test
+      definition:
+        version: '2'
+        services:
+          test:
+            container_name: test
+            image: ubuntu/18.04:Latest

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -22,4 +22,4 @@
         services:
           test:
             container_name: test
-            image: ubuntu/18.04:latest
+            image: hello-world:latest

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -7,18 +7,20 @@
     vars:
       dm_ls_format: !unsafe '{{.Name}} | {{.DriverName}} | {{.State}} | {{.URL}} | {{.Error}}'
       success_regex: "^{{ dm_machine_name }} | [^|]+ | Running | tcp://.+ |$"
-    shell: docker-machine ls --format '{{ dm_ls_format }}'
+    command: docker-machine ls --format '{{ dm_ls_format }}'
     register: result
     failed_when: result.rc != 0 or result.stdout is not match(success_regex)
 
   - name: verify Docker Machine ip
-    shell: docker-machine ip {{ dm_machine_name }}
+    command: docker-machine ip {{ dm_machine_name }}
     register: result
     failed_when: result.rc != 0 or result.stdout != hostvars[dm_machine_name].ansible_host
 
   - name: verify Docker Machine env
-    shell: docker-machine env --shell=sh {{ dm_machine_name }}
+    command: docker-machine env --shell=sh {{ dm_machine_name }}
     register: result
+
+  - debug: var=result.stdout
 
   - assert:
       that:
@@ -26,7 +28,6 @@
         - "'DOCKER_HOST=\"{{ hostvars[dm_machine_name].dm_DOCKER_HOST }}\"' in result.stdout"
         - "'DOCKER_CERT_PATH=\"{{ hostvars[dm_machine_name].dm_DOCKER_CERT_PATH }}\"' in result.stdout"
         - "'DOCKER_MACHINE_NAME=\"{{ hostvars[dm_machine_name].dm_DOCKER_MACHINE_NAME }}\"' in result.stdout"
-      fail_msg: "Got: {{ result.stdout }}"
 
 - hosts: dm-test-machine
   gather_facts: no
@@ -47,12 +48,7 @@
     DOCKER_MACHINE_NAME: "{{ hostvars[dm_machine_name].dm_DOCKER_MACHINE_NAME }}"
     DOCKER_TLS_VERIFY: "{{ hostvars[dm_machine_name].dm_DOCKER_TLS_VERIFY }}"
   tasks:
-  - name: docker-compose up on target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
-    docker_service:
-      project_name: test
-      definition:
-        version: '2'
-        services:
-          test:
-            container_name: test
-            image: hello-world:latest
+  - name: run a Docker container on the target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
+    docker_container:
+      name: test
+      image: hello-world:latest

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -22,4 +22,4 @@
         services:
           test:
             container_name: test
-            image: ubuntu/18.04:Latest
+            image: ubuntu/18.04:latest

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -6,7 +6,7 @@
   - name: sanity check Docker Machine output
     vars:
       dm_ls_format: !unsafe '{{.Name}} | {{.DriverName}} | {{.State}} | {{.URL}} | {{.Error}}'
-      success_regex: "^{{ dm_machine_name }} | digitalocean | Running | tcp://.+ |$"
+      success_regex: "^{{ dm_machine_name }} | [^|]+ | Running | tcp://.+ |$"
     shell: docker-machine ls --format '{{ dm_ls_format }}'
     register: result
     failed_when: result.rc != 0 or result.stdout is not match(success_regex)
@@ -32,16 +32,20 @@
   gather_facts: no
   tasks:
   - name: do something to verify that accept-new ssh setting was applied by the docker-machine inventory plugin
-    file:
-      path: /tmp/deleteme
-      state: directory
+    raw: uname -a
+    register: result
+
+  - debug: var=result.stdout
 
 - hosts: 127.0.0.1
+  gather_facts: no
+  vars:
+    dm_machine_name: "{{ lookup('env', 'DM_MACHINE_NAME') }}"
   environment:
-    DOCKER_CERT_PATH: "{{ hostvars['dm-inventory-test'].dm_DOCKER_CERT_PATH }}"
-    DOCKER_HOST: "{{ hostvars['dm-inventory-test'].dm_DOCKER_HOST }}"
-    DOCKER_MACHINE_NAME: "{{ hostvars['dm-inventory-test'].dm_DOCKER_MACHINE_NAME }}"
-    DOCKER_TLS_VERIFY: "{{ hostvars['dm-inventory-test'].dm_DOCKER_TLS_VERIFY }}"
+    DOCKER_CERT_PATH: "{{ hostvars[dm_machine_name].dm_DOCKER_CERT_PATH }}"
+    DOCKER_HOST: "{{ hostvars[dm_machine_name].dm_DOCKER_HOST }}"
+    DOCKER_MACHINE_NAME: "{{ hostvars[dm_machine_name].dm_DOCKER_MACHINE_NAME }}"
+    DOCKER_TLS_VERIFY: "{{ hostvars[dm_machine_name].dm_DOCKER_TLS_VERIFY }}"
   tasks:
   - name: docker-compose up on target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
     docker_service:

--- a/test/integration/targets/inventory_docker_machine/runme.sh
+++ b/test/integration/targets/inventory_docker_machine/runme.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# set DIGITALOCEAN_TOKEN to your Digital Ocean API token before running this test
 
 SCRIPT_DIR=$(dirname "$0")
-export DM_MACHINE_NAME=dm-test-machine-${RANDOM}
+
+echo "Who am I:    $(whoami)"
+echo "Home:        ${HOME}"
+echo "PWD:         $(pwd)"
+echo "Script dir:  ${SCRIPT_DIR}"
 
 # restrict Ansible just to our inventory plugin, to prevent inventory data being matched by the test but being provided
 # by some other dynamic inventory provider
@@ -12,30 +15,37 @@ export ANSIBLE_INVENTORY_ENABLED=docker_machine
 
 set -euo pipefail
 
+SAVED_PATH="$PATH"
+
 cleanup() {
+    PATH="${SAVED_PATH}"
     echo "Cleanup"
     ansible-playbook -i teardown.docker_machine.yml playbooks/teardown.yml
     echo "Done"
-    exit 0
 }
 
 trap cleanup INT TERM EXIT
 
+echo "Pre-setup (install docker, docker-machine)"
+ANSIBLE_ROLES_PATH=.. ansible-playbook playbooks/pre-setup.yml
+
+echo "Print docker-machine version"
+docker-machine --version
+
 echo "Check preconditions"
 # Host should NOT be known to Ansible before the test starts
-ansible-inventory -i inventory_1.docker_machine.yml --host ${DM_MACHINE_NAME} >/dev/null && exit 1
+ansible-inventory -i inventory_1.docker_machine.yml --host vm >/dev/null && exit 1
 
 echo "Test that the docker_machine inventory plugin is being loaded"
 ANSIBLE_DEBUG=yes ansible-inventory -i inventory_1.docker_machine.yml --list | grep -F "Loading InventoryModule 'docker_machine'"
 
 echo "Setup"
-ansible-playbook -i inventory_1.docker_machine.yml playbooks/setup.yml
+ansible-playbook playbooks/setup.yml
 
 echo "Test docker_machine inventory 1"
 ansible-playbook -i inventory_1.docker_machine.yml playbooks/test_inventory_1.yml
 
 echo "Activate Docker Machine mock"
-SAVED_PATH=$PATH
 PATH=${SCRIPT_DIR}:$PATH
 
 echo "Test docker_machine inventory 2: daemon_required=yes daemon env success=yes"
@@ -55,4 +65,4 @@ ansible-inventory -i inventory_2.docker_machine.yml --list
 unset MOCK_ERROR_IN
 
 echo "Deactivate Docker Machine mock"
-PATH=${SAVED_PATH}
+PATH="${SAVED_PATH}"

--- a/test/integration/targets/inventory_docker_machine/runme.sh
+++ b/test/integration/targets/inventory_docker_machine/runme.sh
@@ -48,18 +48,18 @@ ansible-playbook -i inventory_1.docker_machine.yml playbooks/test_inventory_1.ym
 echo "Activate Docker Machine mock"
 PATH=${SCRIPT_DIR}:$PATH
 
-echo "Test docker_machine inventory 2: daemon_required=yes daemon env success=yes"
+echo "Test docker_machine inventory 2: daemon_env=require daemon env success=yes"
 ansible-inventory -i inventory_2.docker_machine.yml --list
 
-echo "Test docker_machine inventory 2: daemon_required=yes daemon env success=no"
+echo "Test docker_machine inventory 2: daemon_env=require daemon env success=no"
 export MOCK_ERROR_IN=env
 ansible-inventory -i inventory_2.docker_machine.yml --list
 unset MOCK_ERROR_IN
 
-echo "Test docker_machine inventory 3: daemon_required=no daemon env success=yes"
+echo "Test docker_machine inventory 3: daemon_env=optional daemon env success=yes"
 ansible-inventory -i inventory_3.docker_machine.yml --list
 
-echo "Test docker_machine inventory 3: daemon_required=no daemon env success=no"
+echo "Test docker_machine inventory 3: daemon_env=optional daemon env success=no"
 export MOCK_ERROR_IN=env
 ansible-inventory -i inventory_2.docker_machine.yml --list
 unset MOCK_ERROR_IN

--- a/test/integration/targets/inventory_docker_machine/runme.sh
+++ b/test/integration/targets/inventory_docker_machine/runme.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# set DIGITALOCEAN_TOKEN to your Digital Ocean API token before running this test
+DM_MACHINE_NAME="dm-inventory-test"
+
+[[ -n "$DEBUG" || -n "$ANSIBLE_DEBUG" ]] && set -x
+
+set -euo pipefail
+
+cleanup() {
+    echo "Cleanup"
+    docker-machine rm --force ${DM_MACHINE_NAME}
+    echo "Done"
+    exit 0
+}
+
+trap cleanup INT TERM EXIT
+
+echo "Setup"
+docker-machine create \
+        --driver digitalocean \
+        --digitalocean-access-token ${DIGITALOCEAN_TOKEN} \
+        --digitalocean-region ams3 \
+        --digitalocean-image ubuntu-18-04-x64 \
+        --digitalocean-size s-1vcpu-1gb \
+        --digitalocean-tags sometag:somevalue,othertag:othervalue \
+        ${DM_MACHINE_NAME}
+
+echo "Test docker_machine inventory 1"
+ansible-playbook -i inventory_1.docker_machine.yml playbooks/test_inventory_1.yml

--- a/test/integration/targets/inventory_docker_machine/runme.sh
+++ b/test/integration/targets/inventory_docker_machine/runme.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # set DIGITALOCEAN_TOKEN to your Digital Ocean API token before running this test
 
-SCRIPT_DIR=$(dirname $0)
-export DM_MACHINE_NAME=dm-test-machine
+SCRIPT_DIR=$(dirname "$0")
+export DM_MACHINE_NAME=dm-test-machine-${RANDOM}
 
 # restrict Ansible just to our inventory plugin, to prevent inventory data being matched by the test but being provided
 # by some other dynamic inventory provider
@@ -42,13 +42,17 @@ echo "Test docker_machine inventory 2: daemon_required=yes daemon env success=ye
 ansible-inventory -i inventory_2.docker_machine.yml --list
 
 echo "Test docker_machine inventory 2: daemon_required=yes daemon env success=no"
-MOCK_ERROR_IN=env ansible-inventory -i inventory_2.docker_machine.yml --list
+export MOCK_ERROR_IN=env
+ansible-inventory -i inventory_2.docker_machine.yml --list
+unset MOCK_ERROR_IN
 
 echo "Test docker_machine inventory 3: daemon_required=no daemon env success=yes"
 ansible-inventory -i inventory_3.docker_machine.yml --list
 
 echo "Test docker_machine inventory 3: daemon_required=no daemon env success=no"
-MOCK_ERROR_IN=env ansible-inventory -i inventory_2.docker_machine.yml --list
+export MOCK_ERROR_IN=env
+ansible-inventory -i inventory_2.docker_machine.yml --list
+unset MOCK_ERROR_IN
 
 echo "Deactivate Docker Machine mock"
 PATH=${SAVED_PATH}

--- a/test/integration/targets/inventory_docker_machine/runme.sh
+++ b/test/integration/targets/inventory_docker_machine/runme.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 cleanup() {
     echo "Cleanup"
-    docker-machine rm --force ${DM_MACHINE_NAME}
+    docker-machine rm --force "${DM_MACHINE_NAME}"
     echo "Done"
     exit 0
 }
@@ -18,15 +18,15 @@ trap cleanup INT TERM EXIT
 echo "Setup"
 docker-machine create \
         --driver digitalocean \
-        --digitalocean-access-token ${DIGITALOCEAN_TOKEN} \
+        --digitalocean-access-token "${DIGITALOCEAN_TOKEN}" \
         --digitalocean-region ams3 \
         --digitalocean-image ubuntu-18-04-x64 \
         --digitalocean-size s-1vcpu-1gb \
         --digitalocean-tags sometag:somevalue,othertag:othervalue \
-        ${DM_MACHINE_NAME}
+        "${DM_MACHINE_NAME}"
 
 echo "Test docker machine inventory 0"
-ansible-inventory -i inventory_1.docker_machine.yml --list | grep -F ${DM_MACHINE_NAME}
+ansible-inventory -i inventory_1.docker_machine.yml --list | grep -F "${DM_MACHINE_NAME}"
 
 echo "Test docker_machine inventory 1"
 ansible-playbook -i inventory_1.docker_machine.yml playbooks/test_inventory_1.yml

--- a/test/integration/targets/inventory_docker_machine/runme.sh
+++ b/test/integration/targets/inventory_docker_machine/runme.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # set DIGITALOCEAN_TOKEN to your Digital Ocean API token before running this test
 
+SCRIPT_DIR=$(dirname $0)
 export DM_MACHINE_NAME=dm-test-machine
 
 # restrict Ansible just to our inventory plugin, to prevent inventory data being matched by the test but being provided
@@ -13,7 +14,7 @@ set -euo pipefail
 
 cleanup() {
     echo "Cleanup"
-    ansible-playbook -i inventory_1.docker_machine.yml playbooks/teardown.yml
+    ansible-playbook -i teardown.docker_machine.yml playbooks/teardown.yml
     echo "Done"
     exit 0
 }
@@ -22,10 +23,10 @@ trap cleanup INT TERM EXIT
 
 echo "Check preconditions"
 # Host should NOT be known to Ansible before the test starts
-! ansible-inventory -i inventory_1.docker_machine.yml --list --host ${DM_MACHINE_NAME}
+ansible-inventory -i inventory_1.docker_machine.yml --host ${DM_MACHINE_NAME} >/dev/null && exit 1
 
 echo "Test that the docker_machine inventory plugin is being loaded"
-ANSIBLE_DEBUG=yes ansible-inventory -i inventory_1.docker_machine.yml --list >/dev/null | grep -Fq "Loading InventoryModule 'docker_machine'"
+ANSIBLE_DEBUG=yes ansible-inventory -i inventory_1.docker_machine.yml --list | grep -F "Loading InventoryModule 'docker_machine'"
 
 echo "Setup"
 ansible-playbook -i inventory_1.docker_machine.yml playbooks/setup.yml
@@ -33,3 +34,21 @@ ansible-playbook -i inventory_1.docker_machine.yml playbooks/setup.yml
 echo "Test docker_machine inventory 1"
 ansible-playbook -i inventory_1.docker_machine.yml playbooks/test_inventory_1.yml
 
+echo "Activate Docker Machine mock"
+SAVED_PATH=$PATH
+PATH=${SCRIPT_DIR}:$PATH
+
+echo "Test docker_machine inventory 2: daemon_required=yes daemon env success=yes"
+ansible-inventory -i inventory_2.docker_machine.yml --list
+
+echo "Test docker_machine inventory 2: daemon_required=yes daemon env success=no"
+MOCK_ERROR_IN=env ansible-inventory -i inventory_2.docker_machine.yml --list
+
+echo "Test docker_machine inventory 3: daemon_required=no daemon env success=yes"
+ansible-inventory -i inventory_3.docker_machine.yml --list
+
+echo "Test docker_machine inventory 3: daemon_required=no daemon env success=no"
+MOCK_ERROR_IN=env ansible-inventory -i inventory_2.docker_machine.yml --list
+
+echo "Deactivate Docker Machine mock"
+PATH=${SAVED_PATH}

--- a/test/integration/targets/inventory_docker_machine/runme.sh
+++ b/test/integration/targets/inventory_docker_machine/runme.sh
@@ -25,5 +25,8 @@ docker-machine create \
         --digitalocean-tags sometag:somevalue,othertag:othervalue \
         ${DM_MACHINE_NAME}
 
+echo "Test docker machine inventory 0"
+ansible-inventory -i inventory_1.docker_machine.yml --list | grep -F ${DM_MACHINE_NAME}
+
 echo "Test docker_machine inventory 1"
 ansible-playbook -i inventory_1.docker_machine.yml playbooks/test_inventory_1.yml

--- a/test/integration/targets/inventory_docker_machine/teardown.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/teardown.docker_machine.yml
@@ -1,3 +1,3 @@
 plugin: docker_machine
-daemon_required: no
+daemon_env: skip
 running_required: no

--- a/test/integration/targets/inventory_docker_machine/teardown.docker_machine.yml
+++ b/test/integration/targets/inventory_docker_machine/teardown.docker_machine.yml
@@ -1,0 +1,3 @@
+plugin: docker_machine
+daemon_required: no
+running_required: no


### PR DESCRIPTION
##### SUMMARY
Added a new dynamic inventory plugin to integrate Ansible with Docker Machine, just like the existing Docker Swarm dynamic inventory plugin in Ansible 2.8.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
docker_machine.py

##### ADDITIONAL INFORMATION
See https://github.com/ximon18/ansible-docker-machine-inventory-plugin for more information.

The intent of this PR is to begin the process of proposing the module for inclusion in Ansible core. However, there are no unit or integration tests yet. The docker_swarm inventory plugin has integration 
 tests but has some concerning note in its 'aliases' file about disabling docker due to test instability and also I wouldn't know at this point how to get Docker Machine installed on the integration test platform. I did not find any unit tests for the existing docker_swarm inventory plugin to use as a basis for my own module.

Tested with Ansible 2.7.10, Docker Machine 0.16.0, Python 3.6.7 on Ubuntu 18.04.2 LTS.

Thanks,

Ximon