### PR TITLE
jenkins_job module: fix for python3

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -20,7 +20,6 @@ description:
     - Manage Jenkins jobs by using Jenkins REST API.
 requirements:
   - "python-jenkins >= 0.4.12"
-  - "lxml >= 3.3.3"
 version_added: "2.2"
 author: "Sergio Millan Rodriguez (@sermilrod)"
 options:
@@ -147,6 +146,7 @@ url:
 '''
 
 import traceback
+import xml.etree.ElementTree as ET
 
 JENKINS_IMP_ERR = None
 try:
@@ -155,14 +155,6 @@ try:
 except ImportError:
     JENKINS_IMP_ERR = traceback.format_exc()
     python_jenkins_installed = False
-
-LXML_IMP_ERR = None
-try:
-    from lxml import etree as ET
-    python_lxml_installed = True
-except ImportError:
-    LXML_IMP_ERR = traceback.format_exc()
-    python_lxml_installed = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
@@ -334,14 +326,9 @@ def test_dependencies(module):
                                      url="https://python-jenkins.readthedocs.io/en/latest/install.html"),
             exception=JENKINS_IMP_ERR)
 
-    if not python_lxml_installed:
-        module.fail_json(
-            msg=missing_required_lib("lxml", url="https://lxml.de/installation.html"),
-            exception=LXML_IMP_ERR)
-
 
 def job_config_to_string(xml_str):
-    return ET.tostring(ET.fromstring(xml_str))
+    return ET.tostring(ET.fromstring(xml_str)).decode('ascii')
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Fixes #54519

On python3 the jenkins_job fails to reconfigure the respective job due to a parsing issue within lxml when the configuration file contains an encoding declaration:
```
  File "/tmp/ansible_4y5pmpro/ansible_module_jenkins_job.py", line 276, in update_job
    if self.has_config_changed():
  File "/tmp/ansible_4y5pmpro/ansible_module_jenkins_job.py", line 237, in has_config_changed
    config_file = self.get_config()
  File "/tmp/ansible_4y5pmpro/ansible_module_jenkins_job.py", line 227, in get_config
    return job_config_to_string(self.config)
  File "/tmp/ansible_4y5pmpro/ansible_module_jenkins_job.py", line 336, in job_config_to_string
    return ET.tostring(ET.fromstring(xml_str))
  File "src/lxml/lxml.etree.pyx", line 3213, in lxml.etree.fromstring (src/lxml/lxml.etree.c:79010)
  File "src/lxml/parser.pxi", line 1843, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:118282)
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
```
Additionally, after removing encoding declaration it fails inside python-jenkins with: 
```
  File "/tmp/ansible_x5nesxl6/ansible_module_jenkins_job.py", line 279, in update_job
    self.server.reconfig_job(self.name, self.get_config())
  File "/home/mrk/repos/data-processing/venv36/lib/python3.6/site-packages/jenkins/__init__.py", line 1018, in reconfig_job
    self.jenkins_open(Request(reconfig_url, config_xml.encode('utf-8'),
AttributeError: 'bytes' object has no attribute 'encode'
```
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jenkins_job module

##### ADDITIONAL INFORMATION
How it works:
Instead of etree.{fromstring,tostring} it uses xml.etree.ElementTree.{fromstring,tostring} - it resolves problem with unicode strings with encoding declaration. Additionally it calls decode('ascii') on result of ElementTree.tostring - because ElementTree.tostring returns binary string encoded by default with 'US ascii' codec and python-jenkins library expects unicode strings.

I've tested this solution both on python2 and python3 on configs with and without encoding declaration and it seems to work in all cases.
