### PR TITLE
Add wait of image disk after upload

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -401,7 +401,7 @@ def transfer(connection, module, direction, transfer_func):
             raise Exception(
                 "Error occurred while uploading image. The transfer is in %s" % transfer.phase
             )
-        if module.params.get('logical_unit'):
+        if not module.params.get('logical_unit'):
             disks_service = connection.system_service().disks_service()
             wait(
                 service=disks_service.service(module.params['id']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR add a proper wait for disk image after upload, previsouly we waited only for LUN disk, which is wrong, we should wait only in case of non-LUN disk.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_disk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
