### PR TITLE
Added a microsoft teams notification webhook

### DIFF
--- a/lib/ansible/modules/notification/ms_teams.py
+++ b/lib/ansible/modules/notification/ms_teams.py
@@ -19,7 +19,7 @@ author: "Christian Kaiser <c.kaiser@also.com>"
 description:
   - Setup a webhook in Microsoft Teams. Using this webhook you can send html
     notifications.
-  - The module enabley you to write longer text in plain text or html, 
+  - The module enabley you to write longer text in plain text or html,
     instead of sending direct json to the endpoint.
 '''
 
@@ -29,10 +29,10 @@ EXAMPLES = '''
 - ms_teams:
     body: "{{ body }}"
     webhook: https://outlook.office.com/webhook/...
-	subject: Test
-    color: dd1111	
+    subject: Test
+    color: dd1111
   register: result
-- debug: 
+- debug:
     var=result
     verbosity=1
 '''
@@ -42,43 +42,46 @@ from ansible.module_utils.urls import fetch_url
 import json
 import os
 
-def create_payload(body, subject, color):    
-    payload={
+
+def create_payload(body, subject, color):
+    payload = {
         'text': body,
         'title': subject,
         'themeColor': color
     }
     return json.dumps(payload)
-    
+
+
 def post_to_msteams(module):
 
-    payload = create_payload(module.params['body'], 
-        module.params['subject'], 
-        module.params['color'])
-    
+    payload = create_payload(module.params['body'],
+                             module.params['subject'],
+                             module.params['color'])
+
     if module.check_mode:
         changed = False
         failed = False
         meta = payload
     else:
-        
-        headers = { 'Content-Type': 'application/json' }
-        response, info = fetch_url(module=module, 
-            url=module.params['webhook'], 
-            headers=headers, 
-            method='POST', 
-            data=payload)
-        
+
+        headers = {'Content-Type': 'application/json'}
+        response, info = fetch_url(module=modulea,
+                                   url=module.params['webhook'],
+                                   headers=headers,
+                                   method='POST',
+                                   data=payload)
+
         if info['status'] != 200:
             changed = False
             failed = True
-            meta = "failed to send %s: %s" % (payload, info['msg'])            
+            meta = "failed to send %s: %s" % (payload, info['msg'])
         else:
             changed = True
             failed = False
             meta = "Message send."
-        
+
     return (changed, failed, meta)
+
 
 def main():
 
@@ -88,12 +91,12 @@ def main():
         "subject": {"required": True, "type": "str"},
         "color": {"default": "ffffcc", "type": "str"}
     }
-    
+
     module = AnsibleModule(argument_spec=fields)
 
     changed, failed, meta = post_to_msteams(module)
     module.exit_json(changed=changed, meta=meta, failed=failed)
-    
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/notification/ms_teams.py
+++ b/lib/ansible/modules/notification/ms_teams.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (c) 2019, Christian Kaiser <c.kaiser@also.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ms_teams
+short_description: Send messages to a Microsoft Teams channel
+author: "Christian Kaiser <c.kaiser@also.com>"
+description:
+  - Setup a webhook in Microsoft Teams. Using this webhook you can send html notifications.
+  - The module enabley you to write longer text in plain text or html, instead of sending direct json to 
+    the endpoint.
+'''
+
+EXAMPLES = '''
+- tempfile: state=file suffix=html register=body
+- template: src=teams-sample.html.j2 dest={{ body.path }}
+- name: send a message into an ms teams channel using a webhook
+  ms_teams:
+    body: "{{ body.path }}
+    subject: Test
+    webhook: https://outlook.office.com/webhook/...  
+  register: result
+- debug: 
+    var=result
+    verbosity=1
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+import json
+import os
+
+def create_payload(body_file_name, subject, color):
+    with open(body_file_name, 'r') as f:
+        data = f.read()
+    os.remove(body_file_name)
+    
+    payload={
+        'text': data,
+        'title': subject,
+        'themeColor': color
+    }
+    return json.dumps(payload)
+    
+def post_to_msteams(module):
+
+    payload = create_payload(module.params['body'], 
+        module.params['subject'], module.params['color'])
+    
+    if module.check_mode:
+        changed = False
+        failed = False
+        meta = { "payload": payload, "subject": module.params['subject'] }
+    else:
+        
+        headers = { 'Content-Type': 'application/json' }
+        response, info = fetch_url(module=module, 
+            url=module.params['webhook'], 
+            headers=headers, 
+            method='POST', 
+            data=payload)
+        
+        if info['status'] != 200:
+            changed = False
+            failed = True
+            meta = "failed to send %s: %s" % (payload, info['msg'])            
+        else:
+            changed = True
+            failed = False
+            meta = "Message send."
+        
+    return (changed, failed, meta)
+
+def main():
+
+    fields = {
+        "body": {"required": True, "type": "str"},
+        "webhook": {"required": True, "type": "str"},
+        "subject": {"required": True, "type": "str"},
+        "color": {"default": "ffffcc", "type": "str"}
+    }
+    
+    module = AnsibleModule(argument_spec=fields)
+
+    changed, failed, meta = post_to_msteams(module)
+    module.exit_json(changed=changed, meta=meta, failed=failed)
+    
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/notification/ms_teams.py
+++ b/lib/ansible/modules/notification/ms_teams.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: ms_teams
-version_added: 1.0
+version_added: 2.9
 short_description: Send messages to a Microsoft Teams channel
 author: Christian Kaiser (@ckaiser79)
 description:
@@ -57,6 +57,14 @@ EXAMPLES = '''
     verbosity=1
 '''
 
+RETURN = '''
+meta:
+  description: The string message send or the payload in check_mode
+  returned: success
+  type: str
+  sample: "Message send."
+'''
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 import json
@@ -85,7 +93,7 @@ def post_to_msteams(module):
     else:
 
         headers = {'Content-Type': 'application/json'}
-        response, info = fetch_url(module=modulea,
+        response, info = fetch_url(module=module,
                                    url=module.params['webhook'],
                                    headers=headers,
                                    method='POST',

--- a/lib/ansible/modules/notification/ms_teams.py
+++ b/lib/ansible/modules/notification/ms_teams.py
@@ -1,26 +1,46 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2019, Christian Kaiser <c.kaiser@also.com>
+# (c) 2019, Christian Kaiser <c.kaiser () also.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['stableinterface'],
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
 module: ms_teams
+version_added: 1.0
 short_description: Send messages to a Microsoft Teams channel
-author: "Christian Kaiser <c.kaiser@also.com>"
+author: Christian Kaiser (@ckaiser79)
 description:
   - Setup a webhook in Microsoft Teams. Using this webhook you can send html
     notifications.
   - The module enabley you to write longer text in plain text or html,
     instead of sending direct json to the endpoint.
+options:
+  body:
+    required: true
+    description:
+      - The content of the message to be published.
+  subject:
+    required: true
+    description:
+      - The title of the message.
+  webhook:
+    required: true
+    description:
+      - The ms teams configured webhook
+  color:
+    description:
+      - Which color should be shown on the card. HTML code without a leading '#'
+    default: ffffcc
+notes:
+  - "See: https://docs.microsoft.com/de-de/outlook/actionable-messages/message-card-reference"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/notification/ms_teams.py
+++ b/lib/ansible/modules/notification/ms_teams.py
@@ -85,7 +85,7 @@ def post_to_msteams(module):
     else:
 
         headers = {'Content-Type': 'application/json'}
-        response, info = fetch_url(module=modulea,
+        response, info = fetch_url(module=module,
                                    url=module.params['webhook'],
                                    headers=headers,
                                    method='POST',
@@ -115,7 +115,10 @@ def main():
     module = AnsibleModule(argument_spec=fields)
 
     changed, failed, meta = post_to_msteams(module)
-    module.exit_json(changed=changed, meta=meta, failed=failed)
+    if failed:
+        module.fail_json(msg=meta)
+    else:
+        module.exit_json(changed=changed, meta=meta)
 
 
 if __name__ == '__main__':

--- a/test/units/modules/notification/test_ms_teams.py
+++ b/test/units/modules/notification/test_ms_teams.py
@@ -39,7 +39,7 @@ class TestMsTeamsModule(ModuleTestCase):
 
             self.assertTrue(fetch_url_mock.call_count, 1)
             assert fetch_url_mock.call_args[1]['url'] == 'https://outlook.office.com/my-webhook'
-            
+
             call_data = json.loads(fetch_url_mock.call_args[1]['data'])
             assert call_data['text'] == "Hello Teams!"
             assert call_data['title'] == "I am the subject"

--- a/test/units/modules/notification/test_ms_teams.py
+++ b/test/units/modules/notification/test_ms_teams.py
@@ -8,15 +8,15 @@ from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase
 class TestMsTeamsModule(ModuleTestCase):
 
     def setUp(self):
-        super(TestSlackModule, self).setUp()
-        self.module = slack
+        super(TestMsTeamsModule, self).setUp()
+        self.module = ms_teams
 
     def tearDown(self):
-        super(TestSlackModule, self).tearDown()
+        super(TestMsTeamsModule, self).tearDown()
 
     @pytest.fixture
     def fetch_url_mock(self, mocker):
-        return mocker.patch('ansible.module_utils.notification.slack.fetch_url')
+        return mocker.patch('ansible.module_utils.notification.ms_teams.fetch_url')
 
     def test_without_required_parameters(self):
         """Failure must occurs when all parameters are missing"""
@@ -32,7 +32,7 @@ class TestMsTeamsModule(ModuleTestCase):
             'webhook': 'https://outlook.office.com/my-webhook'
         })
 
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
+        with patch.object(ms_teams, "fetch_url") as fetch_url_mock:
             fetch_url_mock.return_value = (None, {"status": 200})
             with self.assertRaises(AnsibleExitJson):
                 self.module.main()
@@ -54,7 +54,7 @@ class TestMsTeamsModule(ModuleTestCase):
             'webhook': 'https://outlook.office.com/my-webhook'
         })
 
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
+        with patch.object(ms_teams, "fetch_url") as fetch_url_mock:
             fetch_url_mock.return_value = (None, {"status": 400, 'msg': 'test'})
             with self.assertRaises(AnsibleFailJson):
                 self.module.main()

--- a/test/units/modules/notification/test_ms_teams.py
+++ b/test/units/modules/notification/test_ms_teams.py
@@ -1,0 +1,60 @@
+import json
+import pytest
+from units.compat.mock import patch
+from ansible.modules.notification import ms_teams
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestMsTeamsModule(ModuleTestCase):
+
+    def setUp(self):
+        super(TestSlackModule, self).setUp()
+        self.module = slack
+
+    def tearDown(self):
+        super(TestSlackModule, self).tearDown()
+
+    @pytest.fixture
+    def fetch_url_mock(self, mocker):
+        return mocker.patch('ansible.module_utils.notification.slack.fetch_url')
+
+    def test_without_required_parameters(self):
+        """Failure must occurs when all parameters are missing"""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            self.module.main()
+
+    def test_sucessful_message(self):
+        """tests sending a message"""
+        set_module_args({
+            'body': 'Hello Teams!',
+            'subject': 'I am the subject',
+            'webhook': 'https://outlook.office.com/my-webhook'
+        })
+
+        with patch.object(slack, "fetch_url") as fetch_url_mock:
+            fetch_url_mock.return_value = (None, {"status": 200})
+            with self.assertRaises(AnsibleExitJson):
+                self.module.main()
+
+            self.assertTrue(fetch_url_mock.call_count, 1)
+            assert fetch_url_mock.call_args[1]['url'] == 'https://outlook.office.com/my-webhook'
+            
+            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+            assert call_data['text'] == "Hello Teams!"
+            assert call_data['title'] == "I am the subject"
+            assert call_data['themeColor'] == "ffffcc"
+
+    def test_failed_message(self):
+        """tests failing to send a message"""
+
+        set_module_args({
+            'body': 'Hello Teams!',
+            'subject': 'I am the subject',
+            'webhook': 'https://outlook.office.com/my-webhook'
+        })
+
+        with patch.object(slack, "fetch_url") as fetch_url_mock:
+            fetch_url_mock.return_value = (None, {"status": 400, 'msg': 'test'})
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()


### PR DESCRIPTION
##### SUMMARY

This pull request adds a new notification module. It is capable to send messages to a [Microsoft Teams room](https://products.office.com/en-us/microsoft-teams/) by using a webhook and json messages. The webhhook can be generated inside the teams client.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

ms_teams

##### ADDITIONAL INFORMATION

I know ansible is able to send data to a webhook without a module, by just sending the json code. The ms_teams module will hide the json specific code and enables a user more easily to send messages into a teams channel by hiding the json specifica for simple messages.

Here is an example of the cards, which can be send to teams: https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/cards/cards-reference#office-365-connector-card

Example playbook, requires:

- a file called ``deployment-successfull.html.j2`` in the template subdirectory
- a  teams channel to use (I can provide one if required per private message)

```yaml
- name: send message to ms teams channel
  ms_teams: 
    body: "{{ lookup('template', 'deployment-successfull.html.j2') }}"
    subject:  "DEPLOYMENT SUCCESSFULL on https://myserver.com"
    webhook: "https://outlook.office.com/..."
  become: false
  delegate_to: localhost
  run_once: true
```

Below is an example message in Teams:

https://photos.app.goo.gl/nkdpCxrKwQEG3rJXA
