### PR TITLE
Make packaging dep explicit

### DIFF
--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -1,6 +1,7 @@
 cryptography
 jinja2
 mock
+packaging  # needed for update-bundled and changelog
 pycodestyle
 pylint ; python_version >= '3.5' # pylint 2.0.0 and later require python 3+
 pytest


### PR DESCRIPTION
A couple sanity tests require the packaging module.  The azure tests are
dragging it in but list it explicitly in sanity so we don't run into
problems if those are ever split up

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
test/runner/requirements/sanity.txt