### PR TITLE
win_domain - fix for checking for domain on new host

### DIFF
--- a/changelogs/fragments/win_domain-setup.yaml
+++ b/changelogs/fragments/win_domain-setup.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain - Fix checking for a domain introduced in a recent patch

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -74,7 +74,8 @@ try {
     # Cannot use Get-ADForest as that requires credential delegation, the below does not
     $forest_context = New-Object -TypeName System.DirectoryServices.ActiveDirectory.DirectoryContext -ArgumentList Forest, $dns_domain_name
     $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($forest_context)
-} catch [System.DirectoryServices.ActiveDirectory.ActiveDirectoryObjectNotFoundException] { }
+} catch [System.DirectoryServices.ActiveDirectory.ActiveDirectoryObjectNotFoundException] {
+} catch [System.DirectoryServices.ActiveDirectory.ActiveDirectoryOperationException] { }
 
 if (-not $forest) {
     $result.changed = $true


### PR DESCRIPTION
##### SUMMARY
Also catch `ActiveDirectoryOperationException` which is raised from `GetForest()` if it cannot resolve the domain name. This issue was introduced with https://github.com/ansible/ansible/pull/53480.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain