### PR TITLE
modules/notification/irc: Fix channel joining for some IRC servers.

### DIFF
--- a/lib/ansible/modules/notification/irc.py
+++ b/lib/ansible/modules/notification/irc.py
@@ -213,7 +213,7 @@ def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, k
     start = time.time()
     while 1:
         join += to_native(irc.recv(1024))
-        if re.search(r'^:\S+ 366 %s %s :' % (nick, channel), join, flags=re.M):
+        if re.search(r'^:\S+ 366 %s %s :' % (nick, channel), join, flags=re.M|re.I):
             break
         elif time.time() - start > timeout:
             raise Exception('Timeout waiting for IRC JOIN response')

--- a/lib/ansible/modules/notification/irc.py
+++ b/lib/ansible/modules/notification/irc.py
@@ -213,7 +213,7 @@ def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, k
     start = time.time()
     while 1:
         join += to_native(irc.recv(1024))
-        if re.search(r'^:\S+ 366 %s %s :' % (nick, channel), join, flags=re.M|re.I):
+        if re.search(r'^:\S+ 366 %s %s :' % (nick, channel), join, flags=re.M | re.I):
             break
         elif time.time() - start > timeout:
             raise Exception('Timeout waiting for IRC JOIN response')


### PR DESCRIPTION
##### SUMMARY
Fix channel joining for some IRC servers.

Some IRC servers may return the channel in a different case than
requested.  For instance, you might request "foo" but the server
returns "FOO".  The regular expression matching must be case-insensitive
for the join response in order to handle this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/notification/irc

##### ADDITIONAL INFORMATION
Prior ticket here that was never resolved: [https://github.com/ansible/ansible-modules-extras/issues/429](https://github.com/ansible/ansible-modules-extras/issues/429)