### PR TITLE
openssl_privatekey: add support for Ed22519, Ed448, X25519 and X448 keys

### DIFF
--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -55,10 +55,6 @@
   when: select_crypto_backend == 'pyopenssl'
 - set_fact:
     ecc_types:
-    # - curve: X448
-    #   min_cryptography_version: "2.5"
-    # - curve: X25519
-    #   min_cryptography_version: "2.0"
     - curve: secp384r1
       openssl_name: secp384r1
       min_cryptography_version: "0.5"
@@ -142,6 +138,41 @@
   loop_control:
     label: "{{ item.curve }}"
   register: privatekey_ecc_idempotency
+
+- block:
+  - name: Test other type generation
+    openssl_privatekey:
+      path: '{{ output_dir }}/privatekey-{{ item.type }}.pem'
+      type: "{{ item.type }}"
+      select_crypto_backend: '{{ select_crypto_backend }}'
+    when: cryptography_version.stdout is version(item.min_version, '>=')
+    loop: "{{ types }}"
+    loop_control:
+      label: "{{ item.type }}"
+    register: privatekey_t1_generate
+
+  - name: Test other type generation (idempotency)
+    openssl_privatekey:
+      path: '{{ output_dir }}/privatekey-{{ item.type }}.pem'
+      type: "{{ item.type }}"
+      select_crypto_backend: '{{ select_crypto_backend }}'
+    when: cryptography_version.stdout is version(item.min_version, '>=')
+    loop: "{{ types }}"
+    loop_control:
+      label: "{{ item.type }}"
+    register: privatekey_t1_idempotency
+
+  when: select_crypto_backend == 'cryptography'
+  vars:
+    types:
+      - type: X25519
+        min_version: '2.5'
+      - type: Ed25519
+        min_version: '2.6'
+      - type: Ed448
+        min_version: '2.6'
+      - type: X448
+        min_version: '2.6'
 
 - name: Generate privatekey with passphrase
   openssl_privatekey:

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -105,6 +105,25 @@
   loop_control:
     label: "{{ item.item.curve }}"
 
+- name: Validate other type generation (just check changed)
+  assert:
+    that:
+    - item is changed
+  loop: "{{ privatekey_t1_generate.results }}"
+  when: "'skip_reason' not in item"
+  loop_control:
+    label: "{{ item.item.type }}"
+
+
+- name: Validate other type generation idempotency
+  assert:
+    that:
+    - item is not changed
+  loop: "{{ privatekey_t1_idempotency.results }}"
+  when: "'skip_reason' not in item"
+  loop_control:
+    label: "{{ item.item.type }}"
+
 - name: Validate passphrase changing
   assert:
     that:


### PR DESCRIPTION
##### SUMMARY
As subject says. cryptography now supports all of them fully, it seems (i.e. including private key serialization).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_privatekey
