### PR TITLE
nxos_snmp_traps:sanity: skip idempotency tests for I7 image bug

### DIFF
--- a/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
@@ -54,16 +54,16 @@
   - assert: *true
 
   - block:
-    # On I2, link command does not work properly
+    # On I2/I7, link command does not work properly
     # On D1, callhome command does not work properly
     # skip for these older platforms
     - name: Idempotence Check
       nxos_snmp_traps: *config1
       register: result
-      when: imagetag is not search("I2|D1")
+      when: imagetag is not search("I2|I7|D1")
 
     - assert: *false
-      when: imagetag is not search("I2|D1")
+      when: imagetag is not search("I2|I7|D1")
 
   - name: Cleanup
     nxos_snmp_traps: *remove


### PR DESCRIPTION
##### SUMMARY
This is a sanity test cleanup to handle a known image bug with (N9K) I7 images.
The I7 image fails to enable some snmp trap link configs causing an idempotency failure in the sanity, so we're skipping the idempotence tests that involve this bug.

Tested on N9K images: 9.2(2), 7.0(3)I7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`network/nxos/nxos_snmp_traps`

