### PR TITLE
Create Ansible groups based on arbitrary host facts.

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -2,7 +2,7 @@
 #
 # This script can be used as an Ansible dynamic inventory.
 # The connection parameters are set up via *foreman.ini*
-# This is how the script founds the configuration file in
+# This is how the script finds the configuration file in
 # order of discovery.
 #
 #     * `/etc/ansible/foreman.ini`
@@ -47,31 +47,84 @@
 #
 #     TASK [test_foreman : debug] ****************************************************
 #     ok: [foo.example.com] => {
-#     "msg": "From Foreman host 50190bd1-052a-a34a-3c9c-df37a39550bf"
+#     "msg": "From Foreman host 50197c10-5ebb-b5cf-b384-a1e203e19e77"
 #     }
 #
 # ## Automatic Ansible groups
 #
 # The inventory will provide a set of groups, by default prefixed by
-# 'foreman_'. If you want to customize this prefix, change the
-# group_prefix option in /etc/ansible/foreman.ini. The rest of this
-# guide will assume the default prefix of 'foreman'
+# 'foreman_'. This is controled by the group_prefix option, which
+# defaults to 'foreman/', the trailing '/' being converted to the
+# legal Ansible group character '_' by the rules described below.
+# The rest of this guide assumes the default prefix of 'foreman/'.
+#
+# Ansible recommends (and in future, may enforce) that all host group
+# names contain only ascii letters, digits, and underscores. To that end,
+# group names generated from foreman must undergo some transformations.
 #
 # The hostgroup, location, organization, content view, and lifecycle
 # environment of each host are created as Ansible groups with a
-# foreman_<grouptype> prefix, all lowercase and problematic parameters
-# removed. So e.g. the foreman hostgroup
+# foreman_<grouptype> prefix, with spaces removed and all remaining
+# non-alphanumeric characters replaced with underscores.
+# Remaining alphabetic characters are then lower-cased (Unless you
+# set preserve_case = False).
 #
-#     myapp / webtier / datacenter1
+# Further changes are determined by the "group_case" parameter, which
+# can be "snake_case" (or unspecified), "Up_case", "camelCase", or
+# "PascalCase". Their various effects are shown in the follow table:
 #
-# would turn into the Ansible group:
+# Context       Group Name
+# -----------   ---------------------------------------------------
+# foreman       myApp / web-tier / Data Center-31-2b
+# snake_case    foreman_hostgroup_myapp_web_tier_datacenter_31_2b
+# Up_case       Foreman_hostgroup_Myapp_Web_tier_Datacenter_31_2b
+# PascalCase    Foreman_Hostgroup_Myapp_WebTier_Datacenter31v2b
+# camelCase     foreman_hostgroup_myapp_webTier_Datacenter31v2b
 #
-#     foreman_hostgroup_myapp_webtier_datacenter1
+# The styles represent a tradeoff between minimal changes, readability,
+# and ambiguity. Note that in PascalCase and camelCase, the
+# only remaining underscores are at actual hierarchical divisions. (To
+# accomplish that while keeping groups of digits within a hierarchical
+# level, an underscore between digits is changed to "v".)
 #
-# If the parameter want_hostcollections is set to true, the
+# By default, only "leaf groups" -- those containing hosts as direct
+# members -- are created. Setting "want_generated_parents=True" causes
+# parent groups to be created as well. Given the example above,
+# "want_generated_parents=True" would create:
+#
+# context       group name
+# -----------   -------------------------------------------------
+# foreman       myApp / web-tier / Data Center-31-2b
+#
+# snake_case    foreman_hostgroup_myapp_web_tier_datacenter_31_2b
+#               foreman_hostgroup_myapp_web_tier
+#               foreman_hostgroup_myapp
+#               foreman_hostgroup
+#               foreman
+#
+# Up_case       Foreman_hostgroup_Myapp_Web_tier_Datacenter_31_2b
+#               Foreman_hostgroup_Myapp_Web_tier
+#               Foreman_hostgroup_Myapp
+#               Foreman_hostgroup
+#               Foreman
+#
+# PascalCase    Foreman_Hostgroup_Myapp_WebTier_Datacenter31v2b
+#               Foreman_Hostgroup_Myapp_WebTier
+#               Foreman_Hostgroup_Myapp
+#               Foreman_Hostgroup
+#               Foreman
+#
+# camelCase     foreman_hostgroup_myapp_webTier_Datacenter31v2b
+#               foreman_hostgroup_myapp_webTier
+#               foreman_hostgroup_myapp
+#               foreman_hostgroup
+#               foreman
+#
+# If the parameter "want_hostcollections" is set to true, the
 # collections each host is in are created as Ansible groups with a
-# foreman_hostcollection prefix, all lowercase and problematic
-# parameters removed. So e.g. the Foreman host collection
+# foreman_hostcollection prefix, with all spaces removed and
+# and other transformations as described above for hostgroups.
+# So e.g. the Foreman host collection
 #
 #     Patch Window Thursday
 #
@@ -79,25 +132,30 @@
 #
 #     foreman_hostcollection_patchwindowthursday
 #
-# If the parameter host_filters is set, it will be used as the
+# If the parameter "host_filters" is set, it will be used as the
 # "search" parameter for the /api/v2/hosts call. This can be used to
-# restrict the list of returned host, as shown below.
+# restrict the list of returned host.
 #
-# Furthermore Ansible groups can be created on the fly using the
-# *group_patterns* variable in *foreman.ini* so that you can build up
-# hierarchies using parameters on the hostgroup and host variables.
+# Furthermore Ansible groups can be created on the fly from foreman
+# host parameters using JSON "group_patterns".
 #
-# Lets assume you have a host that is built using this nested hostgroup:
+# Parameter value case is preserved by default, but you can down-case
+# parameter values by setting "group_patterns_preserve_case=False".
+# Otherwise they are subject to the same transformations as foreman
+# group names.
 #
-#     myapp / webtier / datacenter1
+# Assume you have a host webserver0.my.org that is built using
+# this nested hostgroup:
 #
-# and each of the hostgroups defines a parameters respectively:
+#     myApp / web-tier / Data Center-1
 #
-#     myapp: app_param = myapp
-#     webtier: tier_param = webtier
-#     datacenter1: dc_param = datacenter1
+# and each of the hostgroups defines parameters respectively:
 #
-# The host is also in a subnet called "mysubnet" and provisioned via an image
+#     myapp: app_param = myApp
+#     webtier: tier_param = web-tier
+#     datacenter1: dc_param = Data Center-1
+#
+# and the host is in a subnet called "mysubnet" provisioned via an "image",
 # then *group_patterns* like:
 #
 #     [ansible]
@@ -108,15 +166,77 @@
 #
 # would put the host into the additional Ansible groups:
 #
-#     - myapp-webtier-datacenter1
-#     - myapp-webtier
-#     - myapp
-#     - mysubnet-image
+#     - myApp_web_tier_DataCenter_1
+#     - myApp_web_tier
+#     - myApp
+#     - mysubnet_image
 #
-# by recursively resolving the hostgroups, getting the parameter keys
-# and values and doing a Python *string.format()* like replacement on
-# it.
+# by recursively resolving the hostgroups, getting the parameter keys and
+# and values and doing a Python *string.format()* like replacement on it.
 #
+# If you want host group names with a prefix similar to "foreman_hostgroup"
+# or "foreman_hostcollection" for your parameter-derived group names, include the
+# prefix in your group_patterns. Say your hosts have a parameter "sm_customer"
+# with values "dba", "middleware", and "finance". Then
+#
+#     group_patterns = ["foreman/param/sm_customer/{sm_customer}"]
+#
+# would create these host groups:
+#
+#     foreman_param_sm_customer_dba
+#     foreman_param_sm_customer_middleware
+#     foreman_param_sm_customer_finance
+#
+# With "want_generated_parents=True" and "group_case=camelCase", you would get
+# these groups (indentation representing parent/child relationships):
+#
+#     foreman
+#       foreman_param
+#         foreman_param_smCustomer
+#           foreman_param_smCustomer_dba
+#           foreman_param_smCustomer_middleware
+#           foreman_param_smCustomer_finance
+#
+# The group_facts variable in foreman.ini allows Ansible groups to be
+# created based on foreman host facts. group_facts should be a list of
+# one or more facts from which you wish to create Ansible groups. It will
+# only take effect if "want_facts=True". For example,
+# if you have a "customer" fact with values of "middleware", "dba", and
+# "idman", then these groups would be created:
+#
+#     foreman_customer_middleware
+#     foreman_customer_idman
+#     foreman_customer_dba
+#
+# All group names are subject to further transformations according
+# to preserve_case (or group_patterns_preserve_case for parameter
+# derived group names), group_case, and want_generated_parents.
+#
+# Sets of Ansible group variables can be assigned to final Ansible group
+# names (i.e. after all the transformations are complete) which
+# match regular expressions. For example:
+#
+#     [ansible]
+#     group_vars = { "^foreman_customer_dba_.*" :
+#                           { "ansible_group_priority" : -9 },
+#                    "^foreman_hostgroup_alpha_.*" :
+#                           { "ansible_group_priority" : 20,
+#                             "training_wheels" : "max" } }
+#
+# This sets the "ansible_group_priority" in all groups matching those
+# prefixes. Normally, a host that's in two sibling groups
+# "foreman_hostgroup_alpha_foo" and "foreman_hostgroup_zeta_foo" would
+# first load group variables from the alpha_foo group_vars file, some of
+# which could then be overwritten by identically named variables in the
+# zeta_foo file. However, ansible_group_priority (which defaults to 1)
+# allows you to circumvent alphabetical load order. In this case, the
+# alpha_.* files would load after other group_vars files.
+
+# group_vars is not limited to setting ansible_group_priority; any
+# arbitrarily json dict can be assigned as inventory variables. (Note
+# however that ansible_group_priority is the one Ansible variable that
+# is not inherited by child groups.)
+
 [foreman]
 url = http://localhost:3000/
 user = foreman
@@ -135,15 +255,54 @@ group_patterns = ["{app}-{tier}-{color}",
 	          "{app}-{color}",
 	          "{app}",
 		  "{tier}"]
-group_prefix = foreman_
+
+# Whether to preserve or down-case parameter values loaded
+# from group_patterns. Defaults to True (i.e. preserve case).
+group_patterns_preserve_case=True
+
+# All non-alphabetic characters end up as '_', but '/' initially
+# indicates hierarchy. The trailing '/' is equivalent to '_' unless
+# you also set "want_generated_parents=True".
+group_prefix = foreman/
 
 # Whether to fetch facts from Foreman and store them on the host
 want_facts = True
+
+# Whether to create Ansible groups based on these host facts.
+# Requires "want_facts=True".
+group_facts = []
 
 # Whether to create Ansible groups for host collections. Only tested
 # with Katello (Red Hat Satellite). Disabled by default to not break
 # the script for stand-alone Foreman.
 want_hostcollections = False
+
+# Whether to create Ansible parent groups for all groups, whether
+# from foreman host groups, host parameters in group_patterns,
+# or group_facts.
+want_generated_parents = False
+
+# Whether to down-case alphabetic characters in forman group names
+# and group_facts. (See group_patterns_preserve_case.)
+preserve_case = False
+
+# How to distinguish group hierarchy through capitalization.
+# Applied after all non-alphanumeric characters becomes underscores.
+#  "snake_case" is the default. Interior underscores are retained.
+#  "camelCase" Interior underscores are dropped and the following char capitalized.
+#  "PascalCase" Like camelCase, but first letter is capitalized too.
+#  "Up_case" Interior underscores are retained, first letter of group capitalized.
+# (PascalCase and camelCase also change "<digit>_<digit>" to
+# "<digit>v<digit>" so that all remaining underscores indicate hierarchy.)
+group_case = snake_case
+
+# Assign group_vars at the inventory level:
+#
+#     group_vars = { "^foreman_customer_dba_.*" :
+#                           { "ansible_group_priority" : -9 },
+#                    "^foreman_hostgroup_alpha_.*" :
+#                           { "ansible_group_priority" : 20 } }
+group_vars = {}
 
 # Whether to interpret global parameters value as JSON (if possible, else
 # take as is). Only tested with Katello (Red Hat Satellite).


### PR DESCRIPTION
This only affects the contributed foreman inventory script.
Create Ansible groups based on arbitrary host facts.
Generate parent groups for created Ansible groups.

##### SUMMARY
This allows the easy creation of Ansible groups from indicated foreman host facts.
It also allows the creation of parent groups for all Ansible hostgroups generated from foreman.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
This only affects the foreman.py contributed inventory script.

##### ADDITIONAL INFORMATION
This change adds a couple of parameters to the foreman.ini file which configures the operation of the foreman.py inventory script. Specifically:
want_generated_parents: when True, creates parent groups for all created host groups. Default: False
group_facts: a list of host facts on which to create Ansible host groups. Defaults to an empty list.

For example, given these settings in the foreman.ini file:
```
[ansible]
want_generated_parents: True
group_facts: ["bios_vendor"]
```
The group_facts parameter would create host groups (in our case, for example) of
```
  "foreman_factgroup_bios_vendor": {
    "children": [
      "foreman_factgroup_bios_vendor_phoenixtechnologiesltd", 
      "foreman_factgroup_bios_vendor_ibm", 
      "foreman_factgroup_bios_vendor_hpe", 
      "foreman_factgroup_bios_vendor_hp"
    ]
  }, 
```
The want_generated_parents would generate parent groups for all created "foreman_*" groups, which can be very handy. In our case for example without want_generated_parents we get these host groups:
```
foreman_hostgroup_idman_krb_ones
foreman_hostgroup_idman_krb_zeros
foreman_hostgroup_idman_ng
foreman_hostgroup_idman_prod
```
but with want_generated_parents set to True, we also get these parent groups:
```
foreman_hostgroup_idman_krb
foreman_hostgroup_idman
```
** group_vars
This allows setting arbitrary group_vars at the inventory level. (In particular, "ansible_group_priority" cannot be used _except_ at the inventory level.)

** group_case
Option for controlling the spelling (case, '_') of created groups. See foreman.ini for details.
