### PR TITLE
teach ansible about loop_control/break_when

### DIFF
--- a/changelogs/fragments/55677-break_when.yml
+++ b/changelogs/fragments/55677-break_when.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "loop_control: add the break_when keyword to allow tasks to break out
+    of a loop prematurely."

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -412,6 +412,18 @@ For role authors, writing roles that allow loops, instead of dictating the requi
 
     "{{ lookup('vars', ansible_loop_var) }}"
 
+Breaking from a loop prematurely
+--------------------------------
+.. versionadded:: 2.8
+
+You can cause a loop to exit prematurely using the ``break_when`` attribute to ``loop_control``.  This is a conditional expression in the style of the ``changed_when`` or ``failed_when`` task attributes::
+
+    - debug:
+        msg: "This is item {{ item }}"
+      loop: "{{ range(100)|list }}"
+      loop_control:
+        break_when: item == 10
+
 .. _migrating_to_loop:
 
 Migrating from with_X to loop

--- a/lib/ansible/playbook/loop_control.py
+++ b/lib/ansible/playbook/loop_control.py
@@ -30,9 +30,14 @@ class LoopControl(FieldAttributeBase):
     _label = FieldAttribute(isa='str')
     _pause = FieldAttribute(isa='float', default=0)
     _extended = FieldAttribute(isa='bool')
+    _break_when = FieldAttribute(isa='list', default=list)
 
     def __init__(self):
         super(LoopControl, self).__init__()
+
+    def _validate_break_when(self, attr, name, value):
+        if not isinstance(value, list):
+            setattr(self, name, [value])
 
     @staticmethod
     def load(data, variable_manager=None, loader=None):

--- a/test/integration/targets/loop_control/break_when.yml
+++ b/test/integration/targets/loop_control/break_when.yml
@@ -1,0 +1,40 @@
+---
+- name: loop_control/break_when
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: a loop that runs until completion
+      set_fact:
+        last_item: "{{ item }}"
+      loop: "{{ range(10)|list }}"
+
+    - name: assert that loop exited as expected
+      assert:
+        that:
+          - last_item == 9
+
+    - name: a loop that breaks prematurely using the loop var
+      set_fact:
+        last_item: "{{ item }}"
+      loop: "{{ range(10)|list }}"
+      loop_control:
+        break_when: item == 5
+
+    - name: assert that loop exited as expected
+      assert:
+        that:
+          - last_item == 5
+
+    - name: a loop that breaks prematurely using a registered var
+      debug:
+        msg:
+          item: "{{ item }}"
+      register: result
+      loop: "{{ range(10)|list }}"
+      loop_control:
+        break_when: result.msg.item == 5
+
+    - name: assert that loop exited as expected
+      assert:
+        that:
+          - result.results[-1].item == 5

--- a/test/integration/targets/loop_control/runme.sh
+++ b/test/integration/targets/loop_control/runme.sh
@@ -9,3 +9,4 @@ MATCH='foo_label
 bar_label'
 [ "$(ansible-playbook label.yml "$@" |grep 'item='|sed -e 's/^.*(item=looped_var \(.*\)).*$/\1/')" == "${MATCH}" ]
 
+ansible-playbook break_when.yml -v "$@"

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -145,6 +145,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_task = MagicMock()
         mock_task.copy.side_effect = _copy
+        mock_task.loop_control = {}
 
         mock_play_context = MagicMock()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

this introduces the `break_when` loop_control attribute, which permits a
task loop to stop prematurely if the specified condition is true. This
can save time and reduce the amount of extraneous output if the
execution of a large loop can short circuited.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Loops

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This PR includes tests and documentation.

Here's a simple example of this feature in practice. The playbook can create an arbitrary number of containers (five by default).  If you run it a second time with `container_count` less than the previous value of `container_count`, it needs to remove any existing containers above `container_count` created by the previous run.  Using `break_when` lets the loop exit as soon as there are no more containers to remove:

    ---
    - hosts: localhost
      gather_facts: false
      vars:
        container_count: 5
        max_container_count: 100

      tasks:
        - name: create containers
          docker_container:
            name: "service-{{ item }}"
            state: present
            image: alpine
            command: /bin/sh
            tty: true
            interactive: true
            detach: true
          loop: "{{ range(container_count|int)|list }}"

        - name: remove containers created by previous runs
          docker_container:
            name: "service-{{ item }}"
            state: absent
          register: result
          loop: "{{ range(container_count|int, max_container_count)|list }}"
          loop_control:
            break_when: result is not changed
