### PR TITLE
Doc typo fix- "with in" changed to "within"

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_lookups.rst
+++ b/docs/docsite/rst/user_guide/playbooks_lookups.rst
@@ -7,7 +7,7 @@ Lookup plugins allow access to outside data sources. Like all templating, these 
 
 .. note::
     - Lookups occur on the local computer, not on the remote computer.
-    - They are executed with in the directory containing the role or play, as opposed to local tasks which are executed with the directory of the executed script.
+    - They are executed within the directory containing the role or play, as opposed to local tasks which are executed with the directory of the executed script.
     - You can pass wantlist=True to lookups to use in jinja2 template "for" loops.
     - Lookups are an advanced feature. You should have a good working knowledge of Ansible plays before incorporating them.
 


### PR DESCRIPTION
<!--- Your description here -->

Looks like the correct way to write "within" is without a space between "with" and "in"

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

playbooks_lookups

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before

They are executed with in the directory containing the role or play, as opposed to local tasks which are executed with the directory of the executed script.

after

They are executed within the directory containing the role or play, as opposed to local tasks which are executed with the directory of the executed script.

```
