### PR TITLE
add link in README to build-from-source instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,10 @@ Get Involved
 *  For a list of email lists, IRC channels and Working Groups, see the
    `Communication page <https://docs.ansible.com/ansible/latest/community/communication.html>`_
 
-Branch Info
+Branch and Build Info
 ===========
 
+*  An explanation of how to run the source code can be found `here <https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#running-from-source>`_.
 *  The ``devel`` branch corresponds to the release actively under development.
 *  The ``stable-2.X`` branches correspond to stable releases.
 *  For information about the active branches see the

--- a/README.rst
+++ b/README.rst
@@ -63,9 +63,8 @@ Branch Info
 
 *  The ``devel`` branch corresponds to the release actively under development.
 *  The ``stable-2.X`` branches correspond to stable releases.
-*  To contribute a PR, branch from ``devel`` and `run Ansible from source <https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#running-from-source>`_.
-*  For information about the active branches see the
-   `Ansible release and maintenance <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html>`_ page.
+*  Create a branch based on ``devel`` and set up a `dev environment <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#common-environment-setup`_ if you want to open a PR.
+*  See the `Ansible release and maintenance <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html>`_ page for information about active branches.
 
 Roadmap
 =======

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Branch Info
 
 *  The ``devel`` branch corresponds to the release actively under development.
 *  The ``stable-2.X`` branches correspond to stable releases.
-*  Create a branch based on ``devel`` and set up a `dev environment <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#common-environment-setup`_ if you want to open a PR.
+*  Create a branch based on ``devel`` and set up a `dev environment <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#common-environment-setup>`_ if you want to open a PR.
 *  See the `Ansible release and maintenance <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html>`_ page for information about active branches.
 
 Roadmap

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Get Involved
    code to Ansible.
 *  Join a `Working Group
    <https://github.com/ansible/community/wiki>`_, an organized community devoted to a specific technology domain or platform.
-*  Submit proposed a code update through a pull request to the ``devel`` branch.
+*  Submit a proposed code update through a pull request to the ``devel`` branch.
 *  Talk to us before making larger changes
    to avoid duplicate efforts. This not only helps everyone
    know what is going on, it also helps save time and effort if we decide
@@ -58,12 +58,12 @@ Get Involved
 *  For a list of email lists, IRC channels and Working Groups, see the
    `Communication page <https://docs.ansible.com/ansible/latest/community/communication.html>`_
 
-Branch and Build Info
+Branch Info
 ===========
 
-*  An explanation of how to run the source code can be found `here <https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#running-from-source>`_.
 *  The ``devel`` branch corresponds to the release actively under development.
 *  The ``stable-2.X`` branches correspond to stable releases.
+*  To contribute a PR, branch from ``devel`` and `run Ansible from source <https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#running-from-source>`_.
 *  For information about the active branches see the
    `Ansible release and maintenance <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html>`_ page.
 


### PR DESCRIPTION
##### SUMMARY

Fix issue #55900 

Previously there was nothing in the README or the [Contributing to Ansible](https://docs.ansible.com/ansible/latest/community/development_process.html#) docs which explained how to run ansible from source. The presence of a Makefile is a bit of a red herring.

This patch just adds a link in the README to the instructions which say `source ./hacking/env-setup`.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

README

##### ADDITIONAL INFORMATION


