### PR TITLE
Fix integration test role syntax.

### DIFF
--- a/test/integration/targets/aix_devices/tasks/main.yml
+++ b/test/integration/targets/aix_devices/tasks/main.yml
@@ -1,77 +1,71 @@
----
-- name: AIX devices tests
-  hosts: localhost
-  connection: local
+- name: Scan new devices.
+  aix_devices:
+    device: all
+    state: present
 
-  tasks:
-    - name: Scan new devices.
-      aix_devices:
-        device: all
-        state: present
+- name: Scan new virtual devices (vio0).
+  aix_devices:
+    device: vio0
+    state: present
 
-    - name: Scan new virtual devices (vio0).
-      aix_devices:
-        device: vio0
-        state: present
+- name: Removing IP alias to en0
+  aix_devices:
+    device: en0
+    attributes:
+      delalias4: 10.0.0.100,255.255.255.0
 
-    - name: Removing IP alias to en0
-      aix_devices:
-        device: en0
-        attributes:
-          delalias4: 10.0.0.100,255.255.255.0
+- name: Removes ent2.
+  aix_devices:
+    device: ent2
+    state: absent
 
-    - name: Removes ent2.
-      aix_devices:
-        device: ent2
-        state: absent
+- name: Put device en2 in Defined
+  aix_devices:
+    device: en2
+    state: defined
 
-    - name: Put device en2 in Defined
-      aix_devices:
-        device: en2
-        state: defined
+- name: Removes ent4 (inexistent).
+  aix_devices:
+    device: ent4
+    state: absent
 
-    - name: Removes ent4 (inexistent).
-      aix_devices:
-        device: ent4
-        state: absent
+- name: Put device en4 in Defined (inexistent)
+  aix_devices:
+    device: en4
+    state: defined
 
-    - name: Put device en4 in Defined (inexistent)
-      aix_devices:
-        device: en4
-        state: defined
+- name: Put vscsi1 and children devices in Defined state.
+  aix_devices:
+    device: vscsi1
+    recursive: yes
+    state: defined
 
-    - name: Put vscsi1 and children devices in Defined state.
-      aix_devices:
-        device: vscsi1
-        recursive: yes
-        state: defined
+- name: Removes vscsi1 and children devices.
+  aix_devices:
+    device: vscsi1
+    recursive: yes
+    state: absent
 
-    - name: Removes vscsi1 and children devices.
-      aix_devices:
-        device: vscsi1
-        recursive: yes
-        state: absent
+- name: Changes en1 mtu to 9000 and disables arp.
+  aix_devices:
+    device: en1
+    attributes:
+      mtu: 900
+      arp: off
+    state: present
 
-    - name: Changes en1 mtu to 9000 and disables arp.
-      aix_devices:
-        device: en1
-        attributes:
-          mtu: 900
-          arp: off
-        state: present
+- name: Configure IP, netmask and set en1 up.
+  aix_devices:
+    device: en1
+    attributes:
+      netaddr: 192.168.0.100
+      netmask: 255.255.255.0
+      state: up
+    state: present
 
-    - name: Configure IP, netmask and set en1 up.
-      aix_devices:
-        device: en1
-        attributes:
-          netaddr: 192.168.0.100
-          netmask: 255.255.255.0
-          state: up
-        state: present
-
-    - name: Adding IP alias to en0
-      aix_devices:
-        device: en0
-        attributes:
-          alias4: 10.0.0.100,255.255.255.0
-        state: present
+- name: Adding IP alias to en0
+  aix_devices:
+    device: en0
+    attributes:
+      alias4: 10.0.0.100,255.255.255.0
+    state: present

--- a/test/integration/targets/aix_filesystem/tasks/main.yml
+++ b/test/integration/targets/aix_filesystem/tasks/main.yml
@@ -1,124 +1,120 @@
----
-- name: Testing aix_filesystem module.
-  hosts: lpar24
-  tasks:
-    - name: Umounting /testfs
-      aix_filesystem:
-        filesystem: /testfs
-        state: unmounted
+- name: Umounting /testfs
+  aix_filesystem:
+    filesystem: /testfs
+    state: unmounted
 
-    - name: Removing /testfs
-      aix_filesystem:
-        filesystem: /testfs
-        state: absent
+- name: Removing /testfs
+  aix_filesystem:
+    filesystem: /testfs
+    state: absent
 
-    - name: Creating a new file system
-      aix_filesystem:
-        filesystem: /newfs
-        size: 1G
-        state: present
-        vg: datavg
+- name: Creating a new file system
+  aix_filesystem:
+    filesystem: /newfs
+    size: 1G
+    state: present
+    vg: datavg
 
-    # It requires a host (nfshost) exporting the NFS
-    - name: Creating NFS filesystem from nfshost (Linux NFS server)
-      aix_filesystem:
-       device: /home/ftp
-       nfs_server: nfshost
-       filesystem: /nfs/ftp
-       state: present
-    
-    # It requires a volume group named datavg (next three actions)
-    - name: Creating a logical volume testlv (aix_lvol module)
-      aix_lvol:
-        vg: datavg
-        lv: testlv
-        size: 2G
-        state: present
-    
-    - name: Create filesystem in a previously defined logical volume
-      aix_filesystem:
-        device: testlv
-        filesystem: /testfs
-        state: present
+# It requires a host (nfshost) exporting the NFS
+- name: Creating NFS filesystem from nfshost (Linux NFS server)
+  aix_filesystem:
+   device: /home/ftp
+   nfs_server: nfshost
+   filesystem: /nfs/ftp
+   state: present
 
