### PR TITLE
VMware: vcenter_folder: print full path of the new folder

### DIFF
--- a/changelogs/fragments/vcenter_folder.yaml
+++ b/changelogs/fragments/vcenter_folder.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vcenter_folder - returns a dict instead of a string, the previous output is now in the 'msg' key
+  - vcenter_folder - returns now the full path of the file in the new 'path' key

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1382,3 +1382,12 @@ class PyVmomi(object):
         else:
             result = self._jsonify(obj)
         return result
+
+    def get_folder_path(self, cur):
+        full_path = '/' + cur.name
+        while hasattr(cur, 'parent') and cur.parent:
+            if cur.parent == self.content.rootFolder:
+                break
+            cur = cur.parent
+            full_path = '/' + cur.name + full_path
+        return full_path

--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -122,9 +122,10 @@ EXAMPLES = r'''
 
 RETURN = r'''
 result:
-    description:
-    - a dictionary
-    fields:
+    description: The detail about the new folder
+    returned: On success
+    type: complex
+    contains:
         path: the full path of the new folder
         msg: string stating about result
 '''
@@ -183,7 +184,7 @@ class VmwareFolderManager(PyVmomi):
                 if child_folder_obj:
                     results['result']['path'] = self.get_folder_path(child_folder_obj)
                     results['result']['msg'] = "Folder %s already exists under" \
-                                     " parent folder %s" % (folder_name, parent_folder)
+                        " parent folder %s" % (folder_name, parent_folder)
                     self.module.exit_json(**results)
             else:
                 folder_obj = self.get_folder(datacenter_name=datacenter_name,
@@ -205,7 +206,7 @@ class VmwareFolderManager(PyVmomi):
                         new_folder = p_folder_obj.CreateFolder(folder_name)
                         results['result']['path'] = self.get_folder_path(new_folder)
                         results['result']['msg'] = "Folder '%s' of type '%s' under '%s' created" \
-                                         " successfully." % (folder_name, folder_type, parent_folder)
+                            " successfully." % (folder_name, folder_type, parent_folder)
                     results['changed'] = True
                 elif not parent_folder and not p_folder_obj:
                     if self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY

Print the full path of the freshly created folder in the output string.
e.g:


```
ok: [testhost] => {
    "msg": {
        "changed": true,
        "failed": false,
        "return": {
            "msg": "Folder 'Staging' of type 'host' created successfully.",
            "path": "/dc1/host/Staging"
        }
    }
}
```

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

vcenter_folder
<!--- Write the short name of the module, plugin, task or feature below -->