### PR TITLE
Add single_branch option when cloning repository

### DIFF
--- a/changelogs/fragments/git_single-branch.yml
+++ b/changelogs/fragments/git_single-branch.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - git module - Add single_branch option to specify --single-branch or --no-single-branch
+    when cloning repository (https://github.com/ansible/ansible/issues/55707)

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -10,6 +10,7 @@
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
+    single_branch: yes
 
 - name: DEPTH | try to access earlier commit
   command: "git checkout {{git_shallow_head_1.stdout}}"

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -37,3 +37,6 @@
 - include_tasks: ambiguous-ref.yml
 - include_tasks: archive.yml
 - include_tasks: separate-git-dir.yml
+- include_tasks: single-branch.yml
+  when:
+    - git_version.stdout is version("1.7.10", '>=')

--- a/test/integration/targets/git/tasks/single-branch.yml
+++ b/test/integration/targets/git/tasks/single-branch.yml
@@ -1,0 +1,55 @@
+# test code for single_branch with separate git dir updating
+# see: https://github.com/ansible/ansible/issues/55707
+
+- name: SINGLE_BRANCH | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
+
+- name: SINGLE_BRANCH | Clone example git repo with --single-branch
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}//shallow_branches'
+    dest: '{{ checkout_dir }}'
+    single_branch: yes
+
+- name: SINGLE_BRANCH | git checkout test-branch
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
+    dest: '{{ checkout_dir }}'
+    version: test_branch
+  register: clone_branch
+  ignore_errors: yes
+
+- name: SINGLE_BRANCH | check git checkout test-branch failed
+  assert:
+    that:
+      - clone_branch is failed
+
+- name: SINGLE_BRANCH | clear checkout_dir
+  file:
+    state: absent
+    path: '{{ checkout_dir }}'
+
+- name: SINGLE_BRANCH | Clone example git repo with --no-single-branch
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}//shallow_branches'
+    dest: '{{ checkout_dir }}'
+    single_branch: no
+
+- name: SINGLE_BRANCH | git checkout test-branch
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
+    dest: '{{ checkout_dir }}'
+    version: test_branch
+  register: clone_branch
+  ignore_errors: yes
+
+- name: SINGLE_BRANCH | check git checkout test-branch succeeded
+  assert:
+    that:
+      - clone_branch is succeeded
+
+- name: SINGLE_BRANCH | clear checkout_dir
+  file:
+    state: absent
+    path: '{{ checkout_dir }}'


### PR DESCRIPTION
##### SUMMARY
This option allows to specify --single-branch or --no-single-branch
 when cloning repository (See issue #55707)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- git module (lib/ansible/modules/source_control/git.py)

##### ADDITIONAL INFORMATION
None