### PR TITLE
VMware_guest: remove guest_id check when use template

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -166,7 +166,7 @@ options:
     - "  virtual machine with RHEL7 64 bit, will be 'rhel7_64Guest'"
     - "  virtual machine with CensOS 64 bit, will be 'centos64Guest'"
     - "  virtual machine with Ubuntu 64 bit, will be 'ubuntu64Guest'"
-    - This field is required when creating a virtual machine.
+    - This field is required when creating a virtual machine, not required when creating from the template.
     - >
          Valid values are referenced here:
          U(http://pubs.vmware.com/vsphere-6-5/topic/com.vmware.wssdk.apiref.doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
@@ -867,7 +867,7 @@ class PyVmomiHelper(PyVmomi):
 
     def configure_guestid(self, vm_obj, vm_creation=False):
         # guest_id is not required when using templates
-        if self.params['template'] and not self.params['guest_id']:
+        if self.params['template']:
             return
 
         # guest_id is only mandatory on VM creation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
guest_id is not required if deploying a new VM from the template. If "guest_id" is set when deploy from the template, it will be ignored after this change.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #47646
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
