### PR TITLE
docker_swarm_service_info: Read information about swarm services

### DIFF
--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -249,3 +249,49 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
         if self.docker_py_version < LooseVersion('2.7.0'):
             return None
         return super(AnsibleDockerSwarmClient, self).get_unlock_key()
+
+    def get_all_services_inspect(self):
+        """
+        Returns Swarm service info as in 'docker service inspect' command about all registered services
+
+        :return:
+            Structure with information about all services
+        """
+        try:
+            service_info = self.services()
+        except APIError as exc:
+            if exc.status_code == 503:
+                self.fail("Cannot inspect service: To inspect service execute module on Swarm Manager")
+            self.fail("Error while reading from Swarm manager: %s" % to_native(exc))
+        except Exception as exc:
+            self.fail("Error inspecting swarm service: %s" % exc)
+
+        json_str = json.dumps(service_info, ensure_ascii=False)
+        service_info = json.loads(json_str)
+        return service_info
+
+    def get_service_inspect(self, service_id, skip_missing=False):
+        """
+        Returns Swarm service info as in 'docker service inspect' command about single service
+
+        :param service_id: service ID or name
+        :param skip_missing: if True then function will return None instead of failing the task
+        :return:
+            Single service information structure
+        """
+        try:
+            service_info = self.inspect_service(service=service_id)
+        except APIError as exc:
+            if exc.status_code == 503:
+                self.fail("Cannot inspect service: To inspect service execute module on Swarm Manager")
+            if exc.status_code == 404:
+                if skip_missing is False:
+                    self.fail("Error while reading from Swarm manager: %s" % to_native(exc))
+                else:
+                    return None
+        except Exception as exc:
+            self.fail("Error inspecting swarm service: %s" % exc)
+
+        json_str = json.dumps(service_info, ensure_ascii=False)
+        service_info = json.loads(json_str)
+        return service_info

--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -4,7 +4,6 @@
 
 import json
 from time import sleep
-from re import split
 
 try:
     from docker.errors import APIError

--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -249,26 +249,6 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
             return None
         return super(AnsibleDockerSwarmClient, self).get_unlock_key()
 
-    def get_all_services_inspect(self):
-        """
-        Returns Swarm service info as in 'docker service inspect' command about all registered services
-
-        :return:
-            Structure with information about all services
-        """
-        try:
-            service_info = self.services()
-        except APIError as exc:
-            if exc.status_code == 503:
-                self.fail("Cannot inspect service: To inspect service execute module on Swarm Manager")
-            self.fail("Error while reading from Swarm manager: %s" % to_native(exc))
-        except Exception as exc:
-            self.fail("Error inspecting swarm service: %s" % exc)
-
-        json_str = json.dumps(service_info, ensure_ascii=False)
-        service_info = json.loads(json_str)
-        return service_info
-
     def get_service_inspect(self, service_id, skip_missing=False):
         """
         Returns Swarm service info as in 'docker service inspect' command about single service

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+#
+# (c) 2019 Hannes Ljungberg <hannes.ljungberg@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: docker_swarm_service_info
+
+short_description: Retrieves information about docker services from a Swarm Manager
+
+description:
+  - Retrieves information about a docker service.
+  - Essentially returns the output of C(docker service inspect <name>).
+  - Must be executed on a host running as Swarm Manager, otherwise the module will fail.
+
+version_added: "2.8"
+
+options:
+  name:
+    description:
+      - The name of the service to inspect.
+      - A list of service names to inspect.
+      - If empty it will return information of all services in the swarm.
+    type: list
+extends_documentation_fragment:
+  - docker
+  - docker.docker_py_1_documentation
+
+author:
+  - Hannes Ljungberg (@hannseman)
+
+requirements:
+  - "L(Docker SDK for Python,https://docker-py.readthedocs.io/en/stable/) >= 2.0.0"
+  - "Docker API >= 1.24"
+'''
+
+EXAMPLES = '''
+- name: Get info from all services
+  docker_swarm_service_info:
+  register: result
+
+- name: Get info from a single service
+  docker_swarm_service_info:
+    name: myservice
+  register: result
+
+- name: Get info from a list of services
+  docker_swarm_service_info:
+    name:
+      - myservice1
+      - myservice2
+  register: result
+'''
+
+RETURN = '''
+services:
+    description:
+      - Facts representing the current state of the services. Matches the C(docker service inspect) output.
+      - Can contain multiple entries if more than one service provided in I(name), or I(name) is not provided.
+    returned: always
+    type: list
+'''
+
+from ansible.module_utils.docker.swarm import AnsibleDockerSwarmClient
+
+
+def get_service_info(client):
+    results = []
+
+    if client.module.params['name'] is None:
+        service_info = client.get_all_services_inspect()
+        return service_info
+
+    services = client.module.params['name']
+    if not isinstance(services, list):
+        services = [services]
+
+    for service in services:
+        service_info = client.get_service_inspect(
+            service_id=service,
+            skip_missing=True
+        )
+        if service_info:
+            results.append(service_info)
+    return results
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type='list', elements='str'),
+    )
+
+    client = AnsibleDockerSwarmClient(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        min_docker_version='2.0.0',
+        min_docker_api_version='1.24',
+    )
+
+    client.fail_task_if_not_swarm_manager()
+
+    services = get_service_info(client)
+
+    client.module.exit_json(
+        changed=False,
+        services=services,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
@@ -31,6 +31,7 @@ options:
     description:
       - The name of the service to inspect.
     type: str
+    required: yes
 extends_documentation_fragment:
   - docker
   - docker.docker_py_1_documentation
@@ -78,7 +79,7 @@ def get_service_info(client):
 
 def main():
     argument_spec = dict(
-        name=dict(type='str'),
+        name=dict(type='str', required=True),
     )
 
     client = AnsibleDockerSwarmClient(

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
@@ -51,6 +51,12 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+exists:
+    description:
+      - Returns whether the service exists.
+    type: bool
+    returned: always
+    sample: true
 service:
     description:
       - A dictionary representing the current state of the service. Matches the C(docker service inspect) output.
@@ -89,6 +95,7 @@ def main():
     client.module.exit_json(
         changed=False,
         service=service,
+        exists=bool(service)
     )
 
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service_info.py
@@ -60,7 +60,7 @@ exists:
 service:
     description:
       - A dictionary representing the current state of the service. Matches the C(docker service inspect) output.
-      - Will be C(None) if service does not exist.
+      - Will be C(none) if service does not exist.
     returned: always
     type: dict
 '''

--- a/test/integration/targets/docker_swarm_service_info/aliases
+++ b/test/integration/targets/docker_swarm_service_info/aliases
@@ -1,0 +1,7 @@
+shippable/posix/group3
+skip/osx
+skip/freebsd
+destructive
+skip/docker  # The tests sometimes make docker daemon unstable; hence,
+             # we skip all docker-based CI runs to avoid disrupting
+             # the whole CI system.

--- a/test/integration/targets/docker_swarm_service_info/meta/main.yml
+++ b/test/integration/targets/docker_swarm_service_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/docker_swarm_service_info/tasks/main.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/main.yml
@@ -1,0 +1,5 @@
+- include_tasks: test_docker_swarm_service_info.yml
+  when: docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.24', '>=')
+
+- fail: msg="Too old docker / docker-py version to run docker_swarm_service_info tests!"
+  when: not(docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.24', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm_service_info/tasks/main.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - include_tasks: test_docker_swarm_service_info.yml
   when: docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.24', '>=')
 

--- a/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
@@ -6,9 +6,7 @@
 
 - name: Registering service names
   set_fact:
-    service_name_1: "{{ service_base_name ~ '-1' }}"
-    service_name_2: "{{ service_base_name ~ '-2' }}"
-    service_name_3: "{{ service_base_name ~ '-3' }}"
+    service_name: "{{ service_base_name ~ '-1' }}"
 
 - block:
   - name: Make sure we're not already using Docker swarm
@@ -18,6 +16,7 @@
 
   - name: Try to get docker_swarm_service_info when docker is not running in swarm mode
     docker_swarm_service_info:
+      name: "{{ service_name }}"
     ignore_errors: yes
     register: output
 
@@ -36,49 +35,17 @@
     docker_swarm_service:
       name: "{{ service_name }}"
       image: alpine:3.8
-    loop:
-      - "{{ service_name_1 }}"
-      - "{{ service_name_2 }}"
-      - "{{ service_name_3 }}"
-    loop_control:
-      loop_var: service_name
 
   - name: Try to get docker_swarm_service_info for a single service
     docker_swarm_service_info:
-      name: "{{ service_name_1 }}"
+      name: "{{ service_name }}"
     register: output
 
   - name: assert reading reading service info
     assert:
       that:
-        - 'output.services|length == 1'
-        - 'output.services[0].ID is string'
-
-  - name: Try to get docker_swarm_service_info for all services
-    docker_swarm_service_info:
-    register: output
-
-  - name: assert reading reading service info
-    assert:
-      that:
-        - 'output.services|length == 3'
-        - 'output.services[0].ID is string'
-        - 'output.services[1].ID is string'
-        - 'output.services[2].ID is string'
-
-  - name: Try to get docker_swarm_service_info for multiple services
-    docker_swarm_service_info:
-      name:
-        - "{{ service_name_1 }}"
-        - "{{ service_name_2 }}"
-    register: output
-
-  - name: assert reading reading service info
-    assert:
-      that:
-        - 'output.services|length == 2'
-        - 'output.services[0].ID is string'
-        - 'output.services[1].ID is string'
+        - 'output.service.ID is string'
+        - 'output.service.Spec.Name == service_name'
 
   - name: Create random name
     set_fact:
@@ -92,18 +59,13 @@
   - name: assert reading reading service info
     assert:
       that:
-        - 'output.services|length == 0'
+        - 'output.service is none'
 
   always:
     - name: Remove services
       docker_swarm_service:
         name: "{{ service_name }}"
         state: absent
-      loop:
-        - "{{ service_name_1 }}"
-        - "{{ service_name_2 }}"
-      loop_control:
-        loop_var: service_name
       ignore_errors: yes
 
     - name: Remove swarm

--- a/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
@@ -44,6 +44,7 @@
   - name: assert reading reading service info
     assert:
       that:
+        - 'output.exists == true'
         - 'output.service.ID is string'
         - 'output.service.Spec.Name == service_name'
 
@@ -60,6 +61,7 @@
     assert:
       that:
         - 'output.service is none'
+        - 'output.exists == false'
 
   always:
     - name: Remove services

--- a/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
@@ -1,0 +1,112 @@
+---
+
+- name: Generate service base name
+  set_fact:
+    service_base_name: "{{ 'ansible-test-%0x' % ((2**32) | random) }}"
+
+- name: Registering service names
+  set_fact:
+    service_name_1: "{{ service_base_name ~ '-1' }}"
+    service_name_2: "{{ service_base_name ~ '-2' }}"
+    service_name_3: "{{ service_base_name ~ '-3' }}"
+
+- block:
+  - name: Make sure we're not already using Docker swarm
+    docker_swarm:
+      state: absent
+      force: true
+
+  - name: Try to get docker_swarm_service_info when docker is not running in swarm mode
+    docker_swarm_service_info:
+    ignore_errors: yes
+    register: output
+
+  - name: assert failure when called when swarm is not in use or not run on manager node
+    assert:
+      that:
+        - 'output is failed'
+        - 'output.msg == "Error running docker swarm module: must run on swarm manager node"'
+
+  - name: Create a Swarm cluster
+    docker_swarm:
+      state: present
+    register: output
+
+  - name: Create services
+    docker_swarm_service:
+      name: "{{ service_name }}"
+      image: alpine:3.8
+    loop:
+      - "{{ service_name_1 }}"
+      - "{{ service_name_2 }}"
+      - "{{ service_name_3 }}"
+    loop_control:
+      loop_var: service_name
+
+  - name: Try to get docker_swarm_service_info for a single service
+    docker_swarm_service_info:
+      name: "{{ service_name_1 }}"
+    register: output
+
+  - name: assert reading reading service info
+    assert:
+      that:
+        - 'output.services|length == 1'
+        - 'output.services[0].ID is string'
+
+  - name: Try to get docker_swarm_service_info for all services
+    docker_swarm_service_info:
+    register: output
+
+  - name: assert reading reading service info
+    assert:
+      that:
+        - 'output.services|length == 3'
+        - 'output.services[0].ID is string'
+        - 'output.services[1].ID is string'
+        - 'output.services[2].ID is string'
+
+  - name: Try to get docker_swarm_service_info for multiple services
+    docker_swarm_service_info:
+      name:
+        - "{{ service_name_1 }}"
+        - "{{ service_name_2 }}"
+    register: output
+
+  - name: assert reading reading service info
+    assert:
+      that:
+        - 'output.services|length == 2'
+        - 'output.services[0].ID is string'
+        - 'output.services[1].ID is string'
+
+  - name: Create random name
+    set_fact:
+      random_service_name: "{{ 'random-service-%0x' % ((2**32) | random) }}"
+
+  - name: Try to get docker_swarm_service_info using random service name as parameter
+    docker_swarm_service_info:
+      name: "{{ random_service_name }}"
+    register: output
+
+  - name: assert reading reading service info
+    assert:
+      that:
+        - 'output.services|length == 0'
+
+  always:
+    - name: Remove services
+      docker_swarm_service:
+        name: "{{ service_name }}"
+        state: absent
+      loop:
+        - "{{ service_name_1 }}"
+        - "{{ service_name_2 }}"
+      loop_control:
+        loop_var: service_name
+      ignore_errors: yes
+
+    - name: Remove swarm
+      docker_swarm:
+        state: absent
+        force: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR adds a new module for reading information from docker swarm services. It reflects the `docker service inspect` command in CLI and `GET /services/{id}` in the Docker API.

I followed the structure of previous docker-related `*_info` modules and added two methods for inspecting services in `AnsibleDockerSwarmClient`. 

Not really sure why the `json.dumps` and `json.loads` are used on the return value from docker-py, I added it to this implementation as well as it's used throughout `AnsibleDockerSwarmClient` but I'm quite interested in why it's needed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service_info