### PR TITLE
vmware: refactoring of vmware test roles -- part4

### DIFF
--- a/test/integration/targets/vmware_guest/aliases
+++ b/test/integration/targets/vmware_guest/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
@@ -2,40 +2,12 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: create new VMs with boot_firmware as 'bios'
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: "{{ 'newvm_' + item|basename }}"
     guest_id: centos64Guest
     datacenter: "{{ (item|basename).split('_')[0] }}"
@@ -63,9 +35,9 @@
 #- name: create new VMs again with boot_firmware as 'bios'
 #  vmware_guest:
 #    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
 #    name: "{{ 'newvm_' + item|basename }}"
 #    guest_id: centos64Guest
 #    datacenter: "{{ (item|basename).split('_')[0] }}"
@@ -92,9 +64,9 @@
 - name: create new VMs with boot_firmware as 'efi'
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: "{{ 'newvm_efi_' + item|basename }}"
     guest_id: centos64Guest
     datacenter: "{{ (item|basename).split('_')[0] }}"
@@ -122,9 +94,9 @@
 #- name: create new VMs again with boot_firmware as 'efi'
 #  vmware_guest:
 #    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
 #    name: "{{ 'newvm_efi_' + item|basename }}"
 #    guest_id: centos64Guest
 #    datacenter: "{{ (item|basename).split('_')[0] }}"

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -1,41 +1,13 @@
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-- name: start vcsim with no folders
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Clusters from vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=CCR' }}"
-  register: clusterlist
-
-- debug: var=vcsim_instance
-- debug: var=clusterlist
-
 - name: Create VM with CDROM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "vm"
     name: CDROM-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0]|basename }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:
@@ -62,12 +34,12 @@
 - name: Update CDROM to iso for the new VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "vm"
     name: CDROM-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     cdrom:
       type: iso
       iso_path: "[LocalDS_0] base_new.iso"
@@ -85,12 +57,12 @@
 - name: Update CDROM to client for the new VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: vm
     name: CDROM-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     cdrom:
       type: client
     state: present
@@ -107,12 +79,12 @@
 - name: Update CDROM to none for the new VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: vm
     name: CDROM-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     cdrom:
       type: none
     state: present
@@ -129,13 +101,13 @@
 - name: Create VM with multiple disks and a CDROM - GitHub issue 38679
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: vm
     name: CDROM-Test-38679
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0].split('/')[-1] }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:
@@ -170,13 +142,13 @@
 #- name: Again create VM with multiple disks and a CDROM - GitHub issue 38679
 #  vmware_guest:
 #    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
+#    folder: "/{{ (clusters['json'][0]|basename).split('_')[0] }}/vm"
 #    name: CDROM-Test-38679
-#    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-#    cluster: "{{ clusterlist['json'][0] }}"
+#    datacenter: "{{ (clusters['json'][0]|basename).split('_')[0] }}"
+#    cluster: "{{ clusters['json'][0] }}"
 #    resource_pool: Resources
 #    guest_id: centos64Guest
 #    hardware:

--- a/test/integration/targets/vmware_guest/tasks/check_mode.yml
+++ b/test/integration/targets/vmware_guest/tasks/check_mode.yml
@@ -2,46 +2,14 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-- name: get a guest
-  set_fact:
-    guest1: "{{ vmlist.json[0] }}"
-
 - name: Perform all operation in check mode
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ guest1|basename }}"
-    datacenter: "{{ (guest1|basename).split('_')[0] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ infra.vm_list[0] }}"
+    datacenter: "{{ dc1 }}"
     state: "{{ item }}"
   with_items:
     - absent
@@ -55,22 +23,23 @@
   register: check_mode_state
   check_mode: yes
 
-- debug: var=check_mode_state
+- debug:
+    var: check_mode_state
 
 - name: assert that changes were made
   assert:
     that:
       - "check_mode_state.results|map(attribute='changed')|unique|list == [true]"
-      - "check_mode_state.results|map(attribute='vm_name')|unique|list == [ guest1 | basename ]"
+      - "check_mode_state.results|map(attribute='vm_name')|unique|list == [ infra.vm_list[0] ]"
 
 - name: Perform all operation on non-existent VM in check mode
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: non_existent_vm
-    datacenter: "{{ (guest1|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     state: "{{ item }}"
   with_items:
     - present
@@ -81,7 +50,8 @@
   register: check_mode_state
   check_mode: yes
 
-- debug: var=check_mode_state
+- debug:
+    var: check_mode_state
 
 - name: assert that changes were made
   assert:

--- a/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
@@ -2,56 +2,100 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim   
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-- name: set state to poweroff on all VMs
+- name: create new linked clone without specifying snapshot_src
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
-    template: "{{ item|basename }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-    disk:
-        - size: 1gb
-          type: thin
-          autoselect_datastore: True
-    state: poweredoff
-    folder: "{{ item|dirname }}"
-    convert: thin
-  with_items: "{{ vmlist['json'] }}"
-  register: clone_d1_c1_f0
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: new_vm_1
+    template: "{{ infra.vm_list[0] }}"
+    guest_id: centos64Guest
+    datacenter: "{{ dc1 }}"
+    folder: D1/C1/F0
+    linked_clone: True
+  register: linked_clone_d1_c1_f0
+  ignore_errors: True
 
-- debug: var=clone_d1_c1_f0
+- debug:
+    var: linked_clone_d1_c1_f0
 
-- name: assert that changes were made
+- name: assert that changes were not made
   assert:
     that:
-        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+        - not (linked_clone_d1_c1_f0 is changed)
+
+- name: create new linked clone without specifying linked_clone
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: new_vm_2
+    template: "{{ infra.vm_list[0] }}"
+    guest_id: centos64Guest
+    datacenter: "{{ dc1 }}"
+    folder: D1/C1/F0
+    snapshot_src: "snap_shot1"
+  register: linked_clone_d1_c1_f0
+  ignore_errors: True
+
+- debug:
+    var: linked_clone_d1_c1_f0
+
+- name: assert that changes were not made
+  assert:
+    that:
+        - not (linked_clone_d1_c1_f0 is changed)
+
+# TODO: VCSIM: snapshot is not supported in current vcsim
+#
+#- name: create new linked clone with linked_clone and snapshot_src
+#  vmware_guest:
+#    validate_certs: False
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
+#    name: "{{ 'new_vm_' + item|basename }}"
+#    template: "{{ item|basename }}"
+#    guest_id: centos64Guest
+#    datacenter: "{{ (item|basename).split('_')[0] }}"
+#    folder: "{{ item|dirname }}"
+#    snapshot_src: "snap_shot1"
+#    linked_clone: True
+#  with_items: "{{ vmlist['json'] }}"
+#  register: linked_clone_d1_c1_f0
+#  ignore_errors: True
+
+#- debug: var=linked_clone_d1_c1_f0
+
+#- name: assert that changes were made
+#  assert:
+#    that:
+#        - "linked_clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+
+# TODO: VCSIM: snapshot is not supported in current vcsim
+#
+#- name: create new linked clone with linked_clone and snapshot_src again
+#  vmware_guest:
+#    validate_certs: False
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
+#    name: "{{ 'new_vm_' + item|basename }}"
+#    template: "{{ item|basename }}"
+#    guest_id: centos64Guest
+#    datacenter: "{{ (item|basename).split('_')[0] }}"
+#    folder: "{{ item|dirname }}"
+#    snapshot_src: "snap_shot1"
+#    linked_clone: True
+#  with_items: "{{ vmlist['json'] }}"
+#  register: linked_clone_d1_c1_f0
+#  ignore_errors: True
+
+#- debug: var=linked_clone_d1_c1_f0
+
+#- name: assert that changes were not made
+#  assert:
+#    that:
+#        - "linked_clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [false]"

--- a/test/integration/targets/vmware_guest/tasks/clone_with_convert.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_with_convert.yml
@@ -2,44 +2,15 @@
 # Copyright: (c) 2018, Christophe FERREIRA <christophe.ferreira@cnaf.fr>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim   
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-- name: clone vm from template and convert to thin 
+- name: clone vm from template and convert to thin
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: "{{ 'thin_' + item|basename }}"
     template: "{{ item|basename }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}" 
+    datacenter: "{{ (item|basename).split('_')[0] }}"
     state: poweredoff
     folder: "{{ item|dirname }}"
     convert: thin
@@ -53,15 +24,15 @@
     that:
         - "clone_thin.results|map(attribute='changed')|unique|list == [true]"
 
-- name: clone vm from template and convert to thick 
+- name: clone vm from template and convert to thick
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: "{{ 'thick_' + item|basename }}"
     template: "{{ item|basename }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}" 
+    datacenter: "{{ (item|basename).split('_')[0] }}"
     state: poweredoff
     folder: "{{ item|dirname }}"
     convert: thick
