### PR TITLE
"no macro" command should not be handled by edit_macro(), fixes #55212

### DIFF
--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -356,7 +356,9 @@ def check_args(module, warnings):
 
 
 def edit_config_or_macro(connection, commands):
-    if "macro name" in commands[0]:
+    # only catch the macro configuration command,
+    # not negated 'no' variation.
+    if commands[0].startswith("macro name"):
         connection.edit_macro(candidate=commands)
     else:
         connection.edit_config(candidate=commands)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes #55212
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
