### PR TITLE
Use ansible.module_utils.six in inventory scripts

### DIFF
--- a/changelogs/fragments/use-module_utils-six-in-contrib-inventory.yaml
+++ b/changelogs/fragments/use-module_utils-six-in-contrib-inventory.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - use ansible.module_utils.six for all scripts in contrib/invetroy
+  - use ansible.module_utils.six for all scripts in contrib/inventory

--- a/changelogs/fragments/use-module_utils-six-in-contrib-inventory.yaml
+++ b/changelogs/fragments/use-module_utils-six-in-contrib-inventory.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - use ansible.module_utils.six for all scripts in contrib/invetroy

--- a/contrib/inventory/abiquo.py
+++ b/contrib/inventory/abiquo.py
@@ -44,10 +44,10 @@ imagetemplate: Creates a host group for each image template containing all hosts
 import os
 import sys
 import time
-import ConfigParser
 
 import json
 
+from ansible.module_utils.six.moves import configparser as ConfigParser
 from ansible.module_utils.urls import open_url
 
 

--- a/contrib/inventory/apache-libcloud.py
+++ b/contrib/inventory/apache-libcloud.py
@@ -35,9 +35,9 @@ import os
 import argparse
 import re
 from time import time
-import ConfigParser
 
-from six import iteritems, string_types
+from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils.six.moves import configparser as ConfigParser
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
 import libcloud.security as sec

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -201,14 +201,8 @@ import re
 import sys
 import inspect
 
-try:
-    # python2
-    import ConfigParser as cp
-except ImportError:
-    # python3
-    import configparser as cp
-
 from os.path import expanduser
+from ansible.module_utils.six.moves import configparser as cp
 import ansible.module_utils.six.moves.urllib.parse as urlparse
 
 HAS_AZURE = True

--- a/contrib/inventory/brook.py
+++ b/contrib/inventory/brook.py
@@ -79,10 +79,7 @@ Version: 0.2
 import sys
 import os
 
-try:
-    from ConfigParser import SafeConfigParser as ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+from ansible.module_utils.six.moves.configparser import SafeConfigParser as ConfigParser
 
 import json
 

--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -59,7 +59,6 @@ Changelog:
 ######################################################################
 
 import argparse
-import ConfigParser
 import os
 import re
 from time import time
@@ -67,7 +66,8 @@ import xmlrpclib
 
 import json
 
-from six import iteritems
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import configparser as ConfigParser
 
 # NOTE -- this file assumes Ansible is being accessed FROM the cobbler
 # server, so it does not attempt to login with a username and password.

--- a/contrib/inventory/collins.py
+++ b/contrib/inventory/collins.py
@@ -67,7 +67,6 @@ Tested against Ansible 1.8.2 and Collins 1.3.0.
 
 
 import argparse
-import ConfigParser
 import logging
 import os
 import re
@@ -77,8 +76,9 @@ import traceback
 
 import json
 
-from six import iteritems
-from six.moves.urllib.parse import urlencode
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import configparser as ConfigParser
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible.module_utils.urls import open_url
 

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -136,10 +136,7 @@ import re
 import argparse
 import sys
 
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+from ansible.module_utils.six.moves import configparser
 
 
 def get_log_filename():
@@ -201,7 +198,7 @@ except ImportError as e:
     sys.exit("""failed=True msg='python-consul required for this module.
 See https://python-consul.readthedocs.io/en/latest/#installation'""")
 
-from six import iteritems
+from ansible.module_utils.six import iteritems
 
 
 class ConsulInventory(object):

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -166,9 +166,10 @@ from boto import rds
 from boto import elasticache
 from boto import route53
 from boto import sts
-import six
 
+from ansible.module_utils import six
 from ansible.module_utils import ec2 as ec2_utils
+from ansible.module_utils.six.moves import configparser
 
 HAS_BOTO3 = False
 try:
@@ -177,7 +178,6 @@ try:
 except ImportError:
     pass
 
-from six.moves import configparser
 from collections import defaultdict
 
 import json

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -22,12 +22,6 @@
 # Stdlib imports
 # __future__ imports must occur at the beginning of file
 from __future__ import print_function
-try:
-    # Python 2 version
-    import ConfigParser
-except ImportError:
-    # Python 3 version
-    import configparser as ConfigParser
 import json
 import argparse
 import copy
@@ -47,6 +41,7 @@ if LooseVersion(requests.__version__) < LooseVersion('1.1.0'):
 from requests.auth import HTTPBasicAuth
 
 from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves import configparser as ConfigParser
 
 
 def json_format_dict(data, pretty=False):

--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 from ipalib import api, errors, __version__ as IPA_VERSION
-from six import u
+from ansible.module_utils.six import u
 
 
 def initialize():

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -80,10 +80,7 @@ import argparse
 
 from time import time
 
-if sys.version_info >= (3, 0):
-    import configparser
-else:
-    import ConfigParser as configparser
+from ansible.module_utils.six.moves import configparser
 
 import logging
 logging.getLogger('libcloud.common.google').addHandler(logging.NullHandler())

--- a/contrib/inventory/linode.py
+++ b/contrib/inventory/linode.py
@@ -108,7 +108,7 @@ except Exception:
 load_chube_config()
 
 # Imports for ansible
-import ConfigParser
+from ansible.module_utils.six.moves import configparser as ConfigParser
 
 
 class LinodeInventory(object):

--- a/contrib/inventory/lxd.py
+++ b/contrib/inventory/lxd.py
@@ -27,10 +27,8 @@ from subprocess import Popen, PIPE
 import distutils.spawn
 import sys
 import json
-try:
-    import configparser
-except Exception:
-    from six.moves import configparser
+
+from ansible.module_utils.six.moves import configparser
 
 # Set up defaults
 resource = 'local:'

--- a/contrib/inventory/mdt_dynamic_inventory.py
+++ b/contrib/inventory/mdt_dynamic_inventory.py
@@ -27,10 +27,7 @@ maintainer: J Barnett (github @jbarnett1981)
 import argparse
 import json
 import pymssql
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+from ansible.module_utils.six.moves import configparser
 
 
 class MDTInventory(object):

--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -36,11 +36,7 @@ import re
 import argparse
 import sys
 
-try:
-    import configparser
-except ImportError:
-    import ConfigParser
-    configparser = ConfigParser
+from ansible.module_utils.six.moves import configparser
 import json
 
 try:

--- a/contrib/inventory/nagios_ndo.py
+++ b/contrib/inventory/nagios_ndo.py
@@ -29,11 +29,7 @@ Configuration is read from `nagios_ndo.ini`.
 import os
 import argparse
 import sys
-try:
-    import configparser
-except ImportError:
-    import ConfigParser
-    configparser = ConfigParser
+from ansible.module_utils.six.moves import configparser
 import json
 
 try:

--- a/contrib/inventory/nsot.py
+++ b/contrib/inventory/nsot.py
@@ -148,7 +148,7 @@ from pynsot.client import get_api_client
 from pynsot.app import HttpServerError
 from click.exceptions import UsageError
 
-from six import string_types
+from ansible.module_utils.six import string_types
 
 
 def warning(*objs):

--- a/contrib/inventory/openshift.py
+++ b/contrib/inventory/openshift.py
@@ -32,10 +32,10 @@ import json
 import os
 import os.path
 import sys
-import ConfigParser
 import StringIO
 
 from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves import configparser as ConfigParser
 
 configparser = None
 

--- a/contrib/inventory/ovirt.py
+++ b/contrib/inventory/ovirt.py
@@ -68,8 +68,8 @@ USER_AGENT_VERSION = "v1"
 import sys
 import os
 import argparse
-import ConfigParser
 from collections import defaultdict
+from ansible.module_utils.six.moves import configparser as ConfigParser
 
 import json
 

--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -65,10 +65,7 @@ import sys
 
 from collections import defaultdict
 
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+from ansible.module_utils.six.moves import configparser
 
 import json
 

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -44,7 +44,7 @@ import argparse
 import re
 from time import time
 
-import ansible.module_utils.six
+from ansible.module_utils import six
 from ansible.module_utils.six.moves import configparser
 
 try:

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -43,9 +43,9 @@ import os
 import argparse
 import re
 from time import time
-import six
 
-from six.moves import configparser
+import ansible.module_utils.six
+from ansible.module_utils.six.moves import configparser
 
 try:
     import packet

--- a/contrib/inventory/proxmox.py
+++ b/contrib/inventory/proxmox.py
@@ -30,8 +30,8 @@ import os
 import sys
 from optparse import OptionParser
 
-from six import iteritems
-from six.moves.urllib.parse import urlencode
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible.module_utils.urls import open_url
 

--- a/contrib/inventory/rax.py
+++ b/contrib/inventory/rax.py
@@ -151,9 +151,9 @@ import sys
 import argparse
 import warnings
 import collections
-import ConfigParser
 
-from six import iteritems
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import configparser as ConfigParser
 
 import json
 

--- a/contrib/inventory/rudder.py
+++ b/contrib/inventory/rudder.py
@@ -53,7 +53,7 @@ import sys
 import os
 import re
 import argparse
-import six
+import ansible.module_utils.six
 import httplib2 as http
 from time import time
 from ansible.module_utils.six.moves import configparser

--- a/contrib/inventory/rudder.py
+++ b/contrib/inventory/rudder.py
@@ -53,9 +53,9 @@ import sys
 import os
 import re
 import argparse
-import ansible.module_utils.six
 import httplib2 as http
 from time import time
+from ansible.module_utils import six
 from ansible.module_utils.six.moves import configparser
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 

--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -41,7 +41,7 @@ all: Contains all hosts defined in Scaleway.
 import copy
 import os
 import requests
-import ansible.module_utils.six
+from ansible.module_utils import six
 from ansible.module_utils.six.moves import configparser
 import sys
 import time

--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -41,8 +41,8 @@ all: Contains all hosts defined in Scaleway.
 import copy
 import os
 import requests
-import six
-from six.moves import configparser
+import ansible.module_utils.six
+from ansible.module_utils.six.moves import configparser
 import sys
 import time
 import traceback

--- a/contrib/inventory/spacewalk.py
+++ b/contrib/inventory/spacewalk.py
@@ -47,10 +47,10 @@ import os
 import time
 from optparse import OptionParser
 import subprocess
-import ConfigParser
 import json
 
-from six import iteritems
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import configparser as ConfigParser
 
 
 base_dir = os.path.dirname(os.path.realpath(__file__))

--- a/contrib/inventory/vmware.py
+++ b/contrib/inventory/vmware.py
@@ -38,10 +38,9 @@ import ssl
 import sys
 import time
 
-from six import integer_types, text_type, string_types
-from six.moves import configparser
-
 from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.six import integer_types, text_type, string_types
+from ansible.module_utils.six.moves import configparser
 
 # Disable logging message trigged by pSphere/suds.
 try:

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -39,8 +39,9 @@ import uuid
 from time import time
 
 from jinja2 import Environment
-from six import integer_types, PY3
-from six.moves import configparser
+
+from ansible.module_utils.six import integer_types, PY3
+from ansible.module_utils.six.moves import configparser
 
 try:
     import argparse

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -38,10 +38,7 @@ from __future__ import print_function
 import os
 import sys
 import argparse
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+from ansible.module_utils.six.moves import configparser
 
 try:
     from zabbix_api import ZabbixAPI

--- a/contrib/vault/azure_vault.py
+++ b/contrib/vault/azure_vault.py
@@ -122,12 +122,7 @@ import sys
 import inspect
 from azure.keyvault import KeyVaultClient
 
-try:
-    # python2
-    import ConfigParser as cp
-except ImportError:
-    # python3
-    import configparser as cp
+from ansible.module_utils.six.moves import configparser as cp
 
 from os.path import expanduser
 import ansible.module_utils.six.moves.urllib.parse as urlparse

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -35,12 +35,12 @@ import jinja2
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from jinja2.runtime import Undefined
-from six import iteritems, string_types
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.module_utils.six import iteritems, string_types
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display

--- a/test/sanity/code-smell/use-compat-six.py
+++ b/test/sanity/code-smell/use-compat-six.py
@@ -11,25 +11,6 @@ def main():
         # digital_ocean is checking for six because dopy doesn't specify the
         # requirement on six so it needs to try importing six to give the correct error message
         'lib/ansible/modules/cloud/digital_ocean/digital_ocean.py',
-        # correct imports in the following files and remove them from this list
-        'contrib/inventory/apache-libcloud.py',
-        'contrib/inventory/cobbler.py',
-        'contrib/inventory/collins.py',
-        'contrib/inventory/consul_io.py',
-        'contrib/inventory/ec2.py',
-        'contrib/inventory/freeipa.py',
-        'contrib/inventory/lxd.py',
-        'contrib/inventory/nova.py',
-        'contrib/inventory/nsot.py',
-        'contrib/inventory/packet_net.py',
-        'contrib/inventory/proxmox.py',
-        'contrib/inventory/rax.py',
-        'contrib/inventory/rudder.py',
-        'contrib/inventory/scaleway.py',
-        'contrib/inventory/spacewalk.py',
-        'contrib/inventory/vmware.py',
-        'contrib/inventory/vmware_inventory.py',
-        'docs/bin/plugin_formatter.py',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():

--- a/test/sanity/code-smell/use-compat-six.py
+++ b/test/sanity/code-smell/use-compat-six.py
@@ -11,25 +11,6 @@ def main():
         # digital_ocean is checking for six because dopy doesn't specify the
         # requirement on six so it needs to try importing six to give the correct error message
         'lib/ansible/modules/cloud/digital_ocean/digital_ocean.py',
-        # correct imports in the following files and remove them from this list
-        # 'contrib/inventory/apache-libcloud.py',
-        # 'contrib/inventory/cobbler.py',
-        # 'contrib/inventory/collins.py',
-        # 'contrib/inventory/consul_io.py',
-        # 'contrib/inventory/ec2.py',
-        # 'contrib/inventory/freeipa.py',
-        # 'contrib/inventory/lxd.py',
-        # 'contrib/inventory/nova.py',
-        # 'contrib/inventory/nsot.py',
-        # 'contrib/inventory/packet_net.py',
-        # 'contrib/inventory/proxmox.py',
-        # 'contrib/inventory/rax.py',
-        # 'contrib/inventory/rudder.py',
-        # 'contrib/inventory/scaleway.py',
-        # 'contrib/inventory/spacewalk.py',
-        # 'contrib/inventory/vmware.py',
-        # 'contrib/inventory/vmware_inventory.py',
-        # 'docs/bin/plugin_formatter.py',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():

--- a/test/sanity/code-smell/use-compat-six.py
+++ b/test/sanity/code-smell/use-compat-six.py
@@ -11,6 +11,25 @@ def main():
         # digital_ocean is checking for six because dopy doesn't specify the
         # requirement on six so it needs to try importing six to give the correct error message
         'lib/ansible/modules/cloud/digital_ocean/digital_ocean.py',
+        # correct imports in the following files and remove them from this list
+        # 'contrib/inventory/apache-libcloud.py',
+        # 'contrib/inventory/cobbler.py',
+        # 'contrib/inventory/collins.py',
+        # 'contrib/inventory/consul_io.py',
+        # 'contrib/inventory/ec2.py',
+        # 'contrib/inventory/freeipa.py',
+        # 'contrib/inventory/lxd.py',
+        # 'contrib/inventory/nova.py',
+        # 'contrib/inventory/nsot.py',
+        # 'contrib/inventory/packet_net.py',
+        # 'contrib/inventory/proxmox.py',
+        # 'contrib/inventory/rax.py',
+        # 'contrib/inventory/rudder.py',
+        # 'contrib/inventory/scaleway.py',
+        # 'contrib/inventory/spacewalk.py',
+        # 'contrib/inventory/vmware.py',
+        # 'contrib/inventory/vmware_inventory.py',
+        # 'docs/bin/plugin_formatter.py',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():


### PR DESCRIPTION
##### SUMMARY
Use built-in `ansible.module_utils.six` and update all uses of `ConfigParser` to use `ansible.module_utils.six.moves`.
Also remove skips from sanity test.

Related to #54465

Ideally we would use the Python 3 name, `configparser`, everywhere. But since these are EOL, I made the minimal amount of changes to each file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`contrib/inventory/abiquo.py`
`contrib/inventory/apache-libcloud.py`
`contrib/inventory/azure_rm.py`
`contrib/inventory/brook.py`
`contrib/inventory/cobbler.py`
`contrib/inventory/collins.py`
`contrib/inventory/consul_io.py`
`contrib/inventory/ec2.py`
`contrib/inventory/foreman.py`
`contrib/inventory/freeipa.py`
`contrib/inventory/gce.py`
`contrib/inventory/linode.py`
`contrib/inventory/lxd.py`
`contrib/inventory/mdt_dynamic_inventory.py`
`contrib/inventory/nagios_livestatus.py`
`contrib/inventory/nagios_ndo.py`
`contrib/inventory/nsot.py`
`contrib/inventory/openshift.py`
`contrib/inventory/ovirt.py`
`contrib/inventory/ovirt4.py`
`contrib/inventory/packet_net.py`
`contrib/inventory/proxmox.py`
`contrib/inventory/rax.py`
`contrib/inventory/rudder.py`
`contrib/inventory/scaleway.py`
`contrib/inventory/spacewalk.py`
`contrib/inventory/vmware.py`
`contrib/inventory/vmware_inventory.py`
`contrib/inventory/zabbix.py`
`contrib/vault/azure_vault.py`
`docs/bin/plugin_formatter.py`
