### PR TITLE
Allow config boolean options to default to None

### DIFF
--- a/changelogs/fragments/55951-config-bool-options.yml
+++ b/changelogs/fragments/55951-config-bool-options.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Allow options that are type boolean to default to None rather than only True or False.

--- a/changelogs/fragments/55951-config-bool-options.yml
+++ b/changelogs/fragments/55951-config-bool-options.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Allow options that are type boolean to default to None rather than only True or False.
+  - Allow config options that are type boolean to default to None rather than only True or False.

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -83,11 +83,11 @@ def ensure_type(value, value_type, origin=None):
     if value_type:
         value_type = value_type.lower()
 
-    if value_type in ('boolean', 'bool'):
-        value = boolean(value, strict=False)
-
     elif value is not None:
-        if value_type in ('integer', 'int'):
+        if value_type in ('boolean', 'bool'):
+            value = boolean(value, strict=False)
+
+        elif value_type in ('integer', 'int'):
             value = int(value)
 
         elif value_type == 'float':

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -83,7 +83,7 @@ def ensure_type(value, value_type, origin=None):
     if value_type:
         value_type = value_type.lower()
 
-    elif value is not None:
+    if value is not None:
         if value_type in ('boolean', 'bool'):
             value = boolean(value, strict=False)
 


### PR DESCRIPTION
##### SUMMARY
Fixes that `default: None` is not respected for plugin options that are boolean.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/
