### PR TITLE
[stable-2.7] Fix apache shutdown in subversion test.

### DIFF
--- a/test/integration/targets/subversion/tasks/main.yml
+++ b/test/integration/targets/subversion/tasks/main.yml
@@ -19,7 +19,7 @@
 
   always:
   - name: stop apache after tests
-    command: apachectl -k stop -f {{ subversion_server_dir }}/subversion.conf
+    shell: "kill -9 $(cat '{{ subversion_server_dir }}/apache.pid')"
 
   - name: remove tmp subversion server dir
     file:


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Fix apache shutdown in subversion test.

Backport of https://github.com/ansible/ansible/pull/54997

(cherry picked from commit 58f4947ffeb9684095f9cb809708fd24d19b4901)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

subversion integration test
