### PR TITLE
Ansible.Basic - fix when deserialising a json string of an array

### DIFF
--- a/changelogs/fragments/ps-basic-json.yaml
+++ b/changelogs/fragments/ps-basic-json.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.Basic - Fix issue when deserilizing a JSON string that is not a dictionary - https://github.com/ansible/ansible/pull/55691

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -334,7 +334,7 @@ namespace Ansible.Basic
             LogEvent(String.Format("[WARNING] {0}", message), EventLogEntryType.Warning);
         }
 
-        public static Dictionary<string, object> FromJson(string json) { return FromJson<Dictionary<string, object>>(json); }
+        public static object FromJson(string json) { return FromJson<object>(json); }
         public static T FromJson<T>(string json)
         {
 #if CORECLR
@@ -375,7 +375,7 @@ namespace Ansible.Basic
             if (args.Length > 0)
             {
                 string inputJson = File.ReadAllText(args[0]);
-                Dictionary<string, object> rawParams = FromJson(inputJson);
+                Dictionary<string, object> rawParams = FromJson<Dictionary<string, object>>(inputJson);
                 if (!rawParams.ContainsKey("ANSIBLE_MODULE_ARGS"))
                     throw new ArgumentException("Module was unable to get ANSIBLE_MODULE_ARGS value from the argument path json");
                 return (IDictionary)rawParams["ANSIBLE_MODULE_ARGS"];

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -58,7 +58,7 @@ Function Assert-DictionaryEquals {
 
         if ($actual_value -is [System.Collections.IDictionary]) {
             $actual_value | Assert-DictionaryEquals -Expected $expected_value
-        } elseif ($actual_value -is [System.Collections.ArrayList]) {
+        } elseif ($actual_value -is [System.Collections.ArrayList] -or $actual_value -is [Array]) {
             for ($i = 0; $i -lt $actual_value.Count; $i++) {
                 $actual_entry = $actual_value[$i]
                 $expected_entry = $expected_value[$i]
@@ -2346,6 +2346,23 @@ test_no_log - Invoked with:
         $actual.changed | Assert-Equals -Expected $false
         $actual.invocation | Assert-DictionaryEquals -Expected @{module_args = @{}}
         $actual.output | Assert-DictionaryEquals -Expected @{a = "a"; b = "b"}
+    }
+
+    "String json array to object" = {
+        $input_json = '["abc", "def"]'
+        $actual = [Ansible.Basic.AnsibleModule]::FromJson($input_json)
+        $actual -is [Array] | Assert-Equals -Expected $true
+        $actual.Length | Assert-Equals -Expected 2
+        $actual[0] | Assert-Equals -Expected "abc"
+        $actual[1] | Assert-Equals -Expected "def"
+    }
+
+    "String json array of dictionaries to object" = {
+        $input_json = '[{"abc":"def"}]'
+        $actual = [Ansible.Basic.AnsibleModule]::FromJson($input_json)
+        $actual -is [Array] | Assert-Equals -Expected $true
+        $actual.Length | Assert-Equals -Expected 1
+        $actual[0] | Assert-DictionaryEquals -Expected @{"abc" = "def"}
     }
 }
 

--- a/test/integration/targets/win_uri/tasks/main.yml
+++ b/test/integration/targets/win_uri/tasks/main.yml
@@ -429,3 +429,17 @@
     that:
     - not request_status_code_comma.changed
     - request_status_code_comma.status_code == 202
+
+# https://github.com/ansible/ansible/issues/55294
+- name: get json content that is an array
+  win_uri:
+    url: https://{{httpbin_host}}/base64/{{ '[{"abc":"def"}]' | b64encode }}
+    return_content: yes
+  register: content_array
+
+- name: assert content of json array
+  assert:
+    that:
+    - not content_array is changed
+    - content_array.content == '[{"abc":"def"}]'
+    - content_array.json == [{"abc":"def"}]


### PR DESCRIPTION
##### SUMMARY
The `FromJson()` method in Ansible.Basic expected the JSON string to be a dictionary and would fail if it was an array like `[{"abc":"def"}]`. This change makes the default `FromJson` method output an object and let the deserializer handler that info. The generic type method still exists but this just aligns `FromJson` to `ConvertFrom-Json`.

Also adds a test for this in win_uri in case win_uri ever uses a different mechanism in the future.

Fixes https://github.com/ansible/ansible/issues/55294.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic
win_uri