### PR TITLE
redhat_subscription: Fix usage of ConfigParser (#54815)

### DIFF
--- a/changelogs/fragments/redhat_subscription_use_strings_for_yum_plugin_configs.yaml
+++ b/changelogs/fragments/redhat_subscription_use_strings_for_yum_plugin_configs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- redhat_subscription - For compatibility using the redhat_subscription module on hosts set to use a python 3 interpreter, use string values when updating yum plugin configuration files.

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -249,9 +249,9 @@ class RegistrationBase(object):
             cfg.read([tmpfile])
 
             if enabled:
-                cfg.set('main', 'enabled', 1)
+                cfg.set('main', 'enabled', '1')
             else:
-                cfg.set('main', 'enabled', 0)
+                cfg.set('main', 'enabled', '0')
 
             fd = open(tmpfile, 'w+')
             cfg.write(fd)


### PR DESCRIPTION
##### SUMMARY

Ansible 2.7's `redhat_subscription` is broken on RHEL8 because of a Python 3 that
is resolved in master by https://github.com/ansible/ansible/pull/54815.

(cherry picked from commit 09f68fc6595ab078210fa1846f620dd4ad4cba66)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription