### PR TITLE
mongodb_replicaset and mongodb_shard: Use error code instead of error text

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -381,9 +381,9 @@ def main():
         if excep.code == MONGO_ERRCODE_UNAUTHORIZED: 
             if login_user is not None and login_password is not None: 
                 client.admin.authenticate(login_user, login_password, source=login_database)
-            else: 
+            else:
                 raise excep
-        else: 
+        else:
             raise excep
 
     if len(replica_set) == 0:

--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -376,10 +376,10 @@ def main():
         module.fail_json(msg="When supplying login arguments, both 'login_user' and 'login_password' must be provided")
 
     try:
-        client['admin'].command('listDatabases', 1.0) # if this throws an error we need to authenticate
+        client['admin'].command('listDatabases', 1.0)  # if this throws an error we need to authenticate
     except OperationFailure as excep:
-        if excep.code == MONGO_ERRCODE_UNAUTHORIZED: 
-            if login_user is not None and login_password is not None: 
+        if excep.code == MONGO_ERRCODE_UNAUTHORIZED:
+            if login_user is not None and login_password is not None:
                 client.admin.authenticate(login_user, login_password, source=login_database)
             else:
                 raise excep

--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -376,13 +376,15 @@ def main():
         module.fail_json(msg="When supplying login arguments, both 'login_user' and 'login_password' must be provided")
 
     try:
-        client['admin'].command('listDatabases', 1.0)  # if this throws an error we need to authenticate
+        client['admin'].command('listDatabases', 1.0) # if this throws an error we need to authenticate
     except OperationFailure as excep:
-        if excep.code != MONGO_ERRCODE_UNAUTHORIZED:
+        if excep.code == MONGO_ERRCODE_UNAUTHORIZED: 
+            if login_user is not None and login_password is not None: 
+                client.admin.authenticate(login_user, login_password, source=login_database)
+            else: 
+                raise excep
+        else: 
             raise excep
-        if login_user is None or login_password is None:
-            raise excep
-        client.admin.authenticate(login_user, login_password, source=login_database)
 
     if len(replica_set) == 0:
         module.fail_json(msg="Parameter 'replica_set' must not be an empty string")

--- a/lib/ansible/modules/database/mongodb/mongodb_shard.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_shard.py
@@ -287,13 +287,15 @@ def main():
             module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
 
         try:
-            client['admin'].command('listDatabases', 1.0)  # if this throws an error we need to authenticate
+            client['admin'].command('listDatabases', 1.0) # if this throws an error we need to authenticate
         except OperationFailure as excep:
-            if excep.code != MONGO_ERRCODE_UNAUTHORIZED:
+            if excep.code == MONGO_ERRCODE_UNAUTHORIZED: 
+                if login_user is not None and login_password is not None: 
+                    client.admin.authenticate(login_user, login_password, source=login_database)
+                else: 
+                    raise excep
+            else: 
                 raise excep
-            if login_user is None or login_password is None:
-                raise excep
-            client.admin.authenticate(login_user, login_password, source=login_database)
 
     except Exception as e:
         module.fail_json(msg='unable to connect to database: %s' % to_native(e), exception=traceback.format_exc())

--- a/lib/ansible/modules/database/mongodb/mongodb_shard.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_shard.py
@@ -287,10 +287,10 @@ def main():
             module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
 
         try:
-            client['admin'].command('listDatabases', 1.0) # if this throws an error we need to authenticate
+            client['admin'].command('listDatabases', 1.0)  # if this throws an error we need to authenticate
         except OperationFailure as excep:
-            if excep.code == MONGO_ERRCODE_UNAUTHORIZED: 
-                if login_user is not None and login_password is not None: 
+            if excep.code == MONGO_ERRCODE_UNAUTHORIZED:
+                if login_user is not None and login_password is not None:
                     client.admin.authenticate(login_user, login_password, source=login_database)
                 else:
                     raise excep

--- a/lib/ansible/modules/database/mongodb/mongodb_shard.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_shard.py
@@ -292,9 +292,9 @@ def main():
             if excep.code == MONGO_ERRCODE_UNAUTHORIZED: 
                 if login_user is not None and login_password is not None: 
                     client.admin.authenticate(login_user, login_password, source=login_database)
-                else: 
+                else:
                     raise excep
-            else: 
+            else:
                 raise excep
 
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY

Use error code instead of error text when deciding on if a login is needed.

This fixes an issue where `listDatabases()` failed with the error "pymongo.errors.OperationFailure:
there are no users authenticated" instead of trying to authenticate. Using the error code for
"unauthorized" instead of analysing the error text is a more robust approach. All MongoDB error
codes are documented at https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

- mongodb_replicaset
- mongodb_shard

##### ADDITIONAL INFORMATION

I have an existing MongoDB replica set with 3 instances and authentication enabled.

```
---
- hosts: localhost
  gather_facts: no
  tasks:
    - mongodb_replicaset:
        login_user: admin
        login_password: 123456
        login_database: admin
        login_host: 192.168.1.1
        login_port: 30001
        replica_set: my-rs
        arbiter_at_index: 2
        members:
          - db1:27017
          - db2:27017
          - db-arb:27017
```

Task output before:

```paste below
TASK [mongodb_replicaset] ****************************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false
  module_stderr: |-
    /Users/jonas/.ansible/tmp/ansible-tmp-1556004238.142287-29947431643461/AnsiballZ_mongodb_replicaset.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
      import imp
    Traceback (most recent call last):
      File "/Users/jonas/.ansible/tmp/ansible-tmp-1556004238.142287-29947431643461/AnsiballZ_mongodb_replicaset.py", line 114, in <module>
        _ansiballz_main()
      File "/Users/jonas/.ansible/tmp/ansible-tmp-1556004238.142287-29947431643461/AnsiballZ_mongodb_replicaset.py", line 106, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/Users/jonas/.ansible/tmp/ansible-tmp-1556004238.142287-29947431643461/AnsiballZ_mongodb_replicaset.py", line 49, in invoke_module
        imp.load_module('__main__', mod, module, MOD_DESC)
      File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/imp.py", line 234, in load_module
        return load_source(name, filename, file)
      File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/imp.py", line 169, in load_source
        module = _exec(spec, sys.modules[name])
      File "<frozen importlib._bootstrap>", line 630, in _exec
      File "<frozen importlib._bootstrap_external>", line 728, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/var/folders/kc/5lwqpft17g596cb93br8zs940000gp/T/ansible_mongodb_replicaset_payload_fj0wte9w/__main__.py", line 417, in <module>
      File "/var/folders/kc/5lwqpft17g596cb93br8zs940000gp/T/ansible_mongodb_replicaset_payload_fj0wte9w/__main__.py", line 385, in main
      File "/var/folders/kc/5lwqpft17g596cb93br8zs940000gp/T/ansible_mongodb_replicaset_payload_fj0wte9w/__main__.py", line 377, in main
      File "/Users/jonas/git/github/ansible/venv/lib/python3.7/site-packages/pymongo/database.py", line 658, in command
        codec_options, session=session, **kwargs)
      File "/Users/jonas/git/github/ansible/venv/lib/python3.7/site-packages/pymongo/database.py", line 555, in _command
        client=self.__client)
      File "/Users/jonas/git/github/ansible/venv/lib/python3.7/site-packages/pymongo/pool.py", line 584, in command
        user_fields=user_fields)
      File "/Users/jonas/git/github/ansible/venv/lib/python3.7/site-packages/pymongo/network.py", line 158, in command
        parse_write_concern_error=parse_write_concern_error)
      File "/Users/jonas/git/github/ansible/venv/lib/python3.7/site-packages/pymongo/helpers.py", line 155, in _check_command_response
        raise OperationFailure(msg % errmsg, code, response)
    pymongo.errors.OperationFailure: there are no users authenticated
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

Output after the fix was applied:

```
TASK [mongodb_replicaset] ****************************************************************************************************************************************
ok: [localhost]
```
