### PR TITLE
VMware: Handle VMs with no configurations

### DIFF
--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -411,6 +411,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 # VMware does not provide a way to uniquely identify VM by its name
                 # i.e. there can be two virtual machines with same name
                 # Appending "_" and VMware UUID to make it unique
+                if not vm_obj.obj.config:
+                    # Sometime orphaned VMs return no configurations
+                    continue
+
                 current_host = vm_obj_property.val + "_" + vm_obj.obj.config.uuid
 
                 if current_host not in hostvars:


### PR DESCRIPTION
##### SUMMARY
Sometime VMs does not return any configurations which leads
to failing the inventory plugin.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/vmware_vm_inventory.py
