### PR TITLE
[stable-2.8] Fix ansible-test inventory and vars path handling. (#55186)

### DIFF
--- a/test/runner/lib/env.py
+++ b/test/runner/lib/env.py
@@ -321,7 +321,8 @@ def get_merged_commit(args, commit):
         # This should only fail for pull requests where the commit does not exist.
         # Merge runs would fail much earlier when attempting to checkout the commit.
         raise ApplicationError('Commit %s was not found:\n\n%s\n\n'
-                               'The commit was likely removed by a force push between job creation and execution.\n'
+                               'GitHub may not have fully replicated the commit across their infrastructure.\n'
+                               'It is also possible the commit was removed by a force push between job creation and execution.\n'
                                'Find the latest run for the pull request and restart failed jobs as needed.'
                                % (commit, ex.stderr.strip()))
 

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1241,7 +1241,7 @@ def command_integration_role(args, target, start_at_task, test_dir, inventory_pa
             hosts=hosts,
             gather_facts=gather_facts,
             vars_files=[
-                test_env.vars_file,
+                os.path.relpath(test_env.vars_file, test_env.integration_dir),
             ],
             roles=[
                 target.name,
@@ -1262,7 +1262,7 @@ def command_integration_role(args, target, start_at_task, test_dir, inventory_pa
 
             display.info('>>> Playbook: %s\n%s' % (filename, playbook.strip()), verbosity=3)
 
-            cmd = ['ansible-playbook', filename, '-i', test_env.inventory_path]
+            cmd = ['ansible-playbook', filename, '-i', os.path.relpath(test_env.inventory_path, test_env.integration_dir)]
 
             if start_at_task:
                 cmd += ['--start-at-task', start_at_task]

--- a/test/runner/lib/integration/__init__.py
+++ b/test/runner/lib/integration/__init__.py
@@ -125,15 +125,12 @@ def integration_test_environment(args, target, inventory_path):
     if args.no_temp_workdir or 'no/temp_workdir/' in target.aliases:
         display.warning('Disabling the temp work dir is a temporary debugging feature that may be removed in the future without notice.')
 
-        integration_dir = 'test/integration'
+        integration_dir = os.path.abspath('test/integration')
+        inventory_path = os.path.abspath(inventory_path)
         ansible_config = os.path.join(integration_dir, '%s.cfg' % args.command)
+        vars_file = os.path.join(integration_dir, vars_file)
 
-        inventory_name = os.path.relpath(inventory_path, integration_dir)
-
-        if '/' in inventory_name:
-            inventory_name = inventory_path
-
-        yield IntegrationEnvironment(integration_dir, inventory_name, ansible_config, vars_file)
+        yield IntegrationEnvironment(integration_dir, inventory_path, ansible_config, vars_file)
         return
 
     root_temp_dir = os.path.expanduser('~/.ansible/test/tmp')
@@ -216,7 +213,10 @@ def integration_test_environment(args, target, inventory_path):
                 make_dirs(os.path.dirname(file_dst))
                 shutil.copy2(file_src, file_dst)
 
-        yield IntegrationEnvironment(integration_dir, inventory_name, ansible_config, vars_file)
+        inventory_path = os.path.join(integration_dir, inventory_name)
+        vars_file = os.path.join(integration_dir, vars_file)
+
+        yield IntegrationEnvironment(integration_dir, inventory_path, ansible_config, vars_file)
     finally:
         if not args.explain:
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Fix ansible-test inventory and vars path handling. (#55186)

* Fix ansible-test inventory and vars path handling.
* Improve explanation for missing commit.

Backport of https://github.com/ansible/ansible/pull/55186

(cherry picked from commit a4d0c24bbf1dfa706261877b8a81a8bed66d4b8f)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
