### PR TITLE
Mark ufw integration test unstable.

### DIFF
--- a/test/integration/targets/ufw/aliases
+++ b/test/integration/targets/ufw/aliases
@@ -6,3 +6,4 @@ skip/docker
 needs/root
 destructive
 needs/target/setup_epel
+unstable  # the test fails when run in the group, but not by itself


### PR DESCRIPTION
##### SUMMARY

Mark ufw integration test unstable.

The test fails when run in the group, but not by itself on RHEL 7.6.

Example of the failure: https://app.shippable.com/github/ansible/ansible/runs/118239/62/console

```
16:59 TASK [ufw : assert] ************************************************************
16:59 task path: /root/.ansible/test/tmp/ufw-IadTKz-ÅÑŚÌβŁÈ/test/integration/targets/ufw/tasks/tests/global-state.yml:135
16:59 fatal: [testhost]: FAILED! => {
16:59     "assertion": "default_change_all_idem_check is not changed", 
16:59     "changed": false, 
16:59     "evaluated_to": false, 
16:59     "msg": "Assertion failed"
16:59 }
```

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ufw integration test
