### PR TITLE
Postgresql docs fragments 2 (#55363)

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -17,7 +17,7 @@ module: postgresql_db
 short_description: Add or remove PostgreSQL databases from a remote host.
 description:
    - Add or remove PostgreSQL databases from a remote host.
-version_added: "0.6"
+version_added: '0.6'
 options:
   name:
     description:
@@ -58,7 +58,7 @@ options:
     - Switch to session_role after connecting. The specified session_role must be a role that the current login_user is a member of.
     - Permissions checking for SQL commands is carried out as though the session_role were the one that had logged in originally.
     type: str
-    version_added: "2.8"
+    version_added: '2.8'
   state:
     description:
     - The database state.
@@ -77,19 +77,19 @@ options:
     - File to back up or restore from.
     - Used when I(state) is C(dump) or C(restore).
     type: path
-    version_added: "2.4"
+    version_added: '2.4'
   target_opts:
     description:
     - Further arguments for pg_dump or pg_restore.
     - Used when I(state) is C(dump) or C(restore).
     type: str
-    version_added: "2.4"
+    version_added: '2.4'
   maintenance_db:
     description:
       - The value specifies the initial database (which is also called as maintenance DB) that Ansible connects to.
     type: str
     default: postgres
-    version_added: "2.5"
+    version_added: '2.5'
   conn_limit:
     description:
       - Specifies the database connection limit.

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -38,50 +38,6 @@ options:
     - Name of the schema to add the extension to.
     version_added: '2.8'
     type: str
-  login_user:
-    description:
-    - The username used to authenticate with.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - The password used to authenticate with.
-    type: str
-  login_host:
-    description:
-    - Host running the database.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-    version_added: '2.8'
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    default: prefer
-    choices: [allow, disable, prefer, require, verify-ca, verify-full]
-    type: str
-    version_added: '2.8'
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s). If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    version_added: '2.8'
-    aliases: [ ssl_rootcert ]
-  port:
-    description:
-    - Database port to connect to.
-    default: 5432
-    type: int
-    aliases:
-    - login_port
   session_role:
     description:
     - Switch to session_role after connecting.
@@ -102,6 +58,27 @@ options:
     type: bool
     default: no
     version_added: '2.8'
+  login_unix_socket:
+    description:
+      - Path to a Unix domain socket for local connections.
+    type: str
+    version_added: '2.8'
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    type: str
+    default: prefer
+    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
+    version_added: '2.8'
+  ca_cert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
+      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+    type: str
+    aliases: [ ssl_rootcert ]
+    version_added: '2.8'
 notes:
 - The default authentication assumes that you are either logging in as
   or sudo'ing to the C(postgres) account on the host.
@@ -115,6 +92,7 @@ requirements: [ psycopg2 ]
 author:
 - Daniel Schep (@dschep)
 - Thomas O'Donnell (@andytom)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -37,18 +37,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
   session_role:
     description:
     - Switch to session_role after connecting.
@@ -60,35 +48,6 @@ options:
     description:
     - Name of a database schema where the index will be created.
     type: str
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s). If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
   state:
     description:
     - Index state.
@@ -169,6 +128,7 @@ requirements:
 
 author:
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_info.py
@@ -19,7 +19,7 @@ module: postgresql_info
 short_description: Gather information about PostgreSQL servers
 description:
 - Gathers information about PostgreSQL servers.
-version_added: "2.8"
+version_added: '2.8'
 options:
   filter:
     description:
@@ -39,13 +39,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
   session_role:
     description:
     - Switch to session_role after connecting. The specified session_role must
@@ -53,41 +46,6 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-    default: prefer
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s).
-    - If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -103,6 +61,7 @@ notes:
 requirements: [ psycopg2 ]
 author:
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_lang.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_lang.py
@@ -73,26 +73,6 @@ options:
     - Only used when C(state=absent).
     type: bool
     default: 'no'
-  port:
-    description:
-    - Database port to connect to.
-    default: 5432
-    type: int
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User to authenticate with PostgreSQL.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL (must match C(login_user)).
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL where you want to execute the actions.
-    type: str
   session_role:
     version_added: '2.8'
     description:
@@ -108,29 +88,25 @@ options:
     choices: [ absent, present ]
   login_unix_socket:
     description:
-    - Path to a Unix domain socket for local connections.
+      - Path to a Unix domain socket for local connections.
     type: str
     version_added: '2.8'
   ssl_mode:
     description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - Default of C(prefer) matches libpq default.
     type: str
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     version_added: '2.8'
   ca_cert:
     description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s). If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
+      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     type: str
-    version_added: '2.8'
     aliases: [ ssl_rootcert ]
-
+    version_added: '2.8'
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -145,6 +121,7 @@ requirements: [ psycopg2 ]
 author:
 - Jens Depuydt (@jensdepuydt)
 - Thomas O'Donnell (@andytom)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_membership.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_membership.py
@@ -28,7 +28,7 @@ description:
 - 2) grant them desired privileges by M(postgresql_privs) module
   U(https://docs.ansible.com/ansible/latest/modules/postgresql_privs_module.html)
 - 3) add desired PostgreSQL users to the new group (groups) by this module
