### PR TITLE
jenkins_plugin: Read update file as UTF-8 (fixes #55250)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -559,7 +559,7 @@ class JenkinsPlugin(object):
 
         # Open the updates file
         try:
-            f = open(updates_file)
+            f = open(updates_file, encoding='utf-8')
         except IOError as e:
             self.module.fail_json(
                 msg="Cannot open temporal updates file.",


### PR DESCRIPTION
##### SUMMARY
There seems to be a problem when reading `update-center.json` file which might contain UTF-8 characters. This PR is making the file to read with `encoding="utf-8"`. This should fix issue #55250.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`jenkins_plugin`

##### ADDITIONAL INFORMATION
See the original issue for more details.