### PR TITLE
ansible-test yamllint: fix UnicodeDecodeError

### DIFF
--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -437,13 +437,10 @@ def raw_command(cmd, capture=False, env=None, data=None, cwd=None, explain=False
 
         if communicate:
             encoding = 'utf-8'
-            if data:
-                if isinstance('', bytes):
-                    data_bytes = data
-                else:
-                    data_bytes = data.encode(encoding, 'surrogateescape')
+            if data is None or isinstance(data, bytes):
+                data_bytes = data
             else:
-                data_bytes = None
+                data_bytes = data.encode(encoding, 'surrogateescape')
             stdout_bytes, stderr_bytes = process.communicate(data_bytes)
             stdout_text = stdout_bytes.decode(encoding, str_errors) if stdout_bytes else u''
             stderr_text = stderr_bytes.decode(encoding, str_errors) if stderr_bytes else u''

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -437,7 +437,13 @@ def raw_command(cmd, capture=False, env=None, data=None, cwd=None, explain=False
 
         if communicate:
             encoding = 'utf-8'
-            data_bytes = data.encode(encoding, 'surrogateescape') if data else None
+            if data:
+                if isinstance('', bytes):
+                    data_bytes = data
+                else:
+                    data_bytes = data.encode(encoding, 'surrogateescape')
+            else:
+                data_bytes = None
             stdout_bytes, stderr_bytes = process.communicate(data_bytes)
             stdout_text = stdout_bytes.decode(encoding, str_errors) if stdout_bytes else u''
             stderr_text = stderr_bytes.decode(encoding, str_errors) if stderr_bytes else u''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes the below traceback (triggered by `test/integration/targets/vault/vault-café.yml`) on Python 2:
```
$ ansible-test sanity --test yamllint
Sanity check using yamllint

NOTICE: Killed command to avoid an orphaned child process during handling of an unexpected exception.
Traceback (most recent call last):
  File "/home/mkrizek/src/ansible/bin/ansible-test", line 15, in <module>
    lib.cli.main()
  File "/home/mkrizek/src/ansible/test/runner/lib/cli.py", line 108, in main
    args.func(config)
  File "/home/mkrizek/src/ansible/test/runner/lib/sanity/__init__.py", line 113, in command_sanity
    result = test.test(args, targets)
  File "/home/mkrizek/src/ansible/test/runner/lib/sanity/yamllint.py", line 58, in test
    results += self.test_paths(args, test_paths)
  File "/home/mkrizek/src/ansible/test/runner/lib/sanity/yamllint.py", line 82, in test_paths
    stdout, stderr = run_command(args, cmd, data=data, capture=True)
  File "/home/mkrizek/src/ansible/test/runner/lib/util.py", line 366, in run_command
    cmd_verbosity=cmd_verbosity, str_errors=str_errors)
  File "/home/mkrizek/src/ansible/test/runner/lib/util.py", line 443, in raw_command
    data_bytes = data.encode(encoding, 'surrogateescape') if data else None
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 230711: ordinal not in range(128)
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/runner/lib/util.py
