### PR TITLE
Move missing library abort to use rather than import for netconf

### DIFF
--- a/lib/ansible/plugins/netconf/ce.py
+++ b/lib/ansible/plugins/netconf/ce.py
@@ -33,8 +33,9 @@ try:
     from ncclient.operations import RPCError
     from ncclient.transport.errors import SSHUnknownHostError
     from ncclient.xml_ import to_ele, to_xml, new_ele
-except ImportError:
-    raise AnsibleError("ncclient is not installed")
+    HAS_NCCLIENT = True
+except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    HAS_NCCLIENT = False
 
 
 class Netconf(NetconfBase):

--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -37,16 +37,22 @@ try:
     from ncclient.operations import RPCError
     from ncclient.transport.errors import SSHUnknownHostError
     from ncclient.xml_ import to_ele, to_xml, new_ele
-except ImportError:
-    raise AnsibleError("ncclient is not installed")
+    HAS_NCCLIENT = True
+except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    HAS_NCCLIENT = False
 
 try:
     from lxml import etree
+    HAS_LXML = True
 except ImportError:
-    raise AnsibleError("lxml is not installed")
+    HAS_LXML = False
 
 
 class Netconf(NetconfBase):
+    def __init__(self, *args, **kwargs):
+        if not HAS_LXML:
+            raise AnsibleError("lxml is not installed")
+        super(self, Netconf).__init__(*args, **kwargs)
 
     @ensure_connected
     def get_device_info(self):

--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -29,7 +29,7 @@ from ansible.module_utils.network.common.netconf import remove_namespaces
 from ansible.module_utils.network.iosxr.iosxr import build_xml, etree_find
 from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.netconf import NetconfBase
-from ansible.plugins.netconf import ensure_connected
+from ansible.plugins.netconf import ensure_connected, ensure_ncclient
 
 try:
     from ncclient import manager
@@ -87,13 +87,13 @@ class Netconf(NetconfBase):
         return json.dumps(result)
 
     @staticmethod
+    @ensure_ncclient
     def guess_network_os(obj):
         """
         Guess the remote network os name
         :param obj: Netconf connection class object
         :return: Network OS name
         """
-        Netconf.ensure_ncclient()
         try:
             m = manager.connect(
                 host=obj._play_context.remote_addr,
@@ -119,9 +119,9 @@ class Netconf(NetconfBase):
         return guessed_os
 
     # TODO: change .xml to .data_xml, when ncclient supports data_xml on all platforms
+    @ensure_ncclient
     @ensure_connected
     def get(self, filter=None, remove_ns=False):
-        self.ensure_ncclient()
         if isinstance(filter, list):
             filter = tuple(filter)
         try:
@@ -134,9 +134,9 @@ class Netconf(NetconfBase):
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
+    @ensure_ncclient
     @ensure_connected
     def get_config(self, source=None, filter=None, remove_ns=False):
-        self.ensure_ncclient()
         if isinstance(filter, list):
             filter = tuple(filter)
         try:
@@ -149,9 +149,9 @@ class Netconf(NetconfBase):
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
+    @ensure_ncclient
     @ensure_connected
     def edit_config(self, config=None, format='xml', target='candidate', default_operation=None, test_option=None, error_option=None, remove_ns=False):
-        self.ensure_ncclient()
         if config is None:
             raise ValueError('config value must be provided')
         try:
@@ -165,9 +165,9 @@ class Netconf(NetconfBase):
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
+    @ensure_ncclient
     @ensure_connected
     def commit(self, confirmed=False, timeout=None, persist=None, remove_ns=False):
-        self.ensure_ncclient()
         try:
             resp = self.m.commit(confirmed=confirmed, timeout=timeout, persist=persist)
             if remove_ns:
@@ -178,9 +178,9 @@ class Netconf(NetconfBase):
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
+    @ensure_ncclient
     @ensure_connected
     def validate(self, source="candidate", remove_ns=False):
-        self.ensure_ncclient()
         try:
             resp = self.m.validate(source=source)
             if remove_ns:
@@ -191,9 +191,9 @@ class Netconf(NetconfBase):
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
+    @ensure_ncclient
     @ensure_connected
     def discard_changes(self, remove_ns=False):
-        self.ensure_ncclient()
         try:
             resp = self.m.discard_changes()
             if remove_ns:

--- a/lib/ansible/plugins/netconf/junos.py
+++ b/lib/ansible/plugins/netconf/junos.py
@@ -33,8 +33,9 @@ try:
     from ncclient.operations import RPCError
     from ncclient.transport.errors import SSHUnknownHostError
     from ncclient.xml_ import to_ele, to_xml, new_ele, sub_ele
-except ImportError:
-    raise AnsibleError("ncclient is not installed")
+    HAS_NCCLIENT = True
+except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    HAS_NCCLIENT = False
 
 
 class Netconf(NetconfBase):

--- a/lib/ansible/plugins/netconf/junos.py
+++ b/lib/ansible/plugins/netconf/junos.py
@@ -22,9 +22,8 @@ __metaclass__ = type
 import json
 import re
 
-from ansible import constants as C
-from ansible.module_utils._text import to_text, to_bytes, to_native
-from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.module_utils._text import to_text, to_native
+from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.netconf import NetconfBase
 from ansible.plugins.netconf import ensure_connected
 
@@ -47,6 +46,7 @@ class Netconf(NetconfBase):
             pass
 
     def get_device_info(self):
+        self.ensure_ncclient()
         device_info = dict()
         device_info['network_os'] = 'junos'
         ele = new_ele('get-software-information')
@@ -79,6 +79,7 @@ class Netconf(NetconfBase):
         :param config: The configuration to be loaded on remote host in string format
         :return: Received rpc response from remote host in string format
         """
+        self.ensure_ncclient()
         if config:
             if format == 'xml':
                 config = to_ele(config)
@@ -108,6 +109,7 @@ class Netconf(NetconfBase):
         :param obj: Netconf connection class object
         :return: Network OS name
         """
+        Netconf.ensure_ncclient()
         try:
             m = manager.connect(
                 host=obj._play_context.remote_addr,
@@ -184,6 +186,7 @@ class Netconf(NetconfBase):
         :param at_time: Time at which to activate configuration changes
         :return: Received rpc response from remote host
         """
+        self.ensure_ncclient()
         obj = new_ele('commit-configuration')
         if confirmed:
             sub_ele(obj, 'confirmed')

--- a/lib/ansible/plugins/netconf/sros.py
+++ b/lib/ansible/plugins/netconf/sros.py
@@ -25,6 +25,7 @@ import re
 from ansible.module_utils._text import to_text, to_native
 from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.netconf import NetconfBase
+from ansible.plugins.netconf import ensure_ncclient
 
 try:
     from ncclient import manager
@@ -42,8 +43,8 @@ class Netconf(NetconfBase):
         except AttributeError:
             pass
 
+    @ensure_ncclient
     def get_device_info(self):
-        self.ensure_ncclient()
         device_info = dict()
         device_info['network_os'] = 'sros'
 
@@ -69,8 +70,8 @@ class Netconf(NetconfBase):
         return json.dumps(result)
 
     @staticmethod
+    @ensure_ncclient
     def guess_network_os(obj):
-        Netconf.ensure_ncclient()
         try:
             m = manager.connect(
                 host=obj._play_context.remote_addr,

--- a/lib/ansible/plugins/netconf/sros.py
+++ b/lib/ansible/plugins/netconf/sros.py
@@ -33,16 +33,23 @@ try:
     from ncclient.operations import RPCError
     from ncclient.transport.errors import SSHUnknownHostError
     from ncclient.xml_ import to_ele, to_xml, new_ele
-except ImportError:
-    raise AnsibleError("ncclient is not installed")
+    HAS_NCCLIENT = True
+except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    HAS_NCCLIENT = False
 
 try:
     from lxml import etree
+    HAS_LXML = True
 except ImportError:
-    raise AnsibleError("lxml is not installed")
+    HAS_LXML = False
 
 
 class Netconf(NetconfBase):
+    def __init__(self, *args, **kwargs):
+        if not HAS_LXML:
+            raise AnsibleError("lxml is not installed")
+        super(self, Netconf).__init__(*args, **kwargs)
+
     def get_text(self, ele, tag):
         try:
             return to_text(ele.find(tag).text, errors='surrogate_then_replace').strip()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #55381

`ncclient` imports on implementing plugins have also been moved, but the check in the superclass should suffice for all of them.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf