### PR TITLE
Fix invalid src option return response for network config modules (#5…

### DIFF
--- a/changelogs/fragments/networkos_config_src_option_fix.yaml
+++ b/changelogs/fragments/networkos_config_src_option_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix invalid src option return response for network config modules (https://github.com/ansible/ansible/pull/56076)

--- a/lib/ansible/plugins/action/network.py
+++ b/lib/ansible/plugins/action/network.py
@@ -40,7 +40,10 @@ class ActionModule(_ActionModule):
     def run(self, task_vars=None):
         config_module = hasattr(self, '_config_module') and self._config_module
         if config_module and self._task.args.get('src'):
-            self._handle_src_option()
+            try:
+                self._handle_src_option()
+            except AnsibleError as e:
+                return {'failed': True, 'msg': e.message, 'changed': False}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
…6076)

*  Add changed key in the faliure case to maintain backward compatibility

(cherry picked from commit 1a66121f0319793f05e969b94b4642e6475e6462)

Merged to devel https://github.com/ansible/ansible/pull/56076
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_config
junos_config
eos_config
iosxr_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Network integration test failures

test/integration/targets/junos_config/tests/netconf/src_invalid.yaml:13
Task
```
  - name: configure with invalid src
    junos_config:
      src: basic/foobar.j2
      #provider: "{{ netconf }}"
    register: result
    ignore_errors: yes
  
- assert:
      that:
        - "result.changed == false"
        - "result.failed == true"
        - "result.msg == 'path specified in src not found'"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```paste below
{
"msg": "The conditional check 'result.changed == false' failed. The error was: error while evaluating conditional (result.changed == false): 'dict object' has no attribute 'changed'"
}
```
After:
```
ok: [junos01] => {
    "changed": false,
    "msg": "All assertions passed"
}
```
