### PR TITLE
vmware_host_config_manager: do not apply an empty list of change

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
@@ -164,7 +164,7 @@ class VmwareConfigManager(PyVmomi):
                         changed_list.append(option_key)
                 else:  # Don't silently drop unknown options. This prevents typos from falling through the cracks.
                     self.module.fail_json(msg="Unsupported option %s" % option_key)
-            if changed_list:
+            if change_option_list:
                 if self.module.check_mode:
                     changed_suffix = ' would be changed.'
                 else:


### PR DESCRIPTION
##### SUMMARY

In a multi-host context, `changed_list` will record all the changes
done on any host. So as soon as ONE host is changed, it will be `True`.

A host can potentially already have a parameter set, in this case
`change_option_list` will be empty.

This commit uses `change_option_list` instead of `changed_list` to
decided if a given host should be updated.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_config_manager