### PR TITLE
vmware_host_config_manager: avoid failure if no change

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
@@ -125,7 +125,7 @@ class VmwareConfigManager(PyVmomi):
 
     def set_host_configuration_facts(self):
         changed_list = []
-        changed = False
+        message = ''
         for host in self.hosts:
             option_manager = host.configManager.advancedOption
             host_facts = {}
@@ -161,11 +161,10 @@ class VmwareConfigManager(PyVmomi):
 
                     if option_value != host_facts[option_key]['value']:
                         change_option_list.append(vim.option.OptionValue(key=option_key, value=option_value))
-                        changed = True
                         changed_list.append(option_key)
                 else:  # Don't silently drop unknown options. This prevents typos from falling through the cracks.
                     self.module.fail_json(msg="Unsupported option %s" % option_key)
-            if changed:
+            if changed_list:
                 if self.module.check_mode:
                     changed_suffix = ' would be changed.'
                 else:
@@ -189,7 +188,7 @@ class VmwareConfigManager(PyVmomi):
             else:
                 message = 'All settings are already configured.'
 
-        self.module.exit_json(changed=changed, msg=message)
+        self.module.exit_json(changed=bool(changed_list), msg=message)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY

If nothing was changed, the module was raising the following error
because the `message` variable was not defined:

```
line 192, in set_host_configuration_facts
UnboundLocalError: local variable 'message' referenced before assignment
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_config_manager