### PR TITLE
vmware: refactoring of vmware test roles -- part6

### DIFF
--- a/test/integration/targets/vmware_inventory/aliases
+++ b/test/integration/targets/vmware_inventory/aliases
@@ -4,3 +4,4 @@ skip/python3
 destructive
 needs/file/contrib/inventory/vmware_inventory.py
 needs/file/contrib/inventory/vmware_inventory.ini
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_local_role_facts/aliases
+++ b/test/integration/targets/vmware_local_role_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_local_role_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_local_role_facts/tasks/main.yml
@@ -2,6 +2,9 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- import_role:
+    name: prepare_vmware_tests
+
 - name: Set list of Roles in fact
   set_fact:
     role_list:
@@ -11,56 +14,26 @@
       - Anonymous
       - ReadOnly
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?esx=1
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
-
-- name: Gather Role facts
+- &role_data
+  name: Gather Role facts
   vmware_local_role_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
   register: role_details
 
-- name: Test if role id is present for role
+- &role_test
+  name: Test if role id is present for role
   assert:
     that: "{{ role_details.local_role_facts | json_query(s_query) != [] }}"
   vars:
     s_query: "[?role_name == '{{ item }}'].role_id"
   with_items: "{{ role_list }}"
 
-- name: Gather Role facts in check mode
-  vmware_local_role_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    validate_certs: no
-  register: role_details
+- <<: *role_data
+  name: Gather Role facts in check mode
   check_mode: yes
 
-- name: Test if role id is present for role
-  assert:
-    that: "{{ role_details.local_role_facts | json_query(s_query) != [] }}"
-  vars:
-    s_query: "[?role_name == '{{ item }}'].role_id"
-  with_items: "{{ role_list }}"
+- <<: *role_test
+  name: Test if role id is present for role in check mode

--- a/test/integration/targets/vmware_local_role_manager/aliases
+++ b/test/integration/targets/vmware_local_role_manager/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_local_role_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_local_role_manager/tasks/main.yml
@@ -2,34 +2,14 @@
 # Copyright: (c) 2017-2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?esx=1
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
+- import_role:
+    name: prepare_vmware_tests
 
 - name: Create a role without privileges in check mode
   vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     local_role_name: SampleRole_0001
     validate_certs: no
     state: present
@@ -41,11 +21,12 @@
     that:
       - role_creation.changed
 
-- name: Create a role without privileges
+- &create_role_data
+  name: Create a role without privileges
   vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     local_role_name: SampleRole_0001
     validate_certs: no
     state: present
@@ -56,26 +37,20 @@
     that:
       - role_creation_0001.changed
 
-- name: Again create a role without privileges
-  vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    local_role_name: SampleRole_0001
-    validate_certs: no
-    state: present
-  register: role_creation_0001
+- <<: *create_role_data
+  name: Again create a role without privileges
 
 - name: verify if role is not created again
   assert:
     that:
       - not role_creation_0001.changed
 
-- name: Delete a role
+- &delete_role_data
+  name: Delete a role
   vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     local_role_name: SampleRole_0001
     validate_certs: no
     state: absent
@@ -86,15 +61,8 @@
     that:
       - role_creation_0001.changed
 
-- name: Delete role again
-  vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    local_role_name: SampleRole_0001
-    validate_certs: no
-    state: absent
-  register: role_creation_0001
+- <<: *delete_role_data
+  name: Delete role again
 
 - name: Verify if role is absent again
   assert:
@@ -103,9 +71,9 @@
 
 - name: Create a role with privileges
   vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     local_role_name: SampleRole_0001
     validate_certs: no
     local_privilege_ids: ['VirtualMachine.State.RenameSnapshot']
@@ -117,11 +85,12 @@
     that:
       - role_creation_0001.changed
 
-- name: Add a privilege to existing privileges
+- &exist_role_data
+  name: Add a privilege to existing privileges
   vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     local_role_name: SampleRole_0001
     validate_certs: no
     local_privilege_ids: ['Folder.Create']
@@ -134,28 +103,20 @@
     that:
       - role_add.changed
 
-- name: Again add a privilege to existing privileges
-  vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    local_role_name: SampleRole_0001
-    validate_certs: no
-    local_privilege_ids: ['Folder.Create']
-    action: add
-    state: present
-  register: role_add_0002
+- <<: *exist_role_data
+  name: Again add a privilege to existing privileges
 
 - name: Verify if role is not updated
   assert:
     that:
-      - not role_add_0002.changed
+      - not role_add.changed
 
-- name: Remove a privilege from existing privileges
+- &remove_role_data
+  name: Remove a privilege from existing privileges
   vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     local_role_name: SampleRole_0001
     validate_certs: no
     local_privilege_ids: ['Folder.Create']
@@ -167,27 +128,20 @@
     that:
       - role_remove.changed
 
-- name: Again remove a privilege from existing privileges
-  vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    local_role_name: SampleRole_0001
-    validate_certs: no
-    local_privilege_ids: ['Folder.Create']
-    action: remove
-  register: role_remove_0002
+- <<: *remove_role_data
+  name: Again remove a privilege from existing privileges
 
 - name: Verify if role is not updated
   assert:
     that:
-      - not role_remove_0002.changed
+      - not role_remove.changed
 
-- name: Set a privilege to an existing role
+- &set_priv_role_data
+  name: Set a privilege to an existing role
   vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     local_role_name: SampleRole_0001
     validate_certs: no
     local_privilege_ids: ['Folder.Create']
@@ -199,18 +153,10 @@
     that:
       - role_set.changed
 
-- name: Again set a privilege to an existing role
-  vmware_local_role_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    local_role_name: SampleRole_0001
-    validate_certs: no
-    local_privilege_ids: ['Folder.Create']
-    action: set
-  register: role_set_0002
+- <<: *set_priv_role_data
+  name: Again set a privilege to an existing role
 
 - name: verify if role is not updated
   assert:
     that:
-      - not role_set_0002.changed
+      - not role_set.changed

--- a/test/integration/targets/vmware_local_user_facts/aliases
+++ b/test/integration/targets/vmware_local_user_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_local_user_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_local_user_facts/tasks/main.yml
@@ -4,42 +4,35 @@
 
 # Commenting local user testcases as older vcsim docker image
 # does not support this.
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_esxi_instance: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    # Local user manager works only with standalone ESXi server
+    - &user_fact_data
+      name: Gather facts about users
+      vmware_local_user_facts:
+        hostname: "{{ hostvars[esxi1].ansible_host }}"
+        username: "{{ hostvars[esxi1].ansible_user }}"
+        password: "{{ hostvars[esxi1].ansible_password }}"
+        validate_certs: False
+      register: all_user_facts
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - name: ensure user facts are gathered
+      assert:
+        that:
+            - not all_user_facts.changed
+            - all_user_facts.local_user_facts is defined
 
-# Local user manager works only with standalone ESXi server
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?esx=1
-  register: vcsim_instance
+    - <<: *user_fact_data
+      name: Gather facts about users in check mode
+      check_mode: yes
 
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: Gather facts about users
-  vmware_local_user_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: False
-  register: all_user_facts
-
-- name: ensure user facts are gathered
-  assert:
-    that:
-        - not all_user_facts.changed
-        - all_user_facts.local_user_facts is defined
+    - name: ensure user facts are gathered
+      assert:
+        that:
+            - not all_user_facts.changed
+            - all_user_facts.local_user_facts is defined

--- a/test/integration/targets/vmware_local_user_manager/aliases
+++ b/test/integration/targets/vmware_local_user_manager/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_local_user_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_local_user_manager/tasks/main.yml
@@ -1,94 +1,12 @@
-# Test code for the vmware_local_user_manager module.
-# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
-# Commenting local user testcases as older vcsim docker image
-# does not support this.
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-# Local user manager works only with standalone ESXi server
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?esx=1
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-# Testcase 0001: Add Local user in ESXi server
-- name: add local user
-  vmware_local_user_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    local_user_name: testuser_0001
-    local_user_password: "SamplePassword!"
-    state: present
-  register: user_add_0001
-
-- name: ensure user is created
-  assert:
-    that:
-        - user_add_0001.changed == true
-
-# Testcase 0002: Delete Local user in ESXi server
-- name: Delete local user
-  vmware_local_user_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    validate_certs: no
-    local_user_name: testuser_0001
-    state: absent
-  register: user_delete_0002
-
-- name: ensure user is deleted
-  assert:
-    that:
-        - user_delete_0002.changed == true
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-# Local user manager works only with standalone ESXi server not with vCenter
-# So testcase should check failures
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+- import_role:
+    name: prepare_vmware_tests
 
 # Testcase 0003: Add Local user in vCenter server
 - name: add local user
   vmware_local_user_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     local_user_name: testuser_0003
     local_user_password: "SamplePassword!"
@@ -105,9 +23,9 @@
 # Testcase 0003: Delete Local user in vCenter server
 - name: Delete local user
   vmware_local_user_manager:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     local_user_name: testuser_0003
     state: absent

--- a/test/integration/targets/vmware_maintenancemode/aliases
+++ b/test/integration/targets/vmware_maintenancemode/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_maintenancemode/tasks/main.yml
+++ b/test/integration/targets/vmware_maintenancemode/tasks/main.yml
@@ -1,42 +1,20 @@
 # Test code for the vmware_guest_maintenancemode module.
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: Get a list of host systems from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hostsystems
 
 - name: Enter maintenance mode
   vmware_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: present
-    esxi_hostname: "{{ item | basename }}"
+    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
     validate_certs: no
-  with_items: "{{ hostsystems['json'] }}"
   register: test_result_0001
 
 - debug: var=test_result_0001
@@ -44,17 +22,16 @@
 - name: assert that changes were made
   assert:
     that:
-      - "test_result_0001.results|map(attribute='changed')|unique|list == [true]"
+      - test_result_0001 is changed
 
 - name: Enter maintenance mode again
   vmware_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: present
-    esxi_hostname: "{{ item | basename }}"
+    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
     validate_certs: no
-  with_items: "{{ hostsystems['json'] }}"
   register: test_result_0002
 
 - debug: var=test_result_0002
@@ -62,17 +39,16 @@
 - name: assert that no changes were made
   assert:
     that:
-      - "test_result_0002.results|map(attribute='changed')|unique|list == [false]"
+      - not (test_result_0002 is changed)
 
 - name: Exit maintenance mode
   vmware_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: absent
-    esxi_hostname: "{{ item | basename }}"
+    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
     validate_certs: no
-  with_items: "{{ hostsystems['json'] }}"
   register: test_result_0003
 
 - debug: var=test_result_0003
@@ -80,17 +56,16 @@
 - name: assert that changes were made
   assert:
     that:
-      - "test_result_0003.results|map(attribute='changed')|unique|list == [true]"
+      - test_result_0003 is changed
 
 - name: Exit maintenance mode again
   vmware_maintenancemode:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     state: absent
-    esxi_hostname: "{{ item | basename }}"
+    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
     validate_certs: no
-  with_items: "{{ hostsystems['json'] }}"
   register: test_result_0004
 
 - debug: var=test_result_0004
@@ -98,4 +73,4 @@
 - name: assert that no changes were made
   assert:
     that:
-      - "test_result_0004.results|map(attribute='changed')|unique|list == [false]"
+      - not (test_result_0004 is changed)

--- a/test/integration/targets/vmware_portgroup_facts/aliases
+++ b/test/integration/targets/vmware_portgroup_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_portgroup_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_portgroup_facts/tasks/main.yml
@@ -1,57 +1,17 @@
 # Test code for the vmware_portgroup_facts module.
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
 
 - name: Gather portgroup facts for all ESXi host from given cluster
   vmware_portgroup_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
     cluster_name: "{{ ccr1 }}"
   register: portgroup_0001_results
@@ -63,11 +23,11 @@
 
 - name: Gather portgroup facts for an ESXi host
   vmware_portgroup_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: "{{ host1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
   register: portgroup_0002_results
 
 - assert:
@@ -77,11 +37,11 @@
 
 - name: Gather all portgroup facts for an ESXi host
   vmware_portgroup_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: "{{ host1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     policies: true
   register: portgroup_0003_results
 
@@ -92,11 +52,11 @@
 
 - name: Gather all portgroup facts for an ESXi host in check mode
   vmware_portgroup_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: "{{ host1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     policies: true
   register: portgroup_0004_results
   check_mode: yes

--- a/test/integration/targets/vmware_resource_pool/aliases
+++ b/test/integration/targets/vmware_resource_pool/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/test/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -2,56 +2,19 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug: var=vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact: dc1="{{ datacenters['json'][0] | basename }}"
-
-- debug: var=dc1
-
-- name: get a list of Clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact: ccr1="{{ clusters['json'][0] | basename }}"
-
-- debug: var=ccr1
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
 
 # Testcase 0001: Add Resource pool
 - name: add resource pool
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001
@@ -66,27 +29,19 @@
     state: present
   register: resource_result_0001
 
-- name: get a list of resources from vcsim after adding a resource pool
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=RP
-  register: new_rp_list
-
-- set_fact: new_resource="{% for rp in new_rp_list['json'] %} {{ True if (rp | basename) == 'test_resource_0001' else False }} {% endfor %}"
-
 - name: ensure a resource pool is present
   assert:
     that:
         - "{{ resource_result_0001.changed == true }}"
-        - "{{ 'True' in new_resource }}"
 
 
 # Testcase 0002: Add Resource pool again
 - name: add resource pool again
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001
@@ -111,9 +66,9 @@
 - name: add resource pool again
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001
@@ -129,9 +84,9 @@
 - name: add resource pool again
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001

--- a/test/integration/targets/vmware_resource_pool_facts/aliases
+++ b/test/integration/targets/vmware_resource_pool_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_resource_pool_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_resource_pool_facts/tasks/main.yml
@@ -2,35 +2,15 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug: var=vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+- import_role:
+    name: prepare_vmware_tests
 
 - name: Gather facts about resource pool
   vmware_resource_pool_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
   register: resource_result_0001
 
 - name: ensure a resource pool is present


### PR DESCRIPTION
##### SUMMARY

Refactoring of the following roles to make use of the new
`prepare_vmware_tests` role.

- `vmware_inventory`
- `vmware_local_role_facts`
- `vmware_local_role_manager`
- `vmware_local_user_facts`
- `vmware_local_user_manager`
- `vmware_maintenancemode`
- `vmware_portgroup_facts`
- `vmware_resource_pool`
- `vmware_resource_pool_facts`

This patch depends on: https://github.com/ansible/ansible/pull/55719

Original PR: https://github.com/ansible/ansible/pull/54882

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

vmware