### PR TITLE
clarify docs for rel src state hard

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -52,7 +52,8 @@ options:
     description:
     - Path of the file to link to.
     - This applies only to C(state=link) and C(state=hard).
-    - Will accept absolute, relative and non-existing paths.
+    - Will accept absolute and non-existing paths.
+    - Will accept relative paths unless state=hard.
     - Relative paths are relative to the file being created (C(path)) which is how
       the Unix command C(ln -s SRC DEST) treats relative paths.
     type: path


### PR DESCRIPTION
##### SUMMARY

Clarify the documentation. If using the `file` module and `state=hard`, the `src` *must* be absolute.

This fixes the documentation aspect of issue #55971 .

Ideally we should change the behavior to make it work with a relative `src`. I cannot think of any reason why it would not just, and there is a comment in the code when this error is thrown, asking why.
It would be good to get an expert to explain whether it can or cannot work with a relative path.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

file module

##### ADDITIONAL INFORMATION

