### PR TITLE
Fewer examples use connection: local in docs

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_aws.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aws.rst
@@ -18,7 +18,6 @@ Whereas classically ansible will execute tasks in its host loop against multiple
 In your playbook steps we'll typically be using the following pattern for provisioning steps::
 
     - hosts: localhost
-      connection: local
       gather_facts: False
       tasks:
         - ...
@@ -68,7 +67,6 @@ instance.::
     # demo_setup.yml
 
     - hosts: localhost
-      connection: local
       gather_facts: False
 
       tasks:
@@ -94,7 +92,6 @@ From this, we'll use the add_host module to dynamically create a host group cons
     # demo_setup.yml
 
     - hosts: localhost
-      connection: local
       gather_facts: False
 
       tasks:

--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -88,7 +88,6 @@ you can use the following configuration:
 
    - name: Create IP address
      hosts: localhost
-     connection: local
      gather_facts: no
 
      vars:
@@ -169,7 +168,6 @@ rest.
    - name: Create an instance
      hosts: localhost
      gather_facts: no
-     connection: local
      vars:
          project: my-project
          auth_kind: serviceaccount

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -431,7 +431,6 @@ EXAMPLES = '''
 
 - name: Terminate instances
   hosts: localhost
-  connection: local
   tasks:
     - name: Terminate instances that were previously launched
       ec2:
@@ -444,7 +443,6 @@ EXAMPLES = '''
 - name: Start sandbox instances
   hosts: localhost
   gather_facts: false
-  connection: local
   vars:
     instance_ids:
       - 'i-xxxxxx'
@@ -467,7 +465,6 @@ EXAMPLES = '''
 - name: Stop sandbox instances
   hosts: localhost
   gather_facts: false
-  connection: local
   vars:
     instance_ids:
       - 'i-xxxxxx'

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -165,7 +165,6 @@ EXAMPLES = '''
 
 - name: Run using a project directory
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:
@@ -220,7 +219,6 @@ EXAMPLES = '''
 
 - name: Scale the web service to 2
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:
@@ -234,7 +232,6 @@ EXAMPLES = '''
 
 - name: Run with inline v2 compose
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:
@@ -269,7 +266,6 @@ EXAMPLES = '''
 
 - name: Run with inline v1 compose
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:


### PR DESCRIPTION
##### SUMMARY

This PR improves a handful of examples to avoid using a legacy feature.

99% of the time it is not necessary to use 'connection: local'. When using the implicit localhost it generally isn't necessary. A large number of examples set the connection type explicitly when they don't need to. These lines remain in the docs due to intertia.

For this PR I have stayed to areas that I use regularly.

See also <https://docs.ansible.com/ansible/devel/inventory/implicit_localhost.html>.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs

##### ADDITIONAL INFORMATION

Based on conversation in #ansible-docs on 10 April 2019.