### PR TITLE
fix combine filter using undefined vars

### DIFF
--- a/changelogs/fragments/55840-combine-filter-undefined-variables.yaml
+++ b/changelogs/fragments/55840-combine-filter-undefined-variables.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - combine filter - Validate that undefined variables aren't used (https://github.com/ansible/ansible/issues/55810).

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -48,6 +48,7 @@ from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common._collections_compat import Mapping, MutableMapping
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.parsing.yaml.dumper import AnsibleDumper
+from ansible.template import recursive_check_defined
 from ansible.utils.display import Display
 from ansible.utils.encrypt import passlib_or_crypt
 from ansible.utils.hashing import md5s, checksum_s
@@ -290,20 +291,6 @@ def mandatory(a):
             name = ''
         raise AnsibleFilterError("Mandatory variable %s not defined." % name)
     return a
-
-
-def recursive_check_defined(item):
-    from jinja2.runtime import Undefined
-
-    if isinstance(item, MutableMapping):
-        for key in item:
-            recursive_check_defined(item[key])
-    elif isinstance(item, list):
-        for i in item:
-            recursive_check_defined(i)
-    else:
-        if isinstance(item, Undefined):
-            raise AnsibleFilterError("{0} is undefined".format(item))
 
 
 def combine(*terms, **kwargs):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -178,6 +178,20 @@ def _count_newlines_from_end(in_str):
         return i
 
 
+def recursive_check_defined(item):
+    from jinja2.runtime import Undefined
+
+    if isinstance(item, MutableMapping):
+        for key in item:
+            recursive_check_defined(item[key])
+    elif isinstance(item, list):
+        for i in item:
+            recursive_check_defined(i)
+    else:
+        if isinstance(item, Undefined):
+            raise AnsibleFilterError("{0} is undefined".format(item))
+
+
 class AnsibleUndefined(StrictUndefined):
     '''
     A custom Undefined class, which returns further Undefined objects on access,

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -7,6 +7,6 @@ source virtualenv.sh
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
 
-pip install jmespath netaddr
+pip install jmespath netaddr jinja2 cryptography pyyaml
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -7,6 +7,6 @@ source virtualenv.sh
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
 
-pip install jmespath netaddr jinja2 cryptography pyyaml
+pip install jmespath netaddr
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -277,3 +277,28 @@
   loop: "{{ hostvars|dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+
+- name: Ensure combining two dictionaries containing undefined variables provides a helpful error
+  block:
+    - set_fact:
+        foo:
+          key1: value1
+
+    - set_fact:
+        combined: "{{ foo | combine({'key2': undef_variable}) }}"
+      ignore_errors: yes
+      register: result
+
+    - assert:
+        that:
+          - "result.msg.startswith('The task includes an option with an undefined variable')"
+
+    - set_fact:
+        key2: is_defined
+
+    - set_fact:
+        combined: "{{ foo | combine({'key2': key2}) }}"
+
+    - assert:
+        that:
+          - "combined.key2 == 'is_defined'"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -294,6 +294,15 @@
           - "result.msg.startswith('The task includes an option with an undefined variable')"
 
     - set_fact:
+        combined: "{{ foo | combine({'key2': {'nested': [undef_variable]}})}}"
+      ignore_errors: yes
+      register: result
+
+    - assert:
+        that:
+          - "result.msg.startswith('The task includes an option with an undefined variable')"
+
+    - set_fact:
         key2: is_defined
 
     - set_fact:


### PR DESCRIPTION
##### SUMMARY
Fixes #55810

The combine filter ignores undefined variables leading to unexpected errors. Fail instead, with a helpful message.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py
