### PR TITLE
Fix ansible-test target change classification.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -631,17 +631,14 @@ class PathMapper(object):
             if not os.path.exists(path):
                 return minimal
 
-            target = self.integration_targets_by_name[path.split('/')[3]]
+            target = self.integration_targets_by_name.get(path.split('/')[3])
+
+            if not target:
+                display.warning('Unexpected non-target found: %s' % path)
+                return minimal
 
             if 'hidden/' in target.aliases:
-                if target.type == 'role':
-                    return minimal  # already expanded using get_dependent_paths
-
-                return {
-                    'integration': self.integration_all_target,
-                    'windows-integration': self.integration_all_target,
-                    'network-integration': self.integration_all_target,
-                }
+                return minimal  # already expanded using get_dependent_paths
 
             return {
                 'integration': target.name if 'posix/' in target.aliases else None,


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test target change classification.

Now that declaration of dependencies between targets is enforced, it is safe to rely on dependency expansion for script based hidden targets instead of triggering all tests.

Also fix a traceback when a file is encountered in the targets directory.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
