### PR TITLE
Properly reset timezone in user integration test when it was originally "n/a"

### DIFF
--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -326,6 +326,8 @@
     state: present
     expires: 2529881062
   register: user_test_expires1
+  tags:
+    - timezone
 
 - name: Set user expiration again to ensure no change is made
   user:
@@ -333,6 +335,8 @@
     state: present
     expires: 2529881062
   register: user_test_expires2
+  tags:
+    - timezone
 
 - name: Ensure that account with expiration was created and did not change on subsequent run
   assert:
@@ -382,16 +386,31 @@
         state: present
         expires: 2529881062
       register: user_test_different_tz
+      tags:
+        - timezone
 
     - name: Ensure that no change was reported
       assert:
         that:
           - user_test_different_tz is not changed
+      tags:
+        - timezone
 
   always:
     - name: Restore original timezone - {{ original_timezone.diff.before.name }}
       timezone:
         name: "{{ original_timezone.diff.before.name }}"
+      when: original_timezone.diff.before.name != "n/a"
+      tags:
+        - timezone
+
+    - name: Restore original timezone when n/a
+      file:
+        path: /etc/sysconfig/clock
+        state: absent
+      when:
+        - original_timezone.diff.before.name == "n/a"
+        - "'/etc/sysconfig/clock' in original_timezone.msg"
       tags:
         - timezone
 


### PR DESCRIPTION
##### SUMMARY
The Fedora29 test container returns a timezone of `n/a` from the `timezone` module. Trying to set the timezone back to `n/a` causes the test to fail because that is not a valid timezone.

Change the test to undo the timezone change that was done by the `timezone` module by removing the file it modified, which does not exist in the test container before being modified by the `timezone` module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`test/integration/targets/user/tasks/main.yml`
