### PR TITLE
Correction in the line 309 of the azure_rm.py script

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -306,7 +306,7 @@ class AzureRM(object):
         else:
             # try to look up "well-known" values via the name attribute on azure_cloud members
             all_clouds = [x[1] for x in inspect.getmembers(azure_cloud) if isinstance(x[1], azure_cloud.Cloud)]
-            matched_clouds = [x for x in all_clouds if x.name == raw_cloud_env.name]
+            matched_clouds = [x for x in all_clouds if x.name == raw_cloud_env]
             if len(matched_clouds) == 1:
                 self._cloud_environment = matched_clouds[0]
             elif len(matched_clouds) > 1:

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -306,7 +306,7 @@ class AzureRM(object):
         else:
             # try to look up "well-known" values via the name attribute on azure_cloud members
             all_clouds = [x[1] for x in inspect.getmembers(azure_cloud) if isinstance(x[1], azure_cloud.Cloud)]
-            matched_clouds = [x for x in all_clouds if x.name == raw_cloud_env]
+            matched_clouds = [x for x in all_clouds if x.name == raw_cloud_env.name]
             if len(matched_clouds) == 1:
                 self._cloud_environment = matched_clouds[0]
             elif len(matched_clouds) > 1:


### PR DESCRIPTION
Fetching dynamic inventory throws error : 'Cloud' object has no attribute 'decode'.

To solve this, the following change was made in the line 309:

From:
matched_clouds = [x for x in all_clouds if x.name == raw_cloud_env]
To:
matched_clouds = [x for x in all_clouds if x.name == raw_cloud_env.name]

Reference:
https://github.com/Azure/azure-sdk-for-python/issues/3009

PS. This change was tested in a production environment successfully.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
