### PR TITLE
nxos_vlan: vlan names containing regex ctl chars should be escaped

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -496,8 +496,7 @@ def parse_vlan_non_structured(module, netcfg, vlans):
             if name_match:
                 name = name_match.group(1)
                 obj['name'] = name
-
-                state_match = re.search(r'{0}\s*{1}\s*(\S+)'.format(vlan_id, name), vlan, re.M)
+                state_match = re.search(r'{0}\s*{1}\s*(\S+)'.format(vlan_id, re.escape(name)), vlan, re.M)
                 if state_match:
                     vlan_state_match = state_match.group(1)
                     if vlan_state_match == 'suspended':
@@ -518,7 +517,7 @@ def parse_vlan_non_structured(module, netcfg, vlans):
 
                     vlan = ','.join(vlan.splitlines())
                     interfaces = list()
-                    intfs_match = re.search(r'{0}\s*{1}\s*{2}\s*(.*)'.format(vlan_id, name, vlan_state_match),
+                    intfs_match = re.search(r'{0}\s*{1}\s*{2}\s*(.*)'.format(vlan_id, re.escape(name), vlan_state_match),
                                             vlan, re.M)
                     if intfs_match:
                         intfs = intfs_match.group(1)


### PR DESCRIPTION
##### SUMMARY
The `nxos_vlan` module may raise with regex error `sre_constants.error: multiple repeat` in the non_structured codepath if the device has existing vlan names with certain regex control characters; e.g. trailing asterisks:

```
VLAN Name                             Status    Ports
---- -------------------------------- --------- -------------------------------
1    default                          active    Eth1/3
14   my-vlan-name-is-***              active
```

The problem only occurs in the non_structured output codepath.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`modules/network/nxos/nxos_vlan.py`

