### PR TITLE
[2.7] fix documentation for docker_container publish_ports option

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -294,7 +294,6 @@ options:
       - List of ports to publish from the container to the host.
       - "Use docker CLI syntax: C(8000), C(9000:8000), or C(0.0.0.0:9000:8000), where 8000 is a
         container port, 9000 is a host port, and 0.0.0.0 is a host interface."
-      - Container ports must be exposed either in the Dockerfile or via the C(expose) option.
       - A value of C(all) will publish all exposed container ports to random host ports, ignoring
         any other mappings.
       - If C(networks) parameter is provided, will inspect each network to see if there exists


### PR DESCRIPTION
##### SUMMARY
Backport of #56093 to stable-2.7: remove wrong sentence from documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container
