### PR TITLE
vmware: import prepare_vmware_tests

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/defaults/main.yml
+++ b/test/integration/targets/prepare_vmware_tests/defaults/main.yml
@@ -1,0 +1,25 @@
+dc1: DC0
+ccr1: DC0_C0
+ds1: LocalDS_0
+ds2: LocalDS_1
+f0: F0
+switch1: switch1
+dvswitch1: DVS0
+# The ESXi entries in the inventory
+esxi1: "{{ groups['esxi-lab'][0] }}"
+esxi2: "{{ groups['esxi-lab'][1] }}"
+infra:
+  datastores:
+    LocalDS_0:
+      type: nfs
+      server: 192.168.123.1
+      path: /srv/esx_lab/isos
+      ro: true
+    LocalDS_1:
+      type: nfs
+      server: 192.168.123.1
+      path: /srv/esx_lab/vms
+      ro: false
+  vm_list:
+    - DC0_C0_RP0_VM0
+    - DC0_C0_RP0_VM1

--- a/test/integration/targets/prepare_vmware_tests/meta/main.yml
+++ b/test/integration/targets/prepare_vmware_tests/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/test/integration/targets/prepare_vmware_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- when: vcsim is not defined
+  block:
+    - include_tasks: teardown.yml
+
+- when: vcsim is not defined and setup_esxi_instance is not defined
+  block:
+    - include_tasks: setup_datacenter.yml
+    - include_tasks: setup_cluster.yml
+    - include_tasks: setup_attach_hosts.yml
+      when: setup_attach_host is defined
+    - include_tasks: setup_datastore.yml
+      when: setup_datastore is defined
+    - include_tasks: setup_virtualmachines.yml
+      when: setup_virtualmachines is defined
+    - include_tasks: setup_switch.yml
+      when: setup_switch is defined
+
+
+- when: vcsim is defined
+  block:
+
+    - name: kill vcsim
+      uri:
+        url: http://{{ vcsim }}:5000/killall
+
+    - name: start vcsim (all dressed)
+      uri:
+        url: http://{{ vcsim }}:5000/spawn?cluster=1&folder=1&ds=2
+      register: vcsim_instance
+      when: setup_esxi_instance is not defined
+
+    - name: start vcsim (ESXi only)
+      uri:
+        url: http://{{ vcsim }}:5000/spawn?esx=1
+      register: vcsim_instance
+      when: setup_esxi_instance is defined
+
+    - name: get a list of Hosts from vcsim
+      uri:
+        url: http://{{ vcsim }}:5000/govc_find?filter=H
+      register: vcsim_host_list
+
+    - name: get a list of Hosts from vcsim
+      uri:
+        url: http://{{ vcsim }}:5000/govc_find?filter=F
+      register: vcsim_host_folder
+    - debug: var=vcsim_host_folder
+
+    - name: add the hosts in the inventory
+      add_host:
+        hostname: '{{ item | basename }}'
+        ansible_host: '{{ item | basename }}'
+        ansible_user: 'root'
+        ansible_password: 'pass'
+        groups:
+          - 'esxi-lab'
+      with_items: '{{ vcsim_host_list.json }}'
+
+    - debug:
+        var: vcsim_host_list
+
+    - set_fact:
+        vcenter_hostname: "{{ vcsim }}"
+        vcenter_username: "user"
+        vcenter_password: "pass"

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -1,0 +1,23 @@
+- name: Add ESXi Hosts to vCenter
+  vmware_host:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: '{{ dc1 }}'
+    cluster_name: '{{ ccr1 }}'
+    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    esxi_username: '{{ hostvars[item].ansible_user }}'
+    esxi_password: '{{ hostvars[item].ansible_password }}'
+    state: present
+    validate_certs: no
+  with_items: "{{ groups['esxi-lab'] }}"
+
+- name: Disable the Maintenance Mode
+  vmware_maintenancemode:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    state: absent
+  with_items: "{{ groups['esxi-lab'] }}"

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_cluster.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_cluster.yml
@@ -1,0 +1,9 @@
+- name: Create Cluster
+  vmware_cluster:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: '{{ dc1 }}'
+    cluster_name: '{{ ccr1 }}'
+    validate_certs: no
+    enable_drs: yes

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_datacenter.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_datacenter.yml
@@ -1,0 +1,8 @@
+- name: Create Datacenter
+  vmware_datacenter:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: '{{ dc1 }}'
+    state: present
+    validate_certs: no

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
@@ -1,0 +1,43 @@
+---
+- debug: var=datastores
+- name: Mount NFS (ds1) datastores to ESXi
+  vmware_host_datastore:
+    hostname: '{{ hostvars[item].ansible_host }}'
+    username: '{{ hostvars[item].ansible_user }}'
+    password: '{{ hostvars[item].ansible_password }}'
+    datastore_name: '{{ ds1 }}'
+    datastore_type: '{{ infra.datastores[ds1].type }}'
+    nfs_server: '{{ infra.datastores[ds1].server }}'
+    nfs_path: '{{ infra.datastores[ds1].path }}'
+    nfs_ro: '{{ infra.datastores[ds2].ro }}'
+    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    state: present
+    validate_certs: no
+  with_items: "{{ groups['esxi-lab'] }}"
+
+- name: Mount NFS (ds2) datastores on the ESXi
+  vmware_host_datastore:
+    hostname: '{{ hostvars[item].ansible_host }}'
+    username: '{{ hostvars[item].ansible_user }}'
+    password: '{{ hostvars[item].ansible_password }}'
+    datastore_name: '{{ ds2 }}'
+    datastore_type: '{{ infra.datastores[ds2].type }}'
+    nfs_server: '{{ infra.datastores[ds2].server }}'
+    nfs_path: '{{ infra.datastores[ds2].path }}'
+    nfs_ro: '{{ infra.datastores[ds2].ro }}'
+    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    state: present
+    validate_certs: no
+  with_items: "{{ groups['esxi-lab'] }}"
+
+- name: The vcenter needs a bit of time to refresh the DS list
+  vmware_datastore_facts:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+  register: setup_datastore_datatstore_facts
+  failed_when: setup_datastore_datatstore_facts.datastores|length != 2
+  until: setup_datastore_datatstore_facts is succeeded
+  retries: 60
+  delay: 1

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
@@ -1,0 +1,15 @@
+---
+- name: Create the DVSwitch
+  vmware_dvswitch:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: '{{ dc1 }}'
+    switch_name: '{{ dvswitch1 }}'
+    switch_version: 6.0.0
+    mtu: 9000
+    uplink_quantity: 2
+    discovery_proto: lldp
+    discovery_operation: both
+    state: present

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_switch.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_switch.yml
@@ -1,0 +1,10 @@
+---
+- name: Add a VMware vSwitchs
+  vmware_vswitch:
+    validate_certs: no
+    hostname: '{{ hostvars[item].ansible_host }}'
+    username: '{{ hostvars[item].ansible_user }}'
+    password: '{{ hostvars[item].ansible_password }}'
+    switch_name: "{{ switch1 }}"
+    state: present
+  with_items: "{{ groups['esxi-lab'] }}"

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -1,0 +1,38 @@
+---
+- name: Create a VM folder on given Datacenter
+  vcenter_folder:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ dc1 }}'
+    folder_name: '{{ f0 }}'
+    folder_type: vm
+    state: present
+    validate_certs: no
+
+- name: Create VMs
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    validate_certs: no
+    folder: '{{ f0 }}'
+    cluster: '{{ ccr1 }}'
+    name: '{{ item }}' 
+    state: poweredon
+    guest_id: debian8_64Guest
+    disk:
+    - size_gb: 1
+      type: thin
+      datastore: '{{ ds2 }}'
+    hardware:
+      memory_mb: 128
+      num_cpus: 1
+      scsi: paravirtual
+    cdrom:
+      type: iso
+      iso_path: "[{{ ds1 }}] Fedora-Workstation-Live-x86_64-29-1.2.iso"
+    networks:
+    - name: VM Network
+  with_items: '{{ infra.vm_list }}'

