### PR TITLE
MSO: Remove parameters to specify object ids

### DIFF
--- a/lib/ansible/modules/network/aci/mso_role.py
+++ b/lib/ansible/modules/network/aci/mso_role.py
@@ -127,7 +127,6 @@ def main():
     argument_spec = mso_argument_spec()
     argument_spec.update(
         role=dict(type='str', aliases=['name']),
-        role_id=dict(type='str'),
         display_name=dict(type='str'),
         description=dict(type='str'),
         permissions=dict(type='list', choices=[

--- a/lib/ansible/modules/network/aci/mso_role.py
+++ b/lib/ansible/modules/network/aci/mso_role.py
@@ -21,14 +21,9 @@ author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'
 options:
-  role_id:
-    description:
-    - The ID of the role.
-    type: str
   role:
     description:
     - The name of the role.
-    - Alternative to the name, you can use C(role_id).
     type: str
     required: yes
     aliases: [ name ]
@@ -168,33 +163,24 @@ def main():
     )
 
     role = module.params['role']
-    role_id = module.params['role_id']
     description = module.params['description']
     permissions = module.params['permissions']
     state = module.params['state']
 
     mso = MSOModule(module)
 
+    role_id = None
     path = 'roles'
 
     # Query for existing object(s)
-    if role_id is None and role is None:
-        mso.existing = mso.query_objs(path)
-    elif role_id is None:
+    if role:
         mso.existing = mso.get_obj(path, name=role)
         if mso.existing:
             role_id = mso.existing['id']
-    elif role is None:
-        mso.existing = mso.get_obj(path, id=role_id)
+            # If we found an existing object, continue with it
+            path = 'roles/{id}'.format(id=role_id)
     else:
-        mso.existing = mso.get_obj(path, id=role_id)
-        existing_by_name = mso.get_obj(path, name=role)
-        if existing_by_name and role_id != existing_by_name['id']:
-            mso.fail_json(msg="Provided role '{0}' with id '{1}' does not match existing id '{2}'.".format(role, role_id, existing_by_name['id']))
-
-    # If we found an existing object, continue with it
-    if role_id:
-        path = 'roles/{id}'.format(id=role_id)
+        mso.existing = mso.query_objs(path)
 
     if state == 'query':
         pass

--- a/lib/ansible/modules/network/aci/mso_schema.py
+++ b/lib/ansible/modules/network/aci/mso_schema.py
@@ -21,11 +21,6 @@ author:
 - Dag Wieers (@dagwieers)
 version_added: '2.8'
 options:
-  schema_id:
-    description:
-    - The ID of the schema.
-    type: str
-    required: yes
   schema:
     description:
     - The name of the schema.
@@ -117,7 +112,6 @@ def main():
     argument_spec = mso_argument_spec()
     argument_spec.update(
         schema=dict(type='str', aliases=['name']),
-        schema_id=dict(type='str'),
         templates=dict(type='list'),
         sites=dict(type='list'),
         # messages=dict(type='dict'),
@@ -138,32 +132,23 @@ def main():
     )
 
     schema = module.params['schema']
-    schema_id = module.params['schema_id']
     templates = module.params['templates']
     sites = module.params['sites']
     state = module.params['state']
 
     mso = MSOModule(module)
 
+    schema_id = None
     path = 'schemas'
 
     # Query for existing object(s)
-    if schema_id is None and schema is None:
-        mso.existing = mso.query_objs(path)
-    elif schema_id is None:
+    if schema:
         mso.existing = mso.get_obj(path, displayName=schema)
         if mso.existing:
             schema_id = mso.existing['id']
-    elif schema is None:
-        mso.existing = mso.get_obj(path, id=schema_id)
+            path = 'schemas/{id}'.format(id=schema_id)
     else:
-        mso.existing = mso.get_obj(path, id=schema_id)
-        existing_by_name = mso.get_obj(path, displayName=schema)
-        if existing_by_name and schema_id != existing_by_name['id']:
-            mso.fail_json(msg="Provided schema '{1}' with id '{2}' does not match existing id '{3}'.".format(schema, schema_id, existing_by_name['id']))
-
-    if schema_id:
-        path = 'schemas/{id}'.format(id=schema_id)
+        mso.existing = mso.query_objs(path)
 
     if state == 'query':
         pass


### PR DESCRIPTION
##### SUMMARY
Originally this seemed like a good idea as internally objects are
referenced by ID and we wanted to support non-unique names.

But in the meantime it has become clear names will be unique, so these
parameters are actually useless and unwanted.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
MSO modules