### PR TITLE
Add proxy parameter to k8s module.

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -122,6 +122,7 @@ AUTH_ARG_SPEC = {
         'type': 'path',
         'aliases': ['key_file'],
     },
+    'proxy': {},
 }
 
 

--- a/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
+++ b/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
@@ -67,6 +67,11 @@ options:
       environment variable.
     type: bool
     aliases: [ verify_ssl ]
+  proxy:
+    description:
+    - The URL of an HTTP proxy to use for the connection. Can also be specified via K8S_AUTH_PROXY environment variable.
+    - Please note that this module does not pick up typical proxy settings from the environment (e.g. HTTP_PROXY).
+    version_added: "2.9"
 notes:
   - "The OpenShift Python client wraps the K8s Python client, providing full access to
     all of the APIS and models available on both platforms. For API version details and


### PR DESCRIPTION
##### SUMMARY

When running Ansible behind a proxy, the k8s module is not capable to reach the K8s cluster. Even if `HTTP_PROXY` or `HTTPS_PROXY` environment variables are set.

However, the K8s client allows configuring a proxy for the connection. It only needs to be added to the argument auth spec in order to work as intended.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
