### PR TITLE
Add changelog fragments for #44811

### DIFF
--- a/changelogs/fragments/44811-xml-insertbefore-and-insertafter-parameters.yaml
+++ b/changelogs/fragments/44811-xml-insertbefore-and-insertafter-parameters.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xml - Introduce ``insertbefore`` and ``insertafter`` to specify the position (https://github.com/ansible/ansible/pull/44811)


### PR DESCRIPTION
##### SUMMARY
Add missing changelog fragments for "Introduce 'insertbefore' and 'insertafter' to specify the position" #44811
Should be backported to v2.8

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
xml

##### ADDITIONAL INFORMATION
N/A