### PR TITLE
module_utils fixes in collections

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -324,7 +324,7 @@ class PluginLoader:
             # only current non-class special case, module_utils don't use this loader method
             if append_plugin_type == 'library':
                 append_plugin_type = 'modules'
-            else:
+            elif append_plugin_type != 'module_utils':
                 append_plugin_type = get_plugin_class(append_plugin_type)
             package += '.plugins.{0}'.format(append_plugin_type)
 

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -30,7 +30,7 @@ _SYNTHETIC_PACKAGES = {
 }
 
 # TODO: tighten this up to subset Python identifier requirements (and however we want to restrict ns/collection names)
-_collection_qualified_re = re.compile(to_text(r'^(\w+)\.(\w+)\.(\w+)$'))
+_collection_qualified_re = re.compile(to_text(r'^(\w+)\.(\w+)\.(\w+)'))
 
 
 # FIXME: exception handling/error logging

--- a/test/integration/targets/collections/aliases
+++ b/test/integration/targets/collections/aliases
@@ -1,2 +1,5 @@
+posix
 shippable/posix/group4
+shippable/windows/group2
 skip/python2.6
+windows

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/AnotherCSMU.cs
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/AnotherCSMU.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace AnsibleCollections.testns.testcoll.AnotherCSMU
+{
+    public class AnotherThing
+    {
+        public static string CallMe()
+        {
+            return "Hello from nested user-collection-hosted AnotherCSMU";
+        }
+    }
+}

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyCSMU.cs
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyCSMU.cs
@@ -1,0 +1,15 @@
+using System;
+
+using AnsibleCollections.testns.testcoll.AnotherCSMU;
+
+namespace AnsibleCollections.testns.testcoll.MyCSMU
+{
+    public class CustomThing
+    {
+        public static string HelloWorld()
+        {
+            string res = AnotherThing.CallMe();
+            return String.Format("Hello from user_mu collection-hosted MyCSMU, also {0}", res);
+        }
+    }
+}

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1
@@ -1,4 +1,8 @@
 Function CallMe-FromUserPSMU {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
     return "from user_mu"
 }
 

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1
@@ -1,0 +1,5 @@
+Function CallMe-FromUserPSMU {
+    return "from user_mu"
+}
+
+Export-ModuleMember -Function CallMe-FromUserPSMU

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg/submod.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg/submod.py
@@ -1,0 +1,2 @@
+def thingtocall():
+    return "thingtocall in subpkg.submod"

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg_with_init/__init__.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg_with_init/__init__.py
@@ -1,0 +1,2 @@
+def thingtocall():
+    return "thingtocall in subpkg_with_init"

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_base_mu_granular_nested_import.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_base_mu_granular_nested_import.py
@@ -3,8 +3,6 @@
 import json
 import sys
 
-# FIXME: this is only required due to a bug around "new style module detection"
-from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.testns.testcoll.plugins.module_utils.base import thingtocall
 
 

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_flat_import.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_flat_import.py
@@ -3,8 +3,6 @@
 import json
 import sys
 
-# FIXME: this is only required due to a bug around "new style module detection"
-from ansible.module_utils.basic import AnsibleModule
 import ansible_collections.testns.testcoll.plugins.module_utils.leaf
 
 

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_granular_import.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_granular_import.py
@@ -3,13 +3,11 @@
 import json
 import sys
 
-# FIXME: this is only required due to a bug around "new style module detection"
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.testns.testcoll.plugins.module_utils.leaf import thingtocall
+from ansible_collections.testns.testcoll.plugins.module_utils.leaf import thingtocall as aliasedthing
 
 
 def main():
-    mu_result = thingtocall()
+    mu_result = aliasedthing()
     print(json.dumps(dict(changed=False, source='user', mu_result=mu_result)))
 
     sys.exit()

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_module_import_from.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_module_import_from.py
@@ -3,15 +3,18 @@
 import json
 import sys
 
-# FIXME: this is only required due to a bug around "new style module detection"
-from ansible.module_utils.basic import AnsibleModule
-# FIXME: this style doesn't work yet under collections
-from ansible_collections.testns.testcoll.plugins.module_utils import leaf
+from ansible_collections.testns.testcoll.plugins.module_utils import leaf, secondary
+# FIXME: these don't work yet under collections
+# from ansible_collections.testns.testcoll.plugins.module_utils.subpkg import submod
+# from ansible_collections.testns.testcoll.plugins.module_utils.subpkg_with_init import thingtocall as spwi_thingtocall
 
 
 def main():
     mu_result = leaf.thingtocall()
