### PR TITLE
Fix sublevel configs in dellos6

### DIFF
--- a/lib/ansible/module_utils/network/dellos6/dellos6.py
+++ b/lib/ansible/module_utils/network/dellos6/dellos6.py
@@ -32,7 +32,7 @@
 import re
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network.common.utils import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.network.common.config import NetworkConfig, ConfigLine, ignore_line
@@ -152,16 +152,16 @@ def os6_parse(lines, indent=None, comment_tokens=None):
         re.compile(r'datacenter-bridging.*$'),
         re.compile(r'line (console|telnet|ssh).*$'),
         re.compile(r'ip ssh !(server).*$'),
+        re.compile(r'(ip|mac|management|arp|ipv6) access-list.*$'),
         re.compile(r'ip dhcp pool.*$'),
         re.compile(r'ip vrf !(forwarding).*$'),
-        re.compile(r'(ip|mac|management|arp) access-list.*$'),
         re.compile(r'ipv6 (dhcp pool|router).*$'),
         re.compile(r'mail-server.*$'),
         re.compile(r'vpc domain.*$'),
         re.compile(r'router.*$'),
         re.compile(r'route-map.*$'),
         re.compile(r'policy-map.*$'),
-        re.compile(r'class-map match-all.*$'),
+        re.compile(r'(^class-map)|(class\s\w+).*$'),
         re.compile(r'captive-portal.*$'),
         re.compile(r'admin-profile.*$'),
         re.compile(r'link-dependency group.*$'),
@@ -200,6 +200,10 @@ def os6_parse(lines, indent=None, comment_tokens=None):
                     if children:
                         children.insert(len(parent) - 1, [])
                         children[len(parent) - 2].append(cfg)
+                    if not children and len(parent) > 1:
+                        configlist = [cfg]
+                        children.append(configlist)
+                        children.insert(len(parent) - 1, [])
                     parent_match = True
                     continue
             # handle exit

--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -46,6 +46,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"Invalid|invalid.*$", re.I),
         re.compile(br"((\bout of range\b)|(\bnot found\b)|(\bCould not\b)|(\bUnable to\b)|(\bCannot\b)|(\bError\b)).*", re.I),
         re.compile(br"((\balready exists\b)|(\bnot exist\b)|(\bnot active\b)|(\bFailed\b)|(\bIncorrect\b)|(\bnot enabled\b)).*", re.I),
+        re.compile(br"((\bnot allowed\b)|(\bincompatible\b)).*", re.I),
 
     ]
 


### PR DESCRIPTION
##### SUMMARY
Fix sublevel configs in dellos6

##### ISSUE TYPE
- Bugfix Pull Request

#### COMPONENT NAME
ansible/lib/ansible/module_utils/network/dellos6/dellos6.py

##### ADDITIONAL INFORMATION
```ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admin/MY_ANSIBLE/ansible/lib/ansible
  executable location = /home/admin/MY_ANSIBLE/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
```
