### PR TITLE
Clarifies how Ansible processes multiple `failed_when` conditions

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -63,7 +63,9 @@ the handler from running, such as a host becoming unreachable.)
 Controlling What Defines Failure
 ````````````````````````````````
 
-Suppose the error code of a command is meaningless and to tell if there
+Ansible lets you define what "failure" means in each task. Ansible joins lists of multiple conditions for failure with an implicit ``and`` - if you want any one of multiple conditions to trigger a failure, you must define them in a string with an explicit ``or`` operator.
+
+Sometimes the error code of a command is meaningless and to tell if there
 is a failure what really matters is the output of the command, for instance
 if the string "FAILED" is in the output.
 
@@ -93,18 +95,18 @@ In previous version of Ansible, this can still be accomplished as follows::
         msg: "the command failed"
       when: "'FAILED' in command_result.stderr"
 
-You can also combine multiple conditions to specify this behavior as follows::
+You can also combine multiple conditions for failure. This example will fail if both conditions are true::
 
     - name: Check if a file exists in temp and fail task if it does
       command: ls /tmp/this_should_not_be_here
       register: result
       failed_when:
-        - '"No such" not in result.stdout'
         - result.rc == 0
+        - '"No such" not in result.stdout'
 
-Multiple conditions are joined with a boolean `AND`.
-This example will fail if both conditions are true.
-If only one condition is satisfied, this task will pass.
+ If you want the task to fail when only one condition is satisfied, change the ``failed_when`` definition to::
+
+      failed_when: result.rc == 0 or "No such" not in result.stdout
 
 .. _override_the_changed_result:
 
@@ -172,7 +174,7 @@ Blocks only deal with 'failed' status of a task. A bad task definition or an unr
         - debug:
             msg: 'I caught an error, can do stuff here to fix it, :-)'
 
-This will 'revert' the failed status of the outer ``block`` task for the run and the play will continue as if it had succeeded. 
+This will 'revert' the failed status of the outer ``block`` task for the run and the play will continue as if it had succeeded.
 See :ref:`block_error_handling` for more examples.
 
 .. seealso::
@@ -189,5 +191,3 @@ See :ref:`block_error_handling` for more examples.
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-
-

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -63,13 +63,9 @@ the handler from running, such as a host becoming unreachable.)
 Controlling What Defines Failure
 ````````````````````````````````
 
-Ansible lets you define what "failure" means in each task. Ansible joins lists of multiple conditions for failure with an implicit ``and`` - if you want any one of multiple conditions to trigger a failure, you must define them in a string with an explicit ``or`` operator.
+Ansible lets you define what "failure" means in each task using the ``failed_when`` conditional. As with all conditionals in Ansible, lists of multiple ``failed_when`` conditions are joined with an implicit ``and``, meaning the task only fails when *all* conditions are met. If you want to trigger a failure when any of the conditions is met, you must define the conditions in a string with an explicit ``or`` operator.
 
-Sometimes the error code of a command is meaningless and to tell if there
-is a failure what really matters is the output of the command, for instance
-if the string "FAILED" is in the output.
-
-Ansible provides a way to specify this behavior as follows::
+You may check for failure by searching for a word or phrase in the output of a command::
 
     - name: Fail task when the command error output prints FAILED
       command: /usr/bin/example-command -x -y -z

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -102,6 +102,10 @@ You can also combine multiple conditions to specify this behavior as follows::
         - '"No such" not in result.stdout'
         - result.rc == 0
 
+Multiple conditions are joined with a boolean `AND`.
+This example will fail if both conditions are true.
+If only one condition is satisfied, this task will pass.
+
 .. _override_the_changed_result:
 
 Overriding The Changed Result

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -91,7 +91,7 @@ In previous version of Ansible, this can still be accomplished as follows::
         msg: "the command failed"
       when: "'FAILED' in command_result.stderr"
 
-You can also combine multiple conditions for failure. This example will fail if both conditions are true::
+You can also combine multiple conditions for failure. This task will fail if both conditions are true::
 
     - name: Check if a file exists in temp and fail task if it does
       command: ls /tmp/this_should_not_be_here


### PR DESCRIPTION
##### SUMMARY
Supersedes #55870. The original branch/fork for that PR disappeared.

Clarifies that lists of conditions for `failed_when` are connected with an implicit `AND` operator. Adds an example of a task with multiple `failed_when` conditions connected by an explicit `OR` operator. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
