### PR TITLE
Be sure to use the active state when checking for any_errors_fatal

### DIFF
--- a/changelogs/fragments/55515-use-active-state-for-any_errors_fatal.yaml
+++ b/changelogs/fragments/55515-use-active-state-for-any_errors_fatal.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Be sure to use the active state when checking for any_errors_fatal

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -409,6 +409,9 @@ class StrategyModule(StrategyBase):
                     dont_fail_states = frozenset([iterator.ITERATING_RESCUE, iterator.ITERATING_ALWAYS])
                     for host in hosts_left:
                         (s, _) = iterator.get_next_task_for_host(host, peek=True)
+                        # the state may actually be in a child state, use the get_active_state()
+                        # method in the iterator to figure out the true active state
+                        s = iterator.get_active_state(s)
                         if s.run_state not in dont_fail_states or \
                            s.run_state == iterator.ITERATING_RESCUE and s.fail_state & iterator.FAILED_RESCUE != 0:
                             self._tqm._failed_hosts[host.name] = True


### PR DESCRIPTION
The current code was not properly checking for the active state when
checking any_errors_fatal, so if the error occurred in a sub-block
or included file it is not properly detected.

Fixes #55515
