### PR TITLE
win_region - fix format issues when using psrp

### DIFF
--- a/changelogs/fragments/win_region-format.yaml
+++ b/changelogs/fragments/win_region-format.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_region - Fix the check for ``format`` when running on the ``psrp`` connection plugin


### PR DESCRIPTION
##### SUMMARY
Using `win_region` with psrp fails to detect and set the user format value. This is because the runspace that hosts the PSRP service has an explicit culture of `en-US` set when the runspace is created. This code change uses the Win32 API to get the culture value and uses the legacy way of changing the values in all cases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp