### PR TITLE
ec2_launch_template - fix spelling mistake (#55383)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -73,7 +73,7 @@ options:
       ebs:
         description: Parameters used to automatically set up EBS volumes when the instance is launched.
         suboptions:
-          delete_on_termintation:
+          delete_on_termination:
             description: Indicates whether the EBS volume is deleted on instance termination.
             type: bool
           encrypted:


### PR DESCRIPTION
##### SUMMARY

Backports #55383 - typo fix.

(cherry picked from commit 272dceef4258fdfdc90281ce1d0b02236f16a797)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
