### PR TITLE
[2.7] docker_container: fix support for docker-py 1.7.0

### DIFF
--- a/changelogs/fragments/55496-docker_container-docker-py-1.7.0.yml
+++ b/changelogs/fragments/55496-docker_container-docker-py-1.7.0.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - make again compatible with docker-py 1.7.0."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -991,11 +991,13 @@ class TaskParameters(DockerBaseClass):
             group_add='groups',
             devices='devices',
             pid_mode='pid_mode',
-            tmpfs='tmpfs',
             init='init',
             uts_mode='uts',
             auto_remove='auto_remove',
         )
+
+        if self.client.docker_py_version >= LooseVersion('1.8'):
+            host_config_params['tmpfs'] = 'tmpfs'
 
         if self.client.docker_py_version >= LooseVersion('1.9') and self.client.docker_api_version >= LooseVersion('1.22'):
             # blkio_weight can always be updated, but can only be set on creation
@@ -2260,7 +2262,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
             oom_score_adj=dict(docker_api_version='1.22', docker_py_version='2.0.0'),
             shm_size=dict(docker_api_version='1.22'),
             stop_signal=dict(docker_api_version='1.21'),
-            tmpfs=dict(docker_api_version='1.22'),
+            tmpfs=dict(docker_api_version='1.22', docker_py_version='1.8.0'),
             volume_driver=dict(docker_api_version='1.21'),
             memory_reservation=dict(docker_api_version='1.21'),
             kernel_memory=dict(docker_api_version='1.21'),

--- a/test/integration/targets/docker_container/tasks/main.yml
+++ b/test/integration/targets/docker_container/tasks/main.yml
@@ -30,7 +30,7 @@
     with_items: "{{ dnetworks }}"
     when: docker_py_version is version('1.10.0', '>=')
 
-  when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
+  when: docker_py_version is version('1.7.0', '>=') and docker_api_version is version('1.20', '>=')
 
 - fail: msg="Too old docker / docker-py version to run all docker_container tests!"
   when: not(docker_py_version is version('3.5.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_image/tasks/main.yml
+++ b/test/integration/targets/docker_image/tasks/main.yml
@@ -47,7 +47,7 @@
       stop_timeout: 1
     with_items: "{{ cnames }}"
 
-  when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
+  when: docker_py_version is version('1.7.0', '>=') and docker_api_version is version('1.20', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_image tests!"
-  when: not(docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('1.7.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_image_facts/tasks/main.yml
+++ b/test/integration/targets/docker_image_facts/tasks/main.yml
@@ -48,7 +48,7 @@
       - "'hello-world:latest' in result.images[0].RepoTags"
       - "'alpine:3.8' in result.images[1].RepoTags"
 
-  when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
+  when: docker_py_version is version('1.7.0', '>=') and docker_api_version is version('1.20', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_image_facts tests!"
-  when: not(docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('1.7.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_network/tasks/main.yml
+++ b/test/integration/targets/docker_network/tasks/main.yml
@@ -27,7 +27,7 @@
       force: yes
     loop: "{{ dnetworks }}"
 
-  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.20', '>=')  # FIXME: find out API version!
+  when: docker_py_version is version('1.7.0', '>=') and docker_api_version is version('1.20', '>=')  # FIXME: find out API version!
 
 - fail: msg="Too old docker / docker-py version to run docker_network tests!"
-  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('1.7.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)


### PR DESCRIPTION
##### SUMMARY
docker_container, docker_image and docker_image_facts in stable-2.7 are supposed to support docker-py 1.7.0. Unfortunately, docker_container will always crash when creating a container, and docker_image will crash when pulling or pushing. This is no longer relevant for 2.8, since the minimal docker-py requirement has been bumped to 1.8.0 in general, and 1.10.0 for docker_image.

The pushing/pulling is a bit harder to fix, but the crash for docker_container can be easily fixed. This PR fixes the crash for docker_container and updates the tests so that they will also run for docker-py 1.7.0.

**This is not a backport!**

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
docker_container
docker_image
docker_image_facts
