### PR TITLE
RHSM: use 'remove' instead of deprecated 'unregister'

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -407,7 +407,7 @@ class Rhsm(RegistrationBase):
             Raises:
               * Exception - if error occurs while running command
         '''
-        args = [SUBMAN_CMD, 'unregister']
+        args = [SUBMAN_CMD, 'remove', '--all']
         rc, stderr, stdout = self.module.run_command(args, check_rc=True)
         self.update_plugin_conf('rhnplugin', False)
         self.update_plugin_conf('subscription-manager', False)


### PR DESCRIPTION
##### SUMMARY
The new command to unregister is 'remove':

```
$ subscription-manager -h
remove         Remove all or specific subscriptions from this system
unsubscribe    Deprecated, see remove
```

And also requires one of --serial, --pool or --all.

```
$ subscription-manager remove
Error: This command requires that you specify one of --serial, --pool or --all.
```

This patch:
* switch unregister to remove.
* adds --all by default to remove any subscription on the host.
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription module
