### PR TITLE
vmware: refactoring of vmware test roles -- part2

### DIFF
--- a/test/integration/targets/vmware_datacenter/aliases
+++ b/test/integration/targets/vmware_datacenter/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_datacenter/tasks/main.yml
+++ b/test/integration/targets/vmware_datacenter/tasks/main.yml
@@ -2,95 +2,49 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for vcsim controller to come online {{ vcsim }}
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- debug: var=vcsim_instance
-- debug: var=datacenters
-
-# Testcase 0001: Add Datacenter
-- name: add datacenter
+- &add_dc
+  name: Add datacenter
   vmware_datacenter:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter_name: datacenter_0001
     state: present
   register: dc_result
 
-- name: get a list of Datacenter from vcsim after adding datacenter
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: new_datacenters
+- debug:
+    var: dc_result
 
-- name: ensure datacenter is present
+- name: Ensure datacenter is present
   assert:
     that:
-        - "{{ dc_result.changed == true }}"
-        - "{{ '/datacenter_0001' in new_datacenters['json'] }}"
+        - dc_result.changed
 
-# Testcase 0002: Try to add same datacenter
-- name: add datacenter again to check idempotent behavior
-  vmware_datacenter:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter_name: datacenter_0001
-    state: present
-  register: dc_result_two
+- <<: *add_dc
+  name: add datacenter again to check idempotent behavior
 
-- name: ensure datacenter status is not changed
+- name: Ensure datacenter status is not changed
   assert:
     that:
-        - "{{ dc_result_two.changed == false }}"
+        - not dc_result.changed
 
-# FIXME: Uncomment this testcase once vcsim supports datacenter delete method
-# Currently, vcsim does not support datacenter delete option,
-# Once this feature is available we can uncomment following testcase
+- when: vcsim is not defined
+  block:
+  - name: Delete datacenter
+    vmware_datacenter:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: datacenter_0001
+      state: absent
+    register: dc_result_delete
 
-# Testcase 0002: Delete Datacenter
-#- name: add datacenter
-#  vmware_datacenter:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    datacenter_name: datacenter_0001
-#    state: absent
-#  register: dc_result_delete
-
-#- name: get a list of Datacenter from vcsim after adding datacenter
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-#  register: new_datacenters_delete
-
-#- name: ensure datacenter is absent
-#  assert:
-#    that:
-#        - "{{ dc_result_delete.changed == true }}"
-#        - "{{ '/datacenter_0001' not in new_datacenters_delete['json'] }}
+  - name: Ensure datacenter is absent
+    assert:
+      that:
+        - dc_result_delete.changed

--- a/test/integration/targets/vmware_datastore_cluster/aliases
+++ b/test/integration/targets/vmware_datastore_cluster/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_datastore_cluster/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_cluster/tasks/main.yml
@@ -2,45 +2,14 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: '{{ vcsim }}'
-    port: 5000
-    state: started
-
-- name: Kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: Start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: '{{ vcsim }}'
-    port: 443
-    state: started
-
-- debug:
-    var: vcsim_instance
-
-- name: Get datacenter
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: store the vcenter container ip
-  set_fact:
-    dc1: "{{ datacenters['json'][0] | basename }}"
-
+- import_role:
+    name: prepare_vmware_tests
 
 - name: Add a datastore cluster to datacenter (check-mode)
   vmware_datastore_cluster: &add_datastore_cluster
-    hostname: '{{ vcsim }}'
-    username: '{{ vcsim_instance.json.username }}'
-    password: '{{ vcsim_instance.json.password }}'
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
     validate_certs: no
     datacenter_name: "{{ dc1 }}"
     datastore_cluster_name: DSC1
@@ -50,7 +19,7 @@
 
 - assert:
     that:
-     - add_dsc_check.changed == true
+     - add_dsc_check.changed
 
 - name: Add a datastore cluster to datacenter
   vmware_datastore_cluster: *add_datastore_cluster
@@ -58,7 +27,7 @@
 
 - assert:
     that:
-     - add_dsc.changed == true
+     - add_dsc.changed
 
 - name: Add a datastore cluster to datacenter again
   vmware_datastore_cluster: *add_datastore_cluster
@@ -66,13 +35,13 @@
 
 - assert:
     that:
-     - add_dsc.changed == false
+     - not add_dsc.changed
 
 - name: Delete a datastore cluster to datacenter (check-mode)
   vmware_datastore_cluster: &delete_datastore_cluster
-    hostname: '{{ vcsim }}'
-    username: '{{ vcsim_instance.json.username }}'
-    password: '{{ vcsim_instance.json.password }}'
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
     validate_certs: no
     datacenter_name: "{{ dc1 }}"
     datastore_cluster_name: DSC1
@@ -82,13 +51,14 @@
 
 - assert:
     that:
-     - delete_dsc_check.changed == true
+     - delete_dsc_check.changed
 
-# TODO: vcsim does not support delete operation on datastore cluster
-#- name: Delete a datastore cluster to datacenter
-#  vmware_datastore_cluster: *delete_datastore_cluster
-#  register: delete_dsc_check
+- when: vcsim is not defined
+  block:
+  - name: Delete a datastore cluster to datacenter
+    vmware_datastore_cluster: *delete_datastore_cluster
+    register: delete_dsc_check
 
-#- assert:
-#    that:
-#     - delete_dsc_check.changed == true
+  - assert:
+      that:
+        - delete_dsc_check.changed

--- a/test/integration/targets/vmware_datastore_facts/aliases
+++ b/test/integration/targets/vmware_datastore_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_datastore_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_facts/tasks/main.yml
@@ -3,77 +3,77 @@
 # Copyright (c) 2018, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?ds=2&datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- set_fact:
-    cl1: "{{ clusters['json'][0] }}"
-
-- name: get a list of Datacenters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- set_fact:
-    dc1: "{{ datacenters['json'][0] }}"
-
-- name: get a list of Datastores from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=D
-  register: datastores
-
-- set_fact:
-    ds1: "{{ datastores['json'][0] }}"
-
 # Testcase 0001: Get a full list of datastores in a datacenter
+# - name: get list of facts about datastores
+#   vmware_datastore_facts:
+#     validate_certs: False
+#     hostname: "{{ vcenter_hostname }}"
+#     username: "{{ vcenter_username }}"
+#     password: "{{ vcenter_password }}"
+#     datacenter: "{{ dc1 }}"
+#   register: datastore_facts_0001
+
+# - assert:
+#     that:
+#       - "datastore_facts_0001.datastores|length == 0"
+
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+
+- when: vcsim is not defined
+  block:
+    - name: get list of facts about datastores from the ESXi
+      vmware_datastore_facts:
+        validate_certs: False
+        hostname: '{{ hostvars[item].ansible_host }}'
+        username: '{{ hostvars[item].ansible_user }}'
+        password: '{{ hostvars[item].ansible_password }}'
+      register: facts_from_esxi
+      with_items: "{{ groups['esxi-lab'] }}"
+    - assert:
+        that:
+          - "facts_from_esxi.results[0].datastores|length == 2"
+
 - name: get list of facts about datastores
   vmware_datastore_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
-  register: datastore_facts_0001
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    gather_nfs_mount_info: true
+  register: facts_from_vcenter_with_dc_filter
 
-- debug:
-    msg: "{{ datastore_facts_0001 }}"
+# Depends-On: https://github.com/ansible/ansible/pull/54879
+- when: vcsim is not defined
+  block:
+    - name: get list of facts about datastores
+      vmware_datastore_facts:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        gather_nfs_mount_info: true
+      register: facts_from_vcenter_with_no_filter
 
-- assert:
-    that:
-      - "datastore_facts_0001['datastores'][0]['capacity'] is defined"
-      - "datastore_facts_0001['datastores'][1]['capacity'] is defined"
+    - assert:
+        that:
+          - "facts_from_vcenter_with_dc_filter.datastores|length == 2"
+          - "facts_from_vcenter_with_no_filter.datastores|length == 2"
+          - "facts_from_vcenter_with_no_filter.datastores[0]['capacity'] is defined"
 
 # Testcase 0002: Get a full list of datastores in a cluster
 - name: get list of facts about datastores - no dc
   vmware_datastore_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    cluster: "{{ cl1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    cluster: "{{ ccr1 }}"
   register: datastore_facts_0002
 
 - debug:
@@ -82,17 +82,16 @@
 - assert:
     that:
       - "datastore_facts_0002['datastores'][0]['capacity'] is defined"
-      - "datastore_facts_0002['datastores'][1]['capacity'] is defined"
 
 # Testcase 0003: Find a specific datastore
 - name: get list of facts about one datastore
   vmware_datastore_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
-    name: "{{ ds1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    name: "{{ ds1 }}"
   register: datastore_facts_0003
 
 - debug:
@@ -100,16 +99,16 @@
 
 - assert:
     that:
-      - "datastore_facts_0003['datastores'][0]['name'] == ds1 | basename"
+      - "datastore_facts_0003['datastores'][0]['name'] == ds1"
       - "datastore_facts_0003['datastores'][0]['capacity'] is defined"
 
 - name: get list of extended facts about one datastore
   vmware_datastore_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     name: "{{ ds1 | basename }}"
     gather_nfs_mount_info: True
     gather_vmfs_mount_info: True
@@ -120,16 +119,16 @@
 
 - assert:
     that:
-      - "datastore_facts_0004['datastores'][0]['name'] == ds1 | basename"
+      - "datastore_facts_0004['datastores'][0]['name'] == ds1"
       - "datastore_facts_0004['datastores'][0]['capacity'] is defined"
 
 - name: get list of facts about one datastore in check mode
   vmware_datastore_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     name: "{{ ds1 | basename }}"
   register: datastore_facts_0005
 
@@ -138,5 +137,5 @@
 
 - assert:
     that:
-      - "datastore_facts_0005['datastores'][0]['name'] == ds1 | basename"
+      - "datastore_facts_0005['datastores'][0]['name'] == ds1"
       - "datastore_facts_0005['datastores'][0]['capacity'] is defined"

--- a/test/integration/targets/vmware_datastore_maintenancemode/aliases
+++ b/test/integration/targets/vmware_datastore_maintenancemode/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_datastore_maintenancemode/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_maintenancemode/tasks/main.yml
@@ -3,101 +3,82 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support datastore maintenance mode properties
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+      setup_datastore: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+  - name: Enter datastore in maintenance mode
+    vmware_datastore_maintenancemode:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      state: present
+      datastore: "{{ ds1 }}"
+      validate_certs: no
+    register: test_result_0001
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  - debug:
+      var: test_result_0001
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
+  - name: assert that changes were made
+    assert:
+      that:
+        - test_result_0001 is changed
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+  - name: Enter datastore in maintenance mode again
+    vmware_datastore_maintenancemode:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      state: present
+      datastore: "{{ ds1 }}"
+      validate_certs: no
+    register: test_result_0002
 
-- name: Get a list of datastores from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=D
-  register: datastores
+  - debug:
+      var: test_result_0002
 
-- name: Enter datastore in maintenance mode
-  vmware_datastore_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    state: present
-    datastore: "{{ item | basename }}"
-    validate_certs: False
-  with_items: "{{ datastores['json'] }}"
-  register: test_result_0001
+  - name: assert that no changes were made
+    assert:
+      that:
+        - not (test_result_0002 is changed)
 
-- debug: var=test_result_0001
+  - name: Exit datastores from maintenance mode
+    vmware_datastore_maintenancemode:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      state: absent
+      datastore: "{{ ds1 }}"
+      validate_certs: no
+    register: test_result_0003
 
-- name: assert that changes were made
-  assert:
-    that:
-      - "test_result_0001.results|map(attribute='changed')|unique|list == [true]"
+  - debug:
+      var: test_result_0003
 
-- name: Enter datastore in maintenance mode again
-  vmware_datastore_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    state: present
-    datastore: "{{ item | basename }}"
-    validate_certs: no
-  with_items: "{{ datastores['json'] }}"
-  register: test_result_0002
+  - name: assert that changes were made
+    assert:
+      that:
+        - test_result_0003 is changed
 
-- debug: var=test_result_0002
+  - name: Exit datastores from maintenance mode again
+    vmware_datastore_maintenancemode:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      state: absent
+      datastore: "{{ ds1 }}"
+      validate_certs: no
+    register: test_result_0004
 
-- name: assert that no changes were made
-  assert:
-    that:
-      - "test_result_0002.results|map(attribute='changed')|unique|list == [false]"
+  - debug:
+      var: test_result_0004
 
-- name: Exit datastores from maintenance mode
-  vmware_datastore_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    state: absent
-    esxi_hostname: "{{ item | basename }}"
-    validate_certs: no
-  with_items: "{{ datastores['json'] }}"
-  register: test_result_0003
-
-- debug: var=test_result_0003
-
-- name: assert that changes were made
-  assert:
-    that:
-      - "test_result_0003.results|map(attribute='changed')|unique|list == [true]"
-
-- name: Exit datastores from maintenance mode again
-  vmware_datastore_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    state: absent
-    esxi_hostname: "{{ item | basename }}"
-    validate_certs: no
-  with_items: "{{ datastores['json'] }}"
-  register: test_result_0004
-
-- debug: var=test_result_0004
-
-- name: assert that no changes were made
-  assert:
-    that:
-      - "test_result_0004.results|map(attribute='changed')|unique|list == [false]"
+  - name: assert that no changes were made
+    assert:
+      that:
+        - not (test_result_0004 is changed)


### PR DESCRIPTION
##### SUMMARY

Refactoring of the following roles to make use of the new
`prepare_vmware_tests` role.

- `vmware_datacenter`
- `vmware_datacenter_cluster`
- `vmware_datastore_cluster`
- `vmware_datastore_facts`
- `vmware_datastore_maintenancemode`

This patch depends on: https://github.com/ansible/ansible/pull/55719

Original PR: https://github.com/ansible/ansible/pull/54882

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```