### PR TITLE
[stable-2.7] Fix ansible-test unicode error with redact option.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -300,7 +300,7 @@ class AnsibleCoreCI(object):
             )
 
             if self.connection.password:
-                display.sensitive.add(self.connection.password)
+                display.sensitive.add(str(self.connection.password))
 
         status = 'running' if self.connection.running else 'starting'
 
@@ -452,7 +452,7 @@ class AnsibleCoreCI(object):
         :type config: dict[str, str]
         :rtype: bool
         """
-        self.instance_id = config['instance_id']
+        self.instance_id = str(config['instance_id'])
         self.endpoint = config['endpoint']
         self.started = True
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Fix ansible-test unicode error with redact option.

Backport of #55328

(cherry picked from commit 2ef4ba3b4d3df12b822e359d095c62fa45f5fd04)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
