### PR TITLE
VMware: Add check for valid VLAN id range

### DIFF
--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -98,7 +98,7 @@
     password: "{{ vcsim_instance['json']['password'] }}"
     switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
     portgroup_name: "basic-trunk"
-    vlan_id: 1-4096
+    vlan_id: 1-4094
     vlan_trunk: True
     num_ports: 32
     portgroup_type: earlyBinding
@@ -231,3 +231,26 @@
   assert:
     that:
         - "{{ dvs_pg_result_0008.changed == false }}"
+
+# Testcase 0009: Check valid VLAN id range in DVS Portgroup
+- name: Check valid VLAN id range in DVS Portgroup
+  vmware_dvs_portgroup:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    portgroup_name: "basic_trunk_0001"
+    vlan_id: 1-4096
+    vlan_trunk: True
+    num_ports: 32
+    portgroup_type: earlyBinding
+    state: present
+  register: dvs_pg_result_0009
+  ignore_errors: True
+
+- name: Ensure module fails for invalid VLAN id
+  assert:
+    that:
+        - not dvs_pg_result_0009.changed
+        - "'vlan_id range 1-4096 specified is incorrect. The valid vlan_id range is from 0 to 4094.' == '{{ dvs_pg_result_0009.msg }}'"


### PR DESCRIPTION
##### SUMMARY
Check allows vmware_dvs_portgroup to fail early if user
specified invalid range in VLAN id(s).

Fixes: #54927

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
test/integration/targets/vmware_dvs_portgroup/tasks/main.yml