### PR TITLE
VMware: Rename results key to ansible_module_results

### DIFF
--- a/changelogs/fragments/55038-rename-results-key-vmware-guest.yml
+++ b/changelogs/fragments/55038-rename-results-key-vmware-guest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - The internal key `result` in vmware_guest return renamed to `ansible_module_results`

--- a/changelogs/fragments/55038-rename-results-key-vmware-guest.yml
+++ b/changelogs/fragments/55038-rename-results-key-vmware-guest.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - The internal key `result` in vmware_guest return renamed to `snapshot_results`
+  - The internal key `results` in vmware_guest_snapshot module return renamed to `snapshot_results`.

--- a/changelogs/fragments/55038-rename-results-key-vmware-guest.yml
+++ b/changelogs/fragments/55038-rename-results-key-vmware-guest.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - The internal key `result` in vmware_guest return renamed to `ansible_module_results`
+  - The internal key `result` in vmware_guest return renamed to `snapshot_results`

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -304,7 +304,7 @@ Noteworthy module changes
 * ``vmware_vm_facts`` used to return dict of dict with virtual machine's facts. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
   Please see module ``vmware_vm_facts`` documentation for example.
 
-* ``vmware_guest_snapshots`` module used to return result. Since Ansible 2.8 and onwards result is replaced by snapshot_results.
+* ``vmware_guest_snapshot`` module used to return ``results``. Since Ansible 2.8 and onwards ``results`` is a reserved keyword, it is replaced by ``snapshot_results``.
   Please see module ``vmware_guest_snapshots`` documentation for example.
 
 * The ``panos`` modules have been deprecated in favor of using the Palo Alto Networks `Ansible Galaxy role

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -304,6 +304,9 @@ Noteworthy module changes
 * ``vmware_vm_facts`` used to return dict of dict with virtual machine's facts. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
   Please see module ``vmware_vm_facts`` documentation for example.
 
+* ``vmware_guest_snapshots`` used to return res. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
+  Please see module ``vmware_vm_facts`` documentation for example.
+
 * The ``panos`` modules have been deprecated in favor of using the Palo Alto Networks `Ansible Galaxy role
   <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.  Contributions to the role can be made
   `here <https://github.com/PaloAltoNetworks/ansible-pan>`_.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -304,8 +304,8 @@ Noteworthy module changes
 * ``vmware_vm_facts`` used to return dict of dict with virtual machine's facts. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
   Please see module ``vmware_vm_facts`` documentation for example.
 
-* ``vmware_guest_snapshots`` used to return res. Ansible 2.8 and onwards will return list of dict with virtual machine's facts.
-  Please see module ``vmware_vm_facts`` documentation for example.
+* ``vmware_guest_snapshots`` module used to return result. Since Ansible 2.8 and onwards result is replaced by snapshot_results.
+  Please see module ``vmware_guest_snapshots`` documentation for example.
 
 * The ``panos`` modules have been deprecated in favor of using the Palo Alto Networks `Ansible Galaxy role
   <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.  Contributions to the role can be made

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -361,7 +361,7 @@ class PyVmomiHelper(PyVmomi):
             if task.info.state == 'error':
                 result = {'changed': False, 'failed': True, 'msg': task.info.error.msg}
             else:
-                result = {'changed': True, 'failed': False, 'ansible_module_results': list_snapshots(vm)}
+                result = {'changed': True, 'failed': False, 'snapshot_results': list_snapshots(vm)}
 
         return result
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -361,7 +361,7 @@ class PyVmomiHelper(PyVmomi):
             if task.info.state == 'error':
                 result = {'changed': False, 'failed': True, 'msg': task.info.error.msg}
             else:
-                result = {'changed': True, 'failed': False, 'results': list_snapshots(vm)}
+                result = {'changed': True, 'failed': False, 'ansible_module_results': list_snapshots(vm)}
 
         return result
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -218,11 +218,35 @@ EXAMPLES = '''
 '''
 
 RETURN = """
-instance:
-    description: metadata about the new virtual machine snapshot
+snapshot_results:
+    description: metadata about the virtual machine snapshots
     returned: always
     type: dict
-    sample: None
+    sample: {
+      "current_snapshot": {
+          "creation_time": "2019-04-09T14:40:26.617427+00:00",
+          "description": "Snapshot 4 example",
+          "id": 4,
+          "name": "snapshot4",
+          "state": "poweredOff"
+      },
+      "snapshots": [
+          {
+              "creation_time": "2019-04-09T14:38:24.667543+00:00",
+              "description": "Snapshot 3 example",
+              "id": 3,
+              "name": "snapshot3",
+              "state": "poweredOff"
+          },
+          {
+              "creation_time": "2019-04-09T14:40:26.617427+00:00",
+              "description": "Snapshot 4 example",
+              "id": 4,
+              "name": "snapshot4",
+              "state": "poweredOff"
+          }
+      ]
+    }
 """
 
 import time


### PR DESCRIPTION
##### SUMMARY
Rename results key to ansible_module_results as shown when running the alpha version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_snapshot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [../win-cmdb-state-sync/ : Snapshot state = present] **********************************
 [WARNING]: Found internal 'results' key in module return, renamed to 'ansible_module_results'.

changed: [test]
```

```
TASK [../win-cmdb-state-sync/ : Snapshot state = present] ********************************
changed: [test -> localhost]
```
