### PR TITLE
fix 'APIC Error 403: padding check failed' in python3

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -267,7 +267,7 @@ class ACIModule(object):
         self.headers['Cookie'] = 'APIC-Certificate-Algorithm=v1.0; ' +\
                                  'APIC-Certificate-DN=%s; ' % sig_dn +\
                                  'APIC-Certificate-Fingerprint=fingerprint; ' +\
-                                 'APIC-Request-Signature=%s' % sig_signature
+                                 'APIC-Request-Signature=%s' % sig_signature.decode('ascii')
 
     def response_json(self, rawoutput):
         ''' Handle APIC JSON response output '''

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -39,7 +39,7 @@ from copy import deepcopy
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 
 # Optional, only used for APIC signature-based authentication
 try:
@@ -267,7 +267,7 @@ class ACIModule(object):
         self.headers['Cookie'] = 'APIC-Certificate-Algorithm=v1.0; ' +\
                                  'APIC-Certificate-DN=%s; ' % sig_dn +\
                                  'APIC-Certificate-Fingerprint=fingerprint; ' +\
-                                 'APIC-Request-Signature=%s' % sig_signature.decode('ascii')
+                                 'APIC-Request-Signature=%s' % to_native(sig_signature)
 
     def response_json(self, rawoutput):
         ''' Handle APIC JSON response output '''


### PR DESCRIPTION
##### SUMMARY
With python2 the APIC-Request-Signature is filled in correctly
APIC-Request-Signature=aAvxASu...

But with python3 the string format method seems to
add the binary encoding prefix to the output, causing a padding error:
APIC-Request-Signature=b'lFmHWvwW4dr...

This fixes #50913

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aci

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Reproduce:
**test.py**
```python
# -*- coding: utf-8 -*-
import base64
a = base64.b64encode(b'\u0001')
b = '%s' % a
print(b)
```
```bash
python --version; python test.py
Python 2.7.16 :: Anaconda, Inc.
XHUwMDAx
Python 3.6.3 :: Anaconda, Inc.
b'XHUwMDAx'
```