### PR TITLE
include windows server 2019 in supported hosts

### DIFF
--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -15,7 +15,7 @@ Windows host must meet the following requirements:
 * Ansible's supported Windows versions generally match those under current
   and extended support from Microsoft. Supported desktop OSs include
   Windows 7, 8.1, and 10, and supported server OSs are Windows Server 2008,
-  2008 R2, 2012, 2012 R2, and 2016.
+  2008 R2, 2012, 2012 R2, 2016, and 2019.
 
 * Ansible requires PowerShell 3.0 or newer and at least .NET 4.0 to be
   installed on the Windows host.


### PR DESCRIPTION
<!--- Your description here -->

+label: docsite_pr

##### SUMMARY
Windows Server 2019 was added to the shippable matrix back in February so it should be added as a supported host on the Windows setup guide. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
