### PR TITLE
Fixes PhysicalResourceId KeyError when stack in ROLLBACK state

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
@@ -256,7 +256,7 @@ class CloudFormationServiceManager:
 def to_dict(items, key, value):
     ''' Transforms a list of items to a Key/Value dictionary '''
     if items:
-        return dict(zip([i[key] for i in items], [i[value] for i in items]))
+        return dict(zip([i.get(key) for i in items], [i.get(value) for i in items]))
     else:
         return dict()
 


### PR DESCRIPTION
##### SUMMARY
Fixes PhysicalResourceId KeyError when stack in ROLLBACK state

Fixes #38033

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`modules/cloud/amazon/cloudformation_facts.py`

##### ADDITIONAL INFORMATION

Currently, if we try to get facts from a CloudFormation Stack that is in
`ROLLBACK` state, this module will throw a `KeyError` exception, given that the
`PhysicalResourceId` key does not exist for every resource in the
stack_resource_list. Using the dict `get` method would set the value to None
(null) if the key does not exist:

```
   "stack_resources": {
       "AppSecurityGroup": "sg-XXXXXXXXXX",
       "testawsngxLaunchConfig": null,
       "testawsngxLoadBalancer": "arn:aws:elasticloadbalancing:eu-west-1:XXXXXXXX:loadbalancer/net/test-test-1P5RFLQ266GGP/XXXXXXXXXXXX",
       "testawsngxTargetGroup": "arn:aws:elasticloadbalancing:eu-west-1:XXXXXXX:targetgroup/test-test-1LDHMLKNWNA82/XXXXXXXXXXXX"
   },
```