### PR TITLE
Implement notification cancelling

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -766,6 +766,9 @@ class TaskExecutor:
         if self._task.notify is not None:
             result['_ansible_notify'] = self._task.notify
 
+        if self._task.cancel is not None:
+            result['_ansible_cancel'] = self._task.cancel
+
         # add the delegated vars to the result, so we can reference them
         # on the results side without having to do any further templating
         # FIXME: we only want a limited set of variables here, so this is currently

--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -49,6 +49,12 @@ class Handler(Task):
             return True
         return False
 
+    def cancel_host(self, host):
+        if self.is_host_notified(host):
+            self.notified_hosts.remove(host)
+            return True
+        return False
+
     def is_host_notified(self, host):
         return host in self.notified_hosts
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -71,6 +71,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
     _action = FieldAttribute(isa='string')
 
     _async_val = FieldAttribute(isa='int', default=0, alias='async')
+    _cancel = FieldAttribute(isa='list')
     _changed_when = FieldAttribute(isa='list', default=list)
     _delay = FieldAttribute(isa='int', default=5)
     _delegate_to = FieldAttribute(isa='string')

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -371,6 +371,9 @@ class CallbackBase(AnsiblePlugin):
     def v2_playbook_on_notify(self, handler, host):
         self.playbook_on_notify(host, handler)
 
+    def v2_playbook_on_cancel(self, handler, host):
+        pass  # no v1 correspondence
+
     def v2_playbook_on_no_hosts_matched(self):
         self.playbook_on_no_hosts_matched()
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -404,3 +404,7 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_notify(self, handler, host):
         if self._display.verbosity > 1:
             self._display.display("NOTIFIED HANDLER %s for %s" % (handler.get_name(), host), color=C.COLOR_VERBOSE, screen_only=True)
+
+    def v2_playbook_on_cancel(self, handler, host):
+        if self._display.verbosity > 1:
+            self._display.display("CANCELED HANDLER %s for %s" % (handler.get_name(), host), color=C.COLOR_VERBOSE, screen_only=True)

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -57,6 +57,9 @@ ansible-playbook test_listening_handlers.yml -i inventory.handlers -v "$@"
 # Notify handler listen
 ansible-playbook test_handlers_listen.yml -i inventory.handlers -v "$@"
 
+# Handler cancellation
+ansible-playbook test_handlers_cancel.yml -i inventory.handlers -v "$@"
+
 # Notify inexistent handlers results in error
 set +e
 result="$(ansible-playbook test_handlers_inexistent_notify.yml -i inventory.handlers "$@" 2>&1)"

--- a/test/integration/targets/handlers/test_handlers_cancel.yml
+++ b/test/integration/targets/handlers/test_handlers_cancel.yml
@@ -1,0 +1,151 @@
+---
+- name: test cancellation of in-flight notifications
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: notify handlers
+      command: uptime
+      notify:
+        - test_handler_1_1
+        - test_handler_1_2
+    - name: cancel a handler
+      command: uptime
+      cancel:
+        - test_handler_1_2
+    - meta: flush_handlers
+    - assert:
+        that:
+          - test_handler_1_1 is defined
+          - test_handler_1_2 is not defined
+  handlers:
+    - name: test_handler_1_1
+      set_fact:
+        test_handler_1_1: True
+    - name: test_handler_1_2
+      set_fact:
+        test_handler_1_2: True
+
+- name: test cancellation of in-flight notifications
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: notify handlers
+      command: uptime
+      notify:
+        - test_handler
+    - name: cancel a handler
+      command: uptime
+      cancel:
+        - test_handler_2_2
+    - meta: flush_handlers
+    - assert:
+        that:
+          - test_handler_2_1 is defined
+          - test_handler_2_2 is not defined
+  handlers:
+    - name: test_handler_2_1
+      set_fact:
+        test_handler_2_1: True
+      listen: test_handler
+    - name: test_handler_2_2
+      set_fact:
+        test_handler_2_2: True
+      listen: test_handler
+
+- name: test cancellation of unnamed handler
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: notify listening handler
+      command: uptime
+      notify:
+        - test_handler
+    - name: cancel notification
+      command: uptime
+      cancel:
+        - test_handler
+    - meta: flush_handlers
+    - assert:
+        that:
+          - test_handler_3 is not defined
+  handlers:
+    - set_fact:
+        test_handler_3: True
+      listen: test_handler
+
+- name: test cancellation with mixed notifications
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: notify handlers by name and topic
+      command: uptime
+      notify:
+        - test_handler_topic_1
+        - test_handler_4_1
+        - test_handler_topic_2
+        - test_handler_4_3
+    - name: cancel some of the notifications
+      command: uptime
+      cancel:
+        - test_handler_topic_1
+        - test_handler_4_2
+        - test_handler_4_4
+        - test_handler_4_5
+    - meta: flush_handlers
+    - assert:
+        that:
+          - test_handler_4_1 is not defined
+          - test_handler_4_2 is not defined
+          - test_handler_4_3 is defined
+          - test_handler_4_4 is not defined
+          - test_handler_4_5 is not defined
+  handlers:
+    - name: test_handler_4_1
+      set_fact:
+        test_handler_4_1: True
+      listen: test_handler_topic_1
+    - name: test_handler_4_2
+      set_fact:
+        test_handler_4_2: True
+      listen: test_handler_topic_1
+    - name: test_handler_4_3
+      set_fact:
+        test_handler_4_3: True
+      listen: test_handler_topic_2
+    - name: test_handler_4_4
+      set_fact:
+        test_handler_4_4: True
+      listen: test_handler_topic_2
+    - name: test_handler_4_5
+      # This one just isn't notified
+      set_fact:
+        test_handler_4_5: True
+
+- name: test cancellation from a handler
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: notify handlers
+      command: uptime
+      notify:
+        - test_handler_5_1
+        - test_handler_5_2
+    - meta: flush_handlers
+    - assert:
+        that:
+          - test_handler_5_1 is defined
+          - test_handler_5_2 is not defined
+  handlers:
+    - name: test_handler_5_1
+      set_fact:
+        test_handler_5_1: True
+      changed_when: true
+      cancel: test_handler_5_2
+    - name: test_handler_5_2
+      set_fact:
+        test_handler_5_2: True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated implementation of https://github.com/ansible/proposals/issues/105

Includes tests, does not yet include documentation.

This allows a couple of interesting patterns.

Tasks sometimes make a handler superfluous when they return changed:

```
    - yum: {name: simta, state: latest}
      notify: Restart simta

    - template: {src: simta.conf.j2, dest: /etc/simta.conf}
      notify: Restart simta

    - systemd: {name: simta, state: started}
      cancel: Restart simta
```

Or sometimes one handler will make another superfluous (simta
automatically rebuilds aliases at startup):

```
    - name: Restart simta
      systemd: {name: simta, state: restarted}
      cancel: Rebuild aliases

    - name: Rebuild aliases
      command: /usr/bin/newaliases
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core