### PR TITLE
fix for removing subscripion_id from resource facts (#55203)

### DIFF
--- a/changelogs/fragments/55203-fix-for-removing-subscription-id-from-facts.yaml
+++ b/changelogs/fragments/55203-fix-for-removing-subscription-id-from-facts.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "Fixes an issue when subscription_id is masked in the output when it's passed as one of the parameters."

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -27,7 +27,7 @@ AZURE_COMMON_ARGS = dict(
         choices=['auto', 'cli', 'env', 'credential_file', 'msi']
     ),
     profile=dict(type='str'),
-    subscription_id=dict(type='str', no_log=True),
+    subscription_id=dict(type='str'),
     client_id=dict(type='str', no_log=True),
     secret=dict(type='str', no_log=True),
     tenant=dict(type='str', no_log=True),


### PR DESCRIPTION
(cherry picked from commit 48cb6811409c90c64e9a09a3d7a8f0e0433be6fb)

##### SUMMARY
Subscription_id shouldnt' be removed from output.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
all

##### ADDITIONAL INFORMATION
