### PR TITLE
Fix examples in azure_rm_webappslot.py

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_webappslot.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_webappslot.py
@@ -170,7 +170,7 @@ author:
 
 EXAMPLES = '''
   - name: Create a webapp slot
-    azure_rm_webapp_slot:
+    azure_rm_webappslot:
       resource_group: myResourceGroup
       webapp_name: myJavaWebApp
       name: stage
@@ -179,7 +179,7 @@ EXAMPLES = '''
         testkey: testvalue
 
   - name: swap the slot with production slot
-    azure_rm_webapp_slot:
+    azure_rm_webappslot:
       resource_group: myResourceGroup
       webapp_name: myJavaWebApp
       name: stage
@@ -187,14 +187,14 @@ EXAMPLES = '''
         action: swap
 
   - name: stop the slot
-    azure_rm_webapp_slot:
+    azure_rm_webappslot:
       resource_group: myResourceGroup
       webapp_name: myJavaWebApp
       name: stage
       app_state: stopped
 
   - name: udpate a webapp slot app settings
-    azure_rm_webapp_slot:
+    azure_rm_webappslot:
       resource_group: myResourceGroup
       webapp_name: myJavaWebApp
       name: stage
@@ -202,7 +202,7 @@ EXAMPLES = '''
         testkey: testvalue2
 
   - name: udpate a webapp slot frameworks
-    azure_rm_webapp_slot:
+    azure_rm_webappslot:
       resource_group: myResourceGroup
       webapp_name: myJavaWebApp
       name: stage


### PR DESCRIPTION
##### SUMMARY
Incorrect module name in examples  azure_rm_webappslot 


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
This change only updates the examples in the doc.  It was azure_rm_webapp_slot, but should be azure_rm_webappslot

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
azure_rm_webappslot
