### PR TITLE
ec2_eip: move to boto3, add name and tags

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -89,10 +89,12 @@ options:
         needed to support the associated device.  This is false by default to reflect the fact that AWS is deprecating
         EC2-Classic in preference of VPC.  The old option of in_vpc is aliased to this option and the logic is inverted
         (if in_vpc is set to True, then ec2_classic is False. Likewise if in_vpc = False, then ec2-classic= True).
+        The ec2_classic option was added in version 2.9, but its alias in_vpc was added in 1.4.  The version_added
+        needs to be 1.4 to keep the sanity checks happy.
     required: false
     type: bool
     aliases: [ in_vpc ]
-    version_added: "2.9"
+    version_added: "1.4"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -232,7 +234,7 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO3
 
-from ansible.module_utils.ec2 import (HAS_BOTO3, ec2_argument_spec, compare_aws_tags,
+from ansible.module_utils.ec2 import (ec2_argument_spec, compare_aws_tags,
                                       boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list)
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
@@ -541,7 +543,7 @@ def main():
                                        default=False),
         release_on_disassociation=dict(required=False, type='bool', default=False),
         allow_reassociation=dict(type='bool', default=False),
-        wait_timeout=dict(default=300),
+        wait_timeout=dict(default=300, type='int'),
         private_ip_address=dict(required=False, default=None, type='str'),
         name=dict(required=False, default=None, type='str'),
         purge_tags=dict(required=False, default=False, type='bool'),
@@ -557,9 +559,6 @@ def main():
     )
 
     warnings = []
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     ec2 = module.client('ec2')
 

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -68,20 +68,20 @@ options:
       - Name for the elastic IP.  If name is unique within the account, can be used to maintain idempotency.  This
         field is set as the "Name" tag and will overwrite any existing value in the "Name" tag
     required: false
-    version_added: 2.8
+    version_added: "2.9"
   tags:
     description:
       - A hash/dictionary of tags to add to the new EIP or to add/remove from an existing one.  Please note that
         the name field sets the "Name" tag.  So if you manually clear the Name tag, you will also clear the name.
     required: false
-    version_added: 2.8
+    version_added: "2.9"
   purge_tags:
     description:
       - Delete any tags not specified in the task that are on the instance.
         This means you have to specify all the desired tags on each task affecting an instance.
     default: false
     type: bool
-    version_added: 2.8
+    version_added: "2.9"
   ec2_classic:
     description:
       - Indicates that the elastic ip should be created in the EC2-Classic domain.  This is only needed when
@@ -92,7 +92,7 @@ options:
     required: false
     type: bool
     aliases: [ in_vpc ]
-    version_added: "2.8"
+    version_added: "2.9"
 extends_documentation_fragment:
     - aws
     - ec2