-    print(json.dumps(dict(changed=False, source='user', mu_result=mu_result)))
+    mu2_result = secondary.thingtocall()
+#    mu3_result = submod.thingtocall()
+#    mu4_result = spwi_thingtocall()
+    print(json.dumps(dict(changed=False, source='user', mu_result=mu_result, mu2_result=mu2_result)))
 
     sys.exit()
 

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_csbasic_only.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_csbasic_only.ps1
@@ -1,0 +1,22 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        data = @{ type = "str"; default = "pong" }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$data = $module.Params.data
+
+if ($data -eq "crash") {
+    throw "boom"
+}
+
+$module.Result.ping = $data
+$module.Result.source = "user"
+$module.ExitJson()

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_selfcontained.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_selfcontained.ps1
@@ -1,0 +1,9 @@
+#!powershell
+
+$res = @{
+  changed = $false
+  source = "user"
+  msg = "hi from selfcontained.ps1"
+}
+
+ConvertTo-Json $res

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_selfcontained.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_selfcontained.py
@@ -1,0 +1,1 @@
+# docs for Windows module would go here; just ensure we don't accidentally load this instead of the .ps1

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_csmu.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_csmu.ps1
@@ -1,0 +1,23 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -CSharpUtil AnsibleCollections.testns.testcoll.MyCSMU
+
+$spec = @{
+    options = @{
+        data = @{ type = "str"; default = "called from $([AnsibleCollections.testns.testcoll.MyCSMU.CustomThing]::HelloWorld())" }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$data = $module.Params.data
+
+if ($data -eq "crash") {
+    throw "boom"
+}
+
+$module.Result.ping = $data
+$module.Result.source = "user"
+$module.ExitJson()

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_psmu.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_psmu.ps1
@@ -1,0 +1,23 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -Powershell AnsibleCollections.testns.testcoll.MyPSMU
+
+$spec = @{
+    options = @{
+        data = @{ type = "str"; default = "called from $(CallMe-FromUserPSMU)" }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$data = $module.Params.data
+
+if ($data -eq "crash") {
+    throw "boom"
+}
+
+$module.Result.ping = $data
+$module.Result.source = "user"
+$module.ExitJson()

--- a/test/integration/targets/collections/includeme.yml
+++ b/test/integration/targets/collections/includeme.yml
@@ -1,0 +1,6 @@
+- testns.testcoll.plugin_lookup:
+  register: included_plugin_lookup_out
+
+- assert:
+    that:
+    - included_plugin_lookup_out.collection_list == ['bogus.bogus', 'ansible.legacy']

--- a/test/integration/targets/collections/posix.yml
+++ b/test/integration/targets/collections/posix.yml
@@ -38,11 +38,9 @@
     testns.testcoll.uses_leaf_mu_flat_import:
     register: flat_out
 
-  # FIXME: this one doesn't work yet
   # module with a full-module module_utils import using 'from' (from (this collection).module_utils import leaf)
   - name: exec module with full-module module_utils import using 'from' from this collection
     testns.testcoll.uses_leaf_mu_module_import_from:
-    ignore_errors: true
     register: from_out
 
   - assert:
@@ -54,7 +52,8 @@
       - granular_out.mu_result == 'thingtocall in leaf'
       - granular_nested_out.mu_result == 'thingtocall in base called thingtocall in secondary'
       - flat_out.mu_result == 'thingtocall in leaf'
-      - from_out is failed  # FIXME: switch back once this import is fixed --> from_out.mu_result == 'thingtocall in leaf'
+      - from_out.mu_result == 'thingtocall in leaf'
+      - from_out.mu2_result == 'thingtocall in secondary'
 
   - name: exercise filters/tests/lookups
     assert:
@@ -169,16 +168,10 @@
     systestmodule:
     register: systestmodule_out
 
-  # ensure we're looking up actions properly
-  - name: unqualified action test
-    plugin_lookup:
-    register: pluginlookup_out
-
   - assert:
       that:
       - testmodule_out.source == 'user'
       - systestmodule_out.source == 'sys'
-      - pluginlookup_out.collection_list == ['testns.testcoll', 'testns.coll_in_sys', 'testns.contentadj', 'ansible.legacy']
 
 # FIXME: this won't work until collections list gets passed through task templar
 #  - name: exercise unqualified filters/tests/lookups
@@ -255,6 +248,22 @@
     assert:
       that:
       - test_role_output.msg == test_role_input
+
+
+- name: validate static task include behavior
+  hosts: testhost
+  collections:
+  - bogus.bogus
+  tasks:
+  - import_tasks: includeme.yml
+
+
+- name: validate dynamic task include behavior
+  hosts: testhost
+  collections:
+  - bogus.bogus
+  tasks:
+  - include_tasks: includeme.yml
 
 
 - name: test a collection-hosted connection plugin against a host from a collection-hosted inventory plugin

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -8,7 +8,8 @@ export ANSIBLE_GATHER_SUBSET=minimal
 export ANSIBLE_HOST_PATTERN_MISMATCH=error
 
 # FIXME: just use INVENTORY_PATH as-is once ansible-test sets the right dir
-export INVENTORY_PATH=../../$(basename ${INVENTORY_PATH})
+ipath=../../$(basename "${INVENTORY_PATH}")
+export INVENTORY_PATH="$ipath"
 
 # temporary hack to keep this test from running on Python 2.6 in CI
 if ansible-playbook pythoncheck.yml | grep UNSUPPORTEDPYTHON; then
@@ -20,7 +21,11 @@ fi
 ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m ping | grep "usercallback says ok"
 
 # we need multiple plays, and conditional import_playbook is noisy and causes problems, so choose here which one to use...
-[[ ${INVENTORY_PATH} == *.winrm ]] && export TEST_PLAYBOOK=windows.yml || export TEST_PLAYBOOK=posix.yml
+if [[ ${INVENTORY_PATH} == *.winrm ]]; then
+  export TEST_PLAYBOOK=windows.yml
+else
+  export TEST_PLAYBOOK=posix.yml
+fi
 
 # run test playbook
-ansible-playbook -i ${INVENTORY_PATH}  -i ./a.statichost.yml -v ${TEST_PLAYBOOK}
+ansible-playbook -i "${INVENTORY_PATH}"  -i ./a.statichost.yml -v "${TEST_PLAYBOOK}"

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -5,9 +5,13 @@ set -eux
 export ANSIBLE_COLLECTIONS_PATHS=$PWD/collection_root_user:$PWD/collection_root_sys
 export ANSIBLE_GATHERING=explicit
 export ANSIBLE_GATHER_SUBSET=minimal
+export ANSIBLE_HOST_PATTERN_MISMATCH=error
+
+# FIXME: just use INVENTORY_PATH as-is once ansible-test sets the right dir
+export INVENTORY_PATH=../../$(basename ${INVENTORY_PATH})
 
 # temporary hack to keep this test from running on Python 2.6 in CI
-if ansible-playbook -i ../../inventory pythoncheck.yml | grep UNSUPPORTEDPYTHON; then
+if ansible-playbook pythoncheck.yml | grep UNSUPPORTEDPYTHON; then
   echo skipping test for unsupported Python version...
   exit 0
 fi
@@ -15,5 +19,8 @@ fi
 # test callback
 ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m ping | grep "usercallback says ok"
 
+# we need multiple plays, and conditional import_playbook is noisy and causes problems, so choose here which one to use...
+[[ ${INVENTORY_PATH} == *.winrm ]] && export TEST_PLAYBOOK=windows.yml || export TEST_PLAYBOOK=posix.yml
+
 # run test playbook
-ansible-playbook -i ../../inventory -i ./a.statichost.yml -v play.yml
+ansible-playbook -i ${INVENTORY_PATH}  -i ./a.statichost.yml -v ${TEST_PLAYBOOK}

--- a/test/integration/targets/collections/windows.yml
+++ b/test/integration/targets/collections/windows.yml
@@ -1,4 +1,4 @@
-- hosts: testhost
+- hosts: windows
   tasks:
   - testns.testcoll.win_selfcontained:
     register: selfcontained_out

--- a/test/integration/targets/collections/windows.yml
+++ b/test/integration/targets/collections/windows.yml
@@ -1,0 +1,20 @@
+- hosts: testhost
+  tasks:
+  - testns.testcoll.win_selfcontained:
+    register: selfcontained_out
+
+  - testns.testcoll.win_csbasic_only:
+    register: csbasic_only_out
+
+  - testns.testcoll.win_uses_coll_psmu:
+    register: uses_coll_psmu
+
+  - testns.testcoll.win_uses_coll_csmu:
+    register: uses_coll_csmu
+
+  - assert:
+      that:
+      - selfcontained_out.source == 'user'
+      - csbasic_only_out.source == 'user'
+      - uses_coll_psmu.source == 'user' and 'user_mu' in uses_coll_psmu.ping
+      - uses_coll_csmu.source == 'user' and 'user_mu' in uses_coll_csmu.ping

--- a/test/sanity/code-smell/shebang.py
+++ b/test/sanity/code-smell/shebang.py
@@ -30,6 +30,10 @@ def main():
     }
 
     skip = set([
+        'test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_csbasic_only.ps1',
+        'test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_selfcontained.ps1',
+        'test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_csmu.ps1',
+        'test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_psmu.ps1',
         'test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1',
         'test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1',
         'test/utils/shippable/timing.py',

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -151,6 +151,7 @@ lib/ansible/modules/windows/win_wait_for.ps1 PSAvoidUsingEmptyCatchBlock
 lib/ansible/modules/windows/win_wait_for.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_webpicmd.ps1 PSAvoidUsingInvokeExpression
 lib/ansible/modules/windows/win_xml.ps1 PSCustomUseLiteralPath
+test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1 PSUseApprovedVerbs
 test/integration/targets/win_audit_rule/library/test_get_audit_rule.ps1 PSAvoidUsingCmdletAliases
 test/integration/targets/win_audit_rule/library/test_get_audit_rule.ps1 PSCustomUseLiteralPath
 test/integration/targets/win_chocolatey/files/tools/chocolateyUninstall.ps1 PSCustomUseLiteralPath


### PR DESCRIPTION
##### SUMMARY
* fixed Windows module_utils in collections
* fixed more Python module_utils cases (from X import module)
* "medium style" Ansiballz modules now work properly with collections (ie, non-replacer but also not using basic.py)
* added more tests
* split Windows/POSIX exec

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_common.py

##### ADDITIONAL INFORMATION
