### PR TITLE
Improve testing of FactCache

### DIFF
--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -95,7 +95,6 @@ class TestCachePluginAdjudicator:
         self.cache.update({'cache_key': {'key2': 'updatedvalue'}})
         assert self.cache['cache_key']['key2'] == 'updatedvalue'
 
-
 class TestFactCache(unittest.TestCase):
 
     def setUp(self):
@@ -116,6 +115,13 @@ class TestFactCache(unittest.TestCase):
             self.assertRaisesRegexp(AnsibleError,
                                     "Unable to load the facts cache plugin.*json.*",
                                     FactCache)
+    def test_update(self):
+        self.cache.update({'cache_key': {'key2': 'updatedvalue'}})
+        assert self.cache['cache_key']['key2'] == 'updatedvalue'
+
+    def test_update_legacy(self):
+        self.cache.update('cache_key', {'key2': 'updatedvalue'})
+        assert self.cache['cache_key']['key2'] == 'updatedvalue'
 
     def test_update_legacy_key_exists(self):
         self.cache['cache_key'] = {'key': 'value', 'key2': 'value2'}

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -95,6 +95,7 @@ class TestCachePluginAdjudicator:
         self.cache.update({'cache_key': {'key2': 'updatedvalue'}})
         assert self.cache['cache_key']['key2'] == 'updatedvalue'
 
+
 class TestFactCache(unittest.TestCase):
 
     def setUp(self):
@@ -115,6 +116,7 @@ class TestFactCache(unittest.TestCase):
             self.assertRaisesRegexp(AnsibleError,
                                     "Unable to load the facts cache plugin.*json.*",
                                     FactCache)
+
     def test_update(self):
         self.cache.update({'cache_key': {'key2': 'updatedvalue'}})
         assert self.cache['cache_key']['key2'] == 'updatedvalue'


### PR DESCRIPTION
##### SUMMARY

I think, I found a bug in the rewrite of FactCache (Commit bd7322a3f6b).
Added some tests to show the problem.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
FactCache

##### ADDITIONAL INFORMATION

Legacy calls of FactCache.update() should be handled by FactCache.first_order_merge(), but the latter one is not defined.
My additional tests are showing this:

```paste below
bin/ansible-test units -v --python 3.6 test/units/plugins/cache/test_cache.py
[...]
[gw1] [100%] FAILED test/units/plugins/cache/test_cache.py::TestFactCache::test_update_legacy
[...]
___________________________________________________ TestFactCache.test_update_legacy ____________________________________________________
[gw1] linux -- Python 3.6.7 /tmp/python-idtu1jeh-ansible/python
self = <units.plugins.cache.test_cache.TestFactCache testMethod=test_update_legacy>

    def test_update_legacy(self):
>       self.cache.update('cache_key', {'key2': 'updatedvalue'})

test/units/plugins/cache/test_cache.py:123: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible.plugins.cache.FactCache object at 0x7f23a05285f8>
args = ('cache_key', {'key2': 'updatedvalue'})

    def update(self, *args):
        """
        Backwards compat shim
    
        We thought we needed this to ensure we always called the plugin's set() method but
        MutableMapping.update() will call our __setitem__() just fine.  It's the calls to update
        that we need to be careful of.  This contains a bug::
    
            fact_cache[host.name].update(facts)
    
        It retrieves a *copy* of the facts for host.name and then updates the copy.  So the changes
        aren't persisted.
    
        Instead we need to do::
    
            fact_cache.update({host.name, facts})
    
        Which will use FactCache's update() method.
    
        We currently need this shim for backwards compat because the update() method that we had
        implemented took key and value as arguments instead of taking a dict.  We can remove the
        shim in 2.12 as MutableMapping.update() should do everything that we need.
        """
        if len(args) == 2:
            # Deprecated.  Call the new function with this name
            display.deprecated('Calling FactCache().update(key, value) is deprecated.  Use'
                               ' FactCache().first_order_merge(key, value) if you want the old'
                               ' behaviour or use FactCache().update({key: value}) if you want'
                               ' dict-like behaviour.', version='2.12')
>           return self.first_order_merge(*args)
E           AttributeError: 'FactCache' object has no attribute 'first_order_merge'

lib/ansible/vars/fact_cache.py:90: AttributeError

```
