### PR TITLE
vmware: refactoring of vmware test roles -- part3

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/main.yml
@@ -15,6 +15,8 @@
       when: setup_virtualmachines is defined
     - include_tasks: setup_switch.yml
       when: setup_switch is defined
+    - include_tasks: setup_dvswitch.yml
+      when: setup_dvswitch is defined
 
 
 - when: vcsim is defined

--- a/test/integration/targets/vmware_drs_group/aliases
+++ b/test/integration/targets/vmware_drs_group/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_drs_group/tasks/main.yml
+++ b/test/integration/targets/vmware_drs_group/tasks/main.yml
@@ -2,39 +2,22 @@
 # Copyright: (c) 2018, Karsten Kaj Jakobsen <kj@patientsky.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
-- name: Kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: Start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
-
-- name: "Create DRS VM group"
+- name: Create DRS VM group
   vmware_drs_group:
-    # Login creds
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
     # Options
-    cluster_name: DC0_C0
-    datacenter_name: DC0
+    cluster_name: '{{ ccr1 }}'
+    datacenter_name: '{{ dc1 }}'
     group_name: TEST_VM_01
     vms:
       - DC0_C0_RP0_VM0
@@ -42,53 +25,53 @@
     state: present
   register: drs_vm_group_01_results
 
-- debug: var=drs_vm_group_01_results
+- debug:
+    var: drs_vm_group_01_results
 
 - assert:
     that:
       - "drs_vm_group_01_results.changed"
 
-- name: "Create DRS Host group"
-  vmware_drs_group:
-    # Login creds
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    validate_certs: False
-    # Options
-    cluster_name: DC0_C0
-    datacenter_name: DC0
-    group_name: TEST_HOST_01
-    hosts:
-      - DC0_C0_H0
-      - DC0_C0_H1
-      - DC0_C0_H2
-    state: present
-  register: drs_host_group_01_results
+- when: vcsim is defined or groups['esxi-lab'] | length >= 3
+  block:
+  - name: Create DRS Host group
+    vmware_drs_group:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: False
+      cluster_name: '{{ ccr1 }}'
+      datacenter_name: '{{ dc1 }}'
+      group_name: TEST_HOST_01
+      hosts: "{{ groups['esxi-lab'][0:3] }}"
+      state: present
+    register: drs_host_group_01_results
 
-- debug: var=drs_host_group_01_results
+  - debug:
+      var: drs_host_group_01_results
 
-- assert:
-    that:
-      - "drs_host_group_01_results.changed"
+  - assert:
+      that:
+        - "drs_host_group_01_results.changed"
 
-- name: "Delete DRS Host group"
-  vmware_drs_group:
-    # Login creds
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    validate_certs: False
-    # Options
-    cluster_name: DC0_C0
-    datacenter_name: DC0
-    group_name: TEST_HOST_01
-    hosts: []
-    state: absent
-  register: drs_host_group_01_delete_results
+  - name: Delete DRS Host group
+    vmware_drs_group:
+      # Login creds
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: False
+      # Options
+      cluster_name: DC0_C0
+      datacenter_name: DC0
+      group_name: TEST_HOST_01
+      hosts: []
+      state: absent
+    register: drs_host_group_01_delete_results
 
-- debug: var=drs_host_group_01_delete_results
+  - debug:
+      var: drs_host_group_01_delete_results
 
-- assert:
-    that:
-      - "drs_host_group_01_delete_results.changed"
+  - assert:
+      that:
+        - "drs_host_group_01_delete_results.changed"

--- a/test/integration/targets/vmware_drs_group_facts/aliases
+++ b/test/integration/targets/vmware_drs_group_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_drs_group_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_drs_group_facts/tasks/main.yml
@@ -2,59 +2,43 @@
 # Copyright: (c) 2018, Karsten Kaj Jakobsen <kj@patientsky.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+- when: vcsim is defined or groups['esxi-lab'] | length >= 3
+  block:
+  - name: Gather DRS group facts from given cluster
+    vmware_drs_group_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      cluster_name: '{{ ccr1 }}'
+      validate_certs: False
+    register: drs_group_0001_results
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+  - debug:
+      var: drs_group_0001_results
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+  - assert:
+      that:
+        - "drs_group_0001_results.drs_group_facts.DC0_C0 is defined"
+        - "not drs_group_0001_results.drs_group_facts.DC0_C1 is defined"
+        - "not drs_group_0001_results.changed"
 
-- debug: var=vcsim_instance
+  - name: Gather DRS group facts from given datacenter
+    vmware_drs_group_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter: '{{ dc1 }}'
+      validate_certs: False
+    register: drs_group_0002_results
 
-- name: Gather DRS group facts from given cluster
-  vmware_drs_group_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    cluster_name: DC0_C0
-    validate_certs: False
-  register: drs_group_0001_results
+  - debug:
+      var: drs_group_0002_results
 
-- debug: var=drs_group_0001_results
-
-- assert:
-    that:
-      - "drs_group_0001_results.drs_group_facts.DC0_C0 is defined"
-      - "not drs_group_0001_results.drs_group_facts.DC0_C1 is defined"
-      - "not drs_group_0001_results.changed"
-
-- name: Gather DRS group facts from given datacenter
-  vmware_drs_group_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: DC0
-    validate_certs: False
-  register: drs_group_0002_results
-
-- debug: var=drs_group_0002_results
-
-- assert:
-    that:
-      - "drs_group_0002_results.drs_group_facts.DC0_C0 is defined"
-      - "drs_group_0002_results.drs_group_facts.DC0_C1 is defined"
-      - "not drs_group_0002_results.changed"
+  - assert:
+      that:
+        - "drs_group_0002_results.drs_group_facts.DC0_C0 is defined"
+        - "not drs_group_0002_results.drs_group_facts.DC0_C1 is defined"
+        - "not drs_group_0002_results.changed"

--- a/test/integration/targets/vmware_drs_rule_facts/aliases
+++ b/test/integration/targets/vmware_drs_rule_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_drs_rule_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_drs_rule_facts/tasks/main.yml
@@ -2,56 +2,43 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is defined or groups['esxi-lab'] | length >= 3
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+  - name: Gather facts about DRS rule from given cluster
+    vmware_drs_rule_facts:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      cluster_name: DC0_C0
+    register: drs_rule_0001_results
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+  - debug:
+      var: drs_rule_0001_results
 
-- debug: var=vcsim_instance
+  - assert:
+      that:
+        - "drs_rule_0001_results.drs_rule_facts is defined"
+        - "not drs_rule_0001_results.changed"
 
-- name: Gather facts about DRS rule from given cluster
-  vmware_drs_rule_facts:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    cluster_name: DC0_C0
-  register: drs_rule_0001_results
+  - name: Gather facts about DRS rule from given datacenter
+    vmware_drs_rule_facts:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter: DC0
+    register: drs_rule_0001_results
 
-- debug: var=drs_rule_0001_results
+  - debug:
+      var: drs_rule_0001_results
 
-- assert:
-    that:
-      - "drs_rule_0001_results.drs_rule_facts is defined"
-      - "not drs_rule_0001_results.changed"
-
-- name: Gather facts about DRS rule from given datacenter
-  vmware_drs_rule_facts:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: DC0
-  register: drs_rule_0001_results
-
-- debug: var=drs_rule_0001_results
-
-- assert:
-    that:
-      - "drs_rule_0001_results.drs_rule_facts is defined"
-      - "not drs_rule_0001_results.changed"
+  - assert:
+      that:
+        - "drs_rule_0001_results.drs_rule_facts is defined"
+        - "not drs_rule_0001_results.changed"

--- a/test/integration/targets/vmware_dvs_portgroup/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -1,62 +1,19 @@
 # Test code for the vmware_dvs_portgroup module.
-# (c) 2017, Philippe Dellaert <philippe@dellaert.org>
+# Copyright: (c) 2017, Philippe Dellaert <philippe@dellaert.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_dvswitch: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-
-- name: start vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/spawn?cluster=2' }}"
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
-
-- name: get a list of distributed vswitch from vcsim after adding
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DVS' }}"
-  register: new_dvs_0001
-
-- debug:
-    msg: "{{ item | basename }}"
-  with_items: "{{ new_dvs_0001['json'] }}"
-
-# Testcase 0001: Add basic portgroup
 - name: create basic portgroup
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
@@ -64,19 +21,21 @@
     state: present
   register: dvs_pg_result_0001
 
+- debug:
+    var: dvs_pg_result_0001
+
 - name: ensure dvs portgroup is present
   assert:
     that:
-        - "{{ dvs_pg_result_0001.changed == true }}"
+        - dvs_pg_result_0001.changed
 
-# Testcase 0002: Add basic VLAN portgroup
 - name: create basic VLAN portgroup
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic-vlan10"
     vlan_id: 10
     num_ports: 32
@@ -87,16 +46,15 @@
 - name: ensure dvs portgroup is present
   assert:
     that:
-        - "{{ dvs_pg_result_0002.changed == true }}"
+        - dvs_pg_result_0002.changed
 
-# Testcase 0003: Add basic trunk portgroup
 - name: create basic trunk portgroup
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic-trunk"
     vlan_id: 1-4094
     vlan_trunk: True
@@ -108,16 +66,15 @@
 - name: ensure dvs portgroup is present
   assert:
     that:
-        - "{{ dvs_pg_result_0003.changed == true }}"
+        - dvs_pg_result_0003.changed
 
-# Testcase 0004: Add basic portgroup again
 - name: create basic portgroup again
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
@@ -128,16 +85,15 @@
 - name: ensure dvs portgroup is present
   assert:
     that:
-        - "{{ dvs_pg_result_0004.changed == false }}"
+        - not dvs_pg_result_0004.changed
 
-# Testcase 0005: Add basic portgroup with all security and policy settings enabled
 - name: create basic portgroup with all security and policy settings enabled
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic-all-enabled"
     vlan_id: 0
     num_ports: 32
@@ -164,16 +120,15 @@
 - name: ensure dvs portgroup is present
   assert:
     that:
-        - "{{ dvs_pg_result_0005.changed == true }}"
+        - dvs_pg_result_0005.changed
 
-# Testcase 0006: Add basic portgroup with some settings enabled
 - name: create basic portgroup with all security and policy settings enabled
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic-some-enabled"
     vlan_id: 0
     num_ports: 32
@@ -190,16 +145,15 @@
 - name: ensure dvs portgroup is present
   assert:
     that:
-        - "{{ dvs_pg_result_0006.changed == true }}"
+        - dvs_pg_result_0006.changed
 
-# Testcase 0007: Delete basic portgroup
 - name: delete basic portgroup
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
@@ -210,16 +164,15 @@
 - name: ensure dvs portgroup is removed
   assert:
     that:
-        - "{{ dvs_pg_result_0007.changed == true }}"
+        - dvs_pg_result_0007.changed
 
-# Testcase 0008: Delete basic portgroup again
 - name: delete basic portgroup again
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
@@ -230,16 +183,15 @@
 - name: ensure dvs portgroup is removed
   assert:
     that:
-        - "{{ dvs_pg_result_0008.changed == false }}"
+        - not dvs_pg_result_0008.changed
 
-# Testcase 0009: Check valid VLAN id range in DVS Portgroup
 - name: Check valid VLAN id range in DVS Portgroup
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: "{{ new_dvs_0001['json'][0] | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
     portgroup_name: "basic_trunk_0001"
     vlan_id: 1-4096
     vlan_trunk: True

--- a/test/integration/targets/vmware_dvs_portgroup_facts/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_dvs_portgroup_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup_facts/tasks/main.yml
@@ -2,55 +2,32 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is not defined
+  block:
+    - &dvs_facts
+      name: Gather facts about DVS portgroup
+      vmware_dvs_portgroup_facts:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+      register: dvs_results
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - debug:
+        var: dvs_results
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+    - assert:
+        that:
+          - dvs_results.dvs_portgroup_facts is defined
 
-- debug: var=vcsim_instance
+    - <<: *dvs_facts
+      name: Gather facts about DVS portgroup in check mode
+      check_mode: yes
 
-- name: Gather facts about DVS portgroup
-  vmware_dvs_portgroup_facts:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: DC0
-  register: dvs_results
+    - debug:
+        var: dvs_results
 
-- debug: var=dvs_results
-
-- assert:
-    that:
-      - "dvs_results.dvs_portgroup_facts is defined"
-
-- name: Gather facts about DVS portgroup in check mode
-  vmware_dvs_portgroup_facts:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: DC0
-  register: dvs_results
-  check_mode: yes
-
-- debug: var=dvs_results
-
-- assert:
-    that:
-      - "dvs_results.dvs_portgroup_facts is defined"
+    - assert:
+        that:
+          - dvs_results.dvs_portgroup_facts is defined

--- a/test/integration/targets/vmware_dvswitch/aliases
+++ b/test/integration/targets/vmware_dvswitch/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -2,43 +2,18 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- debug: var=vcsim_instance
-- debug: var=datacenters
+- import_role:
+    name: prepare_vmware_tests
 
 # Testcase 0001: Add Distributed vSwitch
-- name: add distributed vSwitch
+- &dvs_data
+  name: add distributed vSwitch
   vmware_dvswitch:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter_name: "{{ item | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
     state: present
     switch_name: dvswitch_0001
     mtu: 9000
@@ -46,95 +21,43 @@
     discovery_proto: lldp
     discovery_operation: both
   register: dvs_result_0001
-  with_items:
-    - "{{ datacenters['json'] }}"
 
 - name: ensure distributed vswitch is present
   assert:
     that:
-        - "{{ dvs_result_0001.changed == true }}"
-
-- name: get a list of distributed vswitch from vcsim after adding
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DVS
-  register: new_dvs_0001
-
-- debug:
-    msg: "{{ item | basename }}"
-  with_items: "{{ new_dvs_0001['json'] }}"
-
-- set_fact: new_dvs_name="{% for dvs in new_dvs_0001['json'] %} {{ True if (dvs | basename) == 'dvswitch_0001' else False }}{% endfor %}"
-
-- debug: var=new_dvs_name
-- assert:
-    that:
-      - "{{ 'True' in new_dvs_name }}"
-
+      - dvs_result_0001.changed
 
 # Testcase 0002: Add Distributed vSwitch again
 # vcsim doesn't support ldp check (self.dvs.config.linkDiscoveryProtocolConfig.protocol)
-# - name: add distributed vSwitch again
-#   vmware_dvswitch:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter_name: "{{ item | basename }}"
-#     state: present
-#     switch_name: dvswitch_0001
-#     mtu: 9000
-#     uplink_quantity: 2
-#     discovery_proto: lldp
-#     discovery_operation: both
-#   register: dvs_result_0002
-#   with_items:
-#     - "{{ datacenters['json'] }}"
-#
-# - name: ensure distributed vswitch is present
-#   assert:
-#     that:
-#         - "{{ dvs_result_0002.changed == false }}"
+- when: vcsim is not defined
+  block:
+  - <<: *dvs_data
+    name: add distributed vSwitch again
+    register: dvs_result_0002
+
+  - name: ensure distributed vswitch is present
+    assert:
+      that:
+        - not dvs_result_0002.changed
 
 
-# FIXME: Uncomment this testcase once vcsim supports distributed vswitch delete method
+# FIXME: Remove this testcase from block once vcsim supports distributed vswitch delete method
 # Currently, vcsim does not support distributed vswitch delete option,
-# Once this feature is available we can uncomment following testcase
+# Once this feature is available we can move this out of this block
 
 # Testcase 0003: Add Distributed vSwitch
-#- name: add distributed vSwitch
-#  vmware_dvswitch:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: root
-#    password: esxi@123
-#    datacenter_name: "{{ item | basename }}"
-#    state: absent
-#    switch_name: dvswitch_0001
-#    mtu: 9000
-#    uplink_quantity: 2
-#    discovery_proto: lldp
-#    discovery_operation: both
-#  with_items:
-#    - "{{ datacenters['json'] }}"
-#  register: dvs_result_0003
+  - name: delete the distributed vSwitch
+    vmware_dvswitch:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      state: absent
+      switch_name: dvswitch_0001
+    register: dvs_result_0003
 
-#- name: ensure distributed vswitch is present
-#  assert:
-#    that:
-#        - "{{ dvs_result_0003.changed == true }}"
-
-#- name: get a list of Datacenter from vcsim after adding datacenter
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=DVS
-#  register: del_dvs
-
-#- debug:
-#    msg: "{{ item | basename }}"
-#  with_items: "{{ del_dvs['json'] }}"
-
-#- set_fact: del_dvs_name="{% for i in del_dvs['json'] %} {{ True if (i | basename) == 'dvswitch_0001' else False }}{% endfor %}"
-
-#- debug: var=del_dvs_name
-#- assert:
-#    that:
-#      - "{{ 'True' not in del_dvs_name }}"
+  - name: ensure distributed vswitch is present
+    assert:
+      that:
+        - dvs_result_0003.changed

--- a/test/integration/targets/vmware_dvswitch_pvlans/aliases
+++ b/test/integration/targets/vmware_dvswitch_pvlans/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_dvswitch_pvlans/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch_pvlans/tasks/main.yml
@@ -2,43 +2,17 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- debug: var=vcsim_instance
-- debug: var=datacenters
+- import_role:
+    name: prepare_vmware_tests
 
 # Testcase 0001: Add Distributed vSwitch
 - name: add distributed vSwitch
   vmware_dvswitch:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter_name: "{{ item | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
     state: present
     switch_name: dvswitch_0001
     mtu: 9000
@@ -46,63 +20,21 @@
     discovery_proto: lldp
     discovery_operation: both
   register: dvs_result_0001
-  with_items:
-    - "{{ datacenters['json'] }}"
+
+- debug:
+    var: dvs_result_0001
 
 - name: ensure distributed vswitch is present
   assert:
     that:
-        - "{{ dvs_result_0001.changed == true }}"
+        - dvs_result_0001 is changed
 
-- name: get a list of distributed vswitch from vcsim after adding
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DVS
-  register: new_dvs_0001
-
-- debug:
-    msg: "{{ item | basename }}"
-  with_items: "{{ new_dvs_0001['json'] }}"
-
-- set_fact: new_dvs_name="{% for dvs in new_dvs_0001['json'] %} {{ True if (dvs | basename) == 'dvswitch_0001' else False }}{% endfor %}"
-
-- debug: var=new_dvs_name
-- assert:
-    that:
-      - "{{ 'True' in new_dvs_name }}"
-
-- name: Configure PVLANs in check mode
+- &pv_data
+  name: Configure PVLANs
   vmware_dvswitch_pvlans:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch: dvswitch_0001
-    primary_pvlans:
-      - primary_pvlan_id: 1
-      - primary_pvlan_id: 4
-    secondary_pvlans:
-      - primary_pvlan_id: 1
-        secondary_pvlan_id: 2
-        pvlan_type: isolated
-      - primary_pvlan_id: 1
-        secondary_pvlan_id: 3
-        pvlan_type: community
-      - primary_pvlan_id: 4
-        secondary_pvlan_id: 5
-        pvlan_type: community
-    validate_certs: no
-  register: pvlans_result_check_mode
-  check_mode: yes
-
-- name: ensure pvlans were configured
-  assert:
-    that:
-        - pvlans_result_check_mode.changed
-
-- name: Configure PVLANs
-  vmware_dvswitch_pvlans:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     switch: dvswitch_0001
     primary_pvlans:
       - primary_pvlan_id: 1
@@ -120,7 +52,23 @@
     validate_certs: no
   register: pvlans_result
 
+- debug:
+    var: pvlans_result
+
 - name: ensure pvlans were configured
   assert:
     that:
-        - pvlans_result.changed
+      - pvlans_result is changed
+
+- <<: *pv_data
+  name: Configure PVLANs in check mode
+  register: pvlans_result_check_mode
+  check_mode: yes
+
+- debug:
+    var: pvlans_result_check_mode
+
+- name: ensure pvlans were configured
+  assert:
+    that:
+      - pvlans_result_check_mode is changed

--- a/test/integration/targets/vmware_dvswitch_uplink_pg/aliases
+++ b/test/integration/targets/vmware_dvswitch_uplink_pg/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_dvswitch_uplink_pg/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch_uplink_pg/tasks/main.yml
@@ -2,43 +2,17 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- debug: var=vcsim_instance
-- debug: var=datacenters
+- import_role:
+    name: prepare_vmware_tests
 
 # Testcase 0001: Add Distributed vSwitch
 - name: add distributed vSwitch
   vmware_dvswitch:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter_name: "{{ item | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
     state: present
     switch_name: dvswitch_0001
     mtu: 9000
@@ -46,77 +20,55 @@
     discovery_proto: lldp
     discovery_operation: both
   register: dvs_result_0001
-  with_items:
-    - "{{ datacenters['json'] }}"
+
+- debug:
+    var: dvs_result_0001
 
 - name: ensure distributed vswitch is present
   assert:
     that:
-        - "{{ dvs_result_0001.changed == true }}"
+      - dvs_result_0001 is changed
 
-- name: get a list of distributed vswitch from vcsim after adding
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DVS
-  register: new_dvs_0001
+- when: vcsim is not defined
+  block:
+    - &uplink_data
+      name: Configure Uplink portgroup in check mode
+      vmware_dvswitch_uplink_pg:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch: dvswitch_0001
+        name: dvswitch_0001-DVUplinks
+        advanced:
+          port_config_reset_at_disconnect: False
+          block_override: False
+          vendor_config_override: False
+          vlan_override: False
+          netflow_override: False
+          traffic_filter_override: False
+        vlan_trunk_range: [ 2-3967, 4049-4092 ]
+        netflow_enabled: True
+        block_all_ports: False
+        validate_certs: no
+      register: uplink_pg_result_check_mode
+      check_mode: yes
 
-- debug:
-    msg: "{{ item | basename }}"
-  with_items: "{{ new_dvs_0001['json'] }}"
+    - debug:
+        var: uplink_pg_result_check_mode
 
-- set_fact: new_dvs_name="{% for dvs in new_dvs_0001['json'] %} {{ True if (dvs | basename) == 'dvswitch_0001' else False }}{% endfor %}"
+    - name: ensure uplink portgroup was changed
+      assert:
+        that:
+          - uplink_pg_result_check_mode is changed
 
-- debug: var=new_dvs_name
-- assert:
-    that:
-      - "{{ 'True' in new_dvs_name }}"
+    - <<: *uplink_data
+      name: Configure Uplink portgroup
+      check_mode: no
 
-- name: Configure Uplink portgroup in check mode
-  vmware_dvswitch_uplink_pg:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch: dvswitch_0001
-    name: dvswitch_0001-DVUplinks
-    advanced:
-      port_config_reset_at_disconnect: False
-      block_override: False
-      vendor_config_override: False
-      vlan_override: False
-      netflow_override: False
-      traffic_filter_override: False
-    vlan_trunk_range: [ 2-3967, 4049-4092 ]
-    netflow_enabled: True
-    block_all_ports: False
-    validate_certs: no
-  register: uplink_pg_result_check_mode
-  check_mode: yes
+    - debug:
+        var: uplink_pg_result
 
-- name: ensure uplink portgroup was changed
-  assert:
-    that:
-        - uplink_pg_result_check_mode.changed
-
-- name: Configure Uplink portgroup
-  vmware_dvswitch_uplink_pg:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch: dvswitch_0001
-    name: dvswitch_0001-DVUplinks
-    advanced:
-      port_config_reset_at_disconnect: False
-      block_override: False
-      vendor_config_override: False
-      vlan_override: False
-      netflow_override: False
-      traffic_filter_override: False
-    vlan_trunk_range: [ 2-3967, 4049-4092 ]
-    netflow_enabled: True
-    block_all_ports: False
-    validate_certs: no
-  register: uplink_pg_result
-
-- name: ensure uplink portgroup was changed
-  assert:
-    that:
-        - uplink_pg_result.changed
+    - name: ensure uplink portgroup was changed
+      assert:
+        that:
+          - uplink_pg_result is changed


### PR DESCRIPTION
##### SUMMARY

Refactoring of the following roles to make use of the new
`prepare_vmware_tests` role.

- `vmware_drs_group`
- `vmware_drs_group_facts`
- `vmware_drs_rule_facts`
- `vmware_drs_portgroup`
- `vmware_drs_portgroup_facts`
- `vmware_dvs_portgroup_facts`
- `vmware_dvswitch`
- `vmware_dvswitch_pvlans`

This patch depends on: https://github.com/ansible/ansible/pull/55719

Original PR: https://github.com/ansible/ansible/pull/54882

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware