### PR TITLE
fix for removing subscripion_id from resource facts

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -27,7 +27,7 @@ AZURE_COMMON_ARGS = dict(
         choices=['auto', 'cli', 'env', 'credential_file', 'msi']
     ),
     profile=dict(type='str'),
-    subscription_id=dict(type='str', no_log=True),
+    subscription_id=dict(type='str'),
     client_id=dict(type='str', no_log=True),
     secret=dict(type='str', no_log=True),
     tenant=dict(type='str', no_log=True),


### PR DESCRIPTION
##### SUMMARY
This is fixing following issue:

https://github.com/ansible/ansible/issues/55047

subscription_id is being removed from all returned resource urls when parameter **subscription_id** is specified.

in 99.99% of cases subscription_id is returned & displayed in plain text anyway, as subscription_id parameter is not commonly used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
all

##### ADDITIONAL INFORMATION
