### PR TITLE
Clarify fact_path configurable in ansible.cfg (#54992)

### DIFF
--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -53,7 +53,9 @@ options:
             - path used for local ansible facts (C(*.fact)) - files in this dir
               will be run (if executable) and their results be added to C(ansible_local) facts
               if a file is not executable it is read. Check notes for Windows options. (from 2.1 on)
-              File/results format can be json or ini-format
+              File/results format can be JSON or INI-format. The default C(fact_path) can be
+              specified in C(ansible.cfg) for when setup is automatically called as part of
+              C(gather_facts).
         required: false
         default: '/etc/ansible/facts.d'
 description:


### PR DESCRIPTION
##### SUMMARY
Backports #54992.

Docs: Clarify that `fact_path` can be configured in `ansible.cfg`; uppercase two acronyms. 
(cherry picked from commit 46420dd21a24791429bdf7e0a0b49a8aa6347337)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
