### PR TITLE
refactor iscsi network facts module, remove external grep call, add unit test

### DIFF
--- a/changelogs/fragments/55643-network-facts-iscsi.yaml
+++ b/changelogs/fragments/55643-network-facts-iscsi.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - refactor iSCSI network facts for AIX and HP-UX, add unit test, remove external grep call

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -92,16 +92,18 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                     line = self.findstr(aixret, 'initiator_name')
             iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
+            hpuxcmd = "/opt/iscsi/bin/iscsiutil"
             if module is not None:
+                # try to find it in the default PATH
                 cmd = module.get_bin_path('iscsiutil')
                 if not cmd:
-                    cmd = '/opt/iscsi/bin/iscsiutil'
+                    cmd = hpuxcmd
                 cmd = cmd + " -l"
                 rc, out, err = module.run_command(cmd)
                 if out:
                     line = self.findstr(out, 'Initiator Name')
             else:
-                hpuxcmd = "/opt/iscsi/bin/iscsiutil -l"
+                hpuxcmd += " -l"
                 hpuxret = subprocess.check_output(hpuxcmd, shell=True)
                 if hpuxret[0].isalpha():
                     line = self.findstr(hpuxret, 'Initiator Name')

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -80,20 +80,22 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                     iscsi_facts['iscsi_iqn'] = line.split('=', 1)[1]
                     break
         elif sys.platform.startswith('aix'):
-            cmd = get_bin_path('lsattr', required=True)
-            cmd += " -E -l iscsi0"
-            rc, out, err = module.run_command(cmd)
-            if out:
-                line = self.findstr(out, 'initiator_name')
-            iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
+            cmd = get_bin_path('lsattr')
+            if cmd:
+                cmd += " -E -l iscsi0"
+                rc, out, err = module.run_command(cmd)
+                if out:
+                    line = self.findstr(out, 'initiator_name')
+                iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
             # try to find it in the default PATH and opt_dirs
-            cmd = get_bin_path('iscsiutil', opt_dirs=['/opt/iscsi/bin'], required=True)
-            cmd += " -l"
-            rc, out, err = module.run_command(cmd)
-            if out:
-                line = self.findstr(out, 'Initiator Name')
-            iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
+            cmd = get_bin_path('iscsiutil', opt_dirs=['/opt/iscsi/bin'])
+            if cmd:
+                cmd += " -l"
+                rc, out, err = module.run_command(cmd)
+                if out:
+                    line = self.findstr(out, 'Initiator Name')
+                iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
         return iscsi_facts
 
     def findstr(self, text, match):

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -93,7 +93,11 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
             iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
             if module is not None:
-                rc, out, err = module.run_command("/opt/iscsi/bin/iscsiutil -l")
+                cmd = module.get_bin_path('iscsiutil')
+                if not cmd:
+                    cmd = '/opt/iscsi/bin/iscsiutil'
+                cmd = cmd + " -l"
+                rc, out, err = module.run_command(cmd)
                 if out:
                     line = self.findstr(out, 'Initiator Name')
             else:

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -86,7 +86,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 rc, out, err = module.run_command(cmd)
                 if out:
                     line = self.findstr(out, 'initiator_name')
-                iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
+                    iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
             # try to find it in the default PATH and opt_dirs
             cmd = get_bin_path('iscsiutil', opt_dirs=['/opt/iscsi/bin'])
@@ -95,7 +95,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 rc, out, err = module.run_command(cmd)
                 if out:
                     line = self.findstr(out, 'Initiator Name')
-                iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
+                    iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
         return iscsi_facts
 
     def findstr(self, text, match):

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -84,7 +84,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
             if cmd:
                 cmd += " -E -l iscsi0"
                 rc, out, err = module.run_command(cmd)
-                if out:
+                if rc == 0 and out:
                     line = self.findstr(out, 'initiator_name')
                     iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -84,28 +84,28 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 cmd = cmd + " -E -l iscsi0"
                 rc, out, err = module.run_command(cmd)
                 if out:
-                    for line in out.splitlines():
-                        if 'initiator_name' in line:
-                            iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
+                    line = self.findstr(out, 'initiator_name')
             else:
                 aixcmd = '/usr/sbin/lsattr -E -l iscsi0'
                 aixret = subprocess.check_output(aixcmd, shell=True)
                 if aixret[0].isalpha():
-                    for line in aixret.splitlines():
-                        if 'initiator_name' in line:
-                            iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
+                    line = self.findstr(aixret, 'initiator_name')
+            iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
             if module is not None:
                 rc, out, err = module.run_command("/opt/iscsi/bin/iscsiutil -l")
                 if out:
-                    for line in out.splitlines():
-                        if 'Initiator Name' in line:
-                            iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
+                    line = self.findstr(out, 'Initiator Name')
             else:
                 hpuxcmd = "/opt/iscsi/bin/iscsiutil -l"
                 hpuxret = subprocess.check_output(hpuxcmd, shell=True)
                 if hpuxret[0].isalpha():
-                    for line in hpuxret.splitlines():
-                        if 'Initiator Name' in line:
-                            iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
+                    line = self.findstr(hpuxret, 'Initiator Name')
+            iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
         return iscsi_facts
+
+    def findstr(self, text, match):
+        for line in text.splitlines():
+            if match in line:
+                found = line
+        return found

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -79,34 +79,22 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                     iscsi_facts['iscsi_iqn'] = line.split('=', 1)[1]
                     break
         elif sys.platform.startswith('aix'):
-            if module is not None:
-                cmd = module.get_bin_path('lsattr', required=True)
-                cmd = cmd + " -E -l iscsi0"
-                rc, out, err = module.run_command(cmd)
-                if out:
-                    line = self.findstr(out, 'initiator_name')
-            else:
-                aixcmd = '/usr/sbin/lsattr -E -l iscsi0'
-                aixret = subprocess.check_output(aixcmd, shell=True)
-                if aixret[0].isalpha():
-                    line = self.findstr(aixret, 'initiator_name')
+            cmd = module.get_bin_path('lsattr', required=True)
+            cmd += " -E -l iscsi0"
+            rc, out, err = module.run_command(cmd)
+            if out:
+                line = self.findstr(out, 'initiator_name')
             iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
             hpuxcmd = "/opt/iscsi/bin/iscsiutil"
-            if module is not None:
-                # try to find it in the default PATH
-                cmd = module.get_bin_path('iscsiutil')
-                if not cmd:
-                    cmd = hpuxcmd
-                cmd = cmd + " -l"
-                rc, out, err = module.run_command(cmd)
-                if out:
-                    line = self.findstr(out, 'Initiator Name')
-            else:
-                hpuxcmd += " -l"
-                hpuxret = subprocess.check_output(hpuxcmd, shell=True)
-                if hpuxret[0].isalpha():
-                    line = self.findstr(hpuxret, 'Initiator Name')
+            # try to find it in the default PATH
+            cmd = module.get_bin_path('iscsiutil')
+            if not cmd:
+                cmd = hpuxcmd
+            cmd += " -l"
+            rc, out, err = module.run_command(cmd)
+            if out:
+                line = self.findstr(out, 'Initiator Name')
             iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
         return iscsi_facts
 

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -80,23 +80,32 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                     break
         elif sys.platform.startswith('aix'):
             if module is not None:
-                rc, out, err = module.run_command('/usr/sbin/lsattr -E -l iscsi0 | grep initiator_name')
+                cmd = module.get_bin_path('lsattr', required=True)
+                cmd = cmd + " -E -l iscsi0"
+                rc, out, err = module.run_command(cmd)
                 if out:
-                    iscsi_facts['iscsi_iqn'] = out.split()[1].rstrip()
+                    for line in out.splitlines():
+                        if 'initiator_name' in line:
+                            iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
             else:
-                aixcmd = '/usr/sbin/lsattr -E -l iscsi0 | grep initiator_name'
+                aixcmd = '/usr/sbin/lsattr -E -l iscsi0'
                 aixret = subprocess.check_output(aixcmd, shell=True)
                 if aixret[0].isalpha():
-                    iscsi_facts['iscsi_iqn'] = aixret.split()[1].rstrip()
+                    for line in aixret.splitlines():
+                        if 'initiator_name' in line:
+                            iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
             if module is not None:
-                rc, out, err = module.run_command("/opt/iscsi/bin/iscsiutil -l | grep 'Initiator Name'",
-                                                  use_unsafe_shell=True)
+                rc, out, err = module.run_command("/opt/iscsi/bin/iscsiutil -l")
                 if out:
-                    iscsi_facts['iscsi_iqn'] = out.split(":", 1)[1].rstrip()
+                    for line in out.splitlines():
+                        if 'Initiator Name' in line:
+                            iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
             else:
-                hpuxcmd = "/opt/iscsi/bin/iscsiutil -l | grep 'Initiator Name'"
+                hpuxcmd = "/opt/iscsi/bin/iscsiutil -l"
                 hpuxret = subprocess.check_output(hpuxcmd, shell=True)
                 if hpuxret[0].isalpha():
-                    iscsi_facts['iscsi_iqn'] = hpuxret.split(":", 1)[1].rstrip()
+                    for line in hpuxret.splitlines():
+                        if 'Initiator Name' in line:
+                            iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
         return iscsi_facts

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 import sys
 import subprocess
 
+from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.facts.utils import get_file_content
 from ansible.module_utils.facts.network.base import NetworkCollector
 
@@ -79,7 +80,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                     iscsi_facts['iscsi_iqn'] = line.split('=', 1)[1]
                     break
         elif sys.platform.startswith('aix'):
-            cmd = module.get_bin_path('lsattr', required=True)
+            cmd = get_bin_path('lsattr', required=True)
             cmd += " -E -l iscsi0"
             rc, out, err = module.run_command(cmd)
             if out:
@@ -88,7 +89,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
         elif sys.platform.startswith('hp-ux'):
             hpuxcmd = "/opt/iscsi/bin/iscsiutil"
             # try to find it in the default PATH
-            cmd = module.get_bin_path('iscsiutil')
+            cmd = get_bin_path('iscsiutil')
             if not cmd:
                 cmd = hpuxcmd
             cmd += " -l"

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -87,11 +87,8 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 line = self.findstr(out, 'initiator_name')
             iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
         elif sys.platform.startswith('hp-ux'):
-            hpuxcmd = "/opt/iscsi/bin/iscsiutil"
-            # try to find it in the default PATH
+            # try to find it in the default PATH and opt_dirs
             cmd = get_bin_path('iscsiutil', opt_dirs=['/opt/iscsi/bin'], required=True)
-            if not cmd:
-                cmd = hpuxcmd
             cmd += " -l"
             rc, out, err = module.run_command(cmd)
             if out:

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -89,7 +89,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
         elif sys.platform.startswith('hp-ux'):
             hpuxcmd = "/opt/iscsi/bin/iscsiutil"
             # try to find it in the default PATH
-            cmd = get_bin_path('iscsiutil')
+            cmd = get_bin_path('iscsiutil', opt_dirs=['/opt/iscsi/bin'], required=True)
             if not cmd:
                 cmd = hpuxcmd
             cmd += " -l"

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -42,11 +42,13 @@ def test_get_iscsi_info(mocker):
     inst = iscsi.IscsiInitiatorNetworkCollector()
 
     mocker.patch('sys.platform', 'aix6')
+    mocker.patch('ansible.module_utils.facts.network.iscsi.get_bin_path', return_value='/usr/sbin/lsattr')
     mocker.patch.object(module, 'run_command', return_value=(0, LSATTR_OUTPUT, ''))
     aix_iscsi_expected = {"iscsi_iqn": "iqn.localhost.hostid.7f000002"}
     assert aix_iscsi_expected == inst.collect(module=module)
 
     mocker.patch('sys.platform', 'hp-ux')
