### PR TITLE
BIGIP: multiple.fixes

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_gtm_pool_member.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool_member.py
@@ -606,9 +606,8 @@ class ModuleManager(object):
         self.want = None
         self.have = None
         self.changes = None
-        self.replace_all_with = False
+        self.replace_all_with = None
         self.purge_links = list()
-        self.on_device = None
 
     def _set_changed_options(self):
         changed = {}
@@ -711,7 +710,7 @@ class ModuleManager(object):
 
         if diff:
             to_purge = [item['selfLink'] for item in on_device if self._transform_api_names(item) in diff]
-            self.purge_links = to_purge
+            self.purge_links.extend(to_purge)
 
     def execute(self, params=None):
         self.want = ModuleParameters(params=params)

--- a/lib/ansible/modules/network/f5/bigip_gtm_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_server.py
@@ -1157,9 +1157,21 @@ class Difference(object):
             )
         want = [OrderedDict(sorted(d.items())) for d in devices]
         have = [OrderedDict(sorted(d.items())) for d in have_devices]
+        if len(have_devices) > 0:
+            if self._false_positive(devices, have_devices):
+                return False
         if want != have:
             return True
         return False
+
+    def _false_positive(self, devices, have_devices):
+        match = 0
+        for w in devices:
+            for h in have_devices:
+                if w.items() == h.items():
+                    match = match + 1
+        if match == len(devices):
+            return True
 
     def _server_type_changed(self):
         if self.want.server_type is None:

--- a/lib/ansible/modules/network/f5/bigip_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_pool.py
@@ -814,8 +814,8 @@ class ModuleManager(object):
         self.want = None
         self.have = None
         self.changes = None
-        self.replace_all_with = False
-        self.purge_links = None
+        self.replace_all_with = None
+        self.purge_links = list()
 
     def exec_module(self):
         wants = None
@@ -874,7 +874,7 @@ class ModuleManager(object):
 
         if diff:
             to_purge = [item['selfLink'] for item in on_device if item['name'] in diff]
-            self.purge_links = to_purge
+            self.purge_links.extend(to_purge)
 
     def execute(self, params=None):
         self.want = ModuleParameters(params=params)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

fixes an edge case where order of devices parameters breaks idempotency
code correction for aggregates in bigip_gtm_pool_member and bigip_pool to be in line with established patterns
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
 lib/ansible/modules/network/f5/bigip_gtm_pool_member.py
 lib/ansible/modules/network/f5/bigip_gtm_server.py
 lib/ansible/modules/network/f5/bigip_pool.py



