### PR TITLE
TRANSFORM_INVALID_GROUP_CHARS: no warning for "ignore"

### DIFF
--- a/changelogs/fragments/group-chars-ignore.yaml
+++ b/changelogs/fragments/group-chars-ignore.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- fixed ``ignore`` option to ``TRANSFORM_INVALID_GROUP_CHARS`` to suppress deprecation warnings
+- documented ``ignore`` option for ``TRANSFORM_INVALID_GROUP_CHARS``

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1492,13 +1492,14 @@ TRANSFORM_INVALID_GROUP_CHARS:
   description:
     - Make ansible transform invalid characters in group names supplied by inventory sources.
     - If 'never' it will allow for the group name but warn about the issue.
+    - When 'ignore', it does the same as 'never' sans the warnings.
     - When 'always' it will replace any invalid charachters with '_' (underscore) and warn the user
     - When 'silently', it does the same as 'always' sans the warnings.
   env: [{name: ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS}]
   ini:
   - {key: force_valid_group_names, section: defaults}
   type: string
-  choices: ['always', 'never', 'silently']
+  choices: ['always', 'never', 'ignore', 'silently']
   version_added: '2.8'
 INVALID_TASK_ATTRIBUTE_FAILED:
   name: Controls whether invalid attributes for a task result in errors instead of warnings

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -41,11 +41,10 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
                 if not (silent or C.TRANSFORM_INVALID_GROUP_CHARS == 'silently'):
                     display.vvvv('Replacing ' + msg)
                     warn = 'Invalid characters were found in group names and automatically replaced, use -vvvv to see details'
-            else:
-                if C.TRANSFORM_INVALID_GROUP_CHARS == 'never':
-                    display.vvvv('Not replacing %s' % msg)
-                    warn = True
-                    warn = 'Invalid characters were found in group names but not replaced, use -vvvv to see details'
+            elif C.TRANSFORM_INVALID_GROUP_CHARS == 'never':
+                display.vvvv('Not replacing %s' % msg)
+                warn = True
+                warn = 'Invalid characters were found in group names but not replaced, use -vvvv to see details'
 
                 # remove this message after 2.10 AND changing the default to 'always'
                 display.deprecated('The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in group names by default,'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The existing `ignore` option can be used to explicitly opt-in to the old group chars behavior.  Today, this squashes the `Invalid characters were found...` warning but does not squash the deprecation warning about the future changed default `...this will change, but still be user configurable on deprecation`.

This PR fixes the existing `ignore` option so that it also squashes the deprecation warning in this case.  This PR also adds a docs reference to this already-existing option.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
