### PR TITLE
[WIP] sysvinit: check service is started when 'reload' is used and service is stopped

### DIFF
--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -336,6 +336,8 @@ def main():
             result['changed'] = True
             result['status'][module.params['state']]['changed'] = True
             if not module.check_mode:
+                if action == 'reload':
+                    action = 'start'
                 rc, out, err = runme(action)
 
         if not module.check_mode and result['status'][module.params['state']]['changed']:

--- a/test/integration/targets/service/files/ansible_reload.sysv
+++ b/test/integration/targets/service/files/ansible_reload.sysv
@@ -1,0 +1,21 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          ansible_test_reload
+# Required-Start:    $all
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: ansible_test_reload service (fail when reloaded)
+### END INIT INFO
+
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+case "$1" in
+    reload|force-reload)
+        exit 1
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/test/integration/targets/service/tasks/main.yml
+++ b/test/integration/targets/service/tasks/main.yml
@@ -38,15 +38,31 @@
     - name: setup test service script
       include_tasks: '{{ service_type }}_setup.yml'
 
+    - name: install a sysV init file
+      copy:
+        src: ansible_reload.sysv
+        dest: /etc/init.d/ansible_test_reload
+        mode: 0755
+      when: service_type in ['sysv', 'systemd']
+
     - name: execute tests
       import_tasks: tests.yml
 
   always:
     - name: disable and stop ansible test service
       service:
-        name: ansible_test
+        name: '{{ item }}'
         state: stopped
         enabled: false
+      loop:
+        - ansible_test
+        - ansible_test_reload
 
     # cleaning up changes made by this playbook
     - include_tasks: '{{ service_type }}_cleanup.yml'
+
+    - name: remove the sysV init file
+      file:
+        path: '/etc/init.d/ansible_test_reload'
+        state: absent
+      when: service_type in ['sysv', 'systemd']

--- a/test/integration/targets/service/tasks/systemd_cleanup.yml
+++ b/test/integration/targets/service/tasks/systemd_cleanup.yml
@@ -1,19 +1,16 @@
 - name: remove the systemd unit file
-  file: path=/usr/lib/systemd/system/ansible_test.service state=absent
+  file:
+    path: '/etc/systemd/system/{{ item }}'
+    state: absent
+  loop:
+    - ansible_test.service
+    - ansible_test_broken.service
   register: remove_systemd_result
 
-- name: remove the systemd unit file
-  file: path=/usr/lib/systemd/system/ansible_test_broken.service state=absent
-  register: remove_systemd_broken_result
-
-- debug: var=remove_systemd_broken_result
-- name: assert that the systemd unit file was removed
+- name: assert that the systemd unit files were removed
   assert:
     that:
-    - "remove_systemd_result.path == '/usr/lib/systemd/system/ansible_test.service'"
-    - "remove_systemd_result.state == 'absent'"
-    - "remove_systemd_broken_result.path == '/usr/lib/systemd/system/ansible_test_broken.service'"
-    - "remove_systemd_broken_result.state == 'absent'"
+      - remove_systemd_result is changed
 
 - name: make sure systemd is reloaded
   shell: systemctl daemon-reload

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -98,6 +98,26 @@
       - "reload_result is changed"
   when: service_type != "systemd"
 
+- name: Ensure sysvinit start stopped service when reloaded is used
+  when: service_type in ["sysv", "systemd"]
+  block:
+    - name: Ensure ansible_test_reload is stopped
+      sysvinit:
+        name: ansible_test_reload
+        state: stopped
+
+    - name: "Ensure 'start' is used instead of 'reload'"
+      sysvinit:
+        name: ansible_test_reload
+        state: reloaded
+      register: reload_result
+
+    - name: Check results
+      assert:
+        that:
+          - reload_result is success
+          - reload_result is changed
+
 - name: "test for #42786 (sysvinit)"
   when: service_type == "sysv"
   block:


### PR DESCRIPTION
##### SUMMARY
`sysvinit`: check service is started when `state: reloaded` is used and service is stopped

Integration test provided.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sysvinit

##### ADDITIONAL INFORMATION
How to reproduce:
```
$ cat play.yml
- hosts: all
  gather_facts: false
  connection: docker
  tasks:
    - raw: 'DEBIAN_FRONTEND=noninteractive apt-get --assume-yes update'
    - raw: 'DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install python'
    - apt:
        name: openssh-server
    - sysvinit:
        name: ssh
        state: reloaded
$ docker run --rm --name test_sysvinit -d debian:stretch sleep infinity
$ ansible-playbook -i test_sysvinit, play.yml # this command fails
$ docker stop test_sysvinit # cleanup