### PR TITLE
[FactCache] define first_order_merge method

### DIFF
--- a/changelogs/fragments/55781-fact-cache-first_merge_order.yml
+++ b/changelogs/fragments/55781-fact-cache-first_merge_order.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fact_cache - Define the first_order_merge method for the legacy FactCache.update(key, value).

--- a/lib/ansible/vars/fact_cache.py
+++ b/lib/ansible/vars/fact_cache.py
@@ -58,6 +58,19 @@ class FactCache(MutableMapping):
         """ Flush the fact cache of all keys. """
         self._plugin.flush()
 
+    def first_order_merge(self, key, value):
+        host_facts = {key: value}
+
+        try:
+            host_cache = self._plugin.get(key)
+            if host_cache:
+                host_cache.update(value)
+                host_facts[key] = host_cache
+        except KeyError:
+            pass
+
+        super(FactCache, self).update(host_facts)
+
     def update(self, *args):
         """
         Backwards compat shim

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -123,6 +123,7 @@ class TestFactCache(unittest.TestCase):
         assert self.cache['cache_key']['key'] == 'updatedvalue'
         assert self.cache['cache_key']['key2'] == 'value2'
 
+
 class TestAbstractClass(unittest.TestCase):
 
     def setUp(self):

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -117,6 +117,11 @@ class TestFactCache(unittest.TestCase):
                                     "Unable to load the facts cache plugin.*json.*",
                                     FactCache)
 
+    def test_update_legacy_key_exists(self):
+        self.cache['cache_key'] = {'key': 'value', 'key2': 'value2'}
+        self.cache.update('cache_key', {'key': 'updatedvalue'})
+        assert self.cache['cache_key']['key'] == 'updatedvalue'
+        assert self.cache['cache_key']['key2'] == 'value2'
 
 class TestAbstractClass(unittest.TestCase):
 


### PR DESCRIPTION
##### SUMMARY
Add first_order_merge method and a test for updating a key that already exists. #55739 contains an additional test for this.

The first_order_merge method is not defined.

Fixes #55740

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/fact_cache.py
