### PR TITLE
Module kubernetes: Added support for 'kind: NetworkPolicy'

### DIFF
--- a/lib/ansible/modules/clustering/k8s/_kubernetes.py
+++ b/lib/ansible/modules/clustering/k8s/_kubernetes.py
@@ -226,6 +226,7 @@ KIND_URL = {
     "horizontalpodautoscaler": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers",  # NOQA
     "ingress": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
     "job": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs",
+    "networkpolicy": "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies",
 }
 USER_AGENT = "ansible-k8s-module/0.0.1"
 


### PR DESCRIPTION
added support for 'kind: networkpolicy'

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for objects of kind NetworkPolicy in the 'kubernetes' module.
Fixes ansible#55020
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kubernetes
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I added the API endpoint for NetworkPolicies in the KIND_URL variable
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
