### PR TITLE
Fix order integration test.

### DIFF
--- a/test/integration/targets/order/runme.sh
+++ b/test/integration/targets/order/runme.sh
@@ -19,6 +19,6 @@ for EXTRA in '{"inputlist": ["hostB", "hostA", "hostD", "hostC"]}' \
              '{"myorder": "shuffle", "inputlist": ["hostC", "hostD", "hostA", "hostB"]}'
 do
     cleanup
-    ansible-playbook order.yml --forks 1 -i inventory -e "$EXTRA" "$@" || cleanup
+    ansible-playbook order.yml --forks 1 -i inventory -e "$EXTRA" "$@"
 done
 cleanup


### PR DESCRIPTION
##### SUMMARY

Fix order integration test.

Previously the test always passed due to invoking cleanup on failure.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

order integration test
