### PR TITLE
Fixed wrong variable specification format in examples (#55252)

### DIFF
--- a/changelogs/fragments/tower_job_wait-wrong_examples.yml
+++ b/changelogs/fragments/tower_job_wait-wrong_examples.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - tower_job_wait - Fixed wrong variable specification in examples

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -66,7 +66,7 @@ EXAMPLES = '''
 
 - name: Wait for job max 120s
   tower_job_wait:
-    job_id: job.id
+    job_id: "{{ job.id }}"
     timeout: 120
 
 # Launch job template with inventory and credential for prompt on launch
@@ -78,7 +78,7 @@ EXAMPLES = '''
   register: job
 - name: Wait for job max 120s
   tower_job_wait:
-    job_id: job.id
+    job_id: "{{ job.id }}"
     timeout: 120
 '''
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 
 - name: Wait for job max 120s
   tower_job_wait:
-    job_id: job.id
+    job_id: "{{ job.id }}"
     timeout: 120
 '''
 


### PR DESCRIPTION
##### SUMMARY
Backports #55252. 

Signed-off-by: Hideki Saito <saito@fgrep.org>
(cherry picked from commit 83f20e0ea0a5fa46329c68bdcf13cf5dd7a452eb)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

