### PR TITLE
[stable-2.8] meraki_content_filtering - Remove redundant API call with get_nets() …

### DIFF
--- a/changelogs/fragments/meraki_content_filtering-redundant-calls.yml
+++ b/changelogs/fragments/meraki_content_filtering-redundant-calls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "meraki_static_route - Module would make unnecessary API calls to Meraki when ``net_id`` is specified in task."

--- a/lib/ansible/modules/network/meraki/meraki_content_filtering.py
+++ b/lib/ansible/modules/network/meraki/meraki_content_filtering.py
@@ -172,8 +172,6 @@ def main():
     org_id = meraki.params['org_id']
     if not org_id:
         org_id = meraki.get_org_id(meraki.params['org_name'])
-    nets = meraki.get_nets(org_id=org_id)
-
     net_id = None
     if net_id is None:
         nets = meraki.get_nets(org_id=org_id)


### PR DESCRIPTION

##### SUMMARY
…(#55531)

* Remove redundant API call with get_nets()

* Add changelog fragment

(cherry picked from commit 56da3825c6171bc64f1579131d5c2f500d09e7ae)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_content_filtering
