### PR TITLE
Fix bug in ec2_eip parameter parsing

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -388,9 +388,9 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_together=[
-            ['device_id', 'private_ip_address'],
-        ],
+        required_by={
+            'private_ip_address': ['device_id'],
+        },
     )
 
     if not HAS_BOTO:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#28662 introduced `required_by`, but for some reason also incorrectly modified these `ec2_eip` parameters to use `required_together`. `device_id` is required when `private_ip_address` is set, but the reverse is not true.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_eip

##### ADDITIONAL INFORMATION
