### PR TITLE
adding final functionapp settings

### DIFF
--- a/changelogs/fragments/55693-fixing-final-function-app-properties.yml
+++ b/changelogs/fragments/55693-fixing-final-function-app-properties.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - azure_rm_functionapp - adding two properties which need to be set by default, otherwise function app won't behave correctly in Azure Portal.

--- a/changelogs/fragments/55693-fixing-final-function-app-properties.yml
+++ b/changelogs/fragments/55693-fixing-final-function-app-properties.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - azure_rm_functionapp - adding two properties which need to be set by default, otherwise function app won't behave correctly in Azure Portal.

--- a/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
@@ -365,6 +365,8 @@ class AzureRMFunctionApp(AzureRMModuleBase):
             function_app_settings.append(NameValuePair(name='WEBSITE_CONTENTSHARE', value=self.name))
         else:
             function_app_settings.append(NameValuePair(name='FUNCTIONS_EXTENSION_VERSION', value='~2'))
+            function_app_settings.append(NameValuePair(name='WEBSITES_ENABLE_APP_SERVICE_STORAGE', value=False))
+            function_app_settings.append(NameValuePair(name='AzureWebJobsStorage', value=self.storage_connection_string))
 
         return function_app_settings
 


### PR DESCRIPTION
##### SUMMARY
This is final fix for azure_rm_functionapp.
Adding WEBSITES_ENABLE_APP_SERVICE_STORAGE and AzureWebJobsStorage properties by default.
Otherwise user will have to add them manually or function app won't work 100% correctly. (some features in the portal disabled)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_functionapp

##### ADDITIONAL INFORMATION
