### PR TITLE
junos_l2_interface: Fix bug for native_vlan without enhance-mode

### DIFF
--- a/lib/ansible/modules/network/junos/junos_l2_interface.py
+++ b/lib/ansible/modules/network/junos/junos_l2_interface.py
@@ -254,8 +254,9 @@ def main():
 
         validate_param_values(module, param_to_xpath_map, param=item)
 
-        param_to_xpath_map['mode']['xpath'] = \
-            'interface-mode' if param['enhanced_layer'] else 'port-mode'
+        if not param['enhanced_layer']:
+            param_to_xpath_map['mode']['xpath'] = 'port-mode'
+            param_to_xpath_map['native_vlan']['top'] = 'unit/family/ethernet-switching'
 
         want = map_params_to_obj(module, param_to_xpath_map, param=item)
         requests.append(map_obj_to_ele(module, want, top, param=item))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #48876

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
junos_l2_interface

##### ADDITIONAL INFORMATION
The xpath of native_vlan for juniper deivces without enhance mode should be `unit/family/ethernet-switching`.