### PR TITLE
Do not double fail hosts for includes

### DIFF
--- a/changelogs/fragments/23161-fix-rescue-for-includes-in-loop.yaml
+++ b/changelogs/fragments/23161-fix-rescue-for-includes-in-loop.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix executing the rescue section for includes in loops (https://github.com/ansible/ansible/issues/23161)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -822,8 +822,9 @@ class StrategyBase:
             # and increment the stats for this host
             for host in included_file._hosts:
                 tr = TaskResult(host=host, task=included_file._task, return_data=dict(failed=True, reason=reason))
-                iterator.mark_host_failed(host)
-                self._tqm._failed_hosts[host.name] = True
+                if host.name not in self._tqm._failed_hosts:
+                    iterator.mark_host_failed(host)
+                    self._tqm._failed_hosts[host.name] = True
                 self._tqm._stats.increment('failures', host.name)
                 self._tqm.send_callback('v2_runner_on_failed', tr)
             return []
@@ -924,8 +925,9 @@ class StrategyBase:
                                 break
                 except AnsibleError as e:
                     for host in included_file._hosts:
-                        iterator.mark_host_failed(host)
-                        self._tqm._failed_hosts[host.name] = True
+                        if host.name not in self._tqm._failed_hosts:
+                            iterator.mark_host_failed(host)
+                            self._tqm._failed_hosts[host.name] = True
                     display.warning(to_text(e))
                     continue
 

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -226,8 +226,10 @@ class StrategyModule(StrategyBase):
                             new_blocks = self._load_included_file(included_file, iterator=iterator)
                     except AnsibleError as e:
                         for host in included_file._hosts:
-                            iterator.mark_host_failed(host)
-                        display.warning(to_text(e))
+                            if host.name not in self._tqm._failed_hosts:
+                                self._tqm._failed_hosts[host.name] = True
+                                iterator.mark_host_failed(host)
+                        display.error(to_text(e), wrap_text=False)
                         continue
 
                     for new_block in new_blocks:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -375,8 +375,9 @@ class StrategyModule(StrategyBase):
 
                         except AnsibleError as e:
                             for host in included_file._hosts:
-                                self._tqm._failed_hosts[host.name] = True
-                                iterator.mark_host_failed(host)
+                                if host.name not in self._tqm._failed_hosts:
+                                    self._tqm._failed_hosts[host.name] = True
+                                    iterator.mark_host_failed(host)
                             display.error(to_text(e), wrap_text=False)
                             include_failure = True
                             continue


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #23161

```yaml
- block:
  - include_tasks: "{{ item }}.yml"
    loop:
      - this_does_not_exist
      - this_does_not_exist_either
  rescue:
     - debug:
          msg: rescue
```

The above block (either with `include_tasks` or `include_role`) fails to execute the rescue section because we double mark hosts as failed for failed includes and so play iterator skips the rescue section.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
```
lib/ansible/plugins/strategy/__init__.py
lib/ansible/plugins/strategy/free.py
lib/ansible/plugins/strategy/linear.py
```