### PR TITLE
url lookup: add user agent option; use consistent default

### DIFF
--- a/changelogs/fragments/55733-add-url-user-agent-option.yaml
+++ b/changelogs/fragments/55733-add-url-user-agent-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - url - Add user agent option to lookup and use more consistent default

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -36,6 +36,11 @@ options:
     type: string
     default: None
     version_added: "2.8"
+  http_agent:
+    description: Header to identify as, generally appears in web server logs.
+    type: string
+    default: ansible-httpget
+    version_added: "2.9"
 """
 
 EXAMPLES = """
@@ -78,7 +83,8 @@ class LookupModule(LookupBase):
                 response = open_url(term, validate_certs=self.get_option('validate_certs'),
                                     use_proxy=self.get_option('use_proxy'),
                                     url_username=self.get_option('username'),
-                                    url_password=self.get_option('password'))
+                                    url_password=self.get_option('password'),
+                                    http_agent=self.get_option('http_agent'))
             except HTTPError as e:
                 raise AnsibleError("Received HTTP error for %s : %s" % (term, to_native(e)))
             except URLError as e:


### PR DESCRIPTION
##### SUMMARY
Add ability to set user agent with URL lookup. At the same time, apply a default of `ansible-httpget` to match the URL module and various other modules that do HTTP requests.

The change in default is particularly useful because otherwise the default Python user agent of `Python-urllib*` is used, which can end up blocked by the [OWASP ModSecurity ruleset](https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/f844b8510beb619ebad0d17d23a6dac08c1bd62d/rules/scripting-user-agents.data#L22). As a particular example, this currently blocks simple retrieval of [Cloudflare IP ranges](https://www.cloudflare.com/ips-v4).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
url

##### ADDITIONAL INFORMATION
n/a