### PR TITLE
Docs: Improve rendering of default lists

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -155,7 +155,7 @@ Parameters
                     {% endif %}
                     {# Show default value, when multiple choice or no choices #}
                     {% if value.default is defined and value.default not in value.choices %}
-                        <b>Default:</b><br/><div style="color: blue">@{ value.default | escape }@</div>
+                        <b>Default:</b><br/><div style="color: blue">@{ value.default | tojson | escape }@</div>
                     {% endif %}
                 </td>
                 {# configuration #}


### PR DESCRIPTION
##### SUMMARY

Change rendering of default list items in docs, so a list appears as `["myitem"]` rather than `[u'myitem']`

Fixes https://github.com/ansible/ansible/issues/43901

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

Docs Jinja template plugin.rst.j2

##### ADDITIONAL INFORMATION

Current docs show this for Parameters that have a default list:

![image](https://user-images.githubusercontent.com/3607046/57116715-c80eed00-6d0b-11e9-9855-1ce5dd8c2873.png)

After this change, it renders like this:

![image](https://user-images.githubusercontent.com/3607046/57116724-da892680-6d0b-11e9-87b3-7122060a47e5.png)

(NB: Ignore where my 'after' pic now shows a 'list' parameter type, that is separate to this change. Will do that as separate PR for my modules)