### PR TITLE
[Backport 2.8] Remove unneccessary line in config section of purefa_facts (#55164)

### DIFF
--- a/changelogs/fragments/55266-purefa_facts_remove_line.yaml
+++ b/changelogs/fragments/55266-purefa_facts_remove_line.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - "purefa_facts - remove unnecessary line that could cause failure in rare circumstances."

--- a/lib/ansible/modules/storage/purestorage/purefa_facts.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_facts.py
@@ -426,7 +426,6 @@ def generate_config_dict(array):
                 'group': roles[role]['group'],
                 'group_base': roles[role]['group_base'],
             }
-        config_facts['directory_service'].update(array.list_directory_service_roles())
     else:
         config_facts['directory_service'].update(array.get_directory_service(groups=True))
     # NTP


### PR DESCRIPTION
(cherry picked from commit 30a216bf785bae8e7588e176c25d26944fc111a5)

##### SUMMARY
Backport of #55164 to stable-2.8
This line causes a crash of the module in certain circumstances.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_facts.py
