### PR TITLE
Add example for full path on unit tests (#55243)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_units.rst
+++ b/docs/docsite/rst/dev_guide/testing_units.rst
@@ -43,6 +43,11 @@ Or against a specific Python version by doing:
 
    ansible-test units --tox --python 2.7 apt
 
+If you are running unit tests against things other than modules, such as module utilities, specify the whole file path:
+
+.. code:: shell
+
+   ansible-test units --tox test/units/module_utils/basic/test_imports.py
 
 For advanced usage see the online help::
 


### PR DESCRIPTION
##### SUMMARY

Backports #55243. 

Docs: adds an example when a full path is needed for unit tests, with module_utils, etc.

(cherry picked from commit a005dcfbbdf688e2a1dd40ae9aa1454bbc01100f)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
