### PR TITLE
WIP - Add unit testing with Pester for PowerShell modules

### DIFF
--- a/lib/ansible/modules/windows/win_unit_test.ps1
+++ b/lib/ansible/modules/windows/win_unit_test.ps1
@@ -1,0 +1,24 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+Function Test-Function {
+    return "abc"
+}
+
+Function Invoke-AnsibleModule {
+    param (
+        [Parameter(Mandatory=$true)][AllowEmptyCollection()][System.Object[]]$Arguments
+    )
+    $spec = @{
+        options = @{}
+        supports_check_mode = $true
+    }
+    $module = [Ansible.Basic.AnsibleModule]::Create($Arguments, $spec)
+
+    $module.ExitJson()
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-AnsibleModule -Arguments $args
+}

--- a/shippable.yml
+++ b/shippable.yml
@@ -19,6 +19,7 @@ matrix:
     - env: T=units/3.6
     - env: T=units/3.7
     - env: T=units/3.8
+    - env: T=windows-units
 
     - env: T=windows/2008/1
     - env: T=windows/2008-R2/1

--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -33,6 +33,7 @@ from lib.executor import (
     command_network_integration,
     command_windows_integration,
     command_units,
+    command_windows_units,
     command_shell,
     SUPPORTED_PYTHON_VERSIONS,
     ApplicationWarning,
@@ -48,6 +49,7 @@ from lib.config import (
     NetworkIntegrationConfig,
     SanityConfig,
     UnitsConfig,
+    WindowsUnitsConfig,
     ShellConfig,
 )
 
@@ -69,6 +71,7 @@ from lib.target import (
     walk_network_integration_targets,
     walk_windows_integration_targets,
     walk_units_targets,
+    walk_windows_units_targets,
     walk_sanity_targets,
 )
 
@@ -380,6 +383,18 @@ def parse_args():
     units.add_argument('--requirements-mode',
                        choices=('only', 'skip'),
                        help=argparse.SUPPRESS)
+
+    windows_units = subparsers.add_parser('windows-units',
+                                          parents=[test],
+                                          help='windows unit tests')
+
+    windows_units.set_defaults(func=command_windows_units,
+                               targets=walk_windows_units_targets,
+                               config=WindowsUnitsConfig)
+
+    windows_units.add_argument('--requirements-mode',
+                               choices=('only', 'skip'),
+                               help=argparse.SUPPRESS)
 
     add_extra_docker_options(units, integration=False)
 

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -258,6 +258,22 @@ class UnitsConfig(TestConfig):
             self.requirements = False
 
 
+class WindowsUnitsConfig(TestConfig):
+    """Configuration for the windows-units command."""
+    def __init__(self, args):
+        """
+        :type args: any
+        """
+        super(WindowsUnitsConfig, self).__init__(args, 'windows-units')
+
+        self.requirements_mode = args.requirements_mode if 'requirements_mode' in args else ''
+
+        if self.requirements_mode == 'only':
+            self.requirements = True
+        elif self.requirements_mode == 'skip':
+            self.requirements = False
+
+
 class CoverageConfig(EnvironmentConfig):
     """Configuration for the coverage command."""
     def __init__(self, args):

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -210,6 +210,14 @@ def walk_units_targets():
     return walk_test_targets(path='test/units', module_path='test/units/modules/', extensions=('.py',), prefix='test_')
 
 
+def walk_windows_units_targets():
+    """
+    rtype: collections.Iterable[TestTarget[
+    :return:
+    """
+    return walk_test_targets(path='test/units', module_path='test/units/modules/', extensions=('.ps1',), prefix='test_')
+
+
 def walk_compile_targets():
     """
     :rtype: collections.Iterable[TestTarget]

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -180,13 +180,14 @@ def cleanup_python_paths():
         shutil.rmtree(path)
 
 
-def get_coverage_environment(args, target_name, version, temp_path, module_coverage):
+def get_coverage_environment(args, target_name, version, temp_path, module_coverage, language='python'):
     """
     :type args: TestConfig
     :type target_name: str
     :type version: str
     :type temp_path: str
     :type module_coverage: bool
+    :type language: str | python
     :rtype: dict[str, str]
     """
     if temp_path:
@@ -202,7 +203,7 @@ def get_coverage_environment(args, target_name, version, temp_path, module_cover
 
     config_file = os.path.join(coverage_config_base_path, COVERAGE_CONFIG_PATH)
     coverage_file = os.path.join(coverage_output_base_path, COVERAGE_OUTPUT_PATH, '%s=%s=%s=%s=coverage' % (
-        args.command, target_name, args.coverage_label or 'local-%s' % version, 'python-%s' % version))
+        args.command, target_name, args.coverage_label or 'local-%s' % version, '%s-%s' % (language, version)))
 
     if args.coverage_check:
         # cause the 'coverage' module to be found, but not imported or enabled

--- a/test/runner/requirements/windows-units.ps1
+++ b/test/runner/requirements/windows-units.ps1
@@ -1,0 +1,8 @@
+#!/usr/bin/env pwsh
+#Requires -Version 6
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+Install-Module -Name Pester -RequiredVersion 4.7.3

--- a/test/runner/setup/windows-units.ps1
+++ b/test/runner/setup/windows-units.ps1
@@ -1,0 +1,78 @@
+#!/usr/bin/env pwsh
+#Requires -Version 6
+#Requires -Module Pester
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)][System.String]$OutputFile,
+    [Parameter(Mandatory=$true)][System.String]$Tests,
+    [System.String]$Coverage
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$test_config = ConvertFrom-Json -InputObject $Tests
+$include = $test_config.include
+$exclude = $test_config.exclude
+
+# Make sure we dot source helpful test functions that each test can use
+$modules_path = [System.IO.Path]::GetFullPath(
+    [System.IO.Path]::Combine($PSScriptRoot, "..", "..", "units", "pester_functions.ps1")
+)
+.$modules_path
+
+$exclude_scripts = $exclude | ForEach-Object -Process { Join-Path -Path $pwd -ChildPath $_.path }
+$test_scripts = [System.Collections.Generic.List`1[String]]@()
+$coverage_scripts = [System.Collections.Generic.HashSet`1[String]]@()
+
+$find_params = @{
+    Filter = 'test_*.ps1'
+    Force = $true
+    Recurse = $true
+}
+foreach ($include_info in $include) {
+    foreach ($module_name in $include_info.modules) {
+        $module_path = Find-AnsibleModule -Name $module_name
+        $coverage_scripts.Add($module_path) > $null
+    }
+
+    Get-ChildItem -LiteralPath $include_info.path @find_params | `
+        Where-Object -Property FullName -NotIn $exclude_scripts | `
+            ForEach-Object -Process { $test_scripts.Add($_.FullName) }
+}
+
+$pester_params = @{
+    EnableExit = $false
+    OutputFile = $OutputFile
+    OutputFormat = "NUnitXml"
+    PassThru = $true
+    Script = $test_scripts
+}
+
+if ($Coverage) {
+    $utils_path = [System.IO.Path]::GetFullPath(
+        [System.IO.Path]::Combine($PSScriptRoot, "..", "..", "..", "lib", "ansible", "module_utils", "powershell")
+    )
+    Get-ChildItem -LiteralPath $utils_path -Filter "*.psm1" -Recurse | `
+        ForEach-Object -Process { $coverage_scripts.Add($_.FullName) > $null }
+
+    $executor_path = [System.IO.Path]::GetFulLPath(
+        [System.IO.Path]::Combine($PSScriptRoot, "..", "..", "..", "lib", "ansible", "executor", "powershell")
+    )
+    Get-ChildItem -LiteralPath $executor_path -Filter "*.ps1" -Recurse | `
+        ForEach-Object -Process { $coverage_scripts.Add($_.FullName) > $null }
+
+    $pester_params.CodeCoverage = $coverage_scripts
+    $pester_params.CodeCoverageOutputFile = $Coverage
+    $pester_params.CodeCoverageOutputFileFormat = "JaCoCo"
+}
+
+$result = Invoke-Pester @pester_params
+
+if ($result.FailedCount -gt 0) {
+    Write-Error -Message "Failed pester tests with $($result.FailedCount) failing tests"
+    exit 1
+} else {
+    exit 0
+}

--- a/test/units/modules/windows/test_win_unit_test.ps1
+++ b/test/units/modules/windows/test_win_unit_test.ps1
@@ -1,0 +1,12 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Load the win_unit_test module functions
+.(Find-AnsibleModule -Name $MyInvocation.MyCommand.Name.Substring(5))
+
+Describe "Testing win_unit_test" {
+    It "Gets correct result" {
+        $actual = Test-Function
+        $actual | Should -Be "abc"
+    }
+}

--- a/test/units/pester_functions.ps1
+++ b/test/units/pester_functions.ps1
@@ -1,0 +1,42 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+Function Find-AnsibleModule {
+    <#
+    .SYNOPSIS
+    Find the full path to the Ansible module specified.
+
+    .PARAMETER Name
+    [System.String] The name of the module to find.
+
+    .EXAMPLE
+    Find-AnsibleModule -Name win_ping
+
+    Find-AnsibleModule -Name win_ping.ps1
+
+    .OUTPUTS
+    [System.String] The full path to the module specified
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param (
+        [Parameter(Mandatory=$true)][System.String]$Name
+    )
+
+    # Ensure the module name has an extension
+    if ([System.IO.Path]::GetExtension($Name) -eq "") {
+        $Name = "$($Name).ps1"
+    }
+
+    # Get the full path of the windows modules directory relative to this script
+    $modules_path = [System.IO.Path]::GetFullPath(
+        [System.IO.Path]::Combine($PSScriptRoot, "..", "..", "lib", "ansible", "modules", "windows")
+    )
+    $module = Get-ChildItem -LiteralPath $modules_path -Filter $Name -Recurse
+
+    if ($null -eq $module) {
+        Write-Error -Message "Failed to find Windows module '$Name' in '$modules_path'" -Category ObjectNotFound
+    } else {
+        return $module.FullName
+    }
+}

--- a/test/utils/shippable/windows-units.sh
+++ b/test/utils/shippable/windows-units.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o pipefail -eux
+
+declare -a args
+IFS='/:' read -ra args <<< "$1"
+
+if [[ "${COVERAGE:-}" == "--coverage" ]]; then
+    timeout=90
+else
+    timeout=11
+fi
+
+ansible-test env --timeout "${timeout}" --color -v
+
+# shellcheck disable=SC2086
+ansible-test windows-units --color -v --docker default ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \


### PR DESCRIPTION
##### SUMMARY
Adds the ability to create unit tests for PowerShell modules and module utils in ansible-test. This is a basic POC to test out what we need to have in place for this to work. Currently it works by running the tests on the local PSCore container instead of on an actual Windows host. This means that calls to .NET functions that are unavailable on Windows will have to be mocked out but I'm hopeful we can still do proper unit tests this way without the overhead of managing and actual Windows host.

Items that need further discussion;

* For this to work, the current proposal is to change our Windows modules to be in the shape

```
#!powershell

#AnsibleRequires -CSharpUtil Ansible.Basic

Function Invoke-AnsibleModule {
    param (
        [Parameter(Mandatory=$true)][AllowEmptyCollection()][System.Object[]]$Arguments
    )
    $spec = @{
        options = @{}
        supports_check_mode = $true
    }
    $module = [Ansible.Basic.AnsibleModule]::Create($Arguments, $spec)
    $module.ExitJson()
}

if ($MyInvocation.InvocationName -ne '.') {
    Invoke-AnsibleModule -Arguments $args
}
```

* The above allows us to dot source the module without actually executing the module. This is critical so we can load the functions in the script in a unit test scenario
* Unfortunately this means we need to change the way our modules are written but this can easily be part of a sanity check and shouldn't be too hard to write a once off script to convert our builtin modules
* An alternative is to use an AST parser to get all defined functions in a script and then dot source them that way. This has an advantage because it works with our current modules but won't work with coverage collectors
* We could still get coverage working with the above but it would involve creating temp module files with just the module functions in the correct line positions
* The coverage output and test result output is different from the Python output. We still need a conversion script to align the output when using in Ansible

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
windows