### PR TITLE
Allow pslint as user

### DIFF
--- a/test/runner/requirements/sanity.ps1
+++ b/test/runner/requirements/sanity.ps1
@@ -5,7 +5,7 @@ Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.17.1
+Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.17.1 -Scope CurrentUser
 
 # Installed the PSCustomUseLiteralPath rule
-Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1
+Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1 -Scope CurrentUser


### PR DESCRIPTION
##### SUMMARY
Running ansible-test for running pslint tests fails when not run as root.
This PR enables running as a user.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test pslint