### PR TITLE
Fixing hostname module fails when systemd is installed but dbus is not running

### DIFF
--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import stat
 import platform
 import re
 
@@ -50,6 +51,16 @@ class ServiceMgrFactCollector(BaseFactCollector):
             for canary in ["/run/systemd/system/", "/dev/.run/systemd/", "/dev/.systemd/"]:
                 if os.path.exists(canary):
                     return True
+        return False
+
+    @staticmethod
+    def is_dbus_running(module):
+        # ensure dbus installed
+        if module.get_bin_path('dbus-daemon'):
+            # Check if socket file exists
+            # https://www.freedesktop.org/wiki/IntroductionToDBus/
+            if stat.S_ISSOCK(os.stat("/var/run/dbus/system_bus_socket").st_mode):
+                return True
         return False
 
     def collect(self, module=None, collected_facts=None):

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -107,7 +107,9 @@ class Hostname(object):
     def __init__(self, module):
         self.module = module
         self.name = module.params['name']
-        if self.platform == 'Linux' and ServiceMgrFactCollector.is_systemd_managed(module):
+        if self.platform == 'Linux' and (
+            ServiceMgrFactCollector.is_systemd_managed(module) and ServiceMgrFactCollector.is_dbus_running(module)
+        ):
             self.strategy = SystemdStrategy(module)
         else:
             self.strategy = self.strategy_class(module)


### PR DESCRIPTION
##### SUMMARY

Pretty straight-forward decision to add simple check before choosing strategy which relies on DBus.

Fixes #25543

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

hostname

##### ADDITIONAL INFORMATION

https://github.com/ansible/ansible/issues/25543#issuecomment-307518124

>This error happens when `systemd` is installed but `dbus` isn't. I guess it could occur when remote user isn't root and `libpam-systemd` isn't installed.
>
>When `systemd` is available, I am not sure if the module should try to detect if `dbus` is available (and fails when `dbus` isn't available) or if a fallback method should be used in such case.

My point of view is that it's safe to use additional check before using systemd-related strategy in hostname module.

Afterwards I propose to rely in module's logic of strategy selection.
