### PR TITLE
VMware: Fixes Python3 compatibility of vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1603,8 +1603,9 @@ class PyVmomiHelper(PyVmomi):
 
             # Setting hostName, orgName and fullName is mandatory, so we set some default when missing
             ident.userData.computerName = vim.vm.customization.FixedName()
+            # Strips punctuation from string in a Python2 and Python3 compatible way
+            default_name = re.sub(r'[^\w\s]', '', self.params['name'])
             # computer name will be truncated to 15 characters if using VM name
-            default_name = self.params['name'].translate(None, string.punctuation)
             ident.userData.computerName.name = str(self.params['customization'].get('hostname', default_name[0:15]))
             ident.userData.fullName = str(self.params['customization'].get('fullname', 'Administrator'))
             ident.userData.orgName = str(self.params['customization'].get('orgname', 'ACME'))


### PR DESCRIPTION
##### SUMMARY
Fix of previous PR: #51215

This allows the code to run on Python2 and Python3. For some more background information see:
https://stackoverflow.com/questions/23175809/str-translate-gives-typeerror-translate-takes-one-argument-2-given-worked-i

This uses the helper method maketrans() which is available in Python 2([docs](https://docs.python.org/2.7/library/string.html#string.maketrans)) and Python 3([docs](https://docs.python.org/3/library/stdtypes.html?highlight=maketrans#str.maketrans)):

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
```paste below
TASK [../win-cmdb-state-sync/ : Sync virtual machine compute and network with state] *******************************************************************************************************************************************************************************************************************************************
task path: /c/Users/wilmaro/Development/Intermax/Gitlab/configuration-management/roles/win-cmdb-state-sync/tasks/vmware/guest.yml:19
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: wilmardo
<localhost> EXEC /bin/sh -c 'echo ~wilmardo && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748 `" && echo ansible-tmp-1554812000.5973012-275822956085748="` echo /c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748 `" ) && sleep 0'
Using module file /c/Users/wilmaro/Development/Intermax/Gitlab/configuration-management/roles/win-cmdb-state-sync/venv/lib/python3.6/site-packages/ansible/modules/cloud/vmware/vmware_guest.py
<localhost> PUT /c/Users/wilmaro/.ansible/tmp/ansible-local-9554iow96d17/tmp2oc3e07x TO /c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py
<localhost> EXEC /bin/sh -c 'chmod u+x /c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/ /c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py && sleep 0'
<localhost> EXEC /bin/sh -c '/c/Users/wilmaro/Development/Intermax/Gitlab/configuration-management/roles/win-cmdb-state-sync/venv/bin/python3 /c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py", line 114, in <module>
    _ansiballz_main()
  File "/c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py", line 106, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py", line 49, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/usr/lib/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.6/imp.py", line 170, in load_source
    module = _exec(spec, sys.modules[name])
  File "<frozen importlib._bootstrap>", line 618, in _exec
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py", line 2645, in <module>
  File "/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py", line 2634, in main
  File "/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py", line 2164, in deploy_vm
  File "/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py", line 1599, in customize_vm
TypeError: translate() takes exactly one argument (2 given)

fatal: [test]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/c/Users/wilmaro/.ansible/tmp/ansible-tmp-1554812000.5973012-275822956085748/AnsiballZ_vmware_guest.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.6/imp.py\", line 235, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.6/imp.py\", line 170, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 618, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py\", line 2645, in <module>\n  File \"/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py\", line 2634, in main\n  File \"/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py\", line 2164, in deploy_vm\n  File \"/tmp/ansible_vmware_guest_payload_02msqm2_/__main__.py\", line 1599, in customize_vm\nTypeError: translate() takes exactly one argument (2 given)\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
