### PR TITLE
nxos_snmp_host:sanity:6k: Add platform excludes for sanity tests

### DIFF
--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
@@ -8,36 +8,37 @@
 
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
-  when: not (platform is match("N5K"))
+  when: platform is not search('N5K|N6K')
+
 
 - name: Setup - Remove snmp_host if configured
   nxos_snmp_host: &remove
     snmp_host: 192.0.2.3
     community: TESTING
-    version: "{{ snmp_version }}" 
-    snmp_type: "{{ snmp_type }}" 
+    version: "{{ snmp_version }}"
+    snmp_type: "{{ snmp_type }}"
     vrf: management
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     udp: 222
     provider: "{{ connection }}"
-    state: absent 
+    state: absent
   ignore_errors: yes
 
 - block:
 
-  - name: Configure snmp host 
+  - name: Configure snmp host
     nxos_snmp_host: &config
       snmp_host: 192.0.2.3
       community: TESTING
-      version: "{{ snmp_version }}" 
-      snmp_type: "{{ snmp_type }}" 
+      version: "{{ snmp_version }}"
+      snmp_type: "{{ snmp_type }}"
       vrf: management
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       udp: 222
       provider: "{{ connection }}"
-      state: present 
+      state: present
     register: result
 
   - assert: &true
@@ -59,7 +60,7 @@
         vrf_filter: default
         udp: 222
         provider: "{{ connection }}"
-        state: present 
+        state: present
       register: result
 
     - assert: *true
@@ -69,7 +70,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
   - name: remove some configuration
     nxos_snmp_host: &rem1
@@ -107,7 +108,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
 
   - name: Cleanup

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
@@ -8,36 +8,36 @@
 
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
-  when: not (platform is match("N5K"))
+  when: platform is not search('N5K|N6K')
 
 - name: Setup - Remove snmp_host if configured
   nxos_snmp_host: &remove
     snmp_host: 192.0.2.3
     community: TESTING
-    version: "{{ snmp_version }}" 
-    snmp_type: "{{ snmp_type }}" 
+    version: "{{ snmp_version }}"
+    snmp_type: "{{ snmp_type }}"
     vrf: management
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     udp: 222
     provider: "{{ connection }}"
-    state: absent 
+    state: absent
   ignore_errors: yes
 
 - block:
 
-  - name: Configure snmp host 
+  - name: Configure snmp host
     nxos_snmp_host: &config
       snmp_host: 192.0.2.3
       community: TESTING
-      version: "{{ snmp_version }}" 
-      snmp_type: "{{ snmp_type }}" 
+      version: "{{ snmp_version }}"
+      snmp_type: "{{ snmp_type }}"
       vrf: management
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       udp: 222
       provider: "{{ connection }}"
-      state: present 
+      state: present
     register: result
 
   - assert: &true
@@ -59,7 +59,7 @@
         vrf_filter: default
         udp: 222
         provider: "{{ connection }}"
-        state: present 
+        state: present
       register: result
 
     - assert: *true
@@ -69,7 +69,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
   - name: remove some configuration
     nxos_snmp_host: &rem1
@@ -107,7 +107,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
   - name: Cleanup
     nxos_snmp_host: *remove

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
@@ -9,7 +9,8 @@
 
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
-  when: not (platform is match("N5K"))
+  when: platform is not search('N5K|N6K')
+
 
 - set_fact: run="true"
 - set_fact: run="false"
@@ -19,30 +20,30 @@
   nxos_snmp_host: &remove
     snmp_host: 192.0.2.3
     community: TESTING
-    version: "{{ snmp_version }}" 
-    snmp_type: "{{ snmp_type }}" 
-    v3: "{{ snmp_auth }}" 
+    version: "{{ snmp_version }}"
+    snmp_type: "{{ snmp_type }}"
+    v3: "{{ snmp_auth }}"
     vrf: management
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     provider: "{{ connection }}"
-    state: absent 
+    state: absent
   ignore_errors: yes
 
 - block:
 
-  - name: Configure snmp host 
+  - name: Configure snmp host
     nxos_snmp_host: &config
       snmp_host: 192.0.2.3
       community: TESTING
       v3: "{{ snmp_auth|default(omit) }}"
-      version: "{{ snmp_version }}" 
-      snmp_type: "{{ snmp_type }}" 
+      version: "{{ snmp_version }}"
+      snmp_type: "{{ snmp_type }}"
       vrf: management
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       provider: "{{ connection }}"
-      state: present 
+      state: present
     register: result
 
   - assert: &true
@@ -63,7 +64,7 @@
         snmp_host: 192.0.2.3
         vrf_filter: default
         provider: "{{ connection }}"
-        state: present 
+        state: present
       register: result
 
     - assert: *true
@@ -73,7 +74,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
   - name: remove some configuration
     nxos_snmp_host: &rem1
@@ -109,7 +110,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
   - name: Cleanup
     nxos_snmp_host: *remove

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
@@ -9,7 +9,7 @@
 
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
-  when: not (platform is match("N5K"))
+  when: platform is not search('N5K|N6K')
 
 - name: Setup - Remove snmp_host if configured
   nxos_snmp_host: &remove
@@ -17,30 +17,30 @@
     community: TESTING
     udp: 222
     v3: "{{ snmp_auth|default(omit) }}"
-    version: "{{ snmp_version }}" 
-    snmp_type: "{{ snmp_type }}" 
+    version: "{{ snmp_version }}"
+    snmp_type: "{{ snmp_type }}"
     vrf: management
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     provider: "{{ connection }}"
-    state: absent 
+    state: absent
   ignore_errors: yes
 
 - block:
 
-  - name: Configure snmp host 
+  - name: Configure snmp host
     nxos_snmp_host: &config
       snmp_host: 192.0.2.3
       community: TESTING
       udp: 222
       v3: "{{ snmp_auth|default(omit) }}"
-      version: "{{ snmp_version }}" 
-      snmp_type: "{{ snmp_type }}" 
+      version: "{{ snmp_version }}"
+      snmp_type: "{{ snmp_type }}"
       vrf: management
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       provider: "{{ connection }}"
-      state: present 
+      state: present
     register: result
 
   - assert: &true
@@ -62,7 +62,7 @@
         udp: 222
         vrf_filter: default
         provider: "{{ connection }}"
-        state: present 
+        state: present
       register: result
 
     - assert: *true
@@ -72,7 +72,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
   - name: remove some configuration
     nxos_snmp_host: &rem1
@@ -110,7 +110,7 @@
       register: result
 
     - assert: *false
-    when: not (platform is match('N35|N5K'))
+    when: platform is not search('N35|N5K|N6K')
 
   - name: Cleanup
     nxos_snmp_host: *remove


### PR DESCRIPTION
##### SUMMARY
N6K should be present wherever N5K is included/excluded.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`modules/network/nxos/nxos_snmp_host`

##### ADDITIONAL INFORMATION
All nxos_snmp_host sanity tests now pass for N6K.
