### PR TITLE
Decimal handling

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -55,6 +55,7 @@ import traceback
 import types
 
 from collections import deque
+from decimal import Decimal
 from itertools import chain, repeat
 
 try:
@@ -387,7 +388,7 @@ def _remove_values_conditions(value, no_log_strings, deferred_removals):
         deferred_removals.append((value, new_value))
         value = new_value
 
-    elif isinstance(value, tuple(chain(integer_types, (float, bool, NoneType)))):
+    elif isinstance(value, tuple(chain(integer_types, (float, bool, Decimal, NoneType)))):
         stringy_value = to_native(value, encoding='utf-8', errors='surrogate_or_strict')
         if stringy_value in no_log_strings:
             return 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'

--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 import datetime
 import json
 
+from decimal import Decimal
 from itertools import repeat
 
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -25,6 +26,8 @@ def _json_encode_fallback(obj):
         return list(obj)
     elif isinstance(obj, datetime.datetime):
         return obj.isoformat()
+    elif isinstance(obj, Decimal):
+        return float(obj)
     raise TypeError("Cannot json serialize %s" % to_native(obj))
 
 

--- a/lib/ansible/parsing/ajson.py
+++ b/lib/ansible/parsing/ajson.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 import json
 
 from datetime import date, datetime
+from decimal import Decimal
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
@@ -63,6 +64,9 @@ class AnsibleJSONEncoder(json.JSONEncoder):
         elif isinstance(o, (date, datetime)):
             # date object
             value = o.isoformat()
+        elif isinstance(o, Decimal):
+            # decimal.Decimal object
+            value = float(o)
         else:
             # use default encoder
             value = super(AnsibleJSONEncoder, self).default(o)

--- a/test/units/parsing/test_ajson.py
+++ b/test/units/parsing/test_ajson.py
@@ -31,7 +31,7 @@ def test_AnsibleJSONEncoder_decimal():
     )
 
     for test in test_numbers:
-        value = Decimal(test[0])
+        value = Decimal(to_native(test[0]))
         test_data = {'number': value}
         data = json.dumps(test_data, cls=AnsibleJSONEncoder)
         assert '{{"number": {0}}}'.format(to_native(test[1])) == data

--- a/test/units/parsing/test_ajson.py
+++ b/test/units/parsing/test_ajson.py
@@ -34,4 +34,4 @@ def test_AnsibleJSONEncoder_decimal():
         value = Decimal(test[0])
         test_data = {'number': value}
         data = json.dumps(test_data, cls=AnsibleJSONEncoder)
-        assert '{{"number": {}}}'.format(to_native(test[1])) == data
+        assert '{{"number": {0}}}'.format(to_native(test[1])) == data

--- a/test/units/parsing/test_ajson.py
+++ b/test/units/parsing/test_ajson.py
@@ -7,9 +7,10 @@ __metaclass__ = type
 import os
 import json
 
-import pytest
+from decimal import Decimal
 
-from ansible.parsing.ajson import AnsibleJSONDecoder
+from ansible.module_utils._text import to_native
+from ansible.parsing.ajson import AnsibleJSONDecoder, AnsibleJSONEncoder
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 
@@ -20,3 +21,17 @@ def test_AnsibleJSONDecoder_vault():
     assert isinstance(data['password'], AnsibleVaultEncryptedUnicode)
     assert isinstance(data['bar']['baz'][0]['password'], AnsibleVaultEncryptedUnicode)
     assert isinstance(data['foo']['password'], AnsibleVaultEncryptedUnicode)
+
+
+def test_AnsibleJSONEncoder_decimal():
+    test_numbers = (
+        (1, 1.0),
+        (1.0, 1.0),
+        (1.155789, 1.155789),
+    )
+
+    for test in test_numbers:
+        value = Decimal(test[0])
+        test_data = {'number': value}
+        data = json.dumps(test_data, cls=AnsibleJSONEncoder)
+        assert '{{"number": {}}}'.format(to_native(test[1])) == data


### PR DESCRIPTION
##### SUMMARY
To avoid the errors like (for example, in #55434):
```
\"/tmp/ansible_mysql_info_payload_juak_owj/ansible_mysql_info_payload.zip/ansible/module_utils/basic.py\", line 401, in _remove_values_conditions\nTypeError: Value of unknown type: <class 'decimal.Decimal'>, 0.000000\n",
...
/ansible/module_utils/common/text/converters.py\", line 28, in _json_encode_fallback\nTypeError: Cannot json serialize 0.000000\n",
...
```
When the module tries to return a value of decimal.Decimal type (in this case from the database) the errors above occur.
To solve this problem, I added Decimal type handling into the functions when TypeError happens.

It's implemented in https://github.com/ansible/ansible/pull/55434 now
and, to separate core code changes and module's code, we decided to move the code from there to a single PR.
After this PR will be merged I remove this code from #55434.

##### ISSUE TYPE
- Bugfix Pull Request