### PR TITLE
include windows server 2019 in supported hosts (#55367)

### DIFF
--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -15,7 +15,7 @@ Windows host must meet the following requirements:
 * Ansible's supported Windows versions generally match those under current
   and extended support from Microsoft. Supported desktop OSs include
   Windows 7, 8.1, and 10, and supported server OSs are Windows Server 2008,
-  2008 R2, 2012, 2012 R2, and 2016.
+  2008 R2, 2012, 2012 R2, 2016, and 2019.
 
 * Ansible requires PowerShell 3.0 or newer and at least .NET 4.0 to be
   installed on the Windows host.


### PR DESCRIPTION
##### SUMMARY

Backports #55367. 

Adds Windows server 2019 as a supported server OS.

(cherry picked from commit 960df2427202386bd4e43a959a9cfdaae140e6a5)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
