### PR TITLE
[stable-2.7] Move missing library abort to use rather than import

### DIFF
--- a/changelogs/fragments/55384-netconf-import.yaml
+++ b/changelogs/fragments/55384-netconf-import.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Move netconf import errors from import to use.

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -24,13 +24,17 @@ from functools import wraps
 
 from ansible.errors import AnsibleError
 from ansible.plugins import AnsiblePlugin
-
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import missing_required_lib
 
 try:
     from ncclient.operations import RPCError
     from ncclient.xml_ import to_xml, to_ele
-except ImportError:
-    raise AnsibleError("ncclient is not installed")
+    HAS_NCCLIENT = True
+    NCCLIENT_IMP_ERR = None
+except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    HAS_NCCLIENT = False
+    NCCLIENT_IMP_ERR = err
 
 try:
     from lxml.etree import Element, SubElement, tostring, fromstring
@@ -43,6 +47,15 @@ def ensure_connected(func):
     def wrapped(self, *args, **kwargs):
         if not self._connection._connected:
             self._connection._connect()
+        return func(self, *args, **kwargs)
+    return wrapped
+
+
+def ensure_ncclient(func):
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        if not HAS_NCCLIENT:
+            raise AnsibleError("%s: %s" % (missing_required_lib('ncclient'), to_native(NCCLIENT_IMP_ERR)))
         return func(self, *args, **kwargs)
     return wrapped
 
@@ -104,6 +117,7 @@ class NetconfBase(AnsiblePlugin):
         self._connection = connection
         self.m = self._connection._manager
 
+    @ensure_ncclient
     @ensure_connected
     def rpc(self, name):
         """

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -25,7 +25,6 @@ from functools import wraps
 from ansible.errors import AnsibleError
 from ansible.plugins import AnsiblePlugin
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import missing_required_lib
 
 try:
     from ncclient.operations import RPCError
@@ -55,7 +54,7 @@ def ensure_ncclient(func):
     @wraps(func)
     def wrapped(self, *args, **kwargs):
         if not HAS_NCCLIENT:
-            raise AnsibleError("%s: %s" % (missing_required_lib('ncclient'), to_native(NCCLIENT_IMP_ERR)))
+            raise AnsibleError("Package ncclient is not installed: %s. Please install it with `pip install ncclient`" % to_native(NCCLIENT_IMP_ERR))
         return func(self, *args, **kwargs)
     return wrapped
 

--- a/lib/ansible/plugins/netconf/junos.py
+++ b/lib/ansible/plugins/netconf/junos.py
@@ -22,29 +22,29 @@ __metaclass__ = type
 import json
 import re
 
-from ansible import constants as C
-from ansible.module_utils._text import to_text, to_bytes
-from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.module_utils._text import to_text
+from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.netconf import NetconfBase
-from ansible.plugins.netconf import ensure_connected
+from ansible.plugins.netconf import ensure_connected, ensure_ncclient
 
 try:
     from ncclient import manager
     from ncclient.operations import RPCError
     from ncclient.transport.errors import SSHUnknownHostError
     from ncclient.xml_ import to_ele, to_xml, new_ele, sub_ele
-except ImportError:
-    raise AnsibleError("ncclient is not installed")
+    HAS_NCCLIENT = True
+except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    HAS_NCCLIENT = False
 
 
 class Netconf(NetconfBase):
-
     def get_text(self, ele, tag):
         try:
             return to_text(ele.find(tag).text, errors='surrogate_then_replace').strip()
         except AttributeError:
             pass
 
+    @ensure_ncclient
     def get_device_info(self):
         device_info = dict()
         device_info['network_os'] = 'junos'
@@ -68,6 +68,7 @@ class Netconf(NetconfBase):
         """
         return self.rpc(name)
 
+    @ensure_ncclient
     @ensure_connected
     def load_configuration(self, format='xml', action='merge', target='candidate', config=None):
         """
@@ -101,6 +102,7 @@ class Netconf(NetconfBase):
         return json.dumps(result)
 
     @staticmethod
+    @ensure_ncclient
     def guess_network_os(obj):
         """
         Guess the remote network os name
@@ -165,6 +167,7 @@ class Netconf(NetconfBase):
     # below commit() is a workaround which build's raw `commit-configuration` xml with required tags and uses
     # ncclient generic rpc() method to execute rpc on remote host.
     # Remove below method after the issue in ncclient is fixed.
+    @ensure_ncclient
     @ensure_connected
     def commit(self, confirmed=False, check=False, timeout=None, comment=None, synchronize=False, at_time=None):
         """

--- a/lib/ansible/plugins/netconf/sros.py
+++ b/lib/ansible/plugins/netconf/sros.py
@@ -22,24 +22,18 @@ __metaclass__ = type
 import json
 import re
 
-from ansible import constants as C
-from ansible.module_utils._text import to_text, to_bytes
-from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.module_utils._text import to_text
+from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.netconf import NetconfBase
-from ansible.plugins.netconf import ensure_connected
+from ansible.plugins.netconf import ensure_ncclient
 
 try:
     from ncclient import manager
-    from ncclient.operations import RPCError
     from ncclient.transport.errors import SSHUnknownHostError
-    from ncclient.xml_ import to_ele, to_xml, new_ele
-except ImportError:
-    raise AnsibleError("ncclient is not installed")
-
-try:
-    from lxml import etree
-except ImportError:
-    raise AnsibleError("lxml is not installed")
+    from ncclient.xml_ import to_ele
+    HAS_NCCLIENT = True
+except (ImportError, AttributeError):  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+    HAS_NCCLIENT = False
 
 
 class Netconf(NetconfBase):
@@ -49,6 +43,7 @@ class Netconf(NetconfBase):
         except AttributeError:
             pass
 
+    @ensure_ncclient
     def get_device_info(self):
         device_info = dict()
         device_info['network_os'] = 'sros'
@@ -75,6 +70,7 @@ class Netconf(NetconfBase):
         return json.dumps(result)
 
     @staticmethod
+    @ensure_ncclient
     def guess_network_os(obj):
         try:
             m = manager.connect(


### PR DESCRIPTION
for netconf (#55384).

##### SUMMARY
(cherry picked from commit b442706b543d5e890940d14f9701ebdaae27d83e)

Co-authored-by: Nathaniel Case <this.is@nathanielca.se>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf