### PR TITLE
Expand the set of command suboptions aireos supports

### DIFF
--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -117,7 +117,7 @@ import time
 from ansible.module_utils.network.aireos.aireos import run_commands
 from ansible.module_utils.network.aireos.aireos import aireos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.utils import ComplexList
+from ansible.module_utils.network.common.utils import transform_commands
 from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.six import string_types
 
@@ -130,12 +130,7 @@ def to_lines(stdout):
 
 
 def parse_commands(module, warnings):
-    command = ComplexList(dict(
-        command=dict(key=True),
-        prompt=dict(),
-        answer=dict()
-    ), module)
-    commands = command(module.params['commands'])
+    commands = transform_commands(module)
     for index, item in enumerate(commands):
         if module.check_mode and not item['command'].startswith('show'):
             warnings.append(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Adds support for additional suboptions such as `sendonly` and `check_all`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aireos_command