### PR TITLE
Correct link to Thomas' GitHub account

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -307,5 +307,5 @@ use the ``#ansible`` channel.
 Credit
 ======
 
-Thank you to Thomas Stringer (`@tstringer <https://github.com/tstringer>`_) for contributing source
+Thank you to Thomas Stringer (`@trstringer <https://github.com/trstringer>`_) for contributing source
 material for this topic.

--- a/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
@@ -81,7 +81,7 @@ extends_documentation_fragment:
     - azure_tags
 
 author:
-    - "Thomas Stringer (@tstringer)"
+    - "Thomas Stringer (@trstringer)"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_functionapp_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_functionapp_facts.py
@@ -37,7 +37,7 @@ extends_documentation_fragment:
     - azure
 
 author:
-    - "Thomas Stringer (@tstringer)"
+    - "Thomas Stringer (@trstringer)"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
@@ -332,7 +332,7 @@ extends_documentation_fragment:
     - azure_tags
 
 author:
-    - "Thomas Stringer (@tstringer)"
+    - "Thomas Stringer (@trstringer)"
     - "Yuwei Zhou (@yuwzho)"
 '''
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
@@ -39,7 +39,7 @@ extends_documentation_fragment:
     - azure
 
 author:
-    - "Thomas Stringer (@tstringer)"
+    - "Thomas Stringer (@trstringer)"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Thomas renamed his account from @tstringer to @trstringer

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- dev_guide
- azure