-    - name: Create an already existing filesystem using existing logical volume.
-      aix_filesystem:
-        vg: datavg
-        device: mksysblv
-        filesystem: /mksysb
-        state: present
+# It requires a volume group named datavg (next three actions)
+- name: Creating a logical volume testlv (aix_lvol module)
+  aix_lvol:
+    vg: datavg
+    lv: testlv
+    size: 2G
+    state: present
 
-    - name: Create a filesystem in a non-existing VG
-      aix_filesystem:
-        vg: nonexistvg
-        filesystem: /newlv
-        state: present
+- name: Create filesystem in a previously defined logical volume
+  aix_filesystem:
+    device: testlv
+    filesystem: /testfs
+    state: present
 
-    - name: Resizing /mksysb to 1G
-      aix_filesystem:
-        filesystem: /mksysb
-        size: 1G
-        state: present
+- name: Create an already existing filesystem using existing logical volume.
+  aix_filesystem:
+    vg: datavg
+    device: mksysblv
+    filesystem: /mksysb
+    state: present
 
-    - name: Resizing /mksysb to +512M
-      aix_filesystem:
-        filesystem: /mksysb
-        size: +512M
-        state: present
+- name: Create a filesystem in a non-existing VG
+  aix_filesystem:
+    vg: nonexistvg
+    filesystem: /newlv
+    state: present
 
-    - name: Resizing /mksysb to 11G
-      aix_filesystem:
-        filesystem: /mksysb
-        size: 11G
-        state: present
+- name: Resizing /mksysb to 1G
+  aix_filesystem:
+    filesystem: /mksysb
+    size: 1G
+    state: present
 
-    - name: Resizing /mksysb to 11G (already done)
-      aix_filesystem:
-        filesystem: /mksysb
-        size: 11G
-        state: present
+- name: Resizing /mksysb to +512M
+  aix_filesystem:
+    filesystem: /mksysb
+    size: +512M
+    state: present
 
-    - name: Resizing /mksysb to -2G
-      aix_filesystem:
-        filesystem: /mksysb
-        size: -2G
-        state: present
+- name: Resizing /mksysb to 11G
+  aix_filesystem:
+    filesystem: /mksysb
+    size: 11G
+    state: present
 
-    - name: Resizing /mksysb to 100G (no enought space)
-      aix_filesystem:
-        filesystem: /mksysb
-        size: +100G
-        state: present
+- name: Resizing /mksysb to 11G (already done)
+  aix_filesystem:
+    filesystem: /mksysb
+    size: 11G
+    state: present
 
-    - name: Unmount filesystem /home/ftp
-      aix_filesystem:
-        filesystem: /home/ftp
-        state: unmounted
+- name: Resizing /mksysb to -2G
+  aix_filesystem:
+    filesystem: /mksysb
+    size: -2G
+    state: present
 
-    - name: Remove NFS filesystem /home/ftp
-      aix_filesystem:
-        filesystem: /home/ftp
-        rm_mount_point: yes
-        state: absent
+- name: Resizing /mksysb to 100G (no enought space)
+  aix_filesystem:
+    filesystem: /mksysb
+    size: +100G
+    state: present
 
-    - name: Mount filesystem /newfs
-      aix_filesystem:
-        filesystem: /newfs
-        state: mounted
+- name: Unmount filesystem /home/ftp
+  aix_filesystem:
+    filesystem: /home/ftp
+    state: unmounted
 
-    - name: Remove mounted /newfs
-      aix_filesystem:
-        filesystem: /newfs
-        rm_mount_point: yes
-        state: absent
+- name: Remove NFS filesystem /home/ftp
+  aix_filesystem:
+    filesystem: /home/ftp
+    rm_mount_point: yes
+    state: absent
 
-    - name: Umount /newfs
-      aix_filesystem:
-        filesystem: /newfs
-        state: unmounted
+- name: Mount filesystem /newfs
+  aix_filesystem:
+    filesystem: /newfs
+    state: mounted
 
-    - name: Remove /newfs
-      aix_filesystem:
-        filesystem: /newfs
-        rm_mount_point: yes
-        state: absent
+- name: Remove mounted /newfs
+  aix_filesystem:
+    filesystem: /newfs
+    rm_mount_point: yes
+    state: absent
+
+- name: Umount /newfs
+  aix_filesystem:
+    filesystem: /newfs
+    state: unmounted
+
+- name: Remove /newfs
+  aix_filesystem:
+    filesystem: /newfs
+    rm_mount_point: yes
+    state: absent


### PR DESCRIPTION
##### SUMMARY

Fix integration test role syntax.

This does not fix the tests themselves, only the syntax (converting from playbooks to roles).
The aix_devices test fails due to use of unsupported state values.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

aix_devices and aix_filesystem integration tests
