### PR TITLE
meraki_content_filtering - Remove redundant API call with get_nets()

### DIFF
--- a/changelogs/fragments/meraki_content_filtering-redundant-calls.yml
+++ b/changelogs/fragments/meraki_content_filtering-redundant-calls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "meraki_static_route - Module would make unnecessary API calls to Meraki when ``net_id`` is specified in task."

--- a/lib/ansible/modules/network/meraki/meraki_content_filtering.py
+++ b/lib/ansible/modules/network/meraki/meraki_content_filtering.py
@@ -172,8 +172,6 @@ def main():
     org_id = meraki.params['org_id']
     if not org_id:
         org_id = meraki.get_org_id(meraki.params['org_name'])
-    nets = meraki.get_nets(org_id=org_id)
-
     net_id = None
     if net_id is None:
         nets = meraki.get_nets(org_id=org_id)


### PR DESCRIPTION
##### SUMMARY
`get_nets()` downloads all networks. In this module, it is called twice, one of the times is unnecessary and should be removed. This one removes the unnecessary one.

This is a very very similar bug to https://github.com/ansible/ansible/pull/54939

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_content_filtering
