### PR TITLE
vmware_dvs_portgroup: update functionality; add mac_management_policy

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -3,6 +3,7 @@
 
 # Copyright: (c) 2015, Joseph Callen <jcallen () csc.com>
 # Copyright: (c) 2017-2018, Ansible Project
+# Copyright: (c) 2019, VMware Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -24,9 +25,11 @@ version_added: 2.0
 author:
     - Joseph Callen (@jcpowermac)
     - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
+    - Joseph Andreatta (@vmwjoseph)
 notes:
     - Tested on vSphere 5.5
     - Tested on vSphere 6.5
+    - Tested on vSphere 6.7
 requirements:
     - "python >= 2.6"
     - PyVmomi
@@ -53,6 +56,12 @@ options:
             - The number of ports the portgroup should contain.
         required: True
         type: int
+    auto_expand:
+        description:
+            - If set to true, the the distributed vSwitch will ignore the limit on the c(num_ports) in the portgroup.
+        required: False
+        default: True
+        version_added: '2.9'
     portgroup_type:
         description:
             - See VMware KB 1022312 regarding portgroup types.
@@ -143,8 +152,38 @@ options:
             'ipfix_override': False
         }
         type: dict
+    mac_management_policy:
+        description:
+            - Dictionary which configures the MAC management policy settings for the portgroup (requires DVS version >= 6.6.0).
+            - 'Valid attributes are:'
+            - '- (allow_promiscuous) (bool): indicates whether promiscuous mode is allowed. (default: None)'
+            - '- (forged_transmits) (bool): indicates whether forged transmits are allowed. (default: None)'
+            - '- (mac_changes) (bool): indicates whether mac changes are allowed. (default: None)'
+            - '- (mac_learning_policy (dict): (default: dict)'
+                - '- (allow_unicast_flooding) (bool): indicates whether to allow flooding of unlearned MAC for ingress traffic (default: None)'
+                - '- (enabled) (bool): indicates if source MAC address learning is allowed (default: False)'
+                - '- (limit) (int): The maximum number of MAC addresses that can be learned.  (default: None)'
+                - '- (limit_policy) (str): The default switching policy after MAC limit is exceeded. (default: None):
+                    - '   - choices: ['allow', 'drop', None]'
+        required: False
+        version_added: '2.9'
+        type: dict
 
 extends_documentation_fragment: vmware.documentation
+'''
+
+RETURN = r'''
+result:
+    description:
+    - result of the changes
+    returned: success
+    type: string
+updates:
+    description:
+    - dictionary of changes
+    returned: on update
+    type: dict
+    sample: { "port_policy": [ "traffic_filter_override does not equal False", ] }
 '''
 
 EXAMPLES = '''
@@ -223,16 +262,49 @@ try:
 except ImportError as e:
     pass
 
+import re
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import (PyVmomi, find_dvs_by_name, find_dvspg_by_name,
                                          vmware_argument_spec, wait_for_task)
 
 
 class VMwareDvsPortgroup(PyVmomi):
+
     def __init__(self, module):
         super(VMwareDvsPortgroup, self).__init__(module)
         self.dvs_portgroup = None
         self.dv_switch = None
