### PR TITLE
docker_swarm_service: Use str type for configs/secrets gid/uid

### DIFF
--- a/changelogs/fragments/55591-docker_swarm_service-fix-uid-gid-secrets-config-type.yaml
+++ b/changelogs/fragments/55591-docker_swarm_service-fix-uid-gid-secrets-config-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - Change the type of options gid and uid on secrets and configs to str."

--- a/changelogs/fragments/55591-docker_swarm_service-fix-uid-gid-secrets-config-type.yaml
+++ b/changelogs/fragments/55591-docker_swarm_service-fix-uid-gid-secrets-config-type.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- "docker_swarm_service - Change the type of options gid and uid on secrets and configs to str."
+- "docker_swarm_service - Change the type of options ``gid`` and ``uid`` on ``secrets`` and ``configs`` to ``str``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -611,14 +611,14 @@ options:
       uid:
         description:
           - UID of the secret file's owner.
-        type: int
+        type: str
       gid:
         description:
           - GID of the secret file's group.
-        type: int
+        type: str
       mode:
         description:
-          - File access mode inside the container.
+          - File access mode inside the container. Must an octal number (like C(0644) or C(0444)).
         type: int
   state:
     description:
@@ -2263,8 +2263,8 @@ class DockerServiceManager(object):
                     'secret_id': secret_data['SecretID'],
                     'secret_name': secret_data['SecretName'],
                     'filename': secret_data['File'].get('Name'),
-                    'uid': int(secret_data['File'].get('UID')),
-                    'gid': int(secret_data['File'].get('GID')),
+                    'uid': secret_data['File'].get('UID'),
+                    'gid': secret_data['File'].get('GID'),
                     'mode': secret_data['File'].get('Mode')
                 })
 
@@ -2514,8 +2514,8 @@ def main():
             secret_id=dict(type='str', required=True),
             secret_name=dict(type='str', required=True),
             filename=dict(type='str'),
-            uid=dict(type='int'),
-            gid=dict(type='int'),
+            uid=dict(type='str'),
+            gid=dict(type='str'),
             mode=dict(type='int'),
         )),
         networks=dict(type='list', elements='str'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -58,15 +58,15 @@ options:
       uid:
         description:
           - UID of the config file's owner.
-        type: int
+        type: str
       gid:
         description:
           - GID of the config file's group.
-        type: int
+        type: str
       mode:
         description:
-          - File access mode inside the container.
-        type: str
+          - File access mode inside the container. Must an octal number (like C(0644) or C(0444)).
+        type: int
   constraints:
     description:
       - List of the service constraints.
@@ -2250,8 +2250,8 @@ class DockerServiceManager(object):
                     'config_id': config_data['ConfigID'],
                     'config_name': config_data['ConfigName'],
                     'filename': config_data['File'].get('Name'),
-                    'uid': int(config_data['File'].get('UID')),
-                    'gid': int(config_data['File'].get('GID')),
+                    'uid': config_data['File'].get('UID'),
+                    'gid': config_data['File'].get('GID'),
                     'mode': config_data['File'].get('Mode')
                 })
 
@@ -2506,8 +2506,8 @@ def main():
             config_id=dict(type='str', required=True),
             config_name=dict(type='str', required=True),
             filename=dict(type='str'),
-            uid=dict(type='int'),
-            gid=dict(type='int'),
+            uid=dict(type='str'),
+            gid=dict(type='str'),
             mode=dict(type='int'),
         )),
         secrets=dict(type='list', elements='dict', options=dict(

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -65,7 +65,7 @@ options:
         type: str
       mode:
         description:
-          - File access mode inside the container. Must an octal number (like C(0644) or C(0444)).
+          - File access mode inside the container. Must be an octal number (like C(0644) or C(0444)).
         type: int
   constraints:
     description:
@@ -618,7 +618,7 @@ options:
         type: str
       mode:
         description:
-          - File access mode inside the container. Must an octal number (like C(0644) or C(0444)).
+          - File access mode inside the container. Must be an octal number (like C(0644) or C(0444)).
         type: int
   state:
     description:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
@@ -1,0 +1,369 @@
+---
+
+- name: Registering container name
+  set_fact:
+    service_name: "{{ name_prefix ~ '-configs' }}"
+    config_name_1: "{{ name_prefix ~ '-configs-1' }}"
+    config_name_2: "{{ name_prefix ~ '-configs-2' }}"
+
+- name: Registering container name
+  set_fact:
+    config_names: "{{ config_names }} + [config_name_1, config_name_2]"
+
+- docker_config:
+    name: "{{ config_name_1 }}"
+    data: "hello"
+    state: present
+  register: "config_result_1"
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+
+- docker_config:
+    name: "{{ config_name_2 }}"
+    data: "test"
+    state: present
+  register: "config_result_2"
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+
+####################################################################
+## configs #########################################################
+####################################################################
+
+- name: configs
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+  register: configs_1
+  ignore_errors: yes
+
+- name: configs (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+  register: configs_2
+  ignore_errors: yes
+
+- name: configs (add)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+      - config_id: "{{ config_result_2.config_id|default('') }}"
+        config_name: "{{ config_name_2 }}"
+        filename: "/tmp/{{ config_name_2 }}.txt"
+  register: configs_3
+  ignore_errors: yes
+
+- name: configs (empty)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs: []
+  register: configs_4
+  ignore_errors: yes
+
+- name: configs (empty idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs: []
+  register: configs_5
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+    - configs_1 is changed
+    - configs_2 is not changed
+    - configs_3 is changed
+    - configs_4 is changed
+    - configs_5 is not changed
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+
+- assert:
+    that:
+    - configs_1 is failed
+    - "'Minimum version required' in configs_1.msg"
+  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.6.0', '<')
+
+####################################################################
+## configs (uid) ###################################################
+####################################################################
+
+- name: configs (uid int)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        uid: 1000        
+  register: configs_1
+  ignore_errors: yes
+  
+- name: configs (uid int idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        uid: 1000        
+  register: configs_2
+  ignore_errors: yes
+
+- name: configs (uid int change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        uid: 1002      
+  register: configs_3
+  ignore_errors: yes
+  
+- name: configs (uid str)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        uid: "1001"
+  register: configs_4
+  ignore_errors: yes
+
+- name: configs (uid str idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        uid: "1001"
+  register: configs_5
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+- assert:
+    that:
+    - configs_1 is changed
+    - configs_2 is not changed
+    - configs_3 is changed
+    - configs_4 is changed
+    - configs_5 is not changed
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+
+- assert:
+    that:
+    - configs_1 is failed
+    - "'Minimum version required' in configs_1.msg"
+  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.6.0', '<')
+
+
+####################################################################
+## configs (gid) ###################################################
+####################################################################
+
+- name: configs (gid int)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        gid: 1000        
+  register: configs_1
+  ignore_errors: yes
+  
+- name: configs (gid int idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        gid: 1000        
+  register: configs_2
+  ignore_errors: yes
+
+- name: configs (gid int change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        gid: 1002      
+  register: configs_3
+  ignore_errors: yes
+  
+- name: configs (gid str)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        gid: "1001"
+  register: configs_4
+  ignore_errors: yes
+
+- name: configs (gid str idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        gid: "1001"
+  register: configs_5
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+- assert:
+    that:
+    - configs_1 is changed
+    - configs_2 is not changed
+    - configs_3 is changed
+    - configs_4 is changed
+    - configs_5 is not changed
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+
+- assert:
+    that:
+    - configs_1 is failed
+    - "'Minimum version required' in configs_1.msg"
+  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.6.0', '<')
+
+####################################################################
+## configs (mode) ##################################################
+####################################################################
+
+- name: configs (mode)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        mode: 0600
+  register: configs_1
+  ignore_errors: yes
+
+- name: configs (mode idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        mode: 0600
+  register: configs_2
+  ignore_errors: yes
+
+- name: configs (mode change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_id: "{{ config_result_1.config_id|default('') }}"
+        config_name: "{{ config_name_1 }}"
+        mode: 0777
+  register: configs_3
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+- assert:
+    that:
+    - configs_1 is changed
+    - configs_2 is not changed
+    - configs_3 is changed
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+
+- assert:
+    that:
+    - configs_1 is failed
+    - "'Minimum version required' in configs_1.msg"
+  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.6.0', '<')
+
+####################################################################
+####################################################################
+####################################################################
+
+- name: Delete configs
+  docker_config:
+    name: "{{ config_name }}"
+    state: absent
+    force: yes
+  loop:
+    - "{{ config_name_1 }}"
+    - "{{ config_name_2 }}"
+  loop_control:
+    loop_var: config_name
+  ignore_errors: yes
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -7,15 +7,12 @@
     network_name_2: "{{ name_prefix ~ '-network-2' }}"
     config_name_1: "{{ name_prefix ~ '-configs-1' }}"
     config_name_2: "{{ name_prefix ~ '-configs-2' }}"
-    secret_name_1: "{{ name_prefix ~ '-secret-1' }}"
-    secret_name_2: "{{ name_prefix ~ '-secret-2' }}"
 
 - name: Registering container name
   set_fact:
     service_names: "{{ service_names }} + [service_name]"
     network_names: "{{ network_names }} + [network_name_1, network_name_2]"
     config_names: "{{ config_names }} + [config_name_1, config_name_2]"
-    secret_names: "{{ secret_names }} + [secret_name_1, secret_name_2]"
 
 - docker_config:
     name: "{{ config_name_1 }}"
@@ -30,20 +27,6 @@
     state: present
   register: "config_result_2"
   when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
-
-- docker_secret:
-    name: "{{ secret_name_1 }}"
-    data: "secret1"
-    state: "present"
-  register: "secret_result_1"
-  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
-
-- docker_secret:
-    name: "{{ secret_name_2 }}"
-    data: "secret2"
-    state: "present"
-  register: "secret_result_2"
-  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
 
 - docker_network:
     name: "{{ network_name }}"
@@ -1877,93 +1860,6 @@
       - "('version is ' ~ docker_py_version ~'. Minimum version required is 3.2.0') in resolve_image_3.msg"
   when: docker_api_version is version('1.30', '<') or docker_py_version is version('3.2.0', '<')
 
-####################################################################
-## secrets #########################################################
-####################################################################
-
-- name: secrets
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    secrets:
-      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
-        secret_name: "{{ secret_name_1 }}"
-        filename: "/run/secrets/{{ secret_name_1 }}.txt"
-  register: secrets_1
-  ignore_errors: yes
-
-- name: secrets (idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    secrets:
-      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
-        secret_name: "{{ secret_name_1 }}"
-        filename: "/run/secrets/{{ secret_name_1 }}.txt"
-  register: secrets_2
-  ignore_errors: yes
-
-- name: secrets (add)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    secrets:
-      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
-        secret_name: "{{ secret_name_1 }}"
-        filename: "/run/secrets/{{ secret_name_1 }}.txt"
-      - secret_id: "{{ secret_result_2.secret_id|default('') }}"
-        secret_name: "{{ secret_name_2 }}"
-        filename: "/run/secrets/{{ secret_name_2 }}.txt"
-  register: secrets_3
-  ignore_errors: yes
-
-- name: secrets (empty)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    secrets: []
-  register: secrets_4
-  ignore_errors: yes
-
-- name: secrets (empty idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    secrets: []
-  register: secrets_5
-  ignore_errors: yes
-
-- name: cleanup
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    state: absent
-  diff: no
-
-- assert:
-    that:
-      - secrets_1 is changed
-      - secrets_2 is not changed
-      - secrets_3 is changed
-      - secrets_4 is changed
-      - secrets_5 is not changed
-  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
-- assert:
-    that:
-    - secrets_1 is failed
-    - "'Minimum version required' in secrets_1.msg"
-  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
-
-
 ###################################################################
 # tty #############################################################
 ###################################################################
@@ -2138,16 +2034,3 @@
     loop_var: config_name
   ignore_errors: yes
   when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
-
-- name: Delete secrets
-  docker_secret:
-    name: "{{ secret_name }}"
-    state: absent
-    force: yes
-  loop:
-    - "{{ secret_name_1 }}"
-    - "{{ secret_name_2 }}"
-  loop_control:
-    loop_var: secret_name
-  ignore_errors: yes
-  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -5,28 +5,11 @@
     service_name: "{{ name_prefix ~ '-options' }}"
     network_name_1: "{{ name_prefix ~ '-network-1' }}"
     network_name_2: "{{ name_prefix ~ '-network-2' }}"
-    config_name_1: "{{ name_prefix ~ '-configs-1' }}"
-    config_name_2: "{{ name_prefix ~ '-configs-2' }}"
 
 - name: Registering container name
   set_fact:
     service_names: "{{ service_names }} + [service_name]"
     network_names: "{{ network_names }} + [network_name_1, network_name_2]"
-    config_names: "{{ config_names }} + [config_name_1, config_name_2]"
-
-- docker_config:
-    name: "{{ config_name_1 }}"
-    data: "hello"
-    state: present
-  register: "config_result_1"
-  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
-
-- docker_config:
-    name: "{{ config_name_2 }}"
-    data: "test"
-    state: present
-  register: "config_result_2"
-  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - docker_network:
     name: "{{ network_name }}"
@@ -101,93 +84,6 @@
       - args_3 is changed
       - args_4 is changed
       - args_5 is not changed
-
-####################################################################
-## configs #########################################################
-####################################################################
-
-- name: configs
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    configs:
-      - config_id: "{{ config_result_1.config_id|default('') }}"
-        config_name: "{{ config_name_1 }}"
-        filename: "/tmp/{{ config_name_1 }}.txt"
-  register: configs_1
-  ignore_errors: yes
-
-- name: configs (idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    configs:
-      - config_id: "{{ config_result_1.config_id|default('') }}"
-        config_name: "{{ config_name_1 }}"
-        filename: "/tmp/{{ config_name_1 }}.txt"
-  register: configs_2
-  ignore_errors: yes
-
-- name: configs (add)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    configs:
-      - config_id: "{{ config_result_1.config_id|default('') }}"
-        config_name: "{{ config_name_1 }}"
-        filename: "/tmp/{{ config_name_1 }}.txt"
-      - config_id: "{{ config_result_2.config_id|default('') }}"
-        config_name: "{{ config_name_2 }}"
-        filename: "/tmp/{{ config_name_2 }}.txt"
-  register: configs_3
-  ignore_errors: yes
-
-- name: configs (empty)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    configs: []
-  register: configs_4
-  ignore_errors: yes
-
-- name: configs (empty idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    configs: []
-  register: configs_5
-  ignore_errors: yes
-
-- name: cleanup
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    state: absent
-  diff: no
-
-- assert:
-    that:
-    - configs_1 is changed
-    - configs_2 is not changed
-    - configs_3 is changed
-    - configs_4 is changed
-    - configs_5 is not changed
-  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
-
-- assert:
-    that:
-    - configs_1 is failed
-    - "'Minimum version required' in configs_1.msg"
-  when: docker_api_version is version('1.30', '<') or docker_py_version is version('2.6.0', '<')
 
 ####################################################################
 ## command #########################################################
@@ -2021,16 +1917,3 @@
   loop_control:
     loop_var: volume_name
   ignore_errors: yes
-
-- name: Delete configs
-  docker_config:
-    name: "{{ config_name }}"
-    state: absent
-    force: yes
-  loop:
-    - "{{ config_name_1 }}"
-    - "{{ config_name_2 }}"
-  loop_control:
-    loop_var: config_name
-  ignore_errors: yes
-  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')

--- a/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
@@ -1,0 +1,367 @@
+---
+
+- name: Registering container name
+  set_fact:
+    service_name: "{{ name_prefix ~ '-secrets' }}"
+    secret_name_1: "{{ name_prefix ~ '-secret-1' }}"
+    secret_name_2: "{{ name_prefix ~ '-secret-2' }}"
+
+- name: Registering container name
+  set_fact:
+    secret_names: "{{ secret_names }} + [secret_name_1, secret_name_2]"
+
+- docker_secret:
+    name: "{{ secret_name_1 }}"
+    data: "secret1"
+    state: "present"
+  register: "secret_result_1"
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
+
+- docker_secret:
+    name: "{{ secret_name_2 }}"
+    data: "secret2"
+    state: "present"
+  register: "secret_result_2"
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
+
+####################################################################
+## secrets #########################################################
+####################################################################
+
+- name: secrets
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        filename: "/run/secrets/{{ secret_name_1 }}.txt"
+  register: secrets_1
+  ignore_errors: yes
+
+- name: secrets (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        filename: "/run/secrets/{{ secret_name_1 }}.txt"
+  register: secrets_2
+  ignore_errors: yes
+
+- name: secrets (add)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        filename: "/run/secrets/{{ secret_name_1 }}.txt"
+      - secret_id: "{{ secret_result_2.secret_id|default('') }}"
+        secret_name: "{{ secret_name_2 }}"
+        filename: "/run/secrets/{{ secret_name_2 }}.txt"
+  register: secrets_3
+  ignore_errors: yes
+
+- name: secrets (empty)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets: []
+  register: secrets_4
+  ignore_errors: yes
+
+- name: secrets (empty idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets: []
+  register: secrets_5
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - secrets_1 is changed
+      - secrets_2 is not changed
+      - secrets_3 is changed
+      - secrets_4 is changed
+      - secrets_5 is not changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
+- assert:
+    that:
+    - secrets_1 is failed
+    - "'Minimum version required' in secrets_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
+
+####################################################################
+## secrets (uid) ###################################################
+####################################################################
+
+- name: secrets (uid int)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        uid: 1000
+  register: secrets_1
+  ignore_errors: yes
+
+- name: secrets (uid int idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        uid: 1000
+  register: secrets_2
+  ignore_errors: yes
+
+- name: secrets (uid int change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        uid: 1002
+  register: secrets_3
+  ignore_errors: yes
+
+- name: secrets (uid str)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        uid: "1001"
+  register: secrets_4
+  ignore_errors: yes
+
+- name: secrets (uid str idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        uid: "1001"
+  register: secrets_5
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - secrets_1 is changed
+      - secrets_2 is not changed
+      - secrets_3 is changed
+      - secrets_4 is changed
+      - secrets_5 is not changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
+- assert:
+    that:
+    - secrets_1 is failed
+    - "'Minimum version required' in secrets_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
+
+####################################################################
+## secrets (gid) ###################################################
+####################################################################
+
+- name: secrets (gid int)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        gid: 1001
+  register: secrets_1
+  ignore_errors: yes
+
+- name: secrets (gid int idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        gid: 1001
+  register: secrets_2
+  ignore_errors: yes
+
+- name: secrets (gid int change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        gid: 1002
+  register: secrets_3
+  ignore_errors: yes
+
+- name: secrets (gid str)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        gid: "1003"
+  register: secrets_4
+  ignore_errors: yes
+
+- name: secrets (gid str idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        gid: "1003"
+  register: secrets_5
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - secrets_1 is changed
+      - secrets_2 is not changed
+      - secrets_3 is changed
+      - secrets_4 is changed
+      - secrets_5 is not changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
+- assert:
+    that:
+    - secrets_1 is failed
+    - "'Minimum version required' in secrets_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
+
+####################################################################
+## secrets (mode) ##################################################
+####################################################################
+
+- name: secrets (mode)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        mode: 0600
+  register: secrets_1
+  ignore_errors: yes
+
+- name: secrets (mode idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        mode: 0600
+  register: secrets_2
+  ignore_errors: yes
+
+- name: secrets (mode change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
+        secret_name: "{{ secret_name_1 }}"
+        mode: 0777
+  register: secrets_3
+  ignore_errors: yes
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: no
+
+- assert:
+    that:
+      - secrets_1 is changed
+      - secrets_2 is not changed
+      - secrets_3 is changed
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
+- assert:
+    that:
+    - secrets_1 is failed
+    - "'Minimum version required' in secrets_1.msg"
+  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
+
+####################################################################
+####################################################################
+####################################################################
+
+- name: Delete secrets
+  docker_secret:
+    name: "{{ secret_name }}"
+    state: absent
+    force: yes
+  loop:
+    - "{{ secret_name_1 }}"
+    - "{{ secret_name_2 }}"
+  loop_control:
+    loop_var: secret_name
+  ignore_errors: yes
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR fixes an issue which causes a task failure when options `gid` and `uid` are used on `secrets` or `configs`. The Docker API expects them to be strings but the current implementation forces them to be `int`.

I also added some documentation to the `mode` option on `secrets` and `configs` clarifying that they are expected to be octal numbers.

This issue is also present in Ansible 2.7 so we need to make a backport to that version as well. I think the `mode` option is also problematic in 2.7. Looks like it is passed as a string to Docker when it expects an integer (octal). This is solved in Ansible 2.8 because we now specify the type on the options.

Fixes #55581

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service