### PR TITLE
add wait_for_running option in azure_rm_rediscache module

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
@@ -578,7 +578,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
                                                  parameters=params)
             if isinstance(response, AzureOperationPoller) or isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
-            
+
             if self.wait_for_running:
                 self.wait_for_redis_running()
 
@@ -760,6 +760,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
             self.fail("Azure Cache for Redis is not running after 60 mins.")
         except CloudError as e:
             self.fail("Failed to get Azure Cache for Redis: {0}".format(str(e)))
+
 
 def main():
     """Main execution"""

--- a/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
@@ -131,6 +131,12 @@ options:
                 choices:
                     - primary
                     - secondary
+    wait_for_running:
+        description:
+            - Wait till the Azure Cache for Redis instance provisioning_status is running.
+            - It takes several minutes for Azure Cache for Redis to be ready for use or in running status after creation or update or reboot.
+            - Set this option to true to wait for provisioning_status. Set to false if you don't care about provisioning_status.
+        type: bool
     state:
       description:
         - Assert the state of the Azure Cache for Redis.
@@ -366,6 +372,9 @@ class AzureRMRedisCaches(AzureRMModuleBase):
             regenerate_key=dict(
                 type='dict',
                 options=regenerate_key_spec
+            ),
+            wait_for_running=dict(
+                type='bool'
             )
         )
 
@@ -385,6 +394,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
         self.tenant_settings = None
         self.reboot = None
         self.regenerate_key = None
+        self.wait_for_running = None
 
         self.tags = None
 
@@ -564,6 +574,8 @@ class AzureRMRedisCaches(AzureRMModuleBase):
                                                  parameters=params)
             if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
                 response = self.get_poller_result(response)
+            
+            if self.wait_for_running:
 
         except CloudError as exc:
             self.log('Error attempting to create the Azure Cache for Redis instance.')

--- a/test/integration/targets/azure_rm_rediscache/tasks/main.yml
+++ b/test/integration/targets/azure_rm_rediscache/tasks/main.yml
@@ -92,6 +92,7 @@
       enable_non_ssl_port: true
       tags:
         testing: foo
+      wait_for_running: True
     register: output
 
   - name: assert output changed
@@ -126,20 +127,12 @@
         size: C1
       tags:
         testing: foo
+      wait_for_running: True
     register: output
 
   - assert:
       that:
         - output.changed
-
-  - name: Wait for Redis provisioning to complete
-    azure_rm_rediscache_facts:
-        resource_group: "{{ resource_group }}"
-        name: "{{ redis_name }}"
-    register: facts
-    until: facts.rediscaches[0]['provisioning_state'] == 'Succeeded'
-    retries: 30
-    delay: 60
 
   - name: Force reboot redis cache
     azure_rm_rediscache:

--- a/test/integration/targets/azure_rm_rediscache/tasks/main.yml
+++ b/test/integration/targets/azure_rm_rediscache/tasks/main.yml
@@ -13,6 +13,7 @@
     sku:
       name: basic
       size: C1
+  wait_for_provisioning: False
   check_mode: yes
   register: output
 
@@ -28,6 +29,7 @@
     sku:
       name: basic
       size: C1
+    wait_for_provisioning: False
   register: output
 
 - name: Assert creating redis cache
@@ -59,6 +61,7 @@
     sku:
       name: basic
       size: C1
+    wait_for_provisioning: False
   register: output
 
 - name: assert output not changed
@@ -92,7 +95,7 @@
       enable_non_ssl_port: true
       tags:
         testing: foo
-      wait_for_running: True
+      wait_for_provisioning: True
     register: output
 
   - name: assert output changed
@@ -107,7 +110,7 @@
       sku:
         name: basic
         size: C1
-      enable_non_ssl_port: true
+      enable_non_ssl_port: True
       maxmemory_policy: allkeys_lru
       tags:
         testing: foo
@@ -127,7 +130,7 @@
         size: C1
       tags:
         testing: foo
-      wait_for_running: True
+      wait_for_provisioning: True
     register: output
 
   - assert:
@@ -194,6 +197,7 @@
     subnet:
       name: "{{ subnet_name }}"
       virtual_network_name: "{{ vnet_name }}"
+    wait_for_provisioning: False
   register: output
 
 - name: Assert creating redis cache

--- a/test/integration/targets/azure_rm_rediscache/tasks/main.yml
+++ b/test/integration/targets/azure_rm_rediscache/tasks/main.yml
@@ -13,7 +13,7 @@
     sku:
       name: basic
       size: C1
-  wait_for_provisioning: False
+    wait_for_provisioning: False
   check_mode: yes
   register: output
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add wait_for_running option to poll wait redis provisioning_state in azure_rm_rediscache module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/54932

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
