### PR TITLE
ovirt_vm: Check if disk is attached to VM or template

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -612,6 +612,23 @@ def searchable_attributes(module):
     return dict((k, v) for k, v in attributes.items() if v is not None)
 
 
+def get_vm_service(connection, module):
+    if module.params.get('vm_id') is not None or module.params.get('vm_name') is not None and module.params['state'] != 'absent':
+        vms_service = connection.system_service().vms_service()
+
+        # If `vm_id` isn't specified, find VM by name:
+        vm_id = module.params['vm_id']
+        if vm_id is None:
+            vm_id = get_id_by_name(vms_service, module.params['vm_name'])
+
+        if vm_id is None:
+            module.fail_json(
+                msg="VM don't exists, please create it first."
+            )
+
+        return vms_service.vm_service(vm_id)
+
+
 def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(
@@ -678,23 +695,31 @@ def main():
             service=disks_service,
         )
 
+        force_create = False
+        vm_service = get_vm_service(connection, module)
         if lun:
             disk = _search_by_lun(disks_service, lun.get('id'))
+        else:
+            disk = disks_module.search_entity(search_params=searchable_attributes(module))
+            if vm_service:
+                # If the VM don't exist in VMs disks, but still it's found it means it was found
+                # for template with same name as VM, so we should force create the VM disk.
+                force_create = disk.id not in [a.disk.id for a in vm_service.disk_attachments_service().list()]
 
         ret = None
         # First take care of creating the VM, if needed:
         if state in ('present', 'detached', 'attached'):
             ret = disks_module.create(
-                entity=disk,
-                search_params=searchable_attributes(module),
+                entity=disk if not force_create else None,
                 result_state=otypes.DiskStatus.OK if lun is None else None,
                 fail_condition=lambda d: d.status == otypes.DiskStatus.ILLEGAL if lun is None else False,
+                force_create=force_create,
             )
             is_new_disk = ret['changed']
             ret['changed'] = ret['changed'] or disks_module.update_storage_domains(ret['id'])
             # We need to pass ID to the module, so in case we want detach/attach disk
             # we have this ID specified to attach/detach method:
-            module.params['id'] = ret['id'] if disk is None else disk.id
+            module.params['id'] = ret['id']
 
             # Upload disk image in case it's new disk or force parameter is passed:
             if module.params['upload_image_path'] and (is_new_disk or module.params['force']):
@@ -736,20 +761,8 @@ def main():
             ret = disks_module.remove()
 
         # If VM was passed attach/detach disks to/from the VM:
-        if module.params.get('vm_id') is not None or module.params.get('vm_name') is not None and state != 'absent':
-            vms_service = connection.system_service().vms_service()
-
-            # If `vm_id` isn't specified, find VM by name:
-            vm_id = module.params['vm_id']
-            if vm_id is None:
-                vm_id = getattr(search_by_name(vms_service, module.params['vm_name']), 'id', None)
-
-            if vm_id is None:
-                module.fail_json(
-                    msg="VM don't exists, please create it first."
-                )
-
-            disk_attachments_service = vms_service.vm_service(vm_id).disk_attachments_service()
+        if vm_service:
+            disk_attachments_service = vm_service.disk_attachments_service()
             disk_attachments_module = DiskAttachmentsModule(
                 connection=connection,
                 module=module,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If attaching existing disk to VM, we are using search which we can't be sure if it's attached to VM or template and so later we may try to attach template disk, to VM, instead of creating new one.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_disk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
