### PR TITLE
connection/docker: add support for privilege escalation

### DIFF
--- a/changelogs/fragments/53385-docker-privilege-escalation.yml
+++ b/changelogs/fragments/53385-docker-privilege-escalation.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+ - Fix privilege escalation support for the docker connection plugin when
+   credentials needs to be supplied (e.g. sudo with password).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

As described in #53385 (and #31759), the docker connection driver did  not support privilege escalation. This commit is a shameless cut-and-paste of the privilege escalation support from the `local` connection plugin into the `docker` plugin.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker connection plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
