### PR TITLE
Backport/2.7/55083

### DIFF
--- a/changelogs/fragments/55083-univention-diff-UnboundLocalError.yaml
+++ b/changelogs/fragments/55083-univention-diff-UnboundLocalError.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - udm_user - Fix issues when state is absent with undefined variable diff at the module return.
+  - udm_group - Fix issues when state is absent with undefined variable diff at the module return.
+  - udm_share - Fix issues when state is absent with undefined variable diff at the module return.
+  - udm_dns_zone - Fix issues when state is absent with undefined variable diff at the module return.
+  - udm_dns_record - Fix issues when state is absent with undefined variable diff at the module return.

--- a/lib/ansible/modules/cloud/univention/udm_dns_record.py
+++ b/lib/ansible/modules/cloud/univention/udm_dns_record.py
@@ -122,6 +122,7 @@ def main():
     data = module.params['data']
     state = module.params['state']
     changed = False
+    diff = None
 
     obj = list(ldap_search(
         '(&(objectClass=dNSZone)(zoneName={})(relativeDomainName={}))'.format(zone, name),

--- a/lib/ansible/modules/cloud/univention/udm_dns_zone.py
+++ b/lib/ansible/modules/cloud/univention/udm_dns_zone.py
@@ -169,6 +169,7 @@ def main():
     mx = module.params['mx']
     state = module.params['state']
     changed = False
+    diff = None
 
     obj = list(ldap_search(
         '(&(objectClass=dNSZone)(zoneName={}))'.format(zone),

--- a/lib/ansible/modules/cloud/univention/udm_group.py
+++ b/lib/ansible/modules/cloud/univention/udm_group.py
@@ -111,6 +111,7 @@ def main():
     subpath = module.params['subpath']
     state = module.params['state']
     changed = False
+    diff = None
 
     groups = list(ldap_search(
         '(&(objectClass=posixGroup)(cn={}))'.format(name),

--- a/lib/ansible/modules/cloud/univention/udm_share.py
+++ b/lib/ansible/modules/cloud/univention/udm_share.py
@@ -476,6 +476,7 @@ def main():
     name = module.params['name']
     state = module.params['state']
     changed = False
+    diff = None
 
     obj = list(ldap_search(
         '(&(objectClass=univentionShare)(cn={}))'.format(name),

--- a/lib/ansible/modules/cloud/univention/udm_user.py
+++ b/lib/ansible/modules/cloud/univention/udm_user.py
@@ -410,6 +410,7 @@ def main():
     subpath = module.params['subpath']
     state = module.params['state']
     changed = False
+    diff = None
 
     users = list(ldap_search(
         '(&(objectClass=posixAccount)(uid={}))'.format(username),


### PR DESCRIPTION
##### SUMMARY
The variable diff is only assigned if state is 'present', else the
variable is unused. But the module will return the diff variable as a
return value. If the state isn't 'present' the module will fail with an
python UnboundLocalError exception.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
* udm_user
* udm_group
* udm_share
* udm_dns_zone
* udm_dns_record

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```Python
The full traceback is:
Traceback (most recent call last):
 File "/tmp/ansible_Id1UGE/ansible_module_udm_user.py", line 522, in <module>
   main()
 File "/tmp/ansible_Id1UGE/ansible_module_udm_user.py", line 517, in main
   diff=diff,
UnboundLocalError: local variable 'diff' referenced before assignment

fatal: [srv-ucs-01]: FAILED! => {
   "changed": false,  
   "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Id1UGE/ansible_module_udm_user.py\", line 522, in <module>\n    main()\n  File \"/tmp/ansible_Id1UGE/ansible_module_udm_user.py\",
line 517, in main\n    diff=diff,\nUnboundLocalError: local variable 'diff' referenced before assignment\n",                                                                                                      
   "module_stdout": "",  
   "msg": "MODULE FAILURE",  
   "rc": 1
}
```