### PR TITLE
tag off long-running azure_rm_virtualnetworkgateway tests

### DIFF
--- a/test/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
@@ -1,82 +1,120 @@
+# FIXME: needs minimal tests (check mode?) that can run quickly, VNG creation takes > 20min
+
 - name: Prepare random number
   set_fact:
     vnetname: "vnet{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
     vngname: "vng{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
 
-- name: Create virtual network
-  azure_rm_virtualnetwork:
-      resource_group: "{{ resource_group }}"
-      name: "{{ vnetname }}"
-      address_prefixes: "10.0.0.0/16"
+- name: Create virtual network gateway without bgp settings (check mode)
+  check_mode: yes
+  azure_rm_virtualnetworkgateway:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vngname }}"
+    ip_configurations:
+      - name: testipconfig
+        private_ip_allocation_method: Dynamic
+        public_ip_address_name: testPublicIP
+    virtual_network: "{{ vnetname }}"
+    tags:
+      common: "xyz"
+  register: output
 
-- name: Add subnet
-  azure_rm_subnet:
+- assert:
+    that: output.changed
+
+- name: long-running virtualnetworkgateway tests [run with `--tags long_run,untagged` to enable]
+  tags: [long_run, never]
+  block:
+  - name: Create virtual network
+    azure_rm_virtualnetwork:
+        resource_group: "{{ resource_group }}"
+        name: "{{ vnetname }}"
+        address_prefixes: "10.0.0.0/16"
+
+  - name: Add subnet
+    azure_rm_subnet:
+        resource_group: "{{ resource_group }}"
+        name: GatewaySubnet
+        address_prefix: "10.0.2.0/24"
+        virtual_network: "{{ vnetname }}"
+
+  - name: Create public IP address
+    azure_rm_publicipaddress:
+        resource_group: "{{ resource_group }}"
+        allocation_method: Dynamic
+        name: testPublicIP
+
+  - name: Create virtual network gateway without bgp settings
+    azure_rm_virtualnetworkgateway:
       resource_group: "{{ resource_group }}"
-      name: GatewaySubnet
-      address_prefix: "10.0.2.0/24"
+      name: "{{ vngname }}"
+      ip_configurations:
+        - name: testipconfig
+          private_ip_allocation_method: Dynamic
+          public_ip_address_name: testPublicIP
       virtual_network: "{{ vnetname }}"
+      tags:
+        common: "xyz"
+    register: output
 
-- name: Create public IP address
-  azure_rm_publicipaddress:
+  - assert:
+      that: output.changed
+
+  - name: Create virtual network gateway without bgp settings
+    azure_rm_virtualnetworkgateway:
       resource_group: "{{ resource_group }}"
-      allocation_method: Dynamic
-      name: testPublicIP
+      name: "{{ vngname }}"
+      ip_configurations:
+        - name: testipconfig
+          private_ip_allocation_method: Dynamic
+          public_ip_address_name: testPublicIP
+      virtual_network: "{{ vnetname }}"
+      tags:
+        common: "xyz"
+    register: output
 
-- name: Create virtual network gateway without bgp settings
-  azure_rm_virtualnetworkgateway:
-    resource_group: "{{ resource_group }}"
-    name: "{{ vngname }}"
-    ip_configurations:
-      - name: testipconfig
-        private_ip_allocation_method: Dynamic
-        public_ip_address_name: testPublicIP
-    virtual_network: "{{ vnetname }}"
-    tags:
-      common: "xyz"
-  register: output
+  - assert:
+      that: output.changed
 
-- assert:
-    that: output.changed
+  - name: Create virtual network gateway without bgp settings - idempotent
+    azure_rm_virtualnetworkgateway:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vngname }}"
+      ip_configurations:
+        - name: testipconfig
+          private_ip_allocation_method: Dynamic
+          public_ip_address_name: testPublicIP
+      virtual_network: "{{ vnetname }}"
+      tags:
+        common: "xyz"
+    register: output
 
-- name: Create virtual network gateway without bgp settings - idempotent
-  azure_rm_virtualnetworkgateway:
-    resource_group: "{{ resource_group }}"
-    name: "{{ vngname }}"
-    ip_configurations:
-      - name: testipconfig
-        private_ip_allocation_method: Dynamic
-        public_ip_address_name: testPublicIP
-    virtual_network: "{{ vnetname }}"
-    tags:
-      common: "xyz"
-  register: output
+  - assert:
+      that: not output.changed
 
-- assert:
-    that: not output.changed
+  - name: Update virtual network gateway
+    azure_rm_virtualnetworkgateway:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vngname }}"
+      ip_configurations:
+        - name: testipconfig
+          private_ip_allocation_method: Dynamic
+          public_ip_address_name: testPublicIP
+      virtual_network: "{{ vnetname }}"
+      tags:
+        common: "mno"
+    register: output
+  - assert:
+      that: output.changed
 
-- name: Update virtual network gateway
-  azure_rm_virtualnetworkgateway:
-    resource_group: "{{ resource_group }}"
-    name: "{{ vngname }}"
-    ip_configurations:
-      - name: testipconfig
-        private_ip_allocation_method: Dynamic
-        public_ip_address_name: testPublicIP
-    virtual_network: "{{ vnetname }}"
-    tags:
-      common: "mno"
-  register: output
-- assert:
-    that: output.changed
-
-- name: Delete virtual network gateway
-  azure_rm_virtualnetworkgateway:
-    resource_group: "{{ resource_group }}"
-    name: "{{ vngname }}"
-    state: absent
-  register: output
-- assert:
-    that: output.changed
+  - name: Delete virtual network gateway
+    azure_rm_virtualnetworkgateway:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vngname }}"
+      state: absent
+    register: output
+  - assert:
+      that: output.changed
 
 - name: Delete virtual network gateway - idempotent
   azure_rm_virtualnetworkgateway:


### PR DESCRIPTION
##### SUMMARY
VNG creation takes too long for CI, had to tag off most of the tests... Could probably add check-mode

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_virtualnetworkgateway

##### ADDITIONAL INFORMATION
