### PR TITLE
Add a title to the installation guide

### DIFF
--- a/docs/docsite/rst/installation_guide/index.rst
+++ b/docs/docsite/rst/installation_guide/index.rst
@@ -1,6 +1,9 @@
+******************
+Installation Guide
+******************
+
 Welcome to the Ansible Installation Guide!
 
-Introductory install guide text here.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
##### SUMMARY
 
Add a title to the installation guide and also remove placeholder text that adds little.

Before this PR the title element in the HTML is `<title>&lt;no title&gt; — Ansible Documentation</title>` 

See <https://docs.ansible.com/ansible/devel/installation_guide/>

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs

##### ADDITIONAL INFORMATION

Checked and built with:

```sh
cd docs/docsite
rstcheck rst/installation_guide/index.rst
make htmlsingle rst=installation_guide/index.rst
```

Then reviewed in a browser.