### PR TITLE
Fix vyos cli prompt issues

### DIFF
--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -81,9 +81,9 @@ class ActionModule(ActionNetworkModule):
 
         conn = Connection(socket_path)
         out = conn.get_prompt()
-        while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
+        while to_text(out, errors='surrogate_then_replace').strip().endswith('#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('abort')
+            conn.send_command('exit discard')
             out = conn.get_prompt()
 
         result = super(ActionModule, self).run(task_vars=task_vars)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #55201 
- [EDIT] TL;DR - We're always running `exit discard` in action plugin to mitigate this issue.
- For certain configuration commands, running `compare` returns `No changes between working and active configurations`, yet `exit` throws `Cannot exit: configuration modified.
Use 'exit discard' to discard the changes and exit.` 
- The logic in cliconf edit_config for vyos determines whether to run `exit` or `exit discard` based on what `compare` returns.
- Since certain commands behave differently, the prompt remains at `#` and eventually fails subsequent tasks. 
- The current prompt inspection in `action/vyos.py` fails to handle vyos prompts correctly.
- We handle `exit discard` in the cliconf and normal prompt inspection with `exit` in the action plugin.
OR,
_we always just run `exit discard` in action/vyos.py_ (Needs suggestion)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cliconf/vyos.py
action/vyos.py

##### ADDITIONAL INFORMATION
- The following set of tasks reproduces the above issue:
```yaml
tasks:
  - cli_config:
      config: delete interfaces ethernet eth1 speed

  - cli_command:
      command: show version
```
