### PR TITLE
[2.8] k8s: fix API call to _wait_for_response

### DIFF
--- a/changelogs/fragments/k8s-fix_wait_for_response.yaml
+++ b/changelogs/fragments/k8s-fix_wait_for_response.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Fix API call to _wait_for_response in k8s modules (https://github.com/ansible/ansible/pull/53937).

--- a/lib/ansible/module_utils/k8s/scale.py
+++ b/lib/ansible/module_utils/k8s/scale.py
@@ -136,7 +136,7 @@ class KubernetesAnsibleScaleModule(KubernetesRawModule):
             return_obj = self._read_stream(resource, w, stream, name, replicas)
 
         if not return_obj:
-            return_obj = self._wait_for_response(name, namespace)
+            return_obj = self._wait_for_response(resource, name, namespace)
 
         return return_obj
 


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit 94f295e4a1def85a64dfb0f9d2e97e5067a92ea0)

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/k8s-fix_wait_for_response.yaml
lib/ansible/module_utils/k8s/scale.py
