### PR TITLE
Return results even when the cache is disabled

### DIFF
--- a/changelogs/fragments/55505-foreman-inventory.yaml
+++ b/changelogs/fragments/55505-foreman-inventory.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix foreman inventory plugin when inventory caching is disabled

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -162,11 +162,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                     # get next page
                     params['page'] += 1
 
-            # Set the cache if it is enabled or if the cache was refreshed
-            if self.use_cache or self.get_option('cache'):
-                self._cache[self.cache_key][url] = results
-            else:
-                return results
+            self._cache[self.cache_key][url] = results
 
         return self._cache[self.cache_key][url]
 

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -165,6 +165,8 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             # Set the cache if it is enabled or if the cache was refreshed
             if self.use_cache or self.get_option('cache'):
                 self._cache[self.cache_key][url] = results
+            else:
+                return results
 
         return self._cache[self.cache_key][url]
 


### PR DESCRIPTION
##### SUMMARY
As a result of #50446 (I think) the Foreman inventory plugin no longer returns any results.

The line where the results of the Foreman API call are placed into the cache are guarded by a statement which only runs if the cache is enabled. When returning from the function, the value from the cache is always returned which – if noting was put in there – returns nothing.

Fixes #57008

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Foreman inventory plugin