### PR TITLE
Hetzner failover IP module

### DIFF
--- a/lib/ansible/modules/net_tools/hetzner_failover_ip.py
+++ b/lib/ansible/modules/net_tools/hetzner_failover_ip.py
@@ -95,10 +95,14 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 
+# The API endpoint is fixed.
 BASE_URL = "https://robot-ws.your-server.de"
 
 
 def fetch_url_json(module, url, method='GET', timeout=10, data=None, headers=None, accept_errors=None):
+    '''
+    Make general request to Hetzner's JSON robot API.
+    '''
     module.params['url_username'] = module.params['hetzner_user']
     module.params['url_password'] = module.params['hetzner_pass']
     resp, info = fetch_url(module, url, method=method, timeout=timeout, data=data, headers=headers)
@@ -127,6 +131,13 @@ def fetch_url_json(module, url, method='GET', timeout=10, data=None, headers=Non
 
 
 def get_failover(module, ip):
+    '''
+    Get current routing target of failover IP.
+
+    The value ``None`` represents unrouted.
+
+    See https://robot.your-server.de/doc/webservice/en.html#get-failover-failover-ip
+    '''
     url = "{0}/failover/{1}".format(BASE_URL, ip)
     result, error = fetch_url_json(module, url)
     if 'failover' not in result:
@@ -135,6 +146,14 @@ def get_failover(module, ip):
 
 
 def set_failover(module, ip, value, timeout=180):
+    '''
+    Set current routing target of failover IP.
+
+    Return a pair ``(value, changed)``. The value ``None`` for ``value`` represents unrouted.
+
+    See https://robot.your-server.de/doc/webservice/en.html#post-failover-failover-ip
+    and https://robot.your-server.de/doc/webservice/en.html#delete-failover-failover-ip
+    '''
     url = "{0}/failover/{1}".format(BASE_URL, ip)
     if value is None:
         result, error = fetch_url_json(
@@ -165,6 +184,11 @@ def set_failover(module, ip, value, timeout=180):
 
 
 def get_state(value):
+    '''
+    Create result dictionary for failover IP's value.
+
+    The value ``None`` represents unrouted.
+    '''
     return dict(
         value=value,
         state='routed' if value else 'unrouted'

--- a/lib/ansible/modules/net_tools/hetzner_failover_ip.py
+++ b/lib/ansible/modules/net_tools/hetzner_failover_ip.py
@@ -1,0 +1,178 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2019 Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: hetzner_failover_ip
+version_added: "2.9"
+short_description: Manage Hetzner's failover IPs
+author:
+  - Felix Fontein (@felixfontein)
+description:
+  - Manage Hetzner's failover IPs.
+  - See L(https://wiki.hetzner.de/index.php/Failover/en,Hetzner's documentation) for details
+    on failover IPs.
+options:
+  hetzner_user:
+    description: The username for the Robot webservice user.
+    type: str
+    required: yes
+  hetzner_pass:
+    description: The password for the Robot webservice user.
+    type: str
+    required: yes
+  failover_ip:
+    description: The failover IP address.
+    type: str
+    required: yes
+  value:
+    description:
+      - The new value for the failover IP address.
+      - Not setting this will unroute the failover IP.
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Set value of failover IP 1.2.3.4 to 5.6.7.8
+  hetzner_failover_ip:
+    hetzner_user: foo
+    hetzner_pass: bar
+    failover_ip: 1.2.3.4
+    value: 5.6.7.8
+'''
+
+RETURN = r'''
+value:
+  description:
+    - The value of the failover IP.
+    - Will be C(none) if the IP is unrouted.
+  returned: success
+  type: str
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.six.moves.urllib.parse import urlencode
+
+BASE_URL = "https://robot-ws.your-server.de"
+
+
+def fetch_url_json(module, url, method='GET', timeout=10, data=None, headers=None, accept_errors=None):
+    module.params['url_username'] = module.params['hetzner_user']
+    module.params['url_password'] = module.params['hetzner_pass']
+    resp, info = fetch_url(module, url, method=method, timeout=timeout, data=data, headers=headers)
+    try:
+        content = resp.read()
+    except AttributeError:
+        content = info.pop('body', None)
+
+    if not content:
+        module.fail_json(msg='Cannot retrieve content from {0}'.format(url))
+
+    try:
+        result = module.from_json(content.decode('utf8'))
+        if 'error' in result:
+            if accept_errors:
+                if result['error']['code'] in accept_errors:
+                    return result, result['error']['code']
+            module.fail_json(msg='Request failed: {0} {1} ({2})'.format(
+                result['error']['status'],
+                result['error']['code'],
+                result['error']['message']
+            ))
+        return result, None
+    except ValueError:
+        module.fail_json(msg='Cannot decode content retrieved from {0}'.format(url))
+
+
+def get_failover(module, ip):
+    url = "{0}/failover/{1}".format(BASE_URL, ip)
+    result, error = fetch_url_json(module, url)
+    if 'failover' not in result:
+        module.fail_json(msg='Cannot interpret result: {0}'.format(result))
+    return result['failover']['active_server_ip']
+
+
+def set_failover(module, ip, value):
+    url = "{0}/failover/{1}".format(BASE_URL, ip)
+    if value is None:
+        result, error = fetch_url_json(
+            module,
+            url,
+            method='DELETE',
+            timeout=3 * 60,  # 3 minutes timeout should be enough
+            accept_errors=['FAILOVER_ALREADY_ROUTED']
+        )
+    else:
+        headers = {"Content-type": "application/x-www-form-urlencoded"}
+        data = dict(
+            active_server_ip=value,
+        )
+        result, error = fetch_url_json(
+            module,
+            url,
+            method='POST',
+            timeout=3 * 60,  # 3 minutes timeout should be enough
+            data=urlencode(data),
+            headers=headers,
+            accept_errors=['FAILOVER_ALREADY_ROUTED']
+        )
+    if error is not None:
+        return value, False
+    else:
+        return result['failover']['active_server_ip'], True
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            hetzner_user=dict(type='str', required=True),
+            hetzner_pass=dict(type='str', required=True, no_log=True),
+            failover_ip=dict(type='str', required=True),
+            value=dict(type='str'),
+        ),
+        supports_check_mode=True,
+    )
+
+    before = dict()
+    after = dict()
+    changed = False
+
+    failover_ip = module.params['failover_ip']
+    value = get_failover(module, failover_ip)
+    before['value'] = value
+
+    if value != module.params['value']:
+        if module.check_mode:
+            value = module.params['value']
+            changed = True
+        else:
+            value, changed = set_failover(module, failover_ip, module.params['value'])
+
+    after['value'] = value
+    result = dict(
+        changed=changed,
+        value=value,
+    )
+    if module._diff:
+        result['diff'] = dict(
+            before=before,
+            after=after,
+        )
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/net_tools/test_hetzner_failover_ip.py
+++ b/test/units/modules/net_tools/test_hetzner_failover_ip.py
@@ -1,0 +1,111 @@
+# Copyright: (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+import pytest
+
+from mock import MagicMock
+from ansible.modules.net_tools import hetzner_failover_ip
+
+
+class ModuleFailException(Exception):
+    def __init__(self, msg, **kwargs):
+        super(ModuleFailException, self).__init__(msg)
+        self.fail_msg = msg
+        self.fail_kwargs = kwargs
+
+
+def get_module_mock():
+    def f(msg, **kwargs):
+        raise ModuleFailException(msg, **kwargs)
+
+    module = MagicMock()
+    module.fail_json = f
+    module.from_json = json.loads
+    return module
+
+
+FETCH_URL_JSON_SUCCESS = [
+    (
+        (None, dict(
+            body=json.dumps(dict(
+                a='b'
+            )).encode('utf-8'),
+        )),
+        None,
+        (dict(
+            a='b'
+        ), None)
+    ),
+    (
+        (None, dict(
+            body=json.dumps(dict(
+                error=dict(
+                    code="foo",
+                    status=400,
+                    message="bar",
+                ),
+                a='b'
+            )).encode('utf-8'),
+        )),
+        ['foo'],
+        (dict(
+            error=dict(
+                code="foo",
+                status=400,
+                message="bar",
+            ),
+            a='b'
+        ), 'foo')
+    ),
+]
+
+
+FETCH_URL_JSON_FAIL = [
+    (
+        (None, dict(
+            body=json.dumps(dict(
+                error=dict(
+                    code="foo",
+                    status=400,
+                    message="bar",
+                ),
+            )).encode('utf-8'),
+        )),
+        None,
+        'Request failed: 400 foo (bar)'
+    ),
+    (
+        (None, dict(
+            body=json.dumps(dict(
+                error=dict(
+                    code="foo",
+                    status=400,
+                    message="bar",
+                ),
+            )).encode('utf-8'),
+        )),
+        ['bar'],
+        'Request failed: 400 foo (bar)'
+    ),
+]
+
+
+@pytest.mark.parametrize("return_value, accept_errors, result", FETCH_URL_JSON_SUCCESS)
+def test_fetch_url_json(monkeypatch, return_value, accept_errors, result):
+    module = get_module_mock()
+    hetzner_failover_ip.fetch_url = MagicMock(return_value=return_value)
+
+    assert hetzner_failover_ip.fetch_url_json(module, 'https://foo/bar', accept_errors=accept_errors) == result
+
+
+@pytest.mark.parametrize("return_value, accept_errors, result", FETCH_URL_JSON_FAIL)
+def test_fetch_url_json_fail(monkeypatch, return_value, accept_errors, result):
+    module = get_module_mock()
+    hetzner_failover_ip.fetch_url = MagicMock(return_value=return_value)
+
+    with pytest.raises(ModuleFailException) as exc:
+        hetzner_failover_ip.fetch_url_json(module, 'https://foo/bar', accept_errors=accept_errors)
+
+    assert exc.value.fail_msg == result
+    assert exc.value.fail_kwargs == dict()


### PR DESCRIPTION
##### SUMMARY
This module allows to configure [Failover IPs](https://wiki.hetzner.de/index.php/Failover/en) with the german hosting provider [Hetzner](https://www.hetzner.com/?country=ot). Failover IPs route all traffic to them to a destination IP, which can be changed on the fly (they can also be set to unrouted).

Failover IPs are a feature for dedicated and virtual servers, and unrelated to [hcloud](https://docs.ansible.com/ansible/devel/modules/list_of_cloud_modules.html#hcloud). I've put it into `modules/net_tools` because of that. Uses the Robot API [described here](https://robot.your-server.de/doc/webservice/en.html#failover).

The module supports check mode and diff support; so far, I only tested routing failover IPs and not unrouting them, since I only have access to failover IPs used in production.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
hetzner_failover_ip
