### PR TITLE
Add modules names to CLI_SUPPORTED_MODULES and update modules to fix bugs

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_acl.py
+++ b/lib/ansible/modules/network/cloudengine/ce_acl.py
@@ -427,7 +427,7 @@ class BaseAcl(object):
 
             if self.acl_type:
                 conf_str += "<aclType></aclType>"
-            if self.acl_num:
+            if self.acl_num or self.acl_name.isdigit():
                 conf_str += "<aclNumber></aclNumber>"
             if self.acl_step:
                 conf_str += "<aclStep></aclStep>"
@@ -444,12 +444,11 @@ class BaseAcl(object):
                 xml_str = recv_xml.replace('\r', '').replace('\n', '').\
                     replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
                     replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
-
                 root = ElementTree.fromstring(xml_str)
 
                 # parse acl
                 acl_info = root.findall(
-                    "data/acl/aclGroups/aclGroup")
+                    "acl/aclGroups/aclGroup")
                 if acl_info:
                     for tmp in acl_info:
                         tmp_dict = dict()
@@ -460,22 +459,43 @@ class BaseAcl(object):
                         self.cur_acl_cfg["acl_info"].append(tmp_dict)
 
                 if self.cur_acl_cfg["acl_info"]:
+                    find_list = list()
                     for tmp in self.cur_acl_cfg["acl_info"]:
-                        find_flag = True
+                        cur_cfg_dict = dict()
+                        exist_cfg_dict = dict()
+                        if self.acl_name:
+                            if self.acl_name.isdigit() and tmp.get("aclNumber"):
+                                cur_cfg_dict["aclNumber"] = self.acl_name
+                                exist_cfg_dict["aclNumber"] = tmp.get("aclNumber")
+                            else:
+                                cur_cfg_dict["aclNumOrName"] = self.acl_name
+                                exist_cfg_dict["aclNumOrName"] = tmp.get("aclNumOrName")
+                        if self.acl_type:
+                            cur_cfg_dict["aclType"] = self.acl_type
+                            exist_cfg_dict["aclType"] = tmp.get("aclType")
+                        if self.acl_num:
+                            cur_cfg_dict["aclNumber"] = self.acl_num
+                            exist_cfg_dict["aclNumber"] = tmp.get("aclNumber")
+                        if self.acl_step:
+                            cur_cfg_dict["aclStep"] = self.acl_step
+                            exist_cfg_dict["aclStep"] = tmp.get("aclStep")
+                        if self.acl_description:
+                            cur_cfg_dict["aclDescription"] = self.acl_description
+                            exist_cfg_dict["aclDescription"] = tmp.get("aclDescription")
 
-                        if self.acl_name and tmp.get("aclNumOrName") != self.acl_name:
-                            find_flag = False
-                        if self.acl_type and tmp.get("aclType") != self.acl_type:
-                            find_flag = False
-                        if self.acl_num and tmp.get("aclNumber") != self.acl_num:
-                            find_flag = False
-                        if self.acl_step and tmp.get("aclStep") != self.acl_step:
-                            find_flag = False
-                        if self.acl_description and tmp.get("aclDescription") != self.acl_description:
-                            find_flag = False
+                        if cur_cfg_dict == exist_cfg_dict:
+                            find_bool = True
+                        else:
+                            find_bool = False
+                        find_list.append(find_bool)
 
-                        if find_flag:
+                    for mem in find_list:
+                        if mem:
+                            find_flag = True
                             break
+                        else:
+                            find_flag = False
+
                 else:
                     find_flag = False
 
@@ -593,7 +613,7 @@ class BaseAcl(object):
 
                     # parse base rule
                     base_rule_info = root.findall(
-                        "data/acl/aclGroups/aclGroup/aclRuleBas4s/aclRuleBas4")
+                        "acl/aclGroups/aclGroup/aclRuleBas4s/aclRuleBas4")
                     if base_rule_info:
                         for tmp in base_rule_info:
                             tmp_dict = dict()

--- a/lib/ansible/modules/network/cloudengine/ce_acl_advance.py
+++ b/lib/ansible/modules/network/cloudengine/ce_acl_advance.py
@@ -602,7 +602,7 @@ class AdvanceAcl(object):
 
             if self.acl_type:
                 conf_str += "<aclType></aclType>"
-            if self.acl_num:
+            if self.acl_num or self.acl_name.isdigit():
                 conf_str += "<aclNumber></aclNumber>"
             if self.acl_step:
                 conf_str += "<aclStep></aclStep>"
@@ -624,7 +624,7 @@ class AdvanceAcl(object):
 
                 # parse acl
                 acl_info = root.findall(
-                    "data/acl/aclGroups/aclGroup")
+                    "acl/aclGroups/aclGroup")
                 if acl_info:
                     for tmp in acl_info:
                         tmp_dict = dict()
@@ -635,22 +635,42 @@ class AdvanceAcl(object):
                         self.cur_acl_cfg["acl_info"].append(tmp_dict)
 
                 if self.cur_acl_cfg["acl_info"]:
+                    find_list = list()
                     for tmp in self.cur_acl_cfg["acl_info"]:
-                        find_flag = True
+                        cur_cfg_dict = dict()
+                        exist_cfg_dict = dict()
 
-                        if self.acl_name and tmp.get("aclNumOrName") != self.acl_name:
-                            find_flag = False
-                        if self.acl_type and tmp.get("aclType") != self.acl_type:
-                            find_flag = False
-                        if self.acl_num and tmp.get("aclNumber") != self.acl_num:
-                            find_flag = False
-                        if self.acl_step and tmp.get("aclStep") != self.acl_step:
-                            find_flag = False
-                        if self.acl_description and tmp.get("aclDescription") != self.acl_description:
-                            find_flag = False
+                        if self.acl_name:
+                            if self.acl_name.isdigit() and tmp.get("aclNumber"):
+                                cur_cfg_dict["aclNumber"] = self.acl_name
+                                exist_cfg_dict["aclNumber"] = tmp.get("aclNumber")
+                            else:
+                                cur_cfg_dict["aclNumOrName"] = self.acl_name
+                                exist_cfg_dict["aclNumOrName"] = tmp.get("aclNumOrName")
+                        if self.acl_type:
+                            cur_cfg_dict["aclType"] = self.acl_type
+                            exist_cfg_dict["aclType"] = tmp.get("aclType")
+                        if self.acl_num:
+                            cur_cfg_dict["aclNumber"] = self.acl_num
+                            exist_cfg_dict["aclNumber"] = tmp.get("aclNumber")
+                        if self.acl_step:
+                            cur_cfg_dict["aclStep"] = self.acl_step
+                            exist_cfg_dict["aclStep"] = tmp.get("aclStep")
+                        if self.acl_description:
+                            cur_cfg_dict["aclDescription"] = self.acl_description
+                            exist_cfg_dict["aclDescription"] = tmp.get("aclDescription")
 
-                        if find_flag:
+                        if cur_cfg_dict == exist_cfg_dict:
+                            find_bool = True
+                        else:
+                            find_bool = False
+                        find_list.append(find_bool)
+                    for mem in find_list:
+                        if mem:
+                            find_flag = True
                             break
+                        else:
+                            find_flag = False
                 else:
                     find_flag = False
 
@@ -1001,7 +1021,7 @@ class AdvanceAcl(object):
 
                     # parse advance rule
                     adv_rule_info = root.findall(
-                        "data/acl/aclGroups/aclGroup/aclRuleAdv4s/aclRuleAdv4")
+                        "acl/aclGroups/aclGroup/aclRuleAdv4s/aclRuleAdv4")
                     if adv_rule_info:
                         for tmp in adv_rule_info:
                             tmp_dict = dict()

--- a/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
@@ -122,7 +122,7 @@ updates:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config
+from ansible.module_utils.network.cloudengine.ce import get_config, load_config, exec_command
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
 
 
@@ -169,11 +169,18 @@ class AclInterface(object):
                         msg='Error: The len of acl_name is out of [1 - 32].')
 
         if self.interface:
-            regular = "| ignore-case section include ^interface %s$" % self.interface
-            result = self.cli_get_config(regular)
-            if not result:
-                self.module.fail_json(
-                    msg='Error: The interface %s is not in the device.' % self.interface)
+            cmd = "display current-configuration | ignore-case section include ^interface %s$" % self.interface
+            rc, out, err = exec_command(self.module, cmd)
+            if rc != 0:
+                self.module.fail_json(msg=err)
+            result = str(out).strip()
+            if result:
+                tmp = result.split('\n')
+                if "display" in tmp[0]:
+                    tmp.pop(0)
+                if not tmp:
+                    self.module.fail_json(
+                        msg='Error: The interface %s is not in the device.' % self.interface)
 
     def get_proposed(self):
         """ Get proposed config """
@@ -192,28 +199,36 @@ class AclInterface(object):
     def get_existing(self):
         """ Get existing config """
 
-        regular = "| ignore-case section include ^interface %s$ | include traffic-filter" % self.interface
-        result = self.cli_get_config(regular)
-
+        cmd = "display current-configuration | ignore-case section include ^interface %s$ | include traffic-filter" % self.interface
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        result = str(out).strip()
         end = []
         if result:
             tmp = result.split('\n')
+            if "display" in tmp[0]:
+                tmp.pop(0)
             for item in tmp:
-                end.append(item)
+                end.append(item.strip())
             self.cur_cfg["acl interface"] = end
             self.existing["acl interface"] = end
 
     def get_end_state(self):
         """ Get config end state """
 
-        regular = "| ignore-case section include ^interface %s$ | include traffic-filter" % self.interface
-        result = self.cli_get_config(regular)
+        cmd = "display current-configuration | ignore-case section include ^interface %s$ | include traffic-filter" % self.interface
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        result = str(out).strip()
         end = []
         if result:
             tmp = result.split('\n')
+            if "display" in tmp[0]:
+                tmp.pop(0)
             for item in tmp:
-                item = item[1:-1]
-                end.append(item)
+                end.append(item.strip())
             self.end_state["acl interface"] = end
 
     def cli_load_config(self, commands):
@@ -221,15 +236,6 @@ class AclInterface(object):
 
         if not self.module.check_mode:
             load_config(self.module, commands)
-
-    def cli_get_config(self, regular):
-        """ Cli method to get config """
-
-        flags = list()
-        flags.append(regular)
-        tmp_cfg = get_config(self.module, flags)
-
-        return tmp_cfg
 
     def work(self):
         """ Work function """

--- a/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
@@ -169,7 +169,7 @@ class AclInterface(object):
                         msg='Error: The len of acl_name is out of [1 - 32].')
 
         if self.interface:
-            cmd = "display current-configuration | ignore-case section include ^interface %s$" % self.interface
+            cmd = "display current-configuration | ignore-case section include interface %s" % self.interface
             rc, out, err = exec_command(self.module, cmd)
             if rc != 0:
                 self.module.fail_json(msg=err)
@@ -199,7 +199,7 @@ class AclInterface(object):
     def get_existing(self):
         """ Get existing config """
 
-        cmd = "display current-configuration | ignore-case section include ^interface %s$ | include traffic-filter" % self.interface
+        cmd = "display current-configuration | ignore-case section include interface %s | include traffic-filter" % self.interface
         rc, out, err = exec_command(self.module, cmd)
         if rc != 0:
             self.module.fail_json(msg=err)

--- a/lib/ansible/modules/network/cloudengine/ce_bfd_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_global.py
@@ -183,12 +183,6 @@ from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_co
 CE_NC_GET_BFD = """
     <filter type="subtree">
       <bfd xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-      %s
-      </bfd>
-    </filter>
-"""
-
-CE_NC_GET_BFD_GLB = """
         <bfdSchGlobal>
           <bfdEnable></bfdEnable>
           <defaultIp></defaultIp>
@@ -199,6 +193,8 @@ CE_NC_GET_BFD_GLB = """
           <dampSecondWaitTime></dampSecondWaitTime>
           <delayUpTimer></delayUpTimer>
         </bfdSchGlobal>
+      </bfd>
+    </filter>
 """
 
 
@@ -269,7 +265,7 @@ class BfdGlobal(object):
 
         bfd_dict = dict()
         bfd_dict["global"] = dict()
-        conf_str = CE_NC_GET_BFD % CE_NC_GET_BFD_GLB
+        conf_str = CE_NC_GET_BFD
 
         xml_str = get_nc_config(self.module, conf_str)
         if "<data/>" in xml_str:
@@ -281,7 +277,7 @@ class BfdGlobal(object):
         root = ElementTree.fromstring(xml_str)
 
         # get bfd global info
-        glb = root.find("data/bfd/bfdSchGlobal")
+        glb = root.find("bfd/bfdSchGlobal")
         if glb:
             for attr in glb:
                 bfd_dict["global"][attr.tag] = attr.text

--- a/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
@@ -53,6 +53,14 @@ options:
     src_addr:
         description:
             - Indicates the source IP address carried in BFD packets.
+    local_discr:
+	    version_added: "2.9"
+        description:
+            - The BFD session local identifier does not need to be configured when the mode is auto.
+    remote_discr:
+	    version_added: "2.9"
+        description:
+            - The BFD session remote identifier does not need to be configured when the mode is auto.
     vrf_name:
         description:
             - Specifies the name of a Virtual Private Network (VPN) instance that is bound to a BFD session.
@@ -93,6 +101,8 @@ EXAMPLES = '''
       session_name: bfd_l2link
       use_default_ip: true
       out_if_name: 10GE1/0/1
+      local_discr: 163
+      remote_discr: 163
       provider: '{{ cli }}'
 
   - name: Configuring Single-Hop BFD on a VLANIF Interface
@@ -100,12 +110,16 @@ EXAMPLES = '''
       session_name: bfd_vlanif
       dest_addr: 10.1.1.6
       out_if_name: Vlanif100
+      local_discr: 163
+      remote_discr: 163
       provider: '{{ cli }}'
 
   - name: Configuring Multi-Hop BFD
     ce_bfd_session:
       session_name: bfd_multi_hop
       dest_addr: 10.1.1.1
+      local_discr: 163
+      remote_discr: 163
       provider: '{{ cli }}'
 '''
 
@@ -172,19 +186,10 @@ from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_co
 CE_NC_GET_BFD = """
     <filter type="subtree">
       <bfd xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-      %s
-      </bfd>
-    </filter>
-"""
-
-CE_NC_GET_BFD_GLB = """
         <bfdSchGlobal>
           <bfdEnable></bfdEnable>
           <defaultIp></defaultIp>
         </bfdSchGlobal>
-"""
-
-CE_NC_GET_BFD_SESSION = """
         <bfdCfgSessions>
           <bfdCfgSession>
             <sessName>%s</sessName>
@@ -192,11 +197,15 @@ CE_NC_GET_BFD_SESSION = """
             <addrType></addrType>
             <outIfName></outIfName>
             <destAddr></destAddr>
+            <localDiscr></localDiscr>
+            <remoteDiscr></remoteDiscr>
             <srcAddr></srcAddr>
             <vrfName></vrfName>
             <useDefaultIp></useDefaultIp>
           </bfdCfgSession>
         </bfdCfgSessions>
+      </bfd>
+    </filter>
 """
 
 
@@ -301,7 +310,8 @@ class BfdSession(object):
         self.vrf_name = self.module.params['vrf_name']
         self.use_default_ip = self.module.params['use_default_ip']
         self.state = self.module.params['state']
-
+        self.local_discr = self.module.params['local_discr']
+        self.remote_discr = self.module.params['remote_discr']
         # host info
         self.host = self.module.params['host']
         self.username = self.module.params['username']
@@ -331,7 +341,7 @@ class BfdSession(object):
         bfd_dict = dict()
         bfd_dict["global"] = dict()
         bfd_dict["session"] = dict()
-        conf_str = CE_NC_GET_BFD % (CE_NC_GET_BFD_GLB + (CE_NC_GET_BFD_SESSION % self.session_name))
+        conf_str = CE_NC_GET_BFD % self.session_name
 
         xml_str = get_nc_config(self.module, conf_str)
         if "<data/>" in xml_str:
@@ -343,13 +353,13 @@ class BfdSession(object):
         root = ElementTree.fromstring(xml_str)
 
         # get bfd global info
-        glb = root.find("data/bfd/bfdSchGlobal")
+        glb = root.find("bfd/bfdSchGlobal")
         if glb:
             for attr in glb:
                 bfd_dict["global"][attr.tag] = attr.text
 
         # get bfd session info
-        sess = root.find("data/bfd/bfdCfgSessions/bfdCfgSession")
+        sess = root.find("bfd/bfdCfgSessions/bfdCfgSession")
         if sess:
             for attr in sess:
                 bfd_dict["session"][attr.tag] = attr.text
@@ -442,7 +452,10 @@ class BfdSession(object):
                     cmd_session += " source-%s %s" % ("ipv6" if self.addr_type == "ipv6" else "ip", self.src_addr)
                 if self.create_type == "auto":
                     cmd_session += " auto"
-
+                if self.local_discr:
+                    xml_str += "<localDiscr>%s</localDiscr>" % self.local_discr
+                if self.remote_discr:
+                    xml_str += "<remoteDiscr>%s</remoteDiscr>" % self.remote_discr
             elif not self.is_session_match():
                 # Bfd session is not match
                 self.module.fail_json(msg="Error: The specified BFD configuration view has been created.")
@@ -495,6 +508,22 @@ class BfdSession(object):
             if len(self.session_name) < 1 or len(self.session_name) > 15:
                 self.module.fail_json(msg="Error: Session name is invalid.")
 
