### PR TITLE
[WIP] Fixed multibyte character handling issue with py27 for tower_job_wait

### DIFF
--- a/changelogs/fragments/55585-tower_job_wait-with-multibyte.yml
+++ b/changelogs/fragments/55585-tower_job_wait-with-multibyte.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixed multibyte character handling issue for tower_job_wait module (https://github.com/ansible/ansible/issues/55585)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
@@ -83,7 +83,9 @@ status:
 
 
 from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
+from ansible.module_utils.six import PY2
 from ansible.module_utils.six.moves import cStringIO as StringIO
+from codecs import getwriter
 
 
 try:
@@ -119,7 +121,10 @@ def main():
 
         # tower-cli gets very noisy when monitoring.
         # We pass in our our outfile to suppress the out during our monitor call.
-        outfile = StringIO()
+        if PY2:
+            outfile = getwriter('utf-8')(StringIO())
+        else:
+            outfile = StringIO()
         params['outfile'] = outfile
 
         job_id = params.get('job_id')

--- a/test/integration/targets/tower_job_wait/tasks/main.yml
+++ b/test/integration/targets/tower_job_wait/tasks/main.yml
@@ -1,3 +1,21 @@
+- name: create a tempdir for hostvars
+  local_action: shell mktemp -d
+  register: tempdir
+
+- name: write a file w/ hostvars
+  local_action:
+    module: lineinfile
+    dest: "{{ tempdir.stdout }}/vars"
+    line: '{"ansible_connection": "local"}'
+    create: true
+
+- name: Create a Host using multi-byte characters
+  tower_host:
+    name: "テストサーバー"
+    inventory: "Demo Inventory"
+    state: present
+    variables: "@{{ tempdir.stdout }}/vars"
+
 - name: Launch a Job Template
   tower_job_launch:
     job_template: "Demo Job Template"
@@ -24,3 +42,9 @@
 - assert:
     that:
       - "result.msg =='Unable to wait, no job_id 99999999 found: The requested object could not be found.'"
+
+- name: Delete a Host
+  tower_host:
+    name: "テストサーバー"
+    inventory: "Demo Inventory"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
- Fixed multibyte character handling issue for tower_job_wait module for issue  #55585
- Added multibyte hostname handling test as an integration test

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- tower_job_wait module

##### ADDITIONAL INFORMATION
- The original issue is here #55585