### PR TITLE
yarn global should also call add

### DIFF
--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -258,6 +258,9 @@ class Yarn(object):
             # Yarn has a separate command for installing packages by name...
             return self._exec(['add', self.name_version])
         # And one for installing all packages in package.json
+        if self.globally:
+          return self._exec(['add', '--non-interactive'])
+        
         return self._exec(['install', '--non-interactive'])
 
     def update(self):

--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -259,7 +259,7 @@ class Yarn(object):
             return self._exec(['add', self.name_version])
         # And one for installing all packages in package.json
         if self.globally:
-          return self._exec(['add', '--non-interactive'])
+            return self._exec(['add', '--non-interactive'])
         
         return self._exec(['install', '--non-interactive'])
 


### PR DESCRIPTION
##### SUMMARY
Fixes #55097 

When specifying a node package to be installed globally with the Yarn module, the command called is not correct.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Yarn module

##### ADDITIONAL INFORMATION
Fixes #55097 
