### PR TITLE
[2.8] fix documentation for docker_container publish_ports option

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -486,7 +486,6 @@ options:
       - "Bind addresses must be either IPv4 or IPv6 addresses. Hostnames are I(not) allowed. This
         is different from the C(docker) command line utility. Use the L(dig lookup,../lookup/dig.html)
         to resolve hostnames."
-      - Container ports must be exposed either in the Dockerfile or via the C(expose) option.
       - A value of C(all) will publish all exposed container ports to random host ports, ignoring
         any other mappings.
       - If C(networks) parameter is provided, will inspect each network to see if there exists


### PR DESCRIPTION
##### SUMMARY
Backport of #56093 to stable-2.8: remove wrong sentence from documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container
