### PR TITLE
ec2_group: docs: fix example for deletion by group ID (#55169)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -229,6 +229,7 @@ EXAMPLES = '''
 
 - name: "Delete group by its id"
   ec2_group:
+    region: eu-west-1
     group_id: sg-33b4ee5b
     state: absent
 '''


### PR DESCRIPTION
##### SUMMARY

Fixes ec2_group example, to show that region is required for the "delete" example task to work

(cherry picked from commit a5f13dd36182b1458c846c838d4bc32b98f05e2e)

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
docs.ansible.com
