### PR TITLE
meraki_static_route - Remove unnecessary API call

### DIFF
--- a/changelogs/fragments/meraki_static_route_api_calls.yml
+++ b/changelogs/fragments/meraki_static_route_api_calls.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "meraki_static_route - Module would make unnecessary API calls to Meraki when net_id is specified in task."

--- a/changelogs/fragments/meraki_static_route_api_calls.yml
+++ b/changelogs/fragments/meraki_static_route_api_calls.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- "meraki_static_route - Module would make unnecessary API calls to Meraki when net_id is specified in task."
+- "meraki_static_route - Module would make unnecessary API calls to Meraki when ``net_id`` is specified in task."

--- a/lib/ansible/modules/network/meraki/meraki_static_route.py
+++ b/lib/ansible/modules/network/meraki/meraki_static_route.py
@@ -328,9 +328,9 @@ def main():
     org_id = meraki.params['org_id']
     if not org_id:
         org_id = meraki.get_org_id(meraki.params['org_name'])
-    nets = meraki.get_nets(org_id=org_id)
     net_id = meraki.params['net_id']
     if net_id is None:
+        nets = meraki.get_nets(org_id=org_id)
         net_id = meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
 
     if meraki.params['state'] == 'query':


### PR DESCRIPTION
##### SUMMARY
Module is making a call to query all networks, even if `net_id` is specified. This should only happen when `net_name` is used. This shouldn't be too consequential, but for large environments with lots of networks, this bug imposes a significant performance burden.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_static_route
