### PR TITLE
Template: Example of SELinux context type (#54861)

### DIFF
--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -162,6 +162,14 @@ EXAMPLES = r'''
     group: wheel
     mode: u=rw,g=r,o=r
 
+- name: Copy a version of named.conf that is dependent on the OS. setype obtained by doing ls -Z /etc/named.conf on original file
+  template:
+    src: named.conf_{{ ansible_os_family}}.j2
+    dest: /etc/named.conf
+    group: named
+    setype: named_conf_t
+    mode: 0640
+
 - name: Create a DOS-style text file from a template
   template:
     src: config.ini.j2


### PR DESCRIPTION
##### SUMMARY
Backports #54861 

* Update template.py with an example using selinux with a suggestion of how to get the proper file context (cheating!)

(cherry picked from commit f8834c533951154e9cd9a37e7e6bf30f11017f66)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
