### PR TITLE
Allow botocore configuration for aws modules

### DIFF
--- a/changelogs/fragments/55217-aws-modules-config.yml
+++ b/changelogs/fragments/55217-aws-modules-config.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - AWS modules now take an "aws_config" parameter to define botocore configuration settings
+    (https://github.com/ansible/ansible/issues/55182).
+  - AWS modules using boto can use the parameter to define the user agent, while boto3 modules
+    allow any configuration settings listed in the botocore API config documentation.

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -28,6 +28,7 @@
 
 import os
 import re
+import sys
 import traceback
 
 from ansible.module_utils.ansible_release import __version__
@@ -311,7 +312,11 @@ def get_aws_connection_info(module, boto3=False):
         boto_params['validate_certs'] = validate_certs
 
     if config is not None:
-        boto_params['config'] = config
+        if boto3:
+            boto_params['config'] = config
+        else:
+            if 'user_agent' in config:
+                sys.modules["boto.connection"].UserAgent = config['user_agent']
 
     for param, value in boto_params.items():
         if isinstance(value, binary_type):

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -140,8 +140,9 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
     )
 
     if params.get('config') is not None:
-        user_config = botocore.config.Config(**params.pop('config'))
-        config = config.merge(user_config)
+        config = config.merge(params.pop('config'))
+    if params.get('aws_config') is not None:
+        config = config.merge(params.pop('aws_config'))
 
     session = boto3.session.Session(
         profile_name=profile,
@@ -313,7 +314,7 @@ def get_aws_connection_info(module, boto3=False):
 
     if config is not None:
         if HAS_BOTO3 and boto3:
-            boto_params['config'] = config
+            boto_params['aws_config'] = botocore.config.Config(**config)
         elif HAS_BOTO and not boto3:
             if 'user_agent' in config:
                 sys.modules["boto.connection"].UserAgent = config['user_agent']

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -312,9 +312,9 @@ def get_aws_connection_info(module, boto3=False):
         boto_params['validate_certs'] = validate_certs
 
     if config is not None:
-        if boto3:
+        if HAS_BOTO3 and boto3:
             boto_params['config'] = config
-        else:
+        elif HAS_BOTO and not boto3:
             if 'user_agent' in config:
                 sys.modules["boto.connection"].UserAgent = config['user_agent']
 

--- a/lib/ansible/plugins/doc_fragments/aws.py
+++ b/lib/ansible/plugins/doc_fragments/aws.py
@@ -56,7 +56,7 @@ options:
       - Parameters can be found at U(https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config).
       - Only the 'user_agent' key is used for boto modules. See U(http://boto.cloudhackers.com/en/latest/boto_config_tut.html#boto) for more boto configuration.
     type: dict
-    version_added: "2.9"
+    version_added: "2.10"
 requirements:
   - python >= 2.6
   - boto

--- a/lib/ansible/plugins/doc_fragments/aws.py
+++ b/lib/ansible/plugins/doc_fragments/aws.py
@@ -54,6 +54,7 @@ options:
     description:
       - A dictionary to modify the botocore configuration.
       - Parameters can be found at U(https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config).
+      - Only the 'user_agent' key is used for boto modules. See U(http://boto.cloudhackers.com/en/latest/boto_config_tut.html#boto) for further boto configuration.
     type: dict
     version_added: "2.9"
 requirements:

--- a/lib/ansible/plugins/doc_fragments/aws.py
+++ b/lib/ansible/plugins/doc_fragments/aws.py
@@ -54,7 +54,7 @@ options:
     description:
       - A dictionary to modify the botocore configuration.
       - Parameters can be found at U(https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config).
-      - Only the 'user_agent' key is used for boto modules. See U(http://boto.cloudhackers.com/en/latest/boto_config_tut.html#boto) for further boto configuration.
+      - Only the 'user_agent' key is used for boto modules. See U(http://boto.cloudhackers.com/en/latest/boto_config_tut.html#boto) for more boto configuration.
     type: dict
     version_added: "2.9"
 requirements:

--- a/lib/ansible/plugins/doc_fragments/aws.py
+++ b/lib/ansible/plugins/doc_fragments/aws.py
@@ -50,6 +50,12 @@ options:
       - Uses a boto profile. Only works with boto >= 2.24.0.
     type: str
     version_added: "1.6"
+  aws_config:
+    description:
+      - A dictionary to modify the botocore configuration.
+      - Parameters can be found at U(https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config).
+    type: dict
+    version_added: "2.9"
 requirements:
   - python >= 2.6
   - boto


### PR DESCRIPTION
##### SUMMARY
~WIP while still looking at a possible solution for boto modules.~

This PR allows UserAgent to be set for boto modules and allows general configuration for boto3 modules. Many boto configurations can be set by a boto config file like connection timeout and proxy settings. UserAgent is not able to be configured in that way. In boto3 most of those options have been removed and are only modifiable via code. This addresses both problems.

Tested with CloudTrail.

Fix #55182

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
AWS modules

Example use:
```
    - name: create bucket
      aws_s3:
        aws_config:
          user_agent: "{{ custom_user_agent }}"
        bucket: "{{ bucket }}"
        region: us-east-1
        mode: create
```