### PR TITLE
vsphere_guest: corrected fix #19716 misbehaviour (#55285)

### DIFF
--- a/changelogs/fragments/vsphere_guest-corrected-state-operations.yml
+++ b/changelogs/fragments/vsphere_guest-corrected-state-operations.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - vsphere_guest - creating machines without vm_extra_config allowed
+  - vsphere_guest - powering on/off absent virtual machine will fail

--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1904,9 +1904,8 @@ def main():
             module.exit_json(changed=False, msg="vm %s not present" % guest)
 
         # check if user is trying to perform state operation on a vm which doesn't exists
-        elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_extra_config,
-                                                                            vm_hardware, vm_disk, vm_nic, esxi)):
-            module.exit_json(changed=False, msg="vm %s not present" % guest)
+        elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_hardware, vm_disk, vm_nic, esxi)):
+            module.fail_json(msg="vm %s not present and not all options neccessary to create are provided" % guest)
 
         # Create the VM
         elif state in ['present', 'powered_off', 'powered_on']:


### PR DESCRIPTION
##### SUMMARY
* creating machines without vm_extra_config is possible
* power state operation on absent machines will fail
(cherry picked from commit 93758a5141f5d9f441ff77e7ba2d1fdf7fda25d6)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vsphere_guest

##### ADDITIONAL INFORMATION
Backport from stable-2.8 (PR #55285)

```
