### PR TITLE
VMware: Added the rule_affinity while returning about the rule facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_drs_group_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_drs_group_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2018, Karsten Kaj Jakobsen <kj@patientsky.com>
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -16,97 +16,95 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = r'''
 ---
-author:
-  - "Karsten Kaj Jakobsen (@karstenjakobsen)"
+module: vmware_drs_rule_facts
+short_description: Gathers facts about DRS rule on the given cluster
 description:
-  - "This module can be used to gather facts about DRS VM/HOST groups from the given cluster."
-extends_documentation_fragment: vmware.documentation
-module: vmware_drs_group_facts
+- 'This module can be used to gather facts about DRS VM-VM and VM-HOST rules from the given cluster.'
+version_added: '2.5'
+author:
+- Abhijeet Kasurde (@Akasurde)
 notes:
-  - "Tested on vSphere 6.5 and 6.7"
+- Tested on vSphere 6.5
+requirements:
+- python >= 2.6
+- PyVmomi
 options:
   cluster_name:
     description:
-      - "Cluster to search for VM/Host groups."
-      - "If set, facts of DRS groups belonging this cluster will be returned."
-      - "Not needed if C(datacenter) is set."
-    required: false
+    - Name of the cluster.
+    - DRS facts for the given cluster will be returned.
+    - This is required parameter if C(datacenter) parameter is not provided.
   datacenter:
-    aliases:
-      - datacenter_name
     description:
-      - "Datacenter to search for DRS VM/Host groups."
-    required: true
-requirements:
-  - "python >= 2.6"
-  - PyVmomi
-short_description: "Gathers facts about DRS VM/Host groups on the given cluster"
-version_added: "2.8"
+    - Name of the datacenter.
+    - DRS facts for all the clusters from the given datacenter will be returned.
+    - This is required parameter if C(cluster_name) parameter is not provided.
+extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = r'''
----
-- name: "Gather DRS facts about given Cluster"
-  register: cluster_drs_group_facts
-  vmware_drs_group_facts:
-    hostname: "{{ vcenter_hostname }}"
-    password: "{{ vcenter_password }}"
-    username: "{{ vcenter_username }}"
-    cluster_name: "{{ cluster_name }}"
-    datacenter: "{{ datacenter }}"
+- name: Gather DRS facts about given Cluster
+  vmware_drs_rule_facts:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    cluster_name: '{{ cluster_name }}'
   delegate_to: localhost
+  register: cluster_drs_facts
 
-- name: "Gather DRS group facts about all clusters in given datacenter"
-  register: cluster_drs_group_facts
-  vmware_drs_group_facts:
-    hostname: "{{ vcenter_hostname }}"
-    password: "{{ vcenter_password }}"
-    username: "{{ vcenter_username }}"
-    datacenter: "{{ datacenter }}"
+- name: Gather DRS facts about all Clusters in given datacenter
+  vmware_drs_rule_facts:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ datacenter_name }}'
   delegate_to: localhost
+  register: datacenter_drs_facts
 '''
 
 RETURN = r'''
-drs_group_facts:
-    description: Metadata about DRS group from given cluster / datacenter
+drs_rule_facts:
+    description: metadata about DRS rule from given cluster / datacenter
     returned: always
     type: dict
