### PR TITLE
psrp - fix test_command rc for win_reboot

### DIFF
--- a/changelogs/fragments/win_reboot-psrp-command.yaml
+++ b/changelogs/fragments/win_reboot-psrp-command.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_reboot - pass return value for ``test_command`` result when using the ``psrp`` connection plugin

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -46,6 +46,14 @@ class ActionModule(RebootActionModule, ActionBase):
     def get_shutdown_command(self, task_vars, distribution):
         return self.DEFAULT_SHUTDOWN_COMMAND
 
+    def run_test_command(self, distribution, **kwargs):
+        # Need to wrap the test_command in our PowerShell encoded wrapper. This is done to align the command input to a
+        # common shell and to allow the psrp connection plugin to report the correct exit code without manually setting
+        # $LASTEXITCODE for just that plugin.
+        test_command = self._task.args.get('test_command', self.DEFAULT_TEST_COMMAND)
+        kwargs['test_command'] = self._connection._shell._encode_script(test_command)
+        super(ActionModule, self).run_test_command(distribution, **kwargs)
+
     def perform_reboot(self, task_vars, distribution):
         shutdown_command = self.get_shutdown_command(task_vars, distribution)
         shutdown_command_args = self.get_shutdown_command_args(distribution)

--- a/test/integration/targets/win_reboot/tasks/main.yml
+++ b/test/integration/targets/win_reboot/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: reboot with secondary reboot stage
   win_reboot:
-    test_command: powershell.exe -NoProfile -EncodedCommand {{lookup('template', 'post_reboot.ps1')|b64encode(encoding='utf-16-le')}}
+    test_command: '{{ lookup("template", "post_reboot.ps1") }}'
 
 - name: reboot with test command that fails
   win_reboot:
@@ -35,59 +35,27 @@
   register: reboot_fail_test
   failed_when: "reboot_fail_test.msg != 'Timed out waiting for post-reboot test command (timeout=120)'"
 
-# try and reboot the host with a non admin user, we expect an error here
-# this requires a bit of setup to create the user and allow it to connect
-# over WinRM
-- name: create password fact
-  set_fact:
-    standard_user: ansible_user_test
-    standard_pass: password123! + {{ lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}
-
-- name: get original SDDL for WinRM listener
-  win_shell: (Get-Item -Path WSMan:\localhost\Service\RootSDDL).Value
-  register: original_sddl
-
-- name: create standard user
-  win_user:
-    name: '{{standard_user}}'
-    password: '{{standard_pass}}'
-    update_password: always
-    groups: Users
-    state: present
-  register: user_res
-
-- name: add standard user to WinRM listener
-  win_shell: |
-    $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "{{user_res.sid}}"
-    $sd = New-Object -TypeName System.Security.AccessControl.CommonSecurityDescriptor -ArgumentList $false, $false, "{{original_sddl.stdout_lines[0]}}"
-    $sd.DiscretionaryAcl.AddAccess(
-        [System.Security.AccessControl.AccessControlType]::Allow,
-        $sid,
-        (0x80000000 -bor 0x20000000),
-        [System.Security.AccessControl.InheritanceFlags]::None,
-        [System.Security.AccessControl.PropagationFlags]::None
-    )
-    $new_sddl = $sd.GetSddlForm([System.Security.AccessControl.AccessControlSections]::All)
-    Set-Item -Path WSMan:\localhost\Service\RootSDDL -Value $new_sddl -Force
+- name: remove SeRemoteShutdownPrivilege
+  win_user_right:
+    name: SeRemoteShutdownPrivilege
+    users: []
+    action: set
+  register: removed_shutdown_privilege
 
 - block:
-    - name: fail to reboot with non admin user
-      win_reboot:
-      vars:
-        ansible_user: '{{standard_user}}'
-        ansible_password: '{{standard_pass}}'
-        ansible_winrm_transport: ntlm
-      register: fail_shutdown
-      failed_when: "'Reboot command failed, error was:  Access is denied.(5)' not in fail_shutdown.msg"
+  - name: try and reboot without required privilege
+    win_reboot:
+    register: fail_privilege
+    failed_when:
+    - "'Reboot command failed, error was:' not in fail_privilege.msg"
+    - "'Access is denied.(5)' not in fail_privilege.msg"
 
   always:
-    - name: set the original SDDL to the WinRM listener
-      win_shell: 'Set-Item -Path WSMan:\localhost\Service\RootSDDL -Value "{{original_sddl.stdout_lines[0]}}" -Force'
-
-    - name: remove standard user
-      win_user:
-        name: '{{standard_user}}'
-        state: absent
+  - name: reset the SeRemoteShutdownPrivilege
+    win_user_right:
+      name: SeRemoteShutdownPrivilege
+      users: '{{ removed_shutdown_privilege.removed }}'
+      action: add
 
 - name: Use invalid parameter
   reboot:


### PR DESCRIPTION
##### SUMMARY
When using `test_command` with `win_reboot` over `psrp`, the return value was not always returned back to Ansible due to the various escaping. This caused issues as rc of 0 will have win_reboot continue when it shouldn't.

This change also unifies another command input to use a PowerShell context like `raw` and other command inputs. It finally simplifies the access denied errors by removing the remote shutdown privilege instead of trying to create a temp standard user and allow standard users to connect over WinRM.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reboot