### PR TITLE
vmware: refactoring of vmware test roles -- part7

### DIFF
--- a/test/integration/targets/vmware_resource_pool/aliases
+++ b/test/integration/targets/vmware_resource_pool/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/test/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -2,56 +2,19 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug: var=vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact: dc1="{{ datacenters['json'][0] | basename }}"
-
-- debug: var=dc1
-
-- name: get a list of Clusters from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact: ccr1="{{ clusters['json'][0] | basename }}"
-
-- debug: var=ccr1
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
 
 # Testcase 0001: Add Resource pool
 - name: add resource pool
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001
@@ -66,27 +29,19 @@
     state: present
   register: resource_result_0001
 
-- name: get a list of resources from vcsim after adding a resource pool
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=RP
-  register: new_rp_list
-
-- set_fact: new_resource="{% for rp in new_rp_list['json'] %} {{ True if (rp | basename) == 'test_resource_0001' else False }} {% endfor %}"
-
 - name: ensure a resource pool is present
   assert:
     that:
         - "{{ resource_result_0001.changed == true }}"
-        - "{{ 'True' in new_resource }}"
 
 
 # Testcase 0002: Add Resource pool again
 - name: add resource pool again
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001
@@ -111,9 +66,9 @@
 - name: add resource pool again
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001
@@ -129,9 +84,9 @@
 - name: add resource pool again
   vmware_resource_pool:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001

--- a/test/integration/targets/vmware_resource_pool_facts/aliases
+++ b/test/integration/targets/vmware_resource_pool_facts/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_resource_pool_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_resource_pool_facts/tasks/main.yml
@@ -2,35 +2,15 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug: var=vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
+- import_role:
+    name: prepare_vmware_tests
 
 - name: Gather facts about resource pool
   vmware_resource_pool_facts:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
   register: resource_result_0001
 
 - name: ensure a resource pool is present

--- a/test/integration/targets/vmware_target_canonical_facts/aliases
+++ b/test/integration/targets/vmware_target_canonical_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_target_canonical_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_target_canonical_facts/tasks/main.yml
@@ -3,57 +3,17 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support SCSI target releated operations
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Cluster from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-  register: clusters
-
-- name: get a cluster
-  set_fact:
-    ccr1: "{{ clusters.json[0] | basename }}"
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=ccr1
-- debug: var=host1
 
 - name: Gather target facts for all ESXi host from given cluster
   vmware_target_canonical_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
     cluster_name: "{{ ccr1 }}"
   register: target_0001_results
@@ -65,11 +25,11 @@
 
 - name: Gather target facts for ESXi host
   vmware_target_canonical_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
-    esxi_hostname: "{{ host1 }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
   register: target_0002_results
 
 - assert:

--- a/test/integration/targets/vmware_vcenter_settings/aliases
+++ b/test/integration/targets/vmware_vcenter_settings/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vcenter_settings/tasks/main.yml
+++ b/test/integration/targets/vmware_vcenter_settings/tasks/main.yml
@@ -2,44 +2,14 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get datacenter
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact:
-    dc1: "{{ datacenters.json[0] | basename }}"
+- import_role:
+    name: prepare_vmware_tests
 
 - name: Configure general settings in check mode
   vmware_vcenter_settings:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     database:
       max_connections: 50
       task_cleanup: true
@@ -72,18 +42,13 @@
   register: all_settings_results_check_mode
   check_mode: yes
 
-- debug: msg="{{ all_settings_results_check_mode }}"
-
-- name: ensure general settings were configured
-  assert:
-    that:
-        - all_settings_results_check_mode.changed
+- debug: var=all_settings_results_check_mode
 
 - name: Configure general settings
   vmware_vcenter_settings:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     database:
       max_connections: 50
       task_cleanup: true
@@ -115,4 +80,4 @@
     validate_certs: no
   register: all_settings_results
 
-- debug: msg="{{ all_settings_results }}"
+- debug: var=all_settings_results

--- a/test/integration/targets/vmware_vcenter_statistics/aliases
+++ b/test/integration/targets/vmware_vcenter_statistics/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vcenter_statistics/tasks/main.yml
+++ b/test/integration/targets/vmware_vcenter_statistics/tasks/main.yml
@@ -2,44 +2,30 @@
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get datacenter
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- name: get a datacenter
-  set_fact:
-    dc1: "{{ datacenters.json[0] | basename }}"
+- name: Disable all the statistics
+  vmware_vcenter_statistics:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    interval_past_day:
+      enabled: false
+    interval_past_week:
+      enabled: false
+    interval_past_month:
+      enabled: false
+    interval_past_year:
+      enabled: false
+    validate_certs: no
+  register: statistics_results_check_mode
 
 - name: Configure statistics in check mode
-  vmware_vcenter_statistics:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
+  vmware_vcenter_statistics: &stats
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     interval_past_day:
       enabled: true
       interval_minutes: 5
@@ -64,46 +50,37 @@
   register: statistics_results_check_mode
   check_mode: yes
 
-- debug: msg="{{ statistics_results_check_mode }}"
+- debug: var=statistics_results_check_mode
 
 - name: ensure statistics were configured
   assert:
     that:
-        # Doesn't really work with vcsim. No matter which settings are used; they are always shown as already configured!?
-        - statistics_results_check_mode.changed == False
+      # Doesn't really work with vcsim. No matter which settings are used; they are always shown as already configured!?
+      - statistics_results_check_mode is changed
+  when: vcsim is not defined
 
 - name: Configure statistics
   vmware_vcenter_statistics:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance.json.username }}"
-    password: "{{ vcsim_instance.json.password }}"
-    interval_past_day:
-      enabled: true
-      interval_minutes: 5
-      save_for_days: 3
-      level: 2
-    interval_past_week:
-      enabled: true
-      interval_minutes: 30
-      save_for_weeks: 1
-      level: 2
-    interval_past_month:
-      enabled: true
-      interval_hours: 2
-      save_for_months: 1
-      level: 1
-    interval_past_year:
-      enabled: true
-      interval_days: 1
-      save_for_years: 1
-      level: 1
-    validate_certs: no
+    <<: *stats
   register: statistics_results
 
-- debug: msg="{{ statistics_results }}"
+- debug: var=statistics_results
 
 - name: ensure statistics were configured
   assert:
     that:
-        # Doesn't really work with vcsim. No matter which settings are used; they are always shown as already configured!?
-        - statistics_results.changed == False
+      - statistics_results is changed
+  when: vcsim is not defined
+
+- name: Configure statistics (again)
+  vmware_vcenter_statistics:
+    <<: *stats
+  register: statistics_results
+
+- debug: var=statistics_results
+
+- name: ensure statistics were configured
+  assert:
+    that:
+      - not (statistics_results is changed)
+  when: vcsim is not defined

--- a/test/integration/targets/vmware_vm_facts/aliases
+++ b/test/integration/targets/vmware_vm_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 shippable/vcenter/smoketest
 cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -3,36 +3,23 @@
 # Copyright, (c) 2018, Fedor Vompe <f.vompe@comptek.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
 
 - name: Get facts about available vms
   vmware_vm_facts:
     validate_certs: false
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
   register: vm_facts_0001
+
+- debug: var=vm_facts_0001
 
 - name: Verify if VM facts exist
   assert:
@@ -53,9 +40,9 @@
 - name: Get facts about available vms in check mode
   vmware_vm_facts:
     validate_certs: false
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
   register: vm_facts_0001
   check_mode: yes
 

--- a/test/integration/targets/vmware_vm_host_drs_rule/aliases
+++ b/test/integration/targets/vmware_vm_host_drs_rule/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vm_host_drs_rule/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_host_drs_rule/tasks/main.yml
@@ -2,73 +2,81 @@
 # Copyright: (c) 2017, Karsten Kaj Jakobsen <kj@patientsky.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# TODO: vcsim does not support manage DRS rule
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_datastore: true
+        setup_virtualmachines: true
+    - name: Create DRS VM group
+      vmware_drs_group:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: False
+        # Options
+        cluster_name: '{{ ccr1 }}'
+        datacenter_name: '{{ dc1 }}'
+        group_name: DC0_C0_VM_GR1
+        vms: '{{ infra.vm_list }}'
+        state: present
+      register: drs_vm_group_01_results
+    - debug: var=drs_vm_group_01_results
 
-- name: Wait for flask server
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: Create DRS Host group
+      vmware_drs_group:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: False
+        # Options
+        cluster_name: '{{ ccr1 }}'
+        datacenter_name: '{{ dc1 }}'
+        group_name: DC0_C0_HOST_GR1
+        hosts:
+          - '{{ hostvars[esxi1].ansible_host }}'
+          - '{{ hostvars[esxi2].ansible_host }}'
+        state: present
+      register: drs_host_group_01_results
+    - debug: var=drs_host_group_01_results
 
-- name: Kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - name: Create mandatory DRS Affinity rule for VM/Host
+      vmware_vm_host_drs_rule:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_host_aff_0001
+        vm_group_name: DC0_C0_VM_GR1
+        host_group_name: DC0_C0_HOST_GR1
+        cluster_name: "{{ ccr1 }}"
+        enabled: True
+        affinity_rule: True
+        mandatory: True
+      register: drs_rule_host_0001_results
+    - debug: var=drs_rule_host_0001_results
+    - assert:
+        that:
+            - "{{ drs_rule_host_0001_results.changed }}"
 
-- name: Start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=2&cluster=1&folder=0&ds=2&pool=2
-  register: vcsim_instance
-
-- name: Wait for vcsim server
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
-
-# TODO: create host/vm group when vcsim supports this
-
-- name: Create mandatory DRS Affinity rule for VM/Host
-  vmware_vm_host_drs_rule:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    drs_rule_name: drs_rule_host_aff_0001
-    vm_group_name: DC0_C0_VM_GR1
-    host_group_name: DC0_C0_HOST_GR1
-    cluster_name: DC0_C0
-    enabled: True
-    affinity_rule: True
-    mandatory: True
-  register: drs_rule_host_0001_results
-
-- debug: var=drs_rule_host_0001_results
-
-- assert:
-    that:
-        - "{{ drs_rule_host_0001_results.changed }}"
-
-# TODO: create host/vm group when vcsim supports this
-
-- name: Create non-mandatory DRS Anti-Affinity rule for VM/Host
-  vmware_vm_host_drs_rule:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    drs_rule_name: drs_rule_host_aff_0001
-    vm_group_name: DC0_C0_VM_GR1
-    host_group_name: DC0_C0_HOST_GR2
-    cluster_name: DC0_C0
-    enabled: True
-    affinity_rule: False
-    mandatory: False
-  register: drs_rule_host_0002_results
-
-- debug: var=drs_rule_host_0002_results
-
-- assert:
-    that:
-        - "{{ drs_rule_host_0001_results.changed }}"
+    # TODO: create host/vm group when vcsim supports this
+    - name: Create non-mandatory DRS Anti-Affinity rule for VM/Host
+      vmware_vm_host_drs_rule:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_host_aff_0001
+        vm_group_name: DC0_C0_VM_GR1
+        host_group_name: DC0_C0_HOST_GR1
+        cluster_name: "{{ ccr1 }}"
+        enabled: True
+        affinity_rule: False
+        mandatory: False
+      register: drs_rule_host_0002_results
+    - debug: var=drs_rule_host_0002_results
+    - assert:
+        that:
+            - "{{ drs_rule_host_0001_results.changed }}"

--- a/test/integration/targets/vmware_vm_vm_drs_rule/aliases
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
@@ -3,70 +3,46 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support manage DRS rule
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_datastore: true
+        setup_virtualmachines: true
+    - name: Create a DRS Affinity rule for vms
+      vmware_vm_vm_drs_rule:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_0001
+        cluster_name: "{{ ccr1 }}"
+        vms: "{{ infra.vm_list }}"
+        enabled: True
+        affinity_rule: True
+        mandatory: True
+      register: drs_rule_0001_results
+    - debug: var=drs_rule_0001_results
+    - assert:
+        that:
+            - "{{ drs_rule_0001_results.changed }}"
 
-- name: wait for flask server
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=2&cluster=1&folder=0&ds=2&pool=2
-  register: vcsim_instance
-
-- name: wait for vcsim server
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- debug: var=vcsim_instance
-
-- name: Create a DRS Affinity rule for vms
-  vmware_vm_vm_drs_rule:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    drs_rule_name: drs_rule_0001
-    cluster_name: DC0_C0
-    vms:
-      - DC0_C0_RP0_VM0
-      - DC0_C0_RP0_VM1
-    enabled: True
-    affinity_rule: True
-    mandatory: True
-  register: drs_rule_0001_results
-
-- debug: var=drs_rule_0001_results
-
-- assert:
-    that:
-        - "{{ drs_rule_0001_results.changed }}"
-
-- name: Create a DRS Anti-Affinity rule for vms
-  vmware_vm_vm_drs_rule:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    drs_rule_name: drs_rule_0001
-    cluster_name: DC0_C0
-    vms:
-      - DC0_C0_RP0_VM0
-      - DC0_C0_RP0_VM1
-    enabled: False
-    affinity_rule: False
-    mandatory: False
-  register: drs_rule_0002_results
-
-- debug: var=drs_rule_0002_results
-
-- assert:
-    that:
-        - "{{ drs_rule_0002_results.changed }}"
+    - name: Create a DRS Anti-Affinity rule for vms
+      vmware_vm_vm_drs_rule:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_0001
+        cluster_name: "{{ ccr1 }}"
+        vms: "{{ infra.vm_list }}"
+        enabled: False
+        affinity_rule: False
+        mandatory: False
+      register: drs_rule_0002_results
+    - debug: var=drs_rule_0002_results
+    - assert:
+        that:
+            - "{{ drs_rule_0002_results.changed }}"

--- a/test/integration/targets/vmware_vmkernel/aliases
+++ b/test/integration/targets/vmware_vmkernel/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vmkernel/tasks/main.yml
+++ b/test/integration/targets/vmware_vmkernel/tasks/main.yml
@@ -1,138 +1,65 @@
 # Test code for the vmware_vmkernel module.
 # Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
+- when: vcsim is not defined
+  block:
 # TODO: vcsim does not support HostVirtualNicManager-related operations
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_switch: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: create basic portgroup
+      vmware_portgroup:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch_name: "{{ switch1 }}"
+        cluster_name: "{{ ccr1 }}"
+        portgroup_name: vMotion
+        vlan_id: 0
+        state: present
+      register: dvs_pg_result_0001
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+    - debug: var=dvs_pg_result_0001
+    - name: Create VMkernel adapter with vMotion TCP/IP stack
+      vmware_vmkernel: &new_vmkernel
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        vswitch: "{{ switch1 }}"
+        portgroup: vMotion
+        mtu: 9000
+        network:
+          type: static
+          ip_address: 192.168.100.100
+          subnet_mask: 255.255.255.0
+          tcpip_stack: vmotion
+        state: present
+        validate_certs: no
+      register: host_vmkernel
+    - debug: var=host_vmkernel
 
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+    - name: Create VMkernel adapter in check mode
+      vmware_vmkernel:
+        <<: *new_vmkernel
+      register: host_vmkernel
+      check_mode: yes
+    - debug: var=host_vmkernel
 
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Create VMkernel adapter
-  vmware_vmkernel:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    vswitch: vSwitch1
-    portgroup: vMotion
-    mtu: 1500
-    enable_vmotion: True
-    state: present
-    validate_certs: no
-  register: host_vmkernel
-
-- debug: var=host_vmkernel
-
-- name: Create VMkernel adapter in check mode
-  vmware_vmkernel:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    vswitch: vSwitch1
-    portgroup: vMotion
-    mtu: 1500
-    enable_vmotion: True
-    state: present
-    validate_certs: no
-  register: host_vmkernel
-  check_mode: yes
-
-- debug: var=host_vmkernel
-
-- name: Delete VMkernel adapter
-  vmware_vmkernel:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    vswitch: vSwitch1
-    portgroup: vMotion
-    state: absent
-    validate_certs: no
-  register: host_vmkernel
-
-- debug: var=host_vmkernel
-
-- name: Create VMkernel adapter with vMotion TCP/IP stack
-  vmware_vmkernel:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    vswitch: vSwitch1
-    portgroup: vMotion
-    mtu: 9000
-    network:
-      type: static
-      ip_address: 192.168.100.100
-      subnet_mask: 255.255.255.0
-      tcpip_stack: vmotion
-    state: present
-    validate_certs: no
-  register: host_vmkernel
-
-- debug: var=host_vmkernel
-
-- name: Delete VMkernel adapter
-  vmware_vmkernel:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    vswitch: vSwitch1
-    portgroup: vMotion
-    state: absent
-    validate_certs: no
-  register: host_vmkernel
-
-- debug: var=host_vmkernel
-
-- name: Create VMkernel adapter with DHCP
-  vmware_vmkernel:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    vswitch: vSwitch1
-    portgroup: vMotion
-    mtu: 9000
-    network:
-      type: dhcp
-    state: present
-    validate_certs: no
-  register: host_vmkernel
-
-- debug: var=host_vmkernel
+    - name: Delete VMkernel adapter
+      vmware_vmkernel:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        vswitch: "{{ switch1 }}"
+        device: '{{ host_vmkernel.device }}'
+        portgroup: vMotion
+        state: absent
+        validate_certs: no
+      register: host_vmkernel
+    - debug: var=host_vmkernel

--- a/test/integration/targets/vmware_vmkernel_facts/aliases
+++ b/test/integration/targets/vmware_vmkernel_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
@@ -3,69 +3,36 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support HostVirtualNicManager related to operations
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+    - name: Gather VMkernel facts for a given host
+      vmware_vmkernel_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+      register: host_vmkernel
+    - debug: var=host_vmkernel
+    - assert:
+        that:
+          - host_vmkernel.host_vmk_facts is defined
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
-
-- name: Gather VMkernel facts about all hosts in given cluster
-  vmware_vmkernel_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-  register: host_vmkernel
-
-- debug: var=host_vmkernel
-
-- assert:
-    that:
-      - host_vmkernel.host_vmk_facts is defined
-
-- name: Gather VMkernel facts about all hosts in given cluster in check mode
-  vmware_vmkernel_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
-    validate_certs: no
-  register: host_vmkernel_check_mode
-  check_mode: yes
-
-- debug: var=host_vmkernel
-
-- assert:
-    that:
-      - host_vmkernel_check_mode.host_vmk_facts is defined
+    - name: Gather VMkernel facts for a given host in check mode
+      vmware_vmkernel_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        validate_certs: no
+      register: host_vmkernel_check_mode
+      check_mode: yes
+    - debug: var=host_vmkernel
+    - assert:
+        that:
+          - host_vmkernel_check_mode.host_vmk_facts is defined

--- a/test/integration/targets/vmware_vspan_session/aliases
+++ b/test/integration/targets/vmware_vspan_session/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vspan_session/tasks/main.yml
+++ b/test/integration/targets/vmware_vspan_session/tasks/main.yml
@@ -2,42 +2,19 @@
 # Copyright: (c) 2018, Peter Gyorgy <gyorgy.peter@edu.bme.hu>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
 
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of Datacenter from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DC
-  register: datacenters
-
-- debug: var=vcsim_instance
-- debug: var=datacenters
 
 - name: add distributed vSwitch
   vmware_dvswitch:
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter_name: "{{ item | basename }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
     state: present
     switch_name: dvswitch_0001
     mtu: 9000
@@ -45,35 +22,17 @@
     discovery_proto: lldp
     discovery_operation: both
   register: dvs_result_0001
-  with_items:
-    - "{{ datacenters['json'] }}"
-
+- debug: var=dvs_result_0001
 - name: ensure distributed vswitch is present
   assert:
     that:
         - "{{ dvs_result_0001.changed == true }}"
 
-- name: get a list of distributed vswitch from vcsim after adding
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=DVS
-  register: new_dvs_0001
-
-- debug:
-    msg: "{{ item | basename }}"
-  with_items: "{{ new_dvs_0001['json'] }}"
-
-- set_fact: new_dvs_name="{% for dvs in new_dvs_0001['json'] %} {{ True if (dvs | basename) == 'dvswitch_0001' else False }}{% endfor %}"
-
-- debug: var=new_dvs_name
-- assert:
-    that:
-      - "{{ 'True' in new_dvs_name }}"
-
 - name: Create vlan portgroup with all security and port policies
   vmware_dvs_portgroup:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
     portgroup_name: vlan-123-portrgoup
     switch_name: dvswitch_0001
@@ -104,39 +63,40 @@
     that:
         - portgroup_create_result.changed
 
-- name: create a session.
-  vmware_vspan_session:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    validate_certs: False
-    switch: dvswitch_0001
-    name: "session_0001"
-    state: "present"
-    enabled: True
-    description: "basic_description"
-    source_port_transmitted: 13
-    source_port_received: 13
-    destination_port: 12
-  register: vspan_session_create_result
+- when: vcsim is not defined
+  block:
+    - name: create a session.
+      vmware_vspan_session:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: False
+        switch: dvswitch_0001
+        name: "session_0001"
+        state: "present"
+        enabled: True
+        description: "basic_description"
+        source_port_transmitted: 13
+        source_port_received: 13
+        destination_port: 12
+      register: vspan_session_create_result
+    - debug: var=vspan_session_create_result
+    - name: ensure session was created
+      assert:
+        that:
+            - vspan_session_create_result.changed
 
-- name: ensure session was created
-  assert:
-    that:
-        - vspan_session_create_result.changed
-
-- name: delete a session.
-  vmware_vspan_session:
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    validate_certs: False
-    switch: dvswitch_0001
-    name: "session_0001"
-    state: "absent"
-  register: vspan_session_delete_result
-
-- name: ensure session was deleted
-  assert:
-    that:
-        - vspan_session_delete_result.changed
+    - name: delete a session.
+      vmware_vspan_session:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: False
+        switch: dvswitch_0001
+        name: "session_0001"
+        state: "absent"
+      register: vspan_session_delete_result
+    - name: ensure session was deleted
+      assert:
+        that:
+            - vspan_session_delete_result.changed

--- a/test/integration/targets/vmware_vswitch/aliases
+++ b/test/integration/targets/vmware_vswitch/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/main.yml
@@ -2,143 +2,113 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# TODO: akasurde: VCSIM does not suport network manager system
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: '{{ vcsim }}'
-    port: 5000
-    state: started
+  # TODO: akasurde: VCSIM does not suport network manager system
+  # FIXME: Implement check-mode support
 
-- name: Kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
+  - name: Add a nic to a switch
+    vmware_vswitch:
+      hostname: '{{ hostvars[esxi1].ansible_host }}'
+      username: '{{ hostvars[esxi1].ansible_user }}'
+      password: '{{ hostvars[esxi1].ansible_password }}'
+      validate_certs: no
+      switch: vmswitch_0001
+      nics: vnic_1
+      state: present
+    register: add_nic_run
+  - assert:
+      that:
+      - add_nic_run.changed == true
 
-- name: Start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
+  - name: Add a nic to a switch again
+    vmware_vswitch:
+      hostname: '{{ hostvars[esxi1].ansible_host }}'
+      username: '{{ hostvars[esxi1].ansible_user }}'
+      password: '{{ hostvars[esxi1].ansible_password }}'
+      validate_certs: no
+      switch: vmswitch_0001
+      nics: vnic_1
+      state: present
+    register: add_nic_again_run
+  - assert:
+      that:
+      - add_nic_again_run.changed == false
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: '{{ vcsim }}'
-    port: 443
-    state: started
+  - name: Remove a switch (check-mode)
+    vmware_vswitch:
+      hostname: '{{ hostvars[esxi1].ansible_host }}'
+      username: '{{ hostvars[esxi1].ansible_user }}'
+      password: '{{ hostvars[esxi1].ansible_password }}'
+      validate_certs: no
+      switch: vmswitch_0001
+      state: absent
+    check_mode: yes
+    register: remove_nic_check
+  # FIXME: Implement check-mode support
+  - assert:
+      that:
+      - remove_nic_check.changed == true
 
-- debug:
-    var: vcsim_instance
+  # FIXME: Removing a switch fails
+  - name: Remove a switch
+    vmware_vswitch:
+      hostname: '{{ hostvars[esxi1].ansible_host }}'
+      username: '{{ hostvars[esxi1].ansible_user }}'
+      password: '{{ hostvars[esxi1].ansible_password }}'
+      validate_certs: no
+      switch: vmswitch_0001
+      state: absent
+    register: remove_nic_run
+  - assert:
+      that:
+      - remove_nic_run.changed == true
 
-# FIXME: Implement check-mode support
-- name: Add a nic to a switch (check-mode)
-  vmware_vswitch: &add_nic
-    hostname: '{{ vcsim }}'
-    username: '{{ vcsim_instance.json.username }}'
-    password: '{{ vcsim_instance.json.password }}'
-    validate_certs: no
-    switch: vmswitch_0001
-    nics: vnic_1
-    state: present
-  check_mode: yes
-  register: add_nic_check
+  - name: Remove a switch again (check-mode)
+    vmware_vswitch:
+      hostname: '{{ hostvars[esxi1].ansible_host }}'
+      username: '{{ hostvars[esxi1].ansible_user }}'
+      password: '{{ hostvars[esxi1].ansible_password }}'
+      validate_certs: no
+      switch: vmswitch_0001
+      state: absent
+    check_mode: yes
+    register: remove_nic_again_check
+  # FIXME: Implement check-mode support
+  - assert:
+      that:
+      - remove_nic_again_check_mode.changed == false
 
-- assert:
-    that:
-    - add_nic_check.changed == true
-    - add_nic_check.skipped == true
+  # FIXME: Removing a switch fails
+  - name: Remove a switch again
+    vmware_vswitch:
+      hostname: '{{ hostvars[esxi1].ansible_host }}'
+      username: '{{ hostvars[esxi1].ansible_user }}'
+      password: '{{ hostvars[esxi1].ansible_password }}'
+      validate_certs: no
+      switch: vmswitch_0001
+      state: absent
+    register: remove_nic_again_run
+  - assert:
+      that:
+      - remove_nic_again_run.changed == false
 
-- name: Add a nic to a switch
-  vmware_vswitch: *add_nic
-  register: add_nic_run
-
-- assert:
-    that:
-    - add_nic_run.changed == true
-
-# FIXME: Implement check-mode support
-- name: Add a nic to a switch again (check-mode)
-  vmware_vswitch: *add_nic
-  check_mode: yes
-  register: add_nic_again_check
-
-- assert:
-    that:
-    - add_nic_again_check.changed == false
-
-- name: Add a nic to a switch again
-  vmware_vswitch: *add_nic
-  register: add_nic_again_run
-
-- assert:
-    that:
-    - add_nic_again_run.changed == false
-
-- name: Remove a switch (check-mode)
-  vmware_vswitch: &remove_nic
-    hostname: '{{ vcsim }}'
-    username: '{{ vcsim_instance.json.username }}'
-    password: '{{ vcsim_instance.json.password }}'
-    validate_certs: no
-    switch: vmswitch_0001
-    state: absent
-  check_mode: yes
-  register: remove_nic_check
-
-# FIXME: Implement check-mode support
-- assert:
-    that:
-    - remove_nic_check.changed == true
-
-# FIXME: Removing a switch fails
-- name: Remove a switch
-  vmware_vswitch: *remove_nic
-  register: remove_nic_run
-
-- assert:
-    that:
-    - remove_nic_run.changed == true
-
-- name: Remove a switch again (check-mode)
-  vmware_vswitch: *remove_nic
-  check_mode: yes
-  register: remove_nic_again_check
-
-# FIXME: Implement check-mode support
-- assert:
-    that:
-    - remove_nic_again_check_mode.changed == false
-
-# FIXME: Removing a switch fails
-- name: Remove a switch again
-  vmware_vswitch: *remove_nic
-  register: remove_nic_again_run
-
-- assert:
-    that:
-    - remove_nic_again_run.changed == false
-
-- name: get a list of Host Systems from vcsim
-  uri:
-    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=H' }}"
-  register: host_systems
-
-- name: get a host system
-  set_fact: hs1="{{ host_systems['json'][0] | basename }}"
-
-- debug: var=hs1
-
-- name: Add vswitch to a specific host system
-  vmware_vswitch:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch: vmswitch_0002
-    nics: vnic_1
-    esxi_hostname: hs1
-  register: add_vswitch_with_host_system
-
-- debug: var=add_vswitch_with_host_system
-
-- assert:
-    that:
-    - add_vswitch_with_host_system.changed == true
+  - name: Add vswitch to a specific host system
+    vmware_vswitch:
+      validate_certs: False
+      hostname: '{{ hostvars[esxi1].ansible_host }}'
+      username: '{{ hostvars[esxi1].ansible_user }}'
+      password: '{{ hostvars[esxi1].ansible_password }}'
+      switch: vmswitch_0002
+      nics: vnic_1
+      esxi_hostname: guest1
+    register: add_vswitch_with_host_system
+  - debug: var=add_vswitch_with_host_system
+  - assert:
+      that:
+      - add_vswitch_with_host_system.changed == true

--- a/test/integration/targets/vmware_vswitch_facts/aliases
+++ b/test/integration/targets/vmware_vswitch_facts/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-unsupported
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vswitch_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch_facts/tasks/main.yml
@@ -2,49 +2,19 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
 # TODO: vcsim does not support networkConfig related to operations
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-
-- name: start vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?cluster=2
-  register: vcsim_instance
-
-- debug:
-    var: vcsim_instance
-
-- name: Wait for vcsim server to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of hosts from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=H
-  register: hosts
-
-- name: get a host
-  set_fact:
-    host1: "{{ hosts.json[0] | basename }}"
-
-- debug: var=host1
 
 - name: Gather vswitch facts about all hosts in given cluster
   vmware_vswitch_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     validate_certs: no
   register: switch_facts
 
@@ -56,10 +26,10 @@
 
 - name: Gather vswitch facts about all hosts in given cluster in check mode
   vmware_vswitch_facts:
-    hostname: "{{ vcsim }}"
-    username: "{{ user }}"
-    password: "{{ passwd }}"
-    esxi_hostname: "{{ host1 }}"
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
     validate_certs: no
   register: switch_facts_check_mode
   check_mode: yes


### PR DESCRIPTION
Refactoring of the following roles to make use of the new
`prepare_vmware_tests` role.
 
- `vmware_resource_pool`
- `vmware_resource_pool_facts`
- `vmware_target_canonical_facts`
- `vmware_vcenter_settings`
- `vmware_vcenter_statistics`
- `vmware_vm_facts`
- `vmware_vm_host_drs_rule`
- `vmware_vm_vm_drs_rule`
- `vmware_vmkernel`
- `vmware_vmkernel_facts`
- `vmware_vspan_session`
- `vmware_vswitch`
- `vmware_vswitch_facts`
 
This patch depends on: https://github.com/ansible/ansible/pull/55719
   
Original PR: https://github.com/ansible/ansible/pull/54882

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
vmware