@@ -78,12 +49,12 @@
 - name: clone vm from template and convert to eagerzeroedthick
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: "{{ 'eagerzeroedthick_' + item|basename }}"
     template: "{{ item|basename }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}" 
+    datacenter: "{{ (item|basename).split('_')[0] }}"
     state: poweredoff
     folder: "{{ item|dirname }}"
     convert: eagerzeroedthick

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -2,44 +2,16 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: create new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_1
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 4
         num_cpu_cores_per_socket: 2
@@ -62,8 +34,7 @@
           type: thin
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: clone_d1_c1_f0
 
 - debug: var=clone_d1_c1_f0
@@ -71,18 +42,18 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+        - clone_d1_c1_f0 is changed
 
-- name: create new VMs again
+- name: create the VM again
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_1
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 4
         num_cpu_cores_per_socket: 2
@@ -92,8 +63,7 @@
           type: thin
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: clone_d1_c1_f0_recreate
 
 - debug: var=clone_d1_c1_f0_recreate
@@ -101,30 +71,23 @@
 - name: assert that no changes were made after re-creating
   assert:
     that:
-        - "clone_d1_c1_f0_recreate.results|map(attribute='changed')|unique|list == [false]"
-
-- name: assert that no changes were made after re-creating VM and task returns facts
-  assert:
-    that:
-        - "'newvm_' + item | basename in clone_d1_c1_f0.results|map(attribute='instance.hw_name')|list"
-  with_items: "{{ vmlist['json'] }}"
+        - not (clone_d1_c1_f0_recreate is changed)
 
 - name: modify the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_1
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 2
         memory_mb: 1024
     state: present
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: clone_d1_c1_f0_modify
 
 - debug: var=clone_d1_c1_f0_modify
@@ -132,24 +95,23 @@
 - name: assert that changes were made with modification
   assert:
     that:
-        - "clone_d1_c1_f0_modify.results|map(attribute='changed')|unique|list == [true]"
+        - clone_d1_c1_f0_modify is changed
 
 - name: re-modify the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_1
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 2
         memory_mb: 1024
     state: present
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: clone_d1_c1_f0_remodify
 
 - debug: var=clone_d1_c1_f0_remodify
@@ -157,21 +119,20 @@
 - name: assert that no changes were made when re-modified
   assert:
     that:
-        - "clone_d1_c1_f0_remodify.results|map(attribute='changed')|unique|list == [false]"
+        - not (clone_d1_c1_f0_remodify is changed)
 
 - name: delete the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_1
     #template: "{{ item|basename }}"
     #guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     state: absent
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: clone_d1_c1_f0_delete
 
 - debug: var=clone_d1_c1_f0_delete
@@ -179,21 +140,20 @@
 - name: assert that changes were made with deletion
   assert:
     that:
-        - "clone_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+        - clone_d1_c1_f0_delete is changed
 
 - name: re-delete the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_1
     #template: "{{ item|basename }}"
     #guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     state: absent
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: clone_d1_c1_f0_redelete
 
 - debug: var=clone_d1_c1_f0_redelete
@@ -201,4 +161,4 @@
 - name: assert that no changes were made with redeletion
   assert:
     that:
-        - "clone_d1_c1_f0_redelete.results|map(attribute='changed')|unique|list == [false]"
+        - not (clone_d1_c1_f0_redelete is changed)

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0_env.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0_env.yml
@@ -2,35 +2,6 @@
 # Copyright: (c) 2018 Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-
 - name: create new VMs without connection parameters
   vmware_guest:
     name: "{{ 'newvm_' + item|basename }}"
@@ -73,7 +44,7 @@
   register: clone_d1_c1_f0_env
   ignore_errors: True
   environment:
-    VMWARE_HOST: "{{ vcsim }}"
+    VMWARE_HOST: "{{ vcenter_hostname }}"
 - debug: var=clone_d1_c1_f0_env
 
 - name: assert that changes were made
@@ -99,8 +70,8 @@
   register: clone_d1_c1_f0_env
   ignore_errors: True
   environment:
-    VMWARE_HOST: "{{ vcsim }}"
-    VMWARE_USER: "{{ vcsim_instance['json']['username'] }}"
+    VMWARE_HOST: "{{ vcenter_hostname }}"
+    VMWARE_USER: "{{ vcenter_username }}"
 - debug: var=clone_d1_c1_f0_env
 
 - name: assert that changes were not made
@@ -125,9 +96,9 @@
   with_items: "{{ vmlist['json'] }}"
   register: clone_d1_c1_f0_env
   environment:
-    VMWARE_HOST: "{{ vcsim }}"
-    VMWARE_USER: "{{ vcsim_instance['json']['username'] }}"
-    VMWARE_PASSWORD: "{{ vcsim_instance['json']['password'] }}"
+    VMWARE_HOST: "{{ vcenter_hostname }}"
+    VMWARE_USER: "{{ vcenter_username }}"
+    VMWARE_PASSWORD: "{{ vcenter_password }}"
     VMWARE_VALIDATE_CERTS: False
 - debug: var=clone_d1_c1_f0_env
 

--- a/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
@@ -2,48 +2,15 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
-#
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
-#- name: start vcsim with no folders
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-#  register: vcsim_instance
-#
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
-#
-#- debug: var=vcsim_instance
-#
-#- name: get a list of Datacenter from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-#  register: datacenters
-#
-#- set_fact: dc1="{{ datacenters['json'][0] }}"
-#
-#- name: get a list of virtual machines from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-#  register: vms
-#
-#- set_fact: vm1="{{ vms['json'][0] }}"
+
+#- set_fact: vm1="{{ vmlist['json'][0] }}"
 #
 #- name: create new virtual machine with invalid guest id
 #  vmware_guest:
 #    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
 #    name: "{{ 'invalid_vm_' + vm1 | basename }}"
 #    guest_id: "invalid_guest_id"
 #    datacenter: "{{ (vm1|basename).split('_')[0] }}"

--- a/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
@@ -2,43 +2,15 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: create new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvmnw_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvmnw_4
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 4
         memory_mb: 512
@@ -55,8 +27,7 @@
           start_connected: True
           allow_guest_control: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: clone_d1_c1_f0
 
 - debug: var=clone_d1_c1_f0
@@ -64,4 +35,4 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+        - clone_d1_c1_f0 is changed

--- a/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -1,60 +1,14 @@
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=2&pool=2&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- name: get a list of clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusts
-
-- name: get a list of resource pools from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=RP
-  register: res_pools
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-- debug: var=res_pools
-- debug: var=clusts
-- debug: var=hosts
-
 # Create one with the defaults
 - name: create new VM with default resource pool
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -63,8 +17,7 @@
           type: thin
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rp_d1_c1_f0
 
 - debug: var=clone_rp_d1_c1_f0
@@ -72,21 +25,20 @@
 - name: assert that changes were made
   assert:
     that:
-      - "clone_rp_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+      - clone_rp_d1_c1_f0 is changed
 
 - name: delete the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     #guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     state: absent
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rp_d1_c1_f0_delete
 
 - debug: var=clone_rp_d1_c1_f0_delete
@@ -94,20 +46,20 @@
 - name: assert that changes were made with deletion
   assert:
     that:
-        - "clone_rp_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+        - clone_rp_d1_c1_f0_delete is changed
 
 # now create with just a cluster
 - name: create new VM with default resource pool in cluster
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-    cluster: "{{ clusts['json'][0]|basename }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -116,8 +68,7 @@
           type: thin
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rpc_d1_c1_f0
 
 - debug: var=clone_rpc_d1_c1_f0
@@ -125,22 +76,21 @@
 - name: assert that changes were made
   assert:
     that:
-      - "clone_rpc_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+      - clone_rpc_d1_c1_f0 is changed
 
 - name: delete the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     #guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-    cluster: "{{ clusts['json'][0]|basename }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
     state: absent
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rpc_d1_c1_f0_delete
 
 - debug: var=clone_rpc_d1_c1_f0_delete
@@ -148,21 +98,21 @@
 - name: assert that changes were made with deletion
   assert:
     that:
-        - "clone_rpc_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+        - clone_rpc_d1_c1_f0_delete is changed
 
 # now create with a specific resource pool
 - name: create new VM with specific resource pool in cluster
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-    cluster: "{{ clusts['json'][0]|basename }}"
-    resource_pool: "{{ res_pools['json'][2]|basename }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: DC0_C0_RP1
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -171,8 +121,7 @@
           type: thin
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rpcp_d1_c1_f0
 
 - debug: var=clone_rpcp_d1_c1_f0
@@ -180,22 +129,21 @@
 - name: assert that changes were made
   assert:
     that:
-      - "clone_rpcp_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+      - clone_rpcp_d1_c1_f0 is changed
 
 - name: delete the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     #guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-    cluster: "{{ clusts['json'][0]|basename }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
     state: absent
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rpcp_d1_c1_f0_delete
 
 - debug: var=clone_rpcp_d1_c1_f0_delete
