### PR TITLE
Clean up use of `connection: local` in tests.

### DIFF
--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -3,7 +3,7 @@
     - name: Create a local temporary directory
       shell: mktemp -d /tmp/ansible_test.XXXXXXXXX
       register: tempfile_result
-      connection: local
+      delegate_to: localhost
 
     - set_fact:
         local_temp_dir: '{{ tempfile_result.stdout }}'
@@ -66,13 +66,13 @@
       file:
         path: '{{ local_temp_dir }}'
         state: absent
-      connection: local
+      delegate_to: localhost
 
     - name: Remove symbolic link
       file:
         path: '{{ role_path }}/files/subdir/subdir1/{{ item.key }}'
         state: absent
-      connection: local
+      delegate_to: localhost
       with_dict: "{{ symlinks }}"
 
     - name: Remote unprivileged remote user

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -384,7 +384,7 @@
     content: "foo.txt\n"
     dest: '{{ local_temp_dir }}/foo.txt'
     mode: 0547
-  connection: local
+  delegate_to: localhost
 
 - name: Copy with mode=preserve
   copy:
@@ -435,7 +435,7 @@
   file:
     path: '{{ role_path }}/files/subdir/subdira'
     state: directory
-  connection: local
+  delegate_to: localhost
 
 - name: Set the output subdirectory
   set_fact:
@@ -450,13 +450,13 @@
   copy:
     dest: /tmp/ansible-test-abs-link
     content: target
-  connection: local
+  delegate_to: localhost
 
 - name: Setup link target dir for absolute link
   file:
     dest: /tmp/ansible-test-abs-link-dir
     state: directory
-  connection: local
+  delegate_to: localhost
 
 - name: Test recursive copy to directory no trailing slash, local_follow=False
   copy:
@@ -607,13 +607,13 @@
   copy:
     dest: /tmp/ansible-test-abs-link
     content: target
-  connection: local
+  delegate_to: localhost
 
 - name: Setup link target dir for absolute link
   file:
     dest: /tmp/ansible-test-abs-link-dir
     state: directory
-  connection: local
+  delegate_to: localhost
 
 - name: Test recursive copy to directory trailing slash, local_follow=False
   copy:
@@ -762,13 +762,13 @@
   copy:
     dest: /tmp/ansible-test-abs-link
     content: target
-  connection: local
+  delegate_to: localhost
 
 - name: Setup link target dir for absolute link
   file:
     dest: /tmp/ansible-test-abs-link-dir
     state: directory
-  connection: local
+  delegate_to: localhost
 
 - name: Test recursive copy to directory no trailing slash, local_follow=True
   copy:
@@ -940,7 +940,7 @@
     file:
       path: '{{ local_temp_dir }}/dest1'
       state: directory
-  connection: local
+  delegate_to: localhost
 
 - name: Recursive copy the source
   copy:
@@ -1003,7 +1003,7 @@
     file:
       path: '{{ local_temp_dir }}/destination'
       state: directory
-  connection: local
+  delegate_to: localhost
 
 - name: Copy the directory and files within (no trailing slash)
   copy:
@@ -1383,8 +1383,7 @@
       path: '{{ local_temp_dir }}/top_dir/subdir/circle'
       src: '{{ local_temp_dir }}/top_dir/'
       state: link
-
-  connection: local
+    delegate_to: localhost
 
 - name: Copy the directory's link
   copy:

--- a/test/integration/targets/ignore_unreachable/test_cannot_connect.yml
+++ b/test/integration/targets/ignore_unreachable/test_cannot_connect.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: localhost
-  connection: local
   gather_facts: false
   tasks:
     - name: Hi

--- a/test/integration/targets/lookup_paths/play.yml
+++ b/test/integration/targets/lookup_paths/play.yml
@@ -1,6 +1,5 @@
 - name: setup state
-  hosts: testhost
-  connection: local
+  hosts: localhost
   gather_facts: false
   tasks:
     - file: path={{playbook_dir}}/files state=directory
@@ -42,8 +41,7 @@
     play_out: in local
 
 - name: cleanup
-  hosts: testhost
-  connection: local
+  hosts: localhost
   gather_facts: false
   tasks:
     - file: path={{playbook_dir}}/testfile state=absent

--- a/test/integration/targets/lookup_paths/testplay.yml
+++ b/test/integration/targets/lookup_paths/testplay.yml
@@ -1,6 +1,5 @@
 - name: test initial state
-  hosts: testhost
-  connection: local
+  hosts: localhost
   gather_facts: false
   pre_tasks:
     - name: remove {{ remove }}

--- a/test/integration/targets/old_style_cache_plugins/test_fact_gathering.yml
+++ b/test/integration/targets/old_style_cache_plugins/test_fact_gathering.yml
@@ -1,8 +1,6 @@
 ---
 - hosts: localhost
-  connection: local
   gather_facts: no
 
 - hosts: localhost
-  connection: local
   gather_facts: yes

--- a/test/integration/targets/openssh_keypair/tasks/main.yml
+++ b/test/integration/targets/openssh_keypair/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: Generate privatekey1 - standard
-  connection: local
   openssh_keypair:
     path: '{{ output_dir }}/privatekey1'
 

--- a/test/integration/targets/tags/test_tags.yml
+++ b/test/integration/targets/tags/test_tags.yml
@@ -1,8 +1,7 @@
 ---
 - name: verify tags work as expected
-  hosts: localhost
+  hosts: testhost
   gather_facts: False
-  connection: local
   vars:
     the_tags:
       - tag3

--- a/test/integration/targets/templating_settings/test_templating_settings.yml
+++ b/test/integration/targets/templating_settings/test_templating_settings.yml
@@ -1,7 +1,6 @@
 ---
 - name: 'Test templating in name'
   hosts: testhost
-  connection: local
   vars:
     a_list:
       - 'part'


### PR DESCRIPTION
##### SUMMARY

Clean up use of `connection: local` in tests.

Most integration tests should run on `testhost` instead of `localhost`. When `localhost` is required only for some tasks, use `delegate_to: localhost` instead of `connection: local`.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