--- a/test/integration/targets/ec2_eip/aliases
+++ b/test/integration/targets/ec2_eip/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_eip/tasks/main.yaml
+++ b/test/integration/targets/ec2_eip/tasks/main.yaml
@@ -1,0 +1,358 @@
+---
+- block:
+  - name: set up aws connection info
+    set_fact:
+      aws_connection_info: &aws_connection_info
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        region: "{{ aws_region }}"
+    no_log: yes
+
+  # ============================================================
+  - name: create a VPC
+    ec2_vpc_net:
+      name: "{{ resource_prefix }}-vpc"
+      state: present
+      cidr_block: "10.232.232.128/26"
+      <<: *aws_connection_info
+      tags:
+        Name: "{{ resource_prefix }}-vpc"
+        Description: "Created by ansible-test"
+    register: vpc_result
+
+  # ============================================================
+  - name: Create internet gateway
+    ec2_vpc_igw:
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      <<: *aws_connection_info
+      state: present
+    register: igw_result
+
+  # ============================================================
+  - name: create a subnet
+    ec2_vpc_subnet:
+      cidr: "10.232.232.128/28"
+      az: "{{ aws_region }}a"
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      <<: *aws_connection_info
+      tags:
+        Name: "{{ resource_prefix }}-vpc"
+        Description: "Created by ansible-test"
+      state: present
+    register: vpc_subnet_result
+
+  # ============================================================
+  - name: create an ENI with 1 primary address
+    ec2_eni:
+      subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+      <<: *aws_connection_info
+      state: present
+    register: eni_result
+
+  #============================================================
+  - name: Attempt to allocate ec2_classic EIP for VPC device
+    ec2_eip:
+      private_ip_address: "{{ eni_result.interface.private_ip_address }}"
+      device_id: "{{ eni_result.interface.id }}"
+      ec2_classic: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+    register: eip_result
+
+  - debug:
+      var: eip_result
+      verbosity: 2
+
+  - name: Ensure allocation failed due to mismatching domain types
+    assert:
+      that:
+        - eip_result.failed
+
+  #============================================================
+  - name: Allocate EIP in VPC
+    ec2_eip:
+      name: myEIP1
+      private_ip_address: "{{ eni_result.interface.private_ip_address }}"
+      device_id: "{{ eni_result.interface.id }}"
+      <<: *aws_connection_info
+      tags:
+        group: Finance
+    register: eip_result
+
+  - debug:
+      var: eip_result
+      verbosity: 2
+
+  - name: Ensure address was allocated
+    assert:
+      that:
+        - '"public_ip" in eip_result'
+        - '"myEIP1" == eip_result.name'
+        - '"group" in eip_result.tags'
+        - '"Finance" == eip_result.tags.group'
+        - '"Name" in eip_result.tags'
+
+  #============================================================
+  - name: Try to allocate duplicate
+    ec2_eip:
+      name: myEIP1
+      <<: *aws_connection_info
+    register: eip_dup_result
+
+  - debug:
+      var: eip_dup_result
+      verbosity: 2
+
+  - name: Ensure address was allocated
+    assert:
+      that:
+        - eip_dup_result.changed == False
+
+  #============================================================
+  - name: Change tags in EIP
+    ec2_eip:
+      name: myEIP1
+      purge_tags: true
+      <<: *aws_connection_info
+      tags:
+        example: test tag
+    register: eip_result
+
+  - debug:
+      var: eip_result
+      verbosity: 2
+
+  - name: Ensure address was allocated
+    assert:
+      that:
+        - '"public_ip" in eip_result'
+        - '"myEIP1" == eip_result.name'
+        - '"group" not in eip_result.tags'
+        - '"test tag" == eip_result.tags.example'
+        - '"Name" in eip_result.tags'
+
+  #============================================================
+  - name: Disassociate VPC EIP
+    ec2_eip:
+      private_ip_address: "{{ eni_result.interface.private_ip_address }}"
+      device_id: "{{ eni_result.interface.id }}"
+      <<: *aws_connection_info
+      state: absent
+    register: eip_result2
+
+  - debug:
+      var: eip_result2
+      verbosity: 2
+
+  - name: Ensure address no longer exists
+    assert:
+      that:
+        - '"public_ip" not in eip_result2'
+
+  #============================================================
+  - name: Reassociate VPC EIP
+    ec2_eip:
+      public_ip: "{{ eip_result.public_ip }}"
+      device_id: "{{ eni_result.interface.id }}"
+      private_ip_address: "{{ eni_result.interface.private_ip_address }}"
+      <<: *aws_connection_info
+    register: eip_result3
+
+  - debug:
+      var: eip_result3
+      verbosity: 2
+
+  - name: Ensure address we got the address back
+    assert:
+      that:
+        - '"public_ip" in eip_result3'
+        - eip_result.public_ip == eip_result3.public_ip
+
+  #============================================================
+  - name: Allocate EIP for instance
+    ec2_eip:
+      ec2_classic: true
+      <<: *aws_connection_info
+    register: eip2_result
+
+  - debug:
+      var: eip2_result
+      verbosity: 2
+
+  - name: Ensure address was allocated
+    assert:
+      that:
+        - '"public_ip" in eip2_result'
+
+  # ============================================================
+  - name: create instance
+    ec2_instance:
+      name: TestInstance
+      instance_type: t2.micro
+      image_id: ami-0ff8a91507f77f867
+      vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+      <<: *aws_connection_info
+      state: present
+    register: ec2_result
+
+  # ============================================================
+  - name: Attempt to associate standard EIP to vpc instance
+    ec2_eip:
+      device_id: "{{ ec2_result.instances[0].instance_id }}"
+      private_ip_address: "{{ ec2_result.instances[0].private_ip_address }}"
+      public_ip: "{{ eip2_result.public_ip }}"
+      <<: *aws_connection_info
+    ignore_errors: yes
+    register: eip2_result2
+
+  - debug:
+      var: eip2_result2
+      verbosity: 2
+
+  - name: Ensure association failed due to mismatching domain types
+    assert:
+      that:
+        - eip2_result2.failed
+        - 'eip2_result2.msg.startswith("Failed to associate address")'
+
+  #============================================================
+  - name: Attempt to reassociate eip that is in use
+    ec2_eip:
+      public_ip: "{{ eip_result.public_ip }}"
+      device_id: "{{ ec2_result.instances[0].instance_id }}"
+      private_ip_address: "{{ ec2_result.instances[0].private_ip_address }}"
+      <<: *aws_connection_info
+    ignore_errors: yes
+    register: eip_result4
+
+  - debug:
+      var: eip_result4
+      verbosity: 2
+
+  - name: Ensure association failed due to mismatching domain types
+    assert:
+      that:
+        - eip_result4.failed
+        - '"Resource.AlreadyAssociated" in eip_result4.msg'
+
+  #============================================================
+  - name: Disassociate VPC EIP
+    ec2_eip:
+      private_ip_address: "{{ eni_result.interface.private_ip_address }}"
+      device_id: "{{ eni_result.interface.id }}"
+      <<: *aws_connection_info
+      state: absent
+    register: eip_result5
+
+  - debug:
+      var: eip_result5
+      verbosity: 2
+
+  - name: Ensure address no longer exists
+    assert:
+      that:
+        - '"public_ip" not in eip_result5'
+
+  # ============================================================
+  - name: Associate vpc EIP to vpc instance
+    ec2_eip:
+      device_id: "{{ ec2_result.instances[0].instance_id }}"
+      private_ip_address: "{{ ec2_result.instances[0].private_ip_address }}"
+      public_ip: "{{ eip_result.public_ip }}"
+      <<: *aws_connection_info
+    register: eip_result4
+
+  - debug:
+      var: eip_result4
+      verbosity: 2
+
+  - name: Ensure address was allocated
+    assert:
+      that:
+        - '"public_ip" in eip_result4'
+
+  #============================================================
+  - name: Allocate EIP3 in VPC
+    ec2_eip:
+      name: myEIP3
+      <<: *aws_connection_info
+    register: eip3_result
+
+  - debug:
+      var: eip3_result
+      verbosity: 2
+
+  - name: Ensure address was allocated
+    assert:
+      that:
+        - '"public_ip" in eip3_result'
+        - '"myEIP3" == eip3_result.name'
+        - '"Name" in eip3_result.tags'
+
+  always:
+    # ============================================================
+    - name: tidy up instance
+      ec2_instance:
+        instance_ids:
+          - "{{ ec2_result.instances[0].instance_id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up EIP
+      ec2_eip:
+        release_on_disassociation: true
+        public_ip: "{{ eip_result.public_ip }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up EIP2
+      ec2_eip:
+        release_on_disassociation: true
+        ip: "{{ eip2_result.public_ip }}"
+        device_id: "{{ ec2_result.instances[0].instance_id }}"
+        private_ip_address: "{{ ec2_result.instances[0].private_ip_address }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up EIP3
+      ec2_eip:
+        release_on_disassociation: true
+        name: myEIP3
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up IGW
+      ec2_vpc_igw:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up ENI
+      ec2_eni:
+        eni_id: "{{ eni_result.interface.id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up subnet
+      ec2_vpc_subnet:
+        cidr: "10.232.232.128/28"
+        az: "{{ aws_region }}a"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: "10.232.232.128/26"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true

--- a/test/integration/targets/ec2_eip/tasks/main.yaml
+++ b/test/integration/targets/ec2_eip/tasks/main.yaml
@@ -93,6 +93,22 @@
         - '"Finance" == eip_result.tags.group'
         - '"Name" in eip_result.tags'
 
+  - name: Prove creation is idempotent
+    ec2_eip:
+      name: myEIP1
+      private_ip_address: "{{ eni_result.interface.private_ip_address }}"
+      device_id: "{{ eni_result.interface.id }}"
+      <<: *aws_connection_info
+      tags:
+        group: Finance
+    register: eip_result_i
+
+  - name: Prove idempotent creation task made no changes
+    assert:
+      that:
+        - 'eip_result_i is success'
+        - 'not eip_result_i.changed'
+  
   #============================================================
   - name: Try to allocate duplicate
     ec2_eip:
@@ -169,32 +185,31 @@
         - '"public_ip" in eip_result3'
         - eip_result.public_ip == eip_result3.public_ip
 
+  # ============================================================
+  - name: create instance
+    ec2_instance:
+      name: TestInstance
+      instance_type: t2.micro
+      image_id: '{{ ec2_region_images[ec2_region] }}'
+      vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+      <<: *aws_connection_info
+      state: present
+    register: ec2_result
+
   #============================================================
-  - name: Allocate EIP for instance
+  - name: Allocate classic EIP for instance
     ec2_eip:
       ec2_classic: true
       <<: *aws_connection_info
+    ignore_errors: true
     register: eip2_result
 
   - debug:
       var: eip2_result
       verbosity: 2
 
-  - name: Ensure address was allocated
-    assert:
-      that:
-        - '"public_ip" in eip2_result'
-
-  # ============================================================
-  - name: create instance
-    ec2_instance:
-      name: TestInstance
-      instance_type: t2.micro
-      image_id: ami-0ff8a91507f77f867
-      vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      <<: *aws_connection_info
-      state: present
-    register: ec2_result
+  # note: this allocation may fail if the EC2 account is "too new"
+  #       and does not support ec2_classic
 
   # ============================================================
   - name: Attempt to associate standard EIP to vpc instance
@@ -205,16 +220,19 @@
       <<: *aws_connection_info
     ignore_errors: yes
     register: eip2_result2
+    when: "eip2_result is success"
 
   - debug:
       var: eip2_result2
       verbosity: 2
+    when: "eip2_result is success"
 
   - name: Ensure association failed due to mismatching domain types
     assert:
       that:
         - eip2_result2.failed
         - 'eip2_result2.msg.startswith("Failed to associate address")'
+    when: "eip2_result is success"
 
   #============================================================
   - name: Attempt to reassociate eip that is in use
@@ -290,6 +308,39 @@
         - '"myEIP3" == eip3_result.name'
         - '"Name" in eip3_result.tags'
 
+  - name: Destroy EIP by public ip
+    ec2_eip:
+      public_ip: "{{ eip3_result.public_ip }}"
+      <<: *aws_connection_info
+      state: absent
+    register: eip3_destroy
+
+  - debug:
+      var: eip3_destroy
+      verbosity: 2
+
+  - name: Prove destruction succeeded
+    assert:
+      that:
+        - "eip3_destroy is success"
+
+  - name: Attempt to destroy by public ip again
+    ec2_eip:
+      public_ip: "{{ eip3_result.public_ip }}"
+      <<: *aws_connection_info
+      state: absent
+    register: eip3_destroy_idem
+
+  - debug:
+      var: eip3_destroy_idem
+      verbosity: 2
+
+  - name: Prove redundant destruction by public ip is idempotent
+    assert:
+      that:
+        - "eip3_destroy_idem is success"
+        - "not eip3_destroy_idem.changed"
+
   always:
     # ============================================================
     - name: tidy up instance
@@ -300,10 +351,17 @@
         state: absent
       ignore_errors: true
 
-    - name: tidy up EIP
+    - name: tidy up ENI
+      ec2_eni:
+        eni_id: "{{ eni_result.interface.id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up EIP3
       ec2_eip:
         release_on_disassociation: true
-        public_ip: "{{ eip_result.public_ip }}"
+        name: myEIP3
         <<: *aws_connection_info
         state: absent
       ignore_errors: true
@@ -318,24 +376,10 @@
         state: absent
       ignore_errors: true
 
-    - name: tidy up EIP3
+    - name: tidy up EIP
       ec2_eip:
         release_on_disassociation: true
-        name: myEIP3
-        <<: *aws_connection_info
-        state: absent
-      ignore_errors: true
-
-    - name: tidy up IGW
-      ec2_vpc_igw:
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        <<: *aws_connection_info
-        state: absent
-      ignore_errors: true
-
-    - name: tidy up ENI
-      ec2_eni:
-        eni_id: "{{ eni_result.interface.id }}"
+        public_ip: "{{ eip_result.public_ip }}"
         <<: *aws_connection_info
         state: absent
       ignore_errors: true
@@ -344,6 +388,13 @@
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
         az: "{{ aws_region }}a"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        <<: *aws_connection_info
+        state: absent
+      ignore_errors: true
+
+    - name: tidy up IGW
+      ec2_vpc_igw:
         vpc_id: "{{ vpc_result.vpc.id }}"
         <<: *aws_connection_info
         state: absent

--- a/test/integration/targets/ec2_eip/vars/main.yml
+++ b/test/integration/targets/ec2_eip/vars/main.yml
@@ -1,0 +1,20 @@
+---
+# vars file for test_ec2_eip (taken from test_ec2_ami)
+
+# based on Amazon Linux AMI 2017.09.0 (HVM), SSD Volume Type
+ec2_region_images:
+  us-east-1: ami-8c1be5f6
+  us-east-2: ami-c5062ba0
+  us-west-1: ami-02eada62
+  us-west-2: ami-e689729e
+  ca-central-1: ami-fd55ec99
+  eu-west-1: ami-acd005d5
+  eu-central-1: ami-c7ee5ca8
+  eu-west-2: ami-1a7f6d7e
+  ap-southeast-1: ami-0797ea64
+  ap-southeast-2: ami-8536d6e7
+  ap-northeast-2: ami-9bec36f5
+  ap-northeast-1: ami-2a69be4c
+  ap-south-1: ami-4fc58420
+  sa-east-1: ami-f1344b9d
+  cn-north-1: ami-fba67596


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- update to boto3(no longer dependent on boto)
- add name and tags support
    - name can be used to specify the eip (uses the "Name" tag in AWS)
    - name and tags added to command output 
- change "in_vpc" to "ec2_classic" (with backwards compatibility) 
    - This reverses the default logic to better align with AWS deprecation of EC2-Classic instances 
- fixed numerous issues with allocating and deleting eips
- fixed the examples so they now work and align with current functionality
- added significant integration testing
- flattened and simplified much of the branching logic

Fixes:
https://github.com/ansible/ansible/issues/29871
https://github.com/ansible/ansible/issues/34422

Idempotency should be improved with this PR if "name" and/or "public_ip" are used for identification, but I don't feel comfortable saying it is fully fixed without more test coverage.

This closes #50539 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_eip

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Sanity checks run locally against python 2.7, 3.5, and 3.7 using the following command and varying the python version:
`ansible-test sanity -v --docker --python 2.7 ec2_eip`

Manually ran the integration test:
`ansible-test integration ec2_eip --docker --python 3.7`
<!--- Paste verbatim command output below, e.g. before and after your change -->
An example of the new output (captured from the integration test): 
```
ok: [testhost] => {
    "eip_result3": {
        "allocation_id": "eipalloc-0a550674664cbc5ab",
        "changed": true,
        "failed": false,
        "name": "myEIP1",
        "public_ip": "54.92.137.242",
        "resource_actions": [
            "ec2:AssociateAddress",
            "ec2:DescribeAddresses"
        ],
        "tags": {
            "Name": "myEIP1",
            "example": "test tag"
        },
    }
}

```
