### PR TITLE
Using `None` for protocol to should match all rules

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -239,7 +239,7 @@ def _find_matching_rule(module, secgroup, remotegroup):
     remote_group_id = remotegroup['id']
 
     for rule in secgroup['security_group_rules']:
-        if (protocol == rule['protocol'] and
+        if ((not protocol or protocol == rule['protocol']) and
                 remote_ip_prefix == rule['remote_ip_prefix'] and
                 ethertype == rule['ethertype'] and
                 direction == rule['direction'] and


### PR DESCRIPTION
##### SUMMARY
This fixes an issue where you could not remove a rule with the protocol set to `Any`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_security_group_rule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
