### PR TITLE
Bump deps for ntlm-auth and PSScriptAnalyzer

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -48,7 +48,7 @@ Function Exit-Json($obj)
     }
 
     if (-not $obj.ContainsKey('changed')) {
-        Set-Attr $obj "changed" $false
+        Set-Attr -obj $obj -name "changed" -value $false
     }
 
     Write-Output $obj | ConvertTo-Json -Compress -Depth 99
@@ -79,11 +79,11 @@ Function Fail-Json($obj, $message = $null)
     }
 
     # Still using Set-Attr for PSObject compatibility
-    Set-Attr $obj "msg" $message
-    Set-Attr $obj "failed" $true
+    Set-Attr -obj $obj -name "msg" -value $message
+    Set-Attr -obj $obj -name "failed" -value $true
 
     if (-not $obj.ContainsKey('changed')) {
-        Set-Attr $obj "changed" $false
+        Set-Attr -obj $obj -name "changed" -value $false
     }
 
     Write-Output $obj | ConvertTo-Json -Compress -Depth 99

--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -191,7 +191,15 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 			$result.backup = $result.backup_file
 		}
 
-		$after = WriteLines $lines $path $linesep $encodingobj $validate $check_mode;
+		$writelines_params = @{
+			outlines = $lines
+			path = $path
+			linesep = $linesep
+			encodingobj = $encodingobj
+			validate = $validate
+			check_mode = $check_mode
+		}
+		$after = WriteLines @writelines_params;
 
 		if ($diff_support) {
 			$result.diff.after = $after;
@@ -273,7 +281,15 @@ function Absent($path, $regexp, $line, $backup, $validate, $encodingobj, $linese
 			$result.backup = $result.backup_file
 		}
 
-		$after = WriteLines $left $path $linesep $encodingobj $validate $check_mode;
+		$writelines_params = @{
+			outlines = $left
+			path = $path
+			linesep = $linesep
+			encodingobj = $encodingobj
+			validate = $validate
+			check_mode = $check_mode
+		}
+		$after = WriteLines @writelines_params;
 
 		if ($diff_support) {
 			$result.diff.after = $after;
@@ -395,7 +411,22 @@ If ($state -eq "present") {
 		$insertafter = "EOF";
 	}
 
-	Present $path $regexp $line $insertafter $insertbefore $create $backup $backrefs $validate $encodingobj $linesep $check_mode $diff_support;
+	$present_params = @{
+		path = $path
+		regexp = $regexp
+		line = $line
+		insertafter = $insertafter
+		insertbefore = $insertbefore
+		create = $create
+		backup = $backup
+		backrefs = $backrefs
+		validate = $validate
+		encodingobj = $encodingobj
+		linesep = $linesep
+		check_mode = $check_mode
+		diff_support = $diff_support
+	}
+	Present @present_params;
 
 }
 ElseIf ($state -eq "absent") {
@@ -404,5 +435,16 @@ ElseIf ($state -eq "absent") {
 		Fail-Json @{} "one of line= or regexp= is required with state=absent";
 	}
 
-	Absent $path $regexp $line $backup $validate $encodingobj $linesep $check_mode $diff_support;
+	$absent_params = @{
+		path = $path
+		regexp = $regexp
+		line = $line
+		backup = $backup
+		validate = $validate
+		encodingobj = $encodingobj
+		linesep = $linesep
+		check_mode = $check_mode
+		diff_support = $diff_support
+	}
+	Absent @absent_params;
 }

--- a/lib/ansible/modules/windows/win_xml.ps1
+++ b/lib/ansible/modules/windows/win_xml.ps1
@@ -23,7 +23,7 @@ function Copy-Xml($dest, $src, $xmlorig) {
         foreach ($childnode in $src.get_ChildNodes()) {
             if ($childnode.get_NodeType() -eq "Element") {
                 $newnode = $xmlorig.CreateElement($childnode.get_Name(), $xmlorig.get_DocumentElement().get_NamespaceURI())
-                Copy-Xml $newnode $childnode $xmlorig
+                Copy-Xml -dest $newnode -src $childnode -xmlorig $xmlorig
                 $dest.AppendChild($newnode) | Out-Null
             } elseif ($childnode.get_NodeType() -eq "Text") {
                 $dest.set_InnerText($childnode.get_InnerText())
@@ -126,7 +126,7 @@ if ($type -eq "element") {
     }
 
     $child = $xmlorig.CreateElement($xmlchild.get_DocumentElement().get_Name(), $xmlorig.get_DocumentElement().get_NamespaceURI())
-    Copy-Xml $child $xmlchild.DocumentElement $xmlorig
+    Copy-Xml -dest $child -src $xmlchild.DocumentElement -xmlorig $xmlorig
 
     $node = $xmlorig.SelectSingleNode($xpath, $namespaceMgr)
     if ($node.get_NodeType() -eq "Document") {

--- a/test/runner/lib/sanity/pslint.py
+++ b/test/runner/lib/sanity/pslint.py
@@ -101,13 +101,15 @@ class PslintTest(SanitySingleVersion):
             'Information',
             'Warning',
             'Error',
+            'ParseError',
         ]
 
         cwd = os.getcwd() + '/'
 
-        # replace unicode smart quotes with ascii versions
+        # replace unicode smart quotes and ellipsis with ascii versions
         stdout = re.sub(u'[\u2018\u2019]', "'", stdout)
         stdout = re.sub(u'[\u201c\u201d]', '"', stdout)
+        stdout = re.sub(u'[\u2026]', '...', stdout)
 
         messages = json.loads(stdout)
 

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -15,7 +15,7 @@ pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 
 pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later
 pytest-forked >= 1.0.2 ; python_version >= '2.7' # pytest-forked before 1.0.2 does not work with pytest 4.2.0+ (which requires python 2.7+)
-ntlm-auth >= 1.0.6 # message encryption support
+ntlm-auth >= 1.3.0 # message encryption support using cryptography
 requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for python 2.6
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support

--- a/test/runner/requirements/sanity.ps1
+++ b/test/runner/requirements/sanity.ps1
@@ -5,7 +5,7 @@ Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.17.1 -Scope CurrentUser
+Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.18.0 -Scope CurrentUser
 
 # Installed the PSCustomUseLiteralPath rule
 Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1 -Scope CurrentUser

--- a/test/sanity/pslint/pslint.ps1
+++ b/test/sanity/pslint/pslint.ps1
@@ -6,6 +6,12 @@ Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 $WarningPreference = "Stop"
 
+# Until https://github.com/PowerShell/PSScriptAnalyzer/issues/1217 is fixed we need to import Pester if it's
+# available.
+if (Get-Module -Name Pester -ListAvailable -ErrorAction SilentlyContinue) {
+    Import-Module -Name Pester
+}
+
 $LiteralPathRule = Import-Module -Name PSSA-PSCustomUseLiteralPath -PassThru
 $LiteralPathRulePath = Join-Path -Path $LiteralPathRule.ModuleBase -ChildPath $LiteralPathRule.RootModule
 


### PR DESCRIPTION
##### SUMMARY
Updates PSScriptAnalyzer on ansible-test to 1.18.0 for faster sanity analysis and other rule fixes introduced in that version.

This also bumps the version of `ntlm-auth` to `1.3.0` which introduced optional RC4 encryption using cryptography which is extremely faster than the pure Python implementation it currently used. This should speed up the 2016 tests in CI which uses NTLM message encryption over HTTP.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test