### PR TITLE
VMware: Check return of FindByInventoryPath

### DIFF
--- a/changelogs/fragments/54823-vmware_deploy_ovf-folder.yml
+++ b/changelogs/fragments/54823-vmware_deploy_ovf-folder.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Check return value of FindByInventoryPath API used for finding folder value (https://github.com/ansible/ansible/issues/54823).

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -370,6 +370,8 @@ class VMwareDeployOvf:
 
         if self.params['folder']:
             folder = self.si.searchIndex.FindByInventoryPath(self.params['folder'])
+            if not folder:
+                self.module.fail_json(msg="Unable to find the specified folder %(folder)s" % self.params)
         else:
             folder = datacenter.vmFolder
 


### PR DESCRIPTION
##### SUMMARY
Check return value of FindByInventoryPath API which is used for
finding desired folder to deploy OVF.

Fixes: #54823

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/54823-vmware_deploy_ovf-folder.yml
lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
