### PR TITLE
[stable-2.8] meraki_static_route - Remove unnecessary API call (#55528)

### DIFF
--- a/changelogs/fragments/meraki_static_route_api_calls.yml
+++ b/changelogs/fragments/meraki_static_route_api_calls.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "meraki_static_route - Module would make unnecessary API calls to Meraki when ``net_id`` is specified in task."

--- a/lib/ansible/modules/network/meraki/meraki_static_route.py
+++ b/lib/ansible/modules/network/meraki/meraki_static_route.py
@@ -328,9 +328,9 @@ def main():
     org_id = meraki.params['org_id']
     if not org_id:
         org_id = meraki.get_org_id(meraki.params['org_name'])
-    nets = meraki.get_nets(org_id=org_id)
     net_id = meraki.params['net_id']
     if net_id is None:
+        nets = meraki.get_nets(org_id=org_id)
         net_id = meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
 
     if meraki.params['state'] == 'query':


### PR DESCRIPTION
##### SUMMARY
* Make module not get all nets every time it's executed with net_id

* Add changelog fragment

* Update changelogs/fragments/meraki_static_route_api_calls.yml

Co-Authored-By: kbreit <kevin.breit@kevinbreit.net>
(cherry picked from commit 7b7d6a1fef42eed7e144a7c391817a0a8263c3ae)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_static_route
