### PR TITLE
nxos_acl: some platforms/versions raise when no ACLs are present

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -505,7 +505,7 @@ def main():
         if existing_core:
             commands.append(['no {0}'.format(seq)])
     elif state == 'delete_acl':
-        if acl[0].get('acl') != 'no_entries':
+        if acl and acl[0].get('acl') != 'no_entries':
             commands.append(['no ip access-list {0}'.format(name)])
 
     cmds = []

--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -177,7 +177,7 @@ from ansible.module_utils.basic import AnsibleModule
 def execute_show_command(command, module, check_rc=True):
     command += ' | json'
     cmds = [command]
-    body = run_commands(module, cmds, check_rc)
+    body = run_commands(module, cmds, check_rc=check_rc)
     return body
 
 def get_acl(module, acl_name, seq_number):

--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -174,11 +174,13 @@ from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 
+
 def execute_show_command(command, module, check_rc=True):
     command += ' | json'
     cmds = [command]
     body = run_commands(module, cmds, check_rc=check_rc)
     return body
+
 
 def get_acl(module, acl_name, seq_number):
     command = 'show ip access-list'

--- a/test/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
   when: ansible_connection == "local"
 
 - set_fact: time_range="ans-range"
-  when: not (platform is match("N5K")) and not (platform is match("N35"))
+  when: platform is not search('N35|N5K|N6K')
 
 - name: "Setup: Cleanup possibly existing acl."
   nxos_acl: &remove


### PR DESCRIPTION
##### SUMMARY
- nxos_acl: catch 501 'Structured output unsupported' when no ACLs present
  -  *With some older image versions, `show ip access-list | json` will raise a 501 error indicating `'Structured output unsupported'` when there are no access-lists configured. This change turns off the `check_rc` and then looks for the failure condition.*

- `nxos_acl` may fail with `IndexError: list index out of range` while attempting to delete a non-existent ACL.  The failure occurs when the `acl` var is an empty list.

- `N6K`: No support for time `range_range`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`modules/network/nxos/nxos_acl.py`

##### ADDITIONAL INFORMATION
Test failures occurred while running the sanity test on older images and / or N6K platform.

edit: sanity now passes on N6K / N7K / N9Kv (green/ham)