### PR TITLE
relax case-sensitivity check on unit

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -590,13 +590,13 @@ def main():
     if not check_size_format(part_start):
         module.fail_json(
             msg="The argument 'part_start' doesn't respect required format."
-            "Valid units are %s." % ', '.join(parted_units),
+                "Valid units are %s." % ', '.join(parted_units),
             err=parse_unit(part_start)
         )
     if not check_size_format(part_end):
         module.fail_json(
             msg="The argument 'part_end' doesn't respect required format."
-            "Valid units are %s." % ', '.join(parted_units),
+                "Valid units are %s." % ', '.join(parted_units),
             err=parse_unit(part_end)
         )
 

--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -525,7 +525,7 @@ def check_size_format(size_str):
     Checks if the input string is an allowed size
     """
     size, unit = parse_unit(size_str)
-    return unit in parted_units
+    return unit in map(str.lower, parted_units)
 
 
 def main():

--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -525,7 +525,7 @@ def check_size_format(size_str):
     Checks if the input string is an allowed size
     """
     size, unit = parse_unit(size_str)
-    return unit in map(str.lower, parted_units)
+    return unit.lower() in map(str.lower, parted_units)
 
 
 def main():
@@ -590,13 +590,13 @@ def main():
     if not check_size_format(part_start):
         module.fail_json(
             msg="The argument 'part_start' doesn't respect required format."
-                "The size unit is case sensitive.",
+            "Valid units are %s." % ', '.join(parted_units),
             err=parse_unit(part_start)
         )
     if not check_size_format(part_end):
         module.fail_json(
             msg="The argument 'part_end' doesn't respect required format."
-                "The size unit is case sensitive.",
+            "Valid units are %s." % ', '.join(parted_units),
             err=parse_unit(part_end)
         )
 


### PR DESCRIPTION
proposal fix for https://github.com/ansible/ansible/issues/37522

##### SUMMARY
Allow unit to be with capital or not letter

Fixes #37522

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Fix for parted

##### ADDITIONAL INFORMATION
It allows in a playbook task to reuse the `unit` value from a previous parted call.

```yaml
    - name: collect disk info
      parted:
        device: /dev/sda
      register: disk_info

    - name: create data partition
      parted:
        device: /dev/sda
        number: 2
        part_start: '{{ disk_info.partitions[0].end + 1 }}{{ disk_info.partitions[0].unit }}'
        part_end: 100%
        state: present
      when: disk_info.partitions | length == 1
```