### PR TITLE
Network CLI parsing using Cisco's Genie library

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -677,6 +677,85 @@ filter::
 
 Use of the TextFSM filter requires the TextFSM library to be installed.
 
+Network Genie filters
+`````````````````````
+
+.. versionadded:: 2.9
+
+The network genie filter can take unstructured network CLI command output from all
+Cisco network operating systems, and output structured JSON. While similar to other
+network CLI parsers already available (parse_cli, parse_cli_textfsm), this parser is
+powered by a very mature and robust library written by Cisco Systems called Genie (and underlying framework
+called pyATS). This provides over 500 parsers that transform configuration and CLI
+output to structured data that is normalized and conforms to standard, OS-agnostic data models.
+
+.. note:: The Genie library can also serve as an engine to parse tabular and non-tabular free-form text
+    using much less code than traditional screen-scrape parsing requires. This means that it can be used to
+    parse any vendor output; not just that of Cisco devices. That would involve writing custom parsers.
+    This release does not include the functionality to utilize custom parsers. The supported parsers are whatever
+    is included in the release of Genie that the user has installed on the Ansible control machine.
+
+To convert the output of a network device CLI command output, use the ``parse_genie`` filter as shown in this example:
+
+The CLI output of the ``show version`` command from a Cisco IOS-XE device::
+
+    {{ cli_output | parse_genie(command='show version', os='iosxe') }}
+
+The above example would yield the following:
+
+.. code-block:: json
+
+    {
+        "version": {
+            "chassis": "CSR1000V",
+            "chassis_sn": "9TKUWGKX5MO",
+            "curr_config_register": "0x2102",
+            "disks": {
+                "bootflash:.": {
+                    "disk_size": "7774207",
+                    "type_of_disk": "virtual hard disk"
+                },
+                "webui:.": {
+                    "disk_size": "0",
+                    "type_of_disk": "WebUI ODM Files"
+                }
+            },
+            "hostname": "host-172-16-1-96",
+            "image_id": "X86_64_LINUX_IOSD-UNIVERSALK9-M",
+            "image_type": "production image",
+            "last_reload_reason": "Reload Command",
+            "license_level": "ax",
+            "license_type": "Default. No valid license found.",
+            "main_mem": "1126522",
+            "mem_size": {
+                "non-volatile configuration": "32768",
+                "physical": "3018840"
+            },
+            "next_reload_license_level": "ax",
+            "number_of_intfs": {
+                "Gigabit Ethernet": "2"
+            },
+            "os": "IOS-XE",
+            "platform": "Virtual XE",
+            "processor_type": "VXE",
+            "rom": "IOS-XE ROMMON",
+            "rtr_type": "CSR1000V",
+            "system_image": "bootflash:packages.conf",
+            "uptime": "2 minutes",
+            "uptime_this_cp": "3 minutes",
+            "version": "16.5.1b,",
+            "version_short": "16.5"
+        }
+    }
+
+
+.. note:: The list of supported operating systems and commands is available from Cisco at the link below, as well
+    as the data's schema definitions (data models) which describe exactly what fields and
+    data types will be returned for any given command.
+
+    https://pubhub.devnetcloud.com/media/pyats-packages/docs/genie/genie_libs/#/parsers
+
+
 Network XML filters
 ```````````````````
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -695,7 +695,8 @@ output to structured data that is normalized and conforms to standard, OS-agnost
     This release does not include the functionality to utilize custom parsers. The supported parsers are whatever
     is included in the release of Genie that the user has installed on the Ansible control machine.
 
-To convert the output of a network device CLI command output, use the ``parse_genie`` filter as shown in this example:
+To convert the output of a network device CLI command output, use the ``parse_genie`` filter as shown in this example
+(do not use abbreviated CLI commands).
 
 The CLI output of the ``show version`` command from a Cisco IOS-XE device::
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -682,23 +682,23 @@ Network Genie filters
 
 .. versionadded:: 2.9
 
