### PR TITLE
docker_swarm_service: Add updated as a state

### DIFF
--- a/changelogs/fragments/54960-docker_swarm_service-add-updated-state.yaml
+++ b/changelogs/fragments/54960-docker_swarm_service-add-updated-state.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_swarm_service - Added ``updated`` as an option to ``state``.

--- a/changelogs/fragments/54960-docker_swarm_service-add-updated-state.yaml
+++ b/changelogs/fragments/54960-docker_swarm_service-add-updated-state.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "docker_swarm_service - Added ``updated`` as an option to ``state``.
+  - "docker_swarm_service - Added ``updated`` as an option to ``state``."

--- a/test/integration/targets/docker_swarm_service/tasks/tests/state_updated.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/state_updated.yml
@@ -1,0 +1,99 @@
+---
+
+- name: Registering service name
+  set_fact:
+    service_name: "{{ name_prefix ~ '-update_current' }}"
+
+- name: Registering service name
+  set_fact:
+    service_names: "{{ service_names }} + [service_name]"
+
+####################################################################
+## state - updated #################################################
+####################################################################
+
+- name: update_current
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    replicas: 2
+    logging:
+      driver: json-file
+    env:
+      ENVVAR1: envvar1
+      ENVVAR2: envvar2
+  register: update_current_1
+  ignore_errors: yes
+
+- name: update_current (update)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    state: updated
+    replicas: 1
+  register: update_current_2
+  ignore_errors: yes
+
+- name: update_current (update_current idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    state: updated
+    replicas: 1
+  register: update_current_3
+  ignore_errors: yes
+
+- name: update_current (update_current replicas default)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    state: updated
+    reservations:
+      cpus: 0.25
+  register: update_current_4
+  ignore_errors: yes
+
+- name: update_current (no update_current idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    state: present
+    replicas: 1
+    logging:
+      driver: json-file
+    env:
+      ENVVAR1: envvar1
+      ENVVAR2: envvar2
+  register: update_current_5
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - update_current_1 is changed
+      - update_current_2 is changed
+      - update_current_3 is not changed
+      - update_current_4 is changed
+      - update_current_5 is not changed
+  when: docker_py_version is version('2.7.0', '>=')
+
+- assert:
+    that:
+      - update_current_2 is failed
+      - "'Minimum version required' in update_current_2.msg"
+  when: docker_py_version is version('2.7.0', '<')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR adds a new `state` option called `updated`. When used only specified parameters will be updated in the service and others will remain untouched in contrast to the default behaviour where the unspecified parameters revert to the docker defaults. I think a feature like this was though of when creating this module. This would explain the pretty weird default of replicas which is `-1`. This actually set the `replicas` value to the current service value before updating. I can't see how this makes any sense in the current implementation but with this PR it will actually serve a purpose as this feature wouldn't be as easy implemented if the `replicas` default was `1`. 

It is implemented by setting `fetch_current_spec` to `True` in [docker.api.service.ServiceApiMixin.update_service](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.service.ServiceApiMixin.update_service).

This option would enable more lightweight tasks to be used for deploying a new image without having to run dependent tasks to just update an image. For example `docker_config` / `docker_secrets` to fetch related ids to be used in `configs` / `secrets`.

I though about creating a new parameter called something like `update_current` but this felt better suited as an option of `state`. 

Sorry for a PR this close to the feature freeze. This is a feature I've been thinking about for a while and only now had the time to implement and test it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service