### PR TITLE
VMware: Folder support on dynamic inventory plugin - alternative implementation

### DIFF
--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_inventory.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_inventory.rst
@@ -73,6 +73,34 @@ And you can use this vaulted inventory configuration file using:
 
     $ ansible-inventory -i filename.vmware.yml --list --vault-password-file=/path/to/vault_password_file
 
+Generating groups from folders
+==============================
+
+Ansible groups are generated from vCenter folders.
+
+To keep them unique the group names match the full folder path, replacing each foldername is urlencoded so that no namingcollission occure, e.g. VMware allows forward/backward slashes within folder names.
+As an example, suppose a vCenter folder layout for an AWX lab like this:
+
+.. code-block:: text
+
+    /AWX
+    /AWX/lab
+    /AWX/lab/db
+    /AWX/lab/workers
+
+Will generate an inventory like this:
+
+.. code-block:: text
+
+    @all:
+      |--@awx:
+      |  |--@awx_lab:
+      |  |  |--@awx_lab_db:
+      |  |  |  |--awx-db01_xxxx-uuid
+      |  |  |--@awx_lab_workers:
+      |  |  |  |--awx-worker01_xxxx-uuid
+      |  |  |  |--awx-worker02_xxxx-uuid
+    ...
 
 .. seealso::
 

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -593,7 +593,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
                     # Based on power state of virtual machine
                     if "runtime.powerState" in vm_properties:
-                        vm_power = str(self.pyv._get_object_prop(vm_obj.obj, ["runtime","powerState"]))
+                        vm_power = str(self.pyv._get_object_prop(vm_obj.obj, ["runtime", "powerState"]))
                         if vm_power not in cacheable_results:
                             cacheable_results[vm_power] = {'hosts': []}
                             self.inventory.add_group(vm_power)

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -493,6 +493,23 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                     cacheable_results[vm_guest_id]['hosts'].append(current_host)
                     self.inventory.add_child(vm_guest_id, current_host)
 
+                    # Based on folder of virtual machine
+                    folders = current_host.split('/')[1:]
+                    if folders[0] not in cacheable_results:
+                        parent_folder = ''
+                        self.inventory.add_group(folders[0])
+                        while bool(folders):
+                            parent_folder = folders.pop(0)
+                            if len(folders) > 1:
+                                self.inventory.add_group(folders[0])
+                                cacheable_results[parent_folder] = {'hosts': []}
+                                self.inventory.add_child(parent_folder, folders[0])
+                            elif len(folders) == 1:
+                                cacheable_results[parent_folder] = {'hosts': []}
+                                self.inventory.add_child(parent_folder, current_host)
+                            else:
+                                pass
+
         for host in hostvars:
             h = self.inventory.get_host(host)
             cacheable_results['_meta']['hostvars'][h.name] = h.vars

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -101,7 +101,12 @@ EXAMPLES = '''
 import ssl
 import atexit
 from ansible.errors import AnsibleError, AnsibleParserError
-from urllib.parse import quote_plus
+
+import urllib.parse #import quote_plus
+# Overwrite _ALWAYS_SAFE to no longer include b'_.-~', so that these are also quoted
+urllib.parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                         b'abcdefghijklmnopqrstuvwxyz'
+                         b'0123456789')
 
 try:
     # requests is required for exception handling of the ConnectionError
@@ -364,9 +369,9 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
     def _get_fullName(self, vm_obj_obj):
         if(vm_obj_obj.parent):
-            return self._get_fullName(vm_obj_obj.parent) + '/' + quote_plus(vm_obj_obj.name, safe='')
+            return self._get_fullName(vm_obj_obj.parent) + '/' + urllib.parse.quote_plus(vm_obj_obj.name, safe='')
         else:
-            return '/' + quote_plus(vm_obj_obj.name)
+            return '/' + urllib.parse.quote_plus(vm_obj_obj.name)
 
     def _populate_from_cache(self, source_data):
         """ Populate cache using source data """

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -102,26 +102,6 @@ import ssl
 import atexit
 from ansible.errors import AnsibleError, AnsibleParserError
 
-# Overwrite _ALWAYS_SAFE to only include letters and number
-# so that everything is correctly quoted
-try:
-    # python3
-    import urllib.parse
-    urllib.parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                                 b'abcdefghijklmnopqrstuvwxyz'
-                                 b'0123456789')
-    urllib.parse._ALWAYS_SAFE_BYTES = bytes(urllib.parse._ALWAYS_SAFE)
-except ImportError:
-    # python2
-    import urllib
-    urllib.always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                          'abcdefghijklmnopqrstuvwxyz'
-                          '0123456789')
-    urllib._safe_map = {}
-    for i, c in zip(xrange(256), str(bytearray(xrange(256)))):
-        urllib._safe_map[c] = c if (i < 128 and c in urllib.always_safe) else '%{:02X}'.format(i)
-    urllib.parse = urllib # face pyton3 structure, so that python3 syntax can be used afterwards
-
 try:
     # requests is required for exception handling of the ConnectionError
     import requests
@@ -145,6 +125,26 @@ except ImportError:
 
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable
+
+# Overwrite _ALWAYS_SAFE to only include letters and number
+# so that everything is correctly quoted
+try:
+    # python3
+    import urllib.parse
+    urllib.parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                                 b'abcdefghijklmnopqrstuvwxyz'
+                                 b'0123456789')
+    urllib.parse._ALWAYS_SAFE_BYTES = bytes(urllib.parse._ALWAYS_SAFE)
+except ImportError:
+    # python2
+    import urllib
+    urllib.always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                          'abcdefghijklmnopqrstuvwxyz'
+                          '0123456789')
+    urllib._safe_map = {}
+    for i, c in zip(xrange(256), str(bytearray(xrange(256)))):
+        urllib._safe_map[c] = c if (i < 128 and c in urllib.always_safe) else '%{:02X}'.format(i)
+    urllib.parse = urllib # fake pyton3 structure, so that python3 syntax can be used afterwards
 
 
 class BaseVMwareInventory:

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -382,10 +382,22 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             self._cache[cache_key] = cacheable_results
 
     def _get_fullName(self, vm_obj_obj):
+        # This is based on the url schema VMware uses within the PowerCLI api
+        # but the PowerCLI url has collisions, as it uses slashes as folder name
+        # deliminator, but slashes can also occur within folder names themselves
+        # in the original these slashes are not escaped and the resulting path
+        # is inaccessible or even worse it overlays another path and the action
+        # could be performed on the vms within the wrong folder.
+        # To prevent this issue, every foldername within the folderpath gets
+        # urlencode before constructing
         if(vm_obj_obj.parent):
             return self._get_fullName(vm_obj_obj.parent) + '/' + urllib.parse.quote_plus(vm_obj_obj.name, safe='')
         else:
-            return '/' + urllib.parse.quote_plus(vm_obj_obj.name)
+            # For some reason the api returns 'Datencenter' (not Datacenter) as the
+            # root item, but VMware has also not included it within there path schema.
+            # Instead they have added the hostname and the port of the instance
+            # So why not mirror that?
+            return 'vis:/' + self.pyv.hostname + '@' + str(self.pyv.port)
 
     def _populate_from_cache(self, source_data):
         """ Populate cache using source data """

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -538,8 +538,14 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         cacheable_results = {'_meta': {'hostvars': {}}}
         hostvars = {}
+
+        # It's way faster to fetch all wanted properties right now.
+        # Otherwise they are fetched when we try to access them for the first time
+        # and as we're looping over the list the properties would be fetched at a one by one basis
+        # resulting in linear instead of konstant execution time.
+        query_properties = [x for x in set(self.get_option('properties')) if x != "customValue"] or ["name"]
         objects = self.pyv._get_managed_objects_properties(vim_type=vim.VirtualMachine,
-                                                           properties=['name'])
+                                                           properties=query_properties)
 
         if self.pyv.with_tags:
             tag_svc = self.pyv.rest_content.tagging.Tag

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -247,20 +247,20 @@ try:
 
     # overwrite allowed characters e.g. list of characters that are not encoded.
     my_urllib_parse._ALWAYS_SAFE = frozenset(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                                          b'abcdefghijklmnopqrstuvwxyz'
-                                          b'0123456789')
+                                             b'abcdefghijklmnopqrstuvwxyz'
+                                             b'0123456789')
     my_urllib_parse._ALWAYS_SAFE_BYTES = bytes(my_urllib_parse._ALWAYS_SAFE)
 except ImportError:
     # python2
 
     # Import copy of urllib to also encode all special chars.
     import imp
-    my_urllib_parse=imp.load_module('urllib', *imp.find_module('urllib'))
+    my_urllib_parse = imp.load_module('urllib', *imp.find_module('urllib'))
     from past.builtins import xrange
 
     my_urllib_parse.always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                          'abcdefghijklmnopqrstuvwxyz'
-                          '0123456789')
+                                   'abcdefghijklmnopqrstuvwxyz'
+                                   '0123456789')
     my_urllib_parse._safe_map = {}
     for i, c in zip(xrange(256), str(bytearray(xrange(256)))):
         my_urllib_parse._safe_map[c] = c if (i < 128 and c in my_urllib_parse.always_safe) else '%{0:02x}'.format(i)

--- a/test/integration/targets/inventory_vmware_vm_inventory/ansible.cfg
+++ b/test/integration/targets/inventory_vmware_vm_inventory/ansible.cfg
@@ -1,8 +1,7 @@
 [defaults]
-inventory = test-config.vmware.yaml
 
 [inventory]
-enable_plugins = vmware_vm_inventory
+enable_plugins = host_list, vmware_vm_inventory
 cache = True
 cache_plugin = jsonfile
 cache_connection = inventory_cache

--- a/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -48,6 +48,9 @@ curl "http://${VCENTER_HOST}:${port}/spawn?datacenter=1&cluster=1&folder=0" > /d
 echo "Debugging new instances"
 curl "http://${VCENTER_HOST}:${port}/govc_find"
 
+# Creates folder structure to test inventory folder support
+ansible-playbook -i 'localhost,' test_vmware_prep_folders.yml
+
 # Get inventory
 ansible-inventory -i ${VMWARE_CONFIG} --list
 

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
@@ -1,0 +1,60 @@
+# Test code for the vmware guest dynamic plugin module
+# Copyright: (c) 2019, Diego Morales <dgmorales@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+- name: Prepare VMware folders for testing dynamic inventory folder support
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}' # to get the same behavior as implicit localhost
+    vcsim_user: user
+    vcsim_pass: pass
+    datacenter: DC0
+  tasks:
+    - name: store the vcenter container ip
+      set_fact:
+        vcsim: "{{ lookup('env', 'VCENTER_HOST') }}"
+
+    - debug:
+        var: vcsim
+
+    - name: Create root folder
+      vcenter_folder:
+        hostname: '{{ vcsim }}'
+        username: '{{ vcsim_user }}'
+        password: '{{ vcsim_pass }}'
+        validate_certs: no
+        datacenter: '{{ datacenter }}'
+        folder_name: folder0
+        folder_type: vm
+        state: present
+
+    - name: Create subfolders
+      vcenter_folder:
+        hostname: '{{ vcsim }}'
+        username: '{{ vcsim_user }}'
+        password: '{{ vcsim_pass }}'
+        validate_certs: no
+        datacenter: '{{ datacenter }}'
+        folder_name: '{{ item }}'
+        folder_type: vm
+        parent_folder: folder0
+        state: present
+      loop:
+        - subfolderA
+        - subfolderB
+
+    - name: Move VMs to new folders
+      vmware_guest_move:
+        hostname: '{{ vcsim }}'
+        username: '{{ vcsim_user }}'
+        password: '{{ vcsim_pass }}'
+        validate_certs: no
+        datacenter: '{{ datacenter }}'
+        name: '{{ item.vm }}'
+        dest_folder: '{{ item.folder }}'
+      loop:
+        - { vm: 'DC0_H0_VM0', folder: '/{{ datacenter }}/vm/folder0/subfolderA'}
+        - { vm: 'DC0_H0_VM1', folder: '/{{ datacenter }}/vm/folder0/subfolderB'}

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_prep_folders.yml
@@ -9,13 +9,16 @@
   gather_facts: no
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}' # to get the same behavior as implicit localhost
-    vcsim_user: user
-    vcsim_pass: pass
+    vcsim: "{{ lookup('env', 'VCENTER_HOST') }}"
+    vcsim_user: "{{ lookup('env', 'VMWARE_USERNAME') }}"
+    vcsim_pass: "{{ lookup('env', 'VMWARE_PASSWORD') }}"
     datacenter: DC0
   tasks:
-    - name: store the vcenter container ip
-      set_fact:
-        vcsim: "{{ lookup('env', 'VCENTER_HOST') }}"
+    - name: Initialize vmware tests
+      import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_datacenter: true
 
     - debug:
         var: vcsim

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_vm_inventory.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_vm_inventory.yml
@@ -10,9 +10,9 @@
       set_fact:
         vcsim: "{{ lookup('env', 'VCENTER_HOST') }}"
 
-    - name: Check that there are 'all' and 'otherGuest' groups present in inventory
+    - name: Check that some expected groups are present in inventory
       assert:
-        that: "'{{ item }}' in {{ groups.keys() | list }}"
+        that: "item in (groups.keys()|list)"
       with_items:
       - all
       - otherGuest


### PR DESCRIPTION
##### SUMMARY

Include folders within the vmware inventory plugin. As the folder path is required by the gather facts plugin (future work is to make them interact seamlessly, now that we have all required information). This PR includes a commit that is also PR-ed as #55137, because it changes the vmname to its full path, which I here use to generate the inventory information and hierarchie. I'm committing this, because the PR #52782 looks stale and also does not seem to work, it does not include any folder information for my environment. Sof if that PR is going to be improved and merged, this may no longer be necessary.

Fixes #54339
Duplicates #52782

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/vmware_vm_inventory.py

##### ADDITIONAL INFORMATION