### PR TITLE
nxos_bgp_neighbor_af:sanity:6k: skip soft-reconfig 'always' test

### DIFF
--- a/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
   when: ansible_connection == "local"
 
 - set_fact: soft_reconfiguration_ina="always"
-  when: imagetag and (imagetag is version_compare('D1', 'ne'))
+  when: imagetag is not search("D1|N1")
 
 - name: "Disable feature BGP"
   nxos_feature: &disable_bgp


### PR DESCRIPTION
##### SUMMARY
N5K / N6K do not support the `always` keyword on the `soft-reconfig in` configuration.

Modify `sanity.yaml` to omit the `always` for these platforms.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`modules/network/nxos/nxos_bgp_neighbor_af`

##### ADDITIONAL INFORMATION
All nxos_bgp_neighbor_af sanity tests now pass for N6K.