### PR TITLE
[stable-2.8] vmware_tools: ignore absence of urllib3

### DIFF
--- a/lib/ansible/plugins/connection/vmware_tools.py
+++ b/lib/ansible/plugins/connection/vmware_tools.py
@@ -10,8 +10,15 @@ from os.path import exists, getsize
 from socket import gaierror
 from ssl import SSLEOFError, SSLError
 from time import sleep
-import urllib3
 import traceback
+
+URLLIB3_IMP_ERR = None
+try:
+    import urllib3
+    HAS_URLLIB3 = True
+except ImportError:
+    URLLIB3_IMP_ER = traceback.format_exc()
+    HAS_URLLIB3 = False
 
 REQUESTS_IMP_ERR = None
 try:
@@ -290,7 +297,7 @@ class Connection(ConnectionBase):
         if self.validate_certs:
             connect = SmartConnect
         else:
-            if self.get_option("silence_tls_warnings"):
+            if HAS_URLLIB3 and self.get_option("silence_tls_warnings"):
                 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
             connect = SmartConnectNoSSL
 


### PR DESCRIPTION
(cherry picked from commit 05fe9ef)

Co-authored-by: James Cassell <code@james.cassell.me>

##### SUMMARY
Fixes import problem with the vmware_tools connection plugin

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/connection/vmware_tools.py

