### PR TITLE
nxos_vtp_*: Fixes n6k issues

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vtp_password.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_password.py
@@ -101,15 +101,12 @@ changed:
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.network.nxos.nxos import get_capabilities
 from ansible.module_utils.basic import AnsibleModule
 import re
 
 
-def execute_show_command(command, module, command_type='cli_show'):
-    if 'status' not in command:
-        output = 'json'
-    else:
-        output = 'text'
+def execute_show_command(command, module, output='json'):
     cmds = [{
         'command': command,
         'output': output,
@@ -145,7 +142,7 @@ def get_vtp_config(module):
     command = 'show vtp status'
 
     body = execute_show_command(
-        command, module)[0]
+        command, module, 'text')[0]
     vtp_parsed = {}
 
     if body:
@@ -174,16 +171,23 @@ def get_vtp_config(module):
 
 def get_vtp_password(module):
     command = 'show vtp password'
-    body = execute_show_command(command, module)[0]
-    try:
-        password = body['passwd']
-        if password:
-            return str(password)
-        else:
-            return ""
-    except TypeError:
-        return ""
+    output = 'json'
+    cap = get_capabilities(module)['device_info']['network_os_model']
+    if re.search(r'Nexus 6', cap):
+        output = 'text'
 
+    body = execute_show_command(command, module, output)[0]
+
+    if output == 'json':
+        password = body.get('passwd', '')
+    else:
+        password = ''
+        rp = r'VTP Password: (\S+)'
+        mo = re.search(rp, body)
+        if mo:
+            password = mo.group(1)
+
+    return str(password)
 
 def main():
     argument_spec = dict(
@@ -214,8 +218,8 @@ def main():
 
     commands = []
     if state == 'absent':
-        # if vtp_password is not set, some devices returns '\\'
-        if not existing['vtp_password'] or existing['vtp_password'] == '\\':
+        # if vtp_password is not set, some devices returns '\\' or the string 'None'
+        if not existing['vtp_password'] or existing['vtp_password'] == '\\' or existing['vtp_password'] == 'None':
             pass
         elif vtp_password is not None:
             if existing['vtp_password'] == proposed['vtp_password']:

--- a/lib/ansible/modules/network/nxos/nxos_vtp_password.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_password.py
@@ -189,6 +189,7 @@ def get_vtp_password(module):
 
     return str(password)
 
+
 def main():
     argument_spec = dict(
         vtp_password=dict(type='str', no_log=True),

--- a/lib/ansible/modules/network/nxos/nxos_vtp_version.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_version.py
@@ -84,18 +84,12 @@ changed:
 '''
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.network.nxos.nxos import get_capabilities
 from ansible.module_utils.basic import AnsibleModule
-
-
-import re
 import re
 
 
-def execute_show_command(command, module, command_type='cli_show'):
-    if 'status' not in command:
-        output = 'json'
-    else:
-        output = 'text'
+def execute_show_command(command, module, output='json'):
     cmds = [{
         'command': command,
         'output': output,
@@ -117,7 +111,7 @@ def flatten_list(command_lists):
 def get_vtp_config(module):
     command = 'show vtp status'
     body = execute_show_command(
-        command, module)[0]
+        command, module, 'text')[0]
     vtp_parsed = {}
 
     if body:
@@ -146,15 +140,23 @@ def get_vtp_config(module):
 
 def get_vtp_password(module):
     command = 'show vtp password'
-    body = execute_show_command(command, module)[0]
-    try:
-        password = body['passwd']
-        if password:
-            return str(password)
-        else:
-            return ""
-    except TypeError:
-        return ""
+    output = 'json'
+    cap = get_capabilities(module)['device_info']['network_os_model']
+    if re.search(r'Nexus 6', cap):
+        output = 'text'
+
+    body = execute_show_command(command, module, output)[0]
+
+    if output == 'json':
+        password = body.get('passwd', '')
+    else:
+        password = ''
+        rp = r'VTP Password: (\S+)'
+        mo = re.search(rp, body)
+        if mo:
+            password = mo.group(1)
+
+    return str(password)
 
 
 def main():

--- a/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
@@ -3,7 +3,18 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: vtp_run="true"
+- set_fact: vtp_run="false"
+  when: platform is search('N3K-F|N9K-F')
+
 - block:
+  - name: disable feature vtp
+    nxos_feature:
+      feature: vtp
+      provider: "{{ connection }}"
+      state: disabled
+    ignore_errors: yes
+
   - name: enable feature vtp
     nxos_feature:
       feature: vtp
@@ -27,6 +38,8 @@
   - assert: &false
       that:
         - "result.changed == false"
+
+  when: vtp_run
 
   always:
   - name: disable feature vtp

--- a/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
@@ -3,7 +3,18 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: vtp_run="true"
+- set_fact: vtp_run="false"
+  when: platform is search('N3K-F|N9K-F')
+
 - block:
+  - name: disable feature vtp
+    nxos_feature:
+      feature: vtp
+      provider: "{{ connection }}"
+      state: disabled
+    ignore_errors: yes
+
   - name: enable feature vtp
     nxos_feature:
       feature: vtp
@@ -48,6 +59,8 @@
     register: result
 
   - assert: *false
+
+  when: vtp_run
 
   always:
   - name: disable feature vtp

--- a/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
@@ -3,7 +3,18 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: vtp_run="true"
+- set_fact: vtp_run="false"
+  when: platform is search('N3K-F|N9K-F')
+
 - block:
+  - name: disable feature vtp
+    nxos_feature:
+      feature: vtp
+      provider: "{{ connection }}"
+      state: disabled
+    ignore_errors: yes
+
   - name: enable feature vtp
     nxos_feature:
       feature: vtp
@@ -27,6 +38,8 @@
   - assert: &false
       that:
         - "result.changed == false"
+
+  when: vtp_run
 
   always:
   - name: disable feature vtp


### PR DESCRIPTION
##### SUMMARY
Add `n6k` platform support for the `nxos_vtp_domain|password|version` modules.  The `n6k` platform does not support structured output for getting the vtp password.

**Note:** This is essentially the same fix in each module.  All of this code really should be in a single nxos_vtp module but it's been three distinct modules from the beginning.  At some point we should consider deprecating these three modules and combine then into one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_vtp_domain, nxos_vtp_password, nxos_vtp_version

##### ADDITIONAL INFORMATION
Tested on N3k, N6k, N7k, N9k platforms.
