### PR TITLE
WIP: vmware dynamic inventory naming collision

### DIFF
--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -101,7 +101,12 @@ EXAMPLES = '''
 import ssl
 import atexit
 from ansible.errors import AnsibleError, AnsibleParserError
-from urllib.parse import quote_plus
+
+import urllib.parse #import quote_plus
+# Overwrite _ALWAYS_SAFE to no longer include b'_.-~', so that these are also quoted
+urllib.parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                         b'abcdefghijklmnopqrstuvwxyz'
+                         b'0123456789')
 
 try:
     # requests is required for exception handling of the ConnectionError
@@ -364,9 +369,9 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
     def _get_fullName(self, vm_obj_obj):
         if(vm_obj_obj.parent):
-            return self._get_fullName(vm_obj_obj.parent) + '/' + quote_plus(vm_obj_obj.name, safe='')
+            return self._get_fullName(vm_obj_obj.parent) + '/' + urllib.parse.quote_plus(vm_obj_obj.name, safe='')
         else:
-            return '/' + quote_plus(vm_obj_obj.name)
+            return '/' + urllib.parse.quote_plus(vm_obj_obj.name)
 
     def _populate_from_cache(self, source_data):
         """ Populate cache using source data """

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -383,21 +383,31 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             self._cache[cache_key] = cacheable_results
 
     def _get_fullName(self, vm_obj_obj):
-        # This is based on the url schema VMware uses within the PowerCLI api
-        # but the PowerCLI url has collisions, as it uses slashes as folder name
-        # deliminator, but slashes can also occur within folder names themselves
-        # in the original these slashes are not escaped and the resulting path
-        # is inaccessible or even worse it overlays another path and the action
-        # could be performed on the vms within the wrong folder.
-        # To prevent this issue, every foldername within the folderpath gets
-        # urlencode before constructing
+        """
+          This is based on the url schema VMware uses within the PowerCLI api
+          but the PowerCLI url has collisions, as it uses slashes as folder name
+          deliminator, but slashes can also occur within folder names themselves
+          in the original these slashes are not escaped and the resulting path
+          is inaccessible or even worse it overlays another path and the action
+          could be performed on the vms within the wrong folder.
+          To prevent this issue, every foldername within the folderpath gets
+          urlencode before constructing
+          There is also an instanceUUID, but that is never shown to the user, so users
+          are not able to recognize the correct vm that way.
+          Not to be confuse with the uuid which is the UUID of the SMBios, it is not
+          guaranteed to be unique, as it does not necessarily change if a vm is imported
+          or copied.
+          VM names and folders are not restricted to specific characters either,
+          so foldernames need to be encoded first and transformed into a pseudo path.
+        """
         if(vm_obj_obj.parent):
             return self._get_fullName(vm_obj_obj.parent) + '/' + urllib.parse.quote_plus(vm_obj_obj.name, safe='')
         else:
             # For some reason the api returns 'Datencenter' (not Datacenter) as the
-            # root item, but VMware has also not included it within there path schema.
-            # Instead they have added the hostname and the port of the instance
-            # So why not mirror that?
+            # root item, but VMware has also not included it within there path schema,
+            # instead they have added the hostname and the port of the instance.
+            # So why not mirror that as well?
+            # That way we can differentiate vms between multiple isolated vmware instances.
             return 'vis:/' + self.pyv.hostname + '@' + str(self.pyv.port)
 
     def _populate_from_cache(self, source_data):
@@ -442,13 +452,13 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         for vm_obj in objects:
             for vm_obj_property in vm_obj.propSet:
-                # Appending "_" and VMware UUID to make it unique
                 if not vm_obj.obj.config:
                     # Sometime orphaned VMs return no configurations
                     continue
 
-                # VMware does not provide a way to uniquely identify VM by its name
+                # VMware does not provide a way to uniquely identify a VM by its name
                 # i.e. there can be two virtual machines with same name
+                # The full name instead is unique and recognizable to users.
                 current_host = self._get_fullName(vm_obj.obj)
 
                 if current_host not in hostvars:

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -383,10 +383,22 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             self._cache[cache_key] = cacheable_results
 
     def _get_fullName(self, vm_obj_obj):
+        # This is based on the url schema VMware uses within the PowerCLI api
+        # but the PowerCLI url has collisions, as it uses slashes as folder name
+        # deliminator, but slashes can also occur within folder names themselves
+        # in the original these slashes are not escaped and the resulting path
+        # is inaccessible or even worse it overlays another path and the action
+        # could be performed on the vms within the wrong folder.
+        # To prevent this issue, every foldername within the folderpath gets
+        # urlencode before constructing
         if(vm_obj_obj.parent):
             return self._get_fullName(vm_obj_obj.parent) + '/' + urllib.parse.quote_plus(vm_obj_obj.name, safe='')
         else:
-            return '/' + urllib.parse.quote_plus(vm_obj_obj.name)
+            # For some reason the api returns 'Datencenter' (not Datacenter) as the
+            # root item, but VMware has also not included it within there path schema.
+            # Instead they have added the hostname and the port of the instance
+            # So why not mirror that?
+            return 'vis:/' + self.pyv.hostname + '@' + str(self.pyv.port)
 
     def _populate_from_cache(self, source_data):
         """ Populate cache using source data """

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -115,27 +115,6 @@ import ssl
 import atexit
 from ansible.errors import AnsibleError, AnsibleParserError
 
-# Overwrite _ALWAYS_SAFE to only include letters and number
-# so that everything is correctly quoted
-try:
-    # python3
-    import urllib.parse
-    urllib.parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                                          b'abcdefghijklmnopqrstuvwxyz'
-                                          b'0123456789')
-    urllib.parse._ALWAYS_SAFE_BYTES = bytes(urllib.parse._ALWAYS_SAFE)
-except ImportError:
-    # python2
-    import urllib
-    from past.builtins import xrange
-    urllib.always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                          'abcdefghijklmnopqrstuvwxyz'
-                          '0123456789')
-    urllib._safe_map = {}
-    for i, c in zip(xrange(256), str(bytearray(xrange(256)))):
-        urllib._safe_map[c] = c if (i < 128 and c in urllib.always_safe) else '%{0:02X}'.format(i)
-    urllib.parse = urllib  # face pyton3 structure, so that python3 syntax can be used afterwards
-
 try:
     # requests is required for exception handling of the ConnectionError
     import requests
@@ -159,6 +138,41 @@ except ImportError:
 
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable
+
+# Overwrite _ALWAYS_SAFE to only include letters and number
+# so that everything is correctly quoted
+try:
+    # python3
+
+    # Import copy of urllib.parse to also encode all special chars.
+    import sys
+    import importlib.util
+    import urllib
+    SPEC_urllib_parse = importlib.util.find_spec('urllib.parse')
+    my_urllib_parse = importlib.util.module_from_spec(SPEC_urllib_parse)
+    SPEC_urllib_parse.loader.exec_module(my_urllib_parse)
+    sys.modules['my_urllib_parse'] = my_urllib_parse
+    del SPEC_urllib_parse
+
+    # overwrite allowed characters e.g. list of characters that are not encoded.
+    my_urllib_parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                                             b'abcdefghijklmnopqrstuvwxyz'
+                                             b'0123456789')
+    my_urllib_parse._ALWAYS_SAFE_BYTES = bytes(my_urllib_parse._ALWAYS_SAFE)
+except ImportError:
+    # python2
+
+    # Import copy of urllib to also encode all special chars.
+    import imp
+    my_urllib_parse = imp.load_module('urllib', *imp.find_module('urllib'))
+    from past.builtins import xrange
+
+    my_urllib_parse.always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                                   'abcdefghijklmnopqrstuvwxyz'
+                                   '0123456789')
+    my_urllib_parse._safe_map = {}
+    for i, c in zip(xrange(256), str(bytearray(xrange(256)))):
+        my_urllib_parse._safe_map[c] = c if (i < 128 and c in my_urllib_parse.always_safe) else '%{0:02x}'.format(i)
 
 
 class BaseVMwareInventory:
@@ -414,7 +428,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
           so foldernames need to be encoded first and transformed into a pseudo path.
         """
         if(vm_obj_obj.parent):
-            return self._get_fullName(vm_obj_obj.parent) + '/' + urllib.parse.quote_plus(vm_obj_obj.name, safe='')
+            return self._get_fullName(vm_obj_obj.parent) + '/' + my_urllib_parse.quote_plus(vm_obj_obj.name, safe='')
         else:
             # For some reason the api returns 'Datencenter' (not Datacenter) as the
             # root item, but VMware has also not included it within there path schema,

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -81,10 +81,10 @@ DOCUMENTATION = '''
                 - full_name is unique and also expressive, special characters in vm and folder names are urlencoded.
             type: str
             choices:
-                - 'name_and_smbios_uuid'
-                - 'instanceUUID'
-                - 'full_name'
-            default: 'smbios_uuid
+                - name_and_smbios_uuid
+                - instanceUUID
+                - full_name
+            default: name_and_smbios_uuid
             version_added: "2.9"
 '''
 

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -101,6 +101,7 @@ EXAMPLES = '''
 import ssl
 import atexit
 from ansible.errors import AnsibleError, AnsibleParserError
+from urllib.parse import quote_plus
 
 try:
     # requests is required for exception handling of the ConnectionError
@@ -361,6 +362,12 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         if update_cache:
             self._cache[cache_key] = cacheable_results
 
+    def _get_fullName(self, vm_obj_obj):
+        if(vm_obj_obj.parent):
+            return self._get_fullName(vm_obj_obj.parent) + '/' + quote_plus(vm_obj_obj.name, safe='')
+        else:
+            return '/' + quote_plus(vm_obj_obj.name)
+
     def _populate_from_cache(self, source_data):
         """ Populate cache using source data """
         hostvars = source_data.pop('_meta', {}).get('hostvars', {})
@@ -403,14 +410,14 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         for vm_obj in objects:
             for vm_obj_property in vm_obj.propSet:
-                # VMware does not provide a way to uniquely identify VM by its name
-                # i.e. there can be two virtual machines with same name
                 # Appending "_" and VMware UUID to make it unique
                 if not vm_obj.obj.config:
                     # Sometime orphaned VMs return no configurations
                     continue
 
-                current_host = vm_obj_property.val + "_" + vm_obj.obj.config.uuid
+                # VMware does not provide a way to uniquely identify VM by its name
+                # i.e. there can be two virtual machines with same name
+                current_host = self._get_fullName(vm_obj.obj)
 
                 if current_host not in hostvars:
                     hostvars[current_host] = {}

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -102,11 +102,26 @@ import ssl
 import atexit
 from ansible.errors import AnsibleError, AnsibleParserError
 
-import urllib.parse #import quote_plus
-# Overwrite _ALWAYS_SAFE to no longer include b'_.-~', so that these are also quoted
-urllib.parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                         b'abcdefghijklmnopqrstuvwxyz'
-                         b'0123456789')
+# Overwrite _ALWAYS_SAFE to only include letters and number
+# so that everything is correctly quoted
+try:
+    # python3
+    import urllib.parse
+    urllib.parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                                          b'abcdefghijklmnopqrstuvwxyz'
+                                          b'0123456789')
+    urllib.parse._ALWAYS_SAFE_BYTES = bytes(urllib.parse._ALWAYS_SAFE)
+except ImportError:
+    # python2
+    import urllib
+    from past.builtins import xrange
+    urllib.always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                          'abcdefghijklmnopqrstuvwxyz'
+                          '0123456789')
+    urllib._safe_map = {}
+    for i, c in zip(xrange(256), str(bytearray(xrange(256)))):
+        urllib._safe_map[c] = c if (i < 128 and c in urllib.always_safe) else '%{0:02X}'.format(i)
+    urllib.parse = urllib  # face pyton3 structure, so that python3 syntax can be used afterwards
 
 try:
     # requests is required for exception handling of the ConnectionError

