### PR TITLE
Fix template lookup description

### DIFF
--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -11,7 +11,7 @@ DOCUMENTATION = """
     version_added: "0.9"
     short_description: retrieve contents of file after templating with Jinja2
     description:
-      - Returns a string containing the results of processing the template file(s) you pass in.
+      - Returns a list of strings; for each template in the list of templates you pass in, returns a string containing the results of processing that template.
     options:
       _terms:
         description: list of files to template

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -11,7 +11,8 @@ DOCUMENTATION = """
     version_added: "0.9"
     short_description: retrieve contents of file after templating with Jinja2
     description:
-      - this is mostly a noop, to be used as a with_list loop when you do not want the content transformed in any way.
+      - Retrieves the content of a template after substituting variables.
+      - Same content as using the template module, but returns a string instead of writing an output file.
     options:
       _terms:
         description: list of files to template

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -11,8 +11,7 @@ DOCUMENTATION = """
     version_added: "0.9"
     short_description: retrieve contents of file after templating with Jinja2
     description:
-      - Retrieves the content of a template after substituting variables.
-      - Same content as using the template module, but returns a string instead of writing an output file.
+      - Returns a string containing the results of processing the template file(s) you pass in.
     options:
       _terms:
         description: list of files to template


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Previously, template lookup description was documented  as "mostly a noop".
Now,  describe that it returns template content with substituted variables.


##### COMPONENT NAME
template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

