### PR TITLE
[stable-2.7] meraki_vlan - Remove unnecessary API calls

### DIFF
--- a/changelogs/fragments/meraki_vlan_api_calls.yml
+++ b/changelogs/fragments/meraki_vlan_api_calls.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "meraki_vlan - Module would make unnecessary API calls to Meraki when net_id is specified in task."

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -271,13 +271,6 @@ def fixed_ip_factory(meraki, data):
     return fixed_ips
 
 
-def temp_get_nets(meraki, org_name):
-    org_id = meraki.get_org_id(org_name)
-    path = meraki.construct_path('get_all', function='network', org_id=org_id)
-    r = meraki.request(path, method='GET')
-    return r
-
-
 def get_vlans(meraki, net_id):
     path = meraki.construct_path('get_all', net_id=net_id)
     return meraki.request(path, method='GET')
@@ -360,12 +353,10 @@ def main():
     org_id = meraki.params['org_id']
     if org_id is None:
         org_id = meraki.get_org_id(meraki.params['org_name'])
-    nets = meraki.get_nets(org_id=org_id)
-    net_id = None
-    if meraki.params['net_name']:
+    net_id = meraki.params['net_id']
+    if net_id is None:
+        nets = meraki.get_nets(org_id=org_id)
         net_id = meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
-    elif meraki.params['net_id']:
-        net_id = meraki.params['net_id']
 
     if meraki.params['state'] == 'query':
         if not meraki.params['vlan_id']:


### PR DESCRIPTION
##### SUMMARY
    Remove unnecessary API calls when net_id is specified

    Remove temp_get_nets commented out code

(cherry picked from commit fb3cc7f)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_vlan
