### PR TITLE
azure_rm_subnet: fix CI error for deleting the azure_tags (#55276)

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
@@ -219,7 +219,8 @@ class AzureRMSubnet(AzureRMModuleBase):
         self.service_endpoints = None
 
         super(AzureRMSubnet, self).__init__(self.module_arg_spec,
-                                            supports_check_mode=True)
+                                            supports_check_mode=True,
+                                            supports_tags=False)
 
     def exec_module(self, **kwargs):
 

--- a/test/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/test/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -77,9 +77,6 @@
         locations:
           - eastus
           - westus
-    tags:
-       testing: testing
-       delete: on-fini
 
 - name: Should be idempotent
   azure_rm_subnet:
@@ -92,9 +89,6 @@
         locations:
           - eastus
           - westus
-    tags:
-       testing: testing
-       delete: on-fini
   register: output
 
 - assert:
@@ -116,9 +110,6 @@
     security_group:
       name: secgroupfoo
       resource_group: "{{ resource_group_secondary }}"
-    tags:
-       testing: testing
-       delete: on-fini
   register: output
 
 - assert:
@@ -133,9 +124,6 @@
     resource_group: "{{ resource_group }}"
     address_prefix_cidr: "10.1.0.0/16"
     security_group: "{{ nsg.state.id }}"
-    tags:
-       testing: testing
-       delete: on-fini
   register: output
 
 - assert:


### PR DESCRIPTION
##### SUMMARY

Backports #55276. Related to (blocking) #55602 - I'm going to label it "docs" for that reason. 

Fixes CI failure. 

(cherry picked from commit 91e808eed237582c26a9203a2fe838397c251de0)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
azure_rm_subnet
