### PR TITLE
sensu_subscription very minor docstring typo

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_subscription.py
+++ b/lib/ansible/modules/monitoring/sensu_subscription.py
@@ -49,7 +49,7 @@ author: Anders Ingemann (@andsens)
 
 RETURN = '''
 reasons:
-    description: the reasons why the moule changed or did not change something
+    description: the reasons why the module changed or did not change something
     returned: success
     type: list
     sample: ["channel subscription was absent and state is `present'"]


### PR DESCRIPTION
As above, super-small docs typo

+label: docsite_pr

##### SUMMARY

Very small docs typo in `sensu_subscription`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

sensu_subscription

##### ADDITIONAL INFORMATION
