### PR TITLE
fixes formatting on local-testing page

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -71,10 +71,10 @@ Add the ``--coverage`` option to any test command to collect code coverage data.
 aren't using the ``--tox`` or ``--docker`` options which create an isolated python
 environment then you may have to use the ``--requirements`` option to ensure that the
 correct version of the coverage module is installed::
+
    ansible-test units --coverage apt
    ansible-test integration --coverage aws_lambda --tox --requirements
    ansible-test coverage html
-
 
 Reports can be generated in several different formats:
 

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -71,7 +71,6 @@ Add the ``--coverage`` option to any test command to collect code coverage data.
 aren't using the ``--tox`` or ``--docker`` options which create an isolated python
 environment then you may have to use the ``--requirements`` option to ensure that the
 correct version of the coverage module is installed::
-
    ansible-test units --coverage apt
    ansible-test integration --coverage aws_lambda --tox --requirements
    ansible-test coverage html


### PR DESCRIPTION
##### SUMMARY
Closes #54527 

Due to an extra newline, one section of the dev_guide page on testing locally was not formatting correctly as code.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
