### PR TITLE
Use local dummy repo for flatpak integration tests

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -82,6 +82,7 @@ options:
       There might however be some use cases where you would want to have this, like when you are
       packaging your own flatpaks.
     default: false
+    version_added: 2.9
   remote:
     description:
     - The flatpak remote (repository) to install the flatpak from.

--- a/test/integration/targets/flatpak/aliases
+++ b/test/integration/targets/flatpak/aliases
@@ -1,4 +1,3 @@
-unsupported
 destructive
 skip/freebsd
 skip/osx

--- a/test/integration/targets/flatpak/aliases
+++ b/test/integration/targets/flatpak/aliases
@@ -4,4 +4,3 @@ skip/freebsd
 skip/osx
 skip/rhel
 needs/root
-needs/privileged

--- a/test/integration/targets/flatpak/aliases
+++ b/test/integration/targets/flatpak/aliases
@@ -1,3 +1,4 @@
+shippable/posix/group3
 destructive
 skip/freebsd
 skip/osx

--- a/test/integration/targets/flatpak/meta/main.yml
+++ b/test/integration/targets/flatpak/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_flatpak_remote

--- a/test/integration/targets/flatpak/tasks/check_mode.yml
+++ b/test/integration/targets/flatpak/tasks/check_mode.yml
@@ -4,8 +4,8 @@
 
 - name: Test addition of absent flatpak (check mode)
   flatpak:
-    name: org.gnome.Characters
-    remote: flathub
+    name: com.dummy.App1
+    remote: dummy-remote
     state: present
   register: addition_result
   check_mode: true
@@ -18,8 +18,8 @@
 
 - name: Test non-existent idempotency of addition of absent flatpak (check mode)
   flatpak:
-    name: org.gnome.Characters
-    remote: flathub
+    name: com.dummy.App1
+    remote: dummy-remote
     state: present
   register: double_addition_result
   check_mode: true
@@ -36,7 +36,7 @@
 
 - name: Test removal of absent flatpak check mode
   flatpak:
-    name: org.gnome.Characters
+    name: com.dummy.App1
     state: absent
   register: removal_result
   check_mode: true
@@ -51,8 +51,8 @@
 
 - name: Test addition of absent flatpak with url (check mode)
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Characters.flatpakref
-    remote: flathub
+    name: file:///tmp/flatpak/repo/com.dummy.App1.flatpakref
+    remote: dummy-remote
     state: present
   register: url_addition_result
   check_mode: true
@@ -65,8 +65,8 @@
 
 - name: Test non-existent idempotency of addition of absent flatpak with url (check mode)
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Characters.flatpakref
-    remote: flathub
+    name: file:///tmp/flatpak/repo/com.dummy.App1.flatpakref
+    remote: dummy-remote
     state: present
   register: double_url_addition_result
   check_mode: true
@@ -85,7 +85,7 @@
 
 - name: Test removal of absent flatpak with url not doing anything (check mode)
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Characters.flatpakref
+    name: file:///tmp/flatpak/repo/com.dummy.App1.flatpakref
     state: absent
   register: url_removal_result
   check_mode: true
@@ -103,8 +103,8 @@
 
 - name: Test addition of present flatpak (check mode)
   flatpak:
-    name: org.gnome.Calculator
-    remote: flathub
+    name: com.dummy.App8
+    remote: dummy-remote
     state: present
   register: addition_present_result
   check_mode: true
@@ -119,7 +119,7 @@
 
 - name: Test removal of present flatpak (check mode)
   flatpak:
-    name: org.gnome.Calculator
+    name: com.dummy.App8
     state: absent
   register: removal_present_result
   check_mode: true
@@ -132,7 +132,7 @@
 
 - name: Test non-existent idempotency of removal (check mode)
   flatpak:
-    name: org.gnome.Calculator
+    name: com.dummy.App8
     state: absent
   register: double_removal_present_result
   check_mode: true
@@ -149,8 +149,8 @@
 
 - name: Test addition with url of present flatpak (check mode)
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Calculator.flatpakref
-    remote: flathub
+    name: file:///tmp/flatpak/repo/com.dummy.App8.flatpakref
+    remote: dummy-remote
     state: present
   register: url_addition_present_result
   check_mode: true
@@ -165,7 +165,7 @@
 
 - name: Test removal with url of present flatpak (check mode)
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Calculator.flatpakref
+    name: file:///tmp/flatpak/repo/com.dummy.App8.flatpakref
     state: absent
   register: url_removal_present_result
   check_mode: true
@@ -178,8 +178,8 @@
 
 - name: Test non-existent idempotency of removal with url of present flatpak (check mode)
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Calculator.flatpakref
-    remote: flathub
+    name: file:///tmp/flatpak/repo/com.dummy.App8.flatpakref
+    remote: dummy-remote
     state: absent
   register: double_url_removal_present_result
   check_mode: true

--- a/test/integration/targets/flatpak/tasks/main.yml
+++ b/test/integration/targets/flatpak/tasks/main.yml
@@ -25,8 +25,8 @@
 
   - name: Test executable override
     flatpak:
-      name: org.gnome.Characters
-      remote: flathub
+      name: com.dummy.App1
+      remote: dummy-remote
       state: present
       executable: nothing-that-exists
     ignore_errors: true

--- a/test/integration/targets/flatpak/tasks/setup.yml
+++ b/test/integration/targets/flatpak/tasks/setup.yml
@@ -6,36 +6,37 @@
   when: ansible_distribution == 'Fedora'
 
 - block:
