### PR TITLE
Fix minor documentation error: base64 -> b64encode

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -85,7 +85,7 @@ EXAMPLES = '''
     # If the file is JSON or binary, Ansible might modify it (because
     # it is first decoded and later re-encoded). Base64-encoding the
     # file directly after reading it prevents this to happen.
-    data: "{{ lookup('file', '/path/to/config/file') | base64 }}"
+    data: "{{ lookup('file', '/path/to/config/file') | b64encode }}"
     data_is_b64: true
     state: present
 

--- a/lib/ansible/modules/cloud/docker/docker_secret.py
+++ b/lib/ansible/modules/cloud/docker/docker_secret.py
@@ -85,7 +85,7 @@ EXAMPLES = '''
     # If the file is JSON or binary, Ansible might modify it (because
     # it is first decoded and later re-encoded). Base64-encoding the
     # file directly after reading it prevents this to happen.
-    data: "{{ lookup('file', '/path/to/secret/file') | base64 }}"
+    data: "{{ lookup('file', '/path/to/secret/file') | b64encode }}"
     data_is_b64: true
     state: present
 


### PR DESCRIPTION
##### SUMMARY
Fix minor documentation error: base64 -> b64encode

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

* docker_config
* docker_secret

##### ADDITIONAL INFORMATION

The filter for base64 encoding [is named](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#id8) b64encode.