--- a/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -96,7 +96,7 @@ echo "Creates folder structure to test inventory folder support"
 ansible-playbook -i 'localhost,' test_vmware_prep_folders.yml
 
 check_cache() {
-    ls -la $inventory_cache
+    ls -la "$inventory_cache"
     echo "Check if cache is working for inventory plugin"
     if [ ! -n "$(find "${inventory_cache}" -maxdepth 1 -name 'vmware_vm_inventory_*' -print -quit)" ]; then
         echo "Cache directory not found. Please debug"
@@ -112,17 +112,17 @@ clear_cache() {
 
 get_inventory() {
     echo "Get inventory ${1}"
-    ansible-inventory -i ${1} --list
+    ansible-inventory -i "${1}" --list
     check_cache
     clear_cache
 
     echo "Get inventory using YAML"
-    ansible-inventory -i ${1} --list --yaml
+    ansible-inventory -i "${1}" --list --yaml
     check_cache
     clear_cache
 
     echo "Get inventory using TOML"
-    ansible-inventory -i ${1} --list --toml
+    ansible-inventory -i "${1}" --list --toml
     check_cache
     clear_cache
 }

--- a/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -69,7 +69,7 @@ cleanup() {
 # This is required, as otherwise we overwite exit codes of commands we call and the integration
 # test fails prematurely, but reports successful execution
 failure_cleanup() {
-    echo "Previous command faild."
+    echo "Previous command failed."
     cleanup
     exit 1
 }

--- a/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -48,6 +48,9 @@ curl "http://${VCENTER_HOSTNAME}:${port}/spawn?datacenter=1&cluster=1&folder=0" 
 echo "Debugging new instances"
 curl "http://${VCENTER_HOSTNAME}:${port}/govc_find"
 
+# Creates folder structure to test inventory folder support
+ansible-playbook -i 'localhost,' test_vmware_prep_folders.yml
+
 # Get inventory
 ansible-inventory -i ${VMWARE_CONFIG} --list
 

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
@@ -1,0 +1,60 @@
+# Test code for the vmware guest dynamic plugin module
+# Copyright: (c) 2019, Diego Morales <dgmorales@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+- name: Prepare VMware folders for testing dynamic inventory folder support
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}' # to get the same behavior as implicit localhost
+    vcsim_user: user
+    vcsim_pass: pass
+    datacenter: DC0
+  tasks:
+    - name: store the vcenter container ip
+      set_fact:
+        vcsim: "{{ lookup('env', 'VCENTER_HOST') }}"
+
+    - debug:
+        var: vcsim
+
+    - name: Create root folder
+      vcenter_folder:
+        hostname: '{{ vcsim }}'
+        username: '{{ vcsim_user }}'
+        password: '{{ vcsim_pass }}'
+        validate_certs: no
+        datacenter: '{{ datacenter }}'
+        folder_name: folder0
+        folder_type: vm
+        state: present
+
+    - name: Create subfolders
+      vcenter_folder:
+        hostname: '{{ vcsim }}'
+        username: '{{ vcsim_user }}'
+        password: '{{ vcsim_pass }}'
+        validate_certs: no
+        datacenter: '{{ datacenter }}'
+        folder_name: '{{ item }}'
+        folder_type: vm
+        parent_folder: folder0
+        state: present
+      loop:
+        - subfolderA
+        - subfolderB
+
+    - name: Move VMs to new folders
+      vmware_guest_move:
+        hostname: '{{ vcsim }}'
+        username: '{{ vcsim_user }}'
+        password: '{{ vcsim_pass }}'
+        validate_certs: no
+        datacenter: '{{ datacenter }}'
+        name: '{{ item.vm }}'
+        dest_folder: '{{ item.folder }}'
+      loop:
+        - { vm: 'DC0_H0_VM0', folder: '/{{ datacenter }}/vm/folder0/subfolderA'}
+        - { vm: 'DC0_H0_VM1', folder: '/{{ datacenter }}/vm/folder0/subfolderB'}

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
@@ -45,6 +45,8 @@
       loop:
         - subfolderA
         - subfolderB
+        - subfolder_with_special'*:"&^%äß¿èẽ_chars
+        - subfolder/with/\slashes
 
     - name: Move VMs to new folders
       vmware_guest_move:

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
@@ -9,8 +9,8 @@
   gather_facts: no
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}' # to get the same behavior as implicit localhost
-    vcsim_user: user
-    vcsim_pass: pass
+    vcsim_user: "{{ lookup('env', 'VMWARE_USERNAME')|default('user') }}"
+    vcsim_pass: "{{ lookup('env', 'VMWARE_PASSWORD')|default('pass') }}"
     datacenter: DC0
   tasks:
     - name: store the vcenter container ip

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_vm_inventory.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_vm_inventory.yml
@@ -10,9 +10,9 @@
       set_fact:
         vcsim: "{{ lookup('env', 'VCENTER_HOSTNAME') }}"
 
-    - name: Check that there are 'all' and 'otherGuest' groups present in inventory
+    - name: Check that some expected groups are present in inventory
       assert:
-        that: "'{{ item }}' in {{ groups.keys() | list }}"
+        that: "item in (groups.keys()|list)"
       with_items:
       - all
       - otherGuest


### PR DESCRIPTION
##### SUMMARY
Possible name collision within the vmware dynamic inventory plugin.
This change vmname to a urlencoded vmpath (to make it unique).
Fixes #55135 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/vmware_vm_inventory.py

##### ADDITIONAL INFORMATION
Currently the inventory name is the vmname concatenated with it's uuid. But neither the name nor the uuid is guaranteed to be unique (both can be set arbitrarily). The only thing that is unique, is the full folder path including the vm name. Within a single folder, it is not allowed (and not possible) to have two vms with identical name.
Also special chars are not escaped properly. VMware allows any character within vm names, folder names, ... This causes even trouble within VMwares own PowerCLI api (the powershell one)

##### DRAFT Status
Currently this pr is a draft, as it slows down the inventory plugin enormously.