+        self.updates = dict()
+
+        # Parse vlan_ids into an easily comparable data structure
+        # For a single vlan it will look like
+        #    { vlan_id: vlan_id }
+        # For a trunk it will looke like:
+        #    { vlan_range_1_start: vlan_range_1_end,
+        #      vlan_range_2_start: vlan_range_2_end,
+        #      ... }
+        # Note that start and end will be equal for a single vlan
+        self.vlan_ids = dict()
+        try:
+            for vlan_range in self.module.params['vlan_id'].split(','):
+                rx = re.match(r'^\s*(\d+)\s*(?:-\s*(\d+))?\s*$', vlan_range)
+                if not rx:
+                    raise ValueError("Range {} does not have valid format".format(vlan_range))
+
+                start = end = int(rx.groups()[0])
+                if rx.groups()[1]:
+                    end = int(rx.groups()[1])
+
+                if end < start:
+                    raise ValueError("Range {} start of range is greater than end".format(vlan_range))
+
+                if start not in range(0, 4095) or end not in range(0, 4095):
+                    self.module.fail_json(msg="vlan_id range %s specified is incorrect. The valid vlan_id range is from 0 to 4094.".format(vlan_range))
+
+                self.vlan_ids[start] = end
+        except ValueError as e:
+            self.module.fail_json(msg="ValueError parsing vlan_ids: {}".format(to_native(e)))
 
     def process_state(self):
         dvspg_states = {
@@ -253,7 +325,7 @@ class VMwareDvsPortgroup(PyVmomi):
         except vmodl.MethodFault as method_fault:
             self.module.fail_json(msg=method_fault.msg)
         except Exception as e:
-            self.module.fail_json(msg=str(e))
+            self.module.fail_json(msg=to_native(e))
 
     def create_port_group(self):
         config = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
@@ -261,54 +333,29 @@ class VMwareDvsPortgroup(PyVmomi):
         # Basic config
         config.name = self.module.params['portgroup_name']
         config.numPorts = self.module.params['num_ports']
-
-        # Default port config
-        config.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
-        if self.module.params['vlan_trunk']:
-            config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
-            vlan_id_list = []
-            for vlan_id_splitted in self.module.params['vlan_id'].split(','):
-                try:
-                    vlan_id_start, vlan_id_end = map(int, vlan_id_splitted.split('-'))
-                    if vlan_id_start not in range(0, 4095) or vlan_id_end not in range(0, 4095):
-                        self.module.fail_json(msg="vlan_id range %s specified is incorrect. The valid vlan_id range is from 0 to 4094." % vlan_id_splitted)
-                    vlan_id_list.append(vim.NumericRange(start=vlan_id_start, end=vlan_id_end))
-                except ValueError:
-                    vlan_id_list.append(vim.NumericRange(start=int(vlan_id_splitted.strip()), end=int(vlan_id_splitted.strip())))
-            config.defaultPortConfig.vlan.vlanId = vlan_id_list
-        else:
-            config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
-            config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
-        config.defaultPortConfig.vlan.inherited = False
-        config.defaultPortConfig.securityPolicy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
-        config.defaultPortConfig.securityPolicy.allowPromiscuous = vim.BoolPolicy(value=self.module.params['network_policy']['promiscuous'])
-        config.defaultPortConfig.securityPolicy.forgedTransmits = vim.BoolPolicy(value=self.module.params['network_policy']['forged_transmits'])
-        config.defaultPortConfig.securityPolicy.macChanges = vim.BoolPolicy(value=self.module.params['network_policy']['mac_changes'])
-
-        # Teaming Policy
-        teamingPolicy = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortTeamingPolicy()
-        teamingPolicy.policy = vim.StringPolicy(value=self.module.params['teaming_policy']['load_balance_policy'])
-        teamingPolicy.reversePolicy = vim.BoolPolicy(value=self.module.params['teaming_policy']['inbound_policy'])
-        teamingPolicy.notifySwitches = vim.BoolPolicy(value=self.module.params['teaming_policy']['notify_switches'])
-        teamingPolicy.rollingOrder = vim.BoolPolicy(value=self.module.params['teaming_policy']['rolling_order'])
-        config.defaultPortConfig.uplinkTeamingPolicy = teamingPolicy
-
-        # PG policy (advanced_policy)
-        config.policy = vim.dvs.VmwareDistributedVirtualSwitch.VMwarePortgroupPolicy()
-        config.policy.blockOverrideAllowed = self.module.params['port_policy']['block_override']
-        config.policy.ipfixOverrideAllowed = self.module.params['port_policy']['ipfix_override']
-        config.policy.livePortMovingAllowed = self.module.params['port_policy']['live_port_move']
-        config.policy.networkResourcePoolOverrideAllowed = self.module.params['port_policy']['network_rp_override']
-        config.policy.portConfigResetAtDisconnect = self.module.params['port_policy']['port_config_reset_at_disconnect']
-        config.policy.securityPolicyOverrideAllowed = self.module.params['port_policy']['security_override']
-        config.policy.shapingOverrideAllowed = self.module.params['port_policy']['shaping_override']
-        config.policy.trafficFilterOverrideAllowed = self.module.params['port_policy']['traffic_filter_override']
-        config.policy.uplinkTeamingOverrideAllowed = self.module.params['port_policy']['uplink_teaming_override']
-        config.policy.vendorConfigOverrideAllowed = self.module.params['port_policy']['vendor_config_override']
-        config.policy.vlanOverrideAllowed = self.module.params['port_policy']['vlan_override']
+        config.autoExpand = self.module.params['auto_expand']
 
         # PG Type
         config.type = self.module.params['portgroup_type']
+
+        # Default port config
+        config.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
+
+        # vlan_id
+        config.defaultPortConfig.vlan = self._vlan_spec()
+
+        # network_policy
+        config.defaultPortConfig.securityPolicy = self._security_policy_spec()
+
+        # MAC management policy is only supported by cswitch (DVS 6.6+)
+        if self.dv_switch.config.productInfo.forwardingClass == 'cswitch':
+            config.defaultPortConfig.macManagementPolicy = self._mac_management_policy_spec()
+
+        # Teaming Policy
+        config.defaultPortConfig.uplinkTeamingPolicy = self._teaming_policy_spec()
+
+        # PG policy (advanced_policy)
+        config.policy = self._pg_policy_spec()
 
         task = self.dv_switch.AddDVPortgroup_Task([config])
         changed, result = wait_for_task(task)
@@ -327,7 +374,40 @@ class VMwareDvsPortgroup(PyVmomi):
         self.module.exit_json(changed=False)
 
     def state_update_dvspg(self):
-        self.module.exit_json(changed=False, msg="Currently not implemented.")
+        changed = True
+        result = None
+
+        if not self.module.check_mode:
+            config = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
+            config.configVersion = self.dvs_portgroup.config.configVersion
+            config.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
+
+            if 'num_ports' in self.updates:
+                config.numPorts = self.module.params['num_ports']
+            if 'auto_expand' in self.updates:
+                config.autoExpand = self.module.params['auto_expand']
+                if not self.module.params['auto_expand']:
+                    config.numPorts = self.module.params['num_ports']
+            if 'portgroup_type' in self.updates:
+                config.type = self.module.params['portgroup_type']
+                if self.module.params['portgroup_type'] != 'ephemeral':
+                    config.autoExpand = self.module.params['auto_expand']
+                    if not self.module.params['auto_expand']:
+                        config.numPorts = self.module.params['num_ports']
+            if 'vlan_id' in self.updates or 'vlan_trunk' in self.updates:
+                config.defaultPortConfig.vlan = self._vlan_spec()
+            if 'network_policy' in self.updates:
+                config.defaultPortConfig.securityPolicy = self._security_policy_spec()
+            if 'mac_management_policy' in self.updates:
+                config.defaultPortConfig.macManagementPolicy = self._mac_management_policy_spec()
+            if 'teaming_policy' in self.updates:
+                config.defaultPortConfig.uplinkTeamingPolicy = self._teaming_policy_spec()
+            if 'port_policy' in self.updates:
+                config.policy = self._pg_policy_spec()
+
+            task = self.dvs_portgroup.ReconfigureDVPortgroup_Task(config)
+            changed, result = wait_for_task(task)
+        self.module.exit_json(changed=changed, result=str(result), updates=self.updates)
 
     def state_create_dvspg(self):
         changed = True
@@ -342,12 +422,158 @@ class VMwareDvsPortgroup(PyVmomi):
 
         if self.dv_switch is None:
             self.module.fail_json(msg="A distributed virtual switch with name %s does not exist" % self.module.params['switch_name'])
+        if self.module.params['mac_management_policy']['mac_learning_policy']['enabled'] and self.dv_switch.config.productInfo.forwardingClass != 'cswitch':
+            self.module.fail_json(
+                msg="The distributed virtual switch does not support MAC management policy."
+                + "Minimum DVS version is 6.6.0 (current version is {})".format(self.dv_switch.config.productInfo.version)
+            )
+
         self.dvs_portgroup = find_dvspg_by_name(self.dv_switch, self.module.params['portgroup_name'])
 
         if self.dvs_portgroup is None:
             return 'absent'
         else:
-            return 'present'
+            return self.check_dvspg_settings()
+
+    def check_dvspg_settings(self):
+        state = 'present'
+        config = self.dvs_portgroup.config
+        pconfig = config.defaultPortConfig
+        # Map config into something we can compare
+        config_map = dict(
+            portgroup_type=config.type,
+            network_policy=dict(
+                promiscuous=pconfig.securityPolicy.allowPromiscuous.value,
+                forged_transmits=pconfig.securityPolicy.forgedTransmits.value,
+                mac_changes=pconfig.securityPolicy.macChanges.value,
+            ),
+            teaming_policy=dict(
+                inbound_policy=pconfig.uplinkTeamingPolicy.reversePolicy.value,
+                notify_switches=pconfig.uplinkTeamingPolicy.notifySwitches.value,
+                rolling_order=pconfig.uplinkTeamingPolicy.rollingOrder.value,
+                load_balance_policy=pconfig.uplinkTeamingPolicy.policy.value,
+            ),
+            port_policy=dict(
+                block_override=config.policy.blockOverrideAllowed,
+                ipfix_override=config.policy.ipfixOverrideAllowed,
+                live_port_move=config.policy.livePortMovingAllowed,
+                network_rp_override=config.policy.networkResourcePoolOverrideAllowed,
+                port_config_reset_at_disconnect=config.policy.portConfigResetAtDisconnect,
+                security_override=config.policy.securityPolicyOverrideAllowed,
+                shaping_override=config.policy.shapingOverrideAllowed,
+                traffic_filter_override=config.policy.trafficFilterOverrideAllowed,
+                uplink_teaming_override=config.policy.uplinkTeamingOverrideAllowed,
+                vendor_config_override=config.policy.vendorConfigOverrideAllowed,
+                vlan_override=config.policy.vlanOverrideAllowed,
+            ),
+        )
+
+        # If the portgroup is ephemeral then auto_exand and num_ports are ignored
+        if config_map['portgroup_type'] != 'ephemeral':
+            config_map['auto_expand'] = config.autoExpand
+            # If auto_exand is True, then num_ports is ignored
+            if not config_map['auto_expand']:
+                config_map['num_ports'] = config.numPorts
+
+        # To gather the VLANs we need to check whether or not this is a VLAN trunk
+        if isinstance(pconfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
+            config_map['vlan_trunk'] = True
+            config_map['vlan_id'] = dict()
+            for vlan_range in pconfig.vlan.vlanId:
+                config_map['vlan_id'][vlan_range.start] = vlan_range.end
+        else:
+            config_map['vlan_trunk'] = False
+            config_map['vlan_id'] = {pconfig.vlan.vlanId: pconfig.vlan.vlanId}
+
+        # The MAC Management Policy has been added to vSphere 6.7
+        if hasattr(pconfig, 'macManagementPolicy') and pconfig.macManagementPolicy:
+            config_map['mac_management_policy'] = dict(
+                allow_promiscuous=pconfig.macManagementPolicy.allowPromiscuous,
+                forged_transmits=pconfig.macManagementPolicy.forgedTransmits,
+                mac_changes=pconfig.macManagementPolicy.macChanges,
+                mac_learning_policy=dict(
+                    allow_unicast_flooding=pconfig.macManagementPolicy.macLearningPolicy.allowUnicastFlooding,
+                    enabled=pconfig.macManagementPolicy.macLearningPolicy.enabled,
+                    limit=pconfig.macManagementPolicy.macLearningPolicy.limit,
+                    limit_policy=pconfig.macManagementPolicy.macLearningPolicy.limitPolicy,
+                ),
+            )
+
+        # Check desired state versus current state
+        for k, v in config_map.items():
+            desired = self.module.params[k]
+
+            # For vlans we want to compare against the pre-computed vlan_ids instead of params
+            if k == 'vlan_id':
+                desired = self.vlan_ids
+
+            if desired != v:
+                state = 'update'
+                self.updates[k] = "Desired '{}' does not equal current '{}'".format(desired, v)
+
+        return state
+
+    def _vlan_spec(self):
+        vlan = None
+        if self.module.params['vlan_trunk']:
+            vlan_id_list = list()
+            for range_start in self.vlan_ids:
+                vlan_id_list.append(vim.NumericRange(start=range_start, end=self.vlan_ids[range_start]))
+            vlan = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
+            vlan.vlanId = vlan_id_list
+        else:
+            vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+            vlan.vlanId = int(self.module.params['vlan_id'])
+        vlan.inherited = False
+
+        return vlan
+
+    def _security_policy_spec(self):
+        security_policy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
+        security_policy.allowPromiscuous = vim.BoolPolicy(value=self.module.params['network_policy']['promiscuous'])
+        security_policy.forgedTransmits = vim.BoolPolicy(value=self.module.params['network_policy']['forged_transmits'])
+        security_policy.macChanges = vim.BoolPolicy(value=self.module.params['network_policy']['mac_changes'])
+
+        return security_policy
+
+    def _teaming_policy_spec(self):
+
+        teaming_policy = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortTeamingPolicy()
+        teaming_policy.policy = vim.StringPolicy(value=self.module.params['teaming_policy']['load_balance_policy'])
+        teaming_policy.reversePolicy = vim.BoolPolicy(value=self.module.params['teaming_policy']['inbound_policy'])
+        teaming_policy.notifySwitches = vim.BoolPolicy(value=self.module.params['teaming_policy']['notify_switches'])
+        teaming_policy.rollingOrder = vim.BoolPolicy(value=self.module.params['teaming_policy']['rolling_order'])
+
+        return teaming_policy
+
+    def _pg_policy_spec(self):
+        pg_policy = vim.dvs.VmwareDistributedVirtualSwitch.VMwarePortgroupPolicy()
+        pg_policy.blockOverrideAllowed = self.module.params['port_policy']['block_override']
+        pg_policy.ipfixOverrideAllowed = self.module.params['port_policy']['ipfix_override']
+        pg_policy.livePortMovingAllowed = self.module.params['port_policy']['live_port_move']
+        pg_policy.networkResourcePoolOverrideAllowed = self.module.params['port_policy']['network_rp_override']
+        pg_policy.portConfigResetAtDisconnect = self.module.params['port_policy']['port_config_reset_at_disconnect']
+        pg_policy.securityPolicyOverrideAllowed = self.module.params['port_policy']['security_override']
+        pg_policy.shapingOverrideAllowed = self.module.params['port_policy']['shaping_override']
+        pg_policy.trafficFilterOverrideAllowed = self.module.params['port_policy']['traffic_filter_override']
+        pg_policy.uplinkTeamingOverrideAllowed = self.module.params['port_policy']['uplink_teaming_override']
+        pg_policy.vendorConfigOverrideAllowed = self.module.params['port_policy']['vendor_config_override']
+        pg_policy.vlanOverrideAllowed = self.module.params['port_policy']['vlan_override']
+
+        return pg_policy
+
+    def _mac_management_policy_spec(self):
+        mm_policy = vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy()
+        mm_policy.allowPromiscuous = self.module.params['mac_management_policy']['allow_promiscuous']
+        mm_policy.forgedTransmits = self.module.params['mac_management_policy']['forged_transmits']
+        mm_policy.macChanges = self.module.params['mac_management_policy']['mac_changes']
+        mm_policy.macLearningPolicy = vim.dvs.VmwareDistributedVirtualSwitch.MacLearningPolicy()
+        mm_policy.macLearningPolicy.enabled = self.module.params['mac_management_policy']['mac_learning_policy']['enabled']
+        mm_policy.macLearningPolicy.allowUnicastFlooding = self.module.params['mac_management_policy']['mac_learning_policy']['allow_unicast_flooding']
+        mm_policy.macLearningPolicy.limit = self.module.params['mac_management_policy']['mac_learning_policy']['limit']
+        mm_policy.macLearningPolicy.limitPolicy = self.module.params['mac_management_policy']['mac_learning_policy']['limit_policy']
+
+        return mm_policy
 
 
 def main():
@@ -358,6 +584,7 @@ def main():
             switch_name=dict(required=True, type='str'),
             vlan_id=dict(required=True, type='str'),
             num_ports=dict(required=True, type='int'),
+            auto_expand=dict(default=True, type='bool'),
             portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             vlan_trunk=dict(type='bool', default=False),
@@ -426,12 +653,30 @@ def main():
                     vendor_config_override=False,
                     vlan_override=False
                 )
-            )
+            ),
+            mac_management_policy=dict(
+                type='dict',
+                options=dict(
+                    allow_promiscuous=dict(type='bool', default=None),
+                    forged_transmits=dict(type='bool', default=None),
+                    mac_changes=dict(type='bool', default=None),
+                    mac_learning_policy=dict(
+                        type='dict',
+                        options=dict(
+                            allow_unicast_flooding=dict(type='bool', default=None),
+                            enabled=dict(type='bool', default=False),
+                            limit=dict(type='int', default=None),
+                            limit_policy=dict(type='str', choices=['allow', 'drop', None], default=None),
+                        ),
+                        default=dict(allow_unicast_flooding=None, enabled=False, limit=None, limit_policy=None),
+                    ),
+                ),
+                default=dict(),
+            ),
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     vmware_dvs_portgroup = VMwareDvsPortgroup(module)
     vmware_dvs_portgroup.process_state()

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -181,7 +181,7 @@ options:
     vendor_specific_config:
         description:
             - List of key,value dictionaries for the Vendor Specific Configuration.
-            -'Element attributes are:'
+            - 'Element attributes are:'
             - '- C(key) (str): Key of setting. (default: None)'
             - '- C(value) (str): Value of setting. (default: None)'
         required: False

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -164,7 +164,7 @@ options:
             - '    - C(limit) (int): The maximum number of MAC addresses that can be learned.  (default: None)'
             - '    - C(limit_policy) (string): The default switching policy after MAC limit is exceeded. (default: None)'
             - '        - choices: [allow, drop, None]'
-        require: False
+        required: False
         version_added: '2.9'
         default: {
             'allow_promiscuous':,
@@ -298,19 +298,19 @@ class VMwareDvsPortgroup(PyVmomi):
         self.vlan_ids = dict()
         try:
             for vlan_range in self.module.params['vlan_id'].split(','):
-                rx = re.match(r'^\s*(P<start>\d+)\s*(?:-\s*(P<end>\d+))?\s*$', vlan_range)
+                rx = re.match(r'^\s*(?P<start>\d+)\s*(?:-\s*(?P<end>\d+))?\s*$', vlan_range)
                 if not rx:
                     raise ValueError("Range {0} does not have valid format".format(vlan_range))
 
-                start = end = int(rx.groups()['start'])
-                if rx.groups()[1]:
-                    end = int(rx.groups()['end'])
+                start = end = int(rx.group('start'))
+                if rx.group('end'):
+                    end = int(rx.group('end'))
 
                 if end < start:
                     raise ValueError("Range {0} start of range is greater than end".format(vlan_range))
 
                 if start not in range(0, 4095) or end not in range(0, 4095):
-                    self.module.fail_json(msg="vlan_id range %s specified is incorrect. The valid vlan_id range is from 0 to 4094.".format(vlan_range))
+                    self.module.fail_json(msg="vlan_id range {0} specified is incorrect. The valid vlan_id range is from 0 to 4094.".format(vlan_range))
 
                 self.vlan_ids[start] = end
         except ValueError as e:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -186,7 +186,7 @@ options:
             - '- C(value) (str): Value of setting. (default: None)'
         required: False
         version_added: '2.9'
-        type: dict
+        type: list
 
 extends_documentation_fragment: vmware.documentation
 '''

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -178,6 +178,15 @@ options:
             }
         }
         type: dict
+    vendor_specific_config:
+        description:
+            - List of key,value dictionaries for the Vendor Specific Configuration.
+            -'Element attributes are:'
+            - '- C(key) (str): Key of setting. (default: None)'
+            - '- C(value) (str): Value of setting. (default: None)'
+        required: False
+        version_added: '2.9'
+        type: dict
 
 extends_documentation_fragment: vmware.documentation
 '''
@@ -360,6 +369,10 @@ class VMwareDvsPortgroup(PyVmomi):
 
         # vlan_id
         config.defaultPortConfig.vlan = self._vlan_spec()
+
+        # vendor_specific_config
+        if self.module.params['vendor_specific_config']:
+            config.defaultPortConfig.vendorSpecificConfig = self._vendor_specific_config_spec()
 
         # network_policy
         config.defaultPortConfig.securityPolicy = self._security_policy_spec()
@@ -635,6 +648,15 @@ class VMwareDvsPortgroup(PyVmomi):
 
         return mm_policy
 
+    def _vendor_specific_config_spec(self):
+        spec = vim.dvs.DistributedVirtualPort.VendorSpecificConfig()
+        spec.inherited = False
+        spec.keyValue = list()
+        for item in self.params['vendor_specific_config']:
+            spec.keyValue.append(vim.dvs.KeyedOpaqueBlob(key=item['key'], opaqueData=item['value']))
+
+        return spec
+
 
 def main():
     argument_spec = vmware_argument_spec()
@@ -741,6 +763,15 @@ def main():
                         limit=None,
                         limit_policy=None,
                     ),
+                ),
+            ),
+            vendor_specific_config=dict(
+                type='list',
+                elements='dict',
+                required=False,
+                options=dict(
+                    key=dict(type='str', required=True),
+                    value=dict(type='str', required=True),
                 ),
             ),
         )

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -61,6 +61,7 @@ options:
             - If set to true, the the distributed vSwitch will ignore the limit on the c(num_ports) in the portgroup.
         default: True
         version_added: '2.9'
+        type: bool
     portgroup_type:
         description:
             - See VMware KB 1022312 regarding portgroup types.

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -163,7 +163,7 @@ options:
             - '    - C(enabled) (bool): indicates if source MAC address learning is allowed. (default: False)'
             - '    - C(limit) (int): The maximum number of MAC addresses that can be learned.  (default: None)'
             - '    - C(limit_policy) (string): The default switching policy after MAC limit is exceeded. (default: None)'
-            - '        - choices: [allow, drop, None]'
+            - '        - choices: [ALLOW, DROP, None]'
         required: False
         version_added: '2.9'
         default: {
@@ -726,7 +726,7 @@ def main():
                             allow_unicast_flooding=dict(type='bool', default=None),
                             enabled=dict(type='bool', default=False),
                             limit=dict(type='int', default=None),
-                            limit_policy=dict(type='str', choices=['allow', 'drop', None], default=None),
+                            limit_policy=dict(type='str', choices=['ALLOW', 'DROP', None], default=None),
                         ),
                         default=dict(allow_unicast_flooding=None, enabled=False, limit=None, limit_policy=None),
                     ),

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -263,39 +263,42 @@
     that:
         - "{{ dvs_pg_result_0010.changed == true }}"
 
+# TODO: vcsim doesn't actually set most of the configuration fields in the portgroup
+# so each run will be flagged as triggering an update
+# Commenting this out until this is supported by vcsim.
 # Testcase 0011: Update the portgroup port policy settings again
-- name: update portgroup port policy settings again
-  vmware_dvs_portgroup:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
-    portgroup_name: "basic-some-enabled-updates"
-    vlan_id: 0
-    num_ports: 32
-    portgroup_type: earlyBinding
-    state: present
-    auto_expand: true
-    network_policy:
-      promiscuous: yes
-      forged_transmits: yes
-      mac_changes: no
-    port_policy:
-      block_override: yes
-      ipfix_override: yes
-      live_port_move: yes
-      network_rp_override: yes
-      port_config_reset_at_disconnect: yes
-      security_override: yes
-      shaping_override: yes
-      traffic_filter_override: yes
-      uplink_teaming_override: yes
-      vendor_config_override: yes
-      vlan_override: yes
-  register: dvs_pg_result_0011
-
-- name: ensure dvs portgroup has updated
-  assert:
-    that:
-        - "{{ dvs_pg_result_0011.changed == false }}"
+#- name: update portgroup port policy settings again
+#  vmware_dvs_portgroup:
+#    validate_certs: False
+#    hostname: "{{ vcsim }}"
+#    username: "{{ vcsim_instance['json']['username'] }}"
+#    password: "{{ vcsim_instance['json']['password'] }}"
+#    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+#    portgroup_name: "basic-some-enabled-updates"
+#    vlan_id: 0
+#    num_ports: 32
+#    portgroup_type: earlyBinding
+#    state: present
+#    auto_expand: true
+#    network_policy:
+#      promiscuous: yes
+#      forged_transmits: yes
+#      mac_changes: no
+#    port_policy:
+#      block_override: yes
+#      ipfix_override: yes
+#      live_port_move: yes
+#      network_rp_override: yes
+#      port_config_reset_at_disconnect: yes
+#      security_override: yes
+#      shaping_override: yes
+#      traffic_filter_override: yes
+#      uplink_teaming_override: yes
+#      vendor_config_override: yes
+#      vlan_override: yes
+#  register: dvs_pg_result_0011
+#
+#- name: ensure dvs portgroup has updated
+#  assert:
+#    that:
+#        - "{{ dvs_pg_result_0011.changed == false }}"

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -206,3 +206,96 @@
     that:
         - not dvs_pg_result_0009.changed
         - "'vlan_id range 1-4096 specified is incorrect. The valid vlan_id range is from 0 to 4094.' == '{{ dvs_pg_result_0009.msg }}'"
+
+# Testcase 0010: Update the portgroup port policy settings
+- name: create basic portgroup with all security and policy settings enabled
+  vmware_dvs_portgroup:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    portgroup_name: "basic-some-enabled-updates"
+    vlan_id: 0
+    num_ports: 32
+    portgroup_type: earlyBinding
+    state: present
+    network_policy:
+      promiscuous: yes
+      forged_transmits: yes
+      mac_changes: no
+    port_policy:
+      vlan_override: yes
+
+- name: update portgroup port policy settings
+  vmware_dvs_portgroup:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    portgroup_name: "basic-some-enabled-updates"
+    vlan_id: 0
+    num_ports: 32
+    portgroup_type: earlyBinding
+    state: present
+    auto_expand: true
+    network_policy:
+      promiscuous: yes
+      forged_transmits: yes
+      mac_changes: no
+    port_policy:
+      block_override: yes
+      ipfix_override: yes
+      live_port_move: yes
+      network_rp_override: yes
+      port_config_reset_at_disconnect: yes
+      security_override: yes
+      shaping_override: yes
+      traffic_filter_override: yes
+      uplink_teaming_override: yes
+      vendor_config_override: yes
+      vlan_override: yes
+  register: dvs_pg_result_0010
+
+- name: ensure dvs portgroup has updated
+  assert:
+    that:
+        - "{{ dvs_pg_result_0010.changed == true }}"
+
+# Testcase 0011: Update the portgroup port policy settings again
+- name: update portgroup port policy settings again
+  vmware_dvs_portgroup:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    portgroup_name: "basic-some-enabled-updates"
+    vlan_id: 0
+    num_ports: 32
+    portgroup_type: earlyBinding
+    state: present
+    auto_expand: true
+    network_policy:
+      promiscuous: yes
+      forged_transmits: yes
+      mac_changes: no
+    port_policy:
+      block_override: yes
+      ipfix_override: yes
+      live_port_move: yes
+      network_rp_override: yes
+      port_config_reset_at_disconnect: yes
+      security_override: yes
+      shaping_override: yes
+      traffic_filter_override: yes
+      uplink_teaming_override: yes
+      vendor_config_override: yes
+      vlan_override: yes
+  register: dvs_pg_result_0011
+
+- name: ensure dvs portgroup has updated
+  assert:
+    that:
+        - "{{ dvs_pg_result_0011.changed == false }}"

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -211,10 +211,10 @@
 - name: create basic portgroup with all security and policy settings enabled
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic-some-enabled-updates"
     vlan_id: 0
     num_ports: 32
@@ -230,10 +230,10 @@
 - name: update portgroup port policy settings
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic-some-enabled-updates"
     vlan_id: 0
     num_ports: 32
@@ -270,10 +270,10 @@
 #- name: update portgroup port policy settings again
 #  vmware_dvs_portgroup:
 #    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
+#    switch_name: "{{ dvswitch1 }}"
 #    portgroup_name: "basic-some-enabled-updates"
 #    vlan_id: 0
 #    num_ports: 32


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Implement update functionality
- Add auto_expand parameter
- Add mac_management_policy parameter
- Add vendor_specific_config parameter

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vcenter_dvs_portgroup

##### ADDITIONAL INFORMATION
# Testing performed
# Check MAC learning status
```
[root@sc2-v-vm08-dhcp-1-104:~] netdbg vswitch mac-learning port get -p 164 --dvs-alias nova_dvs
MAC Learning:                   False
Unknown Unicast Flooding:       False
MAC Limit:                      4096
MAC Limit Policy:               ALLOW
```

