### PR TITLE
Update bundled copy of selectors2 from 1.1.0 to 1.1.1

### DIFF
--- a/changelogs/fragments/selectors2-bundle.yml
+++ b/changelogs/fragments/selectors2-bundle.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- selectors2 - Update bundled copy of selectors2 from 1.1.0 to 1.1.1 (https://github.com/ansible/ansible/issues/55300)

--- a/lib/ansible/compat/selectors/__init__.py
+++ b/lib/ansible/compat/selectors/__init__.py
@@ -24,7 +24,7 @@ Compat selectors library.  Python-3.5 has this builtin.  The selectors2
 package exists on pypi to backport the functionality as far as python-2.6.
 '''
 # The following makes it easier for us to script updates of the bundled code
-_BUNDLED_METADATA = {"pypi_name": "selectors2", "version": "1.1.0", "version_constraints": ">1.0,<2.0"}
+_BUNDLED_METADATA = {"pypi_name": "selectors2", "version": "1.1.1", "version_constraints": ">1.0,<2.0"}
 
 # Added these bugfix commits from 2.1.0:
 # * https://github.com/SethMichaelLarson/selectors2/commit/3bd74f2033363b606e1e849528ccaa76f5067590

--- a/lib/ansible/compat/selectors/_selectors2.py
+++ b/lib/ansible/compat/selectors/_selectors2.py
@@ -14,7 +14,7 @@
 # Backport of selectors.py from Python 3.5+ to support Python < 3.4
 # Also has the behavior specified in PEP 475 which is to retry syscalls
 # in the case of an EINTR error. This module is required because selectors34
-# does not follow this behavior and instead returns that no dile descriptor
+# does not follow this behavior and instead returns that no file descriptor
 # events have occurred rather than retry the syscall. The decision to drop
 # support for select.devpoll is made to maintain 100% test coverage.
 
@@ -34,7 +34,7 @@ except (AttributeError, ImportError):  # Python 3.3<
 
 __author__ = 'Seth Michael Larson'
 __email__ = 'sethmichaellarson@protonmail.com'
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __license__ = 'MIT'
 
 __all__ = [


### PR DESCRIPTION
##### SUMMARY
Update bundled copy of selectors2 from 1.1.0 to 1.1.1. Fixes #55300

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/compat/selectors

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```