### PR TITLE
return actual error from module logic on gcp_compute

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -131,7 +131,7 @@ class GcpMockModule(object):
         self.params = params
 
     def fail_json(self, *args, **kwargs):
-        raise AnsibleError(kwargs['msg'])
+        raise ValueError(kwargs['msg'])
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -131,7 +131,6 @@ except ImportError:
     raise AnsibleError('The gcp dynamic inventory plugin requires the requests and google-auth libraries')
 
 
-
 # Mocking a module to reuse module_utils
 class GcpMockModule(object):
     def __init__(self, params):

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -124,6 +124,13 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.gcp_utils import GcpSession, navigate_hash, GcpRequestException
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
+try:
+    import google.auth
+    import requests
+except ImportError:
+    raise AnsibleError('The gcp dynamic inventory plugin requires the requests and google-auth libraries')
+
+
 
 # Mocking a module to reuse module_utils
 class GcpMockModule(object):
@@ -131,7 +138,7 @@ class GcpMockModule(object):
         self.params = params
 
     def fail_json(self, *args, **kwargs):
-        raise ValueError(kwargs['msg'])
+        raise AnsibleError(kwargs['msg'])
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):


### PR DESCRIPTION
##### SUMMARY
This should fix #54342 by reporting the actual error message when libraries aren't installed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`gcp_compute`

##### ADDITIONAL INFORMATION
Output:

```
 [WARNING]:  * Failed to parse /Users/alexstephen/ansible/gcp.yml with auto plugin: Please install the requests library

 [WARNING]:  * Failed to parse /Users/alexstephen/ansible/gcp.yml with yaml plugin: Plugin configuration YAML file, not YAML inventory

 [WARNING]:  * Failed to parse /Users/alexstephen/ansible/gcp.yml with ini plugin: Invalid host pattern 'plugin:' supplied, ending in ':' is not allowed, this character is reserved to provide a port.

 [WARNING]: Unable to parse /Users/alexstephen/ansible/gcp.yml as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

{
    "_meta": {
        "hostvars": {}
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    }
}
```
