### PR TITLE
Renamed SafeConfigParser to ConfigParser

### DIFF
--- a/changelogs/fragments/54974-rename-safeconfigparser-to-configparser.yaml
+++ b/changelogs/fragments/54974-rename-safeconfigparser-to-configparser.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - rename safeConfigParser to ConfigParser to suppress DeprecationWarning (The SafeConfigParser class has been renamed to ConfigParser in Python 3.2.)

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -187,7 +187,7 @@ class GceInventory(object):
         """
         Reads the settings from the gce.ini file.
 
-        Populates a SafeConfigParser object with defaults and
+        Populates a ConfigParser object with defaults and
         attempts to read an .ini-style configuration from the filename
         specified in GCE_INI_PATH. If the environment variable is
         not present, the filename defaults to gce.ini in the current
@@ -201,7 +201,7 @@ class GceInventory(object):
         # This provides empty defaults to each key, so that environment
         # variable configuration (as opposed to INI configuration) is able
         # to work.
-        config = configparser.SafeConfigParser(defaults={
+        config = configparser.ConfigParser(defaults={
             'gce_service_account_email_address': '',
             'gce_service_account_pem_file_path': '',
             'gce_project_id': '',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rename SafeConfigParser to ConfigParser in inventory/gce.py.
Because DeprecationWarning happens in python3.2 or later.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
GCP-plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook xxx.yml -l xxx
xxx/inventory/gce.py:213: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser
in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.   'cache_max_age': '300'
...
```
