### PR TITLE
vmware: refactoring of the vcenter_* test roles

### DIFF
--- a/test/integration/targets/vcenter_folder/meta/main.yml
+++ b/test/integration/targets/vcenter_folder/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_vmware_tests

--- a/test/integration/targets/vcenter_folder/tasks/main.yml
+++ b/test/integration/targets/vcenter_folder/tasks/main.yml
@@ -2,44 +2,11 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get datacenter
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact:
-    dc1: "{{ datacenters.json[0] | basename }}"
-
 - name: Create all types of folder in check mode
   vcenter_folder:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ dc1 }}"
     folder_name: "{{ item }}_folder"
@@ -53,7 +20,8 @@
     - network
   check_mode: yes
 
-- debug: msg="{{ all_folder_results }}"
+- debug:
+    msg: "{{ all_folder_results }}"
 
 - name: ensure everything for {{ dc1 }}
   assert:
@@ -62,9 +30,9 @@
 
 - name: Create all types of folder
   vcenter_folder:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ dc1 }}"
     folder_name: "{{ item }}_folder"
@@ -77,7 +45,8 @@
     - datastore
     - network
 
-- debug: msg="{{ all_folder_results }}"
+- debug:
+    msg: "{{ all_folder_results }}"
 
 - name: ensure everything for {{ dc1 }}
   assert:
@@ -86,9 +55,9 @@
 
 - name: Create all types of sub folder in check mode
   vcenter_folder:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ dc1 }}"
     folder_name: "sub_{{ item }}_folder"
@@ -102,7 +71,8 @@
     - network
   check_mode: yes
 
-- debug: msg="{{ all_folder_results }}"
+- debug:
+    msg: "{{ all_folder_results }}"
 
 - name: ensure everything for {{ dc1 }}
   assert:
@@ -111,9 +81,9 @@
 
 - name: Create all types of sub folder
   vcenter_folder:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ dc1 }}"
     folder_name: "sub_{{ item }}_folder"
@@ -128,9 +98,9 @@
 
 - name: Recreate all types of sub folder
   vcenter_folder:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ dc1 }}"
     folder_name: "sub_{{ item }}_folder"
@@ -143,7 +113,8 @@
     - datastore
     - network
 
-- debug: msg="{{ all_folder_results }}"
+- debug:
+    msg: "{{ all_folder_results }}"
 
 - name: ensure everything for {{ dc1 }}
   assert:
@@ -151,54 +122,55 @@
         - all_folder_results.changed
         - not recreate_folders.changed
 
-## Testcase: Delete Delete all types of folder
+## Testcase: Delete all types of folder
 #
 # Doesn't work with vcsim. Looks like UnregisterAndDestroy isn't supported.
-#
-# - name: Delete all types of folder
-#   vcenter_folder:
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance.json.username }}"
-#     password: "{{ vcsim_instance.json.password }}"
-#     validate_certs: no
-#     datacenter: "{{ dc1 }}"
-#     folder_name: "{{ item }}_folder"
-#     folder_type: "{{ item }}"
-#     state: absent
-#   register: all_folder_results
-#   with_items:
-#     - vm
-#     - host
-#     - datastore
-#     - network
-#
-# - debug: msg="{{ all_folder_results }}"
-#
-# - name: ensure everything for {{ dc1 }}
-#   assert:
-#     that:
-#         - all_folder_results.changed
-#
-# - name: Delete all types of folder again
-#   vcenter_folder:
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance.json.username }}"
-#     password: "{{ vcsim_instance.json.password }}"
-#     validate_certs: no
-#     datacenter: "{{ dc1 }}"
-#     folder_name: "{{ item }}_folder"
-#     folder_type: "{{ item }}"
-#     state: absent
-#   register: all_folder_results
-#   with_items:
-#     - vm
-#     - host
-#     - datastore
-#     - network
-#
-# - debug: msg="{{ all_folder_results }}"
-#
-# - name: ensure everything for {{ dc1 }}
-#   assert:
-#     that:
-#         - not all_folder_results.changed
+- when: vcsim is not defined
+  block:
+  - name: Delete all types of folder
+    vcenter_folder:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      datacenter: "{{ dc1 }}"
+      folder_name: "{{ item }}_folder"
+      folder_type: "{{ item }}"
+      state: absent
+    register: all_folder_results
+    with_items:
+      - vm
+      - host
+      - datastore
+      - network
+
+  - debug: msg="{{ all_folder_results }}"
+
+  - name: ensure everything for {{ dc1 }}
+    assert:
+      that:
+          - all_folder_results.changed
+
+  - name: Delete all types of folder again
+    vcenter_folder:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      datacenter: "{{ dc1 }}"
+      folder_name: "{{ item }}_folder"
+      folder_type: "{{ item }}"
+      state: absent
+    register: all_folder_results
+    with_items:
+      - vm
+      - host
+      - datastore
+      - network
+
+  - debug: msg="{{ all_folder_results }}"
+
+  - name: ensure everything for {{ dc1 }}
+    assert:
+      that:
+          - not all_folder_results.changed

--- a/test/integration/targets/vcenter_license/meta/main.yml
+++ b/test/integration/targets/vcenter_license/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_vmware_tests

--- a/test/integration/targets/vcenter_license/tasks/main.yml
+++ b/test/integration/targets/vcenter_license/tasks/main.yml
@@ -2,55 +2,26 @@
 # Copyright: (c) 2017, Dag Wieers <dag@wieers.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for vcsim controller to come online {{ vcsim }}
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is not defined
+  block:
+  - name: Add a vCenter evaluation license
+    vcenter_license: &vcenter_lic_data
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      license: 00000-00000-00000-00000-00000
+      state: present
 
-- name: Kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  - name: Remove an (unused) vCenter evaluation license
+    vcenter_license:
+      <<: *vcenter_lic_data
+      state: absent
 
-- name: Start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online {{ vcsim }}
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug:
-    var: vcsim_instance
-
-# FIXME: ServerFaultCode: LicenseManager:LicenseManager does not implement: AddLicense
-#- name: Add a vCenter evaluation license
-#  vcenter_license:
-#    hostname: '{{ vcsim }}'
-#    username: '{{ vcsim_instance["json"]["username"] }}'
-#    password: '{{ vcsim_instance["json"]["password"] }}'
-#    validate_certs: no
-#    license: 00000-00000-00000-00000-00000
-#    state: present
-
-#- name: Remove an (unused) vCenter evaluation license
-#  vcenter_license:
-#    hostname: '{{ vcsim }}'
-#    username: '{{ vcsim_instance["json"]["username"] }}'
-#    password: '{{ vcsim_instance["json"]["password"] }}'
-#    validate_certs: no
-#    license: 00000-00000-00000-00000-00000
-#    state: absent
-
-#- name: Add an invalid vCenter license
-#  vcenter_license:
-#    hostname: '{{ vcsim }}'
-#    username: '{{ vcsim_instance["json"]["username"] }}'
-#    password: '{{ vcsim_instance["json"]["password"] }}'
-#    validate_certs: no
-#    license: 00000-00000-00000-00000-00001
-#    state: present
-#    ignore_errors: yes
+  - name: Add an invalid vCenter license
+    vcenter_license:
+      <<: *vcenter_lic_data
+      license: 00000-00000-00000-00000-00001
+      state: present
+    register: vcenter_license_output
+    failed_when: '"is not existing or can not be added" not in vcenter_license_output.msg'


### PR DESCRIPTION
Refactoring of `vcenter_folder` and `vcenter_license` to make use of the new `prepare_vmware_tests` role.
This patch depends on: https://github.com/ansible/ansible/pull/55719
    
Original PR: https://github.com/ansible/ansible/pull/54882


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->
