### PR TITLE
ufw: fix default (again)

### DIFF
--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -471,14 +471,9 @@ def main():
                     current_default_values["incoming"] = extract.group(1)
                     current_default_values["outgoing"] = extract.group(2)
                     current_default_values["routed"] = extract.group(3)
-                    if params['direction'] is None:
-                        for v in current_default_values.values():
-                            if v not in (value, 'disabled'):
-                                changed = True
-                    else:
-                        v = current_default_values[params['direction']]
-                        if v not in (value, 'disabled'):
-                            changed = True
+                    v = current_default_values[params['direction'] or 'incoming']
+                    if v not in (value, 'disabled'):
+                        changed = True
                 else:
                     changed = True
             else:

--- a/test/integration/targets/ufw/aliases
+++ b/test/integration/targets/ufw/aliases
@@ -6,4 +6,3 @@ skip/docker
 needs/root
 destructive
 needs/target/setup_epel
-unstable  # the test fails when run in the group, but not by itself

--- a/test/integration/targets/ufw/tasks/tests/global-state.yml
+++ b/test/integration/targets/ufw/tasks/tests/global-state.yml
@@ -108,30 +108,30 @@
     default: deny
     direction: incoming
   register: default_change_2
-- name: Default (change all, check mode)
+- name: Default (change incoming implicitly, check mode)
   ufw:
     default: allow
   check_mode: yes
-  register: default_change_all_check
-- name: Default (change all)
+  register: default_change_implicit_check
+- name: Default (change incoming implicitly)
   ufw:
     default: allow
-  register: default_change_all
+  register: default_change_implicit
 - name: Get defaults
   shell: |
     ufw status verbose | grep "^Default:"
-  register: ufw_defaults_change_all
+  register: ufw_defaults_change_implicit
   environment:
     LC_ALL: C
-- name: Default (change all, idempotent, check mode)
+- name: Default (change incoming implicitly, idempotent, check mode)
   ufw:
     default: allow
   check_mode: yes
-  register: default_change_all_idem_check
-- name: Default (change all, idempotent)
+  register: default_change_implicit_idem_check
+- name: Default (change incoming implicitly, idempotent)
   ufw:
     default: allow
-  register: default_change_all_idem
+  register: default_change_implicit_idem
 - assert:
     that:
     - default_check is changed
@@ -143,9 +143,8 @@
     - default_change is changed
     - "'allow (incoming)' in ufw_defaults_change.stdout"
     - default_change_2 is changed
-    - default_change_all_check is changed
-    - default_change_all is changed
-    - default_change_all_idem_check is not changed
-    - default_change_all_idem is not changed
-    - "'allow (incoming)' in ufw_defaults_change_all.stdout"
-    - "'allow (outgoing)' in ufw_defaults_change_all.stdout"
+    - default_change_implicit_check is changed
+    - default_change_implicit is changed
+    - default_change_implicit_idem_check is not changed
+    - default_change_implicit_idem is not changed
+    - "'allow (incoming)' in ufw_defaults_change_implicit.stdout"


### PR DESCRIPTION
##### SUMMARY
Looks like the default behavior if no direction is specified is different as I assumed (and first passing tests indicated). I've now looked into ufw's code to find out what it actually does, and it turns out that it uses `incoming` as a default direction if none is specified: https://git.launchpad.net/ufw/tree/src/parser.py#n684 This is not specified in the documentation (or I wasn't able to find it).

CC @jbarotin

(No changelog since this is 2.8 only.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
