### PR TITLE
Version in deprecate calls should be a string

### DIFF
--- a/changelogs/fragments/gitlab-deprecated-version.yaml
+++ b/changelogs/fragments/gitlab-deprecated-version.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- gitlab modules - Update version deprecations to use strings instead of integers
+  so that ``2.10`` isn't converted to ``2.1``. (https://github.com/ansible/ansible/pull/55395)

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -241,7 +241,7 @@ class GitLabDeployKey(object):
 def deprecation_warning(module):
     deprecated_aliases = ['private_token', 'access_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -269,15 +269,15 @@ class GitLabGroup(object):
 def deprecation_warning(module):
     deprecated_aliases = ['login_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
 
 
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version=2.10),
-        login_user=dict(type='str', no_log=True, removed_in_version=2.10),
-        login_password=dict(type='str', no_log=True, removed_in_version=2.10),
+        server_url=dict(type='str', required=True, removed_in_version="2.10"),
+        login_user=dict(type='str', no_log=True, removed_in_version="2.10"),
+        login_password=dict(type='str', no_log=True, removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["login_token"]),
         name=dict(type='str', required=True),
         path=dict(type='str'),

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -298,7 +298,7 @@ class GitLabHook(object):
 def deprecation_warning(module):
     deprecated_aliases = ['private_token', 'access_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -289,15 +289,15 @@ class GitLabProject(object):
 def deprecation_warning(module):
     deprecated_aliases = ['login_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
 
 
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version=2.10),
-        login_user=dict(type='str', no_log=True, removed_in_version=2.10),
-        login_password=dict(type='str', no_log=True, removed_in_version=2.10),
+        server_url=dict(type='str', required=True, removed_in_version="2.10"),
+        login_user=dict(type='str', no_log=True, removed_in_version="2.10"),
+        login_password=dict(type='str', no_log=True, removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["login_token"]),
         group=dict(type='str'),
         name=dict(type='str', required=True),

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -288,13 +288,13 @@ class GitLabRunner(object):
 def deprecation_warning(module):
     deprecated_aliases = ['login_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
 
 
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        url=dict(type='str', required=True, removed_in_version=2.10),
+        url=dict(type='str', required=True, removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["private_token"]),
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -411,15 +411,15 @@ class GitLabUser(object):
 def deprecation_warning(module):
     deprecated_aliases = ['login_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), 2.10)
+    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
 
 
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version=2.10),
-        login_user=dict(type='str', no_log=True, removed_in_version=2.10),
-        login_password=dict(type='str', no_log=True, removed_in_version=2.10),
+        server_url=dict(type='str', required=True, removed_in_version="2.10"),
+        login_user=dict(type='str', no_log=True, removed_in_version="2.10"),
+        login_password=dict(type='str', no_log=True, removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["login_token"]),
         name=dict(type='str', required=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),


### PR DESCRIPTION
##### SUMMARY
Version in deprecate calls should be a string. Fixes #55312. Fixes #55313. Fixes #55314. Fixes #55315. Fixes #55316. Fixes #55317.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/source_control/gitlab_deploy_key.py
lib/ansible/modules/source_control/gitlab_group.py
lib/ansible/modules/source_control/gitlab_hook.py
lib/ansible/modules/source_control/gitlab_project.py
lib/ansible/modules/source_control/gitlab_runner.py
lib/ansible/modules/source_control/gitlab_user.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```