### PR TITLE
ec2_eni: Move to boto3, add tags support, add name field

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -27,7 +27,9 @@ description:
       provided, the existing ENI (if any) will be modified. The 'attached' parameter controls the attachment status
       of the network interface.
 version_added: "2.0"
-author: "Rob White (@wimnat)"
+author: 
+    - "Rob White (@wimnat)"
+    - "Mike Healey (@healem)"
 options:
   eni_id:
     description:
@@ -108,12 +110,35 @@ options:
     default: 'no'
     type: bool
     version_added: 2.7
+  name:
+    description:
+      - Name for the ENI.  This will create a tag called "Name" with the value assigned here.  This is used as another
+      means of identifying an ENI, so it works best if the name is unique within a subnet.  AWS does not enforce
+      unique Name tags, so duplicate names are possible if you configure it that way.  If the name is not
+      unique within a subnet, then you will need to provide other identifying information such as private_ip_address
+      or eni_id.
+    required: false
+    version_added: 2.8
+  tags:
+    description:
+      - A hash/dictionary of tags to add to the new ENI or to add/remove from an existing one.  Please note that
+      the name field sets the "Name" tag.  So if you clear all tags, you will also clear the name.
+    required: false
+    version_added: 2.8
+  purge_tags:
+    description:
+      - Delete any tags not specified in the task that are on the instance.
+      This means you have to specify all the desired tags on each task affecting an instance.
+    default: false
+    type: bool
+    version_added: 2.8
 extends_documentation_fragment:
     - aws
     - ec2
 notes:
-    - This module identifies and ENI based on either the eni_id, a combination of private_ip_address and subnet_id,
-      or a combination of instance_id and device_id. Any of these options will let you specify a particular ENI.
+    - This module identifies an ENI based on either the eni_id, the name and subnet_id, 
+    a combination of private_ip_address and subnet_id, or a combination of instance_id and device_id. 
+    Any of these options will let you specify a particular ENI.
 '''
 
 EXAMPLES = '''
@@ -121,9 +146,12 @@ EXAMPLES = '''
 
 # Create an ENI. As no security group is defined, ENI will be created in default security group
 - ec2_eni:
+    name: eni-20
     private_ip_address: 172.31.0.20
     subnet_id: subnet-xxxxxxxx
     state: present
+    tags:
+      group: Finance
 
 # Create an ENI and attach it to an instance
 - ec2_eni:
@@ -164,6 +192,13 @@ EXAMPLES = '''
 # Update an ENI
 - ec2_eni:
     eni_id: eni-xxxxxxx
+    description: "My new description"
+    state: present
+    
+# Update an ENI using name and subnet_id
+- ec2_eni:
+    name: eni-20
+    subnet_id: subnet-xxxxxxx
     description: "My new description"
     state: present
 
@@ -219,6 +254,10 @@ interface:
       description: interface's physical address
       type: str
       sample: "00:00:5E:00:53:23"
+    name:
+      description: The name of the ENI
+      type: str
+      sample: "my-eni-20"
     owner_id:
       description: aws account id
       type: str
@@ -243,6 +282,10 @@ interface:
       description: which vpc subnet the interface is bound
       type: str
       sample: subnet-b0a0393c
+    tags:
+      description: The dictionary of tags associated with the ENI
+      type: dict
+      sample: { "Name": "my-eni", "group": "Finance" }
     vpc_id:
       description: which vpc this network interface is bound
       type: str
@@ -254,62 +297,93 @@ import time
 import re
 
 try:
-    import boto.ec2
-    import boto.vpc
-    from boto.exception import BotoServerError
-    HAS_BOTO = True
+    import boto3
+    import botocore.exceptions
+    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO = False
+    HAS_BOTO3 = False
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import (AnsibleAWSError, connect_to_aws,
-                                      ec2_argument_spec, get_aws_connection_info,
-                                      get_ec2_security_group_ids_from_names)
+from ansible.module_utils.ec2 import (
+    AWSRetry,
+    ec2_argument_spec,
+    get_ec2_security_group_ids_from_names,
+    compare_aws_tags,
+    boto3_tag_list_to_ansible_dict,
+    ansible_dict_to_boto3_tag_list
+)
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
 
 
 def get_eni_info(interface):
 
     # Private addresses
     private_addresses = []
-    for ip in interface.private_ip_addresses:
-        private_addresses.append({'private_ip_address': ip.private_ip_address, 'primary_address': ip.primary})
+    if "PrivateIpAddresses" in interface:
+        for ip in interface["PrivateIpAddresses"]:
+            private_addresses.append({'private_ip_address': ip["PrivateIpAddress"], 'primary_address': ip["Primary"]})
 
-    interface_info = {'id': interface.id,
-                      'subnet_id': interface.subnet_id,
-                      'vpc_id': interface.vpc_id,
-                      'description': interface.description,
-                      'owner_id': interface.owner_id,
-                      'status': interface.status,
-                      'mac_address': interface.mac_address,
-                      'private_ip_address': interface.private_ip_address,
-                      'source_dest_check': interface.source_dest_check,
-                      'groups': dict((group.id, group.name) for group in interface.groups),
+    groups = {}
+    if "Groups" in interface:
+        for group in interface["Groups"]:
+            groups[group["GroupId"]] = group["GroupName"]
+
+    interface_info = {'id': get_value_with_default(interface, "NetworkInterfaceId"),
+                      'subnet_id': get_value_with_default(interface, "SubnetId"),
+                      'vpc_id': get_value_with_default(interface, "VpcId"),
+                      'description': get_value_with_default(interface, "Description"),
+                      'owner_id': get_value_with_default(interface, "OwnerId"),
+                      'status': get_value_with_default(interface, "Status"),
+                      'mac_address': get_value_with_default(interface, "MacAddress"),
+                      'private_ip_address': get_value_with_default(interface, "PrivateIpAddress"),
+                      'source_dest_check': get_value_with_default(interface, "SourceDestCheck"),
+                      'groups': groups,
                       'private_ip_addresses': private_addresses
                       }
 
-    if interface.attachment is not None:
-        interface_info['attachment'] = {'attachment_id': interface.attachment.id,
-                                        'instance_id': interface.attachment.instance_id,
-                                        'device_index': interface.attachment.device_index,
-                                        'status': interface.attachment.status,
-                                        'attach_time': interface.attachment.attach_time,
-                                        'delete_on_termination': interface.attachment.delete_on_termination,
-                                        }
+    if "TagSet" in interface:
+        tags = {}
+        name = None
+        for tag in interface["TagSet"]:
+            tags[tag["Key"]] = tag["Value"]
+            if tag["Key"] == "Name":
+                name = tag["Value"]
+        interface_info["tags"] = tags
+
+        if name is not None:
+            interface_info["name"] = name
+
+    if "Attachment" in interface:
+        interface_info['attachment'] = {
+            'attachment_id': get_value_with_default(interface["Attachment"], "AttachmentId"),
+            'instance_id': get_value_with_default(interface["Attachment"], "InstanceId"),
+            'device_index': get_value_with_default(interface["Attachment"], "DeviceIndex"),
+            'status': get_value_with_default(interface["Attachment"], "Status"),
+            'attach_time': get_value_with_default(interface["Attachment"], "AttachTime"),
+            'delete_on_termination': get_value_with_default(interface["Attachment"], "DeleteOnTermination"),
+        }
 
     return interface_info
 
 
-def wait_for_eni(eni, status):
+def get_value_with_default(dictionary, key, default=None):
+    if key in dictionary:
+        return dictionary[key]
+    else:
+        return default
+
+
+def wait_for_eni(connection, status, module, eni=None):
 
     while True:
         time.sleep(3)
-        eni.update()
+        eni = uniquely_find_eni(connection, module, eni)
         # If the status is detached we just need attachment to disappear
-        if eni.attachment is None:
+        if "Attachment" in eni:
             if status == "detached":
                 break
         else:
-            if status == "attached" and eni.attachment.status == "attached":
+            if status == "attached" and eni["Attachment"]["Status"] == "attached":
                 break
 
 
@@ -323,46 +397,83 @@ def create_eni(connection, vpc_id, module):
     subnet_id = module.params.get('subnet_id')
     private_ip_address = module.params.get('private_ip_address')
     description = module.params.get('description')
-    security_groups = get_ec2_security_group_ids_from_names(module.params.get('security_groups'), connection, vpc_id=vpc_id, boto3=False)
+    security_groups = get_ec2_security_group_ids_from_names(
+        module.params.get('security_groups'),
+        connection,
+        vpc_id=vpc_id,
+        boto3=True
+    )
     secondary_private_ip_addresses = module.params.get("secondary_private_ip_addresses")
     secondary_private_ip_address_count = module.params.get("secondary_private_ip_address_count")
     changed = False
+    tags = module.params.get("tags")
+    name = module.params.get("name")
+    purge_tags = module.params.get("purge_tags")
+
+    if name:
+        tags["Name"] = name
 
     try:
-        eni = connection.create_network_interface(subnet_id, private_ip_address, description, security_groups)
+        args = {"SubnetId": subnet_id}
+        if private_ip_address:
+            args["PrivateIpAddress"] = private_ip_address
+        if description:
+            args["Description"] = description
+        if len(security_groups) > 0:
+            args["Groups"] = security_groups
+        eni_dict = connection.create_network_interface(**args)
+        eni = eni_dict["NetworkInterface"]
         if attached and instance_id is not None:
             try:
-                eni.attach(instance_id, device_index)
-            except BotoServerError:
-                eni.delete()
+                connection.attach_network_interface(
+                    InstanceId=instance_id,
+                    DeviceIndex=device_index,
+                    NetworkInterfaceId=eni["NetworkInterfaceId"]
+                )
+            except botocore.exceptions.ClientError:
+                connection.delete_network_interface(eni["NetworkInterfaceId"])
                 raise
             # Wait to allow creation / attachment to finish
-            wait_for_eni(eni, "attached")
-            eni.update()
+            wait_for_eni(connection, "attached", module, eni)
+            eni = uniquely_find_eni(connection, module, eni)
 
         if secondary_private_ip_address_count is not None:
             try:
-                connection.assign_private_ip_addresses(network_interface_id=eni.id, secondary_private_ip_address_count=secondary_private_ip_address_count)
-            except BotoServerError:
-                eni.delete()
+                connection.assign_private_ip_addresses(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    SecondaryPrivateIpAddressCount=secondary_private_ip_address_count
+                )
+                eni = uniquely_find_eni(connection, module, eni)
+            except botocore.exceptions.ClientError:
+                connection.delete_network_interface(eni["NetworkInterfaceId"])
                 raise
 
         if secondary_private_ip_addresses is not None:
             try:
-                connection.assign_private_ip_addresses(network_interface_id=eni.id, private_ip_addresses=secondary_private_ip_addresses)
-            except BotoServerError:
-                eni.delete()
+                connection.assign_private_ip_addresses(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    PrivateIpAddresses=secondary_private_ip_addresses
+                )
+                eni = uniquely_find_eni(connection, module, eni)
+            except botocore.exceptions.ClientError:
+                connection.delete_network_interface(eni["NetworkInterfaceId"])
                 raise
+
+        eni = uniquely_find_eni(connection, module, eni)
+        manage_tags(eni, tags, purge_tags, connection)
+
+        # Refresh the eni data on last time
+        eni = uniquely_find_eni(connection, module, eni)
 
         changed = True
 
-    except BotoServerError as e:
-        module.fail_json(msg=e.message)
+    except botocore.exceptions.ClientError as e:
+        module.fail_json_aws(e, f"Failed to create eni {name} for {subnet_id} in {vpc_id} with {private_ip_address}")
 
     module.exit_json(changed=changed, interface=get_eni_info(eni))
 
 
-def modify_eni(connection, vpc_id, module, eni):
+def modify_eni(connection, module, eni):
 
     instance_id = module.params.get("instance_id")
     attached = module.params.get("attached")
@@ -378,161 +489,237 @@ def modify_eni(connection, vpc_id, module, eni):
     secondary_private_ip_address_count = module.params.get("secondary_private_ip_address_count")
     allow_reassignment = module.params.get("allow_reassignment")
     changed = False
+    tags = module.params.get("tags")
+    name = module.params.get("name")
+    purge_tags = module.params.get("purge_tags")
+
+    if name:
+        tags["Name"] = name
 
     try:
         if description is not None:
-            if eni.description != description:
-                connection.modify_network_interface_attribute(eni.id, "description", description)
+            if "Description" not in eni or eni["Description"] != description:
+                connection.modify_network_interface_attribute(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    Description={'Value': description}
+                )
                 changed = True
         if len(security_groups) > 0:
-            groups = get_ec2_security_group_ids_from_names(security_groups, connection, vpc_id=vpc_id, boto3=False)
-            if sorted(get_sec_group_list(eni.groups)) != sorted(groups):
-                connection.modify_network_interface_attribute(eni.id, "groupSet", groups)
+            groups = get_ec2_security_group_ids_from_names(security_groups, connection, vpc_id=eni["VpcId"], boto3=True)
+            if sorted(get_sec_group_list(eni["Groups"])) != sorted(groups):
+                connection.modify_network_interface_attribute(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    Groups=groups
+                )
                 changed = True
         if source_dest_check is not None:
-            if eni.source_dest_check != source_dest_check:
-                connection.modify_network_interface_attribute(eni.id, "sourceDestCheck", source_dest_check)
+            if "SourceDestCheck" not in eni or eni["SourceDestCheck"] != source_dest_check:
+                connection.modify_network_interface_attribute(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    SourceDestCheck={'Value': source_dest_check}
+                )
                 changed = True
-        if delete_on_termination is not None and eni.attachment is not None:
-            if eni.attachment.delete_on_termination is not delete_on_termination:
-                connection.modify_network_interface_attribute(eni.id, "deleteOnTermination", delete_on_termination, eni.attachment.id)
+        if delete_on_termination is not None and "Attachment" in eni:
+            if eni["Attachment"]["DeleteOnTermination"] is not delete_on_termination:
+                connection.modify_network_interface_attribute(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    Attachment={'AttachmentId': eni["Attachment"]["AttachmentId"],
+                                'DeleteOnTermination': delete_on_termination}
+                )
                 changed = True
 
-        current_secondary_addresses = [i.private_ip_address for i in eni.private_ip_addresses if not i.primary]
+        current_secondary_addresses = []
+        if "PrivateIpAddresses" in eni:
+            current_secondary_addresses = [i["PrivateIpAddress"] for i in eni["PrivateIpAddresses"] if not i["Primary"]]
+
         if secondary_private_ip_addresses is not None:
             secondary_addresses_to_remove = list(set(current_secondary_addresses) - set(secondary_private_ip_addresses))
             if secondary_addresses_to_remove and purge_secondary_private_ip_addresses:
-                connection.unassign_private_ip_addresses(network_interface_id=eni.id,
-                                                         private_ip_addresses=list(set(current_secondary_addresses) -
-                                                                                   set(secondary_private_ip_addresses)),
-                                                         dry_run=False)
+                connection.unassign_private_ip_addresses(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    PrivateIpAddresses=list(set(current_secondary_addresses) - set(secondary_private_ip_addresses)),
+                )
                 changed = True
 
             secondary_addresses_to_add = list(set(secondary_private_ip_addresses) - set(current_secondary_addresses))
             if secondary_addresses_to_add:
-                connection.assign_private_ip_addresses(network_interface_id=eni.id,
-                                                       private_ip_addresses=secondary_addresses_to_add,
-                                                       secondary_private_ip_address_count=None,
-                                                       allow_reassignment=allow_reassignment, dry_run=False)
+                connection.assign_private_ip_addresses(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    PrivateIpAddresses=secondary_addresses_to_add,
+                    AllowReassignment=allow_reassignment
+                )
                 changed = True
         if secondary_private_ip_address_count is not None:
             current_secondary_address_count = len(current_secondary_addresses)
 
             if secondary_private_ip_address_count > current_secondary_address_count:
-                connection.assign_private_ip_addresses(network_interface_id=eni.id,
-                                                       private_ip_addresses=None,
-                                                       secondary_private_ip_address_count=(secondary_private_ip_address_count -
-                                                                                           current_secondary_address_count),
-                                                       allow_reassignment=allow_reassignment, dry_run=False)
+                connection.assign_private_ip_addresses(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    SecondaryPrivateIpAddressCount=(secondary_private_ip_address_count - current_secondary_address_count),
+                    AllowReassignment=allow_reassignment
+                )
                 changed = True
             elif secondary_private_ip_address_count < current_secondary_address_count:
                 # How many of these addresses do we want to remove
                 secondary_addresses_to_remove_count = current_secondary_address_count - secondary_private_ip_address_count
-                connection.unassign_private_ip_addresses(network_interface_id=eni.id,
-                                                         private_ip_addresses=current_secondary_addresses[:secondary_addresses_to_remove_count],
-                                                         dry_run=False)
+                connection.unassign_private_ip_addresses(
+                    NetworkInterfaceId=eni["NetworkInterfaceId"],
+                    PrivateIpAddresses=current_secondary_addresses[:secondary_addresses_to_remove_count]
+                )
 
         if attached is True:
-            if eni.attachment and eni.attachment.instance_id != instance_id:
-                detach_eni(eni, module)
-                eni.attach(instance_id, device_index)
-                wait_for_eni(eni, "attached")
+            if "Attachment" in eni and eni["Attachment"]["InstanceId"] != instance_id:
+                detach_eni(connection, eni, module)
+                connection.attach_network_interface(
+                    InstanceId=instance_id,
+                    DeviceIndex=device_index,
+                    NetworkInterfaceId=eni["NetworkInterfaceId"]
+                )
+                wait_for_eni(connection, "attached", module)
                 changed = True
-            if eni.attachment is None:
-                eni.attach(instance_id, device_index)
-                wait_for_eni(eni, "attached")
+            if "Attachment" in eni:
+                connection.attach_network_interface(
+                    InstanceId=instance_id,
+                    DeviceIndex=device_index,
+                    NetworkInterfaceId=eni["NetworkInterfaceId"]
+                )
+                wait_for_eni(connection, "attached", module)
                 changed = True
         elif attached is False:
-            detach_eni(eni, module)
+            detach_eni(connection, eni, module)
 
-    except BotoServerError as e:
-        module.fail_json(msg=e.message)
+        manage_tags(eni, tags, purge_tags, connection)
 
-    eni.update()
+    except botocore.exceptions.ClientError as e:
+        module.fail_json_aws(e, f"Failed to modify eni {eni['NetworkInterfaceId']}")
+
+    eni = uniquely_find_eni(connection, module, eni)
     module.exit_json(changed=changed, interface=get_eni_info(eni))
 
 
 def delete_eni(connection, module):
 
-    eni_id = module.params.get("eni_id")
+    eni = uniquely_find_eni(connection, module)
+    if eni:
+        eni_id = eni["NetworkInterfaceId"]
+    else:
+        module.fail_json_aws(f"Failed to delete ENI: could not find ENI with params {module.params}")
+
     force_detach = module.params.get("force_detach")
 
     try:
-        eni_result_set = connection.get_all_network_interfaces(eni_id)
-        eni = eni_result_set[0]
+        eni_result_set = connection.describe_network_interfaces(
+            Filters=[{
+                'Name': 'network-interface-id',
+                'Values': [eni_id]
+            }]
+        )
+        eni = eni_result_set
 
         if force_detach is True:
-            if eni.attachment is not None:
-                eni.detach(force_detach)
+            if "Attachment" in eni:
+                connection.detach_network_interface(
+                    AttachmentId=eni["Attachment"]["AttachmentId"],
+                    Force=True
+                )
                 # Wait to allow detachment to finish
-                wait_for_eni(eni, "detached")
-                eni.update()
-            eni.delete()
+                wait_for_eni(connection, "detached", module)
+            connection.delete_network_interface(NetworkInterfaceId=eni_id)
             changed = True
         else:
-            eni.delete()
+            connection.delete_network_interface(NetworkInterfaceId=eni_id)
             changed = True
 
         module.exit_json(changed=changed)
-    except BotoServerError as e:
+    except botocore.exceptions.ClientError as e:
         regex = re.compile('The networkInterface ID \'.*\' does not exist')
         if regex.search(e.message) is not None:
             module.exit_json(changed=False)
         else:
-            module.fail_json(msg=e.message)
+            module.fail_json_aws(e, f"Failure during delete of {eni_id}")
 
 
-def detach_eni(eni, module):
+def detach_eni(connection, eni, module):
 
     attached = module.params.get("attached")
 
     force_detach = module.params.get("force_detach")
-    if eni.attachment is not None:
-        eni.detach(force_detach)
-        wait_for_eni(eni, "detached")
+    if "Attachment" in eni:
+        connection.detach_network_interface(
+            AttachmentId=eni["Attachment"]["AttachmentId"],
+            Force=force_detach
+        )
+        wait_for_eni(connection, "detached", module)
         if attached:
             return
-        eni.update()
+        eni = uniquely_find_eni(connection, module)
         module.exit_json(changed=True, interface=get_eni_info(eni))
     else:
         module.exit_json(changed=False, interface=get_eni_info(eni))
 
 
-def uniquely_find_eni(connection, module):
+def uniquely_find_eni(connection, module, eni=None):
 
-    eni_id = module.params.get("eni_id")
+    if eni:
+        # In the case of create, eni_id will not be a param but we can still get the eni_id after creation
+        if "NetworkInterfaceId" in eni:
+            eni_id = eni["NetworkInterfaceId"]
+        else:
+            eni_id = None
+    else:
+        eni_id = module.params.get("eni_id")
+
     private_ip_address = module.params.get('private_ip_address')
     subnet_id = module.params.get('subnet_id')
     instance_id = module.params.get('instance_id')
     device_index = module.params.get('device_index')
     attached = module.params.get('attached')
+    name = module.params.get("name")
+
+    filters = []
+
+    # proceed only if we're unequivocally specifying an ENI
+    if eni_id is None and private_ip_address is None and (instance_id is None and device_index is None):
+        return None
+
+    filter_set = False
+    if eni_id:
+        filters.append({'Name': 'network-interface-id',
+                        'Values': [eni_id]})
+        filter_set = True
+
+    if private_ip_address and subnet_id and not filter_set:
+        filters.append({'Name': 'private-ip-address',
+                        'Values': [private_ip_address]})
+        filters.append({'Name': 'subnet-id',
+                        'Values': [subnet_id]})
+        filter_set = True
+
+    if not attached and instance_id and device_index and not filter_set:
+        filters.append({'Name': 'attachment.instance-id',
+                        'Values': [instance_id]})
+        filters.append({'Name': 'attachment.device-index',
+                        'Values': [device_index]})
+        filter_set = True
+
+    if name and subnet_id and not filter_set:
+        filters.append({'Name': 'tag:Name',
+                        'Values': [name]})
+        filters.append({'Name': 'subnet-id',
+                        'Values': [subnet_id]})
+        filter_set = True
+
+    if not filter_set:
+        return None
 
     try:
-        filters = {}
-
-        # proceed only if we're univocally specifying an ENI
-        if eni_id is None and private_ip_address is None and (instance_id is None and device_index is None):
-            return None
-
-        if private_ip_address and subnet_id:
-            filters['private-ip-address'] = private_ip_address
-            filters['subnet-id'] = subnet_id
-
-        if not attached and instance_id and device_index:
-            filters['attachment.instance-id'] = instance_id
-            filters['attachment.device-index'] = device_index
-
-        if eni_id is None and len(filters) == 0:
-            return None
-
-        eni_result = connection.get_all_network_interfaces(eni_id, filters=filters)
+        eni_result = connection.describe_network_interfaces(Filters=filters)["NetworkInterfaces"]
         if len(eni_result) == 1:
             return eni_result[0]
         else:
             return None
-
-    except BotoServerError as e:
-        module.fail_json(msg=e.message)
+    except botocore.exceptions.ClientError as e:
+        module.fail_json_aws(e, f"Failed to find unique eni with filters: {filters}")
 
     return None
 
@@ -542,7 +729,7 @@ def get_sec_group_list(groups):
     # Build list of remote security groups
     remote_security_groups = []
     for group in groups:
-        remote_security_groups.append(group.id.encode())
+        remote_security_groups.append(group["GroupId"].encode())
 
     return remote_security_groups
 
@@ -550,9 +737,40 @@ def get_sec_group_list(groups):
 def _get_vpc_id(connection, module, subnet_id):
 
     try:
-        return connection.get_all_subnets(subnet_ids=[subnet_id])[0].vpc_id
-    except BotoServerError as e:
-        module.fail_json(msg=e.message)
+        subnets = connection.describe_subnets(SubnetIds=[subnet_id])
+        return subnets["Subnets"][0]["VpcId"]
+    except botocore.exceptions.ClientError as e:
+        module.fail_json_aws(e, f"Failed to get vpc_id for {subnet_id}")
+
+
+@AWSRetry.jittered_backoff()
+def manage_tags(eni, new_tags, purge_tags, connection):
+    changed = False
+
+    if "TagSet" in eni:
+        old_tags = boto3_tag_list_to_ansible_dict(eni['TagSet'])
+    elif new_tags:
+        old_tags = {}
+    else:
+        # No new tags and nothing in TagSet
+        return False
+
+    tags_to_set, tags_to_delete = compare_aws_tags(
+        old_tags, new_tags,
+        purge_tags=purge_tags,
+    )
+    if tags_to_set:
+        connection.create_tags(
+            Resources=[eni['NetworkInterfaceId']],
+            Tags=ansible_dict_to_boto3_tag_list(tags_to_set))
+        changed |= True
+    if tags_to_delete:
+        delete_with_current_values = dict((k, old_tags.get(k)) for k in tags_to_delete)
+        connection.delete_tags(
+            Resources=[eni['NetworkInterfaceId']],
+            Tags=ansible_dict_to_boto3_tag_list(delete_with_current_values))
+        changed |= True
+    return changed
 
 
 def main():
@@ -574,35 +792,28 @@ def main():
             purge_secondary_private_ip_addresses=dict(default=False, type='bool'),
             secondary_private_ip_address_count=dict(default=None, type='int'),
             allow_reassignment=dict(default=False, type='bool'),
-            attached=dict(default=None, type='bool')
+            attached=dict(default=None, type='bool'),
+            name=dict(default=None, type='str'),
+            tags=dict(default={}, type='dict'),
+            purge_tags=dict(default=False, type='bool')
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[
-                               ['secondary_private_ip_addresses', 'secondary_private_ip_address_count']
-                           ],
-                           required_if=([
-                               ('state', 'absent', ['eni_id']),
-                               ('attached', True, ['instance_id']),
-                               ('purge_secondary_private_ip_addresses', True, ['secondary_private_ip_addresses'])
-                           ])
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ['secondary_private_ip_addresses', 'secondary_private_ip_address_count']
+        ],
+        required_if=([
+            ('attached', True, ['instance_id']),
+            ('purge_secondary_private_ip_addresses', True, ['secondary_private_ip_addresses'])
+        ])
+    )
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
-
-    if region:
-        try:
-            connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
-            vpc_connection = connect_to_aws(boto.vpc, region, **aws_connect_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
-            module.fail_json(msg=str(e))
-    else:
-        module.fail_json(msg="region must be specified")
-
+    connection = module.client('ec2')
     state = module.params.get("state")
 
     if state == 'present':
@@ -612,11 +823,10 @@ def main():
             if subnet_id is None:
                 module.fail_json(msg="subnet_id is required when creating a new ENI")
 
-            vpc_id = _get_vpc_id(vpc_connection, module, subnet_id)
+            vpc_id = _get_vpc_id(connection, module, subnet_id)
             create_eni(connection, vpc_id, module)
         else:
-            vpc_id = eni.vpc_id
-            modify_eni(connection, vpc_id, module, eni)
+            modify_eni(connection, module, eni)
 
     elif state == 'absent':
         delete_eni(connection, module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR contains 2 major changes to ec2_eni:

1.  Move the module to boto3 from boto (boto is no longer used by this module)
2.  Add support for tags and add a name field (that uses tag:Name in AWS)

This also adds a new way to find an interface - by name and subnet_id.  This will make it
easier to remain idempotent when using dynamic ip addresses. 

I've also squashed a minor bug where secondary ip addresses were not included in the
output.  PR-54630 addresses this bug, but in the old boto-dependent code.
https://github.com/ansible/ansible/pull/54630

PR-54630 should still be pulled in, as the integration tests are valuable.  I'm happy to pull
the integration tests into this PR, once the permissions issues are fixed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_eni

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
    "interface": {
        "description": "myComplexNic descriptn",
        "groups": {
            "sg-0609923bf1372031d": "onlySshAccess"
        },
        "id": "eni-0539ff06598413abc",
        "mac_address": "0a:72:3d:f1:1c:b0",
        "owner_id": "686104308526",
        "private_ip_address": "10.0.84.2",
        "private_ip_addresses": [
            {
                "primary_address": true,
                "private_ip_address": "10.0.84.2"
            }
        ],
        "source_dest_check": true,
        "status": "pending",
        "subnet_id": "subnet-02dc6a04a5460ea5f",
        "vpc_id": "vpc-00fd8af7d3a908c13"
    },
```
After:
```
    "interface": {
        "description": "myComplexNic descriptn",
        "groups": {
            "sg-0609923bf1372031d": "onlySshAccess"
        },
        "id": "eni-0e6eb8bf710e26822",
        "mac_address": "0a:24:b8:de:13:e8",
        "name": "myENI-1",
        "owner_id": "686104308526",
        "private_ip_address": "10.0.84.2",
        "private_ip_addresses": [
            {
                "primary_address": true,
                "private_ip_address": "10.0.84.2"
            },
            {
                "primary_address": false,
                "private_ip_address": "10.0.18.102"
            }
        ],
        "source_dest_check": true,
        "status": "available",
        "subnet_id": "subnet-02dc6a04a5460ea5f",
        "tags": {
            "Name": "myENI-1",
            "another": "tag",
            "group": "Finance"
        },
        "vpc_id": "vpc-00fd8af7d3a908c13"
    }
```
