### PR TITLE
adds better links to tips and pitfalls page

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -5,7 +5,9 @@
 Contributing your module to Ansible
 ***********************************
 
-If you want to contribute a module to Ansible, you must meet our objective and subjective requirements. Modules accepted into the `main project repo <https://github.com/ansible/ansible>`_ ship with every Ansible installation. However, contributing to the main project isn't the only way to distribute a module - you can embed modules in roles on Galaxy or simply share copies of your module code for :ref:`local use <developing_locally>`.
+If you want to contribute a module to Ansible, you must meet our objective and subjective requirements. Please read the details below, and also review our :ref:`tips for module development <developing_modules_best_practices>`.
+
+Modules accepted into the `main project repo <https://github.com/ansible/ansible>`_ ship with every Ansible installation. However, contributing to the main project isn't the only way to distribute a module - you can embed modules in roles on Galaxy or simply share copies of your module code for :ref:`local use <developing_locally>`.
 
 Contributing to Ansible: objective requirements
 ===============================================
@@ -37,5 +39,6 @@ If your module meets our objective requirements, we'll review your code to see i
 Other checklists
 ================
 
+* :ref:`Tips for module development <developing_modules_best_practices>`.
 * `Amazon development checklist <https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md>`_.
 * :ref:`Windows development checklist <developing_modules_general_windows>`.

--- a/docs/docsite/rst/dev_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/index.rst
@@ -31,6 +31,7 @@ Find the task that best describes what you want to do:
    * I want to :ref:`debug my module code <debugging>`.
    * I want to :ref:`add tests <developing_testing>`.
    * I want to :ref:`document my module <module_documenting>`.
+   * I want to follow :ref:`conventions and tips for clean, usable module code <developing_modules_best_practices>`.
    * I want to :ref:`make sure my code runs on Python 2 and Python 3 <developing_python_3>`.
 
 * I want to work on other development projects:


### PR DESCRIPTION
##### SUMMARY
Per discussion in the [Docs Working Group on March 26, 2019](https://github.com/ansible/community/issues/389#issuecomment-476781914), this PR adds better links to the page for tips, tricks, and pitfalls of module development. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
developer guide