-The network genie filter can take unstructured network CLI command output from all
-Cisco network operating systems, and output structured JSON. While similar to other
+The network genie filter takes unstructured network CLI command output from all
+Cisco Systems network operating systems, and outputs structured data. While similar to other
 network CLI parsers already available (parse_cli, parse_cli_textfsm), this parser is
-powered by a very mature and robust library written by Cisco Systems called Genie (and underlying framework
-called pyATS). This provides over 500 parsers that transform configuration and CLI
+powered by a very mature and robust library written by Cisco Systems called Genie (and underlying framework pyATS).
+This provides over 500 parsers that transform configuration and CLI
 output to structured data that is normalized and conforms to standard, OS-agnostic data models.
 
 .. note:: The Genie library can also serve as an engine to parse tabular and non-tabular free-form text
-    using much less code than traditional screen-scrape parsing requires. This means that it can be used to
-    parse any vendor output; not just that of Cisco devices. That would involve writing custom parsers.
+    using much less code than traditional parsing requires. Therefore, it can be used to
+    parse any vendor output; not just that of Cisco devices. However, that would involve writing custom parsers.
     This release does not include the functionality to utilize custom parsers. The supported parsers are whatever
     is included in the release of Genie that the user has installed on the Ansible control machine.
 
-To convert the output of a network device CLI command output, use the ``parse_genie`` filter as shown in this example
+To convert the output of a network device CLI command, use the ``parse_genie`` filter as shown in this example
 (do not use abbreviated CLI commands).
 
-The CLI output of the ``show version`` command from a Cisco IOS-XE device::
+Converting CLI output of the ``show version`` command from a Cisco IOS-XE device to structured data::
 
     {{ cli_output | parse_genie(command='show version', os='iosxe') }}
 
@@ -750,9 +750,9 @@ The above example would yield the following:
     }
 
 
-.. note:: The list of supported operating systems and commands is available from Cisco at the link below, as well
+.. note:: The list of supported operating systems and commands, as well
     as the data's schema definitions (data models) which describe exactly what fields and
-    data types will be returned for any given command.
+    data types will be returned for any given command, is available from Cisco Systems at the link below.
 
     https://pubhub.devnetcloud.com/media/pyats-packages/docs/genie/genie_libs/#/parsers
 

