### PR TITLE
2.7: ansible-test yamllint: fix UnicodeDecodeError (#55364)

### DIFF
--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -385,7 +385,10 @@ def raw_command(cmd, capture=False, env=None, data=None, cwd=None, explain=False
 
     if communicate:
         encoding = 'utf-8'
-        data_bytes = data.encode(encoding, 'surrogateescape') if data else None
+        if data is None or isinstance(data, bytes):
+            data_bytes = data
+        else:
+            data_bytes = data.encode(encoding, 'surrogateescape')
         stdout_bytes, stderr_bytes = process.communicate(data_bytes)
         stdout_text = stdout_bytes.decode(encoding, str_errors) if stdout_bytes else u''
         stderr_text = stderr_bytes.decode(encoding, str_errors) if stderr_bytes else u''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #55364

(cherry picked from commit f8bebc61c8e176f8ebde9743a59b162d1df6ae6a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/runner/lib/util.py
