### PR TITLE
Pluribus Networks modules handling empty output

### DIFF
--- a/changelogs/fragments/54971-PN_modules_handling_empty_output_string.yaml
+++ b/changelogs/fragments/54971-PN_modules_handling_empty_output_string.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- pluribus networks modules to handle empty output string.

--- a/lib/ansible/modules/network/netvisor/pn_access_list.py
+++ b/lib/ansible/modules/network/netvisor/pn_access_list.py
@@ -100,7 +100,10 @@ def check_cli(module, cli):
     list_name = module.params['pn_name']
 
     cli += ' access-list-show format name no-show-headers'
-    out = run_commands(module, cli)
+    out = run_commands(module, cli)[1]
+
+    if out:
+        out = out.split()
 
     return True if list_name in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_cpu_class.py
+++ b/lib/ansible/modules/network/netvisor/pn_cpu_class.py
@@ -124,9 +124,10 @@ def check_cli(module, cli):
         )
 
     cli = clicopy
-    cli += ' cpu-class-show name %s format name no-show-headers' % name
+    cli += ' cpu-class-show format name no-show-headers'
     out = run_commands(module, cli)[1]
-    out = out.split()
+    if out:
+        out = out.split()
 
     return True if name in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
+++ b/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
@@ -103,7 +103,8 @@ def check_cli(module, cli):
     cli += ' dhcp-filter-show format name no-show-headers'
     out = run_commands(module, cli)[1]
 
-    out = out.split()
+    if out:
+        out = out.split()
 
     return True if user_name in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_dscp_map.py
+++ b/lib/ansible/modules/network/netvisor/pn_dscp_map.py
@@ -92,12 +92,13 @@ def check_cli(module, cli):
     """
     name = module.params['pn_name']
 
-    cli += ' dscp-map-show name %s format name no-show-headers' % name
+    cli += ' dscp-map-show format name no-show-headers'
     out = run_commands(module, cli)[1]
 
-    out = out.split()
+    if out:
+        out = out.split()
 
-    return True if name in out[-1] else False
+    return True if name in out else False
 
 
 def main():

--- a/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
+++ b/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
@@ -103,7 +103,8 @@ def check_cli(module, cli):
     cli += ' dscp-map-show format name no-show-headers'
     out = run_commands(module, cli)[1]
 
-    out = out.split()
+    if out:
+        out = out.split()
 
     return True if name in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
+++ b/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
@@ -100,12 +100,12 @@ def check_cli(module, cli):
     """
     name = module.params['pn_name']
 
-    cli += ' dscp-map-show name %s format name no-show-headers' % name
+    cli += ' dscp-map-show format name no-show-headers'
     out = run_commands(module, cli)[1]
 
     out = out.split()
 
-    return True if name in out[-1] else False
+    return True if name in out else False
 
 
 def main():

--- a/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
+++ b/lib/ansible/modules/network/netvisor/pn_prefix_list_network.py
@@ -116,7 +116,7 @@ def check_cli(module, cli):
     rc, out, err = run_commands(module, cli)
 
     if out:
-        out = out.split()[1]
+        out = out.split()[-1]
         return True if network in out.split('/')[0] else False
 
     return False

--- a/lib/ansible/modules/network/netvisor/pn_role.py
+++ b/lib/ansible/modules/network/netvisor/pn_role.py
@@ -133,7 +133,8 @@ def check_cli(module, cli):
     cli += ' role-show format name no-show-headers'
     out = run_commands(module, cli)[1]
 
-    out = out.split()
+    if out:
+        out = out.split()
 
     return True if role_name in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_snmp_community.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_community.py
@@ -102,7 +102,8 @@ def check_cli(module, cli):
     cli += ' snmp-community-show format community-string no-show-headers'
     out = run_commands(module, cli)[1]
 
-    out = out.split()
+    if out:
+        out = out.split()
 
     return True if comm_str in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_snmp_trap_sink.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_trap_sink.py
@@ -110,14 +110,16 @@ def check_cli(module, cli):
     cli += ' snmp-community-show format community-string no-show-headers'
     rc, out, err = run_commands(module, cli)
 
-    out = out.split()
+    if out:
+        out = out.split()
 
     if community in out:
         cli = show
         cli += ' snmp-trap-sink-show community %s format type,dest-host no-show-headers' % community
         rc, out, err = run_commands(module, cli)
 
-        out = out.split()
+        if out:
+            out = out.split()
 
         return True if dest_host in out else False
     else:

--- a/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
+++ b/lib/ansible/modules/network/netvisor/pn_snmp_vacm.py
@@ -113,9 +113,10 @@ def check_cli(module, cli):
     user_name = module.params['pn_user_name']
     show = cli
 
-    cli += ' snmp-user-show user-name %s format user-name no-show-headers' % user_name
+    cli += ' snmp-user-show format user-name no-show-headers'
     rc, out, err = run_commands(module, cli)
-    if out:
+
+    if out and user_name in out.split():
         pass
     else:
         return None
@@ -124,7 +125,8 @@ def check_cli(module, cli):
     cli += ' snmp-vacm-show format user-name no-show-headers'
     out = run_commands(module, cli)[1]
 
-    out = out.split()
+    if out:
+        out = out.split()
 
     return True if user_name in out else False
 

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_interface_ip.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_interface_ip.py
@@ -131,11 +131,12 @@ def check_cli(module, cli):
     nic_str = module.params['pn_nic']
 
     # Check for vRouter
-    check_vrouter = cli + ' vrouter-show name %s format name no-show-headers ' % vrouter_name
+    check_vrouter = cli + ' vrouter-show format name no-show-headers'
     out = run_commands(module, check_vrouter)[1]
-    out = out.split()
+    if out:
+        out = out.split()
 
-    VROUTER_EXISTS = True if vrouter_name in out[-1] else False
+    VROUTER_EXISTS = True if vrouter_name in out else False
 
     if interface_ip:
         # Check for interface and VRRP and fetch nic for VRRP
@@ -151,9 +152,11 @@ def check_cli(module, cli):
     if nic_str:
         # Check for nic
         show = cli + ' vrouter-interface-show vrouter-name %s ' % vrouter_name
-        show += ' format nic no-show-headers'
+        show += 'format nic no-show-headers'
         out = run_commands(module, show)[1]
-        out = out.split()
+
+        if out:
+            out = out.split()
 
         NIC_EXISTS = True if nic_str in out else False
 
@@ -221,7 +224,7 @@ def main():
         if INTERFACE_EXISTS is True:
             module.exit_json(
                 skipped=True,
-                msg='vRouter with interface %s exist' % ip
+                msg='vRouter with interface ip %s exist' % ip
             )
         cli += ' nic %s ip %s ' % (nic, ip)
 
@@ -236,7 +239,7 @@ def main():
         if INTERFACE_EXISTS is False:
             module.exit_json(
                 skipped=True,
-                msg='vRouter with interface %s does not exist' % ip
+                msg='vRouter with interface ip %s does not exist' % ip
             )
         if nic:
             cli += ' nic %s ' % nic

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
@@ -111,7 +111,8 @@ def check_cli(module, cli):
     # Check for vRouter
     check_vrouter = cli + ' vrouter-show format name no-show-headers '
     out = run_commands(module, check_vrouter)[1]
-    out = out.split()
+    if out:
+        out = out.split()
 
     VROUTER_EXISTS = True if vrouter_name in out else False
 
@@ -120,7 +121,7 @@ def check_cli(module, cli):
         show = cli + ' vrouter-ospf6-show vrouter-name %s format nic no-show-headers' % vrouter_name
         out = run_commands(module, show)[1]
 
-        NIC_EXISTS = True if nic_str in out else False
+        NIC_EXISTS = True if nic_str in out.split() else False
 
     return VROUTER_EXISTS, NIC_EXISTS
 

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_ospf6.py
@@ -121,7 +121,10 @@ def check_cli(module, cli):
         show = cli + ' vrouter-ospf6-show vrouter-name %s format nic no-show-headers' % vrouter_name
         out = run_commands(module, show)[1]
 
-        NIC_EXISTS = True if nic_str in out.split() else False
+        if out:
+            out.split()
+
+        NIC_EXISTS = True if nic_str in out else False
 
     return VROUTER_EXISTS, NIC_EXISTS
 

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_pim_config.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_pim_config.py
@@ -97,10 +97,11 @@ def check_cli(module, cli):
     name = module.params['pn_vrouter_name']
 
     show = cli
-    cli += ' vrouter-show name %s format name no-show-headers ' % name
+    cli += ' vrouter-show format name no-show-headers '
     out = run_commands(module, cli)[1]
-    out = out.split()
-    if out[-1] == name:
+    if out:
+        out = out.split()
+    if name in out:
         pass
     else:
         return False
@@ -108,7 +109,8 @@ def check_cli(module, cli):
     cli = show
     cli += ' vrouter-show name %s format proto-multi no-show-headers' % name
     out = run_commands(module, cli)[1]
-    out = out.split()
+    if out:
+        out = out.split()
 
     return True if 'none' not in out else False
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Handling empty string output.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
Pluribus networks modules

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.7.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]


```
