### PR TITLE
Adding a provision to create FIFO queues for SQS

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -183,6 +183,7 @@ def create_or_update_sqs_queue(connection, module):
             result['changed'] = True
 
         if not module.check_mode:
+            result['fifo_queue'] = queue.get_attributes('FifoQueue')['FifoQueue']
             result['queue_arn'] = queue.get_attributes('QueueArn')['QueueArn']
             result['default_visibility_timeout'] = queue.get_attributes('VisibilityTimeout')['VisibilityTimeout']
             result['message_retention_period'] = queue.get_attributes('MessageRetentionPeriod')['MessageRetentionPeriod']
@@ -209,11 +210,12 @@ def update_sqs_queue(queue,
                      redrive_policy=None):
     changed = False
 
+    fifo_queue = module.params.get('fifo_queue')
     if fifo_queue == 'true':
-         changed = set_queue_attribute(queue, 'FifoQueue', true,
+        changed = set_queue_attribute(queue, 'FifoQueue', true,
                                   check_mode=check_mode) or changed
     else:
-         changed = set_queue_attribute(queue, 'FifoQueue', false,
+        changed = set_queue_attribute(queue, 'FifoQueue', false,
                                   check_mode=check_mode) or changed
     
     changed = set_queue_attribute(queue, 'VisibilityTimeout', default_visibility_timeout,
@@ -318,6 +320,7 @@ def main():
         elif (fifo_queue != 'true' and fifo_queue != 'false'):
             module.fail_json(msg='possible value of fifo_queue is true or false')
                 
+        module.params.set('fifo_queue', fifo_queue)
         if state == 'present':
             create_or_update_sqs_queue(connection, module)
         elif state == 'absent':
@@ -326,5 +329,6 @@ def main():
     except (NoAuthHandlerFound, AnsibleAWSError) as e:
         module.fail_json(msg=str(e))
 
+        
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -163,7 +163,7 @@ def create_or_update_sqs_queue(connection, module):
         policy=module.params.get('policy'),
         redrive_policy=module.params.get('redrive_policy')
     )
-    
+
     if fifo_queue == 'true':
         queue_name = queue_name + '.fifo'
 
@@ -182,9 +182,9 @@ def create_or_update_sqs_queue(connection, module):
             # Create new
             if not module.check_mode:
                 if fifo_queue == 'true':
-                    queue = connection.create_queue(queue_name, Attributes={'FifoQueue': 'True'})
+                    queue = connection.create_queue(queue_name)
                 else:
-                    queue = connection.create_queue(queue_name, Attributes={'FifoQueue': 'False'})
+                    queue = connection.create_queue(queue_name)
 
                 update_sqs_queue(queue, **queue_attributes)
             result['changed'] = True
@@ -215,6 +215,8 @@ def update_sqs_queue(queue,
                      redrive_policy=None):
     changed = False
 
+    changed = set_queue_attribute(queue, 'FifoQueue', fifo_queue,
+                                  check_mode=check_mode) or changed
     changed = set_queue_attribute(queue, 'VisibilityTimeout', default_visibility_timeout,
                                   check_mode=check_mode) or changed
     changed = set_queue_attribute(queue, 'MessageRetentionPeriod', message_retention_period,
@@ -257,7 +259,7 @@ def set_queue_attribute(queue, attribute, value, check_mode=False):
 
 def delete_sqs_queue(connection, module):
     queue_name = module.params.get('name')
-    
+
     if module.params.get('fifo_queue') == 'true':
         queue_name = queue_name + '.fifo'
 
@@ -321,6 +323,6 @@ def main():
     except (NoAuthHandlerFound, AnsibleAWSError) as e:
         module.fail_json(msg=str(e))
 
-        
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -152,9 +152,9 @@ from ansible.module_utils.ec2 import AnsibleAWSError, connect_to_aws, ec2_argume
 
 def create_or_update_sqs_queue(connection, module):
     queue_name = module.params.get('name')
-    fifo_queue = module.params.get('fifo_queue')
 
     queue_attributes = dict(
+        fifo_queue = module.params.get('fifo_queue'),
         default_visibility_timeout=module.params.get('default_visibility_timeout'),
         message_retention_period=module.params.get('message_retention_period'),
         maximum_message_size=module.params.get('maximum_message_size'),
@@ -206,6 +206,7 @@ def create_or_update_sqs_queue(connection, module):
 
 def update_sqs_queue(queue,
                      check_mode=False,
+                     fifo_queue=None,
                      default_visibility_timeout=None,
                      message_retention_period=None,
                      maximum_message_size=None,

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -313,6 +313,9 @@ def main():
         if fifo_queue:
             if (fifo_queue != 'true' and fifo_queue != 'false'):
                 module.fail_json(msg='fifo_queue can only be either true or false. If no value is specified standard queue will be created.')
+                
+        if not fifo_queue:
+            fifo_queue = 'false'
         
         if state == 'present':
             create_or_update_sqs_queue(connection, module)

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -41,6 +41,7 @@ options:
       - true or false.
     choices: ['true', 'false']
     default: 'false'
+    version_added: '2.8'
   default_visibility_timeout:
     description:
       - The default visibility timeout in seconds.
@@ -310,6 +311,12 @@ def main():
         connection = connect_to_aws(boto.sqs, region, **aws_connect_params)
 
         state = module.params.get('state')
+        fifo_queue = module.params.get('fifo_queue')
+        
+        if not fifo_queue:
+            fifo_queue = 'false'
+        elif (fifo_queue != 'true' and fifo_queue != 'false'):
+            module.fail_json(msg='possible value of fifo_queue is true or false')
                 
         if state == 'present':
             create_or_update_sqs_queue(connection, module)

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -310,13 +310,12 @@ def main():
         connection = connect_to_aws(boto.sqs, region, **aws_connect_params)
 
         state = module.params.get('state')
-        if fifo_queue:
+        if not fifo_queue:
+            fifo_queue = 'false'
+        else:
             if (fifo_queue != 'true' and fifo_queue != 'false'):
                 module.fail_json(msg='fifo_queue can only be either true or false. If no value is specified standard queue will be created.')
                 
-        if not fifo_queue:
-            fifo_queue = 'false'
-        
         if state == 'present':
             create_or_update_sqs_queue(connection, module)
         elif state == 'absent':

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -310,11 +310,6 @@ def main():
         connection = connect_to_aws(boto.sqs, region, **aws_connect_params)
 
         state = module.params.get('state')
-        if not fifo_queue:
-            fifo_queue = 'false'
-        else:
-            if (fifo_queue != 'true' and fifo_queue != 'false'):
-                module.fail_json(msg='fifo_queue can only be either true or false. If no value is specified standard queue will be created.')
                 
         if state == 'present':
             create_or_update_sqs_queue(connection, module)

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -41,7 +41,6 @@ options:
       - true or false.
     choices: ['true', 'false']
     default: 'false'
-    version_added: "2.6"
   default_visibility_timeout:
     description:
       - The default visibility timeout in seconds.


### PR DESCRIPTION
<!--- Adding a provision to create FIFO queues for SQS -->

+label: Added new variable fifo_queue that defines which type of queues will be created

##### SUMMARY

Added functionality to specify the type of queue.
- Added provision to defined the type of queues

Fixes - Fixes https://github.com/ansible/ansible/issues/26592

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib.ansible.modules.cloud.amazon.sqs_queue```