-  - name: Activate flatpak ppa on Ubuntu
+  - name: Activate flatpak ppa on Ubuntu versions older than 18.04/bionic
     apt_repository:
       repo: "ppa:alexlarsson/flatpak"
       state: present
       mode: 0644
+    when: ansible_lsb.major_release | int < 18
 
   - name: Install flatpak package on Ubuntu
     apt:
       name: flatpak
       state: present
 
-  become: true
   when: ansible_distribution == 'Ubuntu'
 
-- name: Enable flathub for user
+- name: Install dummy remote for user
   flatpak_remote:
-     name: flathub
-     state: present
-     flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
-     method: user
+    name: dummy-remote
+    state: present
+    flatpakrepo_url: /tmp/flatpak/repo/dummy-repo.flatpakrepo
+    method: user
 
-- name: Enable flathub for system
+- name: Install dummy remote for system
   flatpak_remote:
-     name: flathub
-     state: present
-     flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
-     method: system
+    name: dummy-remote
+    state: present
+    flatpakrepo_url: /tmp/flatpak/repo/dummy-repo.flatpakrepo
+    method: system
 
 - name: Add flatpak for testing check mode on present flatpak
   flatpak:
-    name: org.gnome.Calculator
-    remote: flathub
+    name: com.dummy.App8
+    remote: dummy-remote
+    no_dependencies: true
     state: present

--- a/test/integration/targets/flatpak/tasks/test.yml
+++ b/test/integration/targets/flatpak/tasks/test.yml
@@ -2,10 +2,11 @@
 
 - name: Test addition - {{ method }}
   flatpak:
-    name: org.gnome.Characters
-    remote: flathub
+    name: com.dummy.App1
+    remote: dummy-remote
     state: present
     method: "{{ method }}"
+    no_dependencies: true
   register: addition_result
 
 - name: Verify addition test result - {{ method }}
@@ -16,10 +17,11 @@
 
 - name: Test idempotency of addition - {{ method }}
   flatpak:
-    name: org.gnome.Characters
-    remote: flathub
+    name: com.dummy.App1
+    remote: dummy-remote
     state: present
     method: "{{ method }}"
+    no_dependencies: true
   register: double_addition_result
 
 - name: Verify idempotency of addition test result - {{ method }}
@@ -32,9 +34,10 @@
 
 - name: Test removal - {{ method }}
   flatpak:
-    name: org.gnome.Characters
+    name: com.dummy.App1
     state: absent
     method: "{{ method }}"
+    no_dependencies: true
   register: removal_result
 
 - name: Verify removal test result - {{ method }}
@@ -45,9 +48,10 @@
 
 - name: Test idempotency of removal - {{ method }}
   flatpak:
-    name: org.gnome.Characters
+    name: com.dummy.App1
     state: absent
     method: "{{ method }}"
+    no_dependencies: true
   register: double_removal_result
 
 - name: Verify idempotency of removal test result - {{ method }}
@@ -60,10 +64,11 @@
 
 - name: Test addition with url - {{ method }}
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Characters.flatpakref
-    remote: flathub
+    name: file:///tmp/flatpak/repo/com.dummy.App1.flatpakref
+    remote: dummy-remote
     state: present
     method: "{{ method }}"
+    no_dependencies: true
   register: url_addition_result
 
 - name: Verify addition test result - {{ method }}
@@ -74,10 +79,11 @@
 
 - name: Test idempotency of addition with url - {{ method }}
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Characters.flatpakref
-    remote: flathub
+    name: file:///tmp/flatpak/repo/com.dummy.App1.flatpakref
+    remote: dummy-remote
     state: present
     method: "{{ method }}"
+    no_dependencies: true
   register: double_url_addition_result
 
 - name: Verify idempotency of addition with url test result - {{ method }}
@@ -90,9 +96,10 @@
 
 - name: Test removal with url - {{ method }}
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Characters.flatpakref
+    name: file:///tmp/flatpak/repo/com.dummy.App1.flatpakref
     state: absent
     method: "{{ method }}"
+    no_dependencies: true
   register: url_removal_result
 
 - name: Verify removal test result - {{ method }}
@@ -103,9 +110,10 @@
 
 - name: Test idempotency of removal with url - {{ method }}
   flatpak:
-    name: https://flathub.org/repo/appstream/org.gnome.Characters.flatpakref
+    name: file:///tmp/flatpak/repo/com.dummy.App1.flatpakref
     state: absent
     method: "{{ method }}"
+    no_dependencies: true
   register: double_url_removal_result
 
 - name: Verify idempotency of removal with url test result - {{ method }}


### PR DESCRIPTION
##### SUMMARY
This PR fixes the `flatpak` integration tests and enables them in shippable CI runs.

This is done in the same manner as #52668 did for the `flatpak_remote` integration tests:

Before, the tests relied on the availability of the flathub repository infrastructure. This PR replaces the use of flathub with a local dummy repository.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak

##### ADDITIONAL INFORMATION
I had to add a new parameter to the `flatpak` module: `no_dependencies`, which corresponds to the flatpak binary's `--no_deps` flag. That is because I need to install flatpaks without installing their dependency runtimes, which are by convention hosted on flathub. Without this flag that disables dependency runtime installation, I would not be able to remove the dependency on flathub. This effectively makes the installed flatpaks unusable, which is however irrelevant in the scope of these tests.

I also needed to add support for installing flatpaks from local `file://`-URL:s to make the dummy repo work.

I was able to remove the docker-privileged requirements without me noticing any difference in the tests' behaviour.