+        # check local_discr
+        if self.state == "present" and self.create_type == "static":
+            if not self.local_discr:
+                self.module.fail_json(msg="Error: Missing required arguments: local_discr.")
+
+            if self.local_discr:
+                if self.local_discr < 1 or self.local_discr > 16384:
+                    self.module.fail_json(msg="Error: Session local_discr is not ranges from 1 to 16384.")
+
+            # check remote_discr
+            if not self.remote_discr:
+                self.module.fail_json(msg="Error: Missing required arguments: remote_discr.")
+            if self.remote_discr:
+                if self.remote_discr < 1 or self.remote_discr > 4294967295:
+                    self.module.fail_json(msg="Error: Session remote_discr is not ranges from 1 to 4294967295.")
+
         # check out_if_name
         if self.out_if_name:
             if not get_interface_type(self.out_if_name):
@@ -534,6 +563,8 @@ class BfdSession(object):
         self.proposed["vrf_name"] = self.vrf_name
         self.proposed["use_default_ip"] = self.use_default_ip
         self.proposed["state"] = self.state
+        self.proposed["local_discr"] = self.local_discr
+        self.proposed["remote_discr"] = self.remote_discr
 
     def get_existing(self):
         """get existing info"""
@@ -588,14 +619,16 @@ def main():
 
     argument_spec = dict(
         session_name=dict(required=True, type='str'),
-        create_type=dict(required=False, type='str', choices=['static', 'auto']),
+        create_type=dict(required=False, default='static', type='str', choices=['static', 'auto']),
         addr_type=dict(required=False, type='str', choices=['ipv4']),
         out_if_name=dict(required=False, type='str'),
         dest_addr=dict(required=False, type='str'),
         src_addr=dict(required=False, type='str'),
         vrf_name=dict(required=False, type='str'),
         use_default_ip=dict(required=False, type='bool', default=False),
-        state=dict(required=False, default='present', choices=['present', 'absent'])
+        state=dict(required=False, default='present', choices=['present', 'absent']),
+        local_discr=dict(required=False, type='int'),
+        remote_discr=dict(required=False, type='int')
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
@@ -40,6 +40,7 @@ options:
             - BFD session creation mode, the currently created BFD session
               only supports static or static auto-negotiation mode.
         choices: ['static', 'auto']
+        default: 'static'
     addr_type:
         description:
             - Specifies the peer IP address type.
@@ -54,11 +55,11 @@ options:
         description:
             - Indicates the source IP address carried in BFD packets.
     local_discr:
-	    version_added: "2.9"
+        version_added: "2.9"
         description:
             - The BFD session local identifier does not need to be configured when the mode is auto.
     remote_discr:
-	    version_added: "2.9"
+        version_added: "2.9"
         description:
             - The BFD session remote identifier does not need to be configured when the mode is auto.
     vrf_name:
@@ -78,7 +79,7 @@ options:
     state:
         description:
             - Determines whether the config should be present or not on the device.
-        default: present
+        default: 'present'
         choices: ['present', 'absent']
 """
 

--- a/lib/ansible/modules/network/cloudengine/ce_bfd_view.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_view.py
@@ -194,18 +194,9 @@ from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_co
 CE_NC_GET_BFD = """
     <filter type="subtree">
       <bfd xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-      %s
-      </bfd>
-    </filter>
-"""
-
-CE_NC_GET_BFD_GLB = """
         <bfdSchGlobal>
           <bfdEnable></bfdEnable>
         </bfdSchGlobal>
-"""
-
-CE_NC_GET_BFD_SESSION = """
         <bfdCfgSessions>
           <bfdCfgSession>
             <sessName>%s</sessName>
@@ -221,6 +212,8 @@ CE_NC_GET_BFD_SESSION = """
             <description></description>
           </bfdCfgSession>
         </bfdCfgSessions>
+      </bfd>
+    </filter>
 """
 
 
@@ -272,7 +265,7 @@ class BfdView(object):
         bfd_dict = dict()
         bfd_dict["global"] = dict()
         bfd_dict["session"] = dict()
-        conf_str = CE_NC_GET_BFD % (CE_NC_GET_BFD_GLB + (CE_NC_GET_BFD_SESSION % self.session_name))
+        conf_str = CE_NC_GET_BFD % self.session_name
 
         xml_str = get_nc_config(self.module, conf_str)
         if "<data/>" in xml_str:
@@ -284,13 +277,13 @@ class BfdView(object):
         root = ElementTree.fromstring(xml_str)
 
         # get bfd global info
-        glb = root.find("data/bfd/bfdSchGlobal")
+        glb = root.find("bfd/bfdSchGlobal")
         if glb:
             for attr in glb:
                 bfd_dict["global"][attr.tag] = attr.text
 
         # get bfd session info
-        sess = root.find("data/bfd/bfdCfgSessions/bfdCfgSession")
+        sess = root.find("bfd/bfdCfgSessions/bfdCfgSession")
         if sess:
             for attr in sess:
                 bfd_dict["session"][attr.tag] = attr.text

--- a/lib/ansible/modules/network/cloudengine/ce_bgp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bgp.py
@@ -1254,7 +1254,7 @@ class Bgp(object):
             return result
         else:
             re_find = re.findall(
-                r'.*<asNumber>(.*)</asNumber>.*\s*<bgpEnable>(.*)</bgpEnable>.*', xml_str)
+                r'.*<bgpEnable>(.*)</bgpEnable>.*\s*<asNumber>(.*)</asNumber>.*', xml_str)
 
             if re_find:
                 return re_find
@@ -2127,9 +2127,12 @@ def main():
 
         bgp_enable_exist = ce_bgp_obj.get_bgp_enable(module=module)
         existing["bgp enable"] = bgp_enable_exist
-
-        asnumber_exist = bgp_enable_exist[0][0]
-        bgpenable_exist = bgp_enable_exist[0][1]
+        if bgp_enable_exist:
+            asnumber_exist = bgp_enable_exist[0][0]
+            bgpenable_exist = bgp_enable_exist[0][1]
+        else:
+            asnumber_exist = None
+            bgpenable_exist = None
 
         if state == "present":
             bgp_enable_new = (as_number, "true")
@@ -2300,7 +2303,9 @@ def main():
 
     if end_tmp:
         end_state["bgp instance other"] = end_tmp
-
+    if end_state == existing:
+        changed = False
+        updates = list()
     results = dict()
     results['proposed'] = proposed
     results['existing'] = existing

--- a/lib/ansible/modules/network/cloudengine/ce_bgp_af.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bgp_af.py
@@ -2678,10 +2678,17 @@ class BgpAf(object):
         ingress_lsp_policy_name = module.params['ingress_lsp_policy_name']
         if ingress_lsp_policy_name:
             conf_str += "<ingressLspPolicyName>%s</ingressLspPolicyName>" % ingress_lsp_policy_name
+            cmd = "ingress-lsp trigger route-policy %s" % ingress_lsp_policy_name
+            cmds.append(cmd)
 
         originator_prior = module.params['originator_prior']
         if originator_prior != 'no_use':
             conf_str += "<originatorPrior>%s</originatorPrior>" % originator_prior
+            if originator_prior == "true":
+                cmd = "bestroute routerid-prior-clusterlist"
+            else:
+                cmd = "undo bestroute routerid-prior-clusterlist"
+            cmds.append(cmd)
 
         lowest_priority = module.params['lowest_priority']
         if lowest_priority != 'no_use':
@@ -2697,6 +2704,11 @@ class BgpAf(object):
         if relay_delay_enable != 'no_use':
             conf_str += "<relayDelayEnable>%s</relayDelayEnable>" % relay_delay_enable
 
+            if relay_delay_enable == "true":
+                cmd = "nexthop recursive-lookup restrain enable"
+            else:
+                cmd = "nexthop recursive-lookup restrain disable"
+            cmds.append(cmd)
         conf_str += CE_MERGE_BGP_ADDRESS_FAMILY_TAIL
         recv_xml = self.netconf_set_config(module=module, conf_str=conf_str)
 
@@ -2766,7 +2778,7 @@ class BgpAf(object):
             import_process_id = "0"
 
         conf_str = CE_MERGE_BGP_IMPORT_ROUTE_HEADER % (
-            vrf_name, af_type, import_protocol, import_process_id) + CE_MERGE_BGP_ADDRESS_FAMILY_TAIL
+            vrf_name, af_type, import_protocol, import_process_id) + CE_MERGE_BGP_IMPORT_ROUTE_TAIL
 
         recv_xml = self.netconf_set_config(module=module, conf_str=conf_str)
 

--- a/lib/ansible/modules/network/cloudengine/ce_bgp_neighbor.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bgp_neighbor.py
@@ -261,7 +261,7 @@ CE_GET_BGP_PEER_HEADER = """
               <vrfName>%s</vrfName>
               <bgpPeers>
                 <bgpPeer>
-                  <peerAddr></peerAddr>
+                  <peerAddr>%s</peerAddr>
 """
 CE_GET_BGP_PEER_TAIL = """
                 </bgpPeer>
@@ -475,6 +475,7 @@ class BgpNeighbor(object):
         result = dict()
         need_cfg = False
 
+        peerip = module.params['peer_addr']
         vrf_name = module.params['vrf_name']
         if vrf_name:
             if len(vrf_name) > 31 or len(vrf_name) == 0:
@@ -487,7 +488,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The len of description %s is out of [1 - 80].' % description)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<description></description>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -510,7 +511,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The len of fake_as %s is out of [1 - 11].' % fake_as)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<fakeAs></fakeAs>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -530,7 +531,7 @@ class BgpNeighbor(object):
         dual_as = module.params['dual_as']
         if dual_as != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<dualAs></dualAs>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -542,7 +543,7 @@ class BgpNeighbor(object):
 
                 if re_find:
                     result["dual_as"] = re_find
-                    if re_find[0] != fake_as:
+                    if re_find[0] != dual_as:
                         need_cfg = True
                 else:
                     need_cfg = True
@@ -550,10 +551,9 @@ class BgpNeighbor(object):
         conventional = module.params['conventional']
         if conventional != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<conventional></conventional>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
-
             if "<data/>" in recv_xml:
                 need_cfg = True
             else:
@@ -570,7 +570,7 @@ class BgpNeighbor(object):
         route_refresh = module.params['route_refresh']
         if route_refresh != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<routeRefresh></routeRefresh>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -590,7 +590,7 @@ class BgpNeighbor(object):
         four_byte_as = module.params['four_byte_as']
         if four_byte_as != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<fourByteAs></fourByteAs>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -610,7 +610,7 @@ class BgpNeighbor(object):
         is_ignore = module.params['is_ignore']
         if is_ignore != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<isIgnore></isIgnore>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -633,7 +633,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The len of local_if_name %s is out of [1 - 63].' % local_if_name)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<localIfName></localIfName>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -645,7 +645,7 @@ class BgpNeighbor(object):
 
                 if re_find:
                     result["local_if_name"] = re_find
-                    if re_find[0] != local_if_name:
+                    if re_find[0].lower() != local_if_name.lower():
                         need_cfg = True
                 else:
                     need_cfg = True
@@ -656,7 +656,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The value of ebgp_max_hop %s is out of [1 - 255].' % ebgp_max_hop)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<ebgpMaxHop></ebgpMaxHop>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -679,7 +679,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The value of valid_ttl_hops %s is out of [1 - 255].' % valid_ttl_hops)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<validTtlHops></validTtlHops>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -699,7 +699,7 @@ class BgpNeighbor(object):
         connect_mode = module.params['connect_mode']
         if connect_mode:
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<connectMode></connectMode>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -719,7 +719,7 @@ class BgpNeighbor(object):
         is_log_change = module.params['is_log_change']
         if is_log_change != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<isLogChange></isLogChange>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -739,7 +739,7 @@ class BgpNeighbor(object):
         pswd_type = module.params['pswd_type']
         if pswd_type:
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<pswdType></pswdType>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -762,7 +762,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The len of pswd_cipher_text %s is out of [1 - 255].' % pswd_cipher_text)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<pswdCipherText></pswdCipherText>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -785,7 +785,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The len of keep_alive_time %s is out of [0 - 21845].' % keep_alive_time)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<keepAliveTime></keepAliveTime>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -808,7 +808,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The value of hold_time %s is out of [0 or 3 - 65535].' % hold_time)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<holdTime></holdTime>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -831,7 +831,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The value of min_hold_time %s is out of [0 or 20 - 65535].' % min_hold_time)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<minHoldTime></minHoldTime>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -854,7 +854,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The len of key_chain_name %s is out of [1 - 47].' % key_chain_name)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<keyChainName></keyChainName>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -877,7 +877,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The value of conn_retry_time %s is out of [1 - 65535].' % conn_retry_time)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<connRetryTime></connRetryTime>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -900,7 +900,7 @@ class BgpNeighbor(object):
                 module.fail_json(
                     msg='Error: The value of tcp_mss %s is out of [176 - 4096].' % tcp_mss)
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<tcpMSS></tcpMSS>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -920,7 +920,7 @@ class BgpNeighbor(object):
         mpls_local_ifnet_disable = module.params['mpls_local_ifnet_disable']
         if mpls_local_ifnet_disable != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<mplsLocalIfnetDisable></mplsLocalIfnetDisable>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -940,7 +940,7 @@ class BgpNeighbor(object):
         prepend_global_as = module.params['prepend_global_as']
         if prepend_global_as != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<prependGlobalAs></prependGlobalAs>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -960,7 +960,7 @@ class BgpNeighbor(object):
         prepend_fake_as = module.params['prepend_fake_as']
         if prepend_fake_as != 'no_use':
 
-            conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+            conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
                 "<prependFakeAs></prependFakeAs>" + CE_GET_BGP_PEER_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -1276,14 +1276,14 @@ class BgpNeighbor(object):
         """ get_bgp_peer """
 
         module = kwargs["module"]
-
+        peerip = module.params['peer_addr']
         vrf_name = module.params['vrf_name']
         if vrf_name:
             if len(vrf_name) > 31 or len(vrf_name) == 0:
                 module.fail_json(
                     msg='Error: The len of vrf_name %s is out of [1 - 31].' % vrf_name)
 
-        conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + \
+        conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + \
             "<remoteAs></remoteAs>" + CE_GET_BGP_PEER_TAIL
 
         xml_str = self.netconf_get_config(module=module, conf_str=conf_str)
@@ -1305,14 +1305,14 @@ class BgpNeighbor(object):
         """ get_bgp_del_peer """
 
         module = kwargs["module"]
-
+        peerip = module.params['peer_addr']
         vrf_name = module.params['vrf_name']
         if vrf_name:
             if len(vrf_name) > 31 or len(vrf_name) == 0:
                 module.fail_json(
                     msg='Error: The len of vrf_name %s is out of [1 - 31].' % vrf_name)
 
-        conf_str = CE_GET_BGP_PEER_HEADER % vrf_name + CE_GET_BGP_PEER_TAIL
+        conf_str = CE_GET_BGP_PEER_HEADER % (vrf_name, peerip) + CE_GET_BGP_PEER_TAIL
 
         xml_str = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -1494,7 +1494,6 @@ class BgpNeighbor(object):
 
         connect_mode = module.params['connect_mode']
         if connect_mode:
-            conf_str += "<connectMode>%s</connectMode>" % connect_mode
 
             if connect_mode == "listenOnly":
                 cmd = "peer %s listen-only" % peer_addr
@@ -1502,11 +1501,13 @@ class BgpNeighbor(object):
             elif connect_mode == "connectOnly":
                 cmd = "peer %s connect-only" % peer_addr
                 cmds.append(cmd)
-            elif connect_mode == "null":
+            elif connect_mode == "both":
+                connect_mode = "null"
                 cmd = "peer %s listen-only" % peer_addr
                 cmds.append(cmd)
                 cmd = "peer %s connect-only" % peer_addr
                 cmds.append(cmd)
+            conf_str += "<connectMode>%s</connectMode>" % connect_mode
 
         is_log_change = module.params['is_log_change']
         if is_log_change != 'no_use':
@@ -1594,6 +1595,12 @@ class BgpNeighbor(object):
         prepend_fake_as = module.params['prepend_fake_as']
         if prepend_fake_as != 'no_use':
             conf_str += "<prependFakeAs>%s</prependFakeAs>" % prepend_fake_as
+
+            if prepend_fake_as == "true":
+                cmd = "peer %s prepend-local-as" % peer_addr
+            else:
+                cmd = "undo peer %s prepend-local-as" % peer_addr
+            cmds.append(cmd)
 
         conf_str += CE_MERGE_BGP_PEER_TAIL
 
@@ -1759,7 +1766,7 @@ def main():
         local_if_name=dict(type='str'),
         ebgp_max_hop=dict(type='str'),
         valid_ttl_hops=dict(type='str'),
-        connect_mode=dict(choices=['listenOnly', 'connectOnly', 'null']),
+        connect_mode=dict(choices=['listenOnly', 'connectOnly', 'both']),
         is_log_change=dict(type='str', default='no_use', choices=['no_use', 'true', 'false']),
         pswd_type=dict(choices=['null', 'cipher', 'simple']),
         pswd_cipher_text=dict(type='str', no_log=True),
@@ -1913,7 +1920,6 @@ def main():
                 existing["bgp peer"] = bgp_peer_exist
 
                 bgp_peer_new = (peer_addr, remote_as)
-
                 if len(bgp_peer_exist) == 0:
                     cmd = ce_bgp_peer_obj.create_bgp_peer(module=module)
                     changed = True

--- a/lib/ansible/modules/network/cloudengine/ce_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bgp_neighbor_af.py
@@ -402,7 +402,7 @@ CE_GET_BGP_PEER_AF_HEADER = """
                   <afType>%s</afType>
                   <peerAFs>
                     <peerAF>
