### PR TITLE
Fix handling of inventory and credential options for tower_job_launch

### DIFF
--- a/changelogs/fragments/tower_job_launch-options.yaml
+++ b/changelogs/fragments/tower_job_launch-options.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed to handle arguments correctly even if inventory and credential
+    variables are not specified (#25017,#37567)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -58,11 +58,24 @@ extends_documentation_fragment: tower
 '''
 
 EXAMPLES = '''
+# Launch a job template
 - name: Launch a job
   tower_job_launch:
     job_template: "My Job Template"
   register: job
 
+- name: Wait for job max 120s
+  tower_job_wait:
+    job_id: job.id
+    timeout: 120
+
+# Launch job template with inventory and credential for prompt on launch
+- name: Launch a job with inventory and credential
+  tower_job_launch:
+    job_template: "My Job Template"
+    inventory: "My Inventory"
+    credential: "My Credential"
+  register: job
 - name: Wait for job max 120s
   tower_job_wait:
     job_id: job.id
@@ -96,10 +109,10 @@ except ImportError:
 
 def main():
     argument_spec = dict(
-        job_template=dict(required=True),
+        job_template=dict(required=True, type='str'),
         job_type=dict(choices=['run', 'check', 'scan']),
-        inventory=dict(),
-        credential=dict(),
+        inventory=dict(type='str', default=None),
+        credential=dict(type='str', default=None),
         limit=dict(),
         tags=dict(type='list'),
         extra_vars=dict(type='list'),
@@ -126,8 +139,9 @@ def main():
             for field in lookup_fields:
                 try:
                     name = params.pop(field)
-                    result = tower_cli.get_resource(field).get(name=name)
-                    params[field] = result['id']
+                    if name:
+                        result = tower_cli.get_resource(field).get(name=name)
+                        params[field] = result['id']
                 except exc.NotFound as excinfo:
                     module.fail_json(msg='Unable to launch job, {0}/{1} was not found: {2}'.format(field, name, excinfo), changed=False)
 

--- a/test/integration/targets/tower_job_launch/tasks/main.yml
+++ b/test/integration/targets/tower_job_launch/tasks/main.yml
@@ -10,6 +10,18 @@
       - "result is changed"
       - "result.status == 'pending'"
 
+- name: Wait for a job template to complete
+  tower_job_wait:
+    job_id: "{{ result.id }}"
+    max_interval: 10
+    timeout: 120
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+      - "result.status == 'successful'"
+
 - name: Check module fails with correct msg
   tower_job_launch:
      job_template: "Non Existing Job Template"
@@ -21,3 +33,26 @@
 - assert:
     that:
       - "result.msg =='Unable to launch job, job_template/Non Existing Job Template was not found: The requested object could not be found.'"
+
+- name: Create a Job Template for testing prompt on launch
+  tower_job_template:
+    name: "Demo Job Template - ask inventory and credential"
+    project: Demo Project
+    playbook: hello_world.yml
+    job_type: run
+    ask_credential: yes
+    ask_inventory: yes
+    state: present
+  register: result
+
+- name: Launch job template with inventory and credential for prompt on launch
+  tower_job_launch:
+    job_template: "Demo Job Template - ask inventory and credential"
+    inventory: "Demo Inventory"
+    credential: "Demo Credential"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "result.status == 'pending'"

--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -69,6 +69,8 @@ class TowerCloudProvider(CloudProvider):
         tower_cli_version_map = {
             '3.1.5': '3.1.8',
             '3.2.3': '3.3.0',
+            '3.3.5': '3.3.3',
+            '3.4.3': '3.3.3',
         }
 
         cli_version = tower_cli_version_map.get(self.version, fallback)


### PR DESCRIPTION
##### SUMMARY
- Fixed issue #25017,#37567
- Add example for prompt on launch
- Add integration test for prompt on launch
- inventory and credential variables are option(only need to set when a job template turned on `prompt on launch` option), both of them unnecessary to specify when `prompt on launch` is turned off
- Rebased and recreated PR #41497

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - tower_job_launch.py

##### ANSIBLE VERSION

```
Devel
```

##### ADDITIONAL INFORMATION

None