### PR TITLE
User - Do not add incompatible flags in local mode

### DIFF
--- a/changelogs/fragments/user-local-mode-group-append.yaml
+++ b/changelogs/fragments/user-local-mode-group-append.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - omit incompatible options when operating in local mode (https://github.com/ansible/ansible/issues/48722)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -60,12 +60,14 @@ options:
               C(null), or C(~), the user is removed from all groups except the
               primary group. (C(~) means C(null) in YAML)
             - Before Ansible 2.3, the only input format allowed was a comma separated string.
+            - Has no effect when C(local) is C(True)
         type: list
     append:
         description:
             - If C(yes), add the user to the groups specified in C(groups).
             - If C(no), user will only be added to the groups specified in C(groups),
               removing them from all other groups.
+            - Has no effect when C(local) is C(True)
         type: bool
         default: no
     shell:
@@ -616,7 +618,7 @@ class User(object):
             else:
                 cmd.append('-N')
 
-        if self.groups is not None and len(self.groups):
+        if self.groups is not None and not self.local and len(self.groups):
             groups = self.get_groups_set()
             cmd.append('-G')
             cmd.append(','.join(groups))
@@ -737,7 +739,7 @@ class User(object):
                     else:
                         groups_need_mod = True
 
-            if groups_need_mod:
+            if groups_need_mod and not self.local:
                 if self.append and not has_append:
                     cmd.append('-A')
                     cmd.append(','.join(group_diff))

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -853,7 +853,7 @@
     state: absent
     remove: yes
     local: yes
-  register: local_user_test_3
+  register: local_user_test_remove_1
   tags:
     - user_test_local_mode
 
@@ -863,16 +863,68 @@
     state: absent
     remove: yes
     local: yes
+  register: local_user_test_remove_2
+  tags:
+    - user_test_local_mode
+
+- name: Create test group
+  group:
+    name: testgroup
+  tags:
+    - user_test_local_mode
+
+- name: Create local_ansibulluser with groups
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    groups: testgroup
+  register: local_user_test_3
+  tags:
+    - user_test_local_mode
+
+- name: Create local_ansibulluser with groups again
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    groups: testgroup
   register: local_user_test_4
   tags:
     - user_test_local_mode
 
-- name: Ensure local user accounts were created
+- name: Remove local_ansibulluser with groups
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+    groups: testgroup
+  register: local_user_test_remove_3
+  tags:
+    - user_test_local_mode
+
+- name: Remove local_ansibulluser with groups again
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+    groups: testgroup
+  register: local_user_test_remove_4
+  tags:
+    - user_test_local_mode
+
+- name: Ensure local user accounts were created and removed properly
   assert:
     that:
       - local_user_test_1 is changed
       - local_user_test_2 is not changed
       - local_user_test_3 is changed
       - local_user_test_4 is not changed
+      - local_user_test_remove_1 is changed
+      - local_user_test_remove_2 is not changed
+      - local_user_test_remove_3 is changed
+      - local_user_test_remove_4 is not changed
   tags:
     - user_test_local_mode


### PR DESCRIPTION
##### SUMMARY

Fixes #48722 

Omit `-G` and `-A` flags when using `luseradd` since that command does not support those flags.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`/lib/ansible/modules/system/user.py`