### PR TITLE
mitigate task args disclosure

### DIFF
--- a/changelogs/fragments/deprecate_display_args.yml
+++ b/changelogs/fragments/deprecate_display_args.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Remove this setting since it leads to insecure output.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1315,6 +1315,10 @@ DISPLAY_ARGS_TO_STDOUT:
   - {key: display_args_to_stdout, section: defaults}
   type: boolean
   version_added: "2.1"
+  deprecated:
+    why: This can lead to involuntary security disclosures
+    version: "2.12"
+    alternatives: Instead of capturing this data at task start, use the return data's 'invocation' field, which is properly sanatized
 DISPLAY_SKIPPED_HOSTS:
   name: Show skipped results
   default: True

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -194,21 +194,24 @@ class CallbackModule(CallbackBase):
                 self._print_task_banner(task)
 
     def _print_task_banner(self, task):
-        # args can be specified as no_log in several places: in the task or in
-        # the argument spec.  We can check whether the task is no_log but the
-        # argument spec can't be because that is only run on the target
-        # machine and we haven't run it thereyet at this time.
+        # The task options can be specified as no_log in module (argument spec)
+        # You can also set no_log for the whole task/block/play/etc
+        # We can check whether the task is no_log but not the argument spec
+        # because that is only run on the target machine and would appear in 'results'
+        # this normally executes BEFORE that happens.
         #
         # So we give people a config option to affect display of the args so
         # that they can secure this if they feel that their stdout is insecure
         # (shoulder surfing, logging stdout straight to a file, etc).
-        args = u' '
+        # we still try to censor fields that 'look like secrets'.
+        args = [u' ']
         if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
             for k, v in task.args.items():
                 if PASSWORD_MATCH.search(k):
-                    args += u'%s=%s' % (k, '[CENSORED]: POSSIBLE SECRET FIELD')
+                    args.append(u'%s=%s' % (k, '[CENSORED]: POSSIBLE SECRET FIELD'))
                 else:
-                    args += u'%s=%s' % (k, v)
+                    args.append(u'%s=%s' % (k, v))
+        args = ', '.join(args)
 
         prefix = self._task_type_cache.get(task._uuid, 'TASK')
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -20,6 +20,7 @@ DOCUMENTATION = '''
 
 from ansible import constants as C
 from ansible import context
+from ansible.module_utils.basic import PASSWORD_MATCH
 from ansible.playbook.task_include import TaskInclude
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
@@ -201,10 +202,13 @@ class CallbackModule(CallbackBase):
         # So we give people a config option to affect display of the args so
         # that they can secure this if they feel that their stdout is insecure
         # (shoulder surfing, logging stdout straight to a file, etc).
-        args = ''
+        args = u' '
         if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
-            args = u', '.join(u'%s=%s' % a for a in task.args.items())
-            args = u' %s' % args
+            for k, v in task.args.items():
+                if PASSWORD_MATCH.search(k):
+                    args += u'%s=%s' % (k, '[CENSORED]: POSSIBLE SECRET FIELD')
+                else:
+                    args += u'%s=%s' % (k, v)
 
         prefix = self._task_type_cache.get(task._uuid, 'TASK')
 


### PR DESCRIPTION
Also deprecate the setting, since 'invocation' on results should be a better source as it is fully templated and correctly censored.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
callbacks