### PR TITLE
vmware: find_vmdk_file with trailing /

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1273,11 +1273,14 @@ class PyVmomi(object):
         if not changed:
             self.module.fail_json(msg="No valid disk vmdk image found for path %s" % vmdk_path)
 
-        target_folder_path = datastore_name_sq + " " + vmdk_folder + '/'
+        target_folder_paths = [
+            datastore_name_sq + " " + vmdk_folder + '/',
+            datastore_name_sq + " " + vmdk_folder,
+        ]
 
         for file_result in search_res.info.result:
             for f in getattr(file_result, 'file'):
-                if f.path == vmdk_filename and file_result.folderPath == target_folder_path:
+                if f.path == vmdk_filename and file_result.folderPath in target_folder_paths:
                     return f
 
         self.module.fail_json(msg="No vmdk file found for path specified [%s]" % vmdk_path)


### PR DESCRIPTION
##### SUMMARY

With the example below, the `file_result.folderPath` of the file
does not have any trailing '/'. `target_folder_path` is correctly
generated and equal: `[nfs_1] images`.
As a result, the following condition fails and never return the correct
file:

```python
for file_result in search_res.info.result:
    for f in getattr(file_result, 'file'):
        if f.path == vmdk_filename and file_result.folderPath == target_folder_path:
            return f
```

it sound like, sometime, the .folderPath can end-up with a '/' (?). The
following patch, handle the two cases.

Example:

```
---
- name: Create a virtual machine on given ESXi hostname
  vmware_guest:
    hostname: "{{ vcenter_hostname }}"
    username: "{{ vcenter_username }}"
    password: "{{ vcenter_password }}"
    folder: '/'
    name: esxi1
    state: poweredoff
    guest_id: vmkernel65Guest
    # This is hostname of particular ESXi server on which user wants VM to be deployed
    esxi_hostname: "{{ esxi_hostname }}"
    datastore: nfs_1
    hardware:
      memory_mb: 4096
      num_cpus: 2
    disk:
      - size_gb: 10
        type: thin
        state: present
        datastore: nfs_1
        filename: '[nfs_1] images/esxi-6.7.0.vmdk'
        disk_mode: independent_nonpersistent
  register: deploy_vm
```
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->