### PR TITLE
The Univention modules have a issue with an unassigned variable.

### DIFF
--- a/lib/ansible/modules/cloud/univention/udm_dns_record.py
+++ b/lib/ansible/modules/cloud/univention/udm_dns_record.py
@@ -123,6 +123,7 @@ def main():
     data = module.params['data']
     state = module.params['state']
     changed = False
+    diff = None
 
     obj = list(ldap_search(
         '(&(objectClass=dNSZone)(zoneName={0})(relativeDomainName={1}))'.format(zone, name),

--- a/lib/ansible/modules/cloud/univention/udm_dns_zone.py
+++ b/lib/ansible/modules/cloud/univention/udm_dns_zone.py
@@ -170,6 +170,7 @@ def main():
     mx = module.params['mx']
     state = module.params['state']
     changed = False
+    diff = None
 
     obj = list(ldap_search(
         '(&(objectClass=dNSZone)(zoneName={0}))'.format(zone),

--- a/lib/ansible/modules/cloud/univention/udm_group.py
+++ b/lib/ansible/modules/cloud/univention/udm_group.py
@@ -112,6 +112,7 @@ def main():
     subpath = module.params['subpath']
     state = module.params['state']
     changed = False
+    diff = None
 
     groups = list(ldap_search(
         '(&(objectClass=posixGroup)(cn={0}))'.format(name),

--- a/lib/ansible/modules/cloud/univention/udm_share.py
+++ b/lib/ansible/modules/cloud/univention/udm_share.py
@@ -477,6 +477,7 @@ def main():
     name = module.params['name']
     state = module.params['state']
     changed = False
+    diff = None
 
     obj = list(ldap_search(
         '(&(objectClass=univentionShare)(cn={0}))'.format(name),

--- a/lib/ansible/modules/cloud/univention/udm_user.py
+++ b/lib/ansible/modules/cloud/univention/udm_user.py
@@ -413,6 +413,7 @@ def main():
     subpath = module.params['subpath']
     state = module.params['state']
     changed = False
+    diff = None
 
     users = list(ldap_search(
         '(&(objectClass=posixAccount)(uid={0}))'.format(username),


### PR DESCRIPTION
##### SUMMARY
The variable diff is only assigned if state is 'present', else the
variable is unused. But the module will return the diff variable as a
return value. If the state isn't 'present' the module will fail with an
python UnboundLocalError exception.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
* udm_user
* udm_group
* udm_share
* udm_dns_zone
* udm_dns_record

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```Python
The full traceback is:
Traceback (most recent call last):
 File "/tmp/ansible_Id1UGE/ansible_module_udm_user.py", line 522, in <module>
   main()
 File "/tmp/ansible_Id1UGE/ansible_module_udm_user.py", line 517, in main
   diff=diff,
UnboundLocalError: local variable 'diff' referenced before assignment

fatal: [srv-ucs-01]: FAILED! => {
   "changed": false,  
   "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Id1UGE/ansible_module_udm_user.py\", line 522, in <module>\n    main()\n  File \"/tmp/ansible_Id1UGE/ansible_module_udm_user.py\",
line 517, in main\n    diff=diff,\nUnboundLocalError: local variable 'diff' referenced before assignment\n",                                                                                                      
   "module_stdout": "",  
   "msg": "MODULE FAILURE",  
   "rc": 1
}
```
