### PR TITLE
[2.8] docker_container: use restart() API function instead of stop/start sequence

### DIFF
--- a/changelogs/fragments/55894-docker_container-restart.yml
+++ b/changelogs/fragments/55894-docker_container-restart.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - use docker API's ``restart`` instead of ``stop``/``start`` to restart a container."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2351,8 +2351,8 @@ class ContainerManager(DockerBaseClass):
                 container = self.container_start(container.Id)
             elif state == 'started' and self.parameters.restart:
                 self.diff_tracker.add('running', parameter=True, active=was_running)
-                self.container_stop(container.Id)
-                container = self.container_start(container.Id)
+                self.diff_tracker.add('restarted', parameter=True, active=False)
+                container = self.container_restart(container.Id)
             elif state == 'stopped' and container.running:
                 self.diff_tracker.add('running', parameter=False, active=was_running)
                 self.container_stop(container.Id)
@@ -2633,6 +2633,19 @@ class ContainerManager(DockerBaseClass):
             except Exception as exc:
                 self.fail("Error killing container %s: %s" % (container_id, exc))
         return response
+
+    def container_restart(self, container_id):
+        self.results['actions'].append(dict(restarted=container_id, timeout=self.parameters.stop_timeout))
+        self.results['changed'] = True
+        if not self.check_mode:
+            try:
+                if self.parameters.stop_timeout:
+                    response = self.client.restart(container_id, timeout=self.parameters.stop_timeout)
+                else:
+                    response = self.client.restart(container_id)
+            except Exception as exc:
+                self.fail("Error restarting container %s: %s" % (container_id, str(exc)))
+        return self._get_container(container_id)
 
     def container_stop(self, container_id):
         if self.parameters.force_kill:

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -2776,8 +2776,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 9001
-    - 9002
+    - '9001'
+    - '9002'
   register: published_ports_1
 
 - name: published_ports (idempotency)
@@ -2787,8 +2787,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 9002
-    - 9001
+    - '9002'
+    - '9001'
   register: published_ports_2
 
 - name: published_ports (less published_ports)
@@ -2798,7 +2798,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 9002
+    - '9002'
   register: published_ports_3
 
 - name: published_ports (more published_ports)
@@ -2808,8 +2808,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     name: "{{ cname }}"
     state: started
     published_ports:
-    - 9002
-    - 9003
+    - '9002'
+    - '9003'
     force_kill: yes
   register: published_ports_4
 
@@ -2877,109 +2877,6 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     - read_only_1 is changed
     - read_only_2 is not changed
     - read_only_3 is changed
-
-####################################################################
-## recreate ########################################################
-####################################################################
-
-- name: recreate (created)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: present
-    force_kill: yes
-  register: recreate_1
-
-- name: recreate (created, recreate)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    recreate: yes
-    state: present
-    force_kill: yes
-  register: recreate_2
-
-- name: recreate (started)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    force_kill: yes
-  register: recreate_3
-
-- name: recreate (started, recreate)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    recreate: yes
-    state: started
-    force_kill: yes
-  register: recreate_4
-
-- name: cleanup
-  docker_container:
-    name: "{{ cname }}"
-    state: absent
-    force_kill: yes
-  diff: no
-
-- debug: var=recreate_1
-- debug: var=recreate_2
-- debug: var=recreate_3
-- debug: var=recreate_4
-
-- assert:
-    that:
-    - recreate_1 is changed
-    - recreate_2 is changed
-    - recreate_3 is changed
-    - recreate_4 is changed
-    - recreate_1.container.Id != recreate_2.container.Id
-    - recreate_2.container.Id == recreate_3.container.Id
-    - recreate_3.container.Id != recreate_4.container.Id
-
-####################################################################
-## restart #########################################################
-####################################################################
-
-- name: restart
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    force_kill: yes
-  register: restart_1
-
-- name: restart (restart)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    restart: yes
-    state: started
-    force_kill: yes
-  register: restart_2
-
-- name: cleanup
-  docker_container:
-    name: "{{ cname }}"
-    state: absent
-    force_kill: yes
-  diff: no
-
-- debug: var=restart_1
-- debug: var=restart_2
-
-- assert:
-    that:
-    - restart_1 is changed
-    - restart_2 is changed
-    - restart_1.container.Id == restart_2.container.Id
 
 ####################################################################
 ## restart_policy ##################################################

--- a/test/integration/targets/docker_container/tasks/tests/start-stop.yml
+++ b/test/integration/targets/docker_container/tasks/tests/start-stop.yml
@@ -170,6 +170,120 @@
     - start_scratch_4 is not changed
 
 ####################################################################
+## Recreating ######################################################
+####################################################################
+
+- name: Recreating container (created)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: present
+    force_kill: yes
+  register: recreate_1
+
+- name: Recreating container (created, recreate)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    recreate: yes
+    state: present
+    force_kill: yes
+  register: recreate_2
+
+- name: Recreating container (started)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    force_kill: yes
+  register: recreate_3
+
+- name: Recreating container (started, recreate)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    recreate: yes
+    state: started
+    force_kill: yes
+  register: recreate_4
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    force_kill: yes
+  diff: no
+
+- debug: var=recreate_1
+- debug: var=recreate_2
+- debug: var=recreate_3
+- debug: var=recreate_4
+
+- assert:
+    that:
+    - recreate_2 is changed
+    - recreate_3 is changed
+    - recreate_4 is changed
+    - recreate_1.container.Id != recreate_2.container.Id
+    - recreate_2.container.Id == recreate_3.container.Id
+    - recreate_3.container.Id != recreate_4.container.Id
+
+####################################################################
+## Restarting ######################################################
+####################################################################
+
+- name: Restarting
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    stop_timeout: 1
+    volumes:
+    - /tmp/tmp
+  register: restart_1
+
+- name: Restarting (restart)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    restart: yes
+    state: started
+    stop_timeout: 1
+    force_kill: yes
+  register: restart_2
+
+- name: Restarting (verify volumes)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    stop_timeout: 1
+    volumes:
+    - /tmp/tmp
+  register: restart_3
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    force_kill: yes
+  diff: no
+
+- assert:
+    that:
+    - restart_1 is changed
+    - restart_2 is changed
+    - restart_1.container.Id == restart_2.container.Id
+    - restart_3 is not changed
+
+####################################################################
 ## Stopping ########################################################
 ####################################################################
 


### PR DESCRIPTION
##### SUMMARY
Backport of #55894 to stable-2.8: use proper API call for restarting containers instead of calling `stop()` followed by `start()`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
