### PR TITLE
[stable-2.7] Clarify documentation on reboot delay parameters (#55934).

### DIFF
--- a/lib/ansible/modules/system/reboot.py
+++ b/lib/ansible/modules/system/reboot.py
@@ -19,21 +19,21 @@ version_added: "2.7"
 options:
   pre_reboot_delay:
     description:
-      - Seconds for shutdown to wait before requesting reboot.
-      - On Linux, macOS, and OpenBSD this is converted to minutes and rounded down. If less than 60, it will be set to 0.
-      - On Solaris and FreeBSD this will be seconds.
+      - Seconds to wait before reboot. Passed as a parameter to the reboot command.
+      - On Linux, macOS and OpenBSD, this is converted to minutes and rounded down. If less than 60, it will be set to 0.
+      - On Solaris and FreeBSD, this will be seconds.
     default: 0
     type: int
   post_reboot_delay:
     description:
-      - Seconds to wait after the reboot was successful and the connection was re-established.
+      - Seconds to wait after the reboot command was successful before attempting to validate the system rebooted successfully.
       - This is useful if you want wait for something to settle despite your connection already working.
     default: 0
     type: int
   reboot_timeout:
     description:
       - Maximum seconds to wait for machine to reboot and respond to a test command.
-      - This timeout is evaluated separately for both network connection and test command success so the
+      - This timeout is evaluated separately for both reboot verification and test command success so the
         maximum execution time for the module is twice this amount.
     default: 600
     type: int

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -17,14 +17,14 @@ version_added: "2.1"
 options:
   pre_reboot_delay:
     description:
-    - Seconds for shutdown to wait before requesting reboot
+    - Seconds to wait before reboot. Passed as a parameter to the reboot command.
     type: int
     default: 2
     aliases: [ pre_reboot_delay_sec ]
   post_reboot_delay:
     description:
-    - Seconds to wait after the reboot was successful and the connection was re-established
-    - This is useful if you want wait for something to settle despite your connection already working
+    - Seconds to wait after the reboot command was successful before attempting to validate the system rebooted successfully.
+    - This is useful if you want wait for something to settle despite your connection already working.
     type: int
     default: 0
     version_added: '2.4'
@@ -39,8 +39,8 @@ options:
     aliases: [ shutdown_timeout_sec ]
   reboot_timeout:
     description:
-    - Maximum seconds to wait for machine to re-appear on the network and respond to a test command
-    - This timeout is evaluated separately for both network appearance and test command success (so maximum clock time is actually twice this value)
+    - Maximum seconds to wait for machine to re-appear on the network and respond to a test command.
+    - This timeout is evaluated separately for both reboot verification and test command success so maximum clock time is actually twice this value.
     type: int
     default: 600
     aliases: [ reboot_timeout_sec ]


### PR DESCRIPTION
##### SUMMARY
Backport of #55934 for Ansible 2.7

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
`lib/ansible/modules/system/reboot.py`
`lib/ansible/modules/windows/win_reboot.py`