### PR TITLE
--become-method should not be restricted

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -298,7 +298,7 @@ def add_runas_options(parser):
     # consolidated privilege escalation (become)
     runas_group.add_argument("-b", "--become", default=C.DEFAULT_BECOME, action="store_true", dest='become',
                              help="run operations with become (does not imply password prompting)")
-    runas_group.add_argument('--become-method', dest='become_method', default=C.DEFAULT_BECOME_METHOD, choices=C.BECOME_METHODS,
+    runas_group.add_argument('--become-method', dest='become_method', default=C.DEFAULT_BECOME_METHOD,
                              help="privilege escalation method to use (default=%(default)s), use "
                                   "`ansible-doc -t become -l` to list valid choices.")
     runas_group.add_argument('--become-user', default=None, dest='become_user', type=str,


### PR DESCRIPTION
##### SUMMARY
A rebase issue slipped through in the argparse PR, that kept `choices` for the `--become-method` flag.

This PR removes `choices`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/arguments/option_helpers.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```