### PR TITLE
vdo: fix modify stage KeyError on unsupported parameter

### DIFF
--- a/lib/ansible/modules/system/vdo.py
+++ b/lib/ansible/modules/system/vdo.py
@@ -606,14 +606,16 @@ def run_module():
         modtrans = {}
 
         for statfield in statusparamkeys:
-            currentvdoparams[statfield] = processedvdos[desiredvdo][statfield]
+            if statfield in processedvdos[desiredvdo]:
+                currentvdoparams[statfield] = processedvdos[desiredvdo][statfield]
+
             modtrans[statfield] = vdokeytrans[statfield]
 
         # Build a dictionary of current parameters formatted with the
         # same keys as the AnsibleModule parameters.
         currentparams = {}
-        for paramkey in currentvdoparams.keys():
-            currentparams[modtrans[paramkey]] = currentvdoparams[paramkey]
+        for paramkey in modtrans.keys():
+            currentparams[modtrans[paramkey]] = modtrans[paramkey]
 
         diffparams = {}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In "status: present" playbook execution for a VDO volume that is
absent, all of the parameters that are given in the playbook are
issued to the "vdo create" command, therefore any parameters that
become "unrecognized" will result in the "vdo" command returning an
error with the message "unrecognized arguments", which can then be
relayed back to the user.  This is a gracefully handled failure case.

Examples of "unrecognized" parameters are new features that are not
yet in the current version of VDO, or features that were removed
since the current version of VDO.

In "status: present" playbook execution for a VDO volume that is
already present, the same behavior as the "creation" stage of the
module should occur, but doesn't occur, since the key strings for
the "vdo status" output of the parameter do not exist.  This results
in a KeyError on the parameter that no longer exists.

Therefore, use "if statfield in processedvdos[desiredvdo]:" to filter
the modifiable parameters with the ones that are supported in this
VDO version, then use "if statfield not in processedvdos[desiredvdo]:"
to evade the KeyError, and add the "unsupported" parameters.

Also, instead of using the "currentvdoparams" dictionary, which
filters only the parameters reported by the "vdo status" output, use
the "modtrans" dictionary, which contains all of the possible
parameters.  Therefore, if the playbook specifies an "unsupported"
parameter, let it be passed on to the "vdo" command, to display an
actionable error message.

Fixes #54556 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vdo
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
