### PR TITLE
vsphere_guest: corrected fix #19716 misbehaviour

### DIFF
--- a/changelogs/fragments/vsphere_guest-corrected-state-operations.yml
+++ b/changelogs/fragments/vsphere_guest-corrected-state-operations.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - vsphere_guest - creating machines without vm_extra_config allowed
+  - vsphere_guest - powering on/off absent virtual machine will fail

--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1904,9 +1904,8 @@ def main():
             module.exit_json(changed=False, msg="vm %s not present" % guest)
 
         # check if user is trying to perform state operation on a vm which doesn't exists
-        elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_extra_config,
-                                                                            vm_hardware, vm_disk, vm_nic, esxi)):
-            module.exit_json(changed=False, msg="vm %s not present" % guest)
+        elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_hardware, vm_disk, vm_nic, esxi)):
+            module.fail_json(msg="vm %s not present and not all options neccessary to create are provided" % guest)
 
         # Create the VM
         elif state in ['present', 'powered_off', 'powered_on']:


### PR DESCRIPTION
##### SUMMARY
Fix #19716 introduced buggy behaviour to obsolete vsphere_guest module:
A) when creating machine without optional vm_extra_config it returned "vm not present" and OK status instead of creating machine or failing
B) when performing power_on/off operations on absent machine, it didn't fail.

With this patch:
A) machine is created (vm_extra_config is not necessary)
B) operation fails

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vsphere_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Obsolete vsphere_guest module works for old ESXi installation, while vmware_guest refuses because of licensing reasons. That's why I'm motivated to still support it in stable branches (backport to stable-2.7 will follow, if this request is accepted). Standard pull request to devel branch is not possible anymore because of a1c8fc37e86cbf1f6e07f7f38fb3a15ea6e26069.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
