### PR TITLE
Fix to allow multiple origins with origin access identity enabled

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1407,7 +1407,8 @@ class CloudFrontValidationManager(object):
             return None
         try:
             comment = "access-identity-by-ansible-%s-%s" % (origin.get('domain_name'), self.__default_datetime_string)
-            cfoai_config = dict(CloudFrontOriginAccessIdentityConfig=dict(CallerReference=self.__default_datetime_string,
+            caller_reference = "%s-%s" % (origin.get('domain_name'), self.__default_datetime_string)
+            cfoai_config = dict(CloudFrontOriginAccessIdentityConfig=dict(CallerReference=caller_reference,
                                                                           Comment=comment))
             oai = client.create_cloud_front_origin_access_identity(**cfoai_config)['CloudFrontOriginAccessIdentity']['Id']
         except Exception as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
cloudfront_distribution module will fail if adding more than one origin to a distribution that has origin access identity enabled.  The caller_reference is duplicated for each identity and AWS requires the caller_reference to be unique.

``` 
MSG:

Couldn't create Origin Access Identity for id S3-domain2.example.org: An error occurred (CloudFrontOriginAccessIdentityAlreadyExists) when calling the CreateCloudFrontOriginAccessIdentity operation: The caller reference you are using to create the CloudFront origin access identity is associated with another identity.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

[AWS Docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html#CloudFront.Client.create_cloud_front_origin_access_identity) for create_cloud_front_origin_access_identity.

> If the CallerReference is a value you already sent in a previous request to create an identity, but the content of the CloudFrontOriginAccessIdentityConfig is different from the original request, CloudFront returns a CloudFrontOriginAccessIdentityAlreadyExists error.

Test playbook
```
---
- hosts: localhost
  vars:

      cloudfront:
        distribution:
          dist1:
            comment: "Ansible Test"
            aliases: []
            origins:
              - id: "S3-domain1.example.org"
                domain_name: "domain1.example.org.s3.amazonaws.com"
                origin_path: ""
                custom_headers: []
                s3_origin_access_identity_enabled: true
              - id: "S3-domain2.example.org"
                domain_name: "domain2.example.org.s3.amazonaws.com"
                origin_path: "/other"
                custom_headers: []
                s3_origin_access_identity_enabled: true
            enabled: false
            price_class: "PriceClass_100"
            default_root_object: "index.html"
            http_version: "http2"
            viewer_certificate:
              cloudfront_default_certificate: true
              minimum_protocol_version: "TLSv1.1_2016"
            default_cache_behavior:
                target_origin_id: "S3-domain1.example.org"
                forwarded_values:
                  query_string: false
                  cookies:
                    forward: none
                  headers: []
                trusted_signers: {}
                viewer_protocol_policy: "allow-all"
                min_ttl: 0
                max_ttl: 31536000
                allowed_methods:
                  items:
                    - GET
                    - HEAD
                  cached_methods:
                    - GET
                    - HEAD
                compress: false
                lambda_function_associations: []
                smooth_streaming: false
                field_level_encryption_id: ""
            cache_behaviors:
              - target_origin_id: "S3-domain2.example.org"
                path_pattern: "/other/*"
                forwarded_values:
                  query_string: false
                  cookies:
                    forward: none
                  headers: []
                trusted_signers: {}
                viewer_protocol_policy: "allow-all"
                min_ttl: 0
                max_ttl: 31536000
                allowed_methods:
                  items:
                    - GET
                    - HEAD
                  cached_methods:
                    - GET
                    - HEAD
                compress: false
                lambda_function_associations: []
                smooth_streaming: false
                field_level_encryption_id: ""
            custom_error_responses:
              - response_page_path: "/index.html"
                response_code: 200
                error_caching_min_ttl: 300
                error_code: 404
            tags: {}

  tasks:

    - name: "Create Cloudfront Distribution"
      cloudfront_distribution:
        state: "present"
        comment: "{{ item.comment }}"
        aliases: "{{ item.aliases }}"
        tags: "{{ item.tags }}"
        origins: "{{ item.origins }}"
        enabled: "{{ item.enabled }}"
        price_class: "{{ item.price_class }}"
        http_version: "{{ item.http_version }}"
        default_root_object: "{{ item.default_root_object }}"
        viewer_certificate: "{{ item.viewer_certificate }}"
        cache_behaviors: "{{ item.cache_behaviors }}"
        default_cache_behavior: "{{ item.default_cache_behavior }}"
        custom_error_responses: "{{ item.custom_error_responses }}"
      with_items:
        "{{ cloudfront.distribution.values() }}"
```
Results
```
(ansible_dev) [devops@localhost play]$ ansible-playbook cloudfront_test.yml
 [WARNING]: Unable to parse /home/devops/projects/play/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Create Cloudfront Distribution] *******************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: CloudFrontOriginAccessIdentityAlreadyExists: An error occurred (CloudFrontOriginAccessIdentityAlreadyExists) when calling the CreateCloudFrontOriginAccessIdentity operation: The caller reference you are using to create the CloudFront origin access identity is associated with another identity.
failed: [localhost] (item={u'comment': u'Ansible Test', u'origins': [{u'origin_path': u'', u'custom_headers': [], u'id': u'S3-domain1.example.org', u's3_origin_access_identity_enabled': True, u'domain_name': u'domain1.example.org.s3.amazonaws.com'}, {u'origin_path': u'/other', u'custom_headers': [], u'id': u'S3-domain2.example.org', u's3_origin_access_identity_enabled': True, u'domain_name': u'domain2.example.org.s3.amazonaws.com'}], u'tags': {}, u'viewer_certificate': {u'minimum_protocol_version': u'TLSv1.1_2016', u'cloudfront_default_certificate': True}, u'http_version': u'http2', u'enabled': False, u'price_class': u'PriceClass_100', u'default_root_object': u'index.html', u'cache_behaviors': [{u'trusted_signers': {}, u'allowed_methods': {u'items': [u'GET', u'HEAD'], u'cached_methods': [u'GET', u'HEAD']}, u'compress': False, u'target_origin_id': u'S3-domain2.example.org', u'field_level_encryption_id': u'', u'smooth_streaming': False, u'min_ttl': 0, u'viewer_protocol_policy': u'allow-all', u'max_ttl': 31536000, u'path_pattern': u'/other/*', u'forwarded_values': {u'query_string': False, u'headers': [], u'cookies': {u'forward': u'none'}}, u'lambda_function_associations': []}], u'custom_error_responses': [{u'error_caching_min_ttl': 300, u'response_code': 200, u'response_page_path': u'/index.html', u'error_code': 404}], u'default_cache_behavior': {u'trusted_signers': {}, u'allowed_methods': {u'items': [u'GET', u'HEAD'], u'cached_methods': [u'GET', u'HEAD']}, u'compress': False, u'target_origin_id': u'S3-domain1.example.org', u'field_level_encryption_id': u'', u'smooth_streaming': False, u'min_ttl': 0, u'viewer_protocol_policy': u'allow-all', u'max_ttl': 31536000, u'forwarded_values': {u'query_string': False, u'headers': [], u'cookies': {u'forward': u'none'}}, u'lambda_function_associations': []}, u'aliases': []}) => {
    "boto3_version": "1.9.130",
    "botocore_version": "1.12.130",
    "changed": false,
    "error": {
        "code": "CloudFrontOriginAccessIdentityAlreadyExists",
        "message": "The caller reference you are using to create the CloudFront origin access identity is associated with another identity.",
        "type": "Sender"
    },
    "item": {
        "aliases": [],
        "cache_behaviors": [
            {
                "allowed_methods": {
                    "cached_methods": [
                        "GET",
                        "HEAD"
                    ],
                    "items": [
                        "GET",
                        "HEAD"
                    ]
                },
                "compress": false,
                "field_level_encryption_id": "",
                "forwarded_values": {
                    "cookies": {
                        "forward": "none"
                    },
                    "headers": [],
                    "query_string": false
                },
                "lambda_function_associations": [],
                "max_ttl": 31536000,
                "min_ttl": 0,
                "path_pattern": "/other/*",
                "smooth_streaming": false,
                "target_origin_id": "S3-domain2.example.org",
                "trusted_signers": {},
                "viewer_protocol_policy": "allow-all"
            }
        ],
        "comment": "Ansible Test",
        "custom_error_responses": [
            {
                "error_caching_min_ttl": 300,
                "error_code": 404,
                "response_code": 200,
                "response_page_path": "/index.html"
            }
        ],
        "default_cache_behavior": {
            "allowed_methods": {
                "cached_methods": [
                    "GET",
                    "HEAD"
                ],
                "items": [
                    "GET",
                    "HEAD"
                ]
            },
            "compress": false,
            "field_level_encryption_id": "",
            "forwarded_values": {
                "cookies": {
                    "forward": "none"
                },
                "headers": [],
                "query_string": false
            },
            "lambda_function_associations": [],
            "max_ttl": 31536000,
            "min_ttl": 0,
            "smooth_streaming": false,
            "target_origin_id": "S3-domain1.example.org",
            "trusted_signers": {},
            "viewer_protocol_policy": "allow-all"
        },
        "default_root_object": "index.html",
        "enabled": false,
        "http_version": "http2",
        "origins": [
            {
                "custom_headers": [],
                "domain_name": "domain1.example.org.s3.amazonaws.com",
                "id": "S3-domain1.example.org",
                "origin_path": "",
                "s3_origin_access_identity_enabled": true
            },
            {
                "custom_headers": [],
                "domain_name": "domain2.example.org.s3.amazonaws.com",
                "id": "S3-domain2.example.org",
                "origin_path": "/other",
                "s3_origin_access_identity_enabled": true
            }
        ],
        "price_class": "PriceClass_100",
        "tags": {},
        "viewer_certificate": {
            "cloudfront_default_certificate": true,
            "minimum_protocol_version": "TLSv1.1_2016"
        }
    },
    "response_metadata": {
        "http_headers": {
            "content-length": "396",
            "content-type": "text/xml",
            "date": "Thu, 11 Apr 2019 21:53:26 GMT",
            "x-amzn-requestid": "3ca92308-5ca4-11e9-ab35-5b49694665f6"
        },
        "http_status_code": 409,
        "request_id": "3ca92308-5ca4-11e9-ab35-5b49694665f6",
        "retry_attempts": 0
    }
}

MSG:

Couldn't create Origin Access Identity for id S3-domain2.example.org: An error occurred (CloudFrontOriginAccessIdentityAlreadyExists) when calling the CreateCloudFrontOriginAccessIdentity operation: The caller reference you are using to create the CloudFront origin access identity is associated with another identity.


PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```
