### PR TITLE
Only show a task banner if a diff is found

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -239,18 +239,19 @@ class CallbackModule(CallbackBase):
         self._display.banner(msg)
 
     def v2_on_file_diff(self, result):
-        if self._last_task_banner != result._task._uuid:
-            self._print_task_banner(result._task)
-
         if result._task.loop and 'results' in result._result:
             for res in result._result['results']:
                 if 'diff' in res and res['diff'] and res.get('changed', False):
                     diff = self._get_diff(res['diff'])
                     if diff:
+                        if self._last_task_banner != result._task._uuid:
+                            self._print_task_banner(result._task)
                         self._display.display(diff)
         elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
             diff = self._get_diff(result._result['diff'])
             if diff:
+                if self._last_task_banner != result._task._uuid:
+                    self._print_task_banner(result._task)
                 self._display.display(diff)
 
     def v2_runner_item_on_ok(self, result):


### PR DESCRIPTION
##### SUMMARY
Only show a task banner if a diff is found. This prevents the task banner from being shown on ok/skipped tasks when using `ANSIBLE_DISPLAY_OK_HOSTS=false` and/or `ANSIBLE_DISPLAY_SKIPPED_HOSTS=false`.

Fixes #55030 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
default callback plugin

##### ADDITIONAL INFORMATION
N/A