### PR TITLE
Added implicit initialization of APT package manager '_cache' field

### DIFF
--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -177,6 +177,10 @@ class APT(LibMgr):
 
     LIB = 'apt'
 
+    def __init__(self):
+        self._cache = None
+        super(APT, self).__init__()
+
     @property
     def pkg_cache(self):
         if self._cache:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added initialization to None of '_cache' field in constructor of APT class.
This eliminates error at `if self._cache:` (line 182)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #55850 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/packaging/os/package_facts.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
