### PR TITLE
Coverity Bug Fix for cnos_vrf.py

### DIFF
--- a/lib/ansible/modules/network/cnos/cnos_vrf.py
+++ b/lib/ansible/modules/network/cnos/cnos_vrf.py
@@ -247,7 +247,7 @@ def map_config_to_obj(module):
                         if '!' not in intName and 'Interfaces' not in intName:
                             obj['interfaces'].append(intName.strip().lower())
                 objs.append(obj)
-    else:            
+    else:
         module.fail_json(msg='Could not fetch VRF details from device')
     return objs
 

--- a/lib/ansible/modules/network/cnos/cnos_vrf.py
+++ b/lib/ansible/modules/network/cnos/cnos_vrf.py
@@ -228,27 +228,27 @@ def map_obj_to_commands(updates, module):
 def map_config_to_obj(module):
     objs = []
     output = run_commands(module, {'command': 'show vrf'})
-    if output is None:
+    if output is not None:
+        vrfText = output[0].strip()
+        vrfList = vrfText.split('VRF')
+        for vrfItem in vrfList:
+            if 'FIB ID' in vrfItem:
+                obj = dict()
+                list_of_words = vrfItem.split()
+                vrfName = list_of_words[0]
+                obj['name'] = vrfName[:-1]
+                obj['rd'] = list_of_words[list_of_words.index('RD') + 1]
+                start = False
+                obj['interfaces'] = []
+                for intName in list_of_words:
+                    if 'Interfaces' in intName:
+                        start = True
+                    if start is True:
+                        if '!' not in intName and 'Interfaces' not in intName:
+                            obj['interfaces'].append(intName.strip().lower())
+                objs.append(obj)
+    else:            
         module.fail_json(msg='Could not fetch VRF details from device')
-    vrfText = output[0].strip()
-    vrfList = vrfText.split('VRF')
-    for vrfItem in vrfList:
-        if 'FIB ID' in vrfItem:
-            obj = dict()
-            list_of_words = vrfItem.split()
-            vrfName = list_of_words[0]
-            obj['name'] = vrfName[:-1]
-            obj['rd'] = list_of_words[list_of_words.index('RD') + 1]
-            start = False
-            obj['interfaces'] = []
-            for intName in list_of_words:
-                if 'Interfaces' in intName:
-                    start = True
-                if start is True:
-                    if '!' not in intName and 'Interfaces' not in intName:
-                        obj['interfaces'].append(intName.strip().lower())
-            objs.append(obj)
-
     return objs
 
 


### PR DESCRIPTION
##### SUMMARY
This is bug fix on cnos_vrf.py after running coverity. All my modules are passing except this. The error displayed is pasted below. Please merge it back to 2.8 as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/network/cnos/cnos_vrf.py

##### ADDITIONAL INFORMATION
Pasted below is the coverity issue which I am trying address

def map_config_to_obj(module):
229 objs = []
230 output = run_commands(module, {'command': 'show vrf'})

Condition output === None, taking true branch.
null_check: Comparing output to a null-like value implies that output might be null-like.
231 if output is None:
232 module.fail_json(msg='Could not fetch VRF details from device')
CID 80685 (#1 of 1): Bad use of null-like value (FORWARD_NULL)3. property_access: Accessing a property of null-like value output.
233 vrfText = output[0].strip()