### PR TITLE
extends linux cpuinfo test unit with sparc64 data

### DIFF
--- a/test/units/module_utils/facts/fixtures/cpuinfo/sparc-t5-debian-ldom-24vcpu
+++ b/test/units/module_utils/facts/fixtures/cpuinfo/sparc-t5-debian-ldom-24vcpu
@@ -1,0 +1,61 @@
+cpu             : UltraSparc T5 (Niagara5)
+fpu             : UltraSparc T5 integrated FPU
+pmu             : niagara5
+prom            : OBP 4.38.12 2018/03/28 14:54
+type            : sun4v
+ncpus probed    : 24
+ncpus active    : 24
+D$ parity tl1   : 0
+I$ parity tl1   : 0
+cpucaps         : flush,stbar,swap,muldiv,v9,blkinit,n2,mul32,div32,v8plus,popc,vis,vis2,ASIBlkInit,fmaf,vis3,hpc,ima,pause,cbcond,aes,des,kasumi,camellia,md5,sha1,sha256,sha512,mpmul,montmul,montsqr,crc32c
+Cpu0ClkTck      : 00000000d6924470
+Cpu1ClkTck      : 00000000d6924470
+Cpu2ClkTck      : 00000000d6924470
+Cpu3ClkTck      : 00000000d6924470
+Cpu4ClkTck      : 00000000d6924470
+Cpu5ClkTck      : 00000000d6924470
+Cpu6ClkTck      : 00000000d6924470
+Cpu7ClkTck      : 00000000d6924470
+Cpu8ClkTck      : 00000000d6924470
+Cpu9ClkTck      : 00000000d6924470
+Cpu10ClkTck     : 00000000d6924470
+Cpu11ClkTck     : 00000000d6924470
+Cpu12ClkTck     : 00000000d6924470
+Cpu13ClkTck     : 00000000d6924470
+Cpu14ClkTck     : 00000000d6924470
+Cpu15ClkTck     : 00000000d6924470
+Cpu16ClkTck     : 00000000d6924470
+Cpu17ClkTck     : 00000000d6924470
+Cpu18ClkTck     : 00000000d6924470
+Cpu19ClkTck     : 00000000d6924470
+Cpu20ClkTck     : 00000000d6924470
+Cpu21ClkTck     : 00000000d6924470
+Cpu22ClkTck     : 00000000d6924470
+Cpu23ClkTck     : 00000000d6924470
+MMU Type        : Hypervisor (sun4v)
+MMU PGSZs       : 8K,64K,4MB,256MB
+State:
+CPU0:           online
+CPU1:           online
+CPU2:           online
+CPU3:           online
+CPU4:           online
+CPU5:           online
+CPU6:           online
+CPU7:           online
+CPU8:           online
+CPU9:           online
+CPU10:          online
+CPU11:          online
+CPU12:          online
+CPU13:          online
+CPU14:          online
+CPU15:          online
+CPU16:          online
+CPU17:          online
+CPU18:          online
+CPU19:          online
+CPU20:          online
+CPU21:          online
+CPU22:          online
+CPU23:          online

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -536,4 +536,17 @@ CPU_INFO_TEST_SCENARIOS = [
             'processor_vcpus': 48
         },
     },
+    {
+        'cpuinfo': open(os.path.join(os.path.dirname(__file__), '../fixtures/cpuinfo/sparc-t5-debian-ldom-24vcpu')).readlines(),
+        'architecture': 'sparc64',
+        'expected_result': {
+            'processor': [
+                'UltraSparc T5 (Niagara5)',
+            ],
+            'processor_cores': 1,
+            'processor_count': 24,
+            'processor_threads_per_core': 1,
+            'processor_vcpus': 24
+        },
+    },
 ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
added sparc64 cpuinfo data file and updated cpuinfo test unit

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
facts module

##### ADDITIONAL INFORMATION
no user visible changes