### PR TITLE
Renaming idrac_pwd to idrac_password

### DIFF
--- a/lib/ansible/module_utils/remote_management/dellemc/dellemc_idrac.py
+++ b/lib/ansible/module_utils/remote_management/dellemc/dellemc_idrac.py
@@ -32,7 +32,7 @@ class iDRACConnection:
             raise ImportError("Dell EMC OMSDK library is required for this module")
         self.idrac_ip = module_params['idrac_ip']
         self.idrac_user = module_params['idrac_user']
-        self.idrac_pwd = module_params['idrac_pwd']
+        self.idrac_pwd = module_params['idrac_password']
         self.idrac_port = module_params['idrac_port']
         if not all((self.idrac_ip, self.idrac_user, self.idrac_pwd)):
             raise ValueError("hostname, username and password required")

--- a/lib/ansible/modules/remote_management/dellemc/idrac/idrac_firmware.py
+++ b/lib/ansible/modules/remote_management/dellemc/idrac/idrac_firmware.py
@@ -39,7 +39,7 @@ options:
         description: iDRAC username.
         type: str
         required: True
-    idrac_pwd:
+    idrac_password:
         description: iDRAC user password.
         type: str
         required: True
@@ -55,7 +55,7 @@ options:
         description: Network share user in the format 'user@domain' or 'domain\\user' if user is
             part of a domain else 'user'. This option is mandatory for CIFS Network Share.
         type: str
-    share_pwd:
+    share_password:
         description: Network share user password. This option is mandatory for CIFS Network Share.
         type: str
     share_mnt:
@@ -89,10 +89,10 @@ EXAMPLES = """
   idrac_firmware:
        idrac_ip: "192.168.0.1"
        idrac_user: "user_name"
-       idrac_pwd: "user_pwd"
+       idrac_password: "user_password"
        share_name: "192.168.0.0:/share"
        share_user: "share_user_name"
-       share_pwd: "share_user_pwd"
+       share_password: "share_user_pwd"
        share_mnt: "/mnt/share"
        reboot: True
        job_wait: True
@@ -152,7 +152,7 @@ def update_firmware(idrac, module):
                                 isFolder=False,
                                 creds=UserCredentials(
                                     module.params['share_user'],
-                                    module.params['share_pwd'])
+                                    module.params['share_password'])
                                 )
 
         idrac.use_redfish = True
@@ -181,12 +181,12 @@ def main():
         argument_spec={
             "idrac_ip": {"required": True, "type": 'str'},
             "idrac_user": {"required": True, "type": 'str'},
-            "idrac_pwd": {"required": True, "type": 'str', "no_log": True},
+            "idrac_password": {"required": True, "type": 'str', "no_log": True},
             "idrac_port": {"required": False, "default": 443, "type": 'int'},
 
             "share_name": {"required": True, "type": 'str'},
             "share_user": {"required": False, "type": 'str'},
-            "share_pwd": {"required": False, "type": 'str', "no_log": True},
+            "share_password": {"required": False, "type": 'str', "no_log": True},
             "share_mnt": {"required": True, "type": 'str'},
 
             "catalog_file_name": {"required": False, "type": 'str', "default": "Catalog.xml"},


### PR DESCRIPTION
ie idrac_pwd to idrac_password
share_pwd to share_password

##### SUMMARY
idrac_server_config_profile module has a option "idrac_password" but the module_utils class still having "idrac_pwd" which is a bug

So, as per core team comments changing 'idrac_pwd" to "idrac_password" in module_utils/dellemc_idrac.py class and adhering same change in idrac_firmware.py module as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
idrac_firmware.py
module_utils/dellemc_idrac.py

##### ADDITIONAL INFORMATION

