### PR TITLE
vmware: refactoring of vmware test roles -- part5

### DIFF
--- a/test/integration/targets/vmware_host/aliases
+++ b/test/integration/targets/vmware_host/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host/tasks/main.yml
+++ b/test/integration/targets/vmware_host/tasks/main.yml
@@ -1,306 +1,175 @@
 # Test code for the vmware_host module.
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact:
-    dc1: "{{ datacenters.json[0] | basename }}"
-
-- debug: var=dc1
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- debug: var=ccr1
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-# fetch_ssl_thumbprint needs to be disabled because the host only exists in vcsim
-
 # Testcase: Add Host
-- name: add host
-  vmware_host:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: test_host_system_0001
-    esxi_username: "{{ vcsim_instance.json.username }}"
-    esxi_password: "{{ vcsim_instance.json.password }}"
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: "{{ ccr1 }}"
-    fetch_ssl_thumbprint: False
-    state: present
-  register: add_host_result
+- when: vcsim is not defined
+  block:
 
-- name: get a list of host system from vcsim after adding host system
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: host_list
+    - name: Add first ESXi Host to vCenter
+      vmware_host:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        datacenter_name: '{{ dc1 }}'
+        cluster_name: '{{ ccr1 }}'
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_username: '{{ hostvars[esxi1].ansible_user }}'
+        esxi_password: '{{ hostvars[esxi1].ansible_password }}'
+        state: present
+        validate_certs: no
+      register: readd_host_result
 
-- name: ensure host system is present
-  assert:
-    that:
-        - add_host_result is changed
-        - "{% for host in host_list.json if ((host | basename) == 'test_host_system_0001') -%} True {%- else -%} False {%- endfor %}"
+    - name: Add first ESXi Host to vCenter (again)
+      vmware_host:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        datacenter_name: '{{ dc1 }}'
+        cluster_name: '{{ ccr1 }}'
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_username: '{{ hostvars[esxi1].ansible_user }}'
+        esxi_password: '{{ hostvars[esxi1].ansible_password }}'
+        state: present
+        validate_certs: no
+      register: readd_host_result
 
-# Testcase: Add Host again
-- name: add host again
-  vmware_host:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: test_host_system_0001
-    esxi_username: "{{ vcsim_instance.json.username }}"
-    esxi_password: "{{ vcsim_instance.json.password }}"
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: "{{ ccr1 }}"
-    fetch_ssl_thumbprint: False
-    state: present
-  register: readd_host_result
+    - name: ensure precend task didn't changed anything
+      assert:
+        that:
+          - not ( readd_host_result is changed)
 
-- name: ensure precend task didn't changed anything
-  assert:
-    that:
-        - not ( readd_host_result is changed)
+    - name: add second host via add_or_reconnect
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_username: '{{ hostvars[esxi2].ansible_user }}'
+        esxi_password: '{{ hostvars[esxi2].ansible_password }}'
+        datacenter_name: "{{ dc1 }}"
+        cluster_name: "{{ ccr1 }}"
+        fetch_ssl_thumbprint: False
+        state: add_or_reconnect
+      register: add_or_reconnect_host_result
+    - name: ensure host system is present
+      assert:
+        that:
+          - add_or_reconnect_host_result is changed
 
-# Testcase: Add Host via add_or_reconnect state
-- name: add host via add_or_reconnect
-  vmware_host:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: test_host_system_0002
-    esxi_username: "{{ vcsim_instance.json.username }}"
-    esxi_password: "{{ vcsim_instance.json.password }}"
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: "{{ ccr1 }}"
-    fetch_ssl_thumbprint: False
-    state: add_or_reconnect
-  register: add_or_reconnect_host_result
+- when: vcsim is not defined
+  block:
+    - name: disconnect host 2
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        datacenter_name: "{{ dc1 }}"
+        cluster_name: "{{ ccr1 }}"
+        fetch_ssl_thumbprint: False
+        state: absent
 
-- name: get a list of host system from vcsim after adding host system
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: host_list
+    - name: remove host again
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        datacenter_name: "{{ dc1 }}"
+        cluster_name: "{{ ccr1 }}"
+        state: absent
+      register: reremove_host_result
+    - name: ensure precend task didn't changed anything
+      assert:
+        that:
+          - not ( reremove_host_result is changed)
 
-- name: ensure host system is present
-  assert:
-    that:
-        - add_or_reconnect_host_result is changed
-        - "{% for host in host_list.json if ((host | basename) == 'test_host_system_0002') -%} True {%- else -%} False {%- endfor %}"
 
 ## Testcase: Add Host to folder
 #
 # It's not possible to connect an ESXi host via vcsim.
-#
-# - name: Create host folder
-#   vcenter_folder:
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance.json.username }}"
-#     password: "{{ vcsim_instance.json.password }}"
-#     validate_certs: no
-#     datacenter: "{{ dc1 }}"
-#     folder_name: "Staging"
-#     folder_type: host
-#     state: present
-#   register: folder_results
-#
-# - debug: msg="{{ folder_results }}"
-#
-# - name: ensure folder is present
-#   assert:
-#     that:
-#         - folder_results.changed
-#
-# - name: Create host folder again
-#   vcenter_folder:
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance.json.username }}"
-#     password: "{{ vcsim_instance.json.password }}"
-#     validate_certs: no
-#     datacenter: "{{ dc1 }}"
-#     folder_name: "Staging"
-#     folder_type: host
-#     state: present
-#   register: folder_results
-#
-# - debug: msg="{{ folder_results }}"
-#
-# - name: ensure folder is present
-#   assert:
-#     that:
-#         - folder_results.changed == False
-#
-# - name: Add host to folder in check mode
-#   vmware_host:
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance.json.username }}"
-#     password: "{{ vcsim_instance.json.password }}"
-#     validate_certs: no
-#     esxi_hostname: test_host_system_0003
-#     esxi_username: "{{ vcsim_instance.json.username }}"
-#     esxi_password: "{{ vcsim_instance.json.password }}"
-#     datacenter_name: "{{ dc1 }}"
-#     folder_name: "Staging"
-#     state: present
-#   register: add_host_to_folder_result
-#   check_mode: yes
-#
-# - name: get a list of host system from vcsim after adding host system
-#   uri:
-#     url: http://{{ vcsim }}:5000/govc_find?filter=H
-#   register: host_list
-#
-# - name: ensure host system is not present
-#   assert:
-#     that:
-#         - add_host_to_folder_result is changed
-#         - not ("{% for host in host_list.json if ((host | basename) == 'test_host_system_0003') -%} True {%- else -%} False {%- endfor %}")
-#
-# - name: Add host to folder
-#   vmware_host:
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance.json.username }}"
-#     password: "{{ vcsim_instance.json.password }}"
-#     validate_certs: no
-#     esxi_hostname: test_host_system_0003
-#     esxi_username: "{{ vcsim_instance.json.username }}"
-#     esxi_password: "{{ vcsim_instance.json.password }}"
-#     datacenter_name: "{{ dc1 }}"
-#     folder_name: "Staging"
-#     state: present
-#   register: add_host_to_folder_result
-#
-# - name: get a list of host system from vcsim after adding host system
-#   uri:
-#     url: http://{{ vcsim }}:5000/govc_find?filter=H
-#   register: host_list
-#
-# - name: ensure host system is present
-#   assert:
-#     that:
-#         - add_host_to_folder_result is changed
-#         - "{% for host in host_list.json if ((host | basename) == 'test_host_system_0003') -%} True {%- else -%} False {%- endfor %}"
+- when: vcsim is not defined
+  block:
+    - name: Create host folder
+      vcenter_folder:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        datacenter: "{{ dc1 }}"
+        folder_name: "Staging"
+        folder_type: host
+        state: present
+      register: folder_results
 
-## Testcase: Reconnect Host
-#
-# ReconnectHost_Task need to be implemented in vcsim for this test to work
-# https://github.com/vmware/govmomi/tree/master/vcsim#supported-methods
-#
-#- name: reconnect host
-#  vmware_host:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    esxi_hostname: test_host_system_0001
-#    datacenter_name: "{{ dc1 }}"
-#    cluster_name: "{{ ccr1 }}"
-#    state: reconnect
-#  register: reconnect_host_result
-#
-#- name: ensure host system has been reconnected
-#  assert:
-#    that:
-#        - reconnect_host_result is changed
-#        # it would be a good idea to check the events on the host to see the reconnect
-#        # https://github.com/vmware/govmomi/blob/master/govc/USAGE.md#events
-#        # "govc events ..." need to be callable from
-#        # https://github.com/ansible/vcenter-test-container/flask_control.py
+    - debug: msg="{{ folder_results }}"
 
-## Testcase: Remove Host
-#
-# EnterMaintenanceMode_Task need to be implemented in vcsim for this test to work
-# https://github.com/vmware/govmomi/tree/master/vcsim#supported-methods
-#
-#- name: remove host
-#  vmware_host:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    esxi_hostname: test_host_system_0001
-#    datacenter_name: "{{ dc1 }}"
-#    cluster_name: "{{ ccr1 }}"
-#    state: absent
-#  register: remove_host_result
-#
-#- name: get a list of host system from vcsim after removing host system
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: host_list
-#
-#- name: ensure host system is absent
-#  assert:
-#    that:
-#        - remove_host_result is changed
-#        - "{% for host in host_list.json if ((host | basename) == 'test_host_system_0001') -%} False {%- else -%} True {%- endfor %}"
+    - name: ensure folder is present
+      assert:
+        that:
+          - folder_results.changed
 
-## Testcase: Remove Host again
-#
-# EnterMaintenanceMode_Task need to be implemented in vcsim for this test to work
-# https://github.com/vmware/govmomi/tree/master/vcsim#supported-methods
-#
-#- name: remove host again
-#  vmware_host:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    esxi_hostname: test_host_system_0001
-#    datacenter_name: "{{ dc1 }}"
-#    cluster_name: "{{ ccr1 }}"
-#    state: absent
-#  register: reremove_host_result
-#
-#- name: ensure precend task didn't changed anything
-#  assert:
-#    that:
-#        - not ( reremove_host_result is changed)
+    - name: Add host to folder in check mode
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_username: '{{ hostvars[esxi2].ansible_user }}'
+        esxi_password: '{{ hostvars[esxi2].ansible_password }}'
+        datacenter_name: "{{ dc1 }}"
+        folder_name: "/{{ dc1 }}/host/Staging"
+        state: present
+      register: add_host_to_folder_result
+      check_mode: yes
+
+    - name: ensure host system is not present
+      assert:
+        that:
+          - add_host_to_folder_result is changed
+
+    - name: Add host to folder
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_username: '{{ hostvars[esxi2].ansible_user }}'
+        esxi_password: '{{ hostvars[esxi2].ansible_password }}'
+        datacenter_name: "{{ dc1 }}"
+        folder_name: "/{{ dc1 }}/host/Staging"
+        state: present
+      register: add_host_to_folder_result
+
+    - name: ensure host system is present
+      assert:
+        that:
+          - add_host_to_folder_result is changed
+
+    - name: reconnect host
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_username: '{{ hostvars[esxi2].ansible_user }}'
+        esxi_password: '{{ hostvars[esxi2].ansible_password }}'
+        datacenter_name: "{{ dc1 }}"
+        cluster_name: "{{ ccr1 }}"
+        state: reconnect
+      register: reconnect_host_result
+
+    - name: ensure host system has been reconnected
+      assert:
+        that:
+          - reconnect_host_result is changed
+          # it would be a good idea to check the events on the host to see the reconnect
+          # https://github.com/vmware/govmomi/blob/master/govc/USAGE.md#events
+          # "govc events ..." need to be callable from
+          # https://github.com/ansible/vcenter-test-container/flask_control.py

--- a/test/integration/targets/vmware_host_acceptance/aliases
+++ b/test/integration/targets/vmware_host_acceptance/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_acceptance/tasks/main.yml
+++ b/test/integration/targets/vmware_host_acceptance/tasks/main.yml
@@ -2,74 +2,41 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# TODO: vcsim does not support Acceptance Level related to operations
+- when: False
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  - name: Change acceptance level of given hosts
+    vmware_host_acceptance:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      validate_certs: no
+      acceptance_level: vmware_certified
+      state: present
+    register: host_acceptance_facts
+  - debug: var=host_acceptance_facts
+  - assert:
+      that:
+        - host_acceptance_facts.facts is defined
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Change acceptance level of given hosts
-  vmware_host_acceptance:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-    acceptance_level: vmware_certified
-    state: present
-  register: host_acceptance_facts
-
-- debug: var=host_acceptance_facts
-
-- assert:
-    that:
-      - host_acceptance_facts.facts is defined
-
-- name: Change acceptance level of given hosts in check mode
-  vmware_host_acceptance:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-    acceptance_level: vmware_certified
-    state: present
-  register: host_acceptance_facts_check_mode
-  check_mode: yes
-
-- debug: var=host_acceptance_facts_check_mode
-
-- assert:
-    that:
-      - host_acceptance_facts_check_mode.facts is defined
+  - name: Change acceptance level of given hosts in check mode
+    vmware_host_acceptance:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      validate_certs: no
+      acceptance_level: vmware_certified
+      state: present
+    register: host_acceptance_facts_check_mode
+    check_mode: yes
+  - debug: var=host_acceptance_facts_check_mode
+  - assert:
+      that:
+        - host_acceptance_facts_check_mode.facts is defined

--- a/test/integration/targets/vmware_host_active_directory/aliases
+++ b/test/integration/targets/vmware_host_active_directory/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_active_directory/tasks/main.yml
+++ b/test/integration/targets/vmware_host_active_directory/tasks/main.yml
@@ -2,125 +2,86 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
 # Active Directory domain isn't available
 
-- name: Join an AD domain in check mode
-  vmware_host_active_directory:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    ad_domain: example.local
-    ad_user: adjoin
-    ad_password: Password123$
-    ad_state: present
-    validate_certs: no
-  register: host_active_directory_facts_check_mode
-  check_mode: yes
+- when:
+    - vcsim is not defined
+    - active_directory_domain is defined
+  block:
+    - name: Join an AD domain in check mode
+      vmware_host_active_directory:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        ad_domain: '{{ active_directory_domain }}'
+        ad_user: '{{ active_directory_user }}'
+        ad_password: '{{ active_directory_password }}'
+        ad_state: present
+        validate_certs: no
+      register: host_active_directory_facts_check_mode
+      check_mode: yes
 
-- debug: var=host_active_directory_facts_check_mode
+    - debug: var=host_active_directory_facts_check_mode
 
-- assert:
-    that:
-      - host_active_directory_facts_check_mode is defined
-      - host_active_directory_facts_check_mode.changed
+    - assert:
+        that:
+          - host_active_directory_facts_check_mode is defined
+          - host_active_directory_facts_check_mode.changed
 
-- name: Join an AD domain
-  vmware_host_active_directory:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    ad_domain: example.local
-    ad_user: adjoin
-    ad_password: Password123$
-    ad_state: present
-    validate_certs: no
-  register: host_active_directory_facts
+    - name: Join an AD domain
+      vmware_host_active_directory:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        ad_domain: example.local
+        ad_user: adjoin
+        ad_password: Password123$
+        ad_state: present
+        validate_certs: no
+      register: host_active_directory_facts
+      ignore_errors: true
 
-- debug: var=host_active_directory_facts
+    - debug: var=host_active_directory_facts
 
-- assert:
-    that:
-      - host_active_directory_facts is defined
-      - host_active_directory_facts.changed
+    - assert:
+        that:
+          - host_active_directory_facts is defined
+          - host_active_directory_facts.changed
 
-- name: Leave AD domain in check mode
-  vmware_host_active_directory:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    ad_state: absent
-    validate_certs: no
-  register: host_active_directory_facts_2_check_mode
-  check_mode: yes
+    - name: Leave AD domain in check mode
+      vmware_host_active_directory:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        ad_state: absent
+        validate_certs: no
+      register: host_active_directory_facts_2_check_mode
+      check_mode: yes
 
-- debug: var=host_active_directory_facts_2_check_mode
+    - debug: var=host_active_directory_facts_2_check_mode
 
-- assert:
-    that:
-      - host_active_directory_facts_2_check_mode is defined
-      - host_active_directory_facts_2_check_mode.changed
+    - assert:
+        that:
+          - host_active_directory_facts_2_check_mode is defined
+          - host_active_directory_facts_2_check_mode.changed
 
-- name: Leave AD domain
-  vmware_host_active_directory:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    ad_state: absent
-    validate_certs: no
-  register: host_active_directory_facts_2
+    - name: Leave AD domain
+      vmware_host_active_directory:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        ad_state: absent
+        validate_certs: no
+      register: host_active_directory_facts_2
+      ignore_errors: true
 
-- debug: var=host_active_directory_facts_2
+    - debug: var=host_active_directory_facts_2
 
-- assert:
-    that:
-      - host_active_directory_facts_2 is defined
-      - host_active_directory_facts_2.changed
+    - assert:
+        that:
+          - host_active_directory_facts_2 is defined
+          - host_active_directory_facts_2.changed

--- a/test/integration/targets/vmware_host_capability_facts/aliases
+++ b/test/integration/targets/vmware_host_capability_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_capability_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_capability_facts/tasks/main.yml
@@ -4,75 +4,35 @@
 
 # TODO: vcsim does not support host system capabilities
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  - name: Gather capability facts for all ESXi host from given cluster
+    vmware_host_capability_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: False
+      cluster_name: "{{ ccr1 }}"
+    register: capability_0001_results
+  - assert:
+      that:
+        - not (capability_0001_results is changed)
+        - capability_0001_results.hosts_capability_facts is defined
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
-- name: Gather capability facts for all ESXi host from given cluster
-  vmware_host_capability_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: False
-    cluster_name: "{{ ccr1 }}"
-  register: capability_0001_results
-
-- assert:
-    that:
-      - "not capability_0001_results.changed"
-      - "capability_0001_results.hosts_capability_facts is defined"
-
-- name: Gather capability facts for ESXi host
-  vmware_host_capability_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: False
-    esxi_hostname: "{{ host1 }}"
-  register: capability_0002_results
-
-- assert:
-    that:
-      - "not capability_0002_results.changed"
-      - "capability_0002_results.hosts_capability_facts is defined"
+  - name: Gather capability facts for ESXi host
+    vmware_host_capability_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: False
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    register: capability_0002_results
+  - assert:
+      that:
+        - not (capability_0002_results is changed)
+        - capability_0002_results.hosts_capability_facts is defined