--- a/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -1,0 +1,124 @@
+---
+- name: Remove "{{ vm_name }}"
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    cluster: "{{ ccr1 }}"
+    name: "{{ item }}"
+    force: yes
+    state: absent
+  with_items: '{{ infra.vm_list }}'
+  ignore_errors: yes
+
+- name: Remove the DVSwitch
+  vmware_dvswitch:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: '{{ dc1 }}'
+    switch_name: '{{ dvswitch1 }}'
+    state: absent
+  ignore_errors: yes
+
+- name: Remove the vSwitches
+  vmware_vswitch:
+    validate_certs: no
+    hostname: '{{ hostvars[item].ansible_host }}'
+    username: '{{ hostvars[item].ansible_user }}'
+    password: '{{ hostvars[item].ansible_password }}'
+    switch_name: "{{ switch1 }}"
+    state: absent
+  with_items: "{{ groups['esxi-lab'] }}"
+
+- name: Remove ESXi Hosts to vCenter
+  vmware_host:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: '{{ dc1 }}'
+    cluster_name: ccr1
+    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    esxi_username: '{{ hostvars[item].ansible_user }}'
+    esxi_password: '{{ hostvars[item].ansible_password }}'
+    state: absent
+    validate_certs: no
+  with_items: "{{ groups['esxi-lab'] }}"
+  ignore_errors: yes
+
+- name: Manually umount the datastores
+  # Work around to avoid an error from vmware_host_datastore saying
+  # the FS is still in use
+  shell: >
+    esxcli storage nfs remove -v nfs_ro;
+    esxcli storage nfs remove -v nfs_rw
+  with_items: "{{ groups['esxi-lab'] }}"
+  delegate_to: '{{ item }}'
+  ignore_errors: true
+
+- name: Umount NFS datastores to ESXi (1/2)
+  vmware_host_datastore:
+      hostname: '{{ hostvars[item].ansible_host }}'
+      username: '{{ hostvars[item].ansible_user }}'
+      password: '{{ hostvars[item].ansible_password }}'
+      datastore_name: '{{ ds1 }}'
+      esxi_hostname: '{{ item }}'
+      state: absent
+      validate_certs: no
+  with_items: "{{ groups['esxi-lab'] }}"
+  register: teardown_umount_nfs
+  until: teardown_umount_nfs is succeeded
+  retries: 15
+  delay: 1
+  ignore_errors: true
+
+- name: Umount NFS datastores to ESXi (2/2)
+  vmware_host_datastore:
+      hostname: '{{ hostvars[item].ansible_host }}'
+      username: '{{ hostvars[item].ansible_user }}'
+      password: '{{ hostvars[item].ansible_password }}'
+      datastore_name: '{{ ds2 }}'
+      esxi_hostname: '{{ item }}'
+      state: absent
+      validate_certs: no
+  with_items: "{{ groups['esxi-lab'] }}"
+  register: teardown_umount_nfs
+  until: teardown_umount_nfs is succeeded
+  retries: 15
+  delay: 1
+  ignore_errors: true
+
+# - name: get a final list of the datastore
+#   vmware_datastore_facts:
+#     validate_certs: False
+#     hostname: '{{ hostvars[item].ansible_host }}'
+#     username: '{{ hostvars[item].ansible_user }}'
+#     password: '{{ hostvars[item].ansible_password }}'
+#   register: datastore_facts
+#   with_items: "{{ groups['esxi-lab'] }}"
+
+# - name: Ensure nothing is mounted
+#   fail:
+#     msg: "Some datastore are still mounted!"
+#   when: "item.datastores|length > 0"
+#   with_items: "{{ datastore_facts.results }}"
+
+- name: Remove the datacenter
+  vmware_datacenter:
+    validate_certs: no
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: '{{ item }}'
+    state: absent
+  when: vcsim is not defined
+  with_items:
+    - '{{ dc1 }}'
+    - datacenter_0001
+
+- name: kill vcsim
+  uri:
+    url: "http://{{ vcsim }}:5000/killall"
+  when: vcsim is defined


### PR DESCRIPTION
##### SUMMARY

The vmware test roles do a lot of similar operation to prepare
the environment. This role will be used to reduce the amount of
duplicated code.

The role can prepare an environment on a baremetal environment, this
in addition to vcsim.

The original PR: https://github.com/ansible/ansible/pull/54882

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware