### PR TITLE
Fix access_logs_s3_prefix leading/trailing slash (#55148)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -35,12 +35,16 @@ options:
     type: bool
   access_logs_s3_bucket:
     description:
-      - The name of the S3 bucket for the access logs. This attribute is required if access logs in Amazon S3 are enabled. The bucket must exist in the same
+      - The name of the S3 bucket for the access logs.
+      - Required if access logs in Amazon S3 are enabled.
+      - The bucket must exist in the same
         region as the load balancer and have a bucket policy that grants Elastic Load Balancing permission to write to the bucket.
     required: false
   access_logs_s3_prefix:
     description:
-      - The prefix for the location in the S3 bucket. If you don't specify a prefix, the access logs are stored in the root of the bucket.
+      - The prefix for the log location in the S3 bucket.
+      - If you don't specify a prefix, the access logs are stored in the root of the bucket.
+      - Cannot begin or end with a slash.
     required: false
   deletion_protection:
     description:
@@ -161,7 +165,7 @@ EXAMPLES = '''
 - elb_application_lb:
     access_logs_enabled: yes
     access_logs_s3_bucket: mybucket
-    access_logs_s3_prefix: "/logs"
+    access_logs_s3_prefix: "logs"
     name: myelb
     security_groups:
       - sg-12345678
@@ -232,7 +236,7 @@ access_logs_s3_prefix:
     description: The prefix for the location in the S3 bucket.
     returned: when state is present
     type: str
-    sample: /my/logs
+    sample: my/logs
 availability_zones:
     description: The Availability Zones for the load balancer.
     returned: when state is present


### PR DESCRIPTION
##### SUMMARY

Backport of #55148 

- Add documentation regarding restrictions on access_logs_s3_prefix (cannot have a leading or trailing slash)

(cherry picked from commit 698d2454c72384fbf189e2fb5704fd081f0edcb7)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
