### PR TITLE
Use stdout_callback yaml for network-integration tests

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -4,6 +4,7 @@
 [defaults]
 host_key_checking = False
 log_path = /tmp/ansible-test.out
+stdout_callback = yaml
 
 # allow cleanup handlers to run when tests fail
 force_handlers = True


### PR DESCRIPTION
##### SUMMARY
Switch network-integration tests to use yaml stdout callback.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test