### PR TITLE
Fewer examples use connection: local in docs (#55133)

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_aws.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aws.rst
@@ -18,7 +18,6 @@ Whereas classically ansible will execute tasks in its host loop against multiple
 In your playbook steps we'll typically be using the following pattern for provisioning steps::
 
     - hosts: localhost
-      connection: local
       gather_facts: False
       tasks:
         - ...
@@ -68,7 +67,6 @@ instance.::
     # demo_setup.yml
 
     - hosts: localhost
-      connection: local
       gather_facts: False
 
       tasks:
@@ -94,7 +92,6 @@ From this, we'll use the add_host module to dynamically create a host group cons
     # demo_setup.yml
 
     - hosts: localhost
-      connection: local
       gather_facts: False
 
       tasks:

--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -88,7 +88,6 @@ you can use the following configuration:
 
    - name: Create IP address
      hosts: localhost
-     connection: local
      gather_facts: no
 
      vars:
@@ -169,7 +168,6 @@ rest.
    - name: Create an instance
      hosts: localhost
      gather_facts: no
-     connection: local
      vars:
          project: my-project
          auth_kind: serviceaccount

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -431,7 +431,6 @@ EXAMPLES = '''
 
 - name: Terminate instances
   hosts: localhost
-  connection: local
   tasks:
     - name: Terminate instances that were previously launched
       ec2:
@@ -444,7 +443,6 @@ EXAMPLES = '''
 - name: Start sandbox instances
   hosts: localhost
   gather_facts: false
-  connection: local
   vars:
     instance_ids:
       - 'i-xxxxxx'
@@ -467,7 +465,6 @@ EXAMPLES = '''
 - name: Stop sandbox instances
   hosts: localhost
   gather_facts: false
-  connection: local
   vars:
     instance_ids:
       - 'i-xxxxxx'

--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -165,7 +165,6 @@ EXAMPLES = '''
 
 - name: Run using a project directory
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:
@@ -220,7 +219,6 @@ EXAMPLES = '''
 
 - name: Scale the web service to 2
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:
@@ -234,7 +232,6 @@ EXAMPLES = '''
 
 - name: Run with inline v2 compose
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:
@@ -269,7 +266,6 @@ EXAMPLES = '''
 
 - name: Run with inline v1 compose
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
     - docker_compose:


### PR DESCRIPTION
##### SUMMARY

Backport of #55133 

* Fewer connection: local lines in module examples and scenario guides

The line 'connection: local' is not required. See
./docs/docsite/rst/inventory/implicit_localhost.rst

(cherry picked from commit 04220478da26c9c8c084d1b92507fff51474254b)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
