### PR TITLE
add 'finished' to async_wrapper 

### DIFF
--- a/lib/ansible/modules/utilities/logic/async_wrapper.py
+++ b/lib/ansible/modules/utilities/logic/async_wrapper.py
@@ -170,6 +170,8 @@ def _run_module(wrapped_cmd, jid, job_path):
 
         if stderr:
             result['stderr'] = stderr
+        if 'finished' not in result:
+            result['finished'] = 1
         jobfile.write(json.dumps(result))
 
     except (OSError, IOError):
@@ -179,7 +181,8 @@ def _run_module(wrapped_cmd, jid, job_path):
             "cmd": wrapped_cmd,
             "msg": to_text(e),
             "outdata": outdata,  # temporary notice only
-            "stderr": stderr
+            "stderr": stderr,
+            "finished": 1
         }
         result['ansible_job_id'] = jid
         jobfile.write(json.dumps(result))
@@ -190,7 +193,8 @@ def _run_module(wrapped_cmd, jid, job_path):
             "cmd": wrapped_cmd,
             "data": outdata,  # temporary notice only
             "stderr": stderr,
-            "msg": traceback.format_exc()
+            "msg": traceback.format_exc(),
+            "finished": 1
         }
         result['ansible_job_id'] = jid
         jobfile.write(json.dumps(result))


### PR DESCRIPTION
Because some modules are not considered asynchronous when implemented (such as the command module), we need to judge the execution results. If there is no 'finished', add it. This value will be used in async_status. If there is no finished in async_status,It thinks it is always running.
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
