### PR TITLE
add path to return val of file touch

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -547,7 +547,7 @@ def execute_touch(path, follow, timestamps):
     b_path = to_bytes(path, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     changed = False
-    result = {'dest': path}
+    result = {'dest': path, 'path': path}
     mtime = get_timestamp_for_time(timestamps['modification_time'], timestamps['modification_time_format'])
     atime = get_timestamp_for_time(timestamps['access_time'], timestamps['access_time_format'])
 

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -228,15 +228,15 @@ diff:
     description: An object describing the state before and after the task.
     returned: sometimes
     type: dict
-    sample: 
-      after: 
+    sample:
+      after:
         path: file.txt
         state: absent
       before:
         path: file.txt
         state: file
 state:
-    description: 
+    description:
       - Equal to the nature of the path after the task is complete.
       - If the state argument is touch, the returned state value will be one of file, directory, link or absent.
       - If the state argument is not touch, the state returned on success equals the state argument.

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -215,7 +215,7 @@ EXAMPLES = r'''
 '''
 RETURN = r'''
 dest:
-    description: Destination file/path, equal to the value passed to I(path).
+    description: Destination file/path, equal to the value passed to I(dest).
     returned: state=touch, state=hard, state=link
     type: str
     sample: /path/to/file.txt
@@ -224,6 +224,25 @@ path:
     returned: state=absent, state=directory, state=file
     type: str
     sample: /path/to/file.txt
+diff:
+    description: An object describing the state before and after the task.
+    returned: sometimes
+    type: dict
+    sample: 
+      after: 
+        path: file.txt
+        state: absent
+      before:
+        path: file.txt
+        state: file
+state:
+    description: 
+      - Equal to the nature of the path after the task is complete.
+      - If the state argument is touch, the returned state value will be one of file, directory, link or absent.
+      - If the state argument is not touch, the state returned on success equals the state argument.
+    returned: Always
+    type: str
+    sample: file
 '''
 
 import errno


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #55898 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

file module

##### ADDITIONAL INFORMATION

Here is a playbook which fails without this patch, and passes with it.

```
---
- hosts: localhost
  tasks:


     - name: touch file
       file:
          state: touch
          path: file.txt
       register: touch
       failed_when: touch.path != 'file.txt'

     - name: file check
       file:
          state: file
          path: file.txt
       register: file
       failed_when: file.path != 'file.txt'

     - name: remove file
       file:
          state: absent
          path: file.txt
       register: absent
       failed_when: absent.path != 'file.txt'


     - name: directory check
       file:
          state: directory
          path: dir
       register: dir
       failed_when: dir.path != 'dir'
```
