### PR TITLE
nxos_interface DI delay only when operation state check is requested

### DIFF
--- a/changelogs/fragments/nxos_interfaces_27_fix.yaml
+++ b/changelogs/fragments/nxos_interfaces_27_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_interface DI delay only when operation state check is requested (https://github.com/ansible/ansible/pull/54862).

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -590,14 +590,15 @@ def check_declarative_intent_params(module, want):
     failed_conditions = []
     have_neighbors = None
     for w in want:
+        if w['interface_type']:
+            continue
         want_tx_rate = w.get('tx_rate')
         want_rx_rate = w.get('rx_rate')
         want_neighbors = w.get('neighbors')
+        if not (want_tx_rate or want_rx_rate or want_neighbors):
+            continue
 
         time.sleep(module.params['delay'])
-
-        if w['interface_type']:
-            return
 
         cmd = [{'command': 'show interface {0}'.format(w['name']), 'output': 'text'}]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
cherry-pick https://github.com/ansible/ansible/commit/0fe6bf911af78cffda9b17831ab2cb394ce2c0e9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/network/nxos/nxos_interface.py