--- a/test/integration/targets/vmware_host_config_facts/aliases
+++ b/test/integration/targets/vmware_host_config_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_config_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_facts/tasks/main.yml
@@ -1,85 +1,33 @@
 # Test code for the vmware_host_config_facts module.
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a cluster
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
 - name: gather facts about all hosts in given cluster
   vmware_host_config_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     cluster_name: "{{ ccr1 }}"
   register: all_hosts_result
+
+- debug:
+    var: all_hosts_result
 
 - name: ensure facts are gathered for all hosts
   assert:
     that:
         - all_hosts_result.hosts_facts
 
-- name: gather facts about a given host
-  vmware_host_config_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
-  register: single_hosts_result
-
-- name: ensure facts are gathered for all hosts
-  assert:
-    that:
-        - single_hosts_result.hosts_facts
-
 - name: gather facts about all hosts in given cluster in check mode
   vmware_host_config_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     cluster_name: "{{ ccr1 }}"
   register: all_hosts_result_check_mode
@@ -90,17 +38,31 @@
     that:
         - all_hosts_result_check_mode.hosts_facts
 
-- name: gather facts about a given host in check mode
-  vmware_host_config_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
-  register: single_hosts_result_check_mode
-  check_mode: yes
+- when: vcsim is not defined
+  block:
+  - name: gather facts about a given host in check mode
+    vmware_host_config_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      esxi_hostname: "{{ hostvars[esxi1].ansible_host }}"
+    register: single_hosts_result_check_mode
+    check_mode: yes
+  - name: ensure facts are gathered for all hosts
+    assert:
+      that:
+          - single_hosts_result_check_mode.hosts_facts
 
-- name: ensure facts are gathered for all hosts
-  assert:
-    that:
-        - single_hosts_result_check_mode.hosts_facts
+  - name: gather facts about a given host
+    vmware_host_config_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      esxi_hostname: "{{ hostvars[esxi1].ansible_host }}"
+    register: single_hosts_result
+  - name: ensure facts are gathered for all hosts
+    assert:
+      that:
+          - single_hosts_result.hosts_facts

--- a/test/integration/targets/vmware_host_config_manager/aliases
+++ b/test/integration/targets/vmware_host_config_manager/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_config_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_manager/tasks/main.yml
@@ -2,115 +2,89 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Change an invalid key
+  vmware_host_config_manager:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    cluster_name: "{{ ccr1 }}"
+    options:
+      'This.Is.No.Where': 'verbose'
+  failed_when: False
+  register: invalid_key
+- debug: var=invalid_key
+- name: ensure we raise the correct error
+  assert:
+    that:
+      - '"Unsupported option This.Is.No.Where" in invalid_key.msg'
+
 # TODO: vcsim does not support update host configuartion
+- when: vcsim is not defined
+  block:
+  - name: Change facts about all hosts in given cluster
+    vmware_host_config_manager:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      cluster_name: "{{ ccr1 }}"
+      options:
+        'Config.HostAgent.log.level': 'verbose'
+      validate_certs: no
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+  - name: Change facts about a given host
+    vmware_host_config_manager:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      options:
+        'Config.HostAgent.log.level': 'info'
+      validate_certs: no
+    register: host_result
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  - debug: var=host_result
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+  - name: ensure change was applied
+    assert:
+      that:
+          - host_result is changed
 
-- debug:
-    var: vcsim_instance
+  - name: Change facts about all hosts in given cluster in check mode
+    vmware_host_config_manager:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      cluster_name: "{{ ccr1 }}"
+      options:
+        'Config.HostAgent.log.level': 'verbose'
+      validate_certs: no
+    register: all_hosts_result_check_mode
+    check_mode: yes
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+  - name: ensure changes are done to all hosts
+    assert:
+      that:
+          - all_hosts_result_check_mode.changed
 
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
+  - name: Change facts about a given host in check mode
+    vmware_host_config_manager:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      options:
+        'Config.HostAgent.log.level': 'info'
+      validate_certs: no
+    register: host_result_check_mode
+    check_mode: yes
 
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
-- name: Change facts about all hosts in given cluster
-  vmware_host_config_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    cluster_name: "{{ ccr1 }}"
-    options:
-      'Config.HostAgent.log.level': 'verbose'
-    validate_certs: no
-  register: all_hosts_result
-
-- name: ensure changes are done to all hosts
-  assert:
-    that:
-        - all_hosts_result.changed
-
-- name: Change facts about a given host
-  vmware_host_config_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    options:
-      'Config.HostAgent.log.level': 'info'
-    validate_certs: no
-  register: host_result
-
-- name: ensure changes are done to given hosts
-  assert:
-    that:
-        - all_hosts_result.changed
-
-- name: Change facts about all hosts in given cluster in check mode
-  vmware_host_config_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    cluster_name: "{{ ccr1 }}"
-    options:
-      'Config.HostAgent.log.level': 'verbose'
-    validate_certs: no
-  register: all_hosts_result_check_mode
-  check_mode: yes
-
-- name: ensure changes are done to all hosts
-  assert:
-    that:
-        - all_hosts_result_check_mode.changed
-
-- name: Change facts about a given host in check mode
-  vmware_host_config_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    options:
-      'Config.HostAgent.log.level': 'info'
-    validate_certs: no
-  register: host_result_check_mode
-  check_mode: yes
-
-- name: ensure changes are done to given hosts
-  assert:
-    that:
-        - all_hosts_result_check_mode.changed
+  - name: ensure changes are done to given hosts
+    assert:
+      that:
+          - all_hosts_result_check_mode.changed

--- a/test/integration/targets/vmware_host_dns_facts/aliases
+++ b/test/integration/targets/vmware_host_dns_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
@@ -1,58 +1,17 @@
 # Test code for the vmware_host_dns_facts module.
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- debug: var=ccr1
-
-- name: get a list of Hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a cluster
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
 
 - name: gather DNS facts about all hosts in given cluster
   vmware_host_dns_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     cluster_name: "{{ ccr1 }}"
     validate_certs: no
   register: all_hosts_dns_result
@@ -65,10 +24,10 @@
 
 - name: gather DNS facts about host system
   vmware_host_dns_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     validate_certs: no
   register: all_hosts_dns_result
 
@@ -80,9 +39,9 @@
 
 - name: gather DNS facts about all hosts in given cluster in check mode
   vmware_host_dns_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     cluster_name: "{{ ccr1 }}"
     validate_certs: no
   register: all_hosts_dns_result_check_mode
@@ -96,10 +55,10 @@
 
 - name: gather DNS facts about host system in check mode
   vmware_host_dns_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     validate_certs: no
   register: all_hosts_dns_result_check_mode
   check_mode: yes

--- a/test/integration/targets/vmware_host_facts/aliases
+++ b/test/integration/targets/vmware_host_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_facts/tasks/main.yml
@@ -1,28 +1,34 @@
-- name: kill vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-- name: start vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/spawn?cluster=2' }}"
-  register: vcsim_instance
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+    - name: get host facts through a vcenter
+      vmware_host_facts:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      register: facts
+    - debug: var=facts
+    - name: verify some data,like ansible_processor
+      assert:
+        that:
+          - "'ansible_hostname' in facts['ansible_facts']"
+          - "'ansible_processor' in facts['ansible_facts']"
 
-- name: get host facts
-  vmware_host_facts:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-  register: facts
-
-- debug: var=facts
-
-- name: get host info
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/govc_host_info' }}"
-  register: host_info_result
-
-- name: verify some data,like ansible_processor
-  assert:
-    that:
-      - facts['ansible_facts']['ansible_hostname'] in host_info_result['json']
-      - facts['ansible_facts']['ansible_processor'] == host_info_result['json'][facts['ansible_facts']['ansible_hostname']]['Processor type']
+    - name: get host facts through from a host
+      vmware_host_facts:
+        validate_certs: False
+        hostname: '{{ hostvars[esxi1].ansible_host }}'
+        username: '{{ hostvars[esxi1].ansible_user }}'
+        password: '{{ hostvars[esxi1].ansible_password }}'
+      register: facts
+    - debug: var=facts
+    - name: verify some data,like ansible_processor
+      assert:
+        that:
+          - "'ansible_hostname' in facts['ansible_facts']"
+          - "'ansible_processor' in facts['ansible_facts']"

--- a/test/integration/targets/vmware_host_feature_facts/aliases
+++ b/test/integration/targets/vmware_host_feature_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_feature_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_feature_facts/tasks/main.yml
@@ -3,60 +3,22 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support host feature capabilities
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
 
 - name: Gather feature capability facts for all ESXi host from given cluster
   vmware_host_feature_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     cluster_name: "{{ ccr1 }}"
   register: capability_0001_results
+
+- debug: var=capability_0001_results
 
 - assert:
     that:
@@ -65,13 +27,15 @@
 
 - name: Gather feature capability facts for all ESXi host from given cluster in check mode
   vmware_host_feature_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     cluster_name: "{{ ccr1 }}"
   register: capability_0001_results
   check_mode: yes
+
+- debug: var=capability_0001_results
 
 - assert:
     that:
@@ -80,12 +44,14 @@
 
 - name: Gather feature capability facts for ESXi host
   vmware_host_feature_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: "{{ host1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
   register: capability_0002_results
+
+- debug: var=capability_0002_results
 
 - assert:
     that:
@@ -95,13 +61,15 @@
 
 - name: Gather feature capability facts for ESXi host in check mode
   vmware_host_feature_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: "{{ host1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
   register: capability_0002_results
   check_mode: yes
+
+- debug: var=capability_0002_results
 
 - assert:
     that:

--- a/test/integration/targets/vmware_host_firewall_facts/aliases
+++ b/test/integration/targets/vmware_host_firewall_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
@@ -1,102 +1,18 @@
 # Test code for the vmware_host_firewall_facts module.
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_esxi_instance: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
-- name: Gather firewall facts for all ESXi host from given cluster
+- name: Gather firewall facts for a given ESXi
   vmware_host_firewall_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
-    cluster_name: "{{ ccr1 }}"
-  register: firewall_0001_results
-
-- assert:
-    that:
-      - "not firewall_0001_results.changed"
-      - "firewall_0001_results.hosts_firewall_facts is defined"
-
-- name: Gather firewall facts for ESXi host
-  vmware_host_firewall_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
-  register: firewall_0002_results
-
-- assert:
-    that:
-      - "not firewall_0002_results.changed"
-      - "firewall_0002_results.hosts_firewall_facts is defined"
-
-- name: Gather firewall facts for all ESXi host from given cluster in check mode
-  vmware_host_firewall_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    cluster_name: "{{ ccr1 }}"
-  register: firewall_0003_results
-  check_mode: yes
-
-- assert:
-    that:
-      - "not firewall_0003_results.changed"
-      - "firewall_0003_results.hosts_firewall_facts is defined"
-
-- name: Gather firewall facts for ESXi host in check mode
-  vmware_host_firewall_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
   register: firewall_0004_results
   check_mode: yes
 
@@ -104,3 +20,54 @@
     that:
       - "not firewall_0004_results.changed"
       - "firewall_0004_results.hosts_firewall_facts is defined"
+
+
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+
+  - name: Gather firewall facts for all ESXi host from given cluster
+    vmware_host_firewall_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      cluster_name: "{{ ccr1 }}"
+    register: firewall_0001_results
+
+  - assert:
+      that:
+        - "not firewall_0001_results.changed"
+        - "firewall_0001_results.hosts_firewall_facts is defined"
+
+  - name: Gather firewall facts for ESXi host
+    vmware_host_firewall_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    register: firewall_0002_results
+
+  - assert:
+      that:
+        - "not firewall_0002_results.changed"
+        - "firewall_0002_results.hosts_firewall_facts is defined"
+
+  - name: Gather firewall facts for all ESXi host from given cluster in check mode
+    vmware_host_firewall_facts:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      cluster_name: "{{ ccr1 }}"
+    register: firewall_0003_results
+    check_mode: yes
+
+  - assert:
+      that:
+        - "not firewall_0003_results.changed"
+        - "firewall_0003_results.hosts_firewall_facts is defined"

--- a/test/integration/targets/vmware_host_firewall_manager/aliases
+++ b/test/integration/targets/vmware_host_firewall_manager/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -1,170 +1,129 @@
 # Test code for the vmware_host_firewall_manager module.
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: Disable the Firewall vvold rule on the ESXi
+      vmware_host_firewall_manager:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        cluster_name: '{{ ccr1 }}'
+        validate_certs: no
+        rules:
+            - name: vvold
+              enabled: False
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - name: Enable vvold rule set on all hosts of {{ ccr1 }}
+      vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        cluster_name: "{{ ccr1 }}"
+        rules:
+          - name: vvold
+            enabled: True
+      register: all_hosts_result
+    - debug: msg="{{ all_hosts_result }}"
+    - name: ensure everything is changed for all hosts of {{ ccr1 }}
+      assert:
+        that:
+            - all_hosts_result.changed
+            - all_hosts_result.rule_set_state is defined
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - name: ensure facts are gathered for all hosts of {{ ccr1 }}
+      assert:
+        that:
+            - all_hosts_result.rule_set_state[item]['vvold']['current_state'] == True
+            - all_hosts_result.rule_set_state[item]['vvold']['desired_state'] == True
+            - all_hosts_result.rule_set_state[item]['vvold']['previous_state'] == False
+      with_items:
+        - '{{ hostvars[esxi1].ansible_host }}'
+        - '{{ hostvars[esxi2].ansible_host }}'
 
-- debug:
-    var: vcsim_instance
+    - name: Disable vvold for {{ host1 }}
+      vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        rules:
+          - name: vvold
+            enabled: False
+      register: host_result
+    - debug: msg="{{ host_result }}"
+    - name: ensure vvold is disabled for {{ host1 }}
+      assert:
+        that:
+            - host_result.changed
+            - host_result.rule_set_state is defined
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+    - name: ensure facts are gathered for {{ host1 }}
+      assert:
+        that:
+            - host_result.rule_set_state[item]['vvold']['current_state'] == False
+            - host_result.rule_set_state[item]['vvold']['desired_state'] == False
+            - host_result.rule_set_state[item]['vvold']['previous_state'] == True
+      with_items:
+        - '{{ hostvars[esxi1].ansible_host }}'
 
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
+    - name: Enable vvold rule set on all hosts of {{ ccr1 }} in check mode
+      vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        cluster_name: "{{ ccr1 }}"
+        rules:
+          - name: vvold
+            enabled: True
+      register: all_hosts_result_check_mode
+      check_mode: yes
+    - debug: var=all_hosts_result_check_mode
+    - name: ensure everything is changed for all hosts of {{ ccr1 }}
+      assert:
+        that:
+            - all_hosts_result_check_mode.changed
+            - all_hosts_result_check_mode.rule_set_state is defined
 
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
+    - name: ensure facts are gathered for all hosts of {{ ccr1 }}
+      assert:
+        that:
+            - all_hosts_result_check_mode.rule_set_state[hostvars[esxi1].ansible_host]['vvold']['current_state'] == True
+            - all_hosts_result_check_mode.rule_set_state[hostvars[esxi2].ansible_host]['vvold']['current_state'] == True
+            - all_hosts_result_check_mode.rule_set_state[hostvars[esxi2].ansible_host]['vvold']['desired_state'] == True
 
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
+    - name: Disable vvold for {{ host1 }} in check mode
+      vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        rules:
+          - name: vvold
+            enabled: False
+      register: host_result_check_mode
+      check_mode: yes
+    - debug: msg="{{ host_result_check_mode }}"
+    - name: ensure vvold is disabled for {{ host1 }}
+      assert:
+        that:
+            - host_result_check_mode.changed == False
+            - host_result_check_mode.rule_set_state is defined
 
-- name: get a cluster
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
-- name: Enable vvold rule set on all hosts of {{ ccr1 }}
-  vmware_host_firewall_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    cluster_name: "{{ ccr1 }}"
-    rules:
-      - name: vvold
-        enabled: True
-  register: all_hosts_result
-
-- debug: msg="{{ all_hosts_result }}"
-
-- name: ensure everything is changed for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result.changed
-        - all_hosts_result.rule_set_state is defined
-
-- name: ensure facts are gathered for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result.rule_set_state[item]['vvold']['current_state'] == True
-        - all_hosts_result.rule_set_state[item]['vvold']['desired_state'] == True
-        - all_hosts_result.rule_set_state[item]['vvold']['previous_state'] == False
-  with_items:
-    - DC0_C0_H0
-    - DC0_C0_H1
-    - DC0_C0_H2
-
-- name: Disable vvold for {{ host1 }}
-  vmware_host_firewall_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
-    rules:
-      - name: vvold
-        enabled: False
-  register: host_result
-
-- debug: msg="{{ host_result }}"
-
-- name: ensure vvold is disabled for {{ host1 }}
-  assert:
-    that:
-        - host_result.changed
-        - host_result.rule_set_state is defined
-
-- name: ensure facts are gathered for {{ host1 }}
-  assert:
-    that:
-        - host_result.rule_set_state[item]['vvold']['current_state'] == False
-        - host_result.rule_set_state[item]['vvold']['desired_state'] == False
-        - host_result.rule_set_state[item]['vvold']['previous_state'] == True
-  with_items:
-    - "{{ host1 }}"
-
-- name: Enable vvold rule set on all hosts of {{ ccr1 }} in check mode
-  vmware_host_firewall_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    cluster_name: "{{ ccr1 }}"
-    rules:
-      - name: vvold
-        enabled: True
-  register: all_hosts_result_check_mode
-  check_mode: yes
-
-- debug: msg="{{ all_hosts_result_check_mode }}"
-
-- name: ensure everything is changed for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result_check_mode.changed
-        - all_hosts_result_check_mode.rule_set_state is defined
-
-- name: ensure facts are gathered for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result_check_mode.rule_set_state[item]['vvold']['current_state'] == True
-        - all_hosts_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == True
-        - all_hosts_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
-  with_items:
-    - DC0_C0_H0
-    - DC0_C0_H1
-    - DC0_C0_H2
-
-- name: Disable vvold for {{ host1 }} in check mode
-  vmware_host_firewall_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
-    rules:
-      - name: vvold
-        enabled: False
-  register: host_result_check_mode
-  check_mode: yes
-
-- debug: msg="{{ host_result_check_mode }}"
-
-- name: ensure vvold is disabled for {{ host1 }}
-  assert:
-    that:
-        - host_result_check_mode.changed == False
-        - host_result_check_mode.rule_set_state is defined
-
-- name: ensure facts are gathered for {{ host1 }}
-  assert:
-    that:
-        - host_result_check_mode.rule_set_state[item]['vvold']['current_state'] == False
-        - host_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == False
-        - host_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
-  with_items:
-    - "{{ host1 }}"
+    - name: ensure facts are gathered for {{ host1 }}
+      assert:
+        that:
+            - host_result_check_mode.rule_set_state[item]['vvold']['current_state'] == False
+            - host_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == False
+            - host_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
+      with_items:
+        - '{{ hostvars[esxi1].ansible_host }}'

--- a/test/integration/targets/vmware_host_hyperthreading/aliases
+++ b/test/integration/targets/vmware_host_hyperthreading/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_hyperthreading/tasks/main.yml
+++ b/test/integration/targets/vmware_host_hyperthreading/tasks/main.yml
@@ -2,119 +2,91 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
 # Hyperthreading optimization is not available for hosts in vcsim
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
-- name: Disable Hyperthreading for a given host
+
+- name: Enable Hyperthreading everywhere
   vmware_host_hyperthreading:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     state: disabled
-  register: host_hyperthreading_facts
+  register: enable_hyperthreading_everywhere
+  ignore_errors: true
 
-- debug: var=host_hyperthreading_facts
+- when: enable_hyperthreading_everywhere is succeeded
+  block:
 
-- assert:
-    that:
-      - host_hyperthreading_facts is defined
-      - host_hyperthreading_facts.changed
+  - name: Disable Hyperthreading for a given host
+    vmware_host_hyperthreading:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      validate_certs: no
+      state: disabled
+    register: host_hyperthreading_facts
 
-- name: Disable Hyperthreading for a given host in check mode
-  vmware_host_hyperthreading:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-    state: disabled
-  register: host_hyperthreading_facts_check_mode
-  check_mode: yes
+  - debug: var=host_hyperthreading_facts
 
-- debug: var=host_hyperthreading_facts_check_mode
+  - assert:
+      that:
+        - host_hyperthreading_facts is defined
+        - host_hyperthreading_facts.changed
 
-- assert:
-    that:
-      - host_hyperthreading_facts_check_mode is defined
-      - host_hyperthreading_facts_check_mode.changed
+  - name: Disable Hyperthreading for a given host in check mode
+    vmware_host_hyperthreading:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      validate_certs: no
+      state: disabled
+    register: host_hyperthreading_facts_check_mode
+    check_mode: yes
 
-- name: Disable Hyperthreading for all hosts in given cluster
-  vmware_host_hyperthreading:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    cluster_name: "{{ ccr1 }}"
-    validate_certs: no
-    state: disabled
-  register: host_hyperthreading_facts
+  - debug: var=host_hyperthreading_facts_check_mode
 
-- debug: var=host_hyperthreading_facts
+  - assert:
+      that:
+        - host_hyperthreading_facts_check_mode is defined
 
-- assert:
-    that:
-      - host_hyperthreading_facts is defined
-      - host_hyperthreading_facts.changed
+  - name: Disable Hyperthreading for all hosts in given cluster
+    vmware_host_hyperthreading:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      cluster_name: "{{ ccr1 }}"
+      validate_certs: no
+      state: disabled
+    register: host_hyperthreading_facts
 
-- name: Disable Hyperthreading for all hosts in given cluster in check mode
-  vmware_host_hyperthreading:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    cluster_name: "{{ ccr1 }}"
-    validate_certs: no
-    state: disabled
-  register: host_hyperthreading_facts_check_mode
-  check_mode: yes
+  - debug: var=host_hyperthreading_facts
 
-- debug: var=host_hyperthreading_facts_check_mode
+  - assert:
+      that:
+        - host_hyperthreading_facts is defined
+        - host_hyperthreading_facts is changed
 
-- assert:
-    that:
-      - host_hyperthreading_facts_check_mode is defined
-      - host_hyperthreading_facts_check_mode.changed
+  - name: Enable Hyperthreading for all hosts in given cluster in check mode
+    vmware_host_hyperthreading:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      cluster_name: "{{ ccr1 }}"
+      validate_certs: no
+      state: enabled
+    register: host_hyperthreading_facts_check_mode
+    check_mode: yes
+
+  - debug: var=host_hyperthreading_facts_check_mode
+
+  - assert:
+      that:
+        - host_hyperthreading_facts_check_mode is defined
+        - host_hyperthreading_facts_check_mode.changed

--- a/test/integration/targets/vmware_host_ipv6/aliases
+++ b/test/integration/targets/vmware_host_ipv6/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_ipv6/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ipv6/tasks/main.yml
@@ -1,118 +1,81 @@
 # Test code for the vmware_host_ipv6 module.
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: Ensure IPv6 is off
+      vmware_host_ipv6:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: no
+        state: disabled
+      register: host_ipv6_facts
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - name: Enable IPv6 support for a given host
+      vmware_host_ipv6:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+        state: enabled
+      register: host_ipv6_facts
+    - debug: var=host_ipv6_facts
+    - assert:
+        that:
+          - host_ipv6_facts is defined
+          - host_ipv6_facts.changed
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - name: Enable IPv6 support for a given host in check mode
+      vmware_host_ipv6:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+        state: enabled
+      register: host_ipv6_facts_check_mode
+      check_mode: yes
+    - debug: var=host_ipv6_facts_check_mode
+    - assert:
+        that:
+          - host_ipv6_facts_check_mode is defined
+          - not (host_ipv6_facts_check_mode is changed)
 
-- debug:
-    var: vcsim_instance
+    - name: Enable IPv6 support for all hosts in given cluster
+      vmware_host_ipv6:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: no
+        state: enabled
+      register: hosts_ipv6_facts
+    - debug: var=hosts_ipv6_facts
+    - assert:
+        that:
+          - hosts_ipv6_facts is defined
+          - hosts_ipv6_facts.changed
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
-- name: Enable IPv6 support for a given host
-  vmware_host_ipv6:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-    state: enabled
-  register: host_ipv6_facts
-
-- debug: var=host_ipv6_facts
-
-- assert:
-    that:
-      - host_ipv6_facts is defined
-      - host_ipv6_facts.changed
-
-- name: Enable IPv6 support for a given host in check mode
-  vmware_host_ipv6:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-    state: enabled
-  register: host_ipv6_facts_check_mode
-  check_mode: yes
-
-- debug: var=host_ipv6_facts_check_mode
-
-- assert:
-    that:
-      - host_ipv6_facts_check_mode is defined
-      - host_ipv6_facts_check_mode.changed
-
-- name: Enable IPv6 support for all hosts in given cluster
-  vmware_host_ipv6:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    cluster_name: "{{ ccr1 }}"
-    validate_certs: no
-    state: enabled
-  register: hosts_ipv6_facts
-
-- debug: var=hosts_ipv6_facts
-
-- assert:
-    that:
-      - hosts_ipv6_facts is defined
-      - hosts_ipv6_facts.changed
-
-- name: Enable IPv6 support for all hosts in given cluster in check mode
-  vmware_host_ipv6:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    cluster_name: "{{ ccr1 }}"
-    validate_certs: no
-    state: enabled
-  register: hosts_ipv6_facts_check_mode
-  check_mode: yes
-
-- debug: var=hosts_ipv6_facts_check_mode
-
-- assert:
-    that:
-      - hosts_ipv6_facts_check_mode is defined
-      - hosts_ipv6_facts_check_mode.changed
+    - name: Enable IPv6 support for all hosts in given cluster in check mode
+      vmware_host_ipv6:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: no
+        state: enabled
+      register: hosts_ipv6_facts_check_mode
+      check_mode: yes
+    - debug: var=hosts_ipv6_facts_check_mode
+    - assert:
+        that:
+          - hosts_ipv6_facts_check_mode is defined
+          - not (hosts_ipv6_facts_check_mode is changed)

--- a/test/integration/targets/vmware_host_kernel_manager/aliases
+++ b/test/integration/targets/vmware_host_kernel_manager/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_kernel_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_kernel_manager/tasks/main.yml
@@ -1,66 +1,42 @@
 # test code for the vmware_host_kernel_manager module
 # Copyright: (c) 2019, Aaron Longchamps <a.j.longchamps@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_datastore: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: host connected, module exists, options exist, arguments different
+      vmware_host_kernel_manager:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        kernel_module_name: "tcpip4"
+        kernel_module_option: "ipv6=0"
+      register: my_results_01
+    - debug: var=my_results_01
+    - name: Check that the provided kernel_module_name has kernel_module_option set
+      assert:
+        that:
+          - "'original_options' in my_results_01['ansible_module_results']['{{ hostvars[esxi1].ansible_host }}']"
+          - "my_results_01['ansible_module_results']['{{ hostvars[esxi1].ansible_host }}'].original_options == 'ipv6=0'"
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&host=1
-  register: vcsim_instance
-
-- debug: var=vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=host' }}"
-  register: hostlist
-
-- set_fact:
-    host1: "{{ hostlist['json'][0] }}"
-
-- name: host connected, module exists, options exist, arguments different
-  vmware_host_kernel_manager:
-    hostname: '{{ vcsim }}'
-    username: '{{ vcsim_instance.json.username }}'
-    password: '{{ vcsim_instance.json.password }}'
-    validate_certs: False
-    esxi_hostname: '{{ host1 }}'
-    kernel_module_name: "tcpip4"
-    kernel_module_option: "ipv6=0"
-  register: my_results_01
-
-- name: Check that the provided kernel_module_name has kernel_module_option set
-  assert:
-    that:
-      - "my_results_01.results['DC0_H0']['configured_options'] == 'ipv6=0'"
-
-- name: host connected, module exists, same options for idempotence test
-  vmware_host_kernel_manager:
-    hostname: '{{ vcsim }}'
-    username: '{{ vcsim_instance.json.username }}'
-    password: '{{ vcsim_instance.json.password }}'
-    validate_certs: False
-    esxi_hostname: '{{ host1 }}'
-    kernel_module_name: "tcpip4"
-    kernel_module_option: "ipv6=0"
-  register: my_results_02
-
-- name: Check that changed is false
-  assert:
-    that:
-      - "my_results_02.results['DC0_H0']['changed'] == false"
+    - name: host connected, module exists, same options for idempotence test
+      vmware_host_kernel_manager:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        kernel_module_name: "tcpip4"
+        kernel_module_option: "ipv6=0"
+      register: my_results_02
+    - name: Check that changed is false
+      assert:
+        that:
+          - not (my_results_02 is changed)

--- a/test/integration/targets/vmware_host_ntp/aliases
+++ b/test/integration/targets/vmware_host_ntp/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_ntp/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ntp/tasks/main.yml
@@ -3,216 +3,166 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support update host NTP configuration
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: Add NTP server to a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: present
+        ntp_servers:
+          - 0.pool.ntp.org
+        validate_certs: no
+      register: present
+    - debug: var=present
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - name: Add another NTP server to a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: present
+        ntp_servers:
+          - 1.pool.ntp.org
+        validate_certs: no
+      register: present
+    - debug: var=present
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - name: Remove NTP server from a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: absent
+        ntp_servers:
+          - 1.pool.ntp.org
+        validate_certs: no
+      register: absent_one
+    - debug: var=absent_one
 
-- debug:
-    var: vcsim_instance
+    - name: Remove NTP server from a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: present
+        ntp_servers:
+          - 1.pool.ntp.org
+        validate_certs: no
+      register: present
+    - debug: var=present
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+    - name: Add more NTP servers to a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: present
+        ntp_servers:
+          - 2.pool.ntp.org
+          - 3.pool.ntp.org
+          - 4.pool.ntp.org
+        validate_certs: no
+      register: present
+    - debug: var=present
 
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
+    - name: Remove all NTP servers from a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: absent
+        ntp_servers:
+          - 0.pool.ntp.org
+          - 1.pool.ntp.org
+          - 2.pool.ntp.org
+          - 3.pool.ntp.org
+          - 4.pool.ntp.org
+          - 6.pool.ntp.org
+        validate_certs: no
+      register: absent_all
+    - debug: var=absent_all
 
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
+    - name: Configure NTP servers for a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        ntp_servers:
+          - 0.pool.ntp.org
+          - 1.pool.ntp.org
+          - 2.pool.ntp.org
+        validate_certs: no
+      register: ntp_servers
+    - debug: var=ntp_servers
 
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
+    - name: Configure NTP servers for a host
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        ntp_servers:
+          - 3.pool.ntp.org
+          - 4.pool.ntp.org
+          - 5.pool.ntp.org
+        verbose: true
+        validate_certs: no
+      register: ntp_servers
+    - debug: var=ntp_servers
 
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
+    - name: Add NTP server to a host in check mode
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: present
+        ntp_servers:
+          - 0.pool.ntp.org
+        validate_certs: no
+      register: present
+      check_mode: yes
+    - debug: var=present
 
-- debug: var=ccr1
-- debug: var=host1
+    - name: Remove NTP server to a host in check mode
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        state: absent
+        ntp_servers:
+          - 0.pool.ntp.org
+        validate_certs: no
+      register: present
+      check_mode: yes
+    - debug: var=present
 
-- name: Add NTP server to a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: present
-    ntp_server:
-      - 0.pool.ntp.org
-    validate_certs: no
-  register: present
-
-- debug: var=present
-
-- name: Add another NTP server to a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: present
-    ntp_server:
-      - 1.pool.ntp.org
-    validate_certs: no
-  register: present
-
-- debug: var=present
-
-- name: Remove NTP server from a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: absent
-    ntp_server:
-      - 1.pool.ntp.org
-    validate_certs: no
-  register: absent_one
-
-- debug: var=absent_one
-
-- name: Remove NTP server from a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: present
-    ntp_server:
-      - 1.pool.ntp.org
-    validate_certs: no
-  register: present
-
-- debug: var=present
-
-- name: Add more NTP servers to a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: present
-    ntp_server:
-      - 2.pool.ntp.org
-      - 3.pool.ntp.org
-      - 4.pool.ntp.org
-    validate_certs: no
-  register: present
-
-- debug: var=present
-
-- name: Remove all NTP servers from a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: absent
-    ntp_server:
-      - 0.pool.ntp.org
-      - 1.pool.ntp.org
-      - 2.pool.ntp.org
-      - 3.pool.ntp.org
-      - 4.pool.ntp.org
-      - 6.pool.ntp.org
-    validate_certs: no
-  register: absent_all
-
-- debug: var=absent_all
-
-- name: Configure NTP servers for a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    ntp_server:
-      - 0.pool.ntp.org
-      - 1.pool.ntp.org
-      - 2.pool.ntp.org
-    validate_certs: no
-  register: ntp_servers
-
-- debug: var=ntp_servers
-
-- name: Configure NTP servers for a host
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    ntp_server:
-      - 3.pool.ntp.org
-      - 4.pool.ntp.org
-      - 5.pool.ntp.org
-    verbose: true
-    validate_certs: no
-  register: ntp_servers
-
-- debug: var=ntp_servers
-
-- name: Add NTP server to a host in check mode
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: present
-    ntp_server:
-      - 0.pool.ntp.org
-    validate_certs: no
-  register: present
-  check_mode: yes
-
-- debug: var=present
-
-- name: Remove NTP server to a host in check mode
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    state: absent
-    ntp_server:
-      - 0.pool.ntp.org
-    validate_certs: no
-  register: present
-  check_mode: yes
-
-- debug: var=present
-
-- name: Configure NTP servers for a host in check mode
-  vmware_host_ntp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    ntp_server:
-      - 0.pool.ntp.org
-      - 1.pool.ntp.org
-      - 2.pool.ntp.org
-    validate_certs: no
-  register: ntp_servers
-  check_mode: yes
-
-- debug: var=ntp_servers
+    - name: Configure NTP servers for a host in check mode
+      vmware_host_ntp:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        ntp_servers:
+          - 0.pool.ntp.org
+          - 1.pool.ntp.org
+          - 2.pool.ntp.org
+        validate_certs: no
+      register: ntp_servers
+      check_mode: yes
+    - debug: var=ntp_servers

--- a/test/integration/targets/vmware_host_ntp_facts/aliases
+++ b/test/integration/targets/vmware_host_ntp_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_ntp_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ntp_facts/tasks/main.yml
@@ -3,53 +3,22 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support NTP Manager related to operations
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Gather NTP facts about all hosts in given host
-  vmware_host_ntp_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-  register: host_ntp
-
-- debug: var=host_ntp
-
-- assert:
-    that:
-      - host_ntp.hosts_ntp_facts is defined
+    - name: Gather NTP facts about all hosts in given host
+      vmware_host_ntp_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+      register: host_ntp
+    - debug: var=host_ntp
+    - assert:
+        that:
+          - host_ntp.hosts_ntp_facts is defined

--- a/test/integration/targets/vmware_host_package_facts/aliases
+++ b/test/integration/targets/vmware_host_package_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_package_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_package_facts/tasks/main.yml
@@ -3,53 +3,22 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support Package Manager related to operations
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Gather facts about all hosts in given cluster
-  vmware_host_package_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-  register: host_packages
-
-- debug: var=host_packages
-
-- assert:
-    that:
-      - host_packages.hosts_package_facts is defined
+    - name: Gather facts about all hosts in given cluster
+      vmware_host_package_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+      register: host_packages
+    - debug: var=host_packages
+    - assert:
+        that:
+          - host_packages.hosts_package_facts is defined

--- a/test/integration/targets/vmware_host_powermgmt_policy/aliases
+++ b/test/integration/targets/vmware_host_powermgmt_policy/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_powermgmt_policy/tasks/main.yml
+++ b/test/integration/targets/vmware_host_powermgmt_policy/tasks/main.yml
@@ -2,122 +2,76 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    # The following test cases aren't supported by vcsim
+    - name: Set the Power Management Policy for esxi1
+      vmware_host_powermgmt_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        policy: high-performance
+        validate_certs: no
+      register: host_result
+    - debug: var=host_result
+    - name: Ensure Power Management Policy for esxi1
+      assert:
+        that:
+            - host_result.result['{{ hostvars[esxi1].ansible_host }}'].current_state == "high-performance"
 
-- name: Start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - name: Set the Power Management Policy on all hosts of {{ ccr1 }}
+      vmware_host_powermgmt_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster_name: "{{ ccr1 }}"
+        policy: balanced
+        validate_certs: no
+      register: all_hosts_result
+    - debug: var=all_hosts_result
+    - name: Ensure Power Management Policy is changed for all hosts of {{ ccr1 }}
+      assert:
+        that:
+            - all_hosts_result is changed
+            - all_hosts_result.result is defined
 
-- debug:
-    var: vcsim_instance
+    - name: Set the Power Management Policy for esxi1 in check mode
+      vmware_host_powermgmt_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        policy: high-performance
+        validate_certs: no
+      register: host_result
+      check_mode: yes
+    - debug: var=host_result
+    - name: Ensure Power Management Policy for esxi1 in check mode
+      assert:
+        that:
+            - host_result is changed
+            - host_result.result is defined
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: Get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: Get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: Get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: Get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
-# The following test cases aren't supported by vcsim
-- name: Set the Power Management Policy for {{ host1 }}
-  vmware_host_powermgmt_policy:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    policy: high-performance
-    validate_certs: no
-  register: host_result
-
-- debug: msg="{{ host_result }}"
-
-- name: Ensure Power Management Policy for {{ host1 }}
-  assert:
-    that:
-        - host_result is changed
-        - host_result.result is defined
-
-- name: Set the Power Management Policy on all hosts of {{ ccr1 }}
-  vmware_host_powermgmt_policy:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    policy: balanced
-    validate_certs: no
-  register: all_hosts_result
-
-- debug: msg="{{ all_hosts_result }}"
-
-- name: Ensure Power Management Policy is changed for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result is changed
-        - all_hosts_result.result is defined
-
-- name: Set the Power Management Policy for {{ host1 }} in check mode
-  vmware_host_powermgmt_policy:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    policy: high-performance
-    validate_certs: no
-  register: host_result
-  check_mode: yes
-
-- debug: msg="{{ host_result }}"
-
-- name: Ensure Power Management Policy for {{ host1 }} in check mode
-  assert:
-    that:
-        - host_result is changed
-        - host_result.result is defined
-
-- name: Set the Power Management Policy on all hosts of {{ ccr1 }} in check mode
-  vmware_host_powermgmt_policy:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    esxi_hostname: "{{ host1 }}"
-    policy: balanced
-    validate_certs: no
-  register: all_hosts_result
-  check_mode: yes
-
-- debug: msg="{{ all_hosts_result }}"
-
-- name: Ensure Power Management Policy is changed for all hosts of {{ ccr1 }} in check mode
-  assert:
-    that:
-        - all_hosts_result is changed
-        - all_hosts_result.result is defined
+    - name: Set the Power Management Policy on all hosts of {{ ccr1 }}
+      vmware_host_powermgmt_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster_name: "{{ ccr1 }}"
+        policy: balanced
+        validate_certs: no
+      register: all_hosts_result
+      check_mode: yes
+    - debug: var=all_hosts_result
+    - name: Ensure we are still using the 'balanced' mode
+      assert:
+        that:
+            - not (all_hosts_result is changed)
+            - "all_hosts_result.result['{{ hostvars[esxi1].ansible_host }}']current_state == 'balanced'"
+            - "all_hosts_result.result['{{ hostvars[esxi2].ansible_host }}']current_state == 'balanced'"

--- a/test/integration/targets/vmware_host_powerstate/aliases
+++ b/test/integration/targets/vmware_host_powerstate/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_powerstate/tasks/main.yml
+++ b/test/integration/targets/vmware_host_powerstate/tasks/main.yml
@@ -3,55 +3,32 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support Powerstate related to operations
+- when: False
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  # https://kb.vmware.com/s/article/2001651?lang=en_US
+  # It seems like we need a Power managment interface to be able to run the
+  # module.
+  # I currently get:
+  # "Failed to power down '192.168.123.7' to standby as host system due to : ('The operation is not supported on the object.', None)"
+  - name: Restart Host
+    vmware_host_powerstate:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: False
+      state: power-down-to-standby
+      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      force: True
+    register: host_powerstate
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+  - debug: var=host_powerstate
 
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Restart Host
-  vmware_host_powerstate:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: False
-    state: power-down-to-standby
-    esxi_hostname: "{{ host1 }}"
-    force: True
-  register: host_powerstate
-
-- debug: var=host_powerstate
-
-- assert:
-    that:
-      - host_powerstate.results is changed
+  - assert:
+      that:
+        - host_powerstate.results is changed

--- a/test/integration/targets/vmware_host_scanhba/aliases
+++ b/test/integration/targets/vmware_host_scanhba/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
-unsupported
+cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_scanhba/tasks/main.yml
+++ b/test/integration/targets/vmware_host_scanhba/tasks/main.yml
@@ -1,80 +1,25 @@
 # Test code for the vmware_host_scanhba module.
 # Copyright: (c) 2019, Michael Eaton <me@michaeleaton.me>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- when: vcsim is not defined
+  block:
+    - import_role:
+          name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact:
-    dc1: "{{ datacenters.json[0] | basename }}"
-
-- debug: var=dc1
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- debug: var=ccr1
-
-- name: add host
-  vmware_host:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: test_host_system_0001
-    esxi_username: "{{ vcsim_instance.json.username }}"
-    esxi_password: "{{ vcsim_instance.json.password }}"
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: "{{ ccr1 }}"
-    state: present
-
-- name: Recan HBA's for an entire cluster (there should be at least one host as above)
-  vmware_host_scanhba:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    cluster_name: '{{ ccr1 }}'
-    refresh_storage: false
-  register: host_scan_results
-
-- debug: msg="{{ host_scan_results }}"
-
-- name: ensure a change occured (as in the scan happened) and the task didnt fail
-  assert:
-    that:
-        - host_scan_results.changed 
-        - not host_scan_results.failed
+    - name: Recan HBA's for an entire cluster (there should be at least one host as above)
+      vmware_host_scanhba:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        cluster_name: '{{ ccr1 }}'
+        refresh_storage: false
+      register: host_scan_results
+    - debug: msg="{{ host_scan_results }}"
+    - name: ensure a change occured (as in the scan happened) and the task didnt fail
+      assert:
+        that:
+            - host_scan_results.changed
+            - not host_scan_results.failed

--- a/test/integration/targets/vmware_host_service_facts/aliases
+++ b/test/integration/targets/vmware_host_service_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_service_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_facts/tasks/main.yml
@@ -3,53 +3,37 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support service related to operations
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - &host_srv_facts
+      name: Check facts about all hosts in given cluster
+      vmware_host_service_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+      register: host_services
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - debug:
+        var: host_services
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - assert:
+        that:
+          - host_services.host_service_facts is defined
 
-- debug:
-    var: vcsim_instance
+    - <<: *host_srv_facts
+      name: Check facts about all hosts in given cluster in check mode
+      check_mode: yes
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+    - debug:
+        var: host_services
 
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Change facts about all hosts in given cluster
-  vmware_host_service_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-  register: host_services
-
-- debug: var=host_services
-
-- assert:
-    that:
-      - host_services.host_service_facts is defined
+    - assert:
+        that:
+          - host_services.host_service_facts is defined

--- a/test/integration/targets/vmware_host_service_manager/aliases
+++ b/test/integration/targets/vmware_host_service_manager/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_service_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_manager/tasks/main.yml
@@ -4,114 +4,83 @@
 
 # TODO: vcsim does not support service management
 #       commenting this testcase till the time.
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: Start ntpd service on all hosts in given cluster
+      vmware_host_service_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        cluster_name: "{{ ccr1 }}"
+        service_name: ntpd
+        state: present
+      register: all_hosts_result
+    - debug: var=all_hosts_result
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - name: Stop ntpd service on a given host
+      vmware_host_service_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        service_name: ntpd
+        state: absent
+      register: single_hosts_result
+    - name: ensure facts are gathered
+      assert:
+        that:
+            - single_hosts_result is changed
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - name: Start ntpd service on all hosts in given cluster in check mode
+      vmware_host_service_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        cluster_name: "{{ ccr1 }}"
+        service_name: ntpd
+        state: present
+      register: all_hosts_result_check_mode
+      check_mode: yes
+    - name: ensure facts are gathered for all hosts
+      assert:
+        that:
+            - all_hosts_result_check_mode is changed
 
-- debug:
-    var: vcsim_instance
+    - name: Stop ntpd service on a given host in check mode
+      vmware_host_service_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        service_name: ntpd
+        state: absent
+      register: single_hosts_result_check_mode
+      check_mode: yes
+    - name: ensure facts are gathered
+      assert:
+        that:
+            - not (single_hosts_result_check_mode is changed)
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a cluster
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
-
-- name: Start ntpd service on all hosts in given cluster
-  vmware_host_service_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    cluster_name: "{{ ccr1 }}"
-    service_name: ntpd
-    state: present
-  register: all_hosts_result
-
-- name: ensure facts are gathered for all hosts
-  assert:
-    that:
-        - all_hosts_result.changed
-
-- name: Stop ntpd service on a given host
-  vmware_host_service_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
-    service_name: ntpd
-    state: absent
-  register: single_hosts_result
-
-- name: ensure facts are gathered
-  assert:
-    that:
-        - single_hosts_result.changed == False
-
-- name: Start ntpd service on all hosts in given cluster in check mode
-  vmware_host_service_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    cluster_name: "{{ ccr1 }}"
-    service_name: ntpd
-    state: present
-  register: all_hosts_result_check_mode
-  check_mode: yes
-
-- name: ensure facts are gathered for all hosts
-  assert:
-    that:
-        - all_hosts_result_check_mode.changed
-
-- name: Stop ntpd service on a given host in check mode
-  vmware_host_service_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    esxi_hostname: "{{ host1 }}"
-    service_name: ntpd
-    state: absent
-  register: single_hosts_result_check_mode
-  check_mode: yes
-
-- name: ensure facts are gathered
-  assert:
-    that:
-        - single_hosts_result_check_mode.changed == False
+    - name: Start ntpd service on all hosts in given cluster
+      vmware_host_service_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        cluster_name: "{{ ccr1 }}"
+        service_name: ntpd
+        state: present
+      register: all_hosts_result_check_mode
+    - name: finally, ensure ntp is running on the cluster
+      assert:
+        that:
+            - all_hosts_result_check_mode is changed

--- a/test/integration/targets/vmware_host_snmp/aliases
+++ b/test/integration/targets/vmware_host_snmp/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_snmp/tasks/main.yml
+++ b/test/integration/targets/vmware_host_snmp/tasks/main.yml
@@ -2,63 +2,55 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    # SNMP works only with standalone ESXi server
+    - name: Enable and configure SNMP community in check mode
+      vmware_host_snmp:
+        hostname: '{{ hostvars[esxi1].ansible_host }}'
+        username: '{{ hostvars[esxi1].ansible_user }}'
+        password: '{{ hostvars[esxi1].ansible_password }}'
+        community: [ test ]
+        state: enabled
+        validate_certs: no
+      register: snmp_enabled_check_mode
+      check_mode: yes
+    - debug: var=snmp_enabled_check_mode
+    - assert:
+        that:
+          - snmp_enabled_check_mode is defined
+          - snmp_enabled_check_mode.changed
 
-# SNMP works only with standalone ESXi server
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?esx=1
-  register: vcsim_instance
+    - name: Enable and configure SNMP community
+      vmware_host_snmp:
+        hostname: '{{ hostvars[esxi1].ansible_host }}'
+        username: '{{ hostvars[esxi1].ansible_user }}'
+        password: '{{ hostvars[esxi1].ansible_password }}'
+        community: [ test ]
+        state: enabled
+        validate_certs: no
+      register: snmp_enabled
+    - debug: var=snmp_enabled
+    - assert:
+        that:
+          - snmp_enabled is defined
+          - snmp_enabled.changed
 
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: Enable and configure SNMP community in check mode
-  vmware_host_snmp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    community: [ test ]
-    state: enabled
-    validate_certs: no
-  register: snmp_enabled_check_mode
-  check_mode: yes
-
-- debug: var=snmp_enabled_check_mode
-
-- assert:
-    that:
-      - snmp_enabled_check_mode is defined
-      - snmp_enabled_check_mode.changed
-
-- name: Enable and configure SNMP community
-  vmware_host_snmp:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    community: [ test ]
-    state: enabled
-    validate_certs: no
-  register: snmp_enabled
-  check_mode: yes
-
-- debug: var=snmp_enabled
-
-- assert:
-    that:
-      - snmp_enabled is defined
-      - snmp_enabled.changed
+    - name: Disable SNMP
+      vmware_host_snmp:
+        hostname: '{{ hostvars[esxi1].ansible_host }}'
+        username: '{{ hostvars[esxi1].ansible_user }}'
+        password: '{{ hostvars[esxi1].ansible_password }}'
+        state: disabled
+        validate_certs: no
+      register: snmp_disabled
+    - debug: var=snmp_enabled
+    - assert:
+        that:
+          - snmp_enabled is defined
+          - snmp_enabled.changed

--- a/test/integration/targets/vmware_host_ssl_facts/aliases
+++ b/test/integration/targets/vmware_host_ssl_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_ssl_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ssl_facts/tasks/main.yml
@@ -1,58 +1,18 @@
 # Test code for the vmware_host_ssl_facts module.
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a list of clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- name: get a cluster
-  set_fact:
-    cluster1: "{{ clusters.json[0] | basename }}"
-
-- debug: var=host1
-- debug: var=cluster1
 
 - name: Gather SSL facts about ESXi machine
   vmware_host_ssl_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     validate_certs: no
   register: ssl_facts
 
@@ -64,10 +24,10 @@
 
 - name: Gather facts about all hostsystem in given cluster
   vmware_host_ssl_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    cluster_name: "{{ cluster1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    cluster_name: "{{ ccr1 }}"
     validate_certs: no
   register: ssl_facts
 
@@ -79,10 +39,10 @@
 
 - name: Gather SSL facts about ESXi machine in check mode
   vmware_host_ssl_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    esxi_hostname: "{{ host1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     validate_certs: no
   check_mode: yes
   register: ssl_facts
@@ -95,10 +55,10 @@
 
 - name: Gather facts about all hostsystem in given cluster in check mode ee
   vmware_host_ssl_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    cluster_name: "{{ cluster1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    cluster_name: "{{ ccr1 }}"
     validate_certs: no
   check_mode: yes
   register: ssl_facts

--- a/test/integration/targets/vmware_host_vmhba_facts/aliases
+++ b/test/integration/targets/vmware_host_vmhba_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_vmhba_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_vmhba_facts/tasks/main.yml
@@ -3,53 +3,37 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support networkConfig related to operations
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - &vmhba_data
+      name: Gather vmhba facts
+      vmware_host_vmhba_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+      register: host_vmhbas
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - debug:
+        var: host_vmhbas
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - assert:
+        that:
+          - host_vmhbas.hosts_vmhbas_facts is defined
 
-- debug:
-    var: vcsim_instance
+    - <<: *vmhba_data
+      name: Gather vmhba facts in check mode 
+      check_mode: yes
 
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+    - debug:
+        var: host_vmhbas
 
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Gather vmhba facts
-  vmware_host_vmhba_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-  register: host_vmhbas
-
-- debug: var=host_vmhbas
-
-- assert:
-    that:
-      - host_vmhbas.hosts_vmhbas_facts is defined
+    - assert:
+        that:
+          - host_vmhbas.hosts_vmhbas_facts is defined

--- a/test/integration/targets/vmware_host_vmnic_facts/aliases
+++ b/test/integration/targets/vmware_host_vmnic_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
@@ -3,71 +3,38 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support networkConfig related to operations
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: Gather vmnic facts about a host
+      vmware_host_vmnic_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+      register: host_vmnics
+    - debug: var=host_vmnics
+    - assert:
+        that:
+          - host_vmnics.hosts_vmnics_facts is defined
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Gather vmnic facts about a host
-  vmware_host_vmnics_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-  register: host_vmnics
-
-- debug: var=host_vmnics
-
-- assert:
-    that:
-      - host_vmnics.hosts_vmnics_facts is defined
-
-- name: Gather extended vmnic facts about a host
-  vmware_host_vmnics_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-    capabilities: true
-    directpath_io: true
-    sriov: true
-  register: host_vmnics_extended
-
-- debug: var=host_vmnics_extended
-
-- assert:
-    that:
-      - host_vmnics_extended.hosts_vmnics_facts is defined
+    - name: Gather extended vmnic facts about a host
+      vmware_host_vmnic_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+        capabilities: true
+        directpath_io: true
+        sriov: true
+      register: host_vmnics_extended
+    - debug: var=host_vmnics_extended
+    - assert:
+        that:
+          - host_vmnics_extended.hosts_vmnics_facts is defined


### PR DESCRIPTION
##### SUMMARY

Refactoring of the following roles to make use of the new
`prepare_vmware_tests` role.

- `vmware_host`
- `vmware_host_acceptance`
- `vmware_host_active_directory`
- `vmware_host_capability_facts`
- `vmware_host_config_facts`
- `vmware_host_config_manager`
- `vmware_host_dns_facts`
- `vmware_host_facts`
- `vmware_host_feature_facts`
- `vmware_host_firewall_facts`
- `vmware_host_firewall_manager`
- `vmware_host_hyperthreading`
- `vmware_host_ipv6`
- `vmware_host_kernel_manager`
- `vmware_host_ntp`
- `vmware_host_ntp_facts`
- `vmware_host_package_facts`
- `vmware_host_powermgmt_policy`
- `vmware_host_powerstate`
- `vmware_host_scanhba`
- `vmware_host_service_facts`
- `vmware_host_service_manager`
- `vmware_host_snmp`
- `vmware_host_ssl_facts`
- `vmware_host_vmhba_facts`
- `vmware_host_vmnic_facts`

This patch depends on: https://github.com/ansible/ansible/pull/55719

Original PR: https://github.com/ansible/ansible/pull/54882

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware