### PR TITLE
[2.8] Add variable type for performance_insights_retention_period

### DIFF
--- a/changelogs/fragments/49904-rds_instance-datatype.yml
+++ b/changelogs/fragments/49904-rds_instance-datatype.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add variable type for performance_insights_retention_period (https://github.com/ansible/ansible/issues/49904).

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -1050,7 +1050,7 @@ def main():
         new_db_instance_identifier=dict(aliases=['new_instance_id', 'new_id']),
         option_group_name=dict(),
         performance_insights_kms_key_id=dict(),
-        performance_insights_retention_period=dict(),
+        performance_insights_retention_period=dict(type='int'),
         port=dict(type='int'),
         preferred_backup_window=dict(aliases=['backup_window']),
         preferred_maintenance_window=dict(aliases=['maintenance_window']),


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit 5bda9cbebf083ef7c93f578e1cc8ec7237b8f941)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/49904-rds_instance-datatype.yml
lib/ansible/modules/cloud/amazon/rds_instance.py
