### PR TITLE
Add security group info and example to AWS guide

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_aws.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aws.rst
@@ -138,7 +138,7 @@ Security Groups
 ```````````````
 
 Security groups on AWS are stateful. The response of a request from your instance is allowed to flow in regardless of inbound security group rules and vice-versa.
-In case you only want allow traffic with AWS S3 service, you need to fetch the current IP ranges of AWS S3 for one region and apply them as an egress rule.
+In case you only want allow traffic with AWS S3 service, you need to fetch the current IP ranges of AWS S3 for one region and apply them as an egress rule.::
 
     - name: fetch raw ip ranges for aws s3
       set_fact:
@@ -162,7 +162,6 @@ In case you only want allow traffic with AWS S3 service, you need to fetch the c
         rules_egress: "{{ s3_ranges }}"
         tags:
           Name: aws_s3_ip_ranges
-
 
 .. _aws_host_inventory:
 

--- a/docs/docsite/rst/scenario_guides/guide_aws.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aws.rst
@@ -132,6 +132,38 @@ With the host group now created, a second play at the bottom of the same provisi
          - name: Check NTP service
            service: name=ntpd state=started
 
+.. _aws_security_groups:
+
+Security Groups
+```````````````
+
+Security groups on AWS are stateful. The response of a request from your instance is allowed to flow in regardless of inbound security group rules and vice-versa.
+In case you only want allow traffic with AWS S3 service, you need to fetch the current IP ranges of AWS S3 for one region and apply them as an egress rule.
+
+    - name: fetch raw ip ranges for aws s3
+      set_fact:
+        raw_s3_ranges: "{{ lookup('aws_service_ip_ranges', region='eu-central-1', service='S3', wantlist=True) }}"
+
+    - name: prepare list structure for ec2_group module
+      set_fact:
+        s3_ranges: "{{ s3_ranges | default([]) + [{'proto': 'all', 'cidr_ip': item, 'rule_desc': 'S3 Service IP range'}] }}"
+      with_items: "{{ raw_s3_ranges }}"
+
+    - name: set S3 IP ranges to egress rules
+      ec2_group:
+        name: aws_s3_ip_ranges
+        description: allow outgoing traffic to aws S3 service
+        region: eu-central-1
+        state: present
+        vpc_id: vpc-123456
+        purge_rules: true
+        purge_rules_egress: true
+        rules: []
+        rules_egress: "{{ s3_ranges }}"
+        tags:
+          Name: aws_s3_ip_ranges
+
+
 .. _aws_host_inventory:
 
 Host Inventory


### PR DESCRIPTION
##### SUMMARY

Clean version of #54232. Work is by @markuman.

Adds an example of how to use the output of lookup plugin aws_service_ip_ranges with the ec2_group module.

1. fetch the raw data using aws_service_ip_ranges
2. prepare a list structure which can be used in ec2_group module
3. apply the ip ranges from 1 in a security group using ec2_group

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
ec2_group
aws_service_ip_ranges
