### PR TITLE
Clarify fact_path configurable in ansible.cfg

### DIFF
--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -53,7 +53,8 @@ options:
             - path used for local ansible facts (C(*.fact)) - files in this dir
               will be run (if executable) and their results be added to C(ansible_local) facts
               if a file is not executable it is read. Check notes for Windows options. (from 2.1 on)
-              File/results format can be json or ini-format
+              File/results format can be JSON or INI-format. The default C(fact_path) can be
+              specified in C(ansible.cfg).
         required: false
         default: '/etc/ansible/facts.d'
 description:

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -54,7 +54,8 @@ options:
               will be run (if executable) and their results be added to C(ansible_local) facts
               if a file is not executable it is read. Check notes for Windows options. (from 2.1 on)
               File/results format can be JSON or INI-format. The default C(fact_path) can be
-              specified in C(ansible.cfg).
+              specified in C(ansible.cfg) for when setup is automatically called as part of
+              C(gather_facts).
         required: false
         default: '/etc/ansible/facts.d'
 description:


### PR DESCRIPTION
Clarify that `fact_path` can be configured in `ansible.cfg`.
Uppercase two acronyms

+label: docsite_pr

##### SUMMARY
Documentation clarification

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
setup

