### PR TITLE
Add missing selectors2 requirement for network-integration tests

### DIFF
--- a/test/runner/requirements/network-integration.txt
+++ b/test/runner/requirements/network-integration.txt
@@ -4,5 +4,6 @@ junit-xml
 paramiko
 pyyaml
 pexpect # for _user test
+selectors2 # for ncclient
 ncclient # for Junos
 jxmlease # for Junos


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/56087

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test