### PR TITLE
win_acl - fix network path qualifier parsing (#55970) - 2.7

### DIFF
--- a/changelogs/fragments/win_acl-network.yaml
+++ b/changelogs/fragments/win_acl-network.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_acl - Fix qualifier parser when using UNC paths - https://github.com/ansible/ansible/issues/55875

--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -91,8 +91,9 @@ $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "prese
 $inherit = Get-AnsibleParam -obj $params -name "inherit" -type "str"
 $propagation = Get-AnsibleParam -obj $params -name "propagation" -type "str" -default "None" -validateset "InheritOnly","None","NoPropagateInherit"
 
-# We mount the HKCR, HKU, and HKCC registry hives so PS can access them
-$path_qualifier = Split-Path -Path $path -Qualifier
+# We mount the HKCR, HKU, and HKCC registry hives so PS can access them.
+# Network paths have no qualifiers so we use -EA SilentlyContinue to ignore that
+$path_qualifier = Split-Path -Path $path -Qualifier -ErrorAction SilentlyContinue
 if ($path_qualifier -eq "HKCR:" -and (-not (Test-Path -LiteralPath HKCR:\))) {
     New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT > $null
 }
@@ -121,8 +122,10 @@ ElseIf ($null -eq $inherit) {
 }
 
 # Bug in Set-Acl, Get-Acl where -LiteralPath only works for the Registry provider if the location is in that root
-# qualifier.
-Push-Location -LiteralPath $path_qualifier
+# qualifier. We also don't have a qualifier for a network path so only change if not null
+if ($null -ne $path_qualifier) {
+    Push-Location -LiteralPath $path_qualifier
+}
 
 Try {
     SetPrivilegeTokens
@@ -219,7 +222,9 @@ Catch {
 }
 Finally {
     # Make sure we revert the location stack to the original path just for cleanups sake
-    Pop-Location
+    if ($null -ne $path_qualifier) {
+        Pop-Location
+    }
 }
 
 Exit-Json -obj $result

--- a/test/integration/targets/win_acl/defaults/main.yml
+++ b/test/integration/targets/win_acl/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 test_acl_path: '{{ win_output_dir }}\win_acl .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+test_acl_network_path: \\localhost\{{ test_acl_path[0:1] }}$\{{ test_acl_path[3:] }}
 # Use HKU as that path is not automatically loaded in the PSProvider making our test more complex
 test_acl_reg_path: HKU:\.DEFAULT\Ansible Test

--- a/test/integration/targets/win_acl/tasks/tests.yml
+++ b/test/integration/targets/win_acl/tasks/tests.yml
@@ -171,6 +171,48 @@
     that:
     - not remove_deny_right_again is changed
 
+- name: add write rights to Guest - network
+  win_acl:
+    path: '{{ test_acl_network_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+  register: allow_right
+
+- name: get result of add write rights to Guest - network
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: allow_right_actual
+
+- name: assert add write rights to Guest - network
+  assert:
+    that:
+    - allow_right is changed
+    - (allow_right_actual.stdout|from_json)|count == 1
+    - (allow_right_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (allow_right_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (allow_right_actual.stdout|from_json)[0].propagation_flags == 'None'
+    - (allow_right_actual.stdout|from_json)[0].rights == 'Write, Synchronize'
+    - (allow_right_actual.stdout|from_json)[0].type == 'Allow'
+
+- name: remove write rights from Guest - network
+  win_acl:
+    path: '{{ test_acl_network_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+    state: absent
+  register: remove_right
+
+- name: get result of remove write rights from Guest - network
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: remove_right_actual
+
+- name: assert remove write rights from Guest
+  assert:
+    that:
+    - remove_right is changed
+    - remove_right_actual.stdout_lines == ["[", "", "]"]
+
 - name: add write rights to Guest - registry
   win_acl:
     path: '{{ test_acl_reg_path }}'


### PR DESCRIPTION
(cherry picked from commit cc3b8b9f729a6176434a6e76d9940869b8b226c5)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/55970

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_acl