### PR TITLE
Update win_firewall_rule.py to include ICMP echo (ping)  example

### DIFF
--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -133,6 +133,7 @@ EXAMPLES = r'''
     profiles: private
     state: present
     enabled: yes
+<<<<<<< HEAD
 
 - name: Firewall rule to be created for application group
   win_firewall_rule:
@@ -155,7 +156,8 @@ EXAMPLES = r'''
     state: present
     enabled: yes
 
- - name: Firewall rule to allow ICMP v4 echo (ping) 
+- name: Firewall rule to allow ICMP v4 echo (ping) 
+>>>>>>> Remove yaml-breaking space
   win_firewall_rule:
     name: ICMP Allow incoming V4 echo request
     enabled: yes

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -133,7 +133,6 @@ EXAMPLES = r'''
     profiles: private
     state: present
     enabled: yes
-<<<<<<< HEAD
 
 - name: Firewall rule to be created for application group
   win_firewall_rule:
@@ -156,8 +155,7 @@ EXAMPLES = r'''
     state: present
     enabled: yes
 
-- name: Firewall rule to allow ICMP v4 echo (ping) 
->>>>>>> Remove yaml-breaking space
+- name: Firewall rule to allow ICMP v4 echo (ping)
   win_firewall_rule:
     name: ICMP Allow incoming V4 echo request
     enabled: yes

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -144,6 +144,7 @@ EXAMPLES = r'''
     protocol: tcp
     state: present
     enabled: yes
+
 - name: Firewall rule to allow port range
   win_firewall_rule:
     name: Sample port range
@@ -153,4 +154,14 @@ EXAMPLES = r'''
     protocol: tcp
     state: present
     enabled: yes
+
+ - name: Firewall rule to allow ICMP v4 echo (ping) 
+  win_firewall_rule:
+    name: ICMP Allow incoming V4 echo request
+    enabled: yes
+    state: present
+    profiles: private
+    action: allow
+    direction: in
+    protocol: "icmpv4:8,any"
 '''


### PR DESCRIPTION
<!--- Your description here -->
Added example of enabling ICMP protocol, as ping is commonly used for troubleshooting in automation scenarios.  Equivalent netsh command is: 
netsh advfirewall firewall add rule name='ICMP Allow incoming V4 echo request' protocol=icmpv4:8,any dir=in action=allow

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
