### PR TITLE
adding group parameter for win_firewall_rule

### DIFF
--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -183,8 +183,8 @@ try {
         }
     }
 
-    $fwPropertiesToCompare = @('Name','Description','Direction','Action','ApplicationName','ServiceName','Enabled','Profiles','LocalAddresses','RemoteAddresses','LocalPorts','RemotePorts','Protocol','InterfaceTypes', 'EdgeTraversalOptions', 'SecureFlags')
-    $userPassedArguments = @($name, $description, $direction, $action, $program, $service, $enabled, $profiles, $localip, $remoteip, $localport, $remoteport, $protocol, $interfacetypes, $edge, $security)
+    $fwPropertiesToCompare = @('Name','Description','Direction','Action','ApplicationName','Grouping','ServiceName','Enabled','Profiles','LocalAddresses','RemoteAddresses','LocalPorts','RemotePorts','Protocol','InterfaceTypes', 'EdgeTraversalOptions', 'SecureFlags')
+    $userPassedArguments = @($name, $description, $direction, $action, $program, $group, $service, $enabled, $profiles, $localip, $remoteip, $localport, $remoteport, $protocol, $interfacetypes, $edge, $security)
 
     if ($state -eq "absent") {
         if ($null -eq $existingRule) {

--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -117,6 +117,7 @@ $description = Get-AnsibleParam -obj $params -name "description" -type "str"
 $direction = Get-AnsibleParam -obj $params -name "direction" -type "str" -validateset "in","out"
 $action = Get-AnsibleParam -obj $params -name "action" -type "str" -validateset "allow","block"
 $program = Get-AnsibleParam -obj $params -name "program" -type "str"
+$group = Get-AnsibleParam -obj $params -name "group" -type "str"
 $service = Get-AnsibleParam -obj $params -name "service" -type "str"
 $enabled = Get-AnsibleParam -obj $params -name "enabled" -type "bool" -aliases "enable"
 $profiles = Get-AnsibleParam -obj $params -name "profiles" -type "list" -aliases "profile"
@@ -156,6 +157,7 @@ try {
     # the default for enabled in module description is "true", but the actual COM object defaults to "false" when created
     if ($null -ne $enabled) { $new_rule.Enabled = $enabled } else { $new_rule.Enabled = $true }
     if ($null -ne $description) { $new_rule.Description = $description }
+    if ($null -ne $group) { $new_rule.Grouping = $group }
     if ($null -ne $program -and $program -ne "any") { $new_rule.ApplicationName = [System.Environment]::ExpandEnvironmentVariables($program) }
     if ($null -ne $service -and $program -ne "any") { $new_rule.ServiceName = $service }
     if ($null -ne $protocol -and $protocol -ne "any") { $new_rule.Protocol = Parse-ProtocolType -protocol $protocol }

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -33,12 +33,12 @@ options:
     description:
       - The rule's display name.
     type: str
+    required: yes
   group:
     description:
       - The group name for the rule.
     version_added: '2.9'
     type: str
-    required: yes
   direction:
     description:
       - Whether this rule is for inbound or outbound traffic.

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -34,6 +34,12 @@ options:
       - The rule's display name.
     type: str
     required: yes
+  group:
+    description:
+      - The group name for the rule.
+    version_added: '2.8'
+    type: str
+    required: yes
   direction:
     description:
       - Whether this rule is for inbound or outbound traffic.
@@ -131,6 +137,17 @@ EXAMPLES = r'''
     direction: in
     protocol: tcp
     profiles: private
+    state: present
+    enabled: yes
+
+- name: Firewall rule to be created for application group
+  win_firewall_rule:
+    name: SMTP
+    group: application
+    localport: 25
+    action: allow
+    direction: in
+    protocol: tcp
     state: present
     enabled: yes
 '''

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -33,7 +33,6 @@ options:
     description:
       - The rule's display name.
     type: str
-    required: yes
   group:
     description:
       - The group name for the rule.

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -37,7 +37,7 @@ options:
   group:
     description:
       - The group name for the rule.
-    version_added: '2.8'
+    version_added: '2.9'
     type: str
     required: yes
   direction:

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -440,7 +440,7 @@
     - add_firewall_rule_with_var_expand_path.changed == false
 - name: Add firewall rule for application group
   win_firewall_rule:
-    name: http
+    name: Rule for application group
     enabled: yes
     state: present
     localport: 80

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -438,3 +438,19 @@
   assert:
     that:
     - add_firewall_rule_with_var_expand_path.changed == false
+- name: Add firewall rule for application group
+  win_firewall_rule:
+    name: http
+    enabled: yes
+    state: present
+    localport: 80
+    action: allow
+    direction: in
+    protocol: tcp
+    group: application
+  register: add_firewall_rule_with_group
+
+- name: Check that creating firewall rule for application group succeeds with a change
+  assert:
+    that:
+    - add_firewall_rule_with_group.changed == true


### PR DESCRIPTION
##### SUMMARY

Changes in this PR will add support to specify `group` parameter for the firewall rule.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`win_firewall_rule`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->


Current module doesn't support `group` parameter for `win_firewall_rule` module. This is a limitation for the user who needs to specify the group of the Firewall role to set/create.

Before:
```
  - name: test
    win_firewall_rule:
      name: 'Test Rule'
      program: 'c:\app\app1.exe'
      direction: In
      group:  TestGrp
      action: Allow
      state: Present
```
Result: Rule created without setting the group.

After:
 ``` 
- name: test
    win_firewall_rule:
      name: 'Test Rule'
      program: 'c:\app\app1.exe'
      direction: In
      group:  TestGrp
      action: Allow
      state: Present
```
Result: Rule created by setting the group.