### PR TITLE
postgresql_slot - sslrootcert bugfix

### DIFF
--- a/changelogs/fragments/postgresql_slot-fix-sslrootcert.yml
+++ b/changelogs/fragments/postgresql_slot-fix-sslrootcert.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_slot - fixed sslrootcert mapping to psycopg2 connection string

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -340,7 +340,7 @@ def main():
         "login_password": "password",
         "port": "port",
         "sslmode": "ssl_mode",
-        "ca_cert": "ssl_rootcert"
+        "ca_cert": "sslrootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in module.params.items()
               if k in params_map and v != '')


### PR DESCRIPTION
##### SUMMARY
```
"unable to connect to database: invalid dsn: invalid connection option \"ssl_rootcert\"\n"
```
Fixed typo in postgresql_slot module.

Noticed during manual testing.

sslrootcert mapping has been checked for all other modules - no typos found.

(Gonna write CI tests for ssl related options - doesn't exist nowadays)


##### ISSUE TYPE
- Bugfix Pull Request
- Small Patch