### PR TITLE
The module fails on switchport. Check added to fix.

### DIFF
--- a/lib/ansible/modules/network/cnos/cnos_vrf.py
+++ b/lib/ansible/modules/network/cnos/cnos_vrf.py
@@ -137,6 +137,35 @@ def search_obj_in_list(name, lst):
             return o
 
 
+def get_interface_type(interface):
+    intf_type = 'unknown'
+    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE'):
+        intf_type = 'ethernet'
+    elif interface.upper().startswith('VL'):
+        intf_type = 'svi'
+    elif interface.upper().startswith('LO'):
+        intf_type = 'loopback'
+    elif interface.upper()[:2] in ('MG', 'MA'):
+        intf_type = 'management'
+    elif interface.upper().startswith('PO'):
+        intf_type = 'portchannel'
+    elif interface.upper().startswith('NV'):
+        intf_type = 'nve'
+
+    return intf_type
+
+
+def is_switchport(name, module):
+    intf_type = get_interface_type(name)
+
+    if intf_type in ('ethernet', 'portchannel'):
+        config = run_commands(module,
+                              ['show interface {0} switchport'.format(name)])[0]
+        match = re.search(r'Switchport              : enabled', config)
+        return bool(match)
+    return False
+
+
 def map_obj_to_commands(updates, module):
     commands = list()
     want, have = updates
@@ -317,6 +346,13 @@ def main():
         result['warnings'] = warnings
 
     want = map_params_to_obj(module)
+    for w in want:
+        name = w['name']
+        name = name.lower()
+        if is_switchport(name, module):
+            module.fail_json(msg='Ensure interface is configured to be a L3'
+                             '\nport first before using this module. You can use'
+                             '\nthe cnos_interface module for this.')
     have = map_config_to_obj(module)
 
     commands = map_obj_to_commands((want, have), module)

--- a/test/integration/targets/cnos_vrf/tests/cli/basic.yaml
+++ b/test/integration/targets/cnos_vrf/tests/cli/basic.yaml
@@ -12,6 +12,15 @@
   - test4
   - test5
 
+- name: Setup - Ensure interfaces are not switchport
+  cnos_config:
+    lines:
+      - no shutdown
+      - no switchport
+      - no logging monitor
+    parents:
+      - "interface ethernet1/33"
+
 - name: Create vrf
   cnos_vrf:
     name: test

--- a/test/units/modules/network/cnos/test_cnos_vrf.py
+++ b/test/units/modules/network/cnos/test_cnos_vrf.py
@@ -38,15 +38,22 @@ class TestCnosVrfModule(TestCnosModule):
         self.mock_run_commands = patch('ansible.modules.network.cnos.cnos_vrf.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
+        self._patch_is_switchport = patch(
+            'ansible.modules.network.cnos.cnos_vrf.is_switchport'
+        )
+        self._is_switchport = self._patch_is_switchport.start()
+
     def tearDown(self):
         super(TestCnosVrfModule, self).tearDown()
         self.mock_load_config.stop()
         self.mock_run_commands.stop()
+        self._patch_is_switchport.stop()
 
     def load_fixtures(self, commands=None):
         config_file = 'cnos_vrf_config.cfg'
         self.load_config.return_value = load_fixture(config_file)
         self.run_commands.return_value = load_fixture(config_file)
+        self._is_switchport.return_value = False
 
     def test_cnos_vrf_present(self):
         set_module_args(dict(name='test1', state='present'))


### PR DESCRIPTION
##### SUMMARY
Fixing a bug on cnos_vrf module to check if port is configured as switchport 

##### ISSUE TYPE
- Bug Fix Pull Request 

##### COMPONENT NAME

lib/ansible/modules/network/cnos/cnos_vrf.py
test/integration/targets/cnos_vrf/tests/cli/basic.yaml
test/units/modules/network/cnos/test_cnos_vrf.py

##### ANSIBLE VERSION
ansible 2.8.0.dev0 (devel e2b9c36080) last updated 2018/10/12 13:58:41 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/sheru/ansible/lib/ansible
  executable location = /home/ansible/sheru/ansible/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
Unit Test and Integration tests are also successfully tested with CNOS G8272 with image version 10.9.1