### PR TITLE
[2.8] vultr_server: fix idempotency for private network and IPv6 options

### DIFF
--- a/changelogs/fragments/55619-vultr_server_idempotency.yml
+++ b/changelogs/fragments/55619-vultr_server_idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vultr_server - Fix idempotency for options ``ipv6_enabled`` and ``private_network_enabled``.

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -128,15 +128,15 @@ class Vultr:
             return
 
         r_value = resource.get(resource_key)
-        if isinstance(param, bool):
-            if param is True and r_value not in ['yes', 'enable']:
+        if r_value in ['yes', 'no']:
+            if param and r_value != 'yes':
                 return "enable"
-            elif param is False and r_value not in ['no', 'disable']:
+            elif not param and r_value != 'no':
                 return "disable"
         else:
-            if r_value is None:
+            if param and not r_value:
                 return "enable"
-            else:
+            elif not param and r_value:
                 return "disable"
 
     def api_query(self, path="/", method="GET", data=None):

--- a/test/integration/targets/vultr_plan_facts/tasks/main.yml
+++ b/test/integration/targets/vultr_plan_facts/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: verify test gather vultr plan facts in check mode
   assert:
     that:
-    - ansible_facts.vultr_plan_facts|selectattr('name','equalto','16384 MB RAM,110 GB SSD,20.00 TB BW') | list | count == 1
+    - ansible_facts.vultr_plan_facts|selectattr('name','equalto','16384 MB RAM,2x110 GB SSD,20.00 TB BW') | list | count == 1
 
 - name: test gather vultr plan fact
   vultr_plan_facts:
@@ -16,4 +16,4 @@
 - name: verify test gather vultr plan facts
   assert:
     that:
-    - ansible_facts.vultr_plan_facts|selectattr('name','equalto','16384 MB RAM,110 GB SSD,20.00 TB BW') | list | count == 1
+    - ansible_facts.vultr_plan_facts|selectattr('name','equalto','16384 MB RAM,2x110 GB SSD,20.00 TB BW') | list | count == 1

--- a/test/integration/targets/vultr_server/tasks/main.yml
+++ b/test/integration/targets/vultr_server/tasks/main.yml
@@ -313,6 +313,7 @@
     os: CentOS 6 x64
     plan: "{{ vultr_server_plan_2 }}"
     auto_backup_enabled: yes
+    private_network_enabled: yes
     region: Amsterdam
     force: yes
   register: result
@@ -327,6 +328,7 @@
     - result.vultr_server.plan == vultr_server_plan_1
     - result.vultr_server.region == 'Amsterdam'
     - result.vultr_server.auto_backup_enabled == false
+    - result.vultr_server.internal_ip == ''
 
 - name: test update server with force
   vultr_server:
@@ -334,6 +336,7 @@
     os: CentOS 6 x64
     plan: "{{ vultr_server_plan_2 }}"
     auto_backup_enabled: yes
+    private_network_enabled: yes
     region: Amsterdam
     force: yes
   register: result
@@ -347,15 +350,17 @@
     - result.vultr_server.plan == vultr_server_plan_2
     - result.vultr_server.region == 'Amsterdam'
     - result.vultr_server.auto_backup_enabled == true
+    - result.vultr_server.internal_ip != ''
 
 - name: test update server idempotence with force
   vultr_server:
     name: "{{ vultr_server_name }}"
     os: CentOS 6 x64
     plan: "{{ vultr_server_plan_2 }}"
-    auto_backup_enabled: true
+    auto_backup_enabled: yes
+    private_network_enabled: yes
     region: Amsterdam
-    force: true
+    force: yes
   register: result
 - name: verify test update server idempotence with force
   assert:
@@ -367,13 +372,14 @@
     - result.vultr_server.plan == vultr_server_plan_2
     - result.vultr_server.region == 'Amsterdam'
     - result.vultr_server.auto_backup_enabled == true
+    - result.vultr_server.internal_ip != ''
 
 - name: test update server to stopped in check mode
   vultr_server:
     name: "{{ vultr_server_name }}"
     os: CentOS 6 x64
     plan: "{{ vultr_server_plan_2 }}"
-    ipv6_enabled: true
+    ipv6_enabled: yes
     region: Amsterdam
     state: stopped
   register: result
@@ -394,7 +400,7 @@
     name: "{{ vultr_server_name }}"
     os: CentOS 6 x64
     plan: "{{ vultr_server_plan_2 }}"
-    ipv6_enabled: true
+    ipv6_enabled: yes
     region: Amsterdam
     state: stopped
   register: result
@@ -414,6 +420,7 @@
     name: "{{ vultr_server_name }}"
     os: CentOS 6 x64
     plan: "{{ vultr_server_plan_2 }}"
+    ipv6_enabled: yes
     region: Amsterdam
     state: stopped
   register: result

--- a/test/integration/targets/vultr_server_facts/tasks/main.yml
+++ b/test/integration/targets/vultr_server_facts/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: verify test gather vultr server facts - empty resources
   assert:
     that:
-    - ansible_facts.vultr_server_facts | count == 0
+    - ansible_facts.vultr_server_facts | selectattr('name','equalto',vultr_server_name) | list | count == 0
 
 - name: setup firewall group
   vultr_firewall_group:
@@ -38,7 +38,7 @@
 - name: verify test gather vultr server facts in check mode
   assert:
     that:
-    - ansible_facts.vultr_server_facts|selectattr('name','equalto','{{ vultr_server_name }}') | list | count == 1
+    - ansible_facts.vultr_server_facts|selectattr('name','equalto',vultr_server_name) | list | count == 1
 
 - name: test gather vultr server facts
   vultr_server_facts:
@@ -46,7 +46,7 @@
 - name: verify test gather vultr server facts
   assert:
     that:
-    - ansible_facts.vultr_server_facts|selectattr('name','equalto','{{ vultr_server_name }}') | list | count == 1
+    - ansible_facts.vultr_server_facts|selectattr('name','equalto',vultr_server_name) | list | count == 1
 
 - name: Pause for 5 min before deleting the VM
   pause:


### PR DESCRIPTION
##### SUMMARY
Backports #55619 and #55621.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vultr_server

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
