### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -215,7 +215,7 @@ class CobblerInventory(object):
                 for (iname, ivalue) in iteritems(interfaces):
                     if ivalue['management'] or not ivalue['static']:
                         this_dns_name = ivalue.get('dns_name', None)
-                        if this_dns_name is not None and this_dns_name is not "":
+                        if this_dns_name not in (None, ""):
                             dns_name = this_dns_name
 
             if dns_name == '' or dns_name is None:


### PR DESCRIPTION
Easier to read and understand plus avoids an ___is___ comparison with a string literal.
```
./contrib/inventory/cobbler.py:218:58: F632 use ==/!= to compare str, bytes, and int literals
                        if this_dns_name is not None and this_dns_name is not "":
                                                         ^
```
$ __python__
```python
>>> raw = 'ra'
>>> raw += 'w'
>>> raw
'raw'
>>> raw == 'raw'
True
>>> raw is 'raw'
False
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
contrib/inventory

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
