### PR TITLE
Add Accept header to GET method in open_url()

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -26,6 +26,7 @@ class RedfishUtils(object):
     def get_request(self, uri):
         try:
             resp = open_url(uri, method="GET",
+                            headers={'accept': 'application/json'},
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
In some servers with updated OOB controller firmware, all HTTP GET methods were failing with HTTP Error 406. Adding the `Accept` header with value `application/json` in `open_url()` fixes the issue and is also in line with what most of the DMTF tools in https://github.com/dmtf do today.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before patch:
```paste below
TASK [Get CPU Inventory] *******************************************************
Tuesday 09 April 2019  17:13:44 -0500 (0:00:00.438)       0:00:00.620 *********
fatal: [red4]: FAILED! => {"changed": false, "msg": "HTTP Error 406 on GET request to 'https://idrac-7ffg0m2/redfish/v1/', extended message: 'Not Acceptable'"}
```
After patch:
```paste below
TASK [Get CPU Inventory] *******************************************************
Tuesday 09 April 2019  17:14:49 -0500 (0:00:00.483)       0:00:00.654 *********
ok: [red4]
```