### PR TITLE
[2.8] crypto modules: use module_utils.compat.ipaddress when possible

### DIFF
--- a/changelogs/fragments/55278-cryto-use-bundled-ipaddress.yml
+++ b/changelogs/fragments/55278-cryto-use-bundled-ipaddress.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "openssl_csr, openssl_csr_info - use ``ipaddress`` module bundled with Ansible for normalizations needed for pyOpenSSL backend."
+- "acme_certificate - use ``ipaddress`` module bundled with Ansible for normalizations needed for OpenSSL backend."

--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -235,6 +235,7 @@ from ansible.module_utils import crypto as crypto_utils
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils.compat import ipaddress as compat_ipaddress
 
 MINIMAL_CRYPTOGRAPHY_VERSION = '1.6'
 MINIMAL_PYOPENSSL_VERSION = '0.15'
@@ -243,7 +244,6 @@ PYOPENSSL_IMP_ERR = None
 try:
     import OpenSSL
     from OpenSSL import crypto
-    import ipaddress
     PYOPENSSL_VERSION = LooseVersion(OpenSSL.__version__)
     if OpenSSL.SSL.OPENSSL_VERSION_NUMBER >= 0x10100000:
         # OpenSSL 1.1.0 or newer
@@ -609,7 +609,7 @@ class CertificateInfoPyOpenSSL(CertificateInfo):
         if san.startswith('IP Address:'):
             san = 'IP:' + san[len('IP Address:'):]
         if san.startswith('IP:'):
-            ip = ipaddress.ip_address(san[3:])
+            ip = compat_ipaddress.ip_address(san[3:])
             san = 'IP:{0}'.format(ip.compressed)
         return san
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -336,6 +336,7 @@ from distutils.version import LooseVersion
 from ansible.module_utils import crypto as crypto_utils
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native, to_bytes, to_text
+from ansible.module_utils.compat import ipaddress as compat_ipaddress
 
 MINIMAL_PYOPENSSL_VERSION = '0.15'
 MINIMAL_CRYPTOGRAPHY_VERSION = '1.3'
@@ -368,7 +369,6 @@ try:
     import cryptography.hazmat.backends
     import cryptography.hazmat.primitives.serialization
     import cryptography.hazmat.primitives.hashes
-    import ipaddress
     CRYPTOGRAPHY_VERSION = LooseVersion(cryptography.__version__)
 except ImportError:
     CRYPTOGRAPHY_IMP_ERR = traceback.format_exc()
@@ -560,7 +560,7 @@ class CertificateSigningRequestPyOpenSSL(CertificateSigningRequestBase):
         if san.startswith('IP Address:'):
             san = 'IP:' + san[len('IP Address:'):]
         if san.startswith('IP:'):
-            ip = ipaddress.ip_address(san[3:])
+            ip = compat_ipaddress.ip_address(san[3:])
             san = 'IP:{0}'.format(ip.compressed)
         return san
 

--- a/lib/ansible/modules/crypto/openssl_csr_info.py
+++ b/lib/ansible/modules/crypto/openssl_csr_info.py
@@ -165,6 +165,7 @@ from ansible.module_utils import crypto as crypto_utils
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils.compat import ipaddress as compat_ipaddress
 
 MINIMAL_CRYPTOGRAPHY_VERSION = '1.3'
 MINIMAL_PYOPENSSL_VERSION = '0.15'
@@ -173,7 +174,6 @@ PYOPENSSL_IMP_ERR = None
 try:
     import OpenSSL
     from OpenSSL import crypto
-    import ipaddress
     PYOPENSSL_VERSION = LooseVersion(OpenSSL.__version__)
     if OpenSSL.SSL.OPENSSL_VERSION_NUMBER >= 0x10100000:
         # OpenSSL 1.1.0 or newer
@@ -444,7 +444,7 @@ class CertificateSigningRequestInfoPyOpenSSL(CertificateSigningRequestInfo):
         if san.startswith('IP Address:'):
             san = 'IP:' + san[len('IP Address:'):]
         if san.startswith('IP:'):
-            ip = ipaddress.ip_address(san[3:])
+            ip = compat_ipaddress.ip_address(san[3:])
             san = 'IP:{0}'.format(ip.compressed)
         return san
 

--- a/test/sanity/pylint/ignore.txt
+++ b/test/sanity/pylint/ignore.txt
@@ -3,7 +3,6 @@ lib/ansible/cli/console.py blacklisted-name
 lib/ansible/compat/selectors/_selectors2.py blacklisted-name
 lib/ansible/executor/playbook_executor.py blacklisted-name
 lib/ansible/executor/task_queue_manager.py blacklisted-name
-lib/ansible/module_utils/acme.py blacklisted-name
 lib/ansible/module_utils/facts/network/linux.py blacklisted-name
 lib/ansible/module_utils/network/edgeswitch/edgeswitch_interface.py duplicate-string-formatting-argument
 lib/ansible/module_utils/urls.py blacklisted-name


### PR DESCRIPTION
##### SUMMARY
Backport of #55278 to stable-2.8. Replaces some new uses of `ipaddress` (new for 2.8) with `module_utils.compat.ipaddress` to improve compatibility.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/acme.py
acme_certificate
openssl_certificate_info
openssl_csr
openssl_csr_info
