### PR TITLE
[Backport 2.8] VMware: vmware_tools tls warning fixes

### DIFF
--- a/changelogs/fragments/vmware_tools_fix_urllib3_import.yaml
+++ b/changelogs/fragments/vmware_tools_fix_urllib3_import.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Try to use bundled urllib3 first, then falls back to non-bundled version in vmware_tools (https://github.com/ansible/ansible/pull/55187).


### PR DESCRIPTION
##### SUMMARY
* vmware_tools: remove silence_tls_warnings option

* attempt import of bundled urllib3

(cherry picked from commit 7191d4588563107a19def557dc4b439e01c80fda)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_tools_fix_urllib3_import.yaml
lib/ansible/plugins/connection/vmware_tools.py