+    mocker.patch('ansible.module_utils.facts.network.iscsi.get_bin_path', return_value='/opt/iscsi/bin/iscsiutil')
     mocker.patch.object(module, 'run_command', return_value=(0, ISCSIUTIL_OUTPUT, ''))
     hpux_iscsi_expected = {"iscsi_iqn": " iqn.2001-04.com.hp.stor:svcio"}
     assert hpux_iscsi_expected == inst.collect(module=module)

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -42,11 +42,11 @@ def test_get_iscsi_info(mocker):
     inst = iscsi.IscsiInitiatorNetworkCollector()
 
     mocker.patch('sys.platform', 'aix6')
-    module.run_command = Mock(return_value=(0, LSATTR_OUTPUT, ''))  # (rc, out, err)
+    mocker.patch.object(module, 'run_command', return_value=(0, LSATTR_OUTPUT, ''))
     aix_iscsi_expected = {"iscsi_iqn": "iqn.localhost.hostid.7f000002"}
     assert aix_iscsi_expected == inst.collect(module=module)
 
     mocker.patch('sys.platform', 'hp-ux')
-    module.run_command = Mock(return_value=(0, ISCSIUTIL_OUTPUT, ''))  # (rc, out, err)
+    mocker.patch.object(module, 'run_command', return_value=(0, ISCSIUTIL_OUTPUT, ''))
     hpux_iscsi_expected = {"iscsi_iqn": " iqn.2001-04.com.hp.stor:svcio"}
     assert hpux_iscsi_expected == inst.collect(module=module)

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.facts.network import iscsi
+from units.compat.mock import Mock, patch
+
+
+# AIX # lsattr -E -l iscsi0
+LSATTR_OUTPUT = """
+disc_filename  /etc/iscsi/targets            Configuration file                            False
+disc_policy    file                          Discovery Policy                              True
+initiator_name iqn.localhost.hostid.7f000002 iSCSI Initiator Name                          True
+isns_srvnames  auto                          iSNS Servers IP Addresses                     True
+isns_srvports                                iSNS Servers Port Numbers                     True
+max_targets    16                            Maximum Targets Allowed                       True
+num_cmd_elems  200                           Maximum number of commands to queue to driver True
+"""
+
+# HP-UX # iscsiutil -l
+ISCSIUTIL_OUTPUT = """
+Initiator Name             : iqn.2001-04.com.hp.stor:svcio
+Initiator Alias            :
+Authentication Method      : None
+CHAP Method                : CHAP_UNI
+Initiator CHAP Name        :
+CHAP Secret                :
+NAS Hostname               :
+NAS Secret                 :
+Radius Server Hostname     :
+Header Digest              : None,CRC32C (default)
+Data Digest                : None,CRC32C (default)
+SLP Scope list for iSLPD   :
+"""
+
+
+def test_get_iscsi_info(mocker):
+    module = Mock()
+    inst = iscsi.IscsiInitiatorNetworkCollector()
+
+    mocker.patch('sys.platform', 'aix6')
+    module.run_command = Mock(return_value=(0, LSATTR_OUTPUT, ''))  # (rc, out, err)
+    aix_iscsi_expected = {"iscsi_iqn": "iqn.localhost.hostid.7f000002"}
+    assert aix_iscsi_expected == inst.collect(module=module)
+
+    mocker.patch('sys.platform', 'hp-ux')
+    module.run_command = Mock(return_value=(0, ISCSIUTIL_OUTPUT, ''))  # (rc, out, err)
+    hpux_iscsi_expected = {"iscsi_iqn": " iqn.2001-04.com.hp.stor:svcio"}
+    assert hpux_iscsi_expected == inst.collect(module=module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Refactor network facts iscsi module for AIX and HP-UX , by removing external grep call and parse with python.  Add unit test.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
facts module

##### ADDITIONAL INFORMATION
No user visible changes.

Removing code when module is undefined , since module is being defined for this code to run. Using single function for a repeated code (string search).