### PR TITLE
Install hidden galaxy data files (e.g. .travis.yml)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -266,6 +266,7 @@ static_setup_params = dict(
             'modules/windows/*.ps1',
             'modules/windows/*/*.ps1',
             'galaxy/data/*/*.*',
+            'galaxy/data/*/.*',
             'galaxy/data/*/*/.*',
             'galaxy/data/*/*/*.*',
             'galaxy/data/*/tests/inventory',


### PR DESCRIPTION
The package_data globs in setup.py were missing the necessary glob
to install:

galaxy/data/default/.travis.yml

A Python glob pattern will not by default match a hidden file
(i.e. a file basename beginning with a dot). If you want a glob
to pick up a hidden file in a directory you must explicitly specify
a glob pattern with "/.*".

Closes: #1777
Signed-off-by: John Dennis <jdennis@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
