### PR TITLE
VMware: Optimize Rest Client to use vSphere-Api-Client instead of individual Service

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_category.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_category.py
@@ -119,7 +119,7 @@ category_results:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware_rest_client import VmwareRestClient
 try:
-    from com.vmware.cis.tagging_client import Category, CategoryModel
+    from com.vmware.cis.tagging_client import CategoryModel
 except ImportError:
     pass
 
@@ -127,7 +127,7 @@ except ImportError:
 class VmwareCategory(VmwareRestClient):
     def __init__(self, module):
         super(VmwareCategory, self).__init__(module)
-        self.category_service = Category(self.connect)
+        self.category_service = self.api_client.tagging.Category
         self.global_categories = dict()
         self.category_name = self.params.get('category_name')
         self.get_all_categories()

--- a/lib/ansible/modules/cloud/vmware/vmware_category_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_category_facts.py
@@ -91,16 +91,12 @@ tag_category_facts:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware_rest_client import VmwareRestClient
-try:
-    from com.vmware.cis.tagging_client import Category
-except ImportError:
-    pass
 
 
 class VmwareCategoryFactsManager(VmwareRestClient):
     def __init__(self, module):
         super(VmwareCategoryFactsManager, self).__init__(module)
-        self.category_service = Category(self.connect)
+        self.category_service = self.api_client.tagging.Category
 
     def get_all_tag_categories(self):
         """Retrieve all tag category information."""

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -218,17 +218,16 @@ from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
 from ansible.module_utils.vmware_rest_client import VmwareRestClient
 try:
     from com.vmware.vapi.std_client import DynamicID
-    from com.vmware.cis.tagging_client import Tag, TagAssociation
-    HAS_VCLOUD = True
+    HAS_VSPHERE = True
 except ImportError:
-    HAS_VCLOUD = False
+    HAS_VSPHERE = False
 
 
 class VmwareTag(VmwareRestClient):
     def __init__(self, module):
         super(VmwareTag, self).__init__(module)
-        self.tag_service = Tag(self.connect)
-        self.tag_association_svc = TagAssociation(self.connect)
+        self.tag_service = self.api_client.tagging.Tag
+        self.tag_association_svc = self.api_client.tagging.TagAssociation
 
 
 def main():
@@ -268,7 +267,7 @@ def main():
             else:
                 instance = pyv.to_json(vm, module.params['properties'])
             if module.params.get('tags'):
-                if not HAS_VCLOUD:
+                if not HAS_VSPHERE:
                     module.fail_json(msg="Unable to find 'vCloud Suite SDK' Python library which is required."
                                          " Please refer this URL for installation steps"
                                          " - https://code.vmware.com/web/sdk/60/vcloudsuite-python")

--- a/lib/ansible/modules/cloud/vmware/vmware_tag.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag.py
@@ -108,20 +108,17 @@ results:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware_rest_client import VmwareRestClient
-try:
-    from com.vmware.cis.tagging_client import Tag, Category
-except ImportError:
-    pass
 
 
 class VmwareTag(VmwareRestClient):
     def __init__(self, module):
         super(VmwareTag, self).__init__(module)
-        self.tag_service = Tag(self.connect)
         self.global_tags = dict()
+        # api_client to call APIs instead of individual service
+        self.tag_service = self.api_client.tagging.Tag
         self.tag_name = self.params.get('tag_name')
         self.get_all_tags()
-        self.category_service = Category(self.connect)
+        self.category_service = self.api_client.tagging.Category
 
     def ensure_state(self):
         """

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_facts.py
@@ -86,17 +86,13 @@ results:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware_rest_client import VmwareRestClient
-try:
-    from com.vmware.cis.tagging_client import Tag
-except ImportError:
-    pass
 
 
 class VmTagFactManager(VmwareRestClient):
     def __init__(self, module):
         """Constructor."""
         super(VmTagFactManager, self).__init__(module)
-        self.tag_service = Tag(self.connect)
+        self.tag_service = self.api_client.tagging.Tag
         self.global_tags = dict()
 
     def get_all_tags(self):

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -138,7 +138,6 @@ from ansible.module_utils.vmware_rest_client import VmwareRestClient
 from ansible.module_utils.vmware import (PyVmomi, find_dvs_by_name, find_dvspg_by_name)
 try:
     from com.vmware.vapi.std_client import DynamicID
-    from com.vmware.cis.tagging_client import Tag, TagAssociation, Category
 except ImportError:
     pass
 
@@ -186,9 +185,9 @@ class VmwareTagManager(VmwareRestClient):
 
         self.dynamic_managed_object = DynamicID(type=self.object_type, id=self.managed_object._moId)
 
-        self.tag_service = Tag(self.connect)
-        self.category_service = Category(self.connect)
-        self.tag_association_svc = TagAssociation(self.connect)
+        self.tag_service = self.api_client.tagging.Tag
+        self.category_service = self.api_client.tagging.Category
+        self.tag_association_svc = self.api_client.tagging.TagAssociation
 
         self.tag_names = self.params.get('tag_names')
 

--- a/test/integration/targets/vmware_tag/aliases
+++ b/test/integration/targets/vmware_tag/aliases
@@ -1,0 +1,2 @@
+cloud/vcenter
+unsupported

--- a/test/integration/targets/vmware_tag/tasks/main.yml
+++ b/test/integration/targets/vmware_tag/tasks/main.yml
@@ -1,0 +1,6 @@
+# Test code for the vmware_tag Operations.
+# Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- include: tag_crud_ops.yml
+- include: tag_manager_ops.yml 

--- a/test/integration/targets/vmware_tag/tasks/tag_crud_ops.yml
+++ b/test/integration/targets/vmware_tag/tasks/tag_crud_ops.yml
@@ -1,0 +1,78 @@
+# Test code for the vmware_tag CRUD Operations.
+# Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+
+    # Testcase Create Category
+    - name: Create Category
+      vmware_category:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+        category_name: Sample_Cat_0006
+        category_description: Sample Description
+        category_cardinality: 'multiple'
+        state: present
+      register: category_create
+
+    - name: Check Category is created
+      assert:
+        that:
+          - category_create.changed
+
+    - name: Set Cat_ID Paramter. Required for Tag creation
+      set_fact: Cat_ID={{ category_create['category_results']['category_id'] }}
+
+    # Testcase Create Tag
+    - name: Create a tag
+      vmware_tag:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_name: Sample_Tag_0001
+        category_id: "{{ Cat_ID }}"
+        tag_description: Sample Description
+        state: present
+      register: tag_creation
+
+    - name: Check tag is created
+      assert:
+        that:
+          - tag_creation.changed
+
+    # Testcase Update Tag Description (reconfig)
+    - name: Update Tag Description
+      vmware_tag:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_name: Sample_Tag_0001
+        tag_description: Some fancy description
+        state: present
+      register: update_tag_desc
+
+    - name: Check tag description updated
+      assert:
+        that:
+          - update_tag_desc.changed
+
+    # Testcase Delete the Tag
+    - name: Delete Tag
+      vmware_tag:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_name: Sample_Tag_0001
+        state: absent
+      register: delete_tag
+
+    - name: Check Tag is Deleted
+      assert:
+        that:
+          - delete_tag.changed

--- a/test/integration/targets/vmware_tag/tasks/tag_manager_ops.yml
+++ b/test/integration/targets/vmware_tag/tasks/tag_manager_ops.yml
@@ -1,0 +1,49 @@
+# Test code for the vmware_tag Manager Operations.
+# Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+
+    # Get VM name to attach the tag
+    - name: Get VM Facts
+      vmware_vm_facts:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+      register: vm_facts
+
+    - set_fact: vm_name="{{ vm_facts['virtual_machines'][0]['guest_name'] }}"
+
+    # Get Tagname
+    - name: Get facts about tag
+      vmware_tag_facts:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+      register: tag_facts
+
+    - set_fact: Tag_Name={{ tag_facts['tag_facts'].keys() | list }}
+
+    - debug: var=Tag_Name
+
+    # Testcase Assign tag to virtual Machine
+    - name: Add tags to a virtual machine
+      vmware_tag_manager:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_names:
+          - "{{ Tag_Name[0] }}"
+        object_name: "{{ vm_name }}"
+        object_type: VirtualMachine
+        state: add
+      register: tag_manager_ops
+
+    - name: Check Category is created
+      assert:
+        that:
+          - tag_manager_ops.changed"


### PR DESCRIPTION
Optimize Rest Client to use vSphere-Api-Client instead of individual Service. Same api client can be used for other services.

##### SUMMARY
vsphere-automation-python-sdk provides vsphere-client. It acts as api-client. 
Connection to vsphere rest endpoint is handled in vsphere-client.
vsphere-client can be used to initialize each service like Tagging, contentLibrary, VM. Instead of creating stub explicitly and creating each service. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_tag.py
vmware_tag_facts.py
vmware_tag_manager.py
vmware_rest_client.py (module_util)

##### ADDITIONAL INFORMATION
PR to optimize the vmware_rest_client module Util. For new upcoming modules vmware_rest_client remains same.
Testing Details:
Created playbooks for all 3 modules and verified the change. Change is working fine