-version_added: "2.8"
+version_added: '2.8'
 options:
   groups:
     description:
@@ -67,18 +67,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
   session_role:
     description:
     - Switch to session_role after connecting.
@@ -86,34 +74,6 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -128,6 +88,7 @@ notes:
 requirements: [ psycopg2 ]
 author:
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_owner.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_owner.py
@@ -67,18 +67,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
   session_role:
     description:
     - Switch to session_role after connecting.
@@ -86,35 +74,6 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
-
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -132,6 +91,7 @@ requirements:
 
 author:
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -24,7 +24,7 @@ description:
    - The lines in the file should be in a typical pg_hba form and lines should be unique per key (type, databases, users, source).
      If they are not unique and the SID is 'the one to change', only one for C(state=present) or none for C(state=absent) of the SID's will remain.
 extends_documentation_fragment: files
-version_added: "2.8"
+version_added: '2.8'
 options:
   address:
     description:
@@ -119,30 +119,30 @@ author: Sebastiaan Mannem (@sebasmannem)
 EXAMPLES = '''
 - name: Grant users joe and simon access to databases sales and logistics from ipv6 localhost ::1/128 using peer authentication.
   postgresql_pg_hba:
-    dest=/var/lib/postgres/data/pg_hba.conf
-    contype=host
-    users=joe,simon
-    source=::1
-    databases=sales,logistics
-    method=peer
-    create=true
+    dest: /var/lib/postgres/data/pg_hba.conf
+    contype: host
+    users: joe,simon
+    source: ::1
+    databases: sales,logistics
+    method: peer
+    create: true
 
 - name: Grant user replication from network 192.168.0.100/24 access for replication with client cert authentication.
   postgresql_pg_hba:
-    dest=/var/lib/postgres/data/pg_hba.conf
-    contype=host
-    users=replication
-    source=192.168.0.100/24
-    databases=replication
-    method=cert
+    dest: /var/lib/postgres/data/pg_hba.conf
+    contype: host
+    users: replication
+    source: 192.168.0.100/24
+    databases: replication
+    method: cert
 
 - name: Revoke access from local user mary on database mydb.
   postgresql_pg_hba:
-    dest=/var/lib/postgres/data/pg_hba.conf
-    contype=local
-    users=mary
-    databases=mydb
-    state=absent
+    dest: /var/lib/postgres/data/pg_hba.conf
+    contype: local
+    users: mary
+    databases: mydb
+    state: absent
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_ping.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ping.py
@@ -19,7 +19,7 @@ module: postgresql_ping
 short_description: Check remote PostgreSQL server availability
 description:
 - Simple module to check remote PostgreSQL server availability.
-version_added: "2.8"
+version_added: '2.8'
 options:
   db:
     description:
@@ -27,48 +27,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-    default: prefer
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s).
-    - If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -81,6 +39,7 @@ notes:
 requirements: [ psycopg2 ]
 author:
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -21,7 +21,7 @@ short_description: Run PostgreSQL queries
 description:
 - Runs arbitraty PostgreSQL queries.
 - Can run queries from SQL script files.
-version_added: "2.8"
+version_added: '2.8'
 options:
   query:
     description:
@@ -56,48 +56,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s).
-    - If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or
   sudo'ing to the postgres account on the host.
@@ -114,6 +72,7 @@ author:
 - Felix Archambault (@archf)
 - Andrew Klychkov (@Andersson007)
 - Will Rouesnel (@wrouesnel)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -34,34 +34,10 @@ options:
     aliases:
     - db
     - login_db
-  login_user:
-    description:
-    - The username used to authenticate with.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - The password used to authenticate with.
-    type: str
-  login_host:
-    description:
-    - Host running the database.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
   owner:
     description:
     - Name of the role to set as owner of the schema.
     type: str
-  port:
-    description:
-    - Database port to connect to.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
   session_role:
     version_added: '2.8'
     description:
@@ -84,22 +60,20 @@ options:
     version_added: '2.8'
   ssl_mode:
     description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - Default of C(prefer) matches libpq default.
     type: str
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
     version_added: '2.8'
   ca_cert:
     description:
-    - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-    - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
+      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     type: str
-    version_added: '2.8'
     aliases: [ ssl_rootcert ]
+    version_added: '2.8'
 notes:
 - This module uses I(psycopg2), a Python PostgreSQL database adapter.
 - You must ensure that psycopg2 is installed on the host before using this module.
@@ -111,6 +85,7 @@ requirements: [ psycopg2 ]
 author:
 - Flavien Chantelot (@Dorn-) <contact@flavien.io>
 - Thomas O'Donnell (@andytom)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -29,7 +29,7 @@ description:
      string from postgresql.auto.conf and reload I(value=default) (for settings with postmaster context restart is required).
    - After change you can see in the ansible output the previous and
      the new parameter value and other information using returned values and M(debug) module.
-version_added: "2.8"
+version_added: '2.8'
 options:
   name:
     description:
@@ -62,48 +62,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-    default: prefer
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s).
-    - If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
 notes:
 - Supported version of PostgreSQL is 9.4 and later.
 - Pay attention, change setting with 'postmaster' context can return changed is true
@@ -125,6 +83,7 @@ notes:
 requirements: [ psycopg2 ]
 author:
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -67,18 +67,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
   session_role:
     description:
     - Switch to session_role after connecting.
@@ -86,35 +74,6 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-    - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    type: str
-    aliases:
-    - ssl_rootcert
 
 notes:
 - Physical replication slots were introduced to PostgreSQL with version 9.4,
@@ -135,6 +94,7 @@ requirements:
 author:
 - John Scalia (@jscalia)
 - Andew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''
@@ -340,7 +300,7 @@ def main():
         "login_password": "password",
         "port": "port",
         "sslmode": "ssl_mode",
-        "ca_cert": "sslrootcert"
+        "ca_cert": "ssl_rootcert"
     }
     kw = dict((params_map[k], v) for (k, v) in module.params.items()
               if k in params_map and v != '')

--- a/lib/ansible/modules/database/postgresql/postgresql_table.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_table.py
@@ -86,18 +86,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
   session_role:
     description:
     - Switch to session_role after connecting.
@@ -105,35 +93,6 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s). If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    aliases:
-    - ssl_rootcert
 notes:
 - If you do not pass db parameter, tables will be created in the database
   named postgres.
@@ -153,6 +112,7 @@ notes:
 requirements: [ psycopg2 ]
 author:
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_tablespace.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_tablespace.py
@@ -23,7 +23,7 @@ description:
 - Adds or removes PostgreSQL tablespaces from remote hosts
   U(https://www.postgresql.org/docs/current/sql-createtablespace.html),
   U(https://www.postgresql.org/docs/current/manage-ag-tablespaces.html).
-version_added: "2.8"
+version_added: '2.8'
 options:
   tablespace:
     description:
@@ -78,48 +78,6 @@ options:
     type: str
     aliases:
     - login_db
-  port:
-    description:
-    - Database port to connect.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - Password used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s).
-    - If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
 notes:
 - I(state=absent) and I(state=present) (the second one if the tablespace doesn't exist) do not
   support check mode because the corresponding PostgreSQL DROP and CREATE TABLESPACE commands
@@ -139,6 +97,7 @@ author:
 - Flavien Chantelot (@Dorn-)
 - Antoine Levy-Lambert (@antoinell)
 - Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -70,30 +70,6 @@ options:
     type: bool
     aliases:
     - fail_on_role
-  port:
-    description:
-    - Database port to connect to.
-    type: int
-    default: 5432
-    aliases:
-    - login_port
-  login_user:
-    description:
-    - User (role) used to authenticate with PostgreSQL.
-    type: str
-    default: postgres
-  login_password:
-    description:
-    - Password for U(login_user) used to authenticate with PostgreSQL.
-    type: str
-  login_host:
-    description:
-    - Host running PostgreSQL.
-    type: str
-  login_unix_socket:
-    description:
-    - Path to a Unix domain socket for local connections.
-    type: str
   priv:
     description:
     - "Slash-separated PostgreSQL privileges string: C(priv1/priv2), where
@@ -150,30 +126,27 @@ options:
     default: 'no'
     type: bool
     version_added: '2.0'
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection
-      will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
-      more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-    version_added: '2.3'
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA)
-      certificate(s). If the file exists, the server's certificate will be
-      verified to be signed by one of these authorities.
-    type: str
-    version_added: '2.3'
-    aliases: [ ssl_rootcert ]
   conn_limit:
     description:
     - Specifies the user (role) connection limit.
     type: int
     version_added: '2.4'
-
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    type: str
+    default: prefer
+    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
+    version_added: '2.3'
+  ca_cert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
+      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+    type: str
+    aliases: [ ssl_rootcert ]
+    version_added: '2.3'
 notes:
 - The module creates a user (role) with login privilege by default.
   Use NOLOGIN role_attr_flags to change this behaviour.
@@ -194,6 +167,7 @@ requirements:
 
 author:
 - Ansible Core Team
+extends_documentation_fragment: postgres
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/plugins/doc_fragments/postgres.py
+++ b/lib/ansible/plugins/doc_fragments/postgres.py
@@ -29,6 +29,7 @@ options:
       - Database port to connect to.
     type: int
     default: 5432
+    aliases: [ login_port ]
   ssl_mode:
     description:
       - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
@@ -37,13 +38,11 @@ options:
     type: str
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-    version_added: '2.3'
   ca_cert:
     description:
       - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
       - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     type: str
-    version_added: '2.3'
     aliases: [ ssl_rootcert ]
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.


### PR DESCRIPTION
##### SUMMARY

Backports #55363. 

* Postgres to use docsfragments
* Postgres to use docsfragments: redefined options in postgresql_user

(cherry picked from commit c3cbc39dd9b84a43aea0b72b9df953a97208af31)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
