### PR TITLE
parsing: recognize 'stdin' as a module argument in splitter.py

### DIFF
--- a/changelogs/fragments/55921-add-stdin-to-parse_kv.yml
+++ b/changelogs/fragments/55921-add-stdin-to-parse_kv.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Support `stdin` parameter when parsing k=v arguments to command, shell, etc (https://github.com/ansible/ansible/issues/55918)

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -38,6 +38,15 @@ _ESCAPE_SEQUENCE_RE = re.compile(r'''
     | \\[\\'"abfnrtv]  # Single-character escapes
     )'''.format(_HEXCHAR * 8, _HEXCHAR * 4, _HEXCHAR * 2), re.UNICODE | re.VERBOSE)
 
+_COMMAND_ARGS = (
+    'stdin',
+    'creates',
+    'removes',
+    'chdir',
+    'executable',
+    'warn',
+)
+
 
 def _decode_escapes(s):
     def decode_match(match):
@@ -89,7 +98,7 @@ def parse_kv(args, check_raw=False):
 
                 # FIXME: make the retrieval of this list of shell/command
                 #        options a function, so the list is centralized
-                if check_raw and k not in ('creates', 'removes', 'chdir', 'executable', 'warn'):
+                if check_raw and k not in _COMMAND_ARGS:
                     raw_params.append(orig_x)
                 else:
                     options[k.strip()] = unquote(v.strip())

--- a/test/units/parsing/test_splitter.py
+++ b/test/units/parsing/test_splitter.py
@@ -30,10 +30,12 @@ SPLIT_DATA = (
         {u'_raw_params': u'a'}),
     (u'a=b',
         [u'a=b'],
-        {u'a': u'b'}),
+        {u'a': u'b'},
+        {'_raw_params': 'a=b'}),
     (u'a="foo bar"',
         [u'a="foo bar"'],
-        {u'a': u'foo bar'}),
+        {u'a': u'foo bar'},
+        {'_raw_params': 'a="foo bar"'}),
     (u'"foo bar baz"',
         [u'"foo bar baz"'],
         {u'_raw_params': '"foo bar baz"'}),
@@ -94,10 +96,21 @@ SPLIT_DATA = (
     (u'One\n  Two\n    Three\n',
         [u'One\n ', u'Two\n   ', u'Three\n'],
         {u'_raw_params': u'One\n  Two\n    Three\n'}),
+    (u'stdin="this is a test" One Two Three',
+        [u'stdin="this is a test"', 'One', 'Two', 'Three'],
+        {'stdin': 'this is a test', '_raw_params': 'One Two Three'},
+        {'stdin': 'this is a test', '_raw_params': 'One Two Three'}),
+    (u'a=b c d',
+        [u'a=b', u'c', u'd'],
+        {'a': 'b', '_raw_params': 'c d'},
+        {'_raw_params': 'a=b c d'}),
 )
 
 SPLIT_ARGS = ((test[0], test[1]) for test in SPLIT_DATA)
 PARSE_KV = ((test[0], test[2]) for test in SPLIT_DATA)
+PARSE_KV_RAW = ((test[0], test[3])
+                for test in SPLIT_DATA
+                if len(test) == 4)
 
 
 @pytest.mark.parametrize("args, expected", SPLIT_ARGS)
@@ -108,3 +121,8 @@ def test_split_args(args, expected):
 @pytest.mark.parametrize("args, expected", PARSE_KV)
 def test_parse_kv(args, expected):
     assert parse_kv(args) == expected
+
+
+@pytest.mark.parametrize("args, expected", PARSE_KV_RAW)
+def test_parse_kv_check_raw(args, expected):
+    assert parse_kv(args, check_raw=True) == expected


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The `parse_kv` hardcodes a list of module parameter that it will
recognize. This has diverged from the parameters actually supported by
the `command`, `shell`, and `win_command` modules.  This commits
introduces `parse_kv` to the `stdin` parameter.

Fixes: #55918



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
parsing

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See #55918 for details.
