### PR TITLE
optional param was always being set. 

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_net_routes.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_net_routes.py
@@ -133,7 +133,9 @@ class NetAppOntapNetRoutes(object):
             metric = self.parameters['metric']
         else:
             metric = current_metric
-        route_obj.add_new_child("metric", metric)
+        # Metric can be None, Can't set metric to none
+        if metric is not None:
+            route_obj.add_new_child("metric", metric)
         try:
             self.server.invoke_successfully(route_obj, True)
         except netapp_utils.zapi.NaApiError as error:


### PR DESCRIPTION
##### SUMMARY
metric (an optional param) was always being set regardless if it was set by the user or not. If the user didn't set it would attempt to set an INT to None and crash

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_net_routes.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
