### PR TITLE
docs/docsite: minor fixes in docs/docsite/README.md (#55356)

### DIFF
--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -1,4 +1,4 @@
-Homepage and documentation source for Ansible
+Homepage and Documentation Source for Ansible
 =============================================
 
 This project hosts the source behind [docs.ansible.com](https://docs.ansible.com/)
@@ -15,7 +15,7 @@ If you do not want to learn the reStructuredText format, you can also [file issu
 
 Note that module documentation can actually be [generated from a DOCUMENTATION docstring][module-docs] in the modules directory, so corrections to modules written as such need to be made in the module source, rather than in docsite source.
 
-To install sphinx and the required theme, install pip and then "pip install sphinx sphinx_rtd_theme"
+To install sphinx and the required theme, install ``pip`` and then ``pip install sphinx sphinx_rtd_theme``
 
 [file issues]: https://github.com/ansible/ansible/issues
 [module-docs]: https://docs.ansible.com/developing_modules.html#documenting-your-module
@@ -23,7 +23,7 @@ To install sphinx and the required theme, install pip and then "pip install sphi
 HEADERS
 =======
 
-RST allows for arbitrary hierchy for the headers, it will 'learn on the fly' but we want a standard so all our documents can follow:
+RST allows for arbitrary hierarchy for the headers, it will 'learn on the fly'. We also want a standard that all our documents can follow:
 
 ```
 ##########################


### PR DESCRIPTION
##### SUMMARY

Backports #55356. 

Added inline markup to important references. Fixed minor spelling error.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>
(cherry picked from commit da1f86a40f95d50c4610109e12d8824b57368a1a)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
