### PR TITLE
Fix netconf guess_network_os to use ssh_config if supplied.

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -110,7 +110,7 @@ You can either specify the private key used in the SSH config file:
 
   IdentityFile "/absolute/path/to/private-key.pem"
 
-Or you can use an ssh-agent
+Or you can use an ssh-agent.
 
 ansible_network_os auto-detection
 ---------------------------------

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -84,6 +84,39 @@ Example NETCONF Task with configurable variables
      vars:
        ansible_private_key_file: /home/admin/.ssh/newprivatekeyfile
 
-Note: For nectonf connection plugin configurable variables .. _Refer: https://docs.ansible.com/ansible/latest/plugins/connection/netconf.html
+Note: For netconf connection plugin configurable variables .. _Refer: https://docs.ansible.com/ansible/latest/plugins/connection/netconf.html
+
+Bastion/Jumphost Configuration
+------------------------------
+To use a jump host to connect to a netconf enabled device you must set the ANSIBLE_NETCONF_SSH_CONFIG environment variable.
+
+ANSIBLE_NETCONF_SSH_CONFIG can be set to either:
+  - 1 or TRUE (to trigger the use of the default ssh config file ~/.ssh/config)
+  - The absolute path to a custom ssh config file.
+
+The ssh config file should look something like: 
+
+.. code-block::
+
+  Host *
+    proxycommand ssh -o StrictHostKeyChecking=no -W %h:%p jumphost-username@jumphost.fqdn.com
+    StrictHostKeyChecking no
+
+Authentication for the jump host must use key based authentication.
+
+You can either specify the private key used in the ssh config file 
+
+.. code-block::
+
+  IdentityFile "/absolute/path/to/private-key.pem"
+
+Or you can use an ssh-agent
+
+ansible_network_os auto-detection
+---------------------------------
+
+If ansible_network_os is not specified for a host, then ansible will attempt to automatically detect what network_os plugin to use.
+
+ansible_network_os auto-detection can also be triggered by using auto as the ansible_network_os. (Note: Previously default was used instead of auto)
 
 .. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -104,7 +104,7 @@ The ssh config file should look something like:
 
 Authentication for the jump host must use key based authentication.
 
-You can either specify the private key used in the ssh config file 
+You can either specify the private key used in the SSH config file:
 
 .. code-block:: ini
 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -94,7 +94,7 @@ To use a jump host to connect to a NETCONF enabled device you must set the ``ANS
   - 1 or TRUE (to trigger the use of the default SSH config file ~/.ssh/config)
   - The absolute path to a custom SSH config file.
 
-The ssh config file should look something like: 
+The SSH config file should look something like: 
 
 .. code-block:: ini
 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -84,7 +84,7 @@ Example NETCONF Task with configurable variables
      vars:
        ansible_private_key_file: /home/admin/.ssh/newprivatekeyfile
 
-Note: For netconf connection plugin configurable variables .. _Refer: https://docs.ansible.com/ansible/latest/plugins/connection/netconf.html
+Note: For netconf connection plugin configurable variables see :ref:`netconf <netconf_connection>`.
 
 Bastion/Jumphost Configuration
 ------------------------------

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -96,7 +96,7 @@ ANSIBLE_NETCONF_SSH_CONFIG can be set to either:
 
 The ssh config file should look something like: 
 
-.. code-block::
+.. code-block:: sourcecode
 
   Host *
     proxycommand ssh -o StrictHostKeyChecking=no -W %h:%p jumphost-username@jumphost.fqdn.com
@@ -106,7 +106,7 @@ Authentication for the jump host must use key based authentication.
 
 You can either specify the private key used in the ssh config file 
 