--- a/lib/ansible/plugins/filter/genie.py
+++ b/lib/ansible/plugins/filter/genie.py
@@ -1,0 +1,136 @@
+#
+# (c) 2019, Clay Curtis <jccurtis@presidio.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.six import string_types
+from ansible.utils.display import Display
+
+try:
+    from genie.conf.base import Device, Testbed
+    from genie.libs.parser.utils import get_parser
+    HAS_GENIE = True
+except ImportError:
+    HAS_GENIE = False
+
+try:
+    from pyats.datastructures import AttrDict
+    HAS_PYATS = True
+except ImportError:
+    HAS_PYATS = False
+
+
+display = Display()
+
+
+def parse_genie(cli_output, command=None, os=None):
+    """
+    Uses the Cisco pyATS/Genie library to parse cli output into structured data.
+    :param cli_output: (String) CLI output from Cisco device
+    :param command: (String) CLI command that was used to generate the cli_output
+    :param os: (String) Operating system of the device for which cli_output was obtained.
+    :return: Dict object conforming to the defined genie parser schema.
+             https://pubhub.devnetcloud.com/media/pyats-packages/docs/genie/genie_libs/#/parsers/show%20version
+    """
+
+    # Does the user have the necessary packages installed in order to use this filter?
+    if not HAS_GENIE:
+        raise AnsibleFilterError("parse_genie: Genie package is not installed. To install, run 'pip install genie'.")
+
+    if not HAS_PYATS:
+        raise AnsibleFilterError("parse_genie: pyATS package is not installed. To install, run 'pip install pyats'.")
+
+    # Does the user have the required version of Python 3.4 that Genie and pyATS requires?
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
+        pass
+    else:
+        raise AnsibleFilterError("parse_genie: pyATS/Genie package requires python 3.4 or greater.")
+
+    # Input validation
+
+    # Is the CLI output a string?
+    if not isinstance(cli_output, string_types):
+        raise AnsibleError(
+            "The content provided to the genie_parse filter was not a string."
+        )
+
+    # Is the command a string?
+    if not isinstance(command, string_types):
+        raise AnsibleFilterError(
+            "The command provided to the genie_parse filter was not a string."
+        )
+
+    # Is the OS a string?
+    if not isinstance(os, string_types):
+        raise AnsibleFilterError(
+            "The network OS provided to the genie_parse filter was not a string."
+        )
+
+    # Is the OS provided by the user a supported OS by Genie?
+    # Supported Genie OSes: https://github.com/CiscoTestAutomation/genieparser/tree/master/src/genie/libs/parser
+    supported_oses = ["ios", "iosxe", "iosxr", "junos", "nxos"]
+    if os.lower() not in supported_oses:
+        raise AnsibleFilterError(
+            "The network OS provided ({0}) to the genie_parse filter is not a supported OS in Genie.".format(
+                os
+            )
+        )
+
+    # Boilerplate code to get the parser functional
+    # tb = Testbed()
+    device = Device("new_device", os=os)
+
+    device.custom.setdefault("abstraction", {})["order"] = ["os"]
+    device.cli = AttrDict({"execute": None})
+
+    # User input checking of the command provided. Does the command have a Genie parser?
+    try:
+        get_parser(command, device)
+    except Exception as e:
+        raise AnsibleFilterError(
+            "genie_parse: {0} - Available parsers: {1}".format(
+                to_native(e), "https://pubhub.devnetcloud.com/media/pyats-packages/docs/genie/genie_libs/#/parsers"
+            )
+        )
+
+    # Try to parse the output
+    try:
+        parsed_output = device.parse(command, output=cli_output)
+        return parsed_output
+    except Exception as e:
+        raise AnsibleFilterError(
+            "genie_parse: {0} - Failed to parse command output. Hint: Do not use abbreviated cli commands.".format(
+                to_native(e)
+            )
+        )
+
+
+class FilterModule(object):
+    """ Cisco pyATS/Genie Parser Filter """
+
+    def filters(self):
+        return {
+            # jinja2 overrides
+            "parse_genie": parse_genie
+        }

--- a/test/units/plugins/filter/fixtures/network/show_version.txt
+++ b/test/units/plugins/filter/fixtures/network/show_version.txt
@@ -1,0 +1,56 @@
+Cisco IOS XE Software, Version 16.05.01b
+Cisco IOS Software [Everest], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.5.1b, RELEASE SOFTWARE (fc1)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2017 by Cisco Systems, Inc.
+Compiled Tue 11-Apr-17 16:41 by mcpre
+
+
+Cisco IOS-XE software, Copyright (c) 2005-2017 by cisco Systems, Inc.
+All rights reserved.  Certain components of Cisco IOS-XE software are
+licensed under the GNU General Public License ("GPL") Version 2.0.  The
+software code licensed under GPL Version 2.0 is free software that comes
+with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
+GPL code under the terms of GPL Version 2.0.  For more details, see the
+documentation or "License Notice" file accompanying the IOS-XE software,
+or the applicable URL provided on the flyer accompanying the IOS-XE
+software.
+
+
+ROM: IOS-XE ROMMON
+
+host-172-16-1-96 uptime is 2 minutes
+Uptime for this control processor is 3 minutes
+System returned to ROM by reload
+System image file is "bootflash:packages.conf"
+Last reload reason: Reload Command
+
+
+
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+
+License Level: ax
+License Type: Default. No valid license found.
+Next reload license Level: ax
+
+cisco CSR1000V (VXE) processor (revision VXE) with 1126522K/3075K bytes of memory.
+Processor board ID 9TKUWGKX5MO
+2 Gigabit Ethernet interfaces
+32768K bytes of non-volatile configuration memory.
+3018840K bytes of physical memory.
+7774207K bytes of virtual hard disk at bootflash:.
+0K bytes of WebUI ODM Files at webui:.
+
+Configuration register is 0x2102

--- a/test/units/plugins/filter/test_genie.py
+++ b/test/units/plugins/filter/test_genie.py
@@ -1,0 +1,74 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import os
+import sys
+import pytest
+
+from ansible.plugins.filter.genie import parse_genie, HAS_GENIE, HAS_PYATS
+
+
+fixture_path = os.path.join(os.path.dirname(__file__), "fixtures", "network")
+
+with open(os.path.join(fixture_path, "show_version.txt")) as f:
+    show_version_text = f.read()
+
+show_version_parsed = {
+    "version": {
+        "chassis": "CSR1000V",
+        "chassis_sn": "9TKUWGKX5MO",
+        "curr_config_register": "0x2102",
+        "disks": {
+            "bootflash:.": {
+                "disk_size": "7774207",
+                "type_of_disk": "virtual hard disk",
+            },
+            "webui:.": {"disk_size": "0", "type_of_disk": "WebUI ODM Files"},
+        },
+        "hostname": "host-172-16-1-96",
+        "image_id": "X86_64_LINUX_IOSD-UNIVERSALK9-M",
+        "image_type": "production image",
+        "last_reload_reason": "Reload Command",
+        "license_level": "ax",
+        "license_type": "Default. No valid license found.",
+        "main_mem": "1126522",
+        "mem_size": {"non-volatile configuration": "32768", "physical": "3018840"},
+        "next_reload_license_level": "ax",
+        "number_of_intfs": {"Gigabit Ethernet": "2"},
+        "os": "IOS-XE",
+        "platform": "Virtual XE",
+        "processor_type": "VXE",
+        "rom": "IOS-XE ROMMON",
+        "rtr_type": "CSR1000V",
+        "system_image": "bootflash:packages.conf",
+        "uptime": "2 minutes",
+        "uptime_this_cp": "3 minutes",
+        "version": "16.5.1b,",
+        "version_short": "16.5",
+    }
+}
+
+@pytest.mark.skipif(sys.version_info < (3, 4),
+                    reason="Genie requires python3.4 or greater")
+@pytest.mark.skipif(HAS_GENIE is False,
+                    reason="Requires Genie package")
+@pytest.mark.skipif(HAS_PYATS is False,
+                    reason="Requires pyATS package")
+def test_parse_genie():
+    assert parse_genie(show_version_text, command="show version", os="iosxe") == show_version_parsed


### PR DESCRIPTION
##### SUMMARY
The network industry must do a lot of screen-scraping from their devices in order to automate their networks. This is an Ansible filter module that uses Cisco Systems' Genie/pyATS framework to handle the parsing of unstructed CLI output to structured data that conforms to OS-agnostic data models. There is already `parse_cli` and `parse_cli_textfsm`, but those are community efforts. The Genie framework was developed by Cisco Systems and is robust, tested, and officially supported by them. This filter plugin will immediately open the door for Ansible users to parse over 500 commands across four different Cisco network platforms with ease.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`parse_genie` filter plugin

##### ADDITIONAL INFORMATION
If merged, this would provide a significant improvement of automating network devices using the Ansible platform. One of the major benefits that this brings is that the structured data that is returned is based on OS-agnostic schemas, which will make automation tasks for different platforms easier as the data models are the same regardless of the Cisco network OS.

Playbook:
```
---

- hosts: localhost
  connection: local
  vars:
    show_version_output: |
      Cisco IOS XE Software, Version 16.05.01b
      Cisco IOS Software [Everest], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.5.1b, RELEASE SOFTWARE (fc1)
      Technical Support: http://www.cisco.com/techsupport
      Copyright (c) 1986-2017 by Cisco Systems, Inc.
      Compiled Tue 11-Apr-17 16:41 by mcpre


      Cisco IOS-XE software, Copyright (c) 2005-2017 by cisco Systems, Inc.
      All rights reserved.  Certain components of Cisco IOS-XE software are
      licensed under the GNU General Public License ("GPL") Version 2.0.  The
      software code licensed under GPL Version 2.0 is free software that comes
      with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
      GPL code under the terms of GPL Version 2.0.  For more details, see the
      documentation or "License Notice" file accompanying the IOS-XE software,
      or the applicable URL provided on the flyer accompanying the IOS-XE
      software.


      ROM: IOS-XE ROMMON

      host-172-16-1-96 uptime is 2 minutes
      Uptime for this control processor is 3 minutes
      System returned to ROM by reload
      System image file is "bootflash:packages.conf"
      Last reload reason: Reload Command



      This product contains cryptographic features and is subject to United
      States and local country laws governing import, export, transfer and
      use. Delivery of Cisco cryptographic products does not imply
      third-party authority to import, export, distribute or use encryption.
      Importers, exporters, distributors and users are responsible for
      compliance with U.S. and local country laws. By using this product you
      agree to comply with applicable laws and regulations. If you are unable
      to comply with U.S. and local laws, return this product immediately.

      A summary of U.S. laws governing Cisco cryptographic products may be found at:
      http://www.cisco.com/wwl/export/crypto/tool/stqrg.html

      If you require further assistance please contact us by sending email to
      export@cisco.com.

      License Level: ax
      License Type: Default. No valid license found.
      Next reload license Level: ax

      cisco CSR1000V (VXE) processor (revision VXE) with 1126522K/3075K bytes of memory.
      Processor board ID 9TKUWGKX5MO
      2 Gigabit Ethernet interfaces
      32768K bytes of non-volatile configuration memory.
      3018840K bytes of physical memory.
      7774207K bytes of virtual hard disk at bootflash:.
      0K bytes of WebUI ODM Files at webui:.

      Configuration register is 0x2102

  tasks:
  - name: Debug genie filter
    debug:
      msg: "{{ show_version_output | parse_genie(command='show version', os='iosxe') }}"
    delegate_to: localhost
```

Playbook Output:
```
ansible-playbook -i inventory playbook.yml                                                                                                                                                                                                                

PLAY [localhost] *****************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Debug genie filter] ********************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "version": {
            "chassis": "CSR1000V",
            "chassis_sn": "9TKUWGKX5MO",
            "curr_config_register": "0x2102",
            "disks": {
                "bootflash:.": {
                    "disk_size": "7774207",
                    "type_of_disk": "virtual hard disk"
                },
                "webui:.": {
                    "disk_size": "0",
                    "type_of_disk": "WebUI ODM Files"
                }
            },
            "hostname": "host-172-16-1-96",
            "image_id": "X86_64_LINUX_IOSD-UNIVERSALK9-M",
            "image_type": "production image",
            "last_reload_reason": "Reload Command",
            "license_level": "ax",
            "license_type": "Default. No valid license found.",
            "main_mem": "1126522",
            "mem_size": {
                "non-volatile configuration": "32768",
                "physical": "3018840"
            },
            "next_reload_license_level": "ax",
            "number_of_intfs": {
                "Gigabit Ethernet": "2"
            },
            "os": "IOS-XE",
            "platform": "Virtual XE",
            "processor_type": "VXE",
            "rom": "IOS-XE ROMMON",
            "rtr_type": "CSR1000V",
            "system_image": "bootflash:packages.conf",
            "uptime": "2 minutes",
            "uptime_this_cp": "3 minutes",
            "version": "16.5.1b,",
            "version_short": "16.5"
        }
    }
}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```
