### PR TITLE
Add reporter to report logs sent by foreman callback

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -179,7 +179,8 @@ class CallbackModule(CallbackBase):
                     'messages': {
                         'message': json.dumps(msg)
                     },
-                    'level': level
+                    'level': level,
+                    'reporter': 'ansible'
                 }
             })
         return logs


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When ansible fails to connect to remote host,
callback sends a report to Foreman without
any indication that the report comes from
Ansible. As a result, Foreman is unable
to determine the report origin.

This adds a 'reporter' attribute into
the logs that are sent.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
foreman callback plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Is needed to fix https://projects.theforeman.org/issues/22804


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