@@ -203,20 +151,20 @@
 - name: assert that changes were made with deletion
   assert:
     that:
-        - "clone_rpcp_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+        - clone_rpcp_d1_c1_f0_delete is changed
 
 # now create with a specific host
 - name: create new VM with specific host
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-    esxi_hostname: "{{ hosts['json'][0]|basename }}"
+    datacenter: "{{ dc1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -225,8 +173,7 @@
           type: thin
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rph_d1_c1_f0
 
 - debug: var=clone_rph_d1_c1_f0
@@ -234,21 +181,20 @@
 - name: assert that changes were made
   assert:
     that:
-      - "clone_rph_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+      - clone_rph_d1_c1_f0 is changed
 
 - name: delete the new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_2
     #template: "{{ item|basename }}"
     #guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     state: absent
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'][0] }}"
+    folder: F0
   register: clone_rph_d1_c1_f0_delete
 
 - debug: var=clone_rph_d1_c1_f0_delete
@@ -256,4 +202,4 @@
 - name: assert that changes were made with deletion
   assert:
     that:
-        - "clone_rph_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+        - clone_rph_d1_c1_f0_delete is changed

--- a/test/integration/targets/vmware_guest/tasks/delete_vm.yml
+++ b/test/integration/targets/vmware_guest/tasks/delete_vm.yml
@@ -2,75 +2,14 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-- name: get a guest
-  set_fact:
-    guest1: "{{ vmlist.json[0] | basename }}"
-
-- vmware_vm_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    validate_certs: no
-  register: vm_details
-
-- name: store the vcenter container ip
-  set_fact:
-    vm_powerstate: "{{ item.power_state }}"
-  with_items:
-    - "{{ vm_details.virtual_machines| json_query(query) }}"
-  vars:
-    query: "[?guest_name == '{{ guest1 }}' ]"
-
-- debug: var=vm_powerstate
-
-- vmware_guest:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    validate_certs: no
-    name: "{{ guest1 }}"
-    state: poweredon
-  when: "vm_powerstate != 'poweredOn'"
-  register: vmware_guest_poweron_state
-
-- debug: var=vmware_guest_poweron_state
-
 - name: Delete VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ guest1 }}"
-    datacenter: "{{ guest1.split('_')[0] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: nothinghere
+    datacenter: "{{ dc1 }}"
     state: absent
   register: delete_vm
   ignore_errors: yes
@@ -81,4 +20,3 @@
   assert:
     that:
       - "not delete_vm.changed"
-      - "delete_vm.msg"

--- a/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
@@ -2,43 +2,15 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: create new VMs with invalid disk mode
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: disk_mode_d1_c1_f0
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -48,8 +20,7 @@
           autoselect_datastore: True
           disk_mode: 'invalid_disk_mode'
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: "{{ f0 }}"
   register: disk_mode_d1_c1_f0
   ignore_errors: True
 
@@ -58,17 +29,17 @@
 - name: assert that changes were not made
   assert:
     that:
-        - "disk_mode_d1_c1_f0.results|map(attribute='changed')|unique|list == [false]"
+        - not(disk_mode_d1_c1_f0 is changed)
 
 - name: create new VMs with valid disk mode
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: disk_mode_d1_c1_f0
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -78,8 +49,7 @@
           autoselect_datastore: True
           disk_mode: 'independent_persistent'
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: "{{ f0 }}"
   register: disk_mode_d1_c1_f0_2
 
 - debug: var=disk_mode_d1_c1_f0_2
@@ -87,34 +57,33 @@
 - name: assert that changes were made
   assert:
     that:
-        - "disk_mode_d1_c1_f0_2.results|map(attribute='changed')|unique|list == [true]"
+        - disk_mode_d1_c1_f0_2 is changed
 
-# TODO: vcsim does not support reconfiguration of disk mode, fails with types.InvalidDeviceSpec
-#- name: create new VMs with valid disk mode again
-#  vmware_guest:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    name: "{{ 'newvm_' + item|basename }}"
-#    guest_id: centos64Guest
-#    datacenter: "{{ (item|basename).split('_')[0] }}"
-#    hardware:
-#        num_cpus: 1
-#        memory_mb: 512
-#    disk:
-#        - size: 1gb
-#          type: eagerzeroedthick
-#          autoselect_datastore: True
-#          disk_mode: 'independent_persistent'
-#    state: poweredoff
-#    folder: "{{ item|dirname }}"
-#  with_items: "{{ vmlist['json'] }}"
-#  register: disk_mode_d1_c1_f0_2
-
-#- debug: var=disk_mode_d1_c1_f0_2
-
-#- name: assert that changes were not made
-#  assert:
-#    that:
-#        - "disk_mode_d1_c1_f0_2.results|map(attribute='changed')|unique|list == [false]"
+#TODO: vcsim does not support reconfiguration of disk mode, fails with types.InvalidDeviceSpec
+- when: vcsim is not defined
+  block:
+  - name: create new VMs with valid disk mode again
+    vmware_guest:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: disk_mode_d1_c1_f0
+      guest_id: centos64Guest
+      datacenter: "{{ (item|basename).split('_')[0] }}"
+      hardware:
+        num_cpus: 1
+        memory_mb: 512
+      disk:
+        - size: 1gb
+          type: eagerzeroedthick
+          autoselect_datastore: True
+          disk_mode: 'independent_persistent'
+      state: poweredoff
+      folder: "{{ f0 }}"
+    register: disk_mode_d1_c1_f0_2
+  - debug: var=disk_mode_d1_c1_f0_2
+  - name: assert that changes were not made
+    assert:
+      that:
+        - not (disk_mode_d1_c1_f0_2 is changed)

--- a/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
@@ -2,43 +2,15 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: create new VMs with invalid disk size
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_6
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -47,8 +19,7 @@
           type: eagerzeroedthick
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: "{{ f0 }}"
   register: disk_size_d1_c1_f0
   ignore_errors: True
 
@@ -57,4 +28,4 @@
 - name: assert that changes were made
   assert:
     that:
-        - "disk_size_d1_c1_f0.results|map(attribute='changed')|unique|list == [false]"
+        - not (disk_size_d1_c1_f0 is changed)

--- a/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
@@ -2,43 +2,15 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: create new VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ 'newvm_' + item|basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: newvm_3
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -50,8 +22,7 @@
           type: thin
           autoselect_datastore: True
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: F0
   register: disk_type_d1_c1_f0
 
 - debug: var=disk_type_d1_c1_f0
@@ -59,4 +30,4 @@
 - name: assert that changes were made
   assert:
     that:
-        - "disk_type_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+        - disk_type_d1_c1_f0 is changed

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -2,37 +2,15 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
-
 - name: create new VMs with manual MAC address
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ item | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: DC0_H0_VM12
     guest_id: centos64Guest
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
         memory_mb: 512
@@ -47,9 +25,7 @@
           gateway: 192.168.10.254
           mac: aa:bb:cc:dd:aa:42
     state: poweredoff
-    folder: "{{ item | dirname }}"
-  with_items:
-    - "/DC0/vm/DC0_H0_VM12"
+    folder: vm
   register: clone_d1_c1_f0
 
 - debug: var=clone_d1_c1_f0
@@ -57,5 +33,5 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['addresstype'] == 'manual'"
-        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:42'"
+        - "clone_d1_c1_f0['instance']['hw_eth0']['addresstype'] == 'manual'"
+        - "clone_d1_c1_f0['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:42'"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -2,6 +2,14 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
+
+
 - include: poweroff_d1_c1_f0.yml
 - include: poweroff_d1_c1_f1.yml
 - include: check_mode.yml
@@ -15,6 +23,14 @@
 - include: create_nw_d1_c1_f0.yml
 - include: delete_vm.yml
 - include: non_existent_vm_ops.yml
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
+
 - include: network_negative_test.yml
 # VCSIM does not return list of portgroups for dvswitch so commenting following TC
 #- include: network_with_portgroup.yml

--- a/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
@@ -2,49 +2,17 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-
-- debug: var=vmlist
-
-- set_fact:
-   vm1: "{{ vmlist['json'][0] }}"
-
-- debug: var=vm1
+- debug: var=f0
 
 - name: create new VMs with non-existent network
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -55,7 +23,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: non_existent_network
   ignore_errors: yes
 
@@ -64,18 +32,18 @@
 - name: assert that no changes were not made
   assert:
     that:
-        - "not non_existent_network.changed"
-        - "\"Network 'Non existent VM' does not exist\" in non_existent_network.msg"
+        - not (non_existent_network is changed)
+        - "'does not exist' in non_existent_network.msg"
 
 - name: create new VMs with network and with only IP
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -88,7 +56,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: no_netmask
   ignore_errors: yes
 
@@ -103,12 +71,12 @@
 - name: create new VMs with network and with only netmask
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -121,7 +89,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: no_ip
   ignore_errors: yes
 
@@ -136,12 +104,12 @@
 - name: create new VMs with network and without network name
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -154,7 +122,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: no_network_name
   ignore_errors: yes
 
@@ -169,12 +137,12 @@
 - name: create new VMs with network and without network name
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -187,7 +155,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: no_network
   ignore_errors: yes
 
@@ -202,12 +170,12 @@
 - name: create new VMs with invalid device type
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -221,7 +189,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: invalid_device_type
   ignore_errors: yes
 
@@ -236,12 +204,12 @@
 - name: create new VMs with invalid device MAC address
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -256,7 +224,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: invalid_mac
   ignore_errors: yes
 
@@ -271,12 +239,12 @@
 - name: create new VMs with invalid network type
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -292,7 +260,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: invalid_network_type
   ignore_errors: yes
 
@@ -307,12 +275,12 @@
 - name: create new VMs with IP, netmask and network type as "DHCP"
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -328,7 +296,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: invalid_dhcp_network_type
   ignore_errors: yes
 
@@ -343,12 +311,12 @@
 - name: create new VMs with no network type which set network type as "DHCP"
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm_no_nw_type
     guest_id: centos64Guest
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     disk:
       - size: 3mb
         type: thin
@@ -359,7 +327,7 @@
         num_cpus: 3
         memory_mb: 512
     state: poweredoff
-    folder: "{{ vm1 | dirname }}"
+    folder: "{{ f0 }}"
   register: no_network_type
   ignore_errors: yes
 

--- a/test/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -3,53 +3,19 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Testcase to check #38605
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-
-- debug: var=vmlist
-
-- set_fact:
-   vm1: "{{ vmlist['json'][0] }}"
-
-- debug: var=vm1
-
 - set_fact:
     vm_name: "VM_{{ 10000 | random }}"
 
-- name: Deploy VM {{ vm1 | basename }}
+- name: Deploy VM first VM
   vmware_guest:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
-    datacenter: "{{ (vm1|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     state: poweredon
-    folder: "{{ vm1 | dirname }}"
-    name: "{{ vm_name }}"
+    folder: "{{ f0 }}"
+    name: network_with_device
     disk:
       - size: 10mb
         autoselect_datastore: yes
@@ -70,14 +36,14 @@
 
 - name: Deploy VM {{ vm1 | basename }} again
   vmware_guest:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
-    datacenter: "{{ (vm1|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     state: poweredon
-    folder: "{{ vm1 | dirname }}"
-    name: "{{ vm_name }}"
+    folder: "{{ f0 }}"
+    name: network_with_device
     disk:
       - size: 10mb
         autoselect_datastore: yes
@@ -94,4 +60,4 @@
 
 - assert:
     that:
-      - "not vm_result_again.changed"
+      - not (vm_result_again is changed)

--- a/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -2,49 +2,12 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-
-- debug: var=vmlist
-
-- set_fact:
-   vm1: "{{ vmlist['json'][0] }}"
-
-- debug: var=vm1
-
-- set_fact:
-    vm_name: "VM_{{ 10000 | random }}"
-
 # Clone from existing VM with DVPG
 - name: Deploy VM from template {{ vm1 | basename }}
   vmware_guest:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ (vm1|basename).split('_')[0] }}"
     state: poweredon
@@ -76,9 +39,9 @@
 
 - name: Deploy new VM with DVPG
   vmware_guest:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ (vm1|basename).split('_')[0] }}"
     state: poweredon
@@ -103,9 +66,9 @@
 
 - name: Deploy same {{ vm_name }} VM again
   vmware_guest:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ (vm1|basename).split('_')[0] }}"
     state: poweredon

--- a/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -2,47 +2,12 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>, Tim Steinbach <tim@nequissimus.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-
-- debug: var=vmlist
-
-- set_fact:
-   vm1: "{{ vmlist['json'][0] }}"
-
-- debug: var=vm1
-
 - name: Create dvswitch
   vmware_dvswitch:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter_name: "{{ (vm1 | basename).split('_')[0] }}"
     switch_name: dvSwitch
     uplink_quantity: 2
@@ -55,9 +20,9 @@
 - name: Add portgroup
   vmware_dvs_portgroup:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     portgroup_name: "portgroup_network"
     switch_name: "{{ dvswitch.switch_name }}"
     vlan_id: "1"
@@ -69,9 +34,9 @@
 - name: create new VMs with portgroup
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: new_vm_pg
     guest_id: centos64Guest
     datacenter: "{{ (vm1 | basename).split('_')[0] }}"

--- a/test/integration/targets/vmware_guest/tasks/non_existent_vm_ops.yml
+++ b/test/integration/targets/vmware_guest/tasks/non_existent_vm_ops.yml
@@ -2,56 +2,22 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-- name: get a guest
-  set_fact:
-    guest1: "{{ vmlist.json[0] }}"
-
 - name: Perform operation on non-existent VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     name: "non_existent_vm"
-    datacenter: "{{ (guest1|basename).split('_')[0] }}"
-    folder: "{{ guest1 | dirname }}"
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
     state: poweredoff
   register: non_existent_vm_ops
   ignore_errors: yes
-
 - debug: var=non_existent_vm_ops
-
 - name: assert that changes were not made
   assert:
     that:
-      - not non_existent_vm_ops.changed
-      - non_existent_vm_ops.msg is defined
-      - "'Unable to find the datastore with given parameters' in non_existent_vm_ops.msg"
+      - not (non_existent_vm_ops is changed)
+      - "'msg' in non_existent_vm_ops"
+      - "'Unable to find the datastore with given parameters.' in non_existent_vm_ops.msg"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
@@ -2,51 +2,23 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: set state to poweroff on all VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ item|basename }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ item }}"
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+  with_items: "{{ infra.vm_list }}"
   register: poweroff_d1_c1_f0
 
-- debug: var=poweroff_d1_c1_f0
+- debug:
+    var: poweroff_d1_c1_f0
 
 # vcsim (v0.18.0) VMs are spawned PoweredOn
 - name: make sure changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [True]"
+      - "poweroff_d1_c1_f0.results[0].changed == true"
+      - "poweroff_d1_c1_f0.results[1].changed == true"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
@@ -2,34 +2,6 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=1
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 # https://github.com/ansible/ansible/issues/25011
 # Sending "-folders 1" to vcsim nests the datacenter under
 # the folder so that the path prefix is no longer /vm
@@ -39,14 +11,13 @@
 - name: set state to poweredoff on all VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ item|basename }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ item }}"
     state: poweredoff
-    folder: "{{ item|dirname }}"
-  with_items: "{{ vmlist['json'] }}"
+    folder: "DC1/C1/F1"
+  with_items: "{{ infra.vm_list }}"
   register: poweroff_d1_c1_f1
 
 - debug: var=poweroff_d1_c1_f1
@@ -55,4 +26,5 @@
 - name: make sure changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [True]"
+      - '"instance" in poweroff_d1_c1_f1.results[0]'
+      - '"instance" in poweroff_d1_c1_f1.results[1]'

--- a/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
@@ -1,37 +1,9 @@
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: "http://{{ vcsim }}:5000/killall"
-- name: start vcsim with no folders
-  uri:
-    url: "http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0"
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMs from vcsim
-  uri:
-    url: "http://{{ vcsim }}:5000/govc_find?filter=VM"
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
 - name: ensure that VMs are not flagged as templates
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
     folder: "{{ item|dirname }}"
     name: "{{ item|basename }}"
@@ -50,9 +22,9 @@
 - name: convert all VMs to templates
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
     folder: "{{ item|dirname }}"
     name: "{{ item|basename }}"
@@ -71,9 +43,9 @@
 - name: make double sure that all VMs are templates
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
     folder: "{{ item|dirname }}"
     name: "{{ item|basename }}"
@@ -92,9 +64,9 @@
 - name: convert all templates back to VMs
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
     folder: "{{ item|dirname }}"
     name: "{{ item|basename }}"

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -1,41 +1,13 @@
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-- name: start vcsim with no folders
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Clusters from vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=CCR' }}"
-  register: clusterlist
-
-- debug: var=vcsim_instance
-- debug: var=clusterlist
-
 - name: Create test VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "vm"
     name: vApp-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0]|basename }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:
@@ -53,12 +25,12 @@
 - name:  Define vApp properties for the new VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "vm"
     name: vApp-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     vapp_properties:
     - id: prop_id1
       category: category
@@ -81,15 +53,15 @@
       - "vapp_vm.failed == false"
       - "vapp_vm.changed == true"
 
-- name:  Edit one vApp property and removing another 
+- name:  Edit one vApp property and removing another
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "vm"
     name: vApp-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
     vapp_properties:
     - id: prop_id1
       operation: remove

--- a/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
@@ -1,41 +1,13 @@
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-- name: start vcsim with no folders
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Clusters from vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=CCR' }}"
-  register: clusterlist
-
-- debug: var=vcsim_instance
-- debug: var=clusterlist
-
 - name: Create Windows 10 VM with VBS enabled
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "/{{ (clusters['json'][0]|basename).split('_')[0] }}/vm"
     name: vbs-Test
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0] }}"
+    datacenter: "{{ (clusters['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusters['json'][0] }}"
     resource_pool: Resources
     guest_id: windows9_64Guest
     hardware:
@@ -64,13 +36,13 @@
 - name: Create Windows Server 2016 VM without VBS enabled
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "/{{ (clusters['json'][0]|basename).split('_')[0] }}/vm"
     name: vbs-Test2
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0] }}"
+    datacenter: "{{ (clusters['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusters['json'][0] }}"
     resource_pool: Resources
     guest_id: windows9Server64Guest
     hardware:
@@ -98,12 +70,12 @@
 - name: Enable VBS for Windows Server 2016 VM
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "/{{ (clusters['json'][0]|basename).split('_')[0] }}/vm"
     name: vbs-Test2
-    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    datacenter: "{{ (clusters['json'][0]|basename).split('_')[0] }}"
     disk:
     - size_mb: 256
       type: thin

--- a/test/integration/targets/vmware_guest_boot_facts/aliases
+++ b/test/integration/targets/vmware_guest_boot_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_boot_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_boot_facts/tasks/main.yml
@@ -2,75 +2,50 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+      setup_datastore: true
+      setup_virtualmachines: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
+  - name: Gather facts about VM boot order
+    vmware_guest_boot_facts:
+      validate_certs: no
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      name: "{{ infra.vm_list[0] }}"
+    register: vm1_facts
+  - debug: var=vm1_facts
+  - name: assert that values are set
+    assert:
+      that:
+          - vm1_facts.vm_boot_facts.current_boot_delay is defined
+          - vm1_facts.vm_boot_facts.current_boot_firmware is defined
+          - vm1_facts.vm_boot_facts.current_boot_order is defined
+          - vm1_facts.vm_boot_facts.current_boot_retry_delay is defined
+          - vm1_facts.vm_boot_facts.current_boot_retry_enabled is defined
+          - vm1_facts.vm_boot_facts.current_enter_bios_setup is defined
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-- name: Gather facts about VM boot order
-  vmware_guest_boot_facts:
-    validate_certs: no
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ item|basename }}"
-  with_items: "{{ vmlist['json'] }}"
-  register: boot_d1_c1_f0
-
-- debug: var=boot_d1_c1_f0
-
-- name: assert that changes were made
-  assert:
-    that:
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_delay is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_firmware is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_order is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_retry_delay is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_retry_enabled is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_enter_bios_setup is defined
-
-- name: Gather facts about VM boot order in check mode
-  vmware_guest_boot_facts:
-    validate_certs: no
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ item|basename }}"
-  with_items: "{{ vmlist['json'] }}"
-  check_mode: yes
-  register: boot_d1_c1_f0
-
-- debug: var=boot_d1_c1_f0
-
-- name: assert that changes were made
-  assert:
-    that:
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_delay is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_firmware is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_order is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_retry_delay is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_boot_retry_enabled is defined
-        - boot_d1_c1_f0.results.vm_boot_facts.current_enter_bios_setup is defined
+  - name: Gather facts about VM boot order in check mode
+    vmware_guest_boot_facts:
+      validate_certs: no
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      name: "{{ infra.vm_list[0] }}"
+    check_mode: yes
+    register: vm1_facts
+  - debug: var=vm1_facts
+  - name: assert that values are set
+    assert:
+      that:
+          - vm1_facts.vm_boot_facts.current_boot_delay is defined
+          - vm1_facts.vm_boot_facts.current_boot_firmware is defined
+          - vm1_facts.vm_boot_facts.current_boot_order is defined
+          - vm1_facts.vm_boot_facts.current_boot_retry_delay is defined
+          - vm1_facts.vm_boot_facts.current_boot_retry_enabled is defined
+          - vm1_facts.vm_boot_facts.current_enter_bios_setup is defined

--- a/test/integration/targets/vmware_guest_custom_attribute_defs/aliases
+++ b/test/integration/targets/vmware_guest_custom_attribute_defs/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_custom_attribute_defs/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_custom_attribute_defs/tasks/main.yml
@@ -2,48 +2,27 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: list custom attributes
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
+- name: remove attribute definition
   vmware_guest_custom_attribute_defs:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
     validate_certs: False
-    state: list
-  register: list_attrib_def
-
-- debug: var=list_attrib_def
-
-- assert:
-    that:
-      - "not list_attrib_def.changed"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    state: absent
+    attribute_key: sample_5
 
 - name: add custom attribute definition
   vmware_guest_custom_attribute_defs:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: present
     attribute_key: sample_5
   register: add_attrib_def
@@ -52,30 +31,15 @@
 
 - assert:
     that:
-      - "add_attrib_def.changed"
-      - "'sample_5' in add_attrib_def.instance"
-
-- name: list custom attributes
-  vmware_guest_custom_attribute_defs:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    state: list
-  register: list_attrib_def
-
-- debug: var=list_attrib_def
-
-- assert:
-    that:
-      - "not list_attrib_def.changed"
+      - add_attrib_def is changed
+      - "'sample_5' in add_attrib_def.custom_attribute_defs"
 
 - name: add attribute definition again
   vmware_guest_custom_attribute_defs:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: present
     attribute_key: sample_5
   register: add_attrib_def
@@ -84,29 +48,14 @@
 
 - assert:
     that:
-      - "not add_attrib_def.changed"
-
-- name: list attribute definition
-  vmware_guest_custom_attribute_defs:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    state: list
-  register: list_attrib_def
-
-- debug: var=list_attrib_def
-
-- assert:
-    that:
-      - "not list_attrib_def.changed"
+      - not (add_attrib_def is changed)
 
 - name: remove attribute definition
   vmware_guest_custom_attribute_defs:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: absent
     attribute_key: sample_5
   register: remove_attrib_def
@@ -116,14 +65,14 @@
 - assert:
     that:
       - "remove_attrib_def.changed"
-      - "'sample_5' not in remove_attrib_def.instance"
+      - "'sample_5' not in remove_attrib_def.custom_attribute_defs"
 
 - name: remove attribute definition
   vmware_guest_custom_attribute_defs:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: absent
     attribute_key: sample_5
   register: remove_attrib_def
@@ -133,19 +82,4 @@
 - assert:
     that:
       - "not remove_attrib_def.changed"
-      - "'sample_5' not in remove_attrib_def.instance"
-
-- name: list attribute definition
-  vmware_guest_custom_attribute_defs:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    state: list
-  register: list_attrib_def
-
-- debug: var=list_attrib_def
-
-- assert:
-    that:
-      - "not list_attrib_def.changed"
+      - "'sample_5' not in remove_attrib_def.custom_attribute_defs"

--- a/test/integration/targets/vmware_guest_custom_attributes/aliases
+++ b/test/integration/targets/vmware_guest_custom_attributes/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_custom_attributes/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_custom_attributes/tasks/main.yml
@@ -4,51 +4,21 @@
 
 # TODO: Current pinned version of vcsim does not support custom fields
 # commenting testcase below
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- set_fact: dc1="{{ datacenters['json'][0] }}"
-
-- name: get a list of virtual machines from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vms
-
-- set_fact: vm1="{{ vms['json'][0] }}"
-
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 - name: Add custom attribute to the given virtual machine
   vmware_guest_custom_attributes:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
-    name: "{{ vm1 | basename }}"
-    folder: "{{ vm1 | dirname }}"
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    folder: "{{ f0 }}"
     state: present
     attributes:
       - name: 'sample_1'
@@ -59,21 +29,21 @@
         value: 'sample_3_value'
   register: guest_facts_0001
 
-- debug: msg="{{ guest_facts_0001 }}"
+- debug: var=guest_facts_0001
 
 - assert:
     that:
-      - "guest_facts_0001.changed"
+      - guest_facts_0001 is changed
 
 - name: Add custom attribute to the given virtual machine again
   vmware_guest_custom_attributes:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
-    name: "{{ vm1 | basename }}"
-    folder: "{{ vm1 | dirname }}"
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    folder: "{{ f0 }}"
     state: present
     attributes:
       - name: 'sample_1'
@@ -84,21 +54,21 @@
         value: 'sample_3_value'
   register: guest_facts_0002
 
-- debug: msg="{{ guest_facts_0002 }}"
+- debug: var=guest_facts_0002
 
 - assert:
     that:
-      - "not guest_facts_0002.changed"
+      - not (guest_facts_0002 is changed)
 
 - name: Remove custom attribute to the given virtual machine
   vmware_guest_custom_attributes:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
-    name: "{{ vm1 | basename }}"
-    folder: "{{ vm1 | dirname }}"
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    folder: "{{ f0 }}"
     state: absent
     attributes:
       - name: 'sample_1'
@@ -115,24 +85,26 @@
 # TODO: vcsim returns duplicate values so removing custom attributes
 # results in change. vCenter show correct behavior. Commenting this
 # till this is supported by vcsim.
-#- name: Remove custom attribute to the given virtual machine again
-#  vmware_guest_custom_attributes:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    datacenter: "{{ dc1 | basename }}"
-#    name: "{{ vm1 | basename }}"
-#    folder: "{{ vm1 | dirname }}"
-#    state: absent
-#    attributes:
-#      - name: 'sample_1'
-#      - name: 'sample_2'
-#      - name: 'sample_3'
-#  register: guest_facts_0005
+- when: vcsim is not defined
+  block:
+    - name: Remove custom attribute to the given virtual machine again
+      vmware_guest_custom_attributes:
+        validate_certs: False
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        datacenter: "{{ dc1 }}"
+        name: "{{ infra.vm_list[0] }}"
+        folder: "{{ f0 }}"
+        state: absent
+        attributes:
+          - name: 'sample_1'
+          - name: 'sample_2'
+          - name: 'sample_3'
+      register: guest_facts_0005
 
-#- debug: msg="{{ guest_facts_0005 }}"
+    - debug: var=guest_facts_0005
 
-#- assert:
-#    that:
-#      - "not guest_facts_0005.changed"
+    - assert:
+        that:
+          - not (guest_facts_0005 is changed)

--- a/test/integration/targets/vmware_guest_customization_facts/aliases
+++ b/test/integration/targets/vmware_guest_customization_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_customization_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_customization_facts/tasks/main.yml
@@ -4,41 +4,37 @@
 
 # TODO: vcsim does not support customizationspecmanager related functionalities
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+      setup_datastore: true
+      setup_virtualmachines: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  - &vm_guest_facts
+    name: Gather facts about given customization spec
+    vmware_guest_customization_facts:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+    register: vm_custom_spec_facts
 
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=1
-  register: vcsim_instance
+  - debug:
+      var: vm_custom_spec_facts
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+  - assert:
+      that:
+        - "not vm_custom_spec_facts.changed"
 
-- debug: var=vcsim_instance
-- debug: var=vmlist
+  - <<: *vm_guest_facts
+    name: Gather facts about given customization spec in check module
 
-- name: Gather facts about given customization spec
-  vmware_guest_customization_facts:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    spec_name: sample_spec
-  register: vm_custom_spec_facts
+  - debug:
+      var: vm_custom_spec_facts
 
-- debug: var=vm_custom_spec_facts
-
-- assert:
-    that:
-      - "not vm_custom_spec_facts.changed"
+  - assert:
+      that:
+        - "not vm_custom_spec_facts.changed"

--- a/test/integration/targets/vmware_guest_disk_facts/aliases
+++ b/test/integration/targets/vmware_guest_disk_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
@@ -2,49 +2,22 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# TODO: vcsim does not support disk information
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-
-- debug: var=vmlist
-
-- set_fact:
-   vm1: "{{ vmlist['json'][0] }}"
-
-- debug: var=vm1
 
 - name: Gather facts about virtual machine disks
-  vmware_guest_disk_facts:
+  vmware_guest_disk_facts: &get_facts
     validate_certs: no
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ vm1 }}"
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ infra.vm_list[0] }}"
+    datacenter: '{{ dc1 }}'
   register: disk_facts
 
 - debug:
@@ -57,12 +30,7 @@
 
 - name: Gather facts about virtual machine disks in check mode
   vmware_guest_disk_facts:
-    validate_certs: no
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ vm1 }}"
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    <<: *get_facts
   register: disk_facts
   check_mode: yes
 

--- a/test/integration/targets/vmware_guest_facts/aliases
+++ b/test/integration/targets/vmware_guest_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -2,70 +2,36 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # Copyright: (c) 2018, James E. King III (@jeking3) <jking@apache.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
----
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- set_fact: dc1="{{ datacenters['json'][0] }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- set_fact: h1="{{ hosts['json'][0] }}"
-
-- name: get a list of virtual machines from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vms
-
-- set_fact: vm1="{{ vms['json'][0] }}"
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
 # Testcase 0001: Get details about virtual machines
 - name: get list of facts about virtual machines
   vmware_guest_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
-    name: "{{ vm1 | basename }}"
-    folder: "{{ vm1 | dirname }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    folder: "{{ f0 }}"
   register: guest_facts_0001
 
-- debug: var=guest_facts_0001
+- debug:
+    var: guest_facts_0001
 
 - assert:
     that:
-      - "guest_facts_0001['instance']['hw_name'] == vm1 | basename"
+      - "guest_facts_0001['instance']['hw_name'] == infra.vm_list[0]"
       - "guest_facts_0001['instance']['hw_product_uuid'] is defined"
       - "guest_facts_0001['instance']['hw_cores_per_socket'] is defined"
       - "guest_facts_0001['instance']['hw_datastores'] is defined"
-      - "guest_facts_0001['instance']['hw_esxi_host'] == h1 | basename"
+      - "guest_facts_0001['instance']['hw_esxi_host'] is defined"
       - "guest_facts_0001['instance']['hw_files'] is defined"
       - "guest_facts_0001['instance']['hw_guest_ha_state'] is defined"
       - "guest_facts_0001['instance']['hw_is_template'] is defined"
@@ -80,28 +46,30 @@
 
 - set_fact: vm1_instance_uuid="{{ guest_facts_0001['instance']['instance_uuid'] }}"
 
-- debug: var=vm1_uuid
+- debug:
+    var: vm1_uuid
 
 # Testcase 0002: Get details about virtual machines using UUID
 - name: get list of facts about virtual machines using UUID
   vmware_guest_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     uuid: "{{ vm1_uuid }}"
   register: guest_facts_0002
 
-- debug: var=guest_facts_0002
+- debug:
+    var: guest_facts_0002
 
-- name: "Get specific details about virtual machines using the vsphere output schema"
+- name: Get specific details about virtual machines using the vsphere output schema
   vmware_guest_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     uuid: "{{ vm1_uuid }}"
     schema: vsphere
     properties:
@@ -111,11 +79,12 @@
       - summary.runtime.connectionState
   register: guest_facts_0002b
 
-- debug: var=guest_facts_0002b
+- debug:
+    var: guest_facts_0002b
 
 - assert:
     that:
-      - "guest_facts_0002['instance']['hw_name'] == vm1 | basename"
+      - "guest_facts_0002['instance']['hw_name'] == infra.vm_list[0]"
       - "guest_facts_0002['instance']['hw_product_uuid'] is defined"
       - "guest_facts_0002['instance']['hw_product_uuid'] == vm1_uuid"
       - "guest_facts_0002['instance']['hw_cores_per_socket'] is defined"
@@ -128,88 +97,83 @@
 - name: get empty list of snapshots from virtual machine using UUID
   vmware_guest_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     uuid: "{{ vm1_uuid }}"
   register: guest_facts_0003
 
-- debug: var=guest_facts_0003
+- debug:
+    var: guest_facts_0003
 
 - assert:
     that:
       - "guest_facts_0003['instance']['snapshots']|length == 0"
       - "guest_facts_0003['instance']['current_snapshot'] is none"
 
-# Commenting as this is failing right now - 15 Dec 2017
 # Testcase 0004: Get details about virtual machines with two snapshots using UUID
-#- name: Create first snapshot
-#  vmware_guest_snapshot:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    datacenter: "{{ dc1 | basename }}"
-#    name: "{{ vm1 | basename }}"
-#    folder: "{{ vm1 | dirname }}"
-#    state: present
-#    snapshot_name: snap1
+- name: Create first snapshot
+  vmware_guest_snapshot: &vm_snap
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    folder: "{{ f0 }}"
+    state: present
+    snapshot_name: snap1
 
-#- name: Create second snapshot
-#  vmware_guest_snapshot:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    datacenter: "{{ dc1 | basename }}"
-#    name: "{{ vm1 | basename }}"
-#    folder: "{{ vm1 | dirname }}"
-#    state: present
-#    snapshot_name: snap2
+- name: Create second snapshot
+  vmware_guest_snapshot:
+    <<: *vm_snap
+    snapshot_name: snap2
 
-#- name: get list of snapshots from virtual machine using UUID
-#  vmware_guest_facts:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    datacenter: "{{ dc1 | basename }}"
-#    uuid: "{{ vm1_uuid }}"
-#  register: guest_facts_0004
+- name: get list of snapshots from virtual machine using UUID
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    uuid: "{{ vm1_uuid }}"
+  register: guest_facts_0004
 
-#- debug: var=guest_facts_0004
+- debug:
+    var: guest_facts_0004
 
-#- assert:
-#    that:
-#      - "guest_facts_0004['instance']['snapshots'] is defined"
-#      - "guest_facts_0004['instance']['snapshots'][0]['name'] == 'snap1'"
-#      - "guest_facts_0004['instance']['snapshots'][1]['name'] == 'snap2'"
-#      - "guest_facts_0004['instance']['current_snapshot']['name'] == 'snap2'"
-#      - "guest_facts_0002['instance']['hw_folder'] == vm1 | dirname"
+- assert:
+   that:
+     - "guest_facts_0004['instance']['snapshots'] is defined"
+     - "guest_facts_0004['instance']['snapshots'][0]['name'] == 'snap1'"
+     - "guest_facts_0004['instance']['snapshots'][1]['name'] == 'snap2'"
+     - "guest_facts_0004['instance']['current_snapshot']['name'] == 'snap2'"
+     - "guest_facts_0002['instance']['hw_folder'] is defined"
 
 # Testcase 0005: Get details about virtual machines using UUID
 - name: get list of facts about virtual machines using instance UUID
   vmware_guest_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ dc1 | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     uuid: "{{ vm1_instance_uuid }}"
     use_instance_uuid: True
   register: guest_facts_0005
 
-- debug: msg="{{ guest_facts_0005 }}"
+- debug:
+    msg: "{{ guest_facts_0005 }}"
 
 - assert:
     that:
-      - "guest_facts_0005['instance']['hw_name'] == vm1 | basename"
+      - "guest_facts_0005['instance']['hw_name'] == infra.vm_list[0]"
       - "guest_facts_0005['instance']['hw_product_uuid'] is defined"
       - "guest_facts_0005['instance']['hw_product_uuid'] == vm1_uuid"
       - "guest_facts_0005['instance']['hw_cores_per_socket'] is defined"
       - "guest_facts_0005['instance']['hw_datastores'] is defined"
-      - "guest_facts_0005['instance']['hw_esxi_host'] == h1 | basename"
+      - "guest_facts_0005['instance']['hw_esxi_host'] is defined"
       - "guest_facts_0005['instance']['hw_files'] is defined"
       - "guest_facts_0005['instance']['hw_guest_ha_state'] is defined"
       - "guest_facts_0005['instance']['hw_is_template'] is defined"

--- a/test/integration/targets/vmware_guest_find/aliases
+++ b/test/integration/targets/vmware_guest_find/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_find/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_find/tasks/main.yml
@@ -2,52 +2,21 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: wait for flask server
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: wait for vcsim server
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim   
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-- debug: var=vmlist
-
-# vcsim embeds the datacenter into the path and
-# the VM name, so it can be chopped out for later
-# use or verification
-- name: show the datacenter(s)
-  debug:
-    msg: "{{ (item|basename).split('_')[0] }}"
-  with_items: "{{ vmlist['json'] }}"
-
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 - name: find folders for each vm
   vmware_guest_find:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ item|basename }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-  with_items: "{{ vmlist['json'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ item }}"
+    datacenter: "{{ dc1 }}"
+  with_items: "{{ infra.vm_list }}"
   register: folders
 
 - debug: var=item
@@ -62,28 +31,31 @@
         - "{{ item['folders']|length == 1 }}"
   with_items: "{{ folders.results }}"
 
-# Testcase 2: Find VMS using UUID
-- name: get details about VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_vm_info
-  register: vms_detail_list
+- name: get fact of the first VM
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    folder: "{{ f0 }}"
+  register: guest_facts_0001
+
+- debug: var=guest_facts_0001
 
 - name: find folders for each vm using UUID
   vmware_guest_find:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    uuid: "{{ vms_detail_list['json'][item|basename]['UUID'] }}"
-    datacenter: "{{ (item|basename).split('_')[0] }}"
-  with_items: "{{ vmlist['json'] }}"
-  register: folders_uuid
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    uuid: "{{ guest_facts_0001['instance']['hw_product_uuid'] }}"
+  register: folder_uuid
 
-- debug: var=item
-  with_items: "{{ folders_uuid.results }}"
+- debug: var=folder_uuid
 
 - assert:
     that:
-        - "{{ 'folders' in item }}"
-        - "{{ item['folders']|length == 1 }}"
-  with_items: "{{ folders_uuid.results }}"
+        - "{{ 'folders' in folder_uuid }}"
+        - "{{ folder_uuid['folders']|length == 1 }}"

--- a/test/integration/targets/vmware_guest_move/aliases
+++ b/test/integration/targets/vmware_guest_move/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_move/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_move/tasks/main.yml
@@ -1,47 +1,34 @@
 # Test code for the vmware_guest_move module
 # Copyright: (c) 2018, Jose Angel Munoz <josea.munoz@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?folder=2&dc=2
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
-
-- name: get a list of virtual machines from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vms
-
-- set_fact: vm1="{{ vms['json'][0] }}"
+- name: Create a VM folder on given Datacenter
+  vcenter_folder:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ dc1 }}'
+    folder_name: 'f1'
+    folder_type: vm
+    state: present
+    validate_certs: no
 
 # Testcase 0001: Move vm and get changed status
 - name: Move VM (Changed)
   vmware_guest_move:
     validate_certs: false
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ (vm1|basename).split('_')[0] }}"
-    name: "{{ vm1|basename }}"
-    dest_folder: F1/DC1/vm/F1
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    dest_folder: '/F0/DC0/vm/f1'
   register: vm_facts_0001
 
 
@@ -49,12 +36,12 @@
 - name: Move VM (OK)
   vmware_guest_move:
     validate_certs: false
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter: "{{ (vm1|basename).split('_')[0] }}"
-    name: "{{ vm1|basename }}"
-    dest_folder: F1/DC1/vm/F1
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    name: "{{ infra.vm_list[0] }}"
+    dest_folder: 'F0/DC0/vm/f1'
   register: vm_facts_0002
 
 - debug:
@@ -63,11 +50,7 @@
 - debug:
     msg: "{{ vm_facts_0002 }}"
 
-- name: get all VMs
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vms_diff
-
-- name: Difference
-  debug:
-    var: vms_diff.json | difference(vms.json)
+- assert:
+    that:
+      - vm_facts_0001.changed
+      - not vm_facts_0002.changed

--- a/test/integration/targets/vmware_guest_powerstate/aliases
+++ b/test/integration/targets/vmware_guest_powerstate/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -2,5 +2,26 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- include: poweroff_d1_c1_f0.yml
-- include: poweroff_d1_c1_f1.yml
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
+- name: set state to poweroff the first VM
+  vmware_guest_powerstate:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ infra.vm_list[0] }}"
+    state: powered-off
+    folder: '/dc1/vm/f0'
+  register: poweroff_d1_c1_f0
+
+- debug: var=poweroff_d1_c1_f0
+
+- name: make sure change was made
+  assert:
+    that:
+        - poweroff_d1_c1_f0.changed

--- a/test/integration/targets/vmware_guest_snapshot/aliases
+++ b/test/integration/targets/vmware_guest_snapshot/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
@@ -1,225 +1,178 @@
- - name: Wait for Flask controller to come up online
-   wait_for:
-     host: "{{ vcsim }}"
-     port: 5000
-     state: started
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
- - name: kill vcsim
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/killall' }}"
- - name: start vcsim with no folders
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=1' }}"
-   register: vcsim_instance
+# Test0001: Try to delete the non-existent snapshot
+- name: 0001 - Delete non-existent snapshot
+  vmware_guest_snapshot:
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ infra.vm_list[0] }}"
+    state: absent
+    snapshot_name: snap_a
 
- - name: Wait for Flask controller to come up online
-   wait_for:
-     host: "{{ vcsim }}"
-     port: 443
-     state: started
+# Test0002: Create two snapshots
+- name: 0002 - Create snapshot
+  vmware_guest_snapshot:
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ infra.vm_list[0] }}"
+    state: present
+    snapshot_name: "snap_{{item}}"
+    description: "snap named {{item}}"
+  with_items:
+    - a
+    - b
 
- - name: get a list of VMS from vcsim
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
-   register: vmlist
+- when: vcsim is not defined
+  block:
+# Test0003: Reanme a to c
+  - name: 0003 - Rename snapshot
+    vmware_guest_snapshot:
+      validate_certs: False
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      datacenter: "{{ dc1 }}"
+      folder: "{{ f0 }}"
+      name: "{{ infra.vm_list[0] }}"
+      state: present
+      snapshot_name: snap_a
+      new_snapshot_name: snap_c
 
- - set_fact:
-     vm1: "{{ vmlist['json'][0] }}"
+# Test0004: Create snap_a again
+- name: 0004 - Re-create snapshot a
+  vmware_guest_snapshot:
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ infra.vm_list[0] }}"
+    state: present
+    snapshot_name: snap_a
+    description: "snap named a"
 
- - name: get a list of datacenters from vcsim
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DC' }}"
-   register: datacenters
+# Test0005: Change description of snap_c
+- name: 0005 - Change description of snap_c
+  vmware_guest_snapshot:
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ infra.vm_list[0] }}"
+    state: present
+    snapshot_name: snap_c
+    new_description: "renamed to snap_c from snap_a"
 
- - set_fact:
-     dc1: "{{ datacenters['json'][0] }}"
+- when: vcsim is not defined
+  block:
+# Test0006: Delete snap_b with child remove
+  - name: 0006 - Delete snap_b with child remove
+    vmware_guest_snapshot:
+      validate_certs: False
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      datacenter: "{{ dc1 }}"
+      folder: "{{ f0 }}"
+      name: "{{ infra.vm_list[0] }}"
+      state: absent
+      snapshot_name: snap_b
+      remove_children: True
 
- - debug: var=vcsim_instance
- - debug: var=vmlist
- - debug: var=vm1
- - debug: var=dc1
+  # Test0007: Delete all snapshots
+  - name: 0007 - Delete all snapshots
+    vmware_guest_snapshot:
+      validate_certs: False
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      datacenter: "{{ dc1 }}"
+      folder: "{{ f0 }}"
+      name: "{{ infra.vm_list[0] }}"
+      state: remove_all
 
- # Test0001: Try to delete the non-existent snapshot
- - name: 0001 - Delete non-existent snapshot
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: absent
-     snapshot_name: snap_a
+# Test0008: Create snap_a again and revert to it
+- name: 0008 - Re-create snapshot a
+  vmware_guest_snapshot:
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ infra.vm_list[0] }}"
+    state: present
+    snapshot_name: snap_a
+    description: "snap named a"
 
- # Test0002: Create two snapshots
- - name: 0002 - Create snapshot
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: present
-     snapshot_name: "snap_{{item}}"
-     description: "snap named {{item}}"
-   with_items:
-     - a
-     - b
+- when: vcsim is not defined
+  block:
+  - name: 0008 - Revert to snap_a
+    vmware_guest_snapshot:
+      validate_certs: False
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      datacenter: "{{ dc1 }}"
+      folder: "{{ f0 }}"
+      name: "{{ infra.vm_list[0] }}"
+      state: revert
+      snapshot_name: snap_a
 
- # Test0003: Reanme a to c
- - name: 0003 - Rename snapshot
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: present
-     snapshot_name: snap_a
-     new_snapshot_name: snap_c
+# Test0009: Create snap_a and check in result
+- name: 0009 - create snapshot a
+  vmware_guest_snapshot:
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ infra.vm_list[0] }}"
+    state: present
+    snapshot_name: snap_a
+    description: "snap named a"
+  register: snapshot_details
 
- # Test0004: Create snap_a again
- - name: 0004 - Re-create snapshot a
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: present
-     snapshot_name: snap_a
-     description: "snap named a"
+- debug: var=snapshot_details
 
- # Test0005: Change description of snap_c
- - name: 0005 - Change description of snap_c
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: present
-     snapshot_name: snap_c
-     new_description: "renamed to snap_c from snap_a"
+- name: Check if snapshot details available or not
+  assert:
+    that:
+        - "snapshot_details['msg'] == 'Snapshot named [snap_a] already exists and is current.'"
 
- # Test0006: Delete snap_b with child remove
- - name: 0006 - Delete snap_b with child remove
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: absent
-     snapshot_name: snap_b
-     remove_children: True
+# Test0011: Failure sceanrios - when name and UUID is not specified
+- name: 0011 - name and UUID is missing
+  vmware_guest_snapshot:
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
+    state: present
+    snapshot_name: snap_a
+    description: "snap named a"
+  register: snapshot_failure_details
+  ignore_errors: yes
 
- # Test0007: Delete all snapshots
- - name: 0007 - Delete all snapshots
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: remove_all
-
- # Test0008: Create snap_a again and revert to it
- - name: 0008 - Re-create snapshot a
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: present
-     snapshot_name: snap_a
-     description: "snap named a"
-
- - name: 0008 - Revert to snap_a
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: revert
-     snapshot_name: snap_a
-
- # Test0009: Create snap_a and check in result
- - name: 0009 - create snapshot a
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-     name: "{{ vm1 | basename }}"
-     state: present
-     snapshot_name: snap_a
-     description: "snap named a"
-   register: snapshot_details
-
- - name: Check if snapshot details available or not
-   assert:
-     that:
-         - "snapshot_details.results['current_snapshot']['name'] == 'snap_a'"
-
- # Test0010: Failure sceanrios
- - name: 0010 - Folder is missing
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     name: "{{ vm1 | basename }}"
-     state: present
-     snapshot_name: snap_a
-     description: "snap named a"
-   register: snapshot_failure_details
-   ignore_errors: yes
-
- - name: Check if error is shown
-   assert:
-     that:
-         - "'parameters are required together: name, folder' in snapshot_failure_details['msg']"
-         - "snapshot_failure_details.changed == false"
-
- # Test0011: Failure sceanrios - when name and UUID is not specified
- - name: 0011 - name and UUID is missing
-   vmware_guest_snapshot:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     state: present
-     snapshot_name: snap_a
-     description: "snap named a"
-   register: snapshot_failure_details
-   ignore_errors: yes
-
- - name: Check if error is shown
-   assert:
-     that:
-         - "'one of the following is required: name, uuid' in snapshot_failure_details['msg']"
-         - "snapshot_failure_details.changed == false"
+- name: Check if error is shown
+  assert:
+    that:
+        - "'one of the following is required: name, uuid' in snapshot_failure_details['msg']"
+        - "snapshot_failure_details.changed == false"

--- a/test/integration/targets/vmware_guest_snapshot_facts/aliases
+++ b/test/integration/targets/vmware_guest_snapshot_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_snapshot_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_snapshot_facts/tasks/main.yml
@@ -3,60 +3,26 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support snapshot related functionalities
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
- - name: Wait for Flask controller to come up online
-   wait_for:
-     host: "{{ vcsim }}"
-     port: 5000
-     state: started
+- name: Gather snapshot facts about given virtual machine
+  vmware_guest_snapshot_facts:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ infra.vm_list[0] }}"
+  register: vm_snapshot_facts
 
- - name: kill vcsim
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/killall' }}"
- - name: start vcsim with no folders
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=1' }}"
-   register: vcsim_instance
+- debug: var=vm_snapshot_facts
 
- - name: Wait for Flask controller to come up online
-   wait_for:
-     host: "{{ vcsim }}"
-     port: 443
-     state: started
-
- - name: get a list of VMS from vcsim
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
-   register: vmlist
-
- - set_fact:
-     vm1: "{{ vmlist['json'][0] }}"
-
- - name: get a list of datacenters from vcsim
-   uri:
-     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DC' }}"
-   register: datacenters
-
- - set_fact:
-     dc1: "{{ datacenters['json'][0] }}"
-
- - debug: var=vcsim_instance
- - debug: var=vmlist
- - debug: var=vm1
- - debug: var=dc1
-
- - name: Gather snapshot facts about given virtual machine
-   vmware_guest_snapshot_facts:
-     validate_certs: False
-     hostname: "{{ vcsim }}"
-     username: "{{ vcsim_instance['json']['username'] }}"
-     password: "{{ vcsim_instance['json']['password'] }}"
-     datacenter: "{{ dc1 | basename }}"
-     folder: "{{ vm1 | dirname }}"
-   register: vm_snapshot_facts
-
- - debug: vm_snapshot_facts
-
- - assert:
-     that:
-       - "not vm_snapshot_facts.changed"
+- assert:
+    that:
+      - '"guest_snapshots" in vm_snapshot_facts'

--- a/test/integration/targets/vmware_guest_tools_wait/aliases
+++ b/test/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_guest_tools_wait/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_tools_wait/tasks/main.yml
@@ -2,44 +2,23 @@
 # Copyright: (c) 2017 Philippe Dellaert <philippe@dellaert.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of virtual machines from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vms
-
-- set_fact: vm1="{{ vms['json'][0] }}"
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
 - name: Power on VM1
   vmware_guest:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ vm1|basename }}"
-    datacenter: "{{ (vm1|basename).split('_')[0] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ infra.vm_list[0] }}"
+    datacenter: "{{ dc1 }}"
     state: poweredon
-    folder: "{{ vm1|dirname }}"
+    folder: "{{ f0 }}"
 
 # FixMe: govcsim does not support VMware tools status reporting
 ## Testcase 0001: Wait for VMware tools to become available by name


### PR DESCRIPTION
##### SUMMARY

Refactoring of the following roles to make use of the new
`prepare_vmware_tests` role.

- `vmware_guest`
- `vmware_guest_boot_facts`
- `vmware_guest_custom_attribute_defs`
- `vmware_guest_customization_facts`
- `vmware_guest_disk_facts`
- `vmware_guest_facts`
- `vmware_guest_find`
- `vmware_guest_move`
- `vmware_guest_powerstate`
- `vmware_guest_snapshot`
- `vmware_guest_snapshot_facts`
- `vmware_guest_tools_wait`

This patch depends on: https://github.com/ansible/ansible/pull/55719

Original PR: https://github.com/ansible/ansible/pull/54882


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
vmware
<!--- Write the short name of the module, plugin, task or feature below -->