### PR TITLE
Avoid power on/off commands if system already in target state

### DIFF
--- a/changelogs/fragments/56069-make-redfish-power-commands-idempotent.yaml
+++ b/changelogs/fragments/56069-make-redfish-power-commands-idempotent.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_command - make power commands idempotent (https://github.com/ansible/ansible/issues/55869)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -505,16 +505,21 @@ class RedfishUtils(object):
         return result
 
     def manage_system_power(self, command):
-        result = {}
         key = "Actions"
 
         # Search for 'key' entry and extract URI from it
         response = self.get_request(self.root_uri + self.systems_uris[0])
         if response['ret'] is False:
             return response
-        result['ret'] = True
         data = response['data']
         power_state = data["PowerState"]
+
+        if power_state == "On" and command == 'PowerOn':
+            return {'ret': True, 'changed': False}
+
+        if power_state == "Off" and command in ['PowerGracefulShutdown', 'PowerForceOff']:
+            return {'ret': True, 'changed': False}
+
         reset_action = data[key]["#ComputerSystem.Reset"]
         action_uri = reset_action["target"]
         allowable_vals = reset_action.get("ResetType@Redfish.AllowableValues", [])
@@ -542,8 +547,7 @@ class RedfishUtils(object):
         response = self.post_request(self.root_uri + action_uri, payload)
         if response['ret'] is False:
             return response
-        result['ret'] = True
-        return result
+        return {'ret': True, 'changed': True}
 
     def list_users(self):
         result = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See issue #55869 for a description of the original problem. The module was updated to check the current system power state against the requested power command and avoid sending a Reset when the system is already in the target state. The returned `changed` value was also updated accordingly. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #55869 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command.py
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

### Before

Issue PowerGracefulShutdown when the system power is already in the "Off" state.

```paste below
$ ansible-playbook -i myinventory.yml redfish-ansible-module/playbooks/power/power_graceful_shutdown.yml 

PLAY [Manage System Power - Graceful shutdown] *********************************

TASK [Shutdown system power gracefully] ****************************************
 
changed: [mockup-localstorage]

PLAY RECAP *********************************************************************
mockup-localstorage        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

### After

Issue PowerGracefulShutdown when the system power is already in the "Off" state.

```paste below
$ ansible-playbook -i myinventory.yml redfish-ansible-module/playbooks/power/power_graceful_shutdown.yml 

PLAY [Manage System Power - Graceful shutdown] *********************************

TASK [Shutdown system power gracefully] ****************************************
 
ok: [mockup-localstorage]

PLAY RECAP *********************************************************************
mockup-localstorage        : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
