### PR TITLE
ec2_instance: Force int when ebs.volume_size or ebs.iops is specified

### DIFF
--- a/changelogs/fragments/55716-ec2_instance_int_volume_size.yml
+++ b/changelogs/fragments/55716-ec2_instance_int_volume_size.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_instance - Ensures ``ebs.volume_size`` is ``int`` to avoid issues with Jinja2 templating

--- a/changelogs/fragments/55716-ec2_instance_int_volume_size.yml
+++ b/changelogs/fragments/55716-ec2_instance_int_volume_size.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ec2_instance - Ensures ``ebs.volume_size`` is ``int`` to avoid issues with Jinja2 templating
+  - ec2_instance - Ensures ``ebs.volume_size`` and ``ebs.iops`` are ``int`` to avoid issues with Jinja2 templating

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -818,6 +818,9 @@ def manage_tags(match, new_tags, purge_tags, ec2):
 
 def build_volume_spec(params):
     volumes = params.get('volumes') or []
+    for volume in volumes:
+        if ('ebs' in volume) and ('volume_size' in volume['ebs']):
+            volume['ebs']['volume_size'] = int(volume['ebs']['volume_size'])
     return [ec2_utils.snake_dict_to_camel_dict(v, capitalize_first=True) for v in volumes]
 
 

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -819,8 +819,10 @@ def manage_tags(match, new_tags, purge_tags, ec2):
 def build_volume_spec(params):
     volumes = params.get('volumes') or []
     for volume in volumes:
-        if ('ebs' in volume) and ('volume_size' in volume['ebs']):
-            volume['ebs']['volume_size'] = int(volume['ebs']['volume_size'])
+        if 'ebs' in volume:
+            for int_value in ['volume_size', 'iops']:
+                if int_value in volume['ebs']:
+                    volume['ebs'][int_value] = int(volume['ebs'][int_value])
     return [ec2_utils.snake_dict_to_camel_dict(v, capitalize_first=True) for v in volumes]
 
 


### PR DESCRIPTION
##### SUMMARY
Makes sure `ebs.volume_size` and `ebs.iops` are `int` to avoid issues with Jinja2 templating

Fixes #55704

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance.py