### PR TITLE
vmware: refactoring of vmware test roles -- part1

### DIFF
--- a/test/integration/targets/vmware_about_facts/aliases
+++ b/test/integration/targets/vmware_about_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_about_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_about_facts/tasks/main.yml
@@ -2,36 +2,14 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
+- import_role:
+    name: prepare_vmware_tests
 
 - name: Get Details about VMware vCenter Server
-  vmware_about_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+  vmware_about_facts: &vmware_about_data
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
   register: about
 
@@ -56,10 +34,7 @@
 
 - name: Get Details about VMware vCenter Server in check mode
   vmware_about_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
+    <<: *vmware_about_data
   register: about
   check_mode: yes
 

--- a/test/integration/targets/vmware_cluster/aliases
+++ b/test/integration/targets/vmware_cluster/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_cluster/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster/tasks/main.yml
@@ -2,60 +2,59 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug: var=vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact: dc1="{{ datacenters['json'][0] | basename }}"
-
-- debug: var=dc1
+- import_role:
+    name: prepare_vmware_tests
 
 # Testcase 0001: Add Cluster
-- name: add cluster
+- &add_cluster
+  name: add cluster
   vmware_cluster:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_0001
     state: present
   register: cluster_result_0001
 
-- name: get a list of clusters from vcsim after adding cluster
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: new_ccr_list
-
-- set_fact: new_cluster="{% for ccr in new_ccr_list['json'] %} {{ True if (ccr | basename) == 'test_cluster_0001' else False }} {% endfor %}"
-
-- name: ensure cluster is present
+- &ensure_changed
+  name: ensure cluster is present
   assert:
     that:
         - "{{ cluster_result_0001.changed == true }}"
-        - "{{ 'True' in new_cluster }}"
+
+# # Broken by: https://github.com/ansible/ansible/issues/54857
+# - <<: *add_cluster
+#   name: add cluster (again)
+
+# - &ensure_unchanged
+#   name: ensure cluster is unchanged
+#   assert:
+#     that:
+#         - "{{ cluster_result_0001.changed == false }}"
+
+- when: vcsim is not defined
+  block:
+  - &del_cluster
+    name: delete cluster
+    vmware_cluster:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_0001
+      state: absent
+    register: cluster_result_0001
+
+  - <<: *ensure_changed
+
+  - <<: *del_cluster
+    name: delete cluster (again)
+
+  #- <<: *ensure_unchanged
+  - name: ensure cluster is unchanged
+    assert:
+      that:
+          - "{{ cluster_result_0001.changed == false }}"

--- a/test/integration/targets/vmware_cluster_facts/aliases
+++ b/test/integration/targets/vmware_cluster_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_cluster_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster_facts/tasks/main.yml
@@ -2,78 +2,57 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- debug: var=ccr1
-
-- name: get a list of datacenter
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact:
-    dc1: "{{ datacenters.json[0] | basename }}"
-
-- debug: var=dc1
-
-- name: gather facts about all clusters in given datacenter
+- &vc_all_data
+  name: gather facts about all clusters in the given datacenter
   vmware_cluster_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    datacenter: "{{ dc1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
+    datacenter: "{{ dc1 }}"
   register: all_cluster_result
 
-- name: ensure facts are gathered for all cluster
+- &ensure_vc_all_data
+  name: ensure facts are gathered for all clusters
   assert:
     that:
         - all_cluster_result.clusters
         - not all_cluster_result.changed
 
-- name: gather facts about given cluster
+- <<: *vc_all_data
+  name: Gather facts about all clusters in the given datacenter in check mode
+  check_mode: yes
+
+- debug: msg=all_cluster_result
+
+# vmware_cluster_facts does not support check mode
+# - <<: *ensure_vc_all_data
+#   name: Ensure facts are gathered for all clusters in check mode
+
+- &vc_cluster_data
+  name: Gather facts about the given cluster
   vmware_cluster_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    cluster_name: "{{ ccr1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
+    cluster_name: "{{ ccr1 }}"
   register: cluster_result
 
-- name: ensure facts are gathered for the given cluster
+- &ensure_vc_cluster_data
+  name: Ensure facts are gathered for the given cluster
   assert:
     that:
         - cluster_result.clusters
         - not cluster_result.changed
+
+- <<: *vc_cluster_data
+  name: Gather facts about the given cluster in check mode
+  check_mode: yes
+
+# vmware_cluster_facts does not support check mode
+# - <<: *ensure_vc_cluster_data
+#   name: Ensure facts are gathered for the given cluster in check mode


### PR DESCRIPTION
##### SUMMARY

Refactoring of the following roles to make use of the new
`prepare_vmware_tests` role.

- `vmware_about_facts`
- `vmware_cluster`
- `vmware_cluster_facts`

This patch depends on: https://github.com/ansible/ansible/pull/55719
   
Original PR: https://github.com/ansible/ansible/pull/54882

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->