### PR TITLE
Update documentation of filetree to mention limits of 'src' attribute…

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -11,7 +11,7 @@ version_added: "2.4"
 short_description: recursively match all files in a directory tree
 description:
 - This lookup enables you to template a complete tree of files on a target system while retaining permissions and ownership.
-- Supports directories, files and symlinks, including SELinux and other file properties
+- Supports directories, files and symlinks, including SELinux and other file properties.
 - If you provide more than one path, it will implement a first_found logic, and will not process entries it already processed in previous paths.
   This enables merging different trees in order of importance, or add role_vars to specific paths to influence different instances of the same role.
 options:
@@ -29,7 +29,7 @@ EXAMPLES = """
   with_filetree: web/
   when: item.state == 'directory'
 
-- name: Template files
+- name: Template files (explicitly skip directories in order to use the 'src' attribute)
   template:
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
@@ -53,7 +53,9 @@ RETURN = """
     description: list of dictionaries with file information
     contains:
         src:
-          description: TODO
+          description:
+          - full path to file
+          - not returned when C(item.state) is set to C(directory)
         root:
           description: allows filtering by original location
         path:


### PR DESCRIPTION
##### SUMMARY
Backports #54347

* Filetree plugin does not return the 'src' attribute when `item.state` is set to `directory`

Error is `'dict object' has no attribute 'src'`. See https://github.com/ansible/ansible/issues/51513#issuecomment-459150769 .

* Update filetree.py

(cherry picked from commit f40778cae35cdde426336f2d78b45d485e36b521)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
