### PR TITLE
unite poll defaults

### DIFF
--- a/changelogs/fragments/align_poll_defaults.yml
+++ b/changelogs/fragments/align_poll_defaults.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Use async poll default setting for play tasks also, previouslly in only affected adhoc ansible.

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -21,7 +21,7 @@ In this case, however, `async` explicitly sets the timeout you wish to apply to 
 
 To launch a task asynchronously, specify its maximum runtime
 and how frequently you would like to poll for status.  The default
-poll value is 15 seconds if you do not specify a value for `poll`::
+poll value is set by the ``DEFAULT_POLL_INTERVAL`` setting if you do not specify a value for `poll`::
 
     ---
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -79,7 +79,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
     _loop = FieldAttribute()
     _loop_control = FieldAttribute(isa='class', class_type=LoopControl, inherit=False)
     _notify = FieldAttribute(isa='list')
-    _poll = FieldAttribute(isa='int', default=10)
+    _poll = FieldAttribute(isa='int', default=C.DEFAULT_POLL_INTERVAL)
     _register = FieldAttribute(isa='string', static=True)
     _retries = FieldAttribute(isa='int', default=3)
     _until = FieldAttribute(isa='list', default=list)


### PR DESCRIPTION
ensure adhoc and play tasks use same default setting.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
playbook