-                      <remoteAddress></remoteAddress>
+                      <remoteAddress>%s</remoteAddress>
 """
 CE_GET_BGP_PEER_AF_TAIL = """
                     </peerAF>
@@ -539,7 +539,7 @@ class BgpNeighborAf(object):
                 msg='Error: The remote_address %s is invalid.' % remote_address)
 
         conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-            vrf_name, af_type) + CE_GET_BGP_PEER_AF_TAIL
+            vrf_name, af_type, remote_address) + CE_GET_BGP_PEER_AF_TAIL
         recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
         if state == "present":
@@ -548,12 +548,11 @@ class BgpNeighborAf(object):
             else:
                 re_find = re.findall(
                     r'.*<remoteAddress>(.*)</remoteAddress>.*', recv_xml)
-
                 if re_find:
                     result["remote_address"] = re_find
                     result["vrf_name"] = vrf_name
                     result["af_type"] = af_type
-                    if re_find[0] != remote_address:
+                    if remote_address not in re_find:
                         need_cfg = True
                 else:
                     need_cfg = True
@@ -584,6 +583,7 @@ class BgpNeighborAf(object):
         state = module.params['state']
         vrf_name = module.params['vrf_name']
         af_type = module.params['af_type']
+        remote_address = module.params['remote_address']
 
         if state == "absent":
             result["need_cfg"] = need_cfg
@@ -593,15 +593,14 @@ class BgpNeighborAf(object):
         if advertise_irb != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<advertiseIrb></advertiseIrb>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<advertiseIrb></advertiseIrb>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
                 need_cfg = True
             else:
-                re_find = re.findall(
-                    r'.*<advertiseIrb>(.*)</advertiseIrb>.*', recv_xml)
-
+                re_find = re.findall(r'.*<remoteAddress>%s</remoteAddress>\s*'
+                                     r'<advertiseIrb>(.*)</advertiseIrb>.*' % remote_address, recv_xml)
                 if re_find:
                     result["advertise_irb"] = re_find
                     result["vrf_name"] = vrf_name
@@ -615,14 +614,14 @@ class BgpNeighborAf(object):
         if advertise_arp != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<advertiseArp></advertiseArp>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<advertiseArp></advertiseArp>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
                 need_cfg = True
             else:
-                re_find = re.findall(
-                    r'.*<advertiseArp>(.*)</advertiseArp>.*', recv_xml)
+                re_find = re.findall(r'.*<remoteAddress>%s</remoteAddress>\s*'
+                                     r'.*<advertiseArp>(.*)</advertiseArp>.*' % remote_address, recv_xml)
 
                 if re_find:
                     result["advertise_arp"] = re_find
@@ -637,7 +636,7 @@ class BgpNeighborAf(object):
         if advertise_remote_nexthop != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<advertiseRemoteNexthop></advertiseRemoteNexthop>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<advertiseRemoteNexthop></advertiseRemoteNexthop>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -659,7 +658,7 @@ class BgpNeighborAf(object):
         if advertise_community != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<advertiseCommunity></advertiseCommunity>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<advertiseCommunity></advertiseCommunity>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -681,9 +680,8 @@ class BgpNeighborAf(object):
         if advertise_ext_community != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<advertiseExtCommunity></advertiseExtCommunity>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<advertiseExtCommunity></advertiseExtCommunity>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
-
             if "<data/>" in recv_xml:
                 need_cfg = True
             else:
@@ -703,7 +701,7 @@ class BgpNeighborAf(object):
         if discard_ext_community != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<discardExtCommunity></discardExtCommunity>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<discardExtCommunity></discardExtCommunity>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -725,7 +723,7 @@ class BgpNeighborAf(object):
         if allow_as_loop_enable != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<allowAsLoopEnable></allowAsLoopEnable>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<allowAsLoopEnable></allowAsLoopEnable>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -750,7 +748,7 @@ class BgpNeighborAf(object):
                     msg='the value of allow_as_loop_limit %s is out of [1 - 10].' % allow_as_loop_limit)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<allowAsLoopLimit></allowAsLoopLimit>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<allowAsLoopLimit></allowAsLoopLimit>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -772,7 +770,7 @@ class BgpNeighborAf(object):
         if keep_all_routes != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<keepAllRoutes></keepAllRoutes>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<keepAllRoutes></keepAllRoutes>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -794,7 +792,7 @@ class BgpNeighborAf(object):
         if nexthop_configure:
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<nextHopConfigure></nextHopConfigure>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<nextHopConfigure></nextHopConfigure>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -819,7 +817,7 @@ class BgpNeighborAf(object):
                     msg='the value of preferred_value %s is out of [0 - 65535].' % preferred_value)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<preferredValue></preferredValue>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<preferredValue></preferredValue>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -841,7 +839,7 @@ class BgpNeighborAf(object):
         if public_as_only != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<publicAsOnly></publicAsOnly>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<publicAsOnly></publicAsOnly>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -863,7 +861,7 @@ class BgpNeighborAf(object):
         if public_as_only_force != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<publicAsOnlyForce></publicAsOnlyForce>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<publicAsOnlyForce></publicAsOnlyForce>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -885,7 +883,7 @@ class BgpNeighborAf(object):
         if public_as_only_limited != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<publicAsOnlyLimited></publicAsOnlyLimited>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<publicAsOnlyLimited></publicAsOnlyLimited>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -907,7 +905,7 @@ class BgpNeighborAf(object):
         if public_as_only_replace != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<publicAsOnlyReplace></publicAsOnlyReplace>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<publicAsOnlyReplace></publicAsOnlyReplace>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -930,7 +928,7 @@ class BgpNeighborAf(object):
         if public_as_only_skip_peer_as != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<publicAsOnlySkipPeerAs></publicAsOnlySkipPeerAs>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<publicAsOnlySkipPeerAs></publicAsOnlySkipPeerAs>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -956,7 +954,7 @@ class BgpNeighborAf(object):
                     msg='the value of route_limit %s is out of [1 - 4294967295].' % route_limit)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<routeLimit></routeLimit>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<routeLimit></routeLimit>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -982,7 +980,7 @@ class BgpNeighborAf(object):
                     msg='Error: The value of route_limit_percent %s is out of [1 - 100].' % route_limit_percent)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<routeLimitPercent></routeLimitPercent>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<routeLimitPercent></routeLimitPercent>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1004,7 +1002,7 @@ class BgpNeighborAf(object):
         if route_limit_type:
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<routeLimitType></routeLimitType>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<routeLimitType></routeLimitType>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1031,7 +1029,7 @@ class BgpNeighborAf(object):
                         '[1 - 1200].' % route_limit_idle_timeout)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<routeLimitIdleTimeout></routeLimitPercent>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<routeLimitIdleTimeout></routeLimitIdleTimeout>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1057,7 +1055,7 @@ class BgpNeighborAf(object):
                     msg='Error: The value of rt_updt_interval %s is out of [0 - 600].' % rt_updt_interval)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<rtUpdtInterval></rtUpdtInterval>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<rtUpdtInterval></rtUpdtInterval>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1079,7 +1077,7 @@ class BgpNeighborAf(object):
         if redirect_ip != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<redirectIP></redirectIP>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<redirectIP></redirectIP>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1101,7 +1099,7 @@ class BgpNeighborAf(object):
         if redirect_ip_vaildation != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<redirectIPVaildation></redirectIPVaildation>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<redirectIPVaildation></redirectIPVaildation>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1123,7 +1121,7 @@ class BgpNeighborAf(object):
         if reflect_client != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<reflectClient></reflectClient>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<reflectClient></reflectClient>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1145,7 +1143,7 @@ class BgpNeighborAf(object):
         if substitute_as_enable != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<substituteAsEnable></substituteAsEnable>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<substituteAsEnable></substituteAsEnable>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1171,7 +1169,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of import_rt_policy_name %s is out of [1 - 40].' % import_rt_policy_name)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<importRtPolicyName></importRtPolicyName>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<importRtPolicyName></importRtPolicyName>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1197,7 +1195,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of export_rt_policy_name %s is out of [1 - 40].' % export_rt_policy_name)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<exportRtPolicyName></exportRtPolicyName>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<exportRtPolicyName></exportRtPolicyName>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1223,7 +1221,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of import_pref_filt_name %s is out of [1 - 169].' % import_pref_filt_name)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<importPrefFiltName></importPrefFiltName>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<importPrefFiltName></importPrefFiltName>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1249,7 +1247,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of export_pref_filt_name %s is out of [1 - 169].' % export_pref_filt_name)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<exportPrefFiltName></exportPrefFiltName>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<exportPrefFiltName></exportPrefFiltName>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1275,7 +1273,7 @@ class BgpNeighborAf(object):
                     msg='Error: The value of import_as_path_filter %s is out of [1 - 256].' % import_as_path_filter)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<importAsPathFilter></importAsPathFilter>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<importAsPathFilter></importAsPathFilter>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1301,7 +1299,7 @@ class BgpNeighborAf(object):
                     msg='Error: The value of export_as_path_filter %s is out of [1 - 256].' % export_as_path_filter)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<exportAsPathFilter></exportAsPathFilter>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<exportAsPathFilter></exportAsPathFilter>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1329,7 +1327,7 @@ class BgpNeighborAf(object):
                         'of [1 - 51].' % import_as_path_name_or_num)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<importAsPathNameOrNum></importAsPathNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<importAsPathNameOrNum></importAsPathNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1357,7 +1355,7 @@ class BgpNeighborAf(object):
                         'of [1 - 51].' % export_as_path_name_or_num)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<exportAsPathNameOrNum></exportAsPathNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<exportAsPathNameOrNum></exportAsPathNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1383,7 +1381,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of import_acl_name_or_num %s is out of [1 - 32].' % import_acl_name_or_num)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<importAclNameOrNum></importAclNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<importAclNameOrNum></importAclNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1409,7 +1407,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of export_acl_name_or_num %s is out of [1 - 32].' % export_acl_name_or_num)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<exportAclNameOrNum></exportAclNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<exportAclNameOrNum></exportAclNameOrNum>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1430,7 +1428,7 @@ class BgpNeighborAf(object):
         ipprefix_orf_enable = module.params['ipprefix_orf_enable']
         if ipprefix_orf_enable != 'no_use':
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<ipprefixOrfEnable></ipprefixOrfEnable>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<ipprefixOrfEnable></ipprefixOrfEnable>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1452,7 +1450,7 @@ class BgpNeighborAf(object):
         if is_nonstd_ipprefix_mod != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<isNonstdIpprefixMod></isNonstdIpprefixMod>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<isNonstdIpprefixMod></isNonstdIpprefixMod>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1478,7 +1476,7 @@ class BgpNeighborAf(object):
                     msg='Error: The value of orftype %s is out of [0 - 65535].' % orftype)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<orftype></orftype>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<orftype></orftype>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1500,7 +1498,7 @@ class BgpNeighborAf(object):
         if orf_mode:
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<orfMode></orfMode>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<orfMode></orfMode>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1526,7 +1524,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of soostring %s is out of [3 - 21].' % soostring)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<soostring></soostring>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<soostring></soostring>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1548,7 +1546,7 @@ class BgpNeighborAf(object):
         if default_rt_adv_enable != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<defaultRtAdvEnable></defaultRtAdvEnable>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<defaultRtAdvEnable></defaultRtAdvEnable>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1574,7 +1572,7 @@ class BgpNeighborAf(object):
                     msg='Error: The len of default_rt_adv_policy %s is out of [1 - 40].' % default_rt_adv_policy)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<defaultRtAdvPolicy></defaultRtAdvPolicy>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<defaultRtAdvPolicy></defaultRtAdvPolicy>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1596,7 +1594,7 @@ class BgpNeighborAf(object):
         if default_rt_match_mode:
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<defaultRtMatchMode></defaultRtMatchMode>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<defaultRtMatchMode></defaultRtMatchMode>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1618,7 +1616,7 @@ class BgpNeighborAf(object):
         if add_path_mode:
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<addPathMode></addPathMode>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<addPathMode></addPathMode>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1644,7 +1642,7 @@ class BgpNeighborAf(object):
                     msg='Error: The value of adv_add_path_num %s is out of [2 - 64].' % adv_add_path_num)
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<advAddPathNum></advAddPathNum>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<advAddPathNum></advAddPathNum>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1666,7 +1664,7 @@ class BgpNeighborAf(object):
         if origin_as_valid != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<originAsValid></originAsValid>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<originAsValid></originAsValid>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1688,7 +1686,7 @@ class BgpNeighborAf(object):
         if vpls_enable != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<vplsEnable></vplsEnable>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<vplsEnable></vplsEnable>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1710,7 +1708,7 @@ class BgpNeighborAf(object):
         if vpls_ad_disable != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<vplsAdDisable></vplsAdDisable>" + CE_GET_BGP_PEER_AF_TAIL
+                vrf_name, af_type, remote_address) + "<vplsAdDisable></vplsAdDisable>" + CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
             if "<data/>" in recv_xml:
@@ -1733,7 +1731,7 @@ class BgpNeighborAf(object):
         if update_pkt_standard_compatible != 'no_use':
 
             conf_str = CE_GET_BGP_PEER_AF_HEADER % (
-                vrf_name, af_type) + "<updatePktStandardCompatible></updatePktStandardCompatible>" + \
+                vrf_name, af_type, remote_address) + "<updatePktStandardCompatible></updatePktStandardCompatible>" + \
                 CE_GET_BGP_PEER_AF_TAIL
             recv_xml = self.netconf_get_config(module=module, conf_str=conf_str)
 
@@ -1773,6 +1771,7 @@ class BgpNeighborAf(object):
             module.fail_json(msg='Error: Merge bgp peer address family failed.')
 
         cmds = []
+        cmd = af_type
         if af_type == "ipv4uni":
             cmd = "ipv4-family unicast"
         elif af_type == "ipv4multi":
@@ -1802,6 +1801,7 @@ class BgpNeighborAf(object):
             module.fail_json(msg='Error: Create bgp peer address family failed.')
 
         cmds = []
+        cmd = af_type
         if af_type == "ipv4uni":
             cmd = "ipv4-family unicast"
         elif af_type == "ipv4multi":
@@ -1831,6 +1831,7 @@ class BgpNeighborAf(object):
             module.fail_json(msg='Error: Delete bgp peer address family failed.')
 
         cmds = []
+        cmd = af_type
         if af_type == "ipv4uni":
             cmd = "ipv4-family unicast"
         elif af_type == "ipv4multi":
@@ -1861,7 +1862,7 @@ class BgpNeighborAf(object):
         if advertise_irb != 'no_use':
             conf_str += "<advertiseIrb>%s</advertiseIrb>" % advertise_irb
 
-            if advertise_irb == "ture":
+            if advertise_irb == "true":
                 cmd = "peer %s advertise irb" % remote_address
             else:
                 cmd = "undo peer %s advertise irb" % remote_address
@@ -1871,7 +1872,7 @@ class BgpNeighborAf(object):
         if advertise_arp != 'no_use':
             conf_str += "<advertiseArp>%s</advertiseArp>" % advertise_arp
 
-            if advertise_arp == "ture":
+            if advertise_arp == "true":
                 cmd = "peer %s advertise arp" % remote_address
             else:
                 cmd = "undo peer %s advertise arp" % remote_address
@@ -2081,6 +2082,12 @@ class BgpNeighborAf(object):
         if substitute_as_enable != 'no_use':
             conf_str += "<substituteAsEnable>%s</substituteAsEnable>" % substitute_as_enable
 
+            if substitute_as_enable == "true":
+                cmd = "peer %s substitute-as" % remote_address
+            else:
+                cmd = "undo peer %s substitute-as" % remote_address
+            cmds.append(cmd)
+
         import_rt_policy_name = module.params['import_rt_policy_name']
         if import_rt_policy_name:
             conf_str += "<importRtPolicyName>%s</importRtPolicyName>" % import_rt_policy_name
@@ -2210,12 +2217,13 @@ class BgpNeighborAf(object):
                 cmd += "peer %s default-route-advertise" % remote_address
             else:
                 cmd += "undo peer %s default-route-advertise" % remote_address
+            cmds.append(cmd)
 
         default_rt_adv_policy = module.params['default_rt_adv_policy']
         if default_rt_adv_policy:
             conf_str += "<defaultRtAdvPolicy>%s</defaultRtAdvPolicy>" % default_rt_adv_policy
-
-            cmd += " route-policy %s" % default_rt_adv_policy
+            cmd = " route-policy %s" % default_rt_adv_policy
+            cmds.append(cmd)
 
         default_rt_match_mode = module.params['default_rt_match_mode']
         if default_rt_match_mode:
@@ -2226,17 +2234,27 @@ class BgpNeighborAf(object):
             elif default_rt_match_mode == "matchany":
                 cmd += " conditional-route-match-any"
 
-        if cmd:
-            cmds.append(cmd)
+            if cmd:
+                cmds.append(cmd)
 
         add_path_mode = module.params['add_path_mode']
         if add_path_mode:
             conf_str += "<addPathMode>%s</addPathMode>" % add_path_mode
+            if add_path_mode == "receive":
+                cmd += " add-path receive"
+            elif add_path_mode == "send":
+                cmd += " add-path send"
+            elif add_path_mode == "both":
+                cmd += " add-path both"
+            if cmd:
+                cmds.append(cmd)
 
         adv_add_path_num = module.params['adv_add_path_num']
         if adv_add_path_num:
             conf_str += "<advAddPathNum>%s</advAddPathNum>" % adv_add_path_num
