### PR TITLE
added python3 support to nginx_status_facts module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/nginx_status_facts.py
+++ b/lib/ansible/modules/web_infrastructure/nginx_status_facts.py
@@ -96,6 +96,7 @@ nginx_status_facts.data:
 import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_text
 
 
 class NginxStatusFacts(object):
@@ -121,7 +122,7 @@ class NginxStatusFacts(object):
         if not response:
             module.fail_json(msg="No valid or no response from url %s within %s seconds (timeout)" % (self.url, self.timeout))
 
-        data = response.read()
+        data = to_text(response.read(), errors='surrogate_or_strict')
         if not data:
             return result
 


### PR DESCRIPTION
##### SUMMARY
This module doesn't seem to work when used with python3 on managed host as `fetch_url()` will return byte-like object instead of string. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nginx_status_facts

##### ADDITIONAL INFORMATION
Set interpreter to python3 on managed hosts in inventory file:
```ini
host1.example.com ansible_python_interpreter=/usr/bin/python3
```

and run this module against the host. Error you should see:
```bash
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: cannot use a string pattern on a bytes-like object
fatal: [host1.example.com]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "<stdin>", line 113, in <module>
      File "<stdin>", line 105, in _ansiballz_main
      File "<stdin>", line 48, in invoke_module
      File "/usr/lib/python3.5/imp.py", line 234, in load_module
        return load_source(name, filename, file)
      File "/usr/lib/python3.5/imp.py", line 170, in load_source
        module = _exec(spec, sys.modules[name])
      File "<frozen importlib._bootstrap>", line 626, in _exec
      File "<frozen importlib._bootstrap_external>", line 673, in exec_module
      File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
      File "/tmp/user/0/ansible_nginx_status_facts_payload_udoag1xt/__main__.py", line 159, in <module>
      File "/tmp/user/0/ansible_nginx_status_facts_payload_udoag1xt/__main__.py", line 153, in main
      File "/tmp/user/0/ansible_nginx_status_facts_payload_udoag1xt/__main__.py", line 131, in run
      File "/usr/lib/python3.5/re.py", line 163, in match
        return _compile(pattern, flags).match(string)
    TypeError: cannot use a string pattern on a bytes-like object
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```
