### PR TITLE
postgresql SSL related tests

### DIFF
--- a/test/integration/targets/postgresql/defaults/main.yml
+++ b/test/integration/targets/postgresql/defaults/main.yml
@@ -22,3 +22,9 @@ pg_hba_test_ips:
   netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00'
 - source: '172.16.0.0'
   netmask: '255.255.0.0'
+
+# defaults for test SSL
+ssl_db: 'ssl_db'
+ssl_user: 'ssl_user'
+ssl_pass: 'ssl_pass'
+ssl_rootcert: '~{{ pg_user }}/root.crt'

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -794,6 +794,13 @@
     that:
       - "result.stdout_lines[-1] == '(0 rows)'"
 
+# Test ssl.
+# Restricted using Debian family because of there are errors on other distributions
+# that not related with PostgreSQL or psycopg2 SSL support.
+# The tests' key point is to be sure that ssl options work in general
+- include: ssl.yml
+  when: ansible_os_family == 'Debian' and postgres_version_resp.stdout is version('9.4', '>=')
+
 # Test postgresql_set
 - include: postgresql_set.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')
@@ -877,6 +884,7 @@
 # postgres_pg_hba module checks
 # ============================================================
 - include: postgresql_pg_hba.yml
+
 #
 # Cleanup
 #

--- a/test/integration/targets/postgresql/tasks/ssl.yml
+++ b/test/integration/targets/postgresql/tasks/ssl.yml
@@ -1,0 +1,104 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# The aim of this test is to be sure that SSL options work in general
+# and preparing the environment for testing these options in
+# the following PostgreSQL modules (ssl_db, ssl_user, certs)
+
+####################
+# Prepare for tests:
+
+- name: postgresql SSL - create database
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_db:
+    name: "{{ ssl_db }}"
+
+- name: postgresql SSL - create role
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_user:
+    name: "{{ ssl_user }}"
+    role_attr_flags: SUPERUSER
+    password: "{{ ssl_pass }}"
+
+- name: postgresql SSL - install openssl
+  become: yes
+  package: name=openssl state=present
+
+- name: postgresql SSL - create certs 1
+  become_user: "{{ pg_user }}"
+  become: yes
+  shell: 'openssl req -new -nodes -text -out ~{{ pg_user }}/root.csr \
+         -keyout ~{{ pg_user }}/root.key -subj "/CN=localhost.local"'
+
+- name: postgresql SSL - set right permissions to root.key
+  become_user: "{{ pg_user }}"
+  become: yes
+  file:
+    path: '~{{ pg_user }}/root.key'
+    mode: 0770
+
+- name: postgresql SSL - create certs 3
+  become_user: "{{ pg_user }}"
+  become: yes
+  shell: 'openssl x509 -req -in ~{{ pg_user }}/root.csr -text -days 3650 \
+         -extensions v3_ca -signkey ~{{ pg_user }}/root.key -out ~{{ pg_user }}/root.crt'
+
+- name: postgresql SSL - create certs 4
+  become_user: "{{ pg_user }}"
+  become: yes
+  shell: 'openssl req -new -nodes -text -out ~{{ pg_user }}/server.csr \
+         -keyout ~{{ pg_user }}/server.key -subj "/CN=localhost.local"'
+
+- name: postgresql SSL - set right permissions to server.key
+  become_user: "{{ pg_user }}"
+  become: yes
+  file:
+    path: '~{{ pg_user }}/server.key'
+    mode: 0770
+
+- name: postgresql SSL - create certs 5
+  become_user: "{{ pg_user }}"
+  become: yes
+  shell: 'openssl x509 -req -in ~{{ pg_user }}/server.csr -text -days 365 \
+         -CA ~{{ pg_user }}/root.crt -CAkey ~{{ pg_user }}/root.key -CAcreateserial -out server.crt'
+
+- name: postgresql SSL - enable SSL
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_set:
+    login_user: "{{ pg_user }}"
+    db: postgres
+    name: ssl
+    value: on
+
+- name: postgresql SSL - reload PostgreSQL to enable ssl on
+  become: yes
+  service:
+    name: "{{ postgresql_service }}"
+    state: reloaded
+
+###############
+# Do main tests
+
+- name: postgresql SSL - ping DB with SSL
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_ping:
+    db: "{{ ssl_db }}"
+    login_user: "{{ ssl_user }}"
+    login_password: "{{ ssl_pass }}"
+    login_host: 127.0.0.1
+    login_port: 5432
+    ssl_mode: require
+    ca_cert: '{{ ssl_rootcert }}'
+  register: result
+
+- assert:
+    that: 
+    - result.is_available == true
+
+###################################################
+# I decided not to clean ssl_db, ssl_user and certs
+# for testing options related with SSL in other modules

--- a/test/integration/targets/postgresql/tasks/ssl.yml
+++ b/test/integration/targets/postgresql/tasks/ssl.yml
@@ -3,7 +3,8 @@
 
 # The aim of this test is to be sure that SSL options work in general
 # and preparing the environment for testing these options in
-# the following PostgreSQL modules (ssl_db, ssl_user, certs)
+# the following PostgreSQL modules (ssl_db, ssl_user, certs).
+# Configured by https://www.postgresql.org/docs/current/ssl-tcp.html
 
 ####################
 # Prepare for tests:


### PR DESCRIPTION
##### SUMMARY
Added common tests for SSL related options (ssl_mode, ca_cert) in postgresql modules.

The aim of this tests is to be sure that SSL options work in general and preparing the environment for testing these options in the following PostgreSQL modules (ssl_db, ssl_user, certs).

##### ISSUE TYPE
- Docs Pull Request