### PR TITLE
updates documentation to match behavior for ansible-galaxy

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -66,8 +66,7 @@ class GalaxyCLI(CLI):
         roles_path = opt_help.argparse.ArgumentParser(add_help=False)
         roles_path.add_argument('-p', '--roles-path', dest='roles_path', type=opt_help.unfrack_path(pathsep=True),
                                 default=C.DEFAULT_ROLES_PATH, action=opt_help.PrependListAction,
-                                help='The path to the directory containing your roles. The default is the roles_path '
-                                     'configured in your ansible.cfg file (~/ansible/roles if not configured)')
+                                help='The path to the directory containing your roles. By default it will use the first 'writable' directory you have configured in DEFAULT_ROLES_PATH: %s ' % ':'.join(C.DEFAULT_ROLES_PATH)
 
         force = opt_help.argparse.ArgumentParser(add_help=False)
         force.add_argument('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -67,7 +67,7 @@ class GalaxyCLI(CLI):
         roles_path.add_argument('-p', '--roles-path', dest='roles_path', type=opt_help.unfrack_path(pathsep=True),
                                 default=C.DEFAULT_ROLES_PATH, action=opt_help.PrependListAction,
                                 help='The path to the directory containing your roles. The default is the roles_path '
-                                     'configured in your ansible.cfg file (/etc/ansible/roles if not configured)')
+                                     'configured in your ansible.cfg file (~/ansible/roles if not configured)')
 
         force = opt_help.argparse.ArgumentParser(add_help=False)
         force.add_argument('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -66,8 +66,8 @@ class GalaxyCLI(CLI):
         roles_path = opt_help.argparse.ArgumentParser(add_help=False)
         roles_path.add_argument('-p', '--roles-path', dest='roles_path', type=opt_help.unfrack_path(pathsep=True),
                                 default=C.DEFAULT_ROLES_PATH, action=opt_help.PrependListAction,
-                                help='The path to the directory containing your roles.
-                                By default it will use the first writable directory configured in DEFAULT_ROLES_PATH: %s ' % ':'.join(C.DEFAULT_ROLES_PATH)
+                                help='The path to the directory containing your roles. '
+                                'By default it will use the first writable directory configured in DEFAULT_ROLES_PATH: %s ' % ':'.join(C.DEFAULT_ROLES_PATH)
 
         force = opt_help.argparse.ArgumentParser(add_help=False)
         force.add_argument('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -67,7 +67,7 @@ class GalaxyCLI(CLI):
         roles_path.add_argument('-p', '--roles-path', dest='roles_path', type=opt_help.unfrack_path(pathsep=True),
                                 default=C.DEFAULT_ROLES_PATH, action=opt_help.PrependListAction,
                                 help='The path to the directory containing your roles.
-                                By default it will use the first writable directory you have configured in DEFAULT_ROLES_PATH: %s ' % ':'.join(C.DEFAULT_ROLES_PATH)
+                                By default it will use the first writable directory configured in DEFAULT_ROLES_PATH: %s ' % ':'.join(C.DEFAULT_ROLES_PATH)
 
         force = opt_help.argparse.ArgumentParser(add_help=False)
         force.add_argument('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -66,7 +66,8 @@ class GalaxyCLI(CLI):
         roles_path = opt_help.argparse.ArgumentParser(add_help=False)
         roles_path.add_argument('-p', '--roles-path', dest='roles_path', type=opt_help.unfrack_path(pathsep=True),
                                 default=C.DEFAULT_ROLES_PATH, action=opt_help.PrependListAction,
-                                help='The path to the directory containing your roles. By default it will use the first 'writable' directory you have configured in DEFAULT_ROLES_PATH: %s ' % ':'.join(C.DEFAULT_ROLES_PATH)
+                                help='The path to the directory containing your roles.
+                                By default it will use the first writable directory you have configured in DEFAULT_ROLES_PATH: %s ' % ':'.join(C.DEFAULT_ROLES_PATH)
 
         force = opt_help.argparse.ArgumentParser(add_help=False)
         force.add_argument('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')


### PR DESCRIPTION
##### SUMMARY
Fixes #23395.

Updates documentation for `ansible-galaxy` to match behavior - by default it writes roles to ~/.ansible/roles. Running `ansible-galaxy install` as root results into roles being written to the root user's home directory.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible-galaxy
