### PR TITLE
Backport/2.8/55377

### DIFF
--- a/changelogs/fragments/55377-add-proxy-parameter-to-k8s-module.yaml
+++ b/changelogs/fragments/55377-add-proxy-parameter-to-k8s-module.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Adding ``proxy`` parameter to k8s modules that are based on kubernetes-client/python. (https://github.com/ansible/ansible/pull/55377)

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -122,6 +122,7 @@ AUTH_ARG_SPEC = {
         'type': 'path',
         'aliases': ['key_file'],
     },
+    'proxy': {},
 }
 
 

--- a/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
+++ b/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
@@ -67,6 +67,11 @@ options:
       environment variable.
     type: bool
     aliases: [ verify_ssl ]
+  proxy:
+    description:
+    - The URL of an HTTP proxy to use for the connection. Can also be specified via K8S_AUTH_PROXY environment variable.
+    - Please note that this module does not pick up typical proxy settings from the environment (e.g. HTTP_PROXY).
+    version_added: "2.9"
 notes:
   - "The OpenShift Python client wraps the K8s Python client, providing full access to
     all of the APIS and models available on both platforms. For API version details and


### PR DESCRIPTION
##### SUMMARY
When running Ansible behind a proxy, the k8s module is not capable to reach the K8s cluster. Even if HTTP_PROXY or HTTPS_PROXY environment variables are set.

However, the K8s client allows configuring a proxy for the connection. It only needs to be added to the argument auth spec in order to work as intended.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
k8s

##### ADDITIONAL INFORMATION
Backport of https://github.com/ansible/ansible/pull/55377

