### PR TITLE
[stable-2.7] Compat fix for ansible-core-ci on Python 3.7.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -496,7 +496,14 @@ class AnsibleCoreCI(object):
         elif 'errorMessage' in response_json:
             message = response_json['errorMessage'].strip()
             if 'stackTrace' in response_json:
-                trace = '\n'.join([x.rstrip() for x in traceback.format_list(response_json['stackTrace'])])
+                traceback_lines = response_json['stackTrace']
+
+                # AWS Lambda on Python 2.7 returns a list of tuples
+                # AWS Lambda on Python 3.7 returns a list of strings
+                if traceback_lines and isinstance(traceback_lines[0], list):
+                    traceback_lines = traceback.format_list(traceback_lines)
+
+                trace = '\n'.join([x.rstrip() for x in traceback_lines])
                 stack_trace = ('\nTraceback (from remote server):\n%s' % trace)
         else:
             message = str(response_json)


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Compat fix for ansible-core-ci on Python 3.7.

Backport of https://github.com/ansible/ansible/pull/55077

(cherry picked from commit 5b133f345558998074138b94b290a2cf8dd456fd)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
