### PR TITLE
Fixed incorrect response removing a group

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
@@ -35,6 +35,8 @@ version_added: '2.8'
 author: Evert Mulder (@evertmulder)
 description:
   - The manageiq_group module supports adding, updating and deleting groups in ManageIQ.
+requirements:
+- manageiq-client
 
 options:
   state:
@@ -319,9 +321,12 @@ class ManageIQgroup(object):
         """
         try:
             url = '%s/groups/%s' % (self.api_url, group['id'])
-            self.client.post(url, action='delete')
+            result = self.client.post(url, action='delete')
         except Exception as e:
             self.module.fail_json(msg="failed to delete group %s: %s" % (group['description'], str(e)))
+
+        if result['success'] is False:
+            self.module.fail_json(msg=result['message'])
 
         return dict(
             changed=True,
@@ -610,7 +615,7 @@ def main():
         else:
             res_args = dict(
                 changed=False,
-                msg="group %s: does not exist in manageiq" % description)
+                msg="group '%s' does not exist in manageiq" % description)
 
     # group should exist
     if state == "present":


### PR DESCRIPTION
##### SUMMARY
The module reported changed even when a group could not be removed from manageiq. The module should report a failure when the group could not be removed. This is the case when the group has users assigned that do not belong to any other group.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
manageiq_group

##### ADDITIONAL INFORMATION
See in the before the module reports the group was removed even when it was not
This is fixed, see after.

Before the change:
```json
{
  "changed": true,
  "msg": "deleted group DI9_User with id 43",
  "invocation": {
    "module_args": {
      "description": "DI9_User",
      "state": "absent",
      "tenant_id": 4,
...
```

after:
```json
{
  "msg": "The group has users assigned that do not belong to any other group - ",
  "failed": true,
  "invocation": {
    "module_args": {
      "description": "DI9_User",
      "state": "absent",
      "tenant_id": 4,
 ...
}
```