-.. code-block::
+.. code-block:: sourcecode
 
   IdentityFile "/absolute/path/to/private-key.pem"
 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -88,7 +88,7 @@ Note: For netconf connection plugin configurable variables see :ref:`netconf <ne
 
 Bastion/Jumphost Configuration
 ------------------------------
-To use a jump host to connect to a netconf enabled device you must set the ANSIBLE_NETCONF_SSH_CONFIG environment variable.
+To use a jump host to connect to a NETCONF enabled device you must set the ``ANSIBLE_NETCONF_SSH_CONFIG`` environment variable.
 
 ANSIBLE_NETCONF_SSH_CONFIG can be set to either:
   - 1 or TRUE (to trigger the use of the default ssh config file ~/.ssh/config)

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -90,7 +90,7 @@ Bastion/Jumphost Configuration
 ------------------------------
 To use a jump host to connect to a NETCONF enabled device you must set the ``ANSIBLE_NETCONF_SSH_CONFIG`` environment variable.
 
-ANSIBLE_NETCONF_SSH_CONFIG can be set to either:
+``ANSIBLE_NETCONF_SSH_CONFIG`` can be set to either:
   - 1 or TRUE (to trigger the use of the default ssh config file ~/.ssh/config)
   - The absolute path to a custom ssh config file.
 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -117,6 +117,6 @@ ansible_network_os auto-detection
 
 If ``ansible_network_os`` is not specified for a host, then Ansible will attempt to automatically detect what ``network_os`` plugin to use.
 
-ansible_network_os auto-detection can also be triggered by using auto as the ansible_network_os. (Note: Previously default was used instead of auto)
+``ansible_network_os`` auto-detection can also be triggered by using ``auto`` as the ``ansible_network_os``. (Note: Previously ``default`` was used instead of ``auto``).
 
 .. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -96,7 +96,7 @@ ANSIBLE_NETCONF_SSH_CONFIG can be set to either:
 
 The ssh config file should look something like: 
 
-.. code-block:: sourcecode
+.. code-block:: ini
 
   Host *
     proxycommand ssh -o StrictHostKeyChecking=no -W %h:%p jumphost-username@jumphost.fqdn.com
@@ -106,7 +106,7 @@ Authentication for the jump host must use key based authentication.
 
 You can either specify the private key used in the ssh config file 
 
-.. code-block:: sourcecode
+.. code-block:: ini
 
   IdentityFile "/absolute/path/to/private-key.pem"
 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -92,7 +92,7 @@ To use a jump host to connect to a NETCONF enabled device you must set the ``ANS
 
 ``ANSIBLE_NETCONF_SSH_CONFIG`` can be set to either:
   - 1 or TRUE (to trigger the use of the default SSH config file ~/.ssh/config)
-  - The absolute path to a custom ssh config file.
+  - The absolute path to a custom SSH config file.
 
 The ssh config file should look something like: 
 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -91,7 +91,7 @@ Bastion/Jumphost Configuration
 To use a jump host to connect to a NETCONF enabled device you must set the ``ANSIBLE_NETCONF_SSH_CONFIG`` environment variable.
 
 ``ANSIBLE_NETCONF_SSH_CONFIG`` can be set to either:
-  - 1 or TRUE (to trigger the use of the default ssh config file ~/.ssh/config)
+  - 1 or TRUE (to trigger the use of the default SSH config file ~/.ssh/config)
   - The absolute path to a custom ssh config file.
 
 The ssh config file should look something like: 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -115,7 +115,7 @@ Or you can use an ssh-agent.
 ansible_network_os auto-detection
 ---------------------------------
 
-If ansible_network_os is not specified for a host, then ansible will attempt to automatically detect what network_os plugin to use.
+If ``ansible_network_os`` is not specified for a host, then Ansible will attempt to automatically detect what ``network_os`` plugin to use.
 
 ansible_network_os auto-detection can also be triggered by using auto as the ansible_network_os. (Note: Previously default was used instead of auto)
 

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -305,7 +305,7 @@ class Connection(NetworkConnectionBase):
             for cls in netconf_loader.all(class_only=True):
                 network_os = cls.guess_network_os(self)
                 if network_os:
-                    self.queue_message('log', 'discovered network_os %s' % network_os)
+                    self.queue_message('vvv', 'discovered network_os %s' % network_os)
                     self._network_os = network_os
 
         # If we have tried to detect the network_os but were unable to i.e. network_os is still 'auto'
@@ -313,14 +313,15 @@ class Connection(NetworkConnectionBase):
 
         if self._network_os == 'auto':
             # Network os not discovered. Set it to default
+            self.queue_message('vvv', 'Unable do discover network_os. Falling back to default.')
             self._network_os = 'default'
 
         device_params = {'name': NETWORK_OS_DEVICE_PARAM_MAP.get(self._network_os) or self._network_os}
         
         try:
             port = self._play_context.port or 830
-            self.queue_message('vvv', "ESTABLISH NETCONF SSH CONNECTION FOR USER: %s on PORT %s TO %s" %
-                               (self._play_context.remote_user, port, self._play_context.remote_addr))
+            self.queue_message('vvv', "ESTABLISH NETCONF SSH CONNECTION FOR USER: %s on PORT %s TO %s WITH SSH_CONFIG = %s" %
+                               (self._play_context.remote_user, port, self._play_context.remote_addr, self._ssh_config))
             self._manager = manager.connect(
                 host=self._play_context.remote_addr,
                 port=port,

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -46,7 +46,7 @@ options:
         used to load a device specific netconf plugin.  If this option is not
         configured (or set to C(auto)), then Ansible will attempt to guess the
         correct network_os to use.
-        If it can not guess a network_os correctly it will use default.
+        If it can not guess a network_os correctly it will use C(default).
     vars:
       - name: ansible_network_os
   remote_user:

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -313,7 +313,7 @@ class Connection(NetworkConnectionBase):
 
         if self._network_os == 'auto':
             # Network os not discovered. Set it to default
-            self.queue_message('vvv', 'Unable do discover network_os. Falling back to default.')
+            self.queue_message('vvv', 'Unable to discover network_os. Falling back to default.')
             self._network_os = 'default'
 
         device_params = {'name': NETWORK_OS_DEVICE_PARAM_MAP.get(self._network_os) or self._network_os}

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -44,7 +44,7 @@ options:
     description:
       - Configures the device platform network operating system.  This value is
         used to load a device specific netconf plugin.  If this option is not
-        configured (or set to auto), then ansible will attempt to guess the
+        configured (or set to C(auto)), then Ansible will attempt to guess the
         correct network_os to use.
         If it can not guess a network_os correctly it will use default.
     vars:

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -44,8 +44,8 @@ options:
     description:
       - Configures the device platform network operating system.  This value is
         used to load a device specific netconf plugin.  If this option is not
-        configured (or set to auto), then ansible will attempt to guess the 
-        correct network_os to use. 
+        configured (or set to auto), then ansible will attempt to guess the
+        correct network_os to use.
         If it can not guess a network_os correctly it will use default.
     vars:
       - name: ansible_network_os
@@ -317,7 +317,7 @@ class Connection(NetworkConnectionBase):
             self._network_os = 'default'
 
         device_params = {'name': NETWORK_OS_DEVICE_PARAM_MAP.get(self._network_os) or self._network_os}
-        
+
         try:
             port = self._play_context.port or 830
             self.queue_message('vvv', "ESTABLISH NETCONF SSH CONNECTION FOR USER: %s on PORT %s TO %s WITH SSH_CONFIG = %s" %

--- a/lib/ansible/plugins/netconf/ce.py
+++ b/lib/ansible/plugins/netconf/ce.py
@@ -107,7 +107,10 @@ class Netconf(NetconfBase):
                 hostkey_verify=obj.get_option('host_key_checking'),
                 look_for_keys=obj.get_option('look_for_keys'),
                 allow_agent=obj._play_context.allow_agent,
-                timeout=obj.get_option('persistent_connect_timeout')
+                timeout=obj.get_option('persistent_connect_timeout'),
+                # We need to pass in the path to the ssh_config file when guessing
+                # the network_os so that a jumphost is correctly used if defined
+                ssh_config=obj._ssh_config
             )
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(to_native(exc))

--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -109,7 +109,10 @@ class Netconf(NetconfBase):
                 hostkey_verify=obj.get_option('host_key_checking'),
                 look_for_keys=obj.get_option('look_for_keys'),
                 allow_agent=obj._play_context.allow_agent,
-                timeout=obj.get_option('persistent_connect_timeout')
+                timeout=obj.get_option('persistent_connect_timeout'),
+                # We need to pass in the path to the ssh_config file when guessing
+                # the network_os so that a jumphost is correctly used if defined
+                ssh_config=obj._ssh_config
             )
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(to_native(exc))

--- a/lib/ansible/plugins/netconf/junos.py
+++ b/lib/ansible/plugins/netconf/junos.py
@@ -117,7 +117,10 @@ class Netconf(NetconfBase):
                 hostkey_verify=obj.get_option('host_key_checking'),
                 look_for_keys=obj.get_option('look_for_keys'),
                 allow_agent=obj._play_context.allow_agent,
-                timeout=obj.get_option('persistent_connect_timeout')
+                timeout=obj.get_option('persistent_connect_timeout'),
+                # We need to pass in the path to the ssh_config file when guessing
+                # the network_os so that a jumphost is correctly used if defined
+                ssh_config=obj._ssh_config
             )
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(to_native(exc))

--- a/lib/ansible/plugins/netconf/sros.py
+++ b/lib/ansible/plugins/netconf/sros.py
@@ -86,7 +86,10 @@ class Netconf(NetconfBase):
                 hostkey_verify=obj.get_option('host_key_checking'),
                 look_for_keys=obj.get_option('look_for_keys'),
                 allow_agent=obj._play_context.allow_agent,
-                timeout=obj.get_option('persistent_connect_timeout')
+                timeout=obj.get_option('persistent_connect_timeout'),
+                # We need to pass in the path to the ssh_config file when guessing
+                # the network_os so that a jumphost is correctly used if defined
+                ssh_config=obj._ssh_config
             )
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(to_native(exc))

--- a/test/units/plugins/connection/test_netconf.py
+++ b/test/units/plugins/connection/test_netconf.py
@@ -63,7 +63,7 @@ class TestNetconfConnectionClass(unittest.TestCase):
         pc = PlayContext()
         conn = connection_loader.get('netconf', pc, '/dev/null')
 
-        self.assertEqual('default', conn._network_os)
+        self.assertEqual('auto', conn._network_os)
         self.assertIsNone(conn._manager)
         self.assertFalse(conn._connected)
 


### PR DESCRIPTION
##### SUMMARY
When attempting to set up a connection using netconf, if the ansible_network_os is set to either nothing or `default`, ansible will attempt to guess the network_os.

The guess consists of connecting to the target node and using the returned capabilities to try to determine which network_os should be use.

The initial connetion used to guess the network os ignores the ssh_config specified in ANSIBLE_NETCONF_SSH_CONFIG (or ansible.cfg)

As a result this initial connection will fail causing the play to fail.

This PR makes the following changes:

1. Modifies the network_os_guessing to use a ssh_config file if specified.

2. Triggers network_os guessing when the network_os is auto (instead of default). Allowing the user to specify that ansible use the default ncclient driver and not try to guess the network os.

Fixes #54859

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
