### PR TITLE
User - Fix shadow file parsing on AIX

### DIFF
--- a/changelogs/fragments/user-aix-shadow-file-parsing.yaml
+++ b/changelogs/fragments/user-aix-shadow-file-parsing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - properly parse the shadow file on AIX (https://github.com/ansible/ansible/issues/54461)


### PR DESCRIPTION
##### SUMMARY
Fixes #54461

The shadow file format for AIX is wildly different than Linux. The code parsing the expiration date string in the shadowfile (only on systems that lack `spwd`) assumed a Linux-style shadow file, causing an `IndexError` on AIX.

Implement a separate method for parsing the shadow file and subclass it for AIX in order to do the right thing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/modules/system/user.py`