### PR TITLE
azure_rm_subnet: remove documentation that says it supports tags 

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
@@ -84,7 +84,6 @@ options:
 
 extends_documentation_fragment:
     - azure
-    - azure_tags
 
 author:
     - "Chris Houseknecht (@chouseknecht)"


### PR DESCRIPTION
##### SUMMARY

Backports #55233. 

Clarifies azure module docs.

(cherry picked from commit 32345641e7d296453971a1fdc68553b45e83fde9)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
