### PR TITLE
nxos.py:httpapi:return_timestamps causes ValueError when output empty

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -542,7 +542,11 @@ class HttpApi:
 
         out = to_list(out)
         if not out[0]:
-            return out
+            if return_timestamps:
+                # workaround until timestamps are implemented
+                return out, list()
+            else:
+                return out
 
         for index, response in enumerate(out):
             if response[0] == '{':


### PR DESCRIPTION
*This PR replaces #54907. I accidentally deleted the private branch for that PR.*

##### SUMMARY
This is related to issue #52671.

Symptom:
  `nxos_command` (or other calling module) calls httpapi `run_commands()` with
  `return_timestamps` set to `True`; the device returns an empty string;
  then `run_commands()` returns a single variable instead of two variables
  which raises: `ValueError: need more than 1 value to unpack`

This fix is the same workaround as used on line 551/555.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`module_utils/network/nxos/nxos.py`

