### PR TITLE
Disable MySQL related tests.

### DIFF
--- a/test/integration/targets/mysql_db/aliases
+++ b/test/integration/targets/mysql_db/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group1
 skip/osx
 skip/freebsd
+disabled

--- a/test/integration/targets/mysql_user/aliases
+++ b/test/integration/targets/mysql_user/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group1
 skip/osx
 skip/freebsd
+disabled

--- a/test/integration/targets/mysql_variables/aliases
+++ b/test/integration/targets/mysql_variables/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group1
 skip/osx
 skip/freebsd
+disabled

--- a/test/integration/targets/zabbix_host/aliases
+++ b/test/integration/targets/zabbix_host/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled


### PR DESCRIPTION
##### SUMMARY

Disable MySQL related tests.

The tests are unstable when running the setup_mysql_db dependency.

Since the stable-2.5 branch is security fixes only and will be EOL in a little more than one month, it makes sense to disable these tests instead of trying to fix them.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

mysql and zabbix integration tests
