### PR TITLE
Clarify multiple failed_when uses AND not OR

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -102,6 +102,10 @@ You can also combine multiple conditions to specify this behavior as follows::
         - '"No such" not in result.stdout'
         - result.rc == 0
 
+Multiple conditions are joined with a boolean `AND`.
+This example will fail if both conditions are true.
+If only one condition is satisfied, this task will pass.
+
 .. _override_the_changed_result:
 
 Overriding The Changed Result


### PR DESCRIPTION
It is not immediately obvious that multiple `failed_when` conditions are joined with `AND`. 
I assumed they would be joined with `OR`. (Since that would be more useful.) Also, there are multiple third party pages online incorrectly stating that it uses `OR`. ([example](https://groups.google.com/d/msg/ansible-project/cIaQTmY3ZLE/c5w8rlmdHWIJ)). So it's worth clarifying.

+label: docsite_pr

# SUMMARY

Add a paragraph to the docs clarifying that multiple `failed_when` conditions in a list are joined with `AND` not `OR`.

# ISSUE TYPE

- Docs Pull Request

# COMPONENT NAME

Docs for core

# ADDITIONAL INFORMATION

Here is an example task which demonstrates that the behavior is indeed `AND` not `OR`.

Only the first condition is satisfied, and this task does not fail. Therefore `failed_when` uses `AND`.

```
- name: make script to run
  copy:
     content: |
        echo "No such file or directory"
        exit 0
     mode: +x
     dest: ./script.sh

- name: run the script
  shell: ./script.sh
  register: scriptout
  failed_when:
    - '"No such file or directory" in scriptout.stdout'
    - '"Cannot open" in scriptout.stdout'
```