### PR TITLE
Adding Support for NVE Protocol in onyx_protocol

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_protocol.py
+++ b/lib/ansible/modules/network/onyx/onyx_protocol.py
@@ -55,6 +55,10 @@ options:
   ospf:
     description: OSPF protocol
     choices: ['enabled', 'disabled']
+  nve:
+    description: nve protocol
+    choices: ['enabled', 'disabled']
+    version_added: "2.9"
 """
 
 EXAMPLES = """
@@ -107,6 +111,8 @@ class OnyxProtocolModule(BaseOnyxModule):
         bgp=dict(name="bgp", enable="protocol bgp", disable="no protocol bgp"),
         ospf=dict(name="ospf", enable="protocol ospf",
                   disable="no protocol ospf"),
+        nve=dict(name="nve", enable="protocol nve",
+                  disable="no protocol nve"),
     )
 
     @classmethod

--- a/lib/ansible/modules/network/onyx/onyx_protocol.py
+++ b/lib/ansible/modules/network/onyx/onyx_protocol.py
@@ -112,7 +112,7 @@ class OnyxProtocolModule(BaseOnyxModule):
         ospf=dict(name="ospf", enable="protocol ospf",
                   disable="no protocol ospf"),
         nve=dict(name="nve", enable="protocol nve",
-                  disable="no protocol nve"),
+                 disable="no protocol nve"),
     )
 
     @classmethod

--- a/test/units/modules/network/onyx/test_onyx_protocols.py
+++ b/test/units/modules/network/onyx/test_onyx_protocols.py
@@ -132,3 +132,12 @@ class TestOnyxProtocolModule(TestOnyxModule):
     def test_ospf_disable(self):
         set_module_args(dict(ospf='disabled'))
         self.execute_module(changed=False)
+
+    def test_nve_enable(self):
+        set_module_args(dict(nve='enabled'))
+        commands = ['protocol nve']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_nve_disabled(self):
+        set_module_args(dict(nve='disabled'))
+        self.execute_module(changed=False)


### PR DESCRIPTION
Signed-off-by: Anas Badaha <anasb@mellanox.com>

##### SUMMARY
Adding Support for nve protocol in onyx_protocol

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/onyx/onyx_protocol.py
test/units/modules/network/onyx/test_onyx_protocols.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /.autodirect/mtrswgwork/anasb/ansible_dev8/lib/ansible
  executable location = /.autodirect/mtrswgwork/anasb/ansible_dev8/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```
