### PR TITLE
win_acl - fix network path qualifier parsing

### DIFF
--- a/changelogs/fragments/win_acl-network.yaml
+++ b/changelogs/fragments/win_acl-network.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_acl - Fix qualifier parser when using UNC paths - https://github.com/ansible/ansible/issues/55875

--- a/test/integration/targets/win_acl/defaults/main.yml
+++ b/test/integration/targets/win_acl/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 test_acl_path: '{{ win_output_dir }}\win_acl .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+test_acl_network_path: \\localhost\{{ test_acl_path[0:1] }}$\{{ test_acl_path[3:] }}
 # Use HKU as that path is not automatically loaded in the PSProvider making our test more complex
 test_acl_reg_path: HKU:\.DEFAULT\Ansible Test .ÅÑŚÌβŁÈ [$!@^&test(;)]

--- a/test/integration/targets/win_acl/tasks/tests.yml
+++ b/test/integration/targets/win_acl/tasks/tests.yml
@@ -171,6 +171,48 @@
     that:
     - not remove_deny_right_again is changed
 
+- name: add write rights to Guest - network
+  win_acl:
+    path: '{{ test_acl_network_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+  register: allow_right
+
+- name: get result of add write rights to Guest - network
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: allow_right_actual
+
+- name: assert add write rights to Guest - network
+  assert:
+    that:
+    - allow_right is changed
+    - (allow_right_actual.stdout|from_json)|count == 1
+    - (allow_right_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (allow_right_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (allow_right_actual.stdout|from_json)[0].propagation_flags == 'None'
+    - (allow_right_actual.stdout|from_json)[0].rights == 'Write, Synchronize'
+    - (allow_right_actual.stdout|from_json)[0].type == 'Allow'
+
+- name: remove write rights from Guest - network
+  win_acl:
+    path: '{{ test_acl_network_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+    state: absent
+  register: remove_right
+
+- name: get result of remove write rights from Guest - network
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: remove_right_actual
+
+- name: assert remove write rights from Guest
+  assert:
+    that:
+    - remove_right is changed
+    - remove_right_actual.stdout_lines == ["[", "", "]"]
+
 - name: add write rights to Guest - registry
   win_acl:
     path: '{{ test_acl_reg_path }}'


### PR DESCRIPTION
##### SUMMARY
Part of a check in win_acl is to change the location to the qualifier root of the `path` specified. This fails when using a UNC path as it has no qualifier. This PR fixes this issue by making sure it doesn't fail when no qualifier could be found and to only change the location if a qualifier was found.

Fixes https://github.com/ansible/ansible/issues/55875

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_acl