-
+            cmd += " advertise add-path path-number %s" % adv_add_path_num
+            if cmd:
+                cmds.append(cmd)
         origin_as_valid = module.params['origin_as_valid']
         if origin_as_valid != 'no_use':
             conf_str += "<originAsValid>%s</originAsValid>" % origin_as_valid

--- a/lib/ansible/modules/network/cloudengine/ce_dldp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp.py
@@ -321,7 +321,7 @@ class Dldp(object):
 
         # get global DLDP info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/dldp/dldpSys")
+        topo = root.find("dldp/dldpSys")
         if not topo:
             self.module.fail_json(
                 msg="Error: Get current DLDP configration failed.")

--- a/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
@@ -454,7 +454,7 @@ class DldpInterface(object):
 
         # get global DLDP info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/dldp/dldpInterfaces/dldpInterface")
+        topo = root.find("dldp/dldpInterfaces/dldpInterface")
         if topo is None:
             self.module.fail_json(
                 msg="Error: Get current DLDP configration failed.")

--- a/lib/ansible/modules/network/cloudengine/ce_evpn_bd_vni.py
+++ b/lib/ansible/modules/network/cloudengine/ce_evpn_bd_vni.py
@@ -260,7 +260,7 @@ CE_NC_GET_VNI_BD = """
     <nvo3Vni2Bds>
       <nvo3Vni2Bd>
         <vniId></vniId>
-        <bdId>%s</bdId>
+        <bdId></bdId>
       </nvo3Vni2Bd>
     </nvo3Vni2Bds>
   </nvo3>
@@ -552,7 +552,7 @@ class EvpnBd(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
         root = ElementTree.fromstring(xml_str)
-        evpn_inst = root.find("data/evpn/evpnInstances/evpnInstance")
+        evpn_inst = root.find("evpn/evpnInstances/evpnInstance")
         if evpn_inst:
             for eles in evpn_inst:
                 if eles.tag in ["evpnAutoRD", "evpnRD", "evpnRTs", "evpnAutoRTs"]:
@@ -1006,8 +1006,9 @@ class EvpnBd(object):
     def check_vni_bd(self):
         """Check whether vxlan vni is configured in BD view"""
 
-        xml_str = CE_NC_GET_VNI_BD % self.bridge_domain_id
+        xml_str = CE_NC_GET_VNI_BD
         xml_str = get_nc_config(self.module, xml_str)
+
         if "<data/>" in xml_str:
             self.module.fail_json(
                 msg='Error: The vxlan vni is not configured or the bridge domain id is invalid.')

--- a/lib/ansible/modules/network/cloudengine/ce_evpn_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_evpn_global.py
@@ -102,7 +102,7 @@ changed:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config
+from ansible.module_utils.network.cloudengine.ce import load_config, exec_command
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
 
 
@@ -149,6 +149,22 @@ class EvpnGlobal(object):
         if command.lower() not in ["quit", "return"]:
             self.updates_cmd.append(cmd)   # show updates result
 
+    def get_config(self, flags=None):
+        """Retrieves the current config from the device or cache
+        """
+        flags = [] if flags is None else flags
+
+        cmd = 'display current-configuration '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
+
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        cfg = str(out).strip()
+
+        return cfg
+
     def get_evpn_global_info(self):
         """ get current EVPN global configration"""
 
@@ -156,7 +172,7 @@ class EvpnGlobal(object):
         flags = list()
         exp = " | include evpn-overlay enable"
         flags.append(exp)
-        config = get_config(self.module, flags)
+        config = self.get_config(flags)
         if config:
             self.global_info['evpnOverLay'] = 'enable'
 

--- a/lib/ansible/modules/network/cloudengine/ce_facts.py
+++ b/lib/ansible/modules/network/cloudengine/ce_facts.py
@@ -324,7 +324,10 @@ class Interfaces(FactsBase):
             tmp_neighbors = neighbors[2:]
             for item in tmp_neighbors:
                 tmp_item = item.split()
-                neighbors_dict[tmp_item[0]] = tmp_item[3]
+                if len(tmp_item) > 3:
+                    neighbors_dict[tmp_item[0]] = tmp_item[3]
+                else:
+                    neighbors_dict[tmp_item[0]] = None
             self.facts['neighbors'] = neighbors_dict
 
 

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -97,7 +97,7 @@ import re
 import os
 import time
 from xml.etree import ElementTree
-from ansible.module_utils.basic import get_exception, AnsibleModule
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, run_commands, get_nc_config
 
 try:
@@ -150,42 +150,6 @@ CE_NC_GET_SCP_ENABLE = """
   </sshs>
 </filter>
 """
-
-
-def get_cli_exception(exc=None):
-    """Get cli exception message"""
-
-    msg = list()
-    if not exc:
-        exc = get_exception()
-    if exc:
-        errs = str(exc).split("\r\n")
-        for err in errs:
-            if not err:
-                continue
-            if "matched error in response:" in err:
-                continue
-            if " at '^' position" in err:
-                err = err.replace(" at '^' position", "")
-            if err.replace(" ", "") == "^":
-                continue
-            if len(err) > 2 and err[0] in ["<", "["] and err[-1] in [">", "]"]:
-                continue
-            if err[-1] == ".":
-                err = err[:-1]
-            if err.replace(" ", "") == "":
-                continue
-            msg.append(err)
-    else:
-        msg = ["Error: Fail to get cli exception message."]
-
-    while msg[-1][-1] == ' ':
-        msg[-1] = msg[-1][:-1]
-
-    if msg[-1][-1] != ".":
-        msg[-1] += "."
-
-    return ", ".join(msg).capitalize()
 
 
 class FileCopy(object):
@@ -285,7 +249,7 @@ class FileCopy(object):
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(hostname=hostname, username=username, password=password, port=port)
-        full_remote_path = '{}{}'.format(self.file_system, dest)
+        full_remote_path = '{0}{1}'.format(self.file_system, dest)
         scp = SCPClient(ssh.get_transport())
         try:
             scp.put(self.local_file, full_remote_path)

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -95,10 +95,9 @@ remote_file:
 
 import re
 import os
-import sys
 import time
 from xml.etree import ElementTree
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import get_exception, AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, run_commands, get_nc_config
 
 try:
@@ -112,6 +111,21 @@ try:
     HAS_SCP = True
 except ImportError:
     HAS_SCP = False
+
+CE_NC_GET_DISK_INFO = """
+<filter type="subtree">
+  <vfm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dfs>
+      <df>
+        <fileSys></fileSys>
+        <inputPath></inputPath>
+        <totalSize></totalSize>
+        <freeSize></freeSize>
+      </df>
+    </dfs>
+  </vfm>
+</filter>
+"""
 
 CE_NC_GET_FILE_INFO = """
 <filter type="subtree">
@@ -143,7 +157,7 @@ def get_cli_exception(exc=None):
 
     msg = list()
     if not exc:
-        exc = sys.exc_info[1]
+        exc = get_exception()
     if exc:
         errs = str(exc).split("\r\n")
         for err in errs:
@@ -215,7 +229,7 @@ class FileCopy(object):
 
         # get file info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/vfm/dirs/dir")
+        topo = root.find("vfm/dirs/dir")
         if topo is None:
             return False, 0
 
@@ -233,16 +247,19 @@ class FileCopy(object):
     def enough_space(self):
         """Whether device has enough space"""
 
-        commands = list()
-        cmd = 'dir %s' % self.file_system
-        commands.append(cmd)
-        output = run_commands(self.module, commands)
-        if not output:
-            return True
+        xml_str = CE_NC_GET_DISK_INFO
+        ret_xml = get_nc_config(self.module, xml_str)
+        if "<data/>" in ret_xml:
+            return
 
-        match = re.search(r'\((.*) KB free\)', output[0])
-        kbytes_free = match.group(1)
-        kbytes_free = kbytes_free.replace(',', '')
+        xml_str = ret_xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+
+        root = ElementTree.fromstring(xml_str)
+        topo = root.find("vfm/dfs/df/freeSize")
+        kbytes_free = topo.text
+
         file_size = os.path.getsize(self.local_file)
         if int(kbytes_free) * 1024 > file_size:
             return True
@@ -268,7 +285,7 @@ class FileCopy(object):
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(hostname=hostname, username=username, password=password, port=port)
-        full_remote_path = '{0}{1}'.format(self.file_system, dest)
+        full_remote_path = '{}{}'.format(self.file_system, dest)
         scp = SCPClient(ssh.get_transport())
         try:
             scp.put(self.local_file, full_remote_path)
@@ -302,7 +319,7 @@ class FileCopy(object):
 
         # get file info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/sshs/sshServer")
+        topo = root.find("sshs/sshServer")
         if topo is None:
             return False
 

--- a/lib/ansible/modules/network/cloudengine/ce_info_center_debug.py
+++ b/lib/ansible/modules/network/cloudengine/ce_info_center_debug.py
@@ -292,7 +292,7 @@ class InfoCenterDebug(object):
                     replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
                 root = ElementTree.fromstring(xml_str)
-                global_cfg = root.findall("data/syslog/globalParam")
+                global_cfg = root.findall("syslog/globalParam")
                 if global_cfg:
                     for tmp in global_cfg:
                         tmp_dict = dict()
@@ -370,7 +370,7 @@ class InfoCenterDebug(object):
                     replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
                 root = ElementTree.fromstring(xml_str)
-                source_cfg = root.findall("data/syslog/icSources/icSource")
+                source_cfg = root.findall("syslog/icSources/icSource")
                 if source_cfg:
                     for tmp in source_cfg:
                         tmp_dict = dict()