# Set MAC Management Policy
```
changed: [10.193.30.210] => (item={'key': u'vm-network', 'value': {u'mac_management_policy': {u'mac_learning_policy': {u'limit': 4048, u'allow_unicast_flooding': True, u'enabled': True, u'limit_policy': u'drop'}, u'allow_promiscuous': False, u'mac_changes': True, u'forged_transmits': True}, u'teaming_policy': {u'notify_switches': True, u'load_balance_policy': u'loadbalance_srcid', u'inbound_policy': False, u'rolling_order': False}, u'port_policy': {u'traffic_filter_override': True, u'network_rp_override': True, u'ipfix_override': True, u'live_port_move': True, u'security_override': True, u'block_override': True, u'port_config_reset_at_disconnect': True, u'uplink_teaming_override': True, u'vendor_config_override': True, u'shaping_override': True, u'vlan_override': True}, u'network_policy': {u'promiscuous': False, u'mac_changes': False, u'forged_transmits': False}, u'state': u'present', u'num_ports': 15, u'vlan_trunk': False, u'auto_expand': True, u'portgroup_type': u'earlyBinding', u'vlan_id': 0}}) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "auto_expand": true, 
            "hostname": "10.193.30.210", 
            "mac_management_policy": {
                "allow_promiscuous": false, 
                "forged_transmits": true, 
                "mac_changes": true, 
                "mac_learning_policy": {
                    "allow_unicast_flooding": true, 
                    "enabled": true, 
                    "limit": 4048, 
                    "limit_policy": "drop"
                }
            }, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_name": "vm-network", 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "switch_name": "nova_dvs", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vlan_id": "0", 
            "vlan_trunk": false
        }
    }, 
    "item": {
        "key": "vm-network", 
        "value": {
            "auto_expand": true, 
            "mac_management_policy": {
                "allow_promiscuous": false, 
                "forged_transmits": true, 
                "mac_changes": true, 
                "mac_learning_policy": {
                    "allow_unicast_flooding": true, 
                    "enabled": true, 
                    "limit": 4048, 
                    "limit_policy": "drop"
                }
            }, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "vlan_id": 0, 
            "vlan_trunk": false
        }
    }, 
    "result": "None", 
    "updates": {
        "mac_management_policy": [
            "Desired '{'mac_changes': True, 'allow_promiscuous': False, 'mac_learning_policy': {'enabled': True, 'allow_unicast_flooding': True, 'limit': 4048, 'limit_policy': 'drop'}, 'forged_transmits': True}' does not equal current '{'mac_learning_policy': {'limit': 4048, 'allow_unicast_flooding': True, 'enabled': False, 'limit_policy': 'drop'}, 'allow_promiscuous': False, 'mac_changes': True, 'forged_transmits': True}'"
        ]
    }
}

```

# Verifying MAC learning is enabled & working
```
[root@sc2-v-vm08-dhcp-1-104:~] netdbg vswitch mac-learning port get -p 164 --dvs-alias nova_dvs
MAC Learning:                   True
Unknown Unicast Flooding:       True
MAC Limit:                      4048
MAC Limit Policy:               DROP

[root@sc2-v-vm08-dhcp-1-104:~] netdbg vswitch mac-table port get -p 163 --dvs-alias nova_dvs
MAC: 00:50:56:93:06:8e vid: 0      vni: 0        type: static    aging: yes    elapsed: 0     
```

# Trying to set MAC Management on DVS without support for MAC Management Policy
```
failed: [10.193.30.210] (item={'key': u'vm-network', 'value': {u'mac_management_policy': {u'mac_learning_policy': {u'limit': 4048, u'allow_unicast_flooding': True, u'enabled': True, u'limit_policy': u'drop'}, u'allow_promiscuous': False, u'mac_changes': True, u'forged_transmits': True}, u'teaming_policy': {u'notify_switches': True, u'load_balance_policy': u'loadbalance_srcid', u'inbound_policy': False, u'rolling_order': False}, u'port_policy': {u'traffic_filter_override': True, u'network_rp_override': True, u'ipfix_override': True, u'live_port_move': True, u'security_override': True, u'block_override': True, u'port_config_reset_at_disconnect': True, u'uplink_teaming_override': True, u'vendor_config_override': True, u'shaping_override': True, u'vlan_override': True}, u'network_policy': {u'promiscuous': False, u'mac_changes': False, u'forged_transmits': False}, u'state': u'present', u'num_ports': 15, u'vlan_trunk': False, u'auto_expand': True, u'portgroup_type': u'earlyBinding', u'vlan_id': 0}}) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "auto_expand": true, 
            "hostname": "10.193.30.210", 
            "mac_management_policy": {
                "allow_promiscuous": false, 
                "forged_transmits": true, 
                "mac_changes": true, 
                "mac_learning_policy": {
                    "allow_unicast_flooding": true, 
                    "enabled": true, 
                    "limit": 4048, 
                    "limit_policy": "drop"
                }
            }, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_name": "vm-network", 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "switch_name": "test_dvs", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vlan_id": "0", 
            "vlan_trunk": false
        }
    }, 
    "item": {
        "key": "vm-network", 
        "value": {
            "auto_expand": true, 
            "mac_management_policy": {
                "allow_promiscuous": false, 
                "forged_transmits": true, 
                "mac_changes": true, 
                "mac_learning_policy": {
                    "allow_unicast_flooding": true, 
                    "enabled": true, 
                    "limit": 4048, 
                    "limit_policy": "drop"
                }
            }, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "vlan_id": 0, 
            "vlan_trunk": false
        }
    }, 
    "msg": "The distributed virtual switch does not support MAC management policy.Minimum DVS version is 6.6.0 (current version is 6.0.0)"
}
	to retry, use: --limit @/opt/ansible/vsphere/playbooks/config_pgs.retry

PLAY RECAP ************************************************************************************************************************************************************************************************
10.193.30.210              : ok=0    changed=0    unreachable=0    failed=1   
```


# Updating DVS settings
```
changed: [10.193.30.210] => (item={'key': u'vm-network2', 'value': {u'portgroup_type': u'earlyBinding', u'teaming_policy': {u'notify_switches': True, u'load_balance_policy': u'loadbalance_srcid', u'inbound_policy': False, u'rolling_order': False}, u'port_policy': {u'traffic_filter_override': True, u'network_rp_override': True, u'ipfix_override': True, u'live_port_move': True, u'security_override': True, u'block_override': True, u'port_config_reset_at_disconnect': True, u'uplink_teaming_override': True, u'vendor_config_override': True, u'shaping_override': True, u'vlan_override': True}, u'network_policy': {u'promiscuous': False, u'mac_changes': False, u'forged_transmits': False}, u'state': u'present', u'num_ports': 15, u'vlan_trunk': False, u'auto_expand': True, u'vlan_id': 0}}) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "auto_expand": true, 
            "hostname": "10.193.30.210", 
            "mac_management_policy": {
                "allow_promiscuous": null, 
                "forged_transmits": null, 
                "mac_changes": null, 
                "mac_learning_policy": {
                    "allow_unicast_flooding": null, 
                    "enabled": false, 
                    "limit": null, 
                    "limit_policy": null
                }
            }, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_name": "vm-network2", 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "switch_name": "test_dvs", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vlan_id": "0", 
            "vlan_trunk": false
        }
    }, 
    "item": {
        "key": "vm-network2", 
        "value": {
            "auto_expand": true, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "vlan_id": 0, 
            "vlan_trunk": false
        }
    }, 
    "result": "None", 
    "updates": {
        "port_policy": [
            "Desired '{'traffic_filter_override': True, 'network_rp_override': True, 'live_port_move': True, 'security_override': True, 'vendor_config_override': True, 'port_config_reset_at_disconnect': True, 'uplink_teaming_override': True, 'block_override': True, 'shaping_override': True, 'vlan_override': True, 'ipfix_override': True}' does not equal current '{'traffic_filter_override': False, 'network_rp_override': False, 'live_port_move': False, 'security_override': False, 'vendor_config_override': False, 'port_config_reset_at_disconnect': True, 'uplink_teaming_override': False, 'block_override': True, 'shaping_override': False, 'vlan_override': False, 'ipfix_override': False}'"
        ], 
        "teaming_policy": [
            "Desired '{'notify_switches': True, 'load_balance_policy': 'loadbalance_srcid', 'inbound_policy': False, 'rolling_order': False}' does not equal current '{'notify_switches': True, 'load_balance_policy': 'loadbalance_srcid', 'inbound_policy': True, 'rolling_order': False}'"
        ], 
        "vlan_id": [
            "Desired '{0: 0}' does not equal current '{3243: 3243}'"
        ]
    }
}
```

# Rerun (no change)
```
ok: [10.193.30.210] => (item={'key': u'vm-network2', 'value': {u'portgroup_type': u'earlyBinding', u'teaming_policy': {u'notify_switches': True, u'load_balance_policy': u'loadbalance_srcid', u'inbound_policy': False, u'rolling_order': False}, u'port_policy': {u'traffic_filter_override': True, u'network_rp_override': True, u'ipfix_override': True, u'live_port_move': True, u'security_override': True, u'block_override': True, u'port_config_reset_at_disconnect': True, u'uplink_teaming_override': True, u'vendor_config_override': True, u'shaping_override': True, u'vlan_override': True}, u'network_policy': {u'promiscuous': False, u'mac_changes': False, u'forged_transmits': False}, u'state': u'present', u'num_ports': 15, u'vlan_trunk': False, u'auto_expand': True, u'vlan_id': 0}}) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "auto_expand": true, 
            "hostname": "10.193.30.210", 
            "mac_management_policy": {
                "allow_promiscuous": null, 
                "forged_transmits": null, 
                "mac_changes": null, 
                "mac_learning_policy": {
                    "allow_unicast_flooding": null, 
                    "enabled": false, 
                    "limit": null, 
                    "limit_policy": null
                }
            }, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_name": "vm-network2", 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "switch_name": "test_dvs", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vlan_id": "0", 
            "vlan_trunk": false
        }
    }, 
    "item": {
        "key": "vm-network2", 
        "value": {
            "auto_expand": true, 
            "network_policy": {
                "forged_transmits": false, 
                "mac_changes": false, 
                "promiscuous": false
            }, 
            "num_ports": 15, 
            "port_policy": {
                "block_override": true, 
                "ipfix_override": true, 
                "live_port_move": true, 
                "network_rp_override": true, 
                "port_config_reset_at_disconnect": true, 
                "security_override": true, 
                "shaping_override": true, 
                "traffic_filter_override": true, 
                "uplink_teaming_override": true, 
                "vendor_config_override": true, 
                "vlan_override": true
            }, 
            "portgroup_type": "earlyBinding", 
            "state": "present", 
            "teaming_policy": {
                "inbound_policy": false, 
                "load_balance_policy": "loadbalance_srcid", 
                "notify_switches": true, 
                "rolling_order": false
            }, 
            "vlan_id": 0, 
            "vlan_trunk": false
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************************************************************************************************
10.193.30.210              : ok=1    changed=0    unreachable=0    failed=0  
```

# vlan_id error condition checks
```
            "vlan_id": "40-41,43-42,200,400-500", 
    "msg": "ValueError parsing vlan_ids: Range 43-42 start of range is greater than end"
```
```
            "vlan_id": "40-41,-400,200,400-500", 
    "msg": "ValueError parsing vlan_ids: Range -400 does not have valid format"
```
```
            "vlan_id": "40-F,-400,200,400-500",  
    "msg": "ValueError parsing vlan_ids: Range 40-F does not have valid format"
```
```
            "vlan_id": "40-100-400,200,400-500",  
    "msg": "ValueError parsing vlan_ids: Range 40-100-400 does not have valid format"
```
```
            "vlan_id": "400-100,200,400-500",  
    "msg": "ValueError parsing vlan_ids: Range 400-100 stat of range is greater than end"
```