### PR TITLE
Modify/fix handling of noreplace option issue fixes #55365

### DIFF
--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -74,7 +74,7 @@ options:
     description:
       - Do not re-emerge installed packages (--noreplace)
     type: bool
-    default: 'no'
+    default: 'yes'
 
   nodeps:
     description:
@@ -288,9 +288,9 @@ def emerge_packages(module, packages):
     """Run emerge command against given list of atoms."""
     p = module.params
 
-    if not (p['update'] or p['noreplace'] or p['state'] == 'latest'):
+    if p['noreplace'] and not (p['update'] or p['state'] == 'latest'):
         for package in packages:
-            if not query_package(module, package, 'emerge'):
+            if p['noreplace'] and not query_package(module, package, 'emerge'):
                 break
         else:
             module.exit_json(changed=False, msg='Packages already present.')
@@ -472,7 +472,7 @@ def main():
             newuse=dict(default=False, type='bool'),
             changed_use=dict(default=False, type='bool'),
             oneshot=dict(default=False, type='bool'),
-            noreplace=dict(default=False, type='bool'),
+            noreplace=dict(default=True, type='bool'),
             nodeps=dict(default=False, type='bool'),
             onlydeps=dict(default=False, type='bool'),
             depclean=dict(default=False, type='bool'),


### PR DESCRIPTION
##### SUMMARY
Modify/fix handling of noreplace option issue #55365

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
portage.py

##### ADDITIONAL INFORMATION
Presently setting noreplace: no/false has no effect. Negating the default
to true from false and modifying conditionals seems to correct this.
Making it such that you can re-install and existing package. That did not
seem possible without such modifications.

Potential fix for issue #55365 pending issue reporter testing and feedback.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before using playbook from issue #55365 
```
$ ansible-playbook tests.yaml

PLAY [ws] **********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [ws]

TASK [set up packages] *********************************************************
ok: [ws] => (item={'package': 'sys-apps/busybox', 'state': 'present'})
changed: [ws] => (item={'package': 'virtual/eject', 'state': 'absent'})

TASK [test case 1: re-emerge present package] **********************************
ok: [ws]

TASK [test case 2: do not re-emerge present package] ***************************
ok: [ws]

TASK [test case 3: emerge present and absent packages] *************************
changed: [ws]

TASK [set up packages] *********************************************************
ok: [ws] => (item={'package': 'sys-apps/busybox', 'state': 'present'})
changed: [ws] => (item={'package': 'virtual/eject', 'state': 'absent'})

TASK [test case 4: do not re-emerge present and absent packages] ***************
changed: [ws]

TASK [set up packages] *********************************************************
ok: [ws] => (item={'package': 'sys-apps/busybox', 'state': 'present'})
changed: [ws] => (item={'package': 'virtual/eject', 'state': 'absent'})

TASK [bonus test case 5: let Ansible do the right thing with present and absent packages] ***
changed: [ws]

PLAY RECAP *********************************************************************
ws                         : ok=9    changed=6    unreachable=0    failed=0
```

After
```
$ ansible-playbook tests.yaml

PLAY [ws] **********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [ws]

TASK [set up packages] *********************************************************
ok: [ws] => (item={'package': 'sys-apps/busybox', 'state': 'present'})
changed: [ws] => (item={'package': 'virtual/eject', 'state': 'absent'})

TASK [test case 1: re-emerge present package] **********************************
changed: [ws]

TASK [test case 2: do not re-emerge present package] ***************************
ok: [ws]

TASK [test case 3: emerge present and absent packages] *************************
changed: [ws]

TASK [set up packages] *********************************************************
ok: [ws] => (item={'package': 'sys-apps/busybox', 'state': 'present'})
changed: [ws] => (item={'package': 'virtual/eject', 'state': 'absent'})

TASK [test case 4: do not re-emerge present and absent packages] ***************
changed: [ws]

TASK [set up packages] *********************************************************
ok: [ws] => (item={'package': 'sys-apps/busybox', 'state': 'present'})
changed: [ws] => (item={'package': 'virtual/eject', 'state': 'absent'})

TASK [bonus test case 5: let Ansible do the right thing with present and absent packages] ***
changed: [ws]

PLAY RECAP *********************************************************************
ws                         : ok=9    changed=7    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
