### PR TITLE
VMware: get_all_host_objs accepts list of host

### DIFF
--- a/changelogs/fragments/vmware_portgroup_list_host.yml
+++ b/changelogs/fragments/vmware_portgroup_list_host.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_portgroup accepts list of ESXi hostsystem. Modified get_all_host_objs API to accept list of hostsystems.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1109,7 +1109,7 @@ class PyVmomi(object):
                 for host in esxi_host_name:
                     esxi_host_obj = self.find_hostsystem_by_name(host_name=host)
                     if esxi_host_obj:
-                        host_obj_list = [esxi_host_obj]
+                        host_obj_list.append(esxi_host_obj)
                     else:
                         self.module.fail_json(changed=False, msg="ESXi '%s' not found" % host)
 


### PR DESCRIPTION
##### SUMMARY
vmware_portgroup accepts list of hosts, get_all_host_objs API modified
to accept list of hosts.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_portgroup_list_host.yml
lib/ansible/module_utils/vmware.py