### PR TITLE
Update setup.py

### DIFF
--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -82,7 +82,7 @@ notes:
       output of your scripts.
       This option was added in Ansible 2.1.
     - This module is also supported for Windows targets.
-    - This module should be run with elevated priviliges on *BSD systems to gather facts like ansible_product_version.
+    - This module should be run with elevated priviliges on BSD systems to gather facts like ansible_product_version.
 author:
     - "Ansible Core Team"
     - "Michael DeHaan"

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -82,7 +82,7 @@ notes:
       output of your scripts.
       This option was added in Ansible 2.1.
     - This module is also supported for Windows targets.
-    - This module should be run with elevated priviliges on *BSD systems to gather facts like ansible_product_version. 
+    - This module should be run with elevated priviliges on *BSD systems to gather facts like ansible_product_version.
 author:
     - "Ansible Core Team"
     - "Michael DeHaan"

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -82,6 +82,7 @@ notes:
       output of your scripts.
       This option was added in Ansible 2.1.
     - This module is also supported for Windows targets.
+    - This module should be run with elevated priviliges on *BSD systems to gather facts like ansible_product_version. 
 author:
     - "Ansible Core Team"
     - "Michael DeHaan"


### PR DESCRIPTION
adds a note on privileges needed on BSD systems to use dmidecode
+label: docsite_pr

##### SUMMARY
dmidecode is silently ignored, if privileges are not high enough.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
setup module

##### ADDITIONAL INFORMATION
