### PR TITLE
[2.7] ufw: fix default, direction is not necessary for it

### DIFF
--- a/changelogs/fragments/54799-ufw-default-direction.yml
+++ b/changelogs/fragments/54799-ufw-default-direction.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ufw - when ``default`` is specified, ``direction`` does not needs to be specified. This was accidentally introduced in Ansible 2.7.8."

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -311,13 +311,13 @@ def main():
             execute(cmd + [[command], [value]])
 
         elif command == 'default':
-            if params['direction'] not in ['outgoing', 'incoming', 'routed']:
-                module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed".')
+            if params['direction'] not in ['outgoing', 'incoming', 'routed', None]:
+                module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed", or direction must not be specified.')
             execute(cmd + [[command], [value], [params['direction']]])
 
         elif command == 'rule':
             if params['direction'] not in ['in', 'out', None]:
-                module.fail_json(msg='For rules, direction must be one of "in" and "out".')
+                module.fail_json(msg='For rules, direction must be one of "in" and "out", or direction must not be specified.')
             # Rules are constructed according to the long format
             #
             # ufw [--dry-run] [route] [delete] [insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \


### PR DESCRIPTION
##### SUMMARY
Backport of #54799 to stable-2.7. This re-allows not specifying `direction` when `default` is used; this was disallowed accidentally earlier (see #53854).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
