### PR TITLE
add option ipadomainresolutionorder to ipa_config

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -81,7 +81,6 @@ def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None, ipado
     if ipadomainresolutionorder is not None:
         config['ipadomainresolutionorder'] = ipadomainresolutionorder
 
-
     return config
 
 

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -27,7 +27,7 @@ options:
     aliases: ["emaildomain"]
   ipadomainresolutionorder:
     description: colon-separated list of domains used for short name qualification
-    version_added: "2.9" 
+    version_added: "2.9"
 extends_documentation_fragment: ipa.documentation
 version_added: "2.7"
 '''

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -28,7 +28,7 @@ options:
   ipadomainresolutionorder:
     description: colon-separated list of domains used for short name qualification
 extends_documentation_fragment: ipa.documentation
-version_added: "2.7"
+version_added: "2.9"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -27,8 +27,9 @@ options:
     aliases: ["emaildomain"]
   ipadomainresolutionorder:
     description: colon-separated list of domains used for short name qualification
+    version_added: "2.9" 
 extends_documentation_fragment: ipa.documentation
-version_added: "2.9"
+version_added: "2.7"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -25,6 +25,8 @@ options:
   ipadefaultemaildomain:
     description: Default e-mail domain for new users.
     aliases: ["emaildomain"]
+  ipadomainresolutionorder:
+    description: colon-separated list of domains used for short name qualification
 extends_documentation_fragment: ipa.documentation
 version_added: "2.7"
 '''
@@ -70,12 +72,15 @@ class ConfigIPAClient(IPAClient):
         return self._post_json(method='config_mod', name=name, item=item)
 
 
-def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None):
+def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None, ipadomainresolutionorder=None):
     config = {}
     if ipadefaultloginshell is not None:
         config['ipadefaultloginshell'] = ipadefaultloginshell
     if ipadefaultemaildomain is not None:
         config['ipadefaultemaildomain'] = ipadefaultemaildomain
+    if ipadomainresolutionorder is not None:
+        config['ipadomainresolutionorder'] = ipadomainresolutionorder
+
 
     return config
 
@@ -88,6 +93,7 @@ def ensure(module, client):
     module_config = get_config_dict(
         ipadefaultloginshell=module.params.get('ipadefaultloginshell'),
         ipadefaultemaildomain=module.params.get('ipadefaultemaildomain'),
+        ipadomainresolutionorder=module.params.get('ipadomainresolutionorder'),
     )
     ipa_config = client.config_show()
     diff = get_config_diff(client, ipa_config, module_config)
@@ -110,6 +116,7 @@ def main():
     argument_spec.update(
         ipadefaultloginshell=dict(type='str', aliases=['loginshell']),
         ipadefaultemaildomain=dict(type='str', aliases=['emaildomain']),
+        ipadomainresolutionorder=dict(type='str'),
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
ipadomainresolutionorder to ipa_config

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes please add ipa 'domain resolution order' option to the ipa_config module #55879
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipa_config
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