-    sample:
-        "drs_group_facts": {
+    sample: {
             "DC0_C0": [
                 {
-                    "group_name": "GROUP_HOST_S01",
-                    "hosts": [
-                        "vm-01.zone",
-                        "vm-02.zone"
-                    ],
-                    "type": "host"
-                },
-                {
-                    "group_name": "GROUP_HOST_S02",
-                    "hosts": [
-                        "vm-03.zone",
-                        "vm-04.zone"
-                    ],
-                    "type": "host"
-                },
-                {
-                    "group_name": "GROUP_VM_S01",
-                    "type": "vm",
-                    "vms": [
-                        "test-node01"
+                    "rule_affinity": false,
+                    "rule_enabled": true,
+                    "rule_key": 1,
+                    "rule_mandatory": true,
+                    "rule_name": "drs_rule_0001",
+                    "rule_type": "vm_vm_rule",
+                    "rule_uuid": "52be5061-665a-68dc-3d25-85cd2d37e114",
+                    "rule_vms": [
+                        "VM_65",
+                        "VM_146"
                     ]
                 },
+            ],
+            "DC1_C1": [
                 {
-                    "group_name": "GROUP_VM_S02",
-                    "type": "vm",
-                    "vms": [
-                        "test-node02"
+                    "rule_affine_host_group_name": "host_group_1",
+                    "rule_affine_hosts": [
+                        "10.76.33.204"
+                    ],
+                    "rule_anti_affine_host_group_name": null,
+                    "rule_anti_affine_hosts": [],
+                    "rule_enabled": true,
+                    "rule_key": 1,
+                    "rule_mandatory": false,
+                    "rule_name": "vm_host_rule_0001",
+                    "rule_type": "vm_host_rule",
+                    "rule_uuid": "52687108-4d3a-76f2-d29c-b708c40dbe40",
+                    "rule_vm_group_name": "test_vm_group_1",
+                    "rule_vms": [
+                        "VM_8916",
+                        "VM_4010"
                     ]
                 }
             ],
-            "DC0_C1": []
-        }
+            }
 '''
 
 try:
@@ -118,161 +116,143 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi, find_datacenter_by_name, get_all_objs
 
 
-class VmwareDrsGroupFactManager(PyVmomi):
+class VmwareDrsFactManager(PyVmomi):
+    def __init__(self, module):
+        super(VmwareDrsFactManager, self).__init__(module)
 
-    def __init__(self, module, datacenter_name, cluster_name=None):
-        """
-        Doctring: Init
-        """
-
-        super(VmwareDrsGroupFactManager, self).__init__(module)
-
-        self.__datacenter_name = datacenter_name
-        self.__datacenter_obj = None
-        self.__cluster_name = cluster_name
-        self.__cluster_obj = None
-        self.__msg = 'Nothing to see here...'
-        self.__result = dict()
-        self.__changed = False
-
+        datacenter_name = self.params.get('datacenter', None)
         if datacenter_name:
-
             datacenter_obj = find_datacenter_by_name(self.content, datacenter_name=datacenter_name)
             self.cluster_obj_list = []
-
             if datacenter_obj:
                 folder = datacenter_obj.hostFolder
                 self.cluster_obj_list = get_all_objs(self.content, [vim.ClusterComputeResource], folder)
             else:
-                raise Exception("Datacenter '%s' not found" % self.__datacenter_name)
+                self.module.fail_json(changed=False, msg="Datacenter '%s' not found" % datacenter_name)
 
+        cluster_name = self.params.get('cluster_name', None)
         if cluster_name:
-
-            cluster_obj = self.find_cluster_by_name(cluster_name=self.__cluster_name)
-
+            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
             if cluster_obj is None:
-                raise Exception("Cluster '%s' not found" % self.__cluster_name)
+                self.module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
             else:
                 self.cluster_obj_list = [cluster_obj]
 
-    def get_result(self):
+    def get_all_from_group(self, group_name=None, cluster_obj=None, hostgroup=False):
         """
-        Docstring
-        """
-        return self.__result
-
-    def __set_result(self, result):
-        """
-        Sets result
+        Return all VM / Host names using given group name
         Args:
-            result: drs group result list
-
-        Returns: None
-
-        """
-        self.__result = result
-
-    def __get_all_from_group(self, group_obj, host_group=False):
-        """
-        Return all VM / Host names using given group
-        Args:
-            group_obj: Group object
-            host_group: True if we want only host name from group
+            group_name: Rule name
+            cluster_obj: Cluster managed object
+            hostgroup: True if we want only host name from group
 
         Returns: List of VM / Host names belonging to given group object
 
         """
         obj_name_list = []
-
-        if not all([group_obj]):
+        if not all([group_name, cluster_obj]):
             return obj_name_list
 
-        if not host_group and isinstance(group_obj, vim.cluster.VmGroup):
-            obj_name_list = [vm.name for vm in group_obj.vm]
-        elif host_group and isinstance(group_obj, vim.cluster.HostGroup):
-            obj_name_list = [host.name for host in group_obj.host]
+        for group in cluster_obj.configurationEx.group:
+            if group.name == group_name:
+                if not hostgroup and isinstance(group, vim.cluster.VmGroup):
+                    obj_name_list = [vm.name for vm in group.vm]
+                    break
+                elif hostgroup and isinstance(group, vim.cluster.HostGroup):
+                    obj_name_list = [host.name for host in group.host]
+                    break
 
         return obj_name_list
 
-    def __normalize_group_data(self, group_obj):
+    @staticmethod
+    def normalize_vm_vm_rule_spec(rule_obj=None):
         """
-        Return human readable group spec
+        Return human readable rule spec
         Args:
-            group_obj: Group object
+            rule_obj: Rule managed object
 
-        Returns: Dictionary with DRS groups
+        Returns: Dictionary with DRS VM VM Rule info
 
         """
-        if not all([group_obj]):
+        if rule_obj is None:
             return {}
+        return dict(rule_key=rule_obj.key,
+                    rule_enabled=rule_obj.enabled,
+                    rule_name=rule_obj.name,
+                    rule_mandatory=rule_obj.mandatory,
+                    rule_uuid=rule_obj.ruleUuid,
+                    rule_vms=[vm.name for vm in rule_obj.vm],
+                    rule_type="vm_vm_rule",
+                    rule_affinity=True if isinstance(rule_obj, vim.cluster.AffinityRuleSpec) else False,
+                    )
 
-        # Check if group is a host group
-        if hasattr(group_obj, 'host'):
-            return dict(
-                group_name=group_obj.name,
-                hosts=self.__get_all_from_group(group_obj=group_obj, host_group=True),
-                type="host"
-            )
-        else:
-            return dict(
-                group_name=group_obj.name,
-                vms=self.__get_all_from_group(group_obj=group_obj),
-                type="vm"
-            )
-
-    def gather_facts(self):
+    def normalize_vm_host_rule_spec(self, rule_obj=None, cluster_obj=None):
         """
-        Gather DRS group facts about given cluster
-        Returns: Dictionary of clusters with DRS groups
+        Return human readable rule spec
+        Args:
+            rule_obj: Rule managed object
+            cluster_obj: Cluster managed object
+
+        Returns: Dictionary with DRS VM HOST Rule info
 
         """
-        cluster_group_facts = dict()
+        if not all([rule_obj, cluster_obj]):
+            return {}
+        return dict(rule_key=rule_obj.key,
+                    rule_enabled=rule_obj.enabled,
+                    rule_name=rule_obj.name,
+                    rule_mandatory=rule_obj.mandatory,
+                    rule_uuid=rule_obj.ruleUuid,
+                    rule_vm_group_name=rule_obj.vmGroupName,
+                    rule_affine_host_group_name=rule_obj.affineHostGroupName,
+                    rule_anti_affine_host_group_name=rule_obj.antiAffineHostGroupName,
+                    rule_vms=self.get_all_from_group(group_name=rule_obj.vmGroupName,
+                                                     cluster_obj=cluster_obj),
+                    rule_affine_hosts=self.get_all_from_group(group_name=rule_obj.affineHostGroupName,
+                                                              cluster_obj=cluster_obj,
+                                                              hostgroup=True),
+                    rule_anti_affine_hosts=self.get_all_from_group(group_name=rule_obj.antiAffineHostGroupName,
+                                                                   cluster_obj=cluster_obj,
+                                                                   hostgroup=True),
+                    rule_type="vm_host_rule",
+                    )
 
+    def gather_drs_rule_facts(self):
+        """
+        Gather DRS rule facts about given cluster
+        Returns: Dictionary of clusters with DRS facts
+
+        """
+        cluster_rule_facts = dict()
         for cluster_obj in self.cluster_obj_list:
+            cluster_rule_facts[cluster_obj.name] = []
+            for drs_rule in cluster_obj.configuration.rule:
+                if isinstance(drs_rule, vim.cluster.VmHostRuleInfo):
+                    cluster_rule_facts[cluster_obj.name].append(self.normalize_vm_host_rule_spec(rule_obj=drs_rule,
+                                                                                                 cluster_obj=cluster_obj))
+                else:
+                    cluster_rule_facts[cluster_obj.name].append(self.normalize_vm_vm_rule_spec(rule_obj=drs_rule))
 
-            cluster_group_facts[cluster_obj.name] = []
-
-            for drs_group in cluster_obj.configurationEx.group:
-                cluster_group_facts[cluster_obj.name].append(self.__normalize_group_data(drs_group))
-
-        self.__set_result(cluster_group_facts)
+        return cluster_rule_facts
 
 
 def main():
-
     argument_spec = vmware_argument_spec()
-
     argument_spec.update(
-        datacenter=dict(type='str', required=False, aliases=['datacenter_name']),
+        datacenter=dict(type='str', required=False),
         cluster_name=dict(type='str', required=False),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        required_one_of=[
+            ['cluster_name', 'datacenter'],
+        ],
         supports_check_mode=True,
-        required_one_of=[['cluster_name', 'datacenter']],
-        mutually_exclusive=[['cluster_name', 'datacenter']],
     )
 
-    try:
-        # Create instance of VmwareDrsGroupManager
-        vmware_drs_group_facts = VmwareDrsGroupFactManager(module=module,
-                                                           datacenter_name=module.params.get('datacenter'),
-                                                           cluster_name=module.params.get('cluster_name', None))
-
-        vmware_drs_group_facts.gather_facts()
-
-        # Set results
-        results = dict(failed=False,
-                       drs_group_facts=vmware_drs_group_facts.get_result())
-
-    except Exception as error:
-        results = dict(failed=True, msg="Error: %s" % error)
-
-    if results['failed']:
-        module.fail_json(**results)
-    else:
-        module.exit_json(**results)
+    vmware_drs_facts = VmwareDrsFactManager(module)
+    module.exit_json(changed=False, drs_rule_facts=vmware_drs_facts.gather_drs_rule_facts())
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/vmware/vmware_drs_group_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_drs_group_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright: (c) 2018, Karsten Kaj Jakobsen <kj@patientsky.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -16,95 +16,97 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = r'''
 ---
-module: vmware_drs_rule_facts
-short_description: Gathers facts about DRS rule on the given cluster
-description:
-- 'This module can be used to gather facts about DRS VM-VM and VM-HOST rules from the given cluster.'
-version_added: '2.5'
 author:
-- Abhijeet Kasurde (@Akasurde)
+  - "Karsten Kaj Jakobsen (@karstenjakobsen)"
+description:
+  - "This module can be used to gather facts about DRS VM/HOST groups from the given cluster."
+extends_documentation_fragment: vmware.documentation
+module: vmware_drs_group_facts
 notes:
-- Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
+  - "Tested on vSphere 6.5 and 6.7"
 options:
   cluster_name:
     description:
-    - Name of the cluster.
-    - DRS facts for the given cluster will be returned.
-    - This is required parameter if C(datacenter) parameter is not provided.
+      - "Cluster to search for VM/Host groups."
+      - "If set, facts of DRS groups belonging this cluster will be returned."
+      - "Not needed if C(datacenter) is set."
+    required: false
   datacenter:
+    aliases:
+      - datacenter_name
     description:
-    - Name of the datacenter.
-    - DRS facts for all the clusters from the given datacenter will be returned.
-    - This is required parameter if C(cluster_name) parameter is not provided.
-extends_documentation_fragment: vmware.documentation
+      - "Datacenter to search for DRS VM/Host groups."
+    required: true
+requirements:
+  - "python >= 2.6"
+  - PyVmomi
+short_description: "Gathers facts about DRS VM/Host groups on the given cluster"
+version_added: "2.8"
 '''
 
 EXAMPLES = r'''
-- name: Gather DRS facts about given Cluster
-  vmware_drs_rule_facts:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    cluster_name: '{{ cluster_name }}'
+---
+- name: "Gather DRS facts about given Cluster"
+  register: cluster_drs_group_facts
+  vmware_drs_group_facts:
+    hostname: "{{ vcenter_hostname }}"
+    password: "{{ vcenter_password }}"
+    username: "{{ vcenter_username }}"
+    cluster_name: "{{ cluster_name }}"
+    datacenter: "{{ datacenter }}"
   delegate_to: localhost
-  register: cluster_drs_facts
 
-- name: Gather DRS facts about all Clusters in given datacenter
-  vmware_drs_rule_facts:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    datacenter: '{{ datacenter_name }}'
+- name: "Gather DRS group facts about all clusters in given datacenter"
+  register: cluster_drs_group_facts
+  vmware_drs_group_facts:
+    hostname: "{{ vcenter_hostname }}"
+    password: "{{ vcenter_password }}"
+    username: "{{ vcenter_username }}"
+    datacenter: "{{ datacenter }}"
   delegate_to: localhost
-  register: datacenter_drs_facts
 '''
 
 RETURN = r'''
-drs_rule_facts:
-    description: metadata about DRS rule from given cluster / datacenter
+drs_group_facts:
+    description: Metadata about DRS group from given cluster / datacenter
     returned: always
     type: dict
-    sample: {
+    sample:
+        "drs_group_facts": {
             "DC0_C0": [
                 {
-                    "rule_affinity": false,
-                    "rule_enabled": true,
-                    "rule_key": 1,
-                    "rule_mandatory": true,
-                    "rule_name": "drs_rule_0001",
-                    "rule_type": "vm_vm_rule",
-                    "rule_uuid": "52be5061-665a-68dc-3d25-85cd2d37e114",
-                    "rule_vms": [
-                        "VM_65",
-                        "VM_146"
+                    "group_name": "GROUP_HOST_S01",
+                    "hosts": [
+                        "vm-01.zone",
+                        "vm-02.zone"
+                    ],
+                    "type": "host"
+                },
+                {
+                    "group_name": "GROUP_HOST_S02",
+                    "hosts": [
+                        "vm-03.zone",
+                        "vm-04.zone"
+                    ],
+                    "type": "host"
+                },
+                {
+                    "group_name": "GROUP_VM_S01",
+                    "type": "vm",
+                    "vms": [
+                        "test-node01"
                     ]
                 },
-            ],
-            "DC1_C1": [
                 {
-                    "rule_affine_host_group_name": "host_group_1",
-                    "rule_affine_hosts": [
-                        "10.76.33.204"
-                    ],
-                    "rule_anti_affine_host_group_name": null,
-                    "rule_anti_affine_hosts": [],
-                    "rule_enabled": true,
-                    "rule_key": 1,
-                    "rule_mandatory": false,
-                    "rule_name": "vm_host_rule_0001",
-                    "rule_type": "vm_host_rule",
-                    "rule_uuid": "52687108-4d3a-76f2-d29c-b708c40dbe40",
-                    "rule_vm_group_name": "test_vm_group_1",
-                    "rule_vms": [
-                        "VM_8916",
-                        "VM_4010"
+                    "group_name": "GROUP_VM_S02",
+                    "type": "vm",
+                    "vms": [
+                        "test-node02"
                     ]
                 }
             ],
-            }
+            "DC0_C1": []
+        }
 '''
 
 try:
@@ -116,143 +118,161 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi, find_datacenter_by_name, get_all_objs
 
 
-class VmwareDrsFactManager(PyVmomi):
-    def __init__(self, module):
-        super(VmwareDrsFactManager, self).__init__(module)
+class VmwareDrsGroupFactManager(PyVmomi):
 
-        datacenter_name = self.params.get('datacenter', None)
+    def __init__(self, module, datacenter_name, cluster_name=None):
+        """
+        Doctring: Init
+        """
+
+        super(VmwareDrsGroupFactManager, self).__init__(module)
+
+        self.__datacenter_name = datacenter_name
+        self.__datacenter_obj = None
+        self.__cluster_name = cluster_name
+        self.__cluster_obj = None
+        self.__msg = 'Nothing to see here...'
+        self.__result = dict()
+        self.__changed = False
+
         if datacenter_name:
+
             datacenter_obj = find_datacenter_by_name(self.content, datacenter_name=datacenter_name)
             self.cluster_obj_list = []
+
             if datacenter_obj:
                 folder = datacenter_obj.hostFolder
                 self.cluster_obj_list = get_all_objs(self.content, [vim.ClusterComputeResource], folder)
             else:
-                self.module.fail_json(changed=False, msg="Datacenter '%s' not found" % datacenter_name)
+                raise Exception("Datacenter '%s' not found" % self.__datacenter_name)
 
-        cluster_name = self.params.get('cluster_name', None)
         if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
+
+            cluster_obj = self.find_cluster_by_name(cluster_name=self.__cluster_name)
+
             if cluster_obj is None:
-                self.module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
+                raise Exception("Cluster '%s' not found" % self.__cluster_name)
             else:
                 self.cluster_obj_list = [cluster_obj]
 
-    def get_all_from_group(self, group_name=None, cluster_obj=None, hostgroup=False):
+    def get_result(self):
         """
-        Return all VM / Host names using given group name
+        Docstring
+        """
+        return self.__result
+
+    def __set_result(self, result):
+        """
+        Sets result
         Args:
-            group_name: Rule name
-            cluster_obj: Cluster managed object
-            hostgroup: True if we want only host name from group
+            result: drs group result list
+
+        Returns: None
+
+        """
+        self.__result = result
+
+    def __get_all_from_group(self, group_obj, host_group=False):
+        """
+        Return all VM / Host names using given group
+        Args:
+            group_obj: Group object
+            host_group: True if we want only host name from group
 
         Returns: List of VM / Host names belonging to given group object
 
         """
         obj_name_list = []
-        if not all([group_name, cluster_obj]):
+
+        if not all([group_obj]):
             return obj_name_list
 
-        for group in cluster_obj.configurationEx.group:
-            if group.name == group_name:
-                if not hostgroup and isinstance(group, vim.cluster.VmGroup):
-                    obj_name_list = [vm.name for vm in group.vm]
-                    break
-                elif hostgroup and isinstance(group, vim.cluster.HostGroup):
-                    obj_name_list = [host.name for host in group.host]
-                    break
+        if not host_group and isinstance(group_obj, vim.cluster.VmGroup):
+            obj_name_list = [vm.name for vm in group_obj.vm]
+        elif host_group and isinstance(group_obj, vim.cluster.HostGroup):
+            obj_name_list = [host.name for host in group_obj.host]
 
         return obj_name_list
 
-    @staticmethod
-    def normalize_vm_vm_rule_spec(rule_obj=None):
+    def __normalize_group_data(self, group_obj):
         """
-        Return human readable rule spec
+        Return human readable group spec
         Args:
-            rule_obj: Rule managed object
+            group_obj: Group object
 
-        Returns: Dictionary with DRS VM VM Rule info
+        Returns: Dictionary with DRS groups
 
         """
-        if rule_obj is None:
+        if not all([group_obj]):
             return {}
-        return dict(rule_key=rule_obj.key,
-                    rule_enabled=rule_obj.enabled,
-                    rule_name=rule_obj.name,
-                    rule_mandatory=rule_obj.mandatory,
-                    rule_uuid=rule_obj.ruleUuid,
-                    rule_vms=[vm.name for vm in rule_obj.vm],
-                    rule_type="vm_vm_rule",
-                    rule_affinity=True if isinstance(rule_obj, vim.cluster.AffinityRuleSpec) else False,
-                    )
 
-    def normalize_vm_host_rule_spec(self, rule_obj=None, cluster_obj=None):
+        # Check if group is a host group
+        if hasattr(group_obj, 'host'):
+            return dict(
+                group_name=group_obj.name,
+                hosts=self.__get_all_from_group(group_obj=group_obj, host_group=True),
+                type="host"
+            )
+        else:
+            return dict(
+                group_name=group_obj.name,
+                vms=self.__get_all_from_group(group_obj=group_obj),
+                type="vm"
+            )
+
+    def gather_facts(self):
         """
-        Return human readable rule spec
-        Args:
-            rule_obj: Rule managed object
-            cluster_obj: Cluster managed object
-
-        Returns: Dictionary with DRS VM HOST Rule info
-
-        """
-        if not all([rule_obj, cluster_obj]):
-            return {}
-        return dict(rule_key=rule_obj.key,
-                    rule_enabled=rule_obj.enabled,
-                    rule_name=rule_obj.name,
-                    rule_mandatory=rule_obj.mandatory,
-                    rule_uuid=rule_obj.ruleUuid,
-                    rule_vm_group_name=rule_obj.vmGroupName,
-                    rule_affine_host_group_name=rule_obj.affineHostGroupName,
-                    rule_anti_affine_host_group_name=rule_obj.antiAffineHostGroupName,
-                    rule_vms=self.get_all_from_group(group_name=rule_obj.vmGroupName,
-                                                     cluster_obj=cluster_obj),
-                    rule_affine_hosts=self.get_all_from_group(group_name=rule_obj.affineHostGroupName,
-                                                              cluster_obj=cluster_obj,
-                                                              hostgroup=True),
-                    rule_anti_affine_hosts=self.get_all_from_group(group_name=rule_obj.antiAffineHostGroupName,
-                                                                   cluster_obj=cluster_obj,
-                                                                   hostgroup=True),
-                    rule_type="vm_host_rule",
-                    )
-
-    def gather_drs_rule_facts(self):
-        """
-        Gather DRS rule facts about given cluster
-        Returns: Dictionary of clusters with DRS facts
+        Gather DRS group facts about given cluster
+        Returns: Dictionary of clusters with DRS groups
 
         """
-        cluster_rule_facts = dict()
+        cluster_group_facts = dict()
+
         for cluster_obj in self.cluster_obj_list:
-            cluster_rule_facts[cluster_obj.name] = []
-            for drs_rule in cluster_obj.configuration.rule:
-                if isinstance(drs_rule, vim.cluster.VmHostRuleInfo):
-                    cluster_rule_facts[cluster_obj.name].append(self.normalize_vm_host_rule_spec(rule_obj=drs_rule,
-                                                                                                 cluster_obj=cluster_obj))
-                else:
-                    cluster_rule_facts[cluster_obj.name].append(self.normalize_vm_vm_rule_spec(rule_obj=drs_rule))
 
-        return cluster_rule_facts
+            cluster_group_facts[cluster_obj.name] = []
+
+            for drs_group in cluster_obj.configurationEx.group:
+                cluster_group_facts[cluster_obj.name].append(self.__normalize_group_data(drs_group))
+
+        self.__set_result(cluster_group_facts)
 
 
 def main():
+
     argument_spec = vmware_argument_spec()
+
     argument_spec.update(
-        datacenter=dict(type='str', required=False),
+        datacenter=dict(type='str', required=False, aliases=['datacenter_name']),
         cluster_name=dict(type='str', required=False),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_one_of=[
-            ['cluster_name', 'datacenter'],
-        ],
         supports_check_mode=True,
+        required_one_of=[['cluster_name', 'datacenter']],
+        mutually_exclusive=[['cluster_name', 'datacenter']],
     )
 
-    vmware_drs_facts = VmwareDrsFactManager(module)
-    module.exit_json(changed=False, drs_rule_facts=vmware_drs_facts.gather_drs_rule_facts())
+    try:
+        # Create instance of VmwareDrsGroupManager
+        vmware_drs_group_facts = VmwareDrsGroupFactManager(module=module,
+                                                           datacenter_name=module.params.get('datacenter'),
+                                                           cluster_name=module.params.get('cluster_name', None))
+
+        vmware_drs_group_facts.gather_facts()
+
+        # Set results
+        results = dict(failed=False,
+                       drs_group_facts=vmware_drs_group_facts.get_result())
+
+    except Exception as error:
+        results = dict(failed=True, msg="Error: %s" % error)
+
+    if results['failed']:
+        module.fail_json(**results)
+    else:
+        module.exit_json(**results)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
@@ -69,7 +69,8 @@ drs_rule_facts:
     type: dict
     sample: {
             "DC0_C0": [
-                {
+                {  
+                    "rule_affinity": false,
                     "rule_enabled": true,
                     "rule_key": 1,
                     "rule_mandatory": true,
@@ -182,6 +183,7 @@ class VmwareDrsFactManager(PyVmomi):
                     rule_uuid=rule_obj.ruleUuid,
                     rule_vms=[vm.name for vm in rule_obj.vm],
                     rule_type="vm_vm_rule",
+                    rule_affinity=True if isinstance(rule_obj, vim.cluster.AffinityRuleSpec) else False,
                     )
 
     def normalize_vm_host_rule_spec(self, rule_obj=None, cluster_obj=None):

--- a/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
@@ -69,7 +69,7 @@ drs_rule_facts:
     type: dict
     sample: {
             "DC0_C0": [
-                {  
+                {
                     "rule_affinity": false,
                     "rule_enabled": true,
                     "rule_key": 1,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The vmware_drs_rule_facts doesn't send whether the Rule is Affinity or Anti Affinity.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_drs_rule_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
While returning the rule facts added whether the DRS rule is Affinity or Anti Affinity in Boolean.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```