### PR TITLE
nxos_interface: Fix admin_state check for n6k

### DIFF
--- a/test/integration/targets/nxos_interface/tests/common/intent.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/intent.yaml
@@ -26,11 +26,16 @@
     that:
       - "result.failed == false"
 
+- name: "Clear interface {{ testint2 }} counters before next task"
+  nxos_command:
+    commands: "clear counters interface {{ testint2 }}"
+  ignore_errors: yes
+
 - name: Check intent arguments (failed condition)
   nxos_interface:
     name: "{{ testint2 }}"
     admin_state: down
-    tx_rate: gt(0)
+    tx_rate: gt(10000)
     rx_rate: lt(0)
     provider: "{{ connection }}"
   ignore_errors: yes
@@ -39,7 +44,7 @@
 - assert:
     that:
       - "result.failed == true"
-      - "'tx_rate gt(0)' in result.failed_conditions"
+      - "'tx_rate gt(10000)' in result.failed_conditions"
       - "'rx_rate lt(0)' in result.failed_conditions"
 
 - name: aggregate definition of interface


### PR DESCRIPTION
##### SUMMARY
This PR fixes two problems with the nxos_interface module:

*  Certain NX-OS platforms like the N6k do not have the `admin_state` key as part of the structured output for the `show interface` command.
    *  This update makes use of other keys that are available to determine the admin state of the interface.
* This also fixes a problem with the `tx_rate` negative test.  The counters can be greater then 0 when the test runs so we first clear the counters and then set test rate to a high value to ensure the test fails.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_interface

##### ADDITIONAL INFORMATION
Tested on N3k, N6k, N7k, N9k platforms