### PR TITLE
Extend jinja2 nested undefined support to keys/indices

### DIFF
--- a/changelogs/fragments/jinja2_nested_undefined_getitem.yaml
+++ b/changelogs/fragments/jinja2_nested_undefined_getitem.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- jinja2 - accesses to keys/indices on an undefined value now return further undefined values rather than throwing an exception

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -207,6 +207,10 @@ class AnsibleUndefined(StrictUndefined):
         # Return original Undefined object to preserve the first failure context
         return self
 
+    def __getitem__(self, key):
+        # Return original Undefined object to preserve the first failure context
+        return self
+
     def __repr__(self):
         return 'AnsibleUndefined'
 

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -666,6 +666,24 @@
       - list_var.0.foo.bar | default('DEFAULT') == 'DEFAULT'
       - list_var.1.foo is not defined
       - list_var.1.foo | default('DEFAULT') == 'DEFAULT'
+      - dict_var is defined
+      - dict_var['bar'] is defined
+      - dict_var['bar']['baz'] is not defined
+      - dict_var['bar']['baz'] | default('DEFAULT') == 'DEFAULT'
+      - dict_var['bar']['baz']['abc'] is not defined
+      - dict_var['bar']['baz']['abc'] | default('DEFAULT') == 'DEFAULT'
+      - dict_var['baz'] is not defined
+      - dict_var['baz']['abc'] is not defined
+      - dict_var['baz']['abc'] | default('DEFAULT') == 'DEFAULT'
+      - list_var[0] is defined
+      - list_var[1] is not defined
+      - list_var[0]['foo'] is defined
+      - list_var[0]['foo']['bar'] is not defined
+      - list_var[0]['foo']['bar'] | default('DEFAULT') == 'DEFAULT'
+      - list_var[1]['foo'] is not defined
+      - list_var[1]['foo'] | default('DEFAULT') == 'DEFAULT'
+      - dict_var['bar'].baz is not defined
+      - dict_var['bar'].baz | default('DEFAULT') == 'DEFAULT'
 
 - template:
     src: template_destpath_test.j2


### PR DESCRIPTION
##### SUMMARY

Currently the `AnsibleUndefined` class only implements nested undefined support when using dot notation.  This PR extends this functionality to keys/indices via subscript/bracket notation.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/template/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
