### PR TITLE
Update k8s inventory "connections" data type

### DIFF
--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -95,14 +95,14 @@ EXAMPLES = '''
 # Authenticate with token, and return all pods and services for all namespaces
 plugin: k8s
 connections:
-    host: https://192.168.64.4:8443
+  - host: https://192.168.64.4:8443
     token: xxxxxxxxxxxxxxxx
     validate_certs: false
 
 # Use default config (~/.kube/config) file and active context, and return objects for a specific namespace
 plugin: k8s
 connections:
-    namespaces:
+  - namespaces:
     - testing
 
 # Use a custom config file, and a specific context.


### PR DESCRIPTION
##### SUMMARY
Updated documentation:

`connections` in the example YAML for the k8s inventory plugin is expected to be a list.  Example:

```
 [WARNING]:  * Failed to parse
{...}/inventory.yml with k8s
plugin: Expecting connections to be a list.
```

Updated example for `host` and  `namespaces` to reflect this.  `kubeconfig` was already correct.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
k8s inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
None