### PR TITLE
Clean up local_action and delegate_to in tests.

### DIFF
--- a/test/integration/targets/binary_modules/download_binary_modules.yml
+++ b/test/integration/targets/binary_modules/download_binary_modules.yml
@@ -14,8 +14,8 @@
 
     - name: download binary module
       tags: test_binary_modules
-      local_action:
-        module: get_url
+      get_url:
         url: "https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_binary_modules/{{ module_filename }}"
         dest: "{{ playbook_dir }}/library/{{ module_filename }}"
         mode: 0755
+      delegate_to: localhost

--- a/test/integration/targets/dnf/meta/main.yml
+++ b/test/integration/targets/dnf/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_rpm_repo
+  - setup_remote_tmp_dir

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -1,6 +1,6 @@
 # make a installroot
 - name: Create installroot
-  command: mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
+  command: mktemp -d "{{ remote_tmp_dir }}/ansible.test.XXXXXX"
   register: dnfroot
 
 - name: Make a necessary directory

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -1,7 +1,6 @@
 # make a installroot
 - name: Create installroot
-  local_action:
-    module: command mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
+  command: mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
   register: dnfroot
 
 - name: Make a necessary directory

--- a/test/integration/targets/dnf/tasks/dnfreleasever.yml
+++ b/test/integration/targets/dnf/tasks/dnfreleasever.yml
@@ -1,6 +1,6 @@
 # make an installroot
 - name: Create installroot
-  command: mktemp -d "{{lookup('env', 'TMPDIR') | default('/tmp', true)}}/ansible.test.XXXXXX"
+  command: mktemp -d "{{ remote_tmp_dir }}/ansible.test.XXXXXX"
   register: dnfroot
 
 - name: Make a necessary directory

--- a/test/integration/targets/dnf/tasks/dnfreleasever.yml
+++ b/test/integration/targets/dnf/tasks/dnfreleasever.yml
@@ -1,7 +1,6 @@
 # make an installroot
 - name: Create installroot
-  local_action:
-    module: command mktemp -d "{{lookup('env', 'TMPDIR') | default('/tmp', true)}}/ansible.test.XXXXXX"
+  command: mktemp -d "{{lookup('env', 'TMPDIR') | default('/tmp', true)}}/ansible.test.XXXXXX"
   register: dnfroot
 
 - name: Make a necessary directory

--- a/test/integration/targets/java_cert/tasks/main.yml
+++ b/test/integration/targets/java_cert/tasks/main.yml
@@ -3,8 +3,7 @@
   copy: src="{{ test_pkcs12_path }}" dest="{{output_dir}}/{{ test_pkcs12_path }}"
 
 - name: import pkcs12
-  local_action:
-     module: java_cert
+  java_cert:
      pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
      pkcs12_password: changeit
      pkcs12_alias: default
@@ -20,8 +19,7 @@
     - result_success is successful
 
 - name: import pkcs12 with wrong password
-  local_action:
-     module: java_cert
+  java_cert:
      pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
      pkcs12_password: wrong_pass
      pkcs12_alias: default
@@ -39,8 +37,7 @@
     - result_wrong_pass is failed
 
 - name: test fail on mutually exclusive params
-  local_action:
-     module: java_cert
+  java_cert:
      cert_path: ca.crt
      pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
      cert_alias: default

--- a/test/integration/targets/memset_dns_reload/tasks/main.yml
+++ b/test/integration/targets/memset_dns_reload/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: request reload with invalid API key
-  local_action:
-    module: memset_dns_reload
+  memset_dns_reload:
     api_key: "wa9aerahhie0eekee9iaphoorovooyia"
   ignore_errors: true
   register: result
@@ -13,8 +12,7 @@
       - result is not successful
 
 - name: request reload and poll
-  local_action:
-    module: memset_dns_reload
+  memset_dns_reload:
     api_key: "{{ api_key }}"
     poll: true
   register: result

--- a/test/integration/targets/memset_memstore_facts/tasks/main.yml
+++ b/test/integration/targets/memset_memstore_facts/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: query API with invalid API key
-  local_action:
-    module: memset_memstore_facts
+  memset_memstore_facts:
     api_key: 'wa9aerahhie0eekee9iaphoorovooyia'
     name: 'mstestyaa1'
   ignore_errors: true
@@ -14,8 +13,7 @@
       - result is not successful
 
 - name: request memstore facts
-  local_action:
-    module: memset_memstore_facts
+  memset_memstore_facts:
     api_key: "{{ api_key }}"
     name: 'mstestyaa1'
   register: result

--- a/test/integration/targets/memset_server_facts/tasks/main.yml
+++ b/test/integration/targets/memset_server_facts/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: query API with invalid API key
-  local_action:
-    module: memset_server_facts
+  memset_server_facts:
     api_key: 'wa9aerahhie0eekee9iaphoorovooyia'
     name: 'testyaa1'
   ignore_errors: true
@@ -14,8 +13,7 @@
       - result is not successful
 
 - name: request server facts
-  local_action:
-    module: memset_server_facts
+  memset_server_facts:
     api_key: "{{ api_key }}"
     name: 'testyaa1'
   register: result

--- a/test/integration/targets/memset_zone/tasks/main.yml
+++ b/test/integration/targets/memset_zone/tasks/main.yml
@@ -4,8 +4,7 @@
     zone_name: "{{ 65535 | random | string }}.ansible.example.com"
 
 - name: create zone with incorrect API key
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "wa9aerahhie0eekee9iaphoorovooyia"
     state: present
     name: "{{ zone_name }}"
@@ -20,8 +19,7 @@
       - result is not successful
 
 - name: test creating zone
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "{{ api_key }}"
     state: present
     name: "{{ zone_name }}"
@@ -36,8 +34,7 @@
       - result is successful
 
 - name: create zone
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "{{ api_key }}"
     state: present
     name: "{{ zone_name }}"
@@ -51,8 +48,7 @@
       - result is successful
 
 - name: create duplicate zone
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "{{ api_key }}"
     state: present
     name: "{{ zone_name }}"
@@ -65,8 +61,7 @@
       - result is not changed
 
 - name: test deleting zone
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "{{ api_key }}"
     state: absent
     name: "{{ zone_name }}"
@@ -80,8 +75,7 @@
       - result is successful
 
 - name: delete empty zone
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "{{ api_key }}"
     state: absent
     name: "{{ zone_name }}"
@@ -95,8 +89,7 @@
       - result is successful
 
 - name: create zone for deletion test
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "{{ api_key }}"
     state: present
     name: "{{ zone_name }}"
@@ -109,8 +102,7 @@
       - result is successful
 
 - name: delete zone with force
-  local_action:
-    module: memset_zone
+  memset_zone:
     api_key: "{{ api_key }}"
     state: absent
     name: "{{ zone_name }}"

--- a/test/integration/targets/memset_zone_domain/tasks/main.yml
+++ b/test/integration/targets/memset_zone_domain/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: create domain with invalid API key
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "wa9aerahhie0eekee9iaphoorovooyia"
     state: present
     domain: "{{ test_domain }}"
@@ -16,8 +15,7 @@
       - result is not successful
 
 - name: create domain over 250 chars
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: present
     domain: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com'
@@ -32,8 +30,7 @@
       - "'Zone domain must be less than 250 characters in length' in result.stderr"
 
 - name: create domain in non-existent zone
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: present
     domain: "{{ test_domain }}"
@@ -48,8 +45,7 @@
       - "'does not exist, cannot create domain.' in result.stderr"
 
 - name: create domain in non-unique zone
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: present
     domain: "{{ test_domain }}"
@@ -64,8 +60,7 @@
       - "'matches multiple zones, cannot create domain' in result.stderr"
 
 - name: test creating domain
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: present
     domain: "{{ test_domain }}"
@@ -80,8 +75,7 @@
       - result is successful
 
 - name: create domain
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: present
     domain: "{{ test_domain }}"
@@ -95,8 +89,7 @@
       - result is successful
 
 - name: create existing domain
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: present
     domain: "{{ test_domain }}"
@@ -109,8 +102,7 @@
       - result is not changed
 
 - name: test deleting domain
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: absent
     domain: "{{ test_domain }}"
@@ -125,8 +117,7 @@
       - result is successful
 
 - name: delete domain
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: absent
     domain: "{{ test_domain }}"
@@ -139,8 +130,7 @@
       - result is changed
 
 - name: delete non-existent domain
-  local_action:
-    module: memset_zone_domain
+  memset_zone_domain:
     api_key: "{{ api_key }}"
     state: absent
     domain: "{{ test_domain }}"

--- a/test/integration/targets/memset_zone_record/tasks/main.yml
+++ b/test/integration/targets/memset_zone_record/tasks/main.yml
@@ -1,6 +1,5 @@
 - name: create record with incorrect API key
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "wa9aerahhie0eekee9iaphoorovooyia"
     state: present
     zone: "{{ test_zone }}"
@@ -15,8 +14,7 @@
       - result is not successful
 
 - name: create record in non-existent zone
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "a-non-existent-zone"
@@ -32,8 +30,7 @@
       - result is not successful
 
 - name: create record in non-unique zone
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ duplicate_zone }}"
@@ -49,8 +46,7 @@
       - result is not successful
 
 - name: create record with invalid priority
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ test_zone }}"
@@ -68,8 +64,7 @@
       - result is not successful
 
 - name: create record with address longer than 250 chars
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ test_zone }}"
@@ -86,8 +81,7 @@
       - result is not successful
 
 - name: create record longer than 63 chars
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ test_zone }}"
@@ -104,8 +98,7 @@
       - result is not successful
 
 - name: create record which cannot have relative enabled
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ test_zone }}"
@@ -122,8 +115,7 @@
       - result is not successful
 
 - name: test creating valid A record
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ test_zone }}"
@@ -140,8 +132,7 @@
       - result is successful
 
 - name: actually create valid A record
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ test_zone }}"
@@ -157,8 +148,7 @@
       - result is successful
 
 - name: create valid SPF record
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: present
     zone: "{{ test_zone }}"
@@ -173,8 +163,7 @@
       - result is successful
 
 - name: test deleting A record
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: absent
     zone: "{{ test_zone }}"
@@ -191,8 +180,7 @@
       - result is successful
 
 - name: actually delete A record
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: absent
     zone: "{{ test_zone }}"
@@ -208,8 +196,7 @@
       - result is successful
 
 - name: delete SPF record
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: absent
     zone: "{{ test_zone }}"
@@ -224,8 +211,7 @@
       - result is successful
 
 - name: delete non-existent SPF record
-  local_action:
-    module: memset_zone_record
+  memset_zone_record:
     api_key: "{{ api_key }}"
     state: absent
     zone: "{{ test_zone }}"

--- a/test/integration/targets/scaleway_s3/tasks/aws_s3.yml
+++ b/test/integration/targets/scaleway_s3/tasks/aws_s3.yml
@@ -1,8 +1,7 @@
-- name: Create a local file
+- name: Create a file
   tempfile:
     state: file
     suffix: temp
-  delegate_to: localhost
   register: tempfile
 
 - import_tasks: aws_s3_create.yml

--- a/test/integration/targets/scaleway_s3/tasks/aws_s3_get.yml
+++ b/test/integration/targets/scaleway_s3/tasks/aws_s3_get.yml
@@ -1,8 +1,7 @@
-- name: Create a destination local file
+- name: Create a destination file
   tempfile:
     state: file
     suffix: temp
-  delegate_to: localhost
   register: tempfile_dst
 
 - name: Get from bucket

--- a/test/integration/targets/tower_credential/tasks/main.yml
+++ b/test/integration/targets/tower_credential/tasks/main.yml
@@ -1,9 +1,11 @@
 - name: create a tempdir for an SSH key
-  local_action: shell mktemp -d
+  shell: mktemp -d
+  delegate_to: localhost
   register: tempdir
 
 - name: Generate a local SSH key
-  local_action: "shell ssh-keygen -b 2048 -t rsa -f {{ tempdir.stdout }}/id_rsa -q -N 'passphrase'"
+  shell: "ssh-keygen -b 2048 -t rsa -f {{ tempdir.stdout }}/id_rsa -q -N 'passphrase'"
+  delegate_to: localhost
 
 - name: Read the generated key
   set_fact:

--- a/test/integration/targets/tower_group/tasks/main.yml
+++ b/test/integration/targets/tower_group/tasks/main.yml
@@ -1,10 +1,9 @@
 - name: create a tempdir for hostvars
-  local_action: shell mktemp -d
+  shell: mktemp -d
   register: tempdir
 
 - name: write a file w/ hostvars
-  local_action:
-    module: lineinfile
+  lineinfile:
     dest: "{{ tempdir.stdout }}/vars"
     line: '{"foo": "bar"}'
     create: true

--- a/test/integration/targets/tower_host/tasks/main.yml
+++ b/test/integration/targets/tower_host/tasks/main.yml
@@ -1,10 +1,9 @@
 - name: create a tempdir for hostvars
-  local_action: shell mktemp -d
+  shell: mktemp -d
   register: tempdir
 
 - name: write a file w/ hostvars
-  local_action:
-    module: lineinfile
+  lineinfile:
     dest: "{{ tempdir.stdout }}/vars"
     line: '{"foo": "bar"}'
     create: true

--- a/test/integration/targets/vmware_vspan_session/tasks/main.yml
+++ b/test/integration/targets/vmware_vspan_session/tasks/main.yml
@@ -97,7 +97,6 @@
       uplink_teaming_override: yes
       vendor_config_override: yes
       vlan_override: yes
-  delegate_to: localhost
   register: portgroup_create_result
 
 - name: ensure portgroup was created
@@ -119,7 +118,6 @@
     source_port_transmitted: 13
     source_port_received: 13
     destination_port: 12
-  delegate_to: localhost
   register: vspan_session_create_result
 
 - name: ensure session was created
@@ -136,7 +134,6 @@
     switch: dvswitch_0001
     name: "session_0001"
     state: "absent"
-  delegate_to: localhost
   register: vspan_session_delete_result
 
 - name: ensure session was deleted

--- a/test/integration/targets/vultr_server/tasks/main.yml
+++ b/test/integration/targets/vultr_server/tasks/main.yml
@@ -13,7 +13,7 @@
 
 # Servers can only be destroyed 5 min after creation
 - name: wait for 5 min
-  local_action: wait_for
+  wait_for:
   when: result is changed
 
 - name: test fail if missing name
@@ -481,7 +481,7 @@
 
 # Servers can only be destroyed 5 min after creation
 - name: wait for 5 min
-  local_action: wait_for
+  wait_for:
 
 - name: test absent server
   vultr_server:

--- a/test/integration/targets/vultr_server_facts/tasks/main.yml
+++ b/test/integration/targets/vultr_server_facts/tasks/main.yml
@@ -9,7 +9,7 @@
 
 # Servers can only be destroyed 5 min after creation
 - name: wait for 5 min until VM is absent
-  local_action: wait_for
+  wait_for:
   when: result is changed
 
 - name: test gather vultr server facts - empty resources

--- a/test/integration/targets/win_fetch/tasks/main.yml
+++ b/test/integration/targets/win_fetch/tasks/main.yml
@@ -21,11 +21,13 @@
     host_output_dir: "{{ output_dir }}/{{ inventory_hostname }}"
 
 - name: clean out the test directory
-  local_action: file name={{ host_output_dir|mandatory }} state=absent
+  file: name={{ host_output_dir|mandatory }} state=absent
+  delegate_to: localhost
   run_once: true
 
 - name: create the test directory
-  local_action: file name={{ host_output_dir }} state=directory
+  file: name={{ host_output_dir }} state=directory
+  delegate_to: localhost
   run_once: true
 
 - name: fetch a small file
@@ -38,7 +40,8 @@
       - "fetch_small.changed"
 
 - name: check file created by fetch small
-  local_action: stat path={{ fetch_small.dest }}
+  stat: path={{ fetch_small.dest }}
+  delegate_to: localhost
   register: fetch_small_stat
 
 - name: verify fetched small file exists locally
@@ -67,7 +70,8 @@
       - "fetch_flat.changed"
 
 - name: check file created by fetch flat
-  local_action: stat path="{{ host_output_dir }}/win.ini"
+  stat: path="{{ host_output_dir }}/win.ini"
+  delegate_to: localhost
   register: fetch_flat_stat
 
 - name: verify fetched file exists locally in host_output_dir
@@ -96,7 +100,8 @@
       - "fetch_large.changed"
 
 - name: check file created by fetch large binary
-  local_action: stat path={{ fetch_large.dest }}
+  stat: path={{ fetch_large.dest }}
+  delegate_to: localhost
   register: fetch_large_stat
 
 - name: verify fetched large file exists locally
@@ -125,7 +130,8 @@
       - "fetch_small_bs.changed"
 
 - name: check file created by fetch small with backslashes
-  local_action: stat path={{ fetch_small_bs.dest }}
+  stat: path={{ fetch_small_bs.dest }}
+  delegate_to: localhost
   register: fetch_small_bs_stat
 
 - name: verify fetched small file with backslashes exists locally

--- a/test/integration/targets/yum/meta/main.yml
+++ b/test/integration/targets/yum/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_rpm_repo
+  - setup_remote_tmp_dir

--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -1,7 +1,6 @@
 # make a installroot
 - name: Create installroot
-  local_action:
-    module: command mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
+  command: mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
   register: yumroot
 
 #- name: Populate directory

--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -1,6 +1,6 @@
 # make a installroot
 - name: Create installroot
-  command: mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
+  command: mktemp -d "{{ remote_tmp_dir }}/ansible.test.XXXXXX"
   register: yumroot
 
 #- name: Populate directory

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_doc.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_doc.yml
@@ -2,8 +2,7 @@
 # These two tests are close to documentation example
 
 - name: Create a new host or update an existing host's info
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -47,8 +46,7 @@
   register: zabbix_host1
 
 - name: Update an existing host's tls settings
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_setup.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_setup.yml
@@ -2,8 +2,7 @@
 # set up a zabbix proxy to test zabbix_host with
 
 - name: Create a new proxy
-  local_action:
-    module: zabbix_proxy
+  zabbix_proxy:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_teardown.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_teardown.yml
@@ -2,8 +2,7 @@
 # remove zabbix_proxy (hopefully) created earlier
 
 - name: remove proxy
-  local_action:
-    module: zabbix_proxy
+  zabbix_proxy:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
@@ -1,8 +1,7 @@
 ---
 
 - name: "test: create host with many options set"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -51,8 +50,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: try to create the same host with the same settings"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -101,8 +99,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change visible_name"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -116,8 +113,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change visible_name (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -131,8 +127,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change description"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -146,8 +141,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change description (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -161,8 +155,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change host groups (adding one group)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -179,8 +172,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host groups (remove one group)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -196,8 +188,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host groups (add one group using force=no)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -214,8 +205,7 @@
 
 
 - name: "test: change host groups (check whether we are at three groups)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -232,8 +222,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change host groups (attempt to remove all host groups)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -249,8 +238,7 @@
           - "zabbix_host1 is failed"
 
 - name: "test: change host linked templates (same as before)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -266,8 +254,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change host linked templates (add one template)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -284,8 +271,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host linked templates (add one template, using force=no)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -301,8 +287,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host linked templates (make sure we are at 4 templates)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -320,8 +305,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change host linked templates (remove all templates)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -336,8 +320,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host linked templates (check we have no templates left)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -352,8 +335,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change host status"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -367,8 +349,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host status (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -382,8 +363,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change host inventory mode"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -397,8 +377,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host inventory mode"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -412,8 +391,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change host inventory data (one field)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -434,8 +412,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change host inventory data (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -456,8 +433,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: remove host proxy"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -471,8 +447,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: add host proxy"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -486,8 +461,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: add host proxy (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -501,8 +475,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change tls settings"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -521,8 +494,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change tls settings (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -541,8 +513,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change interface settings (remove one)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -562,8 +533,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change interface settings (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -583,8 +553,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: change interface settings (add one interface using force=no)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -605,8 +574,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: change interface settings (verify that we are at two interfaces)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -632,8 +600,7 @@
           - "not zabbix_host1 is changed"
 
 - name: "test: add IPMI settings"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -650,8 +617,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: add IPMI settings again"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -668,8 +634,7 @@
           - "zabbix_host1 is not changed"
 
 - name: "test: verify that an empty change is idempotent"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -682,8 +647,7 @@
           - "zabbix_host1 is not changed"
 
 - name: "test: IPMI set default values"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -700,8 +664,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: IPMI set default values (again)"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -718,8 +681,7 @@
           - "zabbix_host1 is not changed"
 
 - name: "test: attempt to delete host created earlier"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
@@ -733,8 +695,7 @@
           - "zabbix_host1 is changed"
 
 - name: "test: attempt deleting a non-existant host"
-  local_action:
-    module: zabbix_host
+  zabbix_host:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"


### PR DESCRIPTION
##### SUMMARY

Clean up `local_action` and `delegate_to: localhost` in integration tests.

Most module integration tests should not explicitly test localhost, but instead run tests on testhost. Using `delegate_to: localhost` or `local_action` is in most cases incorrect and can result in tests running entirely on the controller or failing when tasks intended for the remote run on the controller instead.

For cases when running on the controller is desired, favor `delegate_to: localhost` over `local_action`.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
