### PR TITLE
DOCS: Update "connections" data type (#55290)

### DIFF
--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -95,14 +95,14 @@ EXAMPLES = '''
 # Authenticate with token, and return all pods and services for all namespaces
 plugin: k8s
 connections:
-    host: https://192.168.64.4:8443
+  - host: https://192.168.64.4:8443
     token: xxxxxxxxxxxxxxxx
     validate_certs: false
 
 # Use default config (~/.kube/config) file and active context, and return objects for a specific namespace
 plugin: k8s
 connections:
-    namespaces:
+  - namespaces:
     - testing
 
 # Use a custom config file, and a specific context.


### PR DESCRIPTION
##### SUMMARY

Backports #55290.

The k8s plugin expects the "connections" field to be a list - current docs examples trigger:
 [WARNING]:  * Failed to parse {...}/inventory.yml with k8s plugin: Expecting connections to be a list.

Updated examples for `host` and  `namespaces` to reflect this.

(cherry picked from commit e90df4b5660d24958d3e51b7d573dfc0f138a735)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
