### PR TITLE
Add missing selectors2 requirement for network-integration tests

### DIFF
--- a/test/runner/requirements/network-integration.txt
+++ b/test/runner/requirements/network-integration.txt
@@ -4,5 +4,6 @@ junit-xml
 paramiko
 pyyaml
 pexpect # for _user test
+selectors2 # for ncclient
 ncclient # for Junos
 jxmlease # for Junos


### PR DESCRIPTION
##### SUMMARY
Fix ansible-test for network-integration

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ./test/runner/ansible-test network-integration --tox --python 3.6 --inventory /etc/ansible/hosts vyos_.* netconf_.* -v
Run command: tox -c test/runner/tox.ini -e py36 -- /usr/bin/env LC_ALL=en_US.UTF-8 /home/zuul/src/github.com/ansible/ansible/bin/ansible-test network-integration --python 3.6 --inventor ...
py36 create: /home/zuul/src/github.com/ansible/ansible/test/runner/.tox/py36
py36 installdeps: setuptools == 35.0.2, wheel < 0.30.0 ; python_version < '2.7'
py36 installed: appdirs==1.4.3,packaging==19.0,pyparsing==2.4.0,six==1.12.0
py36 run-test-pre: PYTHONHASHSEED='3022060303'
py36 runtests: commands[0] | /usr/bin/env LC_ALL=en_US.UTF-8 /home/zuul/src/github.com/ansible/ansible/bin/ansible-test network-integration --python 3.6 --inventory /etc/ansible/hosts 'vyos_.*' 'netconf_.*' -v --metadata metadata-5MSZBM.json --truncate 190 --color yes --requirements
Run command: /home/zuul/src/github.com/ansible/ansible/test/runner/.tox/py36/bin/python -m pip.__main__ install --disable-pip-version-check -c test/runner/requirements/constraints.txt - ...
Ignoring cryptography: markers 'python_version < "2.7"' don't match your environment
Ignoring deepdiff: markers 'python_version < "3"' don't match your environment
Ignoring urllib3: markers 'python_version < "2.7"' don't match your environment
Ignoring sphinx: markers 'python_version < "2.7"' don't match your environment
Ignoring wheel: markers 'python_version < "2.7"' don't match your environment
Ignoring yamllint: markers 'python_version < "2.7"' don't match your environment
Ignoring paramiko: markers 'python_version < "2.7"' don't match your environment
Ignoring pytest: markers 'python_version < "2.7"' don't match your environment
Ignoring pytest: markers 'python_version == "2.7"' don't match your environment
Ignoring pytest-forked: markers 'python_version < "2.7"' don't match your environment
Ignoring requests: markers 'python_version < "2.7"' don't match your environment
Ignoring virtualenv: markers 'python_version < "2.7"' don't match your environment
Ignoring pyopenssl: markers 'python_version < "2.7"' don't match your environment
Ignoring pyyaml: markers 'python_version < "2.7"' don't match your environment
Ignoring pycparser: markers 'python_version < "2.7"' don't match your environment
Ignoring xmltodict: markers 'python_version < "2.7"' don't match your environment
Ignoring lxml: markers 'python_version < "2.7"' don't match your environment
Ignoring pyvmomi: markers 'python_version < "2.7"' don't match your environment
Collecting ncclient>=0.5.2 (from -c test/runner/requirements/constraints.txt (line 11))
  Downloading https://files.pythonhosted.org/packages/22/4d/05b21cc52eedb44f994600ed527e4dda3fcb6f4c1e0e9c6aa8f72348131a/ncclient-0.6.4.tar.gz (88kB)
     |████████████████████████████████| 92kB 6.9MB/s 
  Ignoring selectors2: markers 'python_version <= "3.4"' don't match your environment
Collecting cryptography (from -r test/runner/requirements/network-integration.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/5b/12/b0409a94dad366d98a8eee2a77678c7a73aafd8c0e4b835abea634ea3896/cryptography-2.6.1-cp34-abi3-manylinux1_x86_64.whl (2.3MB)
     |████████████████████████████████| 2.3MB 17.6MB/s 
Collecting jinja2 (from -r test/runner/requirements/network-integration.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/1d/e7/fd8b501e7a6dfe492a433deb7b9d833d39ca74916fa8bc63dd1a4947a671/Jinja2-2.10.1-py2.py3-none-any.whl (124kB)
     |████████████████████████████████| 133kB 22.7MB/s 
Collecting junit-xml (from -r test/runner/requirements/network-integration.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/a6/2a/f8d5aab80bb31fcc789d0f2b34b49f08bd6121cd8798d2e37f416df2b9f8/junit-xml-1.8.tar.gz
Collecting paramiko (from -r test/runner/requirements/network-integration.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/cf/ae/94e70d49044ccc234bfdba20114fa947d7ba6eb68a2e452d89b920e62227/paramiko-2.4.2-py2.py3-none-any.whl (193kB)
     |████████████████████████████████| 194kB 22.7MB/s 
Collecting pyyaml (from -r test/runner/requirements/network-integration.txt (line 5))
  Downloading https://files.pythonhosted.org/packages/9f/2c/9417b5c774792634834e730932745bc09a7d36754ca00acf1ccd1ac2594d/PyYAML-5.1.tar.gz (274kB)
     |████████████████████████████████| 276kB 22.2MB/s 
Collecting pexpect (from -r test/runner/requirements/network-integration.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/0e/3e/377007e3f36ec42f1b84ec322ee12141a9e10d808312e5738f52f80a232c/pexpect-4.7.0-py2.py3-none-any.whl (58kB)
     |████████████████████████████████| 61kB 14.4MB/s 
Collecting jxmlease (from -r test/runner/requirements/network-integration.txt (line 8))
  Downloading https://files.pythonhosted.org/packages/61/66/aea1d3ab6c45bc7653a0d31afcc7b38614ee74c4f205622b668aa175726c/jxmlease-1.0.1-py2.py3-none-any.whl
Requirement already satisfied: setuptools>0.6 in ./test/runner/.tox/py36/lib/python3.6/site-packages (from ncclient>=0.5.2->-c test/runner/requirements/constraints.txt (line 11)) (35.0.2)
Collecting lxml>=3.3.0 (from ncclient>=0.5.2->-c test/runner/requirements/constraints.txt (line 11))
  Downloading https://files.pythonhosted.org/packages/35/8a/5e066949f2b40caac32c7b2a77da63ad304b5fbe869036cc3fe4a198f724/lxml-4.3.3-cp36-cp36m-manylinux1_x86_64.whl (5.7MB)
     |████████████████████████████████| 5.7MB 17.4MB/s 
Requirement already satisfied: six in ./test/runner/.tox/py36/lib/python3.6/site-packages (from ncclient>=0.5.2->-c test/runner/requirements/constraints.txt (line 11)) (1.12.0)
Collecting cffi!=1.11.3,>=1.8 (from cryptography->-r test/runner/requirements/network-integration.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/5f/bf/6aa1925384c23ffeb579e97a5569eb9abce41b6310b329352b8252cee1c3/cffi-1.12.3-cp36-cp36m-manylinux1_x86_64.whl (430kB)
     |████████████████████████████████| 440kB 21.3MB/s 
Collecting asn1crypto>=0.21.0 (from cryptography->-r test/runner/requirements/network-integration.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl (101kB)
     |████████████████████████████████| 102kB 17.3MB/s 
Collecting MarkupSafe>=0.23 (from jinja2->-r test/runner/requirements/network-integration.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/b2/5f/23e0023be6bb885d00ffbefad2942bc51a620328ee910f64abe5a8d18dd1/MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl
Collecting pynacl>=1.0.1 (from paramiko->-r test/runner/requirements/network-integration.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/27/15/2cd0a203f318c2240b42cd9dd13c931ddd61067809fee3479f44f086103e/PyNaCl-1.3.0-cp34-abi3-manylinux1_x86_64.whl (759kB)
     |████████████████████████████████| 768kB 9.7MB/s 
Collecting pyasn1>=0.1.7 (from paramiko->-r test/runner/requirements/network-integration.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/7b/7c/c9386b82a25115cccf1903441bba3cbadcfae7b678a20167347fa8ded34c/pyasn1-0.4.5-py2.py3-none-any.whl (73kB)
     |████████████████████████████████| 81kB 11.0MB/s 
Collecting bcrypt>=3.1.3 (from paramiko->-r test/runner/requirements/network-integration.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/d0/79/79a4d167a31cc206117d9b396926615fa9c1fdbd52017bcced80937ac501/bcrypt-3.1.6-cp34-abi3-manylinux1_x86_64.whl (55kB)
     |████████████████████████████████| 61kB 14.1MB/s 
Collecting ptyprocess>=0.5 (from pexpect->-r test/runner/requirements/network-integration.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/d1/29/605c2cc68a9992d18dada28206eeada56ea4bd07a239669da41674648b6f/ptyprocess-0.6.0-py2.py3-none-any.whl
Requirement already satisfied: appdirs>=1.4.0 in ./test/runner/.tox/py36/lib/python3.6/site-packages (from setuptools>0.6->ncclient>=0.5.2->-c test/runner/requirements/constraints.txt (line 11)) (1.4.3)
Requirement already satisfied: packaging>=16.8 in ./test/runner/.tox/py36/lib/python3.6/site-packages (from setuptools>0.6->ncclient>=0.5.2->-c test/runner/requirements/constraints.txt (line 11)) (19.0)
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography->-r test/runner/requirements/network-integration.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz (158kB)
     |████████████████████████████████| 163kB 22.8MB/s 
Requirement already satisfied: pyparsing>=2.0.2 in ./test/runner/.tox/py36/lib/python3.6/site-packages (from packaging>=16.8->setuptools>0.6->ncclient>=0.5.2->-c test/runner/requirements/constraints.txt (line 11)) (2.4.0)
Building wheels for collected packages: ncclient, junit-xml, pyyaml, pycparser
  Building wheel for ncclient (setup.py) ... done
  Stored in directory: /home/zuul/.cache/pip/wheels/63/35/57/80de67e67371a73250faa48b1830ebe0904b6d05185c084fc4
  Building wheel for junit-xml (setup.py) ... done
  Stored in directory: /home/zuul/.cache/pip/wheels/c6/c5/65/5b166afb6eac87dc300368ec4d92f39502dd41cdc73056d49e
  Building wheel for pyyaml (setup.py) ... done
  Stored in directory: /home/zuul/.cache/pip/wheels/ad/56/bc/1522f864feb2a358ea6f1a92b4798d69ac783a28e80567a18b
  Building wheel for pycparser (setup.py) ... done
  Stored in directory: /home/zuul/.cache/pip/wheels/f2/9a/90/de94f8556265ddc9d9c8b271b0f63e57b26fb1d67a45564511
Successfully built ncclient junit-xml pyyaml pycparser
ERROR: ncclient 0.6.4 requires selectors2>=2.0.1, which is not installed.
Installing collected packages: pycparser, cffi, asn1crypto, cryptography, pynacl, pyasn1, bcrypt, paramiko, lxml, ncclient, MarkupSafe, jinja2, junit-xml, pyyaml, ptyprocess, pexpect, jxmlease
Successfully installed MarkupSafe-1.1.1 asn1crypto-0.24.0 bcrypt-3.1.6 cffi-1.12.3 cryptography-2.6.1 jinja2-2.10.1 junit-xml-1.8 jxmlease-1.0.1 lxml-4.3.3 ncclient-0.6.4 paramiko-2.4.2 pexpect-4.7.0 ptyprocess-0.6.0 pyasn1-0.4.5 pycparser-2.19 pynacl-1.3.0 pyyaml-5.1
Run command: /home/zuul/src/github.com/ansible/ansible/test/runner/.tox/py36/bin/python -m pip.__main__ check --disable-pip-version-check
ERROR: Command "/home/zuul/src/github.com/ansible/ansible/test/runner/.tox/py36/bin/python -m pip.__main__ check --disable-pip-version-check" returned exit status 1.
>>> Standard Output
ncclient 0.6.4 requires selectors2, which is not installed.
ERROR: InvocationError for command '/usr/bin/env LC_ALL=en_US.UTF-8 /home/zuul/src/github.com/ansible/ansible/bin/ansible-test network-integration --python 3.6 --inventory /etc/ansible/hosts vyos_.* netconf_.* -v --metadata metadata-5MSZBM.json --truncate 190 --color yes --requirements' (exited with code 1)
__________________________________________________________________________________________ summary ___________________________________________________________________________________________
ERROR:   py36: commands failed
ERROR: Command "tox -c test/runner/tox.ini -e py36 -- /usr/bin/env LC_ALL=en_US.UTF-8 /home/zuul/src/github.com/ansible/ansible/bin/ansible-test network-integration --python 3.6 --inventory /etc/ansible/hosts 'vyos_.*' 'netconf_.*' -v --metadata metadata-5MSZBM.json --truncate 190 --color yes --requirements" returned exit status 1.
```