### PR TITLE
[stable-2.8] Disable hcloud tests until issues are resolved.

### DIFF
--- a/test/integration/targets/hcloud_datacenter_facts/aliases
+++ b/test/integration/targets/hcloud_datacenter_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_floating_ip_facts/aliases
+++ b/test/integration/targets/hcloud_floating_ip_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_image_facts/aliases
+++ b/test/integration/targets/hcloud_image_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_location_facts/aliases
+++ b/test/integration/targets/hcloud_location_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_server/aliases
+++ b/test/integration/targets/hcloud_server/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_server_facts/aliases
+++ b/test/integration/targets/hcloud_server_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_server_type_facts/aliases
+++ b/test/integration/targets/hcloud_server_type_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_ssh_key/aliases
+++ b/test/integration/targets/hcloud_ssh_key/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_ssh_key_facts/aliases
+++ b/test/integration/targets/hcloud_ssh_key_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_volume/aliases
+++ b/test/integration/targets/hcloud_volume/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_volume_facts/aliases
+++ b/test/integration/targets/hcloud_volume_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Disable hcloud tests until issues are resolved.

Backport of https://github.com/ansible/ansible/pull/55231

(cherry picked from commit 216cd86cb89ced346ce59fffd56667ff13339c21)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

hcloud integration tests
