### PR TITLE
ec2_instance fix name idempotency (on 2nd call Name tag was being removed)

### DIFF
--- a/changelogs/fragments/55224-ec2_instance-idempotent-tags.yaml
+++ b/changelogs/fragments/55224-ec2_instance-idempotent-tags.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_instance - make Name tag idempotent (https://github.com/ansible/ansible/pull/55224)

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1680,7 +1680,11 @@ def main():
         for match in existing_matches:
             warn_if_public_ip_assignment_changed(match)
             warn_if_cpu_options_changed(match)
-            changed |= manage_tags(match, (module.params.get('tags') or {}), module.params.get('purge_tags', False), ec2)
+            tags = module.params.get('tags') or {}
+            name = module.params.get('name')
+            if name:
+                tags['Name'] = name
+            changed |= manage_tags(match, tags, module.params.get('purge_tags', False), ec2)
 
     if state in ('present', 'running', 'started'):
         ensure_present(existing_matches=existing_matches, changed=changed, ec2=ec2, state=state)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If you run ec2_instance with name:, it gets a Name tag.
If you run the same playbook again, the Name tag disappears.
If you run it a third time, a new instance is created because it does not find the one where the name was removed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
