### PR TITLE
Removes PLAYBOOK_VARS_ROOT configuration option

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1691,19 +1691,6 @@ PERSISTENT_COMMAND_TIMEOUT:
   ini:
   - {key: command_timeout, section: persistent_connection}
   type: int
-PLAYBOOK_VARS_ROOT:
-  name: playbook vars files root
-  default: top
-  version_added: "2.4.1"
-  description:
-    - This sets which playbook dirs will be used as a root to process vars plugins, which includes finding host_vars/group_vars
-    - The ``top`` option follows the traditional behaviour of using the top playbook in the chain to find the root directory.
-    - The ``bottom`` option follows the 2.4.0 behaviour of using the current playbook to find the root directory.
-    - The ``all`` option examines from the first parent to the current playbook.
-  env: [{name: ANSIBLE_PLAYBOOK_VARS_ROOT}]
-  ini:
-  - {key: playbook_vars_root, section: defaults}
-  choices: [ top, bottom, all ]
 PLUGIN_FILTERS_CFG:
   name: Config file for limiting valid plugins
   default: null

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -184,15 +184,6 @@ class VariableManager:
                 all_vars = combine_vars(all_vars, role.get_default_vars())
 
         if task:
-            # set basedirs
-            if C.PLAYBOOK_VARS_ROOT == 'all':  # should be default
-                basedirs = task.get_search_path()
-            elif C.PLAYBOOK_VARS_ROOT in ('bottom', 'playbook_dir'):  # only option in 2.4.0
-                basedirs = [task.get_search_path()[0]]
-            elif C.PLAYBOOK_VARS_ROOT != 'top':
-                # preserves default basedirs, only option pre 2.3
-                raise AnsibleError('Unknown playbook vars logic: %s' % C.PLAYBOOK_VARS_ROOT)
-
             # if we have a task in this context, and that task has a role, make
             # sure it sees its defaults above any other roles, as we previously
             # (v1) made sure each task had a copy of its roles default vars


### PR DESCRIPTION
##### SUMMARY
Removes PLAYBOOK_VARS_ROOT configuration variable since it does nothing anymore

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vars\manager.py

##### ADDITIONAL INFORMATION
Since Ansible 2.3.x and 2.4.x are deprecated and the whole import/include playbook has been introduced this variable does nothing anymore and can only cause misunderstandings.