### PR TITLE
Increase async timeout for psrp connection test

### DIFF
--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -51,7 +51,7 @@
 
   - name: test out async with psrp
     win_shell: Start-Sleep -Seconds 2; Write-Output abc
-    async: 5
+    async: 10
     poll: 1
     register: async_out
 


### PR DESCRIPTION
##### SUMMARY
Having async with a timeout of 5 seconds comes really close to the time the module actually takes to complete. The test waits for 2 seconds but the time it would take for the powershell instance to start up and then compile the C# code to execute processes is typically around .5 to 1 second in total. If the host is under load or a large profile is used this could exceed the timeout and the test would fail.

This PR just increases the max time it could run for but still test that async works with psrp. Fixes issues like this https://app.shippable.com/github/ansible/ansible/runs/118449/15/tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp