### PR TITLE
azure_rm_virtualmachine: support user assigned identities

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -1060,7 +1060,7 @@ class AzureRMModuleBase(object):
         self.log('Getting msi client')
         if not self._msi_client:
             self._msi_client = self.get_mgmt_svc_client(ManagedServiceIdentityClient,
-                                                   base_url=self._cloud_environment.endpoints.resource_manager)
+                                                        base_url=self._cloud_environment.endpoints.resource_manager)
 
         return self._msi_client
 

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -171,6 +171,7 @@ try:
     from azure.mgmt.containerinstance import ContainerInstanceManagementClient
     from azure.mgmt.loganalytics import LogAnalyticsManagementClient
     import azure.mgmt.loganalytics.models as LogAnalyticsModels
+    from azure.mgmt.msi import ManagedServiceIdentityClient
     from azure.mgmt.automation import AutomationClient
     import azure.mgmt.automation.models as AutomationModel
     from azure.mgmt.iothub import IotHubClient
@@ -328,6 +329,7 @@ class AzureRMModuleBase(object):
         self._resource = None
         self._log_analytics_client = None
         self._servicebus_client = None
+        self._msi_client = None
         self._automation_client = None
         self._IoThub_client = None
         self._lock_client = None
@@ -1052,6 +1054,15 @@ class AzureRMModuleBase(object):
             self._servicebus_client = self.get_mgmt_svc_client(ServiceBusManagementClient,
                                                                base_url=self._cloud_environment.endpoints.resource_manager)
         return self._servicebus_client
+
+    @property
+    def msi_client(self):
+        self.log('Getting msi client')
+        if not self._msi_client:
+            self._msi_client = self.get_mgmt_svc_client(ManagedServiceIdentityClient,
+                                                   base_url=self._cloud_environment.endpoints.resource_manager)
+
+        return self._msi_client
 
     @property
     def servicebus_models(self):

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -346,7 +346,8 @@ options:
             - 'SystemAssigned, UserAssigned'
     vm_user_assigned_identities:
         description:
-            - List of user assigned identity names to assign to the VM. Only used when I(vm_identity=UserAssigned) or I(vm_identity='SystemAssigned, UserAssigned').
+            - List of user assigned identity names to assign to the VM. Only used when I(vm_identity=UserAssigned)
+              or I(vm_identity='SystemAssigned, UserAssigned').
         type: list
         version_added: 2.9
     winrm:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -346,7 +346,7 @@ options:
             - 'SystemAssigned, UserAssigned'
     vm_user_assigned_identities:
         description:
-            - List of user assigned identity names to assign to the VM. Only useful with vm_identity='UserAssigned' or 'SystemAssigned, UserAssigned'.
+            - List of user assigned identity names to assign to the VM. Only used when I(vm_identity=UserAssigned) or I(vm_identity='SystemAssigned, UserAssigned').
         type: list
         version_added: 2.9
     winrm:
@@ -850,7 +850,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             accept_terms=dict(type='bool', default=False),
             license_type=dict(type='str', choices=['Windows_Server', 'Windows_Client']),
             vm_identity=dict(type='str', choices=['SystemAssigned', 'UserAssigned', 'SystemAssigned, UserAssigned']),
-            vm_user_assigned_identities=dict(type='list', default=None),
+            vm_user_assigned_identities=dict(type='list'),
             winrm=dict(type='list'),
             boot_diagnostics=dict(type='dict'),
         )

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -344,12 +344,13 @@ options:
             - 'SystemAssigned'
             - 'UserAssigned'
             - 'SystemAssigned, UserAssigned'
+        version_added: "2.8"
     vm_user_assigned_identities:
         description:
             - List of user assigned identity names to assign to the VM. Only used when I(vm_identity=UserAssigned)
               or I(vm_identity='SystemAssigned, UserAssigned').
         type: list
-        version_added: 2.9
+        version_added: "2.10"
     winrm:
         description:
             - List of Windows Remote Management configurations of the VM.

--- a/packaging/requirements/requirements-azure.txt
+++ b/packaging/requirements/requirements-azure.txt
@@ -35,5 +35,6 @@ azure-mgmt-cosmosdb==0.5.2
 azure-mgmt-hdinsight==0.1.0
 azure-mgmt-devtestlabs==3.0.0
 azure-mgmt-loganalytics==0.2.0
+azure-mgmt-msi==0.2.0
 azure-mgmt-automation==0.1.1
 azure-mgmt-iothub==0.7.0

--- a/test/lib/ansible_test/_data/requirements/integration.cloud.azure.txt
+++ b/test/lib/ansible_test/_data/requirements/integration.cloud.azure.txt
@@ -35,5 +35,6 @@ azure-mgmt-cosmosdb==0.5.2
 azure-mgmt-hdinsight==0.1.0
 azure-mgmt-devtestlabs==3.0.0
 azure-mgmt-loganalytics==0.2.0
+azure-mgmt-msi==0.2.0
 azure-mgmt-automation==0.1.1
 azure-mgmt-iothub==0.7.0


### PR DESCRIPTION
##### SUMMARY
Virtual machines can be provisioned and assigned a system assigned identity. This pull request adds support to also allow assigning a number of user assigned identities or both a system identity and user assigned identities.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

Example useage:
```
- name: Create VM
  azure_rm_virtualmachine:
    resource_group: "group
    name: "new_vm"
    vm_size: "Standard_DS1_v2"
    network_interfaces: "{{nic}}"
    image: "{{ image }}"
    vm_identity: "UserAssigned"
    vm_user_assigned_identities: ["new_identity", "other_identity"]
```