### PR TITLE
nxos_install_os: Fix nxapi local failures

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -444,7 +444,7 @@ class LocalNxapi:
         commands = to_list(commands)
         try:
             resp = self.send_request(commands, output='config', check_status=True,
-                                                     return_error=return_error, opts=opts)
+                                     return_error=return_error, opts=opts)
         except ValueError as exc:
             code = getattr(exc, 'code', 1)
             message = getattr(exc, 'err', exc)

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -443,7 +443,7 @@ class LocalNxapi:
 
         commands = to_list(commands)
         try:
-            resp, msg_timestamps = self.send_request(commands, output='config', check_status=True,
+            resp = self.send_request(commands, output='config', check_status=True,
                                                      return_error=return_error, opts=opts)
         except ValueError as exc:
             code = getattr(exc, 'code', 1)

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -126,12 +126,6 @@ from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 
-import datetime
-def logit(msg):
-    with open('/tmp/alog.txt', 'a') as of:
-        d = datetime.datetime.now().replace(microsecond=0).isoformat()
-        of.write("---- %s ----\n%s\n" % (d,msg))
-
 
 # Output options are 'text' or 'json'
 def execute_show_command(module, command, output='text'):
@@ -207,10 +201,8 @@ def parse_show_install(data):
         21       lcn9k                7.0(3)F3(2)    7.0(3)F2(2)           yes
         21        bios                     v01.70         v01.70            no
     """
-    logit("data before massage:\n%s" % data)
     if len(data) > 0:
         data = massage_install_data(data)
-    logit("data after massage:\n%s" % data)
     ud = {'raw': data}
     ud['processed'] = []
     ud['disruptive'] = False

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -126,6 +126,12 @@ from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 
+import datetime
+def logit(msg):
+    with open('/tmp/alog.txt', 'a') as of:
+        d = datetime.datetime.now().replace(microsecond=0).isoformat()
+        of.write("---- %s ----\n%s\n" % (d,msg))
+
 
 # Output options are 'text' or 'json'
 def execute_show_command(module, command, output='text'):
@@ -201,8 +207,10 @@ def parse_show_install(data):
         21       lcn9k                7.0(3)F3(2)    7.0(3)F2(2)           yes
         21        bios                     v01.70         v01.70            no
     """
+    logit("data before massage:\n%s" % data)
     if len(data) > 0:
         data = massage_install_data(data)
+    logit("data after massage:\n%s" % data)
     ud = {'raw': data}
     ud['processed'] = []
     ud['disruptive'] = False
@@ -221,6 +229,8 @@ def parse_show_install(data):
         elif data >= 500:
             ud['server_error'] = True
         elif data == -32603:
+            ud['server_error'] = True
+        elif data == 1:
             ud['server_error'] = True
         return ud
     else:

--- a/test/integration/targets/nxos_install_os/defaults/main.yaml
+++ b/test/integration/targets/nxos_install_os/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-testcase: "upgrade"
+testcase: " {{ testcase }}"

--- a/test/integration/targets/nxos_install_os/meta/main.yml
+++ b/test/integration/targets/nxos_install_os/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
-  - prepare_nxos_tests
+  # Prepare nxos tests is not required for this test.
+  #- prepare_nxos_tests

--- a/test/integration/targets/nxos_install_os/tasks/main.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/main.yaml
@@ -1,5 +1,12 @@
 ---
-- { include: network_cli.yaml, tags: ['cli'] }
-- { include: network_local.yaml, tags: ['local'] }
-- { include: httpapi.yaml, tags: ['httpapi'] }
-- { include: nxapi.yaml, tags: ['nxapi'] }
+# Upgrade using SSH
+- include: network_cli.yaml
+  when: connection_type == 'network_cli'
+- include: network_local.yaml
+  when: connection_type == 'cli_local'
+
+# Upgrade using NX-API
+- include: httpapi.yaml
+  when: connection_type == 'httpapi'
+- include: nxapi.yaml
+  when: connection_type == 'nxapi_local'

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -5,14 +5,20 @@
 
 - include: targets/nxos_install_os/tasks/upgrade/enable_scp_server.yaml
 
+- name: 'Remove SSH known_hosts file before scp of image file'
+  nxos_command:
+    commands: 'run bash rm /var/home/admin/.ssh/known_hosts'
+    provider: "{{ connection }}"
+  ignore_errors: yes
+
 - name: "Copy {{ si }} to bootflash"
   nxos_file_copy:
     file_pull: True
     file_pull_timeout: 1200
     remote_file: "{{image_dir}}{{ si }}"
-    remote_scp_server: 192.168.1.1
-    remote_scp_server_user: scp_user
-    remote_scp_server_password: scp_password
+    remote_scp_server: "{{ remote_scp_server }}"
+    remote_scp_server_user: "{{ remote_scp_user }}"
+    remote_scp_server_password: "{{ remote_scp_password }}"
   register: result
 
 #- name: "Copy {{ si }} to bootflash"
@@ -33,9 +39,9 @@
     file_pull: True
     file_pull_timeout: 1200
     remote_file: "{{image_dir}}{{ ki }}"
-    remote_scp_server: 192.168.1.1
-    remote_scp_server_user: scp_user
-    remote_scp_server_password: scp_password
+    remote_scp_server: "{{ remote_scp_server }}"
+    remote_scp_server_user: "{{ remote_scp_user }}"
+    remote_scp_server_password: "{{ remote_scp_password }}"
   when: ki is defined
   register: result
 

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -8,12 +8,20 @@
   register: result
   when: not force
 
-- name: "Set OS image {{ si }} boot pointers"
+- name: "Remove old boot pointers if any"
   nxos_config:
     lines:
       - no boot nxos
       - no boot kickstart
       - no boot system
+    match: line
+    provider: "{{ connection }}"
+  ignore_errors: yes
+  when: force
+
+- name: "Set OS image {{ si }} boot pointers"
+  nxos_config:
+    lines:
       - "boot nxos bootflash:{{ si }}"
       - copy run start
     match: line
@@ -21,8 +29,10 @@
   when: force
 
 - name: "Boot image {{ si }} using reload"
-  nxos_command:
-    commands: 'terminal dont-ask ; reload'
+  nxos_config:
+    lines:
+      - 'terminal dont-ask'
+      - 'reload'
     provider: "{{ connection }}"
   ignore_errors: yes
   when: force

--- a/test/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
+++ b/test/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
@@ -7,13 +7,13 @@
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/greensboro/REL_7_0_3_I7_4/'
 
 - set_fact: checkmode='no'
-- set_fact: issu='yes'
-- set_fact: copy_images=False
+- set_fact: issu='desired'
+- set_fact: copy_images=True
 
 # Set boot pointers and reload
 - set_fact: force=False
 
-- set_fact: delete_files=False
+- set_fact: delete_files=True
 - set_fact:
     delete_image_list:
       - nxos*.bin

--- a/test/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
+++ b/test/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
@@ -4,14 +4,14 @@
   when: connection is defined
 
 # Set directory pointer to software images
-- set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/hamilton/REL_9_2_1/'
+- set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/greensboro/REL_7_0_3_I7_4/'
 
 - set_fact: checkmode='no'
 - set_fact: issu='desired'
 - set_fact: copy_images=True
 
 # Set boot pointers and reload
-- set_fact: force=False
+- set_fact: force=True
 
 - set_fact: delete_files=True
 - set_fact:
@@ -25,7 +25,9 @@
   nxos_config:
     lines:
       - terminal dont-ask
-      - no feature ngmvpn
+      - no feature nv overlay
+      - no nxapi ssl protocols
+      - no nxapi ssl ciphers weak
     match: none
     provider: "{{ connection }}"
   ignore_errors: yes
@@ -33,7 +35,7 @@
 #---------------------------------------------------------#
 # Upgrade Device                                          #
 #---------------------------------------------------------#
-- set_fact: si='nxos.9.2.1.bin'
+- set_fact: si='nxos.7.0.3.I7.4.bin'
 
-- name: Upgrade N9k Device to Hamilton Release Image
+- name: Upgrade N9k Device to Greensboro Release Image
   include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml


### PR DESCRIPTION
##### SUMMARY
Fixes the following issues for `nxos_install_os` in the devel branch
    * Recent refactoring in module_utils broke upgrades using nxapi local
    * Refactored integration tests to make them more flexible for choosing connection type

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_install_os

##### ADDITIONAL INFORMATION

Please cherry-pick into stable-2.8
