### PR TITLE
mark entire module result untrusted as template

### DIFF
--- a/changelogs/fragments/ensure_facts_safe.yml
+++ b/changelogs/fragments/ensure_facts_safe.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - ensure facts are always unsafe objects and don't rely on plugin returns
+    - ensure module results and facts are marked untrusted as templates for safer use within the same task

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -968,6 +968,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 data['deprecations'] = []
             data['deprecations'].extend(self._discovery_deprecation_warnings)
 
+        # mark the entire module results untrusted as a template right here, since the current action could
+        # possibly template one of these values.
+        data = wrap_var(data)
+
         display.debug("done with _execute_module (%s, %s)" % (module_name, module_args))
         return data
 
@@ -978,9 +982,6 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 display.warning(w)
 
             data = json.loads(filtered_output)
-
-            if 'ansible_facts' in data and isinstance(data['ansible_facts'], dict):
-                data['ansible_facts'] = wrap_var(data['ansible_facts'])
             data['_ansible_parsed'] = True
         except ValueError:
             # not valid json, lets try to capture error


### PR DESCRIPTION
##### SUMMARY
* prevents accidental templating on intra-action postprocessing of an untrusted module result
* moves `wrap_var` call to the very end of `ActionBase._execute_module()`, just in case anything else is added in the middle.
* makes the view of a module result within an action consistent with the way it would be stored for future use (eg facts, register)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ActionBase 

##### ADDITIONAL INFORMATION