--- a/lib/ansible/modules/network/cloudengine/ce_info_center_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_info_center_global.py
@@ -625,7 +625,7 @@ class InfoCenterGlobal(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         channel_info["channelInfos"] = list()
-        channels = root.findall("data/syslog/icChannels/icChannel")
+        channels = root.findall("syslog/icChannels/icChannel")
         if channels:
             for channel in channels:
                 channel_dict = dict()
@@ -716,7 +716,7 @@ class InfoCenterGlobal(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         channel_direct_info["channelDirectInfos"] = list()
-        dir_channels = root.findall("data/syslog/icDirChannels/icDirChannel")
+        dir_channels = root.findall("syslog/icDirChannels/icDirChannel")
         if dir_channels:
             for ic_dir_channel in dir_channels:
                 channel_direct_dict = dict()
@@ -806,7 +806,7 @@ class InfoCenterGlobal(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         filter_info["filterInfos"] = list()
-        ic_filters = root.findall("data/syslog/icFilters/icFilter")
+        ic_filters = root.findall("syslog/icFilters/icFilter")
         if ic_filters:
             for ic_filter in ic_filters:
                 filter_dict = dict()
@@ -894,7 +894,7 @@ class InfoCenterGlobal(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         server_ip_info["serverIpInfos"] = list()
-        syslog_servers = root.findall("data/syslog/syslogServers/syslogServer")
+        syslog_servers = root.findall("syslog/syslogServers/syslogServer")
         if syslog_servers:
             for syslog_server in syslog_servers:
                 server_dict = dict()
@@ -1065,7 +1065,7 @@ class InfoCenterGlobal(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         server_domain_info["serverAddressInfos"] = list()
-        syslog_dnss = root.findall("data/syslog/syslogDNSs/syslogDNS")
+        syslog_dnss = root.findall("syslog/syslogDNSs/syslogDNS")
         if syslog_dnss:
             for syslog_dns in syslog_dnss:
                 dns_dict = dict()
@@ -1172,7 +1172,7 @@ class InfoCenterGlobal(object):
 
             root = ElementTree.fromstring(xml_str)
             global_info = root.findall(
-                "data/syslog/globalParam")
+                "syslog/globalParam")
 
             if global_info:
                 for tmp in global_info:
@@ -1253,7 +1253,7 @@ class InfoCenterGlobal(object):
 
             root = ElementTree.fromstring(xml_str)
             logfile_info = root.findall(
-                "data/syslog/icLogFileInfos/icLogFileInfo")
+                "syslog/icLogFileInfos/icLogFileInfo")
             if logfile_info:
                 for tmp in logfile_info:
                     for site in tmp:

--- a/lib/ansible/modules/network/cloudengine/ce_info_center_log.py
+++ b/lib/ansible/modules/network/cloudengine/ce_info_center_log.py
@@ -274,7 +274,7 @@ class InfoCenterLog(object):
         root = ElementTree.fromstring(xml_str)
 
         # get global param info
-        glb = root.find("data/syslog/globalParam")
+        glb = root.find("syslog/globalParam")
         if glb:
             for attr in glb:
                 if attr.tag in ["bufferSize", "logTimeStamp", "icLogBuffEn"]:
@@ -282,7 +282,7 @@ class InfoCenterLog(object):
 
         # get info-center source info
         log_dict["source"] = dict()
-        src = root.find("data/syslog/icSources/icSource")
+        src = root.find("syslog/icSources/icSource")
         if src:
             for attr in src:
                 if attr.tag in ["moduleName", "icChannelId", "icChannelName", "logEnFlg", "logEnLevel"]:

--- a/lib/ansible/modules/network/cloudengine/ce_info_center_trap.py
+++ b/lib/ansible/modules/network/cloudengine/ce_info_center_trap.py
@@ -334,7 +334,7 @@ class InfoCenterTrap(object):
                     replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
                 root = ElementTree.fromstring(xml_str)
-                global_cfg = root.findall("data/syslog/globalParam")
+                global_cfg = root.findall("syslog/globalParam")
                 if global_cfg:
                     for tmp in global_cfg:
                         tmp_dict = dict()
@@ -417,7 +417,7 @@ class InfoCenterTrap(object):
                     replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
                 root = ElementTree.fromstring(xml_str)
-                source_cfg = root.findall("data/syslog/icSources/icSource")
+                source_cfg = root.findall("syslog/icSources/icSource")
                 if source_cfg:
                     for tmp in source_cfg:
                         tmp_dict = dict()

--- a/lib/ansible/modules/network/cloudengine/ce_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_interface.py
@@ -149,6 +149,7 @@ changed:
 
 
 import re
+from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config, ce_argument_spec
 
@@ -376,21 +377,22 @@ class Interface(object):
         if "<data/>" in recv_xml:
             return intfs_info
 
-        intf = re.findall(
-            r'.*<ifName>(.*)</ifName>.*\s*<ifPhyType>(.*)</ifPhyType>.*\s*'
-            r'<ifNumber>(.*)</ifNumber>.*\s*<ifDescr>(.*)</ifDescr>.*\s*'
-            r'<isL2SwitchPort>(.*)</isL2SwitchPort>.*\s*<ifAdminStatus>'
-            r'(.*)</ifAdminStatus>.*\s*<ifMtu>(.*)</ifMtu>.*', recv_xml)
+        xml_str = recv_xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
-        for tmp in intf:
-            if tmp[1]:
-                if not intfs_info.get(tmp[1].lower()):
-                    # new interface type list
-                    intfs_info[tmp[1].lower()] = list()
-                intfs_info[tmp[1].lower()].append(dict(ifName=tmp[0], ifPhyType=tmp[1], ifNumber=tmp[2],
-                                                       ifDescr=tmp[3], isL2SwitchPort=tmp[4],
-                                                       ifAdminStatus=tmp[5], ifMtu=tmp[6]))
-
+        root = ElementTree.fromstring(xml_str)
+        intfs = root.findall("ifm/interfaces/")
+        if intfs:
+            for intf in intfs:
+                intf_type = intf.find("ifPhyType").text.lower()
+                if intf_type:
+                    if not intfs_info.get(intf_type):
+                        intfs_info[intf_type] = list()
+                    intf_info = dict()
+                    for tmp in intf:
+                        intf_info[tmp.tag] = tmp.text
+                    intfs_info[intf_type].append(intf_info)
         return intfs_info
 
     def get_interface_dict(self, ifname):
@@ -402,22 +404,15 @@ class Interface(object):
 
         if "<data/>" in recv_xml:
             return intf_info
+        xml_str = recv_xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
-        intf = re.findall(
-            r'.*<ifName>(.*)</ifName>.*\s*'
-            r'<ifPhyType>(.*)</ifPhyType>.*\s*'
-            r'<ifNumber>(.*)</ifNumber>.*\s*'
-            r'<ifDescr>(.*)</ifDescr>.*\s*'
-            r'<isL2SwitchPort>(.*)</isL2SwitchPort>.*\s*'
-            r'<ifAdminStatus>(.*)</ifAdminStatus>.*\s*'
-            r'<ifMtu>(.*)</ifMtu>.*', recv_xml)
-
-        if intf:
-            intf_info = dict(ifName=intf[0][0], ifPhyType=intf[0][1],
-                             ifNumber=intf[0][2], ifDescr=intf[0][3],
-                             isL2SwitchPort=intf[0][4],
-                             ifAdminStatus=intf[0][5], ifMtu=intf[0][6])
-
+        root = ElementTree.fromstring(xml_str)
+        intfs = root.findall("ifm/interfaces/interface/")
+        if intfs:
+            for intf in intfs:
+                intf_info[intf.tag] = intf.text
         return intf_info
 
     def create_interface(self, ifname, description, admin_state, mode, l2sub):
@@ -752,10 +747,23 @@ class Interface(object):
                 else:
                     self.existing["mode"] = "layer3"
 
+        if self.intfs_info:
+            intfs = self.intfs_info.get(self.intf_type.lower())
+            for intf in intfs:
+                intf_para = dict()
+                if intf["ifAdminStatus"]:
+                    intf_para["admin_state"] = intf["ifAdminStatus"]
+                intf_para["description"] = intf["ifDescr"]
+
+                if intf["isL2SwitchPort"] == "true":
+                    intf_para["mode"] = "layer2"
+                else:
+                    intf_para["mode"] = "layer3"
+                self.existing[intf["ifName"]] = intf_para
+
     def get_end_state(self):
         """get_end_state"""
-
-        if self.intf_info:
+        if self.interface:
             end_info = self.get_interface_dict(self.interface)
             if end_info:
                 self.end_state["interface"] = end_info["ifName"]
@@ -767,6 +775,21 @@ class Interface(object):
                         self.end_state["mode"] = "layer2"
                     else:
                         self.end_state["mode"] = "layer3"
+
+        if self.interface_type:
+            end_info = self.get_interfaces_dict()
+            intfs = end_info.get(self.intf_type.lower())
+            for intf in intfs:
+                intf_para = dict()
+                if intf["ifAdminStatus"]:
+                    intf_para["admin_state"] = intf["ifAdminStatus"]
+                intf_para["description"] = intf["ifDescr"]
+
+                if intf["isL2SwitchPort"] == "true":
+                    intf_para["mode"] = "layer2"
+                else:
+                    intf_para["mode"] = "layer3"
+                self.end_state[intf["ifName"]] = intf_para
 
     def work(self):
         """worker"""

--- a/lib/ansible/modules/network/cloudengine/ce_interface_ospf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_interface_ospf.py
@@ -424,7 +424,7 @@ class InterfaceOSPF(object):
 
         # get process base info
         root = ElementTree.fromstring(xml_str)
-        ospfsite = root.find("data/ospfv2/ospfv2comm/ospfSites/ospfSite")
+        ospfsite = root.find("ospfv2/ospfv2comm/ospfSites/ospfSite")
         if not ospfsite:
             self.module.fail_json(msg="Error: ospf process does not exist.")
 
@@ -435,7 +435,7 @@ class InterfaceOSPF(object):
         # get areas info
         ospf_info["areaId"] = ""
         areas = root.find(
-            "data/ospfv2/ospfv2comm/ospfSites/ospfSite/areas/area")
+            "ospfv2/ospfv2comm/ospfSites/ospfSite/areas/area")
         if areas:
             for area in areas:
                 if area.tag == "areaId":
@@ -445,7 +445,7 @@ class InterfaceOSPF(object):
         # get interface info
         ospf_info["interface"] = dict()
         intf = root.find(
-            "data/ospfv2/ospfv2comm/ospfSites/ospfSite/areas/area/interfaces/interface")
+            "ospfv2/ospfv2comm/ospfSites/ospfSite/areas/area/interfaces/interface")
         if intf:
             for attr in intf:
                 if attr.tag in ["ifName", "networkType",

--- a/lib/ansible/modules/network/cloudengine/ce_mlag_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_mlag_interface.py
@@ -144,8 +144,8 @@ updates:
 import re
 from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import load_config
-from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config, ce_argument_spec
+from ansible.module_utils.network.cloudengine.ce import load_config, ce_argument_spec
+from ansible.module_utils.connection import exec_command
 
 CE_NC_GET_MLAG_INFO = """
 <filter type="subtree">
@@ -163,6 +163,20 @@ CE_NC_CREATE_MLAG_INFO = """
 <mlag xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
   <mlagInstances>
     <mlagInstance operation="create">
+      <dfsgroupId>%s</dfsgroupId>
+      <mlagId>%s</mlagId>
+      <localMlagPort>%s</localMlagPort>
+    </mlagInstance>
+  </mlagInstances>
+</mlag>
+</config>
+"""
+
+CE_NC_MERGE_MLAG_INFO = """
+<config>
+<mlag xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+  <mlagInstances>
+    <mlagInstance operation="merge">
       <dfsgroupId>%s</dfsgroupId>
       <mlagId>%s</mlagId>
       <localMlagPort>%s</localMlagPort>
@@ -268,6 +282,7 @@ CE_NC_CREATE_MLAG_ERROR_DOWN_INFO = """
     <errordown operation="create">
       <dfsgroupId>1</dfsgroupId>
       <portName>%s</portName>
+      <errordownAction>Suspend</errordownAction>
     </errordown>
   </errordowns>
 </mlag>
@@ -286,6 +301,16 @@ CE_NC_DELETE_MLAG_ERROR_DOWN_INFO = """
 </mlag>
 </config>
 
+"""
+
+CE_NC_GET_SYSTEM_MAC_INFO = """
+<filter type="subtree">
+  <system xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <systemInfo>
+      <mac></mac>
+    </systemInfo>
+  </system>
+</filter>
 """
 
 
@@ -358,12 +383,6 @@ class MlagInterface(object):
         self.module = AnsibleModule(
             argument_spec=self.spec, supports_check_mode=True)
 
-    def check_response(self, xml_str, xml_name):
-        """Check if response message is already succeed."""
-
-        if "<ok/>" not in xml_str:
-            self.module.fail_json(msg='Error: %s failed.' % xml_name)
-
     def cli_add_command(self, command, undo=False):
         """add command to self.update_cmd and self.commands"""
 
@@ -371,10 +390,9 @@ class MlagInterface(object):
             cmd = "undo " + command
         else:
             cmd = command
-
-        self.commands.append(cmd)          # set to device
+        self.commands.append(cmd)
         if command.lower() not in ["quit", "return"]:
-            self.updates_cmd.append(cmd)   # show updates result
+            self.updates_cmd.append(cmd)
 
     def cli_load_config(self, commands):
         """load config by cli"""
@@ -382,109 +400,106 @@ class MlagInterface(object):
         if not self.module.check_mode:
             load_config(self.module, commands)
 
+    def get_config(self, flags=None):
+        """Retrieves the current config from the device or cache
+        """
+        flags = [] if flags is None else flags
+
+        cmd = 'display current-configuration '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
+
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        cfg = str(out).strip()
+
+        return cfg
+
     def get_mlag_info(self):
         """ get mlag info."""
 
         mlag_info = dict()
-        conf_str = CE_NC_GET_MLAG_INFO
-        xml_str = get_nc_config(self.module, conf_str)
-        if "<data/>" in xml_str:
+
+        flags = list()
+        exp = "interface eth-trunk %s" % self.eth_trunk_id
+        flags.append(exp)
+        cfg = self.get_config(flags)
+        if not cfg:
             return mlag_info
+
         else:
-            xml_str = xml_str.replace('\r', '').replace('\n', '').\
-                replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
-                replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
-
             mlag_info["mlagInfos"] = list()
-            root = ElementTree.fromstring(xml_str)
-            dfs_mlag_infos = root.findall(
-                "data/mlag/mlagInstances/mlagInstance")
+            re_find = re.findall(r'.*dfs-group\s*(\d*)\s*m-lag\s*(\d*)\s*', cfg)
+            if re_find:
+                mlag_dict = dict(dfsgroupId=re_find[0][0], mlagId=re_find[0][1], localMlagPort=self.eth_trunk_id)
+                mlag_info["mlagInfos"].append(mlag_dict)
 
-            if dfs_mlag_infos:
-                for dfs_mlag_info in dfs_mlag_infos:
-                    mlag_dict = dict()
-                    for ele in dfs_mlag_info:
-                        if ele.tag in ["dfsgroupId", "mlagId", "localMlagPort"]:
-                            mlag_dict[ele.tag] = ele.text
-                    mlag_info["mlagInfos"].append(mlag_dict)
             return mlag_info
 
     def get_mlag_global_info(self):
         """ get mlag global info."""
 
         mlag_global_info = dict()
-        conf_str = CE_NC_GET_GLOBAL_LACP_MLAG_INFO
-        xml_str = get_nc_config(self.module, conf_str)
-        if "<data/>" in xml_str:
+
+        flags = list()
+        exp = "| inc lacp"
+        flags.append(exp)
+        cfg = self.get_config(flags)
+        if not cfg:
             return mlag_global_info
+
         else:
-            xml_str = xml_str.replace('\r', '').replace('\n', '').\
-                replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
-                replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+            re_find_mac = re.findall(r'.*lacp\s*m-lag\s*system-id\s*(\S*)\s*', cfg)
+            re_find_priority = re.findall(r'.*lacp\s*m-lag\s*priority\s*(\d*)\s*', cfg)
 
-            root = ElementTree.fromstring(xml_str)
-            global_info = root.findall(
-                "data/ifmtrunk/lacpSysInfo/lacpMlagGlobal")
+            if re_find_priority:
+                mlag_global_info["lacpMlagPriority"] = re_find_priority[0]
+            if re_find_mac:
+                mlag_global_info["lacpMlagSysId"] = re_find_mac[0]
 
-            if global_info:
-                for tmp in global_info:
-                    for site in tmp:
-                        if site.tag in ["lacpMlagSysId", "lacpMlagPriority"]:
-                            mlag_global_info[site.tag] = site.text
             return mlag_global_info
 
     def get_mlag_trunk_attribute_info(self):
         """ get mlag global info."""
 
         mlag_trunk_attribute_info = dict()
-        eth_trunk = "Eth-Trunk"
-        eth_trunk += self.eth_trunk_id
-        conf_str = CE_NC_GET_LACP_MLAG_INFO % eth_trunk
-        xml_str = get_nc_config(self.module, conf_str)
-        if "<data/>" in xml_str:
+
+        flags = list()
+        exp = "interface eth-trunk %s" % self.eth_trunk_id
+        flags.append(exp)
+        cfg = self.get_config(flags)
+        if not cfg:
             return mlag_trunk_attribute_info
+
         else:
-            xml_str = xml_str.replace('\r', '').replace('\n', '').\
-                replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
-                replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+            re_find_mac = re.findall(r'.*lacp\s*m-lag\s*system-id\s*(\S*)\s*', cfg)
+            re_find_priority = re.findall(r'.*lacp\s*m-lag\s*priority\s*(\d*)\s*', cfg)
 
-            root = ElementTree.fromstring(xml_str)
-            global_info = root.findall(
-                "data/ifmtrunk/TrunkIfs/TrunkIf/lacpMlagIf")
+            if re_find_priority:
+                mlag_trunk_attribute_info["lacpMlagPriority"] = re_find_priority[0]
+            if re_find_mac:
+                mlag_trunk_attribute_info["lacpMlagSysId"] = re_find_mac[0]
 
-            if global_info:
-                for tmp in global_info:
-                    for site in tmp:
-                        if site.tag in ["lacpMlagSysId", "lacpMlagPriority"]:
-                            mlag_trunk_attribute_info[site.tag] = site.text
             return mlag_trunk_attribute_info
 
     def get_mlag_error_down_info(self):
         """ get error down info."""
 
         mlag_error_down_info = dict()
-        conf_str = CE_NC_GET_MLAG_ERROR_DOWN_INFO
-        xml_str = get_nc_config(self.module, conf_str)
-        if "<data/>" in xml_str:
+
+        flags = list()
+        exp = "interface %s" % self.interface
+        flags.append(exp)
+        cfg = self.get_config(flags)
+        if not cfg:
             return mlag_error_down_info
+
         else:
-            xml_str = xml_str.replace('\r', '').replace('\n', '').\
-                replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
-                replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+            re_find = re.findall(r'.*m-lag\s*unpaired-port\s*suspend\s*', cfg)
+            if re_find:
+                mlag_error_down_info = dict(dfsgroupId=1, portName=self.interface)
 
-            mlag_error_down_info["mlagErrorDownInfos"] = list()
-            root = ElementTree.fromstring(xml_str)
-            mlag_error_infos = root.findall(
-                "data/mlag/errordowns/errordown")
-
-            if mlag_error_infos:
-                for mlag_error_info in mlag_error_infos:
-                    mlag_error_dict = dict()
-                    for ele in mlag_error_info:
-                        if ele.tag in ["dfsgroupId", "portName"]:
-                            mlag_error_dict[ele.tag] = ele.text
-                    mlag_error_down_info[
-                        "mlagErrorDownInfos"].append(mlag_error_dict)
             return mlag_error_down_info
 
     def check_macaddr(self):
@@ -559,288 +574,95 @@ class MlagInterface(object):
                     msg='Error: Interface name of %s '
                         'is error.' % self.interface)
 
-    def is_mlag_info_change(self):
-        """whether mlag info change"""
-
-        if not self.mlag_info:
-            return True
-
-        eth_trunk = "Eth-Trunk"
-        eth_trunk += self.eth_trunk_id
-        for info in self.mlag_info["mlagInfos"]:
-            if info["mlagId"] == self.mlag_id and info["localMlagPort"] == eth_trunk:
-                return False
-        return True
-
-    def is_mlag_info_exist(self):
-        """whether mlag info exist"""
-
-        if not self.mlag_info:
-            return False
-
-        eth_trunk = "Eth-Trunk"
-        eth_trunk += self.eth_trunk_id
-
-        for info in self.mlag_info["mlagInfos"]:
-            if info["mlagId"] == self.mlag_id and info["localMlagPort"] == eth_trunk:
-                return True
-        return False
-
-    def is_mlag_error_down_info_change(self):
-        """whether mlag error down info change"""
-
-        if not self.mlag_error_down_info:
-            return True
-
-        for info in self.mlag_error_down_info["mlagErrorDownInfos"]:
-            if info["portName"].upper() == self.interface.upper():
-                return False
-        return True
-
-    def is_mlag_error_down_info_exist(self):
-        """whether mlag error down info exist"""
-
-        if not self.mlag_error_down_info:
-            return False
-
-        for info in self.mlag_error_down_info["mlagErrorDownInfos"]:
-            if info["portName"].upper() == self.interface.upper():
-                return True
-        return False
-
-    def is_mlag_interface_info_change(self):
-        """whether mlag interface attribute info change"""
-
-        if not self.mlag_trunk_attribute_info:
-            return True
-
-        if self.mlag_system_id:
-            if self.mlag_trunk_attribute_info["lacpMlagSysId"] != self.mlag_system_id:
-                return True
-        if self.mlag_priority_id:
-            if self.mlag_trunk_attribute_info["lacpMlagPriority"] != self.mlag_priority_id:
-                return True
-        return False
-
-    def is_mlag_interface_info_exist(self):
-        """whether mlag interface attribute info exist"""
-
-        if not self.mlag_trunk_attribute_info:
-            return False
-
-        if self.mlag_system_id:
-            if self.mlag_priority_id:
-                if self.mlag_trunk_attribute_info["lacpMlagSysId"] == self.mlag_system_id \
-                        and self.mlag_trunk_attribute_info["lacpMlagPriority"] == self.mlag_priority_id:
-                    return True
-            else:
-                if self.mlag_trunk_attribute_info["lacpMlagSysId"] == self.mlag_system_id:
-                    return True
-
-        if self.mlag_priority_id:
-            if self.mlag_system_id:
-                if self.mlag_trunk_attribute_info["lacpMlagSysId"] == self.mlag_system_id \
-                        and self.mlag_trunk_attribute_info["lacpMlagPriority"] == self.mlag_priority_id:
-                    return True
-            else:
-                if self.mlag_trunk_attribute_info["lacpMlagPriority"] == self.mlag_priority_id:
-                    return True
-
-        return False
-
-    def is_mlag_global_info_change(self):
-        """whether mlag global attribute info change"""
-
-        if not self.mlag_global_info:
-            return True
-
-        if self.mlag_system_id:
-            if self.mlag_global_info["lacpMlagSysId"] != self.mlag_system_id:
-                return True
-        if self.mlag_priority_id:
-            if self.mlag_global_info["lacpMlagPriority"] != self.mlag_priority_id:
-                return True
-        return False
-
-    def is_mlag_global_info_exist(self):
-        """whether mlag global attribute info exist"""
-
-        if not self.mlag_global_info:
-            return False
-
-        if self.mlag_system_id:
-            if self.mlag_priority_id:
-                if self.mlag_global_info["lacpMlagSysId"] == self.mlag_system_id \
-                        and self.mlag_global_info["lacpMlagPriority"] == self.mlag_priority_id:
-                    return True
-            else:
-                if self.mlag_global_info["lacpMlagSysId"] == self.mlag_system_id:
-                    return True
-
-        if self.mlag_priority_id:
-            if self.mlag_system_id:
-                if self.mlag_global_info["lacpMlagSysId"] == self.mlag_system_id \
-                        and self.mlag_global_info["lacpMlagPriority"] == self.mlag_priority_id:
-                    return True
-            else:
-                if self.mlag_global_info["lacpMlagPriority"] == self.mlag_priority_id:
-                    return True
-
-        return False
-
-    def create_mlag(self):
+    def set_mlag(self):
         """create mlag info"""
 
-        if self.is_mlag_info_change():
-            mlag_port = "Eth-Trunk"
-            mlag_port += self.eth_trunk_id
-            conf_str = CE_NC_CREATE_MLAG_INFO % (
-                self.dfs_group_id, self.mlag_id, mlag_port)
-            recv_xml = set_nc_config(self.module, conf_str)
-            if "<ok/>" not in recv_xml:
-                self.module.fail_json(
-                    msg='Error: create mlag info failed.')
-
-            self.updates_cmd.append("interface %s" % mlag_port)
-            self.updates_cmd.append("dfs-group %s m-lag %s" %
-                                    (self.dfs_group_id, self.mlag_id))
-            self.changed = True
+        cmd = "interface eth-trunk %s" % self.eth_trunk_id
+        self.cli_add_command(cmd)
+        cmd = "dfs-group %s m-lag %s" % (self.dfs_group_id, self.mlag_id)
+        self.cli_add_command(cmd)
+        self.cli_load_config(self.commands)
 
     def delete_mlag(self):
         """delete mlag info"""
 
-        if self.is_mlag_info_exist():
-            mlag_port = "Eth-Trunk"
-            mlag_port += self.eth_trunk_id
-            conf_str = CE_NC_DELETE_MLAG_INFO % (
-                self.dfs_group_id, self.mlag_id, mlag_port)
-            recv_xml = set_nc_config(self.module, conf_str)
-            if "<ok/>" not in recv_xml:
-                self.module.fail_json(
-                    msg='Error: delete mlag info failed.')
+        cmd = "interface eth-trunk %s" % self.eth_trunk_id
+        self.cli_add_command(cmd)
 
-            self.updates_cmd.append("interface %s" % mlag_port)
-            self.updates_cmd.append(
-                "undo dfs-group %s m-lag %s" % (self.dfs_group_id, self.mlag_id))
-            self.changed = True
+        cmd = "dfs-group %s m-lag %s" % (self.dfs_group_id, self.mlag_id)
+        self.cli_add_command(cmd, undo=True)
 
-    def create_mlag_error_down(self):
+        self.cli_load_config(self.commands)
+
+    def set_mlag_error_down(self):
         """create mlag error down info"""
 
-        if self.is_mlag_error_down_info_change():
-            conf_str = CE_NC_CREATE_MLAG_ERROR_DOWN_INFO % self.interface
-            recv_xml = set_nc_config(self.module, conf_str)
-            if "<ok/>" not in recv_xml:
-                self.module.fail_json(
-                    msg='Error: create mlag error down info failed.')
-
-            self.updates_cmd.append("interface %s" % self.interface)
-            self.updates_cmd.append("m-lag unpaired-port suspend")
-            self.changed = True
+        cmd = "interface %s" % self.interface
+        self.cli_add_command(cmd)
+        cmd = "m-lag unpaired-port suspend"
+        self.cli_add_command(cmd)
+        self.cli_load_config(self.commands)
 
     def delete_mlag_error_down(self):
         """delete mlag error down info"""
 
-        if self.is_mlag_error_down_info_exist():
-
-            conf_str = CE_NC_DELETE_MLAG_ERROR_DOWN_INFO % self.interface
-            recv_xml = set_nc_config(self.module, conf_str)
-            if "<ok/>" not in recv_xml:
-                self.module.fail_json(
-                    msg='Error: delete mlag error down info failed.')
-
-            self.updates_cmd.append("interface %s" % self.interface)
-            self.updates_cmd.append("undo m-lag unpaired-port suspend")
-            self.changed = True
+        cmd = "interface %s" % self.interface
+        self.cli_add_command(cmd)
+        cmd = "m-lag unpaired-port suspend"
+        self.cli_add_command(cmd, undo=True)
+        self.cli_load_config(self.commands)
 
     def set_mlag_interface(self):
         """set mlag interface atrribute info"""
 
-        if self.is_mlag_interface_info_change():
-            mlag_port = "Eth-Trunk"
-            mlag_port += self.eth_trunk_id
-            conf_str = CE_NC_SET_LACP_MLAG_INFO_HEAD % mlag_port
+        if self.mlag_priority_id or self.mlag_system_id:
+            cmd = "interface eth-trunk %s" % self.eth_trunk_id
+            self.cli_add_command(cmd)
             if self.mlag_priority_id:
-                conf_str += "<lacpMlagPriority>%s</lacpMlagPriority>" % self.mlag_priority_id
+                cmd = "lacp m-lag priority %s" % self.mlag_priority_id
+                self.cli_add_command(cmd)
             if self.mlag_system_id:
-                conf_str += "<lacpMlagSysId>%s</lacpMlagSysId>" % self.mlag_system_id
-            conf_str += CE_NC_SET_LACP_MLAG_INFO_TAIL
-            recv_xml = set_nc_config(self.module, conf_str)
-            if "<ok/>" not in recv_xml:
-                self.module.fail_json(
-                    msg='Error: set mlag interface atrribute info failed.')
+                cmd = "lacp m-lag system %s" % self.mlag_system_id
+                self.cli_add_command(cmd)
 
-            self.updates_cmd.append("interface %s" % mlag_port)
-            if self.mlag_priority_id:
-                self.updates_cmd.append(
-                    "lacp m-lag priority %s" % self.mlag_priority_id)
-
-            if self.mlag_system_id:
-                self.updates_cmd.append(
-                    "lacp m-lag system-id %s" % self.mlag_system_id)
-            self.changed = True
+            self.cli_load_config(self.commands)
 
     def delete_mlag_interface(self):
         """delete mlag interface attribute info"""
 
-        if self.is_mlag_interface_info_exist():
-            mlag_port = "Eth-Trunk"
-            mlag_port += self.eth_trunk_id
-
-            cmd = "interface %s" % mlag_port
+        if self.mlag_priority_id or self.mlag_system_id:
+            cmd = "interface eth-trunk %s" % self.eth_trunk_id
             self.cli_add_command(cmd)
-
             if self.mlag_priority_id:
                 cmd = "lacp m-lag priority %s" % self.mlag_priority_id
-                self.cli_add_command(cmd, True)
-
+                self.cli_add_command(cmd, undo=True)
             if self.mlag_system_id:
-                cmd = "lacp m-lag system-id %s" % self.mlag_system_id
-                self.cli_add_command(cmd, True)
+                cmd = "lacp m-lag system %s" % self.mlag_system_id
+                self.cli_add_command(cmd, undo=True)
 
-            if self.commands:
-                self.cli_load_config(self.commands)
-                self.changed = True
+            self.cli_load_config(self.commands)
 
     def set_mlag_global(self):
         """set mlag global attribute info"""
 
-        if self.is_mlag_global_info_change():
-            conf_str = CE_NC_SET_GLOBAL_LACP_MLAG_INFO_HEAD
-            if self.mlag_priority_id:
-                conf_str += "<lacpMlagPriority>%s</lacpMlagPriority>" % self.mlag_priority_id
-            if self.mlag_system_id:
-                conf_str += "<lacpMlagSysId>%s</lacpMlagSysId>" % self.mlag_system_id
-            conf_str += CE_NC_SET_GLOBAL_LACP_MLAG_INFO_TAIL
-            recv_xml = set_nc_config(self.module, conf_str)
-            if "<ok/>" not in recv_xml:
-                self.module.fail_json(
-                    msg='Error: set mlag interface atrribute info failed.')
-
-            if self.mlag_priority_id:
-                self.updates_cmd.append(
-                    "lacp m-lag priority %s" % self.mlag_priority_id)
-
-            if self.mlag_system_id:
-                self.updates_cmd.append(
-                    "lacp m-lag system-id %s" % self.mlag_system_id)
-            self.changed = True
+        if self.mlag_priority_id:
+            cmd = "lacp m-lag priority %s" % self.mlag_priority_id
+            self.cli_add_command(cmd)
+        if self.mlag_system_id:
+            cmd = "lacp m-lag system %s" % self.mlag_system_id
+            self.cli_add_command(cmd)
+            self.cli_load_config(self.commands)
 
     def delete_mlag_global(self):
         """delete mlag global attribute info"""
 
-        if self.is_mlag_global_info_exist():
-            if self.mlag_priority_id:
-                cmd = "lacp m-lag priority %s" % self.mlag_priority_id
-                self.cli_add_command(cmd, True)
-
-            if self.mlag_system_id:
-                cmd = "lacp m-lag system-id %s" % self.mlag_system_id
-                self.cli_add_command(cmd, True)
-
-            if self.commands:
-                self.cli_load_config(self.commands)
-                self.changed = True
+        if self.mlag_priority_id:
+            cmd = "lacp m-lag priority %s" % self.mlag_priority_id
+            self.cli_add_command(cmd, undo=True)
+        if self.mlag_system_id:
+            cmd = "lacp m-lag system %s" % self.mlag_system_id
+            self.cli_add_command(cmd, undo=True)
+            self.cli_load_config(self.commands)
 
     def get_proposed(self):
         """get proposed info"""
@@ -865,37 +687,32 @@ class MlagInterface(object):
     def get_existing(self):
         """get existing info"""
 
-        self.mlag_info = self.get_mlag_info()
-        self.mlag_global_info = self.get_mlag_global_info()
-        self.mlag_error_down_info = self.get_mlag_error_down_info()
-
         if self.eth_trunk_id or self.dfs_group_id or self.mlag_id:
+            self.mlag_info = self.get_mlag_info()
             if not self.mlag_system_id and not self.mlag_priority_id:
                 if self.mlag_info:
                     self.existing["mlagInfos"] = self.mlag_info["mlagInfos"]
 
         if self.mlag_system_id or self.mlag_priority_id:
             if self.eth_trunk_id:
+                self.mlag_trunk_attribute_info = self.get_mlag_trunk_attribute_info()
                 if self.mlag_trunk_attribute_info:
                     if self.mlag_system_id:
-                        self.end_state["lacpMlagSysId"] = self.mlag_trunk_attribute_info[
-                            "lacpMlagSysId"]
+                        self.existing["lacpMlagSysId"] = self.mlag_trunk_attribute_info.get("lacpMlagSysId")
                     if self.mlag_priority_id:
-                        self.end_state["lacpMlagPriority"] = self.mlag_trunk_attribute_info[
-                            "lacpMlagPriority"]
+                        self.existing["lacpMlagPriority"] = self.mlag_trunk_attribute_info.get("lacpMlagPriority")
             else:
+                self.mlag_global_info = self.get_mlag_global_info()
                 if self.mlag_global_info:
                     if self.mlag_system_id:
-                        self.end_state["lacpMlagSysId"] = self.mlag_global_info[
-                            "lacpMlagSysId"]
+                        self.existing["lacpMlagSysId"] = self.mlag_global_info.get("lacpMlagSysId")
                     if self.mlag_priority_id:
-                        self.end_state["lacpMlagPriority"] = self.mlag_global_info[
-                            "lacpMlagPriority"]
+                        self.existing["lacpMlagPriority"] = self.mlag_global_info.get("lacpMlagPriority")
 
         if self.interface or self.mlag_error_down:
+            self.mlag_error_down_info = self.get_mlag_error_down_info()
             if self.mlag_error_down_info:
-                self.existing["mlagErrorDownInfos"] = self.mlag_error_down_info[
-                    "mlagErrorDownInfos"]
+                self.existing["mlagErrorDownInfos"] = self.mlag_error_down_info
 
     def get_end_state(self):
         """get end state info"""
@@ -911,26 +728,21 @@ class MlagInterface(object):
                 self.mlag_trunk_attribute_info = self.get_mlag_trunk_attribute_info()
                 if self.mlag_trunk_attribute_info:
                     if self.mlag_system_id:
-                        self.end_state["lacpMlagSysId"] = self.mlag_trunk_attribute_info[
-                            "lacpMlagSysId"]
+                        self.end_state["lacpMlagSysId"] = self.mlag_trunk_attribute_info.get("lacpMlagSysId")
                     if self.mlag_priority_id:
-                        self.end_state["lacpMlagPriority"] = self.mlag_trunk_attribute_info[
-                            "lacpMlagPriority"]
+                        self.end_state["lacpMlagPriority"] = self.mlag_trunk_attribute_info.get("lacpMlagPriority")
             else:
                 self.mlag_global_info = self.get_mlag_global_info()
                 if self.mlag_global_info:
                     if self.mlag_system_id:
-                        self.end_state["lacpMlagSysId"] = self.mlag_global_info[
-                            "lacpMlagSysId"]
+                        self.end_state["lacpMlagSysId"] = self.mlag_global_info.get("lacpMlagSysId")
                     if self.mlag_priority_id:
-                        self.end_state["lacpMlagPriority"] = self.mlag_global_info[
-                            "lacpMlagPriority"]
+                        self.end_state["lacpMlagPriority"] = self.mlag_global_info.get("lacpMlagPriority")
 
         if self.interface or self.mlag_error_down:
             self.mlag_error_down_info = self.get_mlag_error_down_info()
             if self.mlag_error_down_info:
-                self.end_state["mlagErrorDownInfos"] = self.mlag_error_down_info[
-                    "mlagErrorDownInfos"]
+                self.end_state["mlagErrorDownInfos"] = self.mlag_error_down_info
 
     def work(self):
         """worker"""
@@ -941,11 +753,29 @@ class MlagInterface(object):
 
         if self.eth_trunk_id or self.dfs_group_id or self.mlag_id:
             self.mlag_info = self.get_mlag_info()
+
             if self.eth_trunk_id and self.dfs_group_id and self.mlag_id:
-                if self.state == "present":
-                    self.create_mlag()
+                mlag_cfg = self.mlag_info["mlagInfos"]
+                port_cfg = None
+                for cfg in mlag_cfg:
+                    if cfg.get("localMlagPort") == self.eth_trunk_id:
+                        port_cfg = cfg
+
+                if port_cfg:
+                    if self.state == "present":
+                        if self.dfs_group_id != port_cfg.get("dfsgroupId") or self.mlag_id != port_cfg.get("mlagId"):
+                            self.set_mlag()
+                            self.changed = True
+
+                    else:
+                        if self.dfs_group_id == port_cfg.get("dfsgroupId") and self.mlag_id == port_cfg.get("mlagId"):
+                            self.delete_mlag()
+                            self.changed = True
                 else:
-                    self.delete_mlag()
+                    if self.state == "present":
+                        self.set_mlag()
+                        self.changed = True
+
             else:
                 if not self.mlag_system_id and not self.mlag_priority_id:
                     self.module.fail_json(
@@ -954,27 +784,42 @@ class MlagInterface(object):
         if self.mlag_system_id or self.mlag_priority_id:
 
             if self.eth_trunk_id:
-                self.mlag_trunk_attribute_info = self.get_mlag_trunk_attribute_info()
-                if self.mlag_system_id or self.mlag_priority_id:
+                mlag_trunk_attribute_info = self.get_mlag_trunk_attribute_info()
+                if self.mlag_system_id != mlag_trunk_attribute_info.get("lacpMlagSysId") or \
+                        self.mlag_priority_id != mlag_trunk_attribute_info.get("lacpMlagPriority"):
                     if self.state == "present":
                         self.set_mlag_interface()
-                    else:
+                        self.changed = True
+
+                if self.mlag_system_id == mlag_trunk_attribute_info.get("lacpMlagSysId") and \
+                        self.mlag_priority_id == mlag_trunk_attribute_info.get("lacpMlagPriority"):
+
+                    if self.state == "absent":
                         self.delete_mlag_interface()
+                        self.changed = True
             else:
-                self.mlag_global_info = self.get_mlag_global_info()
-                if self.mlag_system_id or self.mlag_priority_id:
+                mlag_global_info = self.get_mlag_global_info()
+                if self.mlag_system_id != mlag_global_info.get("lacpMlagSysId") or \
+                        self.mlag_priority_id != mlag_global_info.get("lacpMlagPriority"):
                     if self.state == "present":
                         self.set_mlag_global()
-                    else:
+                        self.changed = True
+
+                if self.mlag_system_id == mlag_global_info.get("lacpMlagSysId") and \
+                        self.mlag_priority_id == mlag_global_info.get("lacpMlagPriority"):
+                    if self.state == "absent":
                         self.delete_mlag_global()
+                        self.changed = True
 
         if self.interface or self.mlag_error_down:
-            self.mlag_error_down_info = self.get_mlag_error_down_info()
+            mlag_error_down_info = self.get_mlag_error_down_info()
             if self.interface and self.mlag_error_down:
-                if self.mlag_error_down == "enable":
-                    self.create_mlag_error_down()
-                else:
+                if self.mlag_error_down == "enable" and not mlag_error_down_info:
+                    self.set_mlag_error_down()
+                    self.changed = True
+                if self.mlag_error_down == "disable" and mlag_error_down_info:
                     self.delete_mlag_error_down()
+                    self.changed = True
             else:
                 self.module.fail_json(
                     msg='Error: interface, mlag_error_down must be config at the same time.')

--- a/lib/ansible/modules/network/cloudengine/ce_ntp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_ntp.py
@@ -442,7 +442,7 @@ class Ntp(object):
 
         # get all ntp config info
         root = ElementTree.fromstring(xml_str)
-        ntpsite = root.findall("data/ntp/ntpUCastCfgs/ntpUCastCfg")
+        ntpsite = root.findall("ntp/ntpUCastCfgs/ntpUCastCfg")
         for nexthop in ntpsite:
             ntp_dict = dict()
             for ele in nexthop:

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -134,7 +134,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool', default='false'),
+        confirm=dict(required=True, type='bool'),
         save_config=dict(required=False, type='bool', default='false')
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,13 +34,13 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        default: false
+        default: False
     save_config:
         description:
             - Flag indicating whether to save the configuration.
-        required: false
+        required: False
         type: bool
-        default: false
+        default: False
 '''
 
 EXAMPLES = '''
@@ -134,8 +134,8 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool'),
-        save_config=dict(required=False, type='bool', default='false')
+        confirm=dict(required=True, type='bool', default=False),
+        save_config=dict(required=False, type='bool', default=False)
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_static_route.py
+++ b/lib/ansible/modules/network/cloudengine/ce_static_route.py
@@ -276,7 +276,7 @@ def is_valid_v6addr(addr):
         addr_list = addr.split(':')
         if len(addr_list) > 6:
             return False
-        if addr_list[1] != "":
+        if addr_list[1] == "":
             return False
         return True
     return False
@@ -393,6 +393,7 @@ class StaticRoute(object):
             if self.prefix.find('.') == -1:
                 return False
             if self.mask == '32':
+                self.prefix = self.prefix
                 return True
             if self.mask == '0':
                 self.prefix = '0.0.0.0'
@@ -407,12 +408,13 @@ class StaticRoute(object):
                 if int(each_num) > 255:
                     return False
             byte_len = 8
-            ip_len = int(self.mask) / byte_len
+            ip_len = int(self.mask) // byte_len
             ip_bit = int(self.mask) % byte_len
         else:
             if self.prefix.find(':') == -1:
                 return False
             if self.mask == '128':
+                self.prefix = self.prefix
                 return True
             if self.mask == '0':
                 self.prefix = '::'
@@ -422,7 +424,7 @@ class StaticRoute(object):
             if length > 6:
                 return False
             byte_len = 16
-            ip_len = int(self.mask) / byte_len
+            ip_len = int(self.mask) // byte_len
             ip_bit = int(self.mask) % byte_len
 
         if self.aftype == "v4":
@@ -571,7 +573,7 @@ class StaticRoute(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         static_routes = root.findall(
-            "data/staticrt/staticrtbase/srRoutes/srRoute")
+            "staticrt/staticrtbase/srRoutes/srRoute")
 
         if static_routes:
             for static_route in static_routes:
@@ -763,6 +765,8 @@ class StaticRoute(object):
 
         self.get_static_route(self.state)
         self.end_state['sroute'] = self.static_routes_info["sroute"]
+        if self.existing['sroute'] == self.end_state['sroute']:
+            self.changed = False
 
     def work(self):
         """worker"""

--- a/lib/ansible/modules/network/cloudengine/ce_static_route.py
+++ b/lib/ansible/modules/network/cloudengine/ce_static_route.py
@@ -150,6 +150,7 @@ changed:
 '''
 
 
+import re
 from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config, ce_argument_spec

--- a/lib/ansible/modules/network/cloudengine/ce_static_route.py
+++ b/lib/ansible/modules/network/cloudengine/ce_static_route.py
@@ -274,10 +274,20 @@ def is_valid_v6addr(addr):
     """check if ipv6 addr is valid"""
     if addr.find(':') != -1:
         addr_list = addr.split(':')
-        if len(addr_list) > 6:
+        if len(addr_list) > 8:
             return False
-        if addr_list[1] == "":
-            return False
+        re_find = re.findall(r"::", addr)
+        if re_find:
+            if len(re_find) > 1:
+                return False
+        if len(addr_list) < 8:
+            if not re_find:
+                return False
+        for addr in addr_list:
+            if len(addr) > 4:
+                return False
+            if re.findall(r"[^0-9a-fA-F]", addr):
+                return False
         return True
     return False
 
@@ -607,6 +617,9 @@ class StaticRoute(object):
                 if not is_valid_v4addr(self.next_hop):
                     self.module.fail_json(
                         msg='Error: The %s is not a valid address' % self.next_hop)
+            if not is_valid_v4addr(self.prefix):
+                self.module.fail_json(
+                    msg='Error: The %s is not a valid address' % self.prefix)
         # ipv6 check
         if self.aftype == "v6":
             if int(self.mask) > 128 or int(self.mask) < 0:
@@ -616,6 +629,9 @@ class StaticRoute(object):
                 if not is_valid_v6addr(self.next_hop):
                     self.module.fail_json(
                         msg='Error: The %s is not a valid address' % self.next_hop)
+            if not is_valid_v6addr(self.prefix):
+                self.module.fail_json(
+                    msg='Error: The %s is not a valid address' % self.prefix)
 
         # description check
         if self.description:

--- a/lib/ansible/modules/network/cloudengine/ce_stp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_stp.py
@@ -167,7 +167,7 @@ updates:
 
 import re
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config, ce_argument_spec
+from ansible.module_utils.network.cloudengine.ce import get_config, load_config, ce_argument_spec, exec_command
 
 
 class Stp(object):
@@ -219,20 +219,22 @@ class Stp(object):
     def cli_get_stp_config(self):
         """ Cli get stp configuration """
 
-        regular = "| include stp"
+        cmd = "display current-configuration | include stp"
 
-        flags = list()
-        flags.append(regular)
-        self.stp_cfg = get_config(self.module, flags)
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self._module.fail_json(msg=err)
+        self.stp_cfg = str(out).strip()
 
     def cli_get_interface_stp_config(self):
         """ Cli get interface's stp configuration """
 
         if self.interface:
-            regular = "| ignore-case section include ^interface %s$" % self.interface
-            flags = list()
-            flags.append(regular)
-            tmp_cfg = get_config(self.module, flags)
+            cmd = "display current-configuration | ignore-case section include ^interface %s$" % self.interface
+            rc, out, err = exec_command(self.module, cmd)
+            if rc != 0:
+                self._module.fail_json(msg=err)
+            tmp_cfg = str(out).strip()
 
             if not tmp_cfg:
                 self.module.fail_json(

--- a/lib/ansible/modules/network/cloudengine/ce_stp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_stp.py
@@ -223,18 +223,21 @@ class Stp(object):
 
         rc, out, err = exec_command(self.module, cmd)
         if rc != 0:
-            self._module.fail_json(msg=err)
+            self.module.fail_json(msg=err)
         self.stp_cfg = str(out).strip()
 
     def cli_get_interface_stp_config(self):
         """ Cli get interface's stp configuration """
 
         if self.interface:
-            cmd = "display current-configuration | ignore-case section include ^interface %s$" % self.interface
+            cmd = "display current-configuration | ignore-case section include interface %s" % self.interface
             rc, out, err = exec_command(self.module, cmd)
             if rc != 0:
-                self._module.fail_json(msg=err)
-            tmp_cfg = str(out).strip()
+                self.module.fail_json(msg=err)
+            cfg_list = out.split('\n')
+            tmp_cfg = out
+            if len(cfg_list) > 0 and cfg_list[0].startswith('display'):
+                tmp_cfg = '\n'.join(cfg_list[1:])
 
             if not tmp_cfg:
                 self.module.fail_json(

--- a/lib/ansible/modules/network/cloudengine/ce_vrf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf.py
@@ -214,7 +214,7 @@ class Vrf(object):
 
         root = ElementTree.fromstring(xml_str)
         vpn_instances = root.findall(
-            "data/l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
+            "l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
         if vpn_instances:
             for vpn_instance in vpn_instances:
                 if vpn_instance.find('vrfName').text == self.vrf:

--- a/lib/ansible/modules/network/cloudengine/ce_vrf_af.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf_af.py
@@ -568,7 +568,7 @@ class VrfAf(object):
 
         # get the vpn address family and RD text
         vrf_addr_types = root.findall(
-            "data/l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance/vpnInstAFs/vpnInstAF")
+            "l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance/vpnInstAFs/vpnInstAF")
         if vrf_addr_types:
             for vrf_addr_type in vrf_addr_types:
                 vrf_af_info = dict()

--- a/lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
@@ -147,7 +147,7 @@ CE_NC_GET_VRF_INTERFACE = """
           <vrfName></vrfName>
           <l3vpnIfs>
             <l3vpnIf>
-              <ifName></ifName>
+              <ifName>%s</ifName>
             </l3vpnIf>
           </l3vpnIfs>
         </l3vpnInstance>
@@ -353,13 +353,13 @@ class VrfInterface(object):
         for l3vpn_ifinfo in l3vpn_if:
             for ele in l3vpn_ifinfo:
                 if ele.tag in ['ifName']:
-                    if ele.text == self.vpn_interface:
+                    if ele.text.lower() == self.vpn_interface.lower():
                         self.intf_info['vrfName'] = vpn_name
 
     def get_interface_vpn(self):
         """ get the VPN instance associated with the interface"""
 
-        xml_str = CE_NC_GET_VRF_INTERFACE
+        xml_str = CE_NC_GET_VRF_INTERFACE % (self.vpn_interface)
         con_obj = get_nc_config(self.module, xml_str)
         if "<data/>" in con_obj:
             return
@@ -371,14 +371,13 @@ class VrfInterface(object):
         # get global vrf interface info
         root = ElementTree.fromstring(xml_str)
         vpns = root.findall(
-            "data/l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
+            "l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
         if vpns:
             for vpnele in vpns:
                 vpn_name = None
                 for vpninfo in vpnele:
                     if vpninfo.tag == 'vrfName':
                         vpn_name = vpninfo.text
-
                     if vpninfo.tag == 'l3vpnIfs':
                         self.get_interface_vpn_name(vpninfo, vpn_name)
 
@@ -408,7 +407,7 @@ class VrfInterface(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
         root = ElementTree.fromstring(xml_str)
-        interface = root.find("data/ifm/interfaces/interface")
+        interface = root.find("ifm/interfaces/interface")
         if interface:
             for eles in interface:
                 if eles.tag in ["isL2SwitchPort"]:

--- a/lib/ansible/modules/network/cloudengine/ce_vrrp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrrp.py
@@ -482,7 +482,7 @@ class Vrrp(object):
             virtual_ip_info["vrrpVirtualIpInfos"] = list()
             root = ElementTree.fromstring(xml_str)
             vrrp_virtual_ip_infos = root.findall(
-                "data/vrrp/vrrpGroups/vrrpGroup/virtualIps/virtualIp")
+                "vrrp/vrrpGroups/vrrpGroup/virtualIps/virtualIp")
             if vrrp_virtual_ip_infos:
                 for vrrp_virtual_ip_info in vrrp_virtual_ip_infos:
                     virtual_ip_dict = dict()
@@ -508,7 +508,7 @@ class Vrrp(object):
 
             root = ElementTree.fromstring(xml_str)
             global_info = root.findall(
-                "data/vrrp/vrrpGlobalCfg")
+                "vrrp/vrrpGlobalCfg")
 
             if global_info:
                 for tmp in global_info:
@@ -532,7 +532,7 @@ class Vrrp(object):
 
             root = ElementTree.fromstring(xml_str)
             global_info = root.findall(
-                "data/vrrp/vrrpGroups/vrrpGroup")
+                "vrrp/vrrpGroups/vrrpGroup")
 
             if global_info:
                 for tmp in global_info:
@@ -693,12 +693,11 @@ class Vrrp(object):
 
     def is_vrrp_group_info_change(self):
         """whether vrrp group attribute info change"""
-
         if self.vrrp_type:
             if self.vrrp_group_info["vrrpType"] != self.vrrp_type:
                 return True
         if self.admin_ignore_if_down:
-            if self.vrrp_group_info["adminIgnoreIfDown"] != self.admin_ignore_if_down:
+            if self.vrrp_group_info["adminIgnoreIfDown"] != str(self.admin_ignore_if_down).lower():
                 return True
         if self.admin_vrid:
             if self.vrrp_group_info["adminVrrpId"] != self.admin_vrid:
@@ -745,7 +744,7 @@ class Vrrp(object):
             if self.vrrp_group_info["vrrpType"] != self.vrrp_type:
                 return False
         if self.admin_ignore_if_down:
-            if self.vrrp_group_info["adminIgnoreIfDown"] != self.admin_ignore_if_down:
+            if self.vrrp_group_info["adminIgnoreIfDown"] != str(self.admin_ignore_if_down).lower():
                 return False
         if self.admin_vrid:
             if self.vrrp_group_info["adminVrrpId"] != self.admin_vrid:
@@ -1174,7 +1173,7 @@ class Vrrp(object):
             self.existing["vrrp_type"] = self.vrrp_group_info["vrrpType"]
             if self.vrrp_type == "admin":
                 self.existing["admin_ignore_if_down"] = self.vrrp_group_info[
-                    "authenticationMode"]
+                    "adminIgnoreIfDown"]
             if self.admin_vrid and self.admin_interface:
                 self.existing["admin_vrid"] = self.vrrp_group_info[
                     "adminVrrpId"]
@@ -1237,7 +1236,7 @@ class Vrrp(object):
             self.end_state["vrrp_type"] = self.vrrp_group_info["vrrpType"]
             if self.vrrp_type == "admin":
                 self.end_state["admin_ignore_if_down"] = self.vrrp_group_info[
-                    "authenticationMode"]
+                    "adminIgnoreIfDown"]
             if self.admin_vrid and self.admin_interface:
                 self.existing["admin_vrid"] = self.vrrp_group_info[
                     "adminVrrpId"]

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_arp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_arp.py
@@ -150,8 +150,9 @@ changed:
 
 import re
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config
+from ansible.module_utils.network.cloudengine.ce import load_config
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
+from ansible.module_utils.connection import exec_command
 
 
 def is_config_exist(cmp_cfg, test_cfg):
@@ -265,6 +266,22 @@ class VxlanArp(object):
         if not self.module.check_mode:
             load_config(self.module, commands)
 
+    def get_config(self, flags=None):
+        """Retrieves the current config from the device or cache
+        """
+        flags = [] if flags is None else flags
+
+        cmd = 'display current-configuration '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
+
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        cfg = str(out).strip()
+
+        return cfg
+
     def get_current_config(self):
         """get current configuration"""
 
@@ -277,9 +294,14 @@ class VxlanArp(object):
             exp += "|^bridge-domain %s$" % self.bridge_domain_id
 
         flags.append(exp)
-        config = get_config(self.module, flags)
+        cfg_str = self.get_config(flags)
+        config = cfg_str.split("\n")
 
-        return config
+        exist_config = ""
+        for cfg in config:
+            if not cfg.startswith("display"):
+                exist_config += cfg
+        return exist_config
 
     def cli_add_command(self, command, undo=False):
         """add command to self.update_cmd and self.commands"""

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_gateway.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_gateway.py
@@ -400,9 +400,9 @@ class VxlanGateway(object):
         flags = list()
         exp = " | ignore-case section include dfs-group"
         if self.vpn_instance:
-            exp += "|^ip vpn-instance %s$" % self.vpn_instance
+            exp += "| ip vpn-instance %s" % self.vpn_instance
         if self.vbdif_name:
-            exp += "|^interface %s$" % self.vbdif_name
+            exp += "| interface %s " % self.vbdif_name
         flags.append(exp)
         return self.get_config(flags)
 

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_global.py
@@ -123,23 +123,10 @@ changed:
 '''
 
 import re
-from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config, get_nc_config
+from ansible.module_utils.network.cloudengine.ce import load_config
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
-
-
-CE_NC_GET_BRIDGE_DOMAIN = """
-    <filter type="subtree">
-      <evc xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-        <bds>
-          <bd>
-            <bdId></bdId>
-          </bd>
-        </bds>
-      </evc>
-    </filter>
-"""
+from ansible.module_utils.connection import exec_command
 
 
 def is_config_exist(cmp_cfg, test_cfg):
@@ -206,13 +193,29 @@ class VxlanGlobal(object):
         if not self.module.check_mode:
             load_config(self.module, commands)
 
+    def get_config(self, flags=None):
+        """Retrieves the current config from the device or cache
+        """
+        flags = [] if flags is None else flags
+
+        cmd = 'display current-configuration '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
+
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        cfg = str(out).strip()
+
+        return cfg
+
     def get_current_config(self):
         """get current configuration"""
 
         flags = list()
         exp = " include-default | include vxlan|assign | exclude undo"
         flags.append(exp)
-        return get_config(self.module, flags)
+        return self.get_config(flags)
 
     def cli_add_command(self, command, undo=False):
         """add command to self.update_cmd and self.commands"""
@@ -228,27 +231,15 @@ class VxlanGlobal(object):
 
     def get_bd_list(self):
         """get bridge domain list"""
-
+        flags = list()
         bd_info = list()
-        conf_str = CE_NC_GET_BRIDGE_DOMAIN
-        xml_str = get_nc_config(self.module, conf_str)
-        if "<data/>" in xml_str:
+        exp = " include-default | include bridge-domain | exclude undo"
+        flags.append(exp)
+        bd_str = self.get_config(flags)
+        if not bd_str:
             return bd_info
-
-        xml_str = xml_str.replace('\r', '').replace('\n', '').\
-            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
-            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
-
-        # get bridge domain info
-        root = ElementTree.fromstring(xml_str)
-        bds = root.findall("data/evc/bds/bd/bdId")
-        if not bds:
-            return bd_info
-
-        for bridge_domain in bds:
-            if bridge_domain.tag == "bdId":
-                bd_info.append(bridge_domain.text)
-
+        bd_num = re.findall(r'bridge-domain\s*([0-9]+)', bd_str)
+        bd_info.append(bd_num)
         return bd_info
 
     def config_bridge_domain(self):

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
@@ -451,9 +451,6 @@ class VxlanVap(object):
         conf_str = CE_NC_GET_BD_VAP % self.bridge_domain_id
         xml_str = get_nc_config(self.module, conf_str)
 
-        if "<data/>" in xml_str:
-            return vap_info
-
         xml_str = xml_str.replace('\r', '').replace('\n', '').\
             replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
@@ -462,8 +459,7 @@ class VxlanVap(object):
         vap_info["bdId"] = self.bridge_domain_id
         root = ElementTree.fromstring(xml_str)
         vap_info["vlanList"] = ""
-        vap_vlan = root.find("data/evc/bds/bd/bdBindVlan")
-        vap_info["vlanList"] = ""
+        vap_vlan = root.find("evc/bds/bd/bdBindVlan")
         if vap_vlan:
             for ele in vap_vlan:
                 if ele.tag == "vlanList":
@@ -471,7 +467,7 @@ class VxlanVap(object):
 
         # get vap: l2 su-interface
         vap_ifs = root.findall(
-            "data/evc/bds/bd/servicePoints/servicePoint/ifName")
+            "evc/bds/bd/servicePoints/servicePoint/ifName")
         if_list = list()
         if vap_ifs:
             for vap_if in vap_ifs:
@@ -500,7 +496,7 @@ class VxlanVap(object):
 
         # get l2 sub interface encapsulation info
         root = ElementTree.fromstring(xml_str)
-        bds = root.find("data/ethernet/servicePoints/servicePoint")
+        bds = root.find("ethernet/servicePoints/servicePoint")
         if not bds:
             return intf_info
 
@@ -510,7 +506,7 @@ class VxlanVap(object):
 
         if intf_info.get("flowType") == "dot1q":
             ce_vid = root.find(
-                "data/ethernet/servicePoints/servicePoint/flowDot1qs")
+                "ethernet/servicePoints/servicePoint/flowDot1qs")
             intf_info["dot1qVids"] = ""
             if ce_vid:
                 for ele in ce_vid:
@@ -518,7 +514,7 @@ class VxlanVap(object):
                         intf_info["dot1qVids"] = ele.text
         elif intf_info.get("flowType") == "qinq":
             vids = root.find(
-                "data/ethernet/servicePoints/servicePoint/flowQinqs/flowQinq")
+                "ethernet/servicePoints/servicePoint/flowQinqs/flowQinq")
             if vids:
                 for ele in vids:
                     if ele.tag in ["peVlanId", "ceVids"]:
@@ -707,9 +703,9 @@ class VxlanVap(object):
 
     def config_vap_vlan(self):
         """configure a VLAN as a service access point"""
-
-        if not self.vap_info:
-            self.module.fail_json(msg="Error: Bridge domain %s does not exist." % self.bridge_domain_id)
+        #
+        # if not self.vap_info:
+        #     self.module.fail_json(msg="Error: Bridge domain %s does not exist." % self.bridge_domain_id)
 
         xml_str = ""
         if self.state == "present":

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -19,7 +19,13 @@ from ansible.utils.display import Display
 
 display = Display()
 
-CLI_SUPPORTED_MODULES = ['ce_config', 'ce_command', 'ce_facts']
+CLI_SUPPORTED_MODULES = ['ce_rollback', 'ce_mlag_interface', 'ce_startup', 'ce_config',
+                         'ce_command', 'ce_facts', 'ce_evpn_global', 'ce_evpn_bgp_rr',
+                         'ce_mtu', 'ce_evpn_bgp', 'ce_snmp_location', 'ce_snmp_contact',
+                         'ce_snmp_traps', 'ce_netstream_global', 'ce_netstream_aging',
+                         'ce_netstream_export', 'ce_netstream_template', 'ce_ntp_auth',
+                         'ce_stp', 'ce_vxlan_global', 'ce_vxlan_arp', 'ce_vxlan_gateway',
+                         'ce_acl_interface']
 
 
 class ActionModule(ActionNetworkModule):


### PR DESCRIPTION
SUMMARY
CLI_SUPPORTED_MODULES is a set of which modules connection type is network_cli.

Ansible Version Info
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Nov 13 2018, 12:45:42) [GCC 4.8.4]


ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME
lib/ansible/modules/network/cloudengine/ce_acl.py
lib/ansible/modules/network/cloudengine/ce_acl_advance.py
lib/ansible/modules/network/cloudengine/ce_acl_interface.py
lib/ansible/modules/network/cloudengine/ce_bfd_global.py
lib/ansible/modules/network/cloudengine/ce_bfd_session.py
lib/ansible/modules/network/cloudengine/ce_bfd_view.py
lib/ansible/modules/network/cloudengine/ce_bgp.py
lib/ansible/modules/network/cloudengine/ce_bgp_af.py
lib/ansible/modules/network/cloudengine/ce_bgp_neighbor.py
lib/ansible/modules/network/cloudengine/ce_bgp_neighbor_af.py
lib/ansible/modules/network/cloudengine/ce_dldp.py
lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
lib/ansible/modules/network/cloudengine/ce_evpn_bd_vni.py
lib/ansible/modules/network/cloudengine/ce_evpn_bgp_rr.py
lib/ansible/modules/network/cloudengine/ce_evpn_global.py
lib/ansible/modules/network/cloudengine/ce_facts.py
lib/ansible/modules/network/cloudengine/ce_file_copy.py
lib/ansible/modules/network/cloudengine/ce_info_center_debug.py
lib/ansible/modules/network/cloudengine/ce_info_center_global.py
lib/ansible/modules/network/cloudengine/ce_info_center_log.py
lib/ansible/modules/network/cloudengine/ce_info_center_trap.py
lib/ansible/modules/network/cloudengine/ce_interface.py
lib/ansible/modules/network/cloudengine/ce_interface_ospf.py
lib/ansible/modules/network/cloudengine/ce_ntp.py
lib/ansible/modules/network/cloudengine/ce_reboot.py
lib/ansible/modules/network/cloudengine/ce_static_route.py
lib/ansible/modules/network/cloudengine/ce_stp.py
lib/ansible/modules/network/cloudengine/ce_switchport.py
lib/ansible/modules/network/cloudengine/ce_vrf.py
lib/ansible/modules/network/cloudengine/ce_vrf_af.py
lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
lib/ansible/modules/network/cloudengine/ce_vrrp.py
lib/ansible/modules/network/cloudengine/ce_vxlan_arp.py
lib/ansible/modules/network/cloudengine/ce_vxlan_gateway.py
lib/ansible/modules/network/cloudengine/ce_vxlan_global.py
lib/ansible/modules/network/cloudengine/ce_vxlan_tunnel.py
lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
lib/ansible/plugins/action/ce.py
lib/ansible/modules/network/cloudengine/ce_mlag_interface.py
lib/ansible/modules/network/cloudengine/ce_netstream_export.py

ADDITIONAL INFORMATION
tasks:
  - name: "Gather_subset is config"
    ce_facts:
      gather_subset: config  
<---Before modify-->
<172.101.14.11> using connection plugin network_cli (was local)
<172.101.14.11> ESTABLISH LOCAL CONNECTION FOR USER: root
<172.101.14.11> EXEC /bin/sh -c 'echo ~root && sleep 0'
<172.101.14.11> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832 `" && echo ansible-tmp-1555571807.65-165202209042832="` echo /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832 `" ) && sleep 0'
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/network/cloudengine/ce_facts.py
<172.101.14.11> PUT /root/.ansible/tmp/ansible-local-10275HeLSGN/tmpVC5ANl TO /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py
<172.101.14.11> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/ /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py && sleep 0'
<172.101.14.11> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py && sleep 0'
<172.101.14.11> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 113, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_ce_facts_payload_eBI4g1/__main__.py", line 411, in <module>
  File "/tmp/ansible_ce_facts_payload_eBI4g1/__main__.py", line 396, in main
  File "/tmp/ansible_ce_facts_payload_eBI4g1/__main__.py", line 327, in populate
IndexError: list index out of range

fatal: [Friend-XYS-CCM-AZ2-TP&TS-KVM-TOR-CE6850-SW1]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_ce_facts_payload_eBI4g1/__main__.py\", line 411, in <module>\n  File \"/tmp/ansible_ce_facts_payload_eBI4g1/__main__.py\", line 396, in main\n  File \"/tmp/ansible_ce_facts_payload_eBI4g1/__main__.py\", line 327, in populate\nIndexError: list index out of range\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

<----After-->
ok: [10.130.200.118] => {
    "ansible_facts": {
        "BIOS Version": "433",
        "Board Type": "CE5855-48T4S2Q-EI",
        "CPLD1 Version": "102",
        "MAB Version": "1",
        "PCB Version": "CEM48T4S2QP03 VER B",
        "config": [
            "#",
            "sysname 130.20",
            "#",
            "port split dimension interface 40GE1/0/1",
            "port split dimension interface 40GE2/0/1",
            "#",
            "vlan batch 100 4060 to 4062",
            "#",
            "arp static 1.1.8.2 0008-0008-0008 interface Eth-Trunk1",
            "#",
            "lldp enable",
            "#",
            "return"
        ],
        "discovered_interpreter_python": "/usr/bin/python",
        "gather_subset": [
            "default",
            "config"
        ],
        "hostname": "130.20"
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "gather_subset": [
                "config"
            ],
            "host": "10.130.200.118",
            "password": null,
            "port": 10066,
            "provider": {
                "host": "10.130.200.118",
                "password": null,
                "port": 10066,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "rsa_user",
                "validate_certs": null
            },
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "rsa_user",
            "validate_certs": null
        }
    }
}




changed: [10.130.200.118] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "arp_suppress": "disable",
        "evn_bgp": "enable",
        "evn_peer_ip": [
            "7.7.7.7"
        ],
        "evn_reflect_client": null,
        "evn_server": "disable",
        "evn_source_ip": "6.6.6.6",
        "host_collect_protocol": null
    },
    "existing": {
        "arp_suppress": "disable",
        "evn_bgp": "disable",
        "host_collect_protocol": null
    },
    "invocation": {
        "module_args": {
            "arp_collect_host": null,
            "arp_suppress": null,
            "bridge_domain_id": null,
            "evn_bgp": "enable",
            "evn_peer_ip": "7.7.7.7",
            "evn_reflect_client": null,
            "evn_server": null,
            "evn_source_ip": "6.6.6.6",
            "host": "10.130.200.118",
            "host_collect_protocol": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10088,
            "provider": {
                "host": "10.130.200.118",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10088,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null,
            "vbdif_name": null
        }
    },
    "proposed": {
        "evn_bgp": "enable",
        "evn_peer_ip": "7.7.7.7",
        "evn_source_ip": "6.6.6.6",
        "state": "present"
    },
    "updates": [
        "evn bgp",
        "source-address 6.6.6.6",
        "peer 7.7.7.7"
    ]
}
TASK [test the bridge_domain_id] *************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:26
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH NETCONF SSH CONNECTION FOR USER: huawei on PORT 10088 TO 10.130.200.118
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158 `" && echo ansible-tmp-1556004587.56-77734157287158="` echo /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158 `" ) && sleep 0'
<10.130.200.118> Attempting python interpreter discovery
<10.130.200.118> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'python3.5'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'python2.6'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_evpn_bd_vni.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-54387KNgHE5/tmp81OBZ9 TO /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/AnsiballZ_ce_evpn_bd_vni.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/ /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/AnsiballZ_ce_evpn_bd_vni.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/AnsiballZ_ce_evpn_bd_vni.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/ > /dev/null 2>&1 && sleep 0'
 [WARNING]: The value 100 (type int) in a string field was converted to u'100' (type string). If this does not look like what you
expect, quote the entire value to ensure it does not change.

[DEPRECATION WARNING]: Param 'transport' is deprecated. See the module docs for more information. This feature will be removed in
 version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [10.130.200.118] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "bridge_domain_id": "100",
        "evpn": "enable",
        "route_distinguisher": null,
        "vpn_target_both": [],
        "vpn_target_export": [],
        "vpn_target_import": []
    },
    "existing": {
        "bridge_domain_id": "100",
        "evpn": "disable",
        "route_distinguisher": null,
        "vpn_target_both": [],
        "vpn_target_export": [],
        "vpn_target_import": []
    },
    "invocation": {
        "module_args": {
            "bridge_domain_id": "100",
            "evpn": "enable",
            "host": "10.130.200.118",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10088,
            "provider": {
                "host": "10.130.200.118",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10088,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "route_distinguisher": null,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null,
            "vpn_target_both": null,
            "vpn_target_export": null,
            "vpn_target_import": null
        }
    },
    "proposed": {
        "bridge_domain_id": "100",
        "evpn": "enable",
        "route_distinguisher": null,
        "state": "present",
        "vpn_target_both": [],
        "vpn_target_export": [],
        "vpn_target_import": []
    },
    "updates": [
        "bridge-domain 100",
        "  evpn"
    ]
}

TASK [test the interface] ********************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:31
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495 `" && echo ansible-tmp-1556004589.29-3954101342495="` echo /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_interface.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-54387KNgHE5/tmpTxXDW8 TO /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/AnsiballZ_ce_interface.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/ /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/AnsiballZ_ce_interface.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/AnsiballZ_ce_interface.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/ > /dev/null 2>&1 && sleep 0'
changed: [10.130.200.118] => {
    "changed": true,
    "end_state": {
        "admin_state": "down",
        "description": "12121qwq",
        "interface": "Vlanif3111"
    },
    "existing": {
        "admin_state": "up",
        "description": "12121qwq",
        "interface": "Vlanif3111"
    },
    "invocation": {
        "module_args": {
            "admin_state": "down",
            "description": null,
            "host": "10.130.200.118",
            "interface": "vlanif 3111",
            "interface_type": null,
            "l2sub": false,
            "mode": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10088,
            "provider": {
                "host": "10.130.200.118",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10088,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null
        }
    },
    "proposed": {
        "admin_state": "down",
        "interface": "vlanif 3111",
        "l2sub": false,
        "state": "present"
    },
    "updates": [
        "interface vlanif 3111",
        "shutdown"
    ]
}



changed: [10.130.200.118] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "arp_suppress": "disable",
        "evn_bgp": "enable",
        "evn_peer_ip": [
            "7.7.7.7"
        ],
        "evn_reflect_client": null,
        "evn_server": "disable",
        "evn_source_ip": "6.6.6.6",
        "host_collect_protocol": null
    },
    "existing": {
        "arp_suppress": "disable",
        "evn_bgp": "disable",
        "host_collect_protocol": null
    },
    "invocation": {
        "module_args": {
            "arp_collect_host": null,
            "arp_suppress": null,
            "bridge_domain_id": null,
            "evn_bgp": "enable",
            "evn_peer_ip": "7.7.7.7",
            "evn_reflect_client": null,
            "evn_server": null,
            "evn_source_ip": "6.6.6.6",
            "host": "10.130.200.118",
            "host_collect_protocol": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10088,
            "provider": {
                "host": "10.130.200.118",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10088,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null,
            "vbdif_name": null
        }
    },
    "proposed": {
        "evn_bgp": "enable",
        "evn_peer_ip": "7.7.7.7",
        "evn_source_ip": "6.6.6.6",
        "state": "present"
    },
    "updates": [
        "evn bgp",
        "source-address 6.6.6.6",
        "peer 7.7.7.7"
    ]
}

TASK [test the  vni_id] **********************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:22
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH NETCONF SSH CONNECTION FOR USER: huawei on PORT 10088 TO 10.130.200.118
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393 `" && echo ansible-tmp-1556004310.25-206399494407393="` echo /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_vxlan_tunnel.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-53767vAtgrn/tmp0QNpCa TO /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/AnsiballZ_ce_vxlan_tunnel.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/ /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/AnsiballZ_ce_vxlan_tunnel.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/AnsiballZ_ce_vxlan_tunnel.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/ > /dev/null 2>&1 && sleep 0'
 [WARNING]: The value 100 (type int) in a string field was converted to u'100' (type string). If this does not look like what you
expect, quote the entire value to ensure it does not change.

ok: [10.130.200.118] => {
    "changed": false,
    "end_state": {
        "nve_interface_name": "Nve1",
        "nve_mode": "mode-l2",
        "source_ip": null,
        "vni_peer_list_ip": [],
        "vni_peer_list_protocol": [
            {
                "protocol": "bgp",
                "vniId": "100"
            }
        ]
    },
    "existing": {
        "nve_interface_name": "Nve1",
        "nve_mode": "mode-l2",
        "source_ip": null,
        "vni_peer_list_ip": [],
        "vni_peer_list_protocol": [
            {
                "protocol": "bgp",
                "vniId": "100"
            }
        ]
    },
    "invocation": {
        "module_args": {
            "bridge_domain_id": null,
            "host": "10.130.200.118",
            "nve_mode": null,
            "nve_name": "Nve1",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "peer_list_ip": null,
            "port": 10088,
            "protocol_type": "bgp",
            "provider": {
                "host": "10.130.200.118",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10088,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "source_ip": null,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null,
            "vni_id": "100"
        }
    },
    "proposed": {
        "nve_name": "Nve1",
        "state": "present",
        "vni_id": "100"
    },
    "updates": []
}


TASK [test the  bridge_domain_id] ************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:37
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH NETCONF SSH CONNECTION FOR USER: huawei on PORT 10088 TO 10.130.200.118
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001 `" && echo ansible-tmp-1556004738.93-48991297696001="` echo /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001 `" ) && sleep 0'
<10.130.200.118> Attempting python interpreter discovery
<10.130.200.118> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'python3.5'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'python2.6'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_vxlan_vap.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-54847YBeSzT/tmpTTTdXY TO /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/AnsiballZ_ce_vxlan_vap.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/ /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/AnsiballZ_ce_vxlan_vap.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/AnsiballZ_ce_vxlan_vap.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/ > /dev/null 2>&1 && sleep 0'
 [WARNING]: The value 100 (type int) in a string field was converted to u'100' (type string). If this does not look like what you
expect, quote the entire value to ensure it does not change.

[DEPRECATION WARNING]: Param 'transport' is deprecated. See the module docs for more information. This feature will be removed in
 version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [10.130.200.118] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "bind_intf_list": [],
        "bind_vlan_list": [
            "100"
        ],
        "bridge_domain_id": "100"
    },
    "existing": {
        "bind_intf_list": [],
        "bind_vlan_list": [],
        "bridge_domain_id": "100"
    },
    "invocation": {
        "module_args": {
            "bind_vlan_id": "100",
            "bridge_domain_id": "100",
            "ce_vid": null,
            "encapsulation": null,
            "host": "10.130.200.118",
            "l2_sub_interface": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "pe_vid": null,
            "port": 10088,
            "provider": {
                "host": "10.130.200.118",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10088,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null
        }
    },
    "proposed": {
        "bind_vlan_id": "100",
        "bridge_domain_id": "100",
        "state": "present"
    },
    "updates": [
        "bridge-domain 100",
        "l2 binding vlan 100"
    ]
}
META: ran handlers
META: ran handlers




