### PR TITLE
Allow for lazy evaluation of Jinja2 expressions

### DIFF
--- a/changelogs/fragments/56017-allow-lazy-eval-on-jinja2-expr.yml
+++ b/changelogs/fragments/56017-allow-lazy-eval-on-jinja2-expr.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow for lazy evaluation of Jinja2 expressions (https://github.com/ansible/ansible/issues/56017)

--- a/changelogs/fragments/56017-allow-lazy-eval-on-jinja2-expr.yml
+++ b/changelogs/fragments/56017-allow-lazy-eval-on-jinja2-expr.yml
@@ -1,2 +1,2 @@
-minor_changes:
+breaking_changes:
   - Allow for lazy evaluation of Jinja2 expressions (https://github.com/ansible/ansible/issues/56017)

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
@@ -35,20 +35,6 @@ Playbook
 
 * The ``finalize`` method is no longer exposed in the globals for use in templating. To convert ``None`` to an empty string the following expression can be used: ``{{ value if value is not none }}``.
 
-* Variables are now evaluated lazily; only when they are actually used. For example, in ansible-core 2.13 an expression ``{{ defined_variable or undefined_variable }}`` does not fail on ``undefined_variable`` if the first part of ``or`` is evaluated to ``True`` as it is not needed to evaluate the second part. One particular case of a change in behavior to note is the task below which uses the ``undefined`` test. Prior to version 2.13 this would result in a fatal error trying to access the undefined value in the dictionary. In 2.13 the assertion passes as the dictionary is evaluated as undefined through one of its undefined values:
-
- .. code-block:: yaml
-
-     - assert:
-         that:
-           - some_defined_dict_with_undefined_values is undefined
-       vars:
-         dict_value: 1
-         some_defined_dict_with_undefined_values:
-           key1: value1
-           key2: '{{ dict_value }}'
-           key3: '{{ undefined_dict_value }}'
-
 
 Command Line
 ============

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
@@ -35,6 +35,20 @@ Playbook
 
 * The ``finalize`` method is no longer exposed in the globals for use in templating. To convert ``None`` to an empty string the following expression can be used: ``{{ value if value is not none }}``.
 
+* Variables are now evaluated lazily; only when they are actually used. For example, in ansible-core 2.13 an expression ``{{ defined_variable or undefined_variable }}`` does not fail on ``undefined_variable`` if the first part of ``or`` is evaluated to ``True`` as it is not needed to evaluate the second part. One particular case of a change in behavior to note is the task below which uses the ``undefined`` test. Prior to version 2.13 this would result in a fatal error trying to access the undefined value in the dictionary. In 2.13 the assertion passes as the dictionary is evaluated as undefined through one of its undefined values:
+
+ .. code-block:: yaml
+
+     - assert:
+         that:
+           - some_defined_dict_with_undefined_values is undefined
+       vars:
+         dict_value: 1
+         some_defined_dict_with_undefined_values:
+           key1: value1
+           key2: '{{ dict_value }}'
+           key3: '{{ undefined_dict_value }}'
+
 
 Command Line
 ============

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.14.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.14.rst
@@ -19,7 +19,19 @@ This document is part of a collection on porting. The complete list of porting g
 Playbook
 ========
 
-No notable changes
+* Variables are now evaluated lazily; only when they are actually used. For example, in ansible-core 2.14 an expression ``{{ defined_variable or undefined_variable }}`` does not fail on ``undefined_variable`` if the first part of ``or`` is evaluated to ``True`` as it is not needed to evaluate the second part. One particular case of a change in behavior to note is the task below which uses the ``undefined`` test. Prior to version 2.14 this would result in a fatal error trying to access the undefined value in the dictionary. In 2.14 the assertion passes as the dictionary is evaluated as undefined through one of its undefined values:
+
+ .. code-block:: yaml
+
+     - assert:
+         that:
+           - some_defined_dict_with_undefined_values is undefined
+       vars:
+         dict_value: 1
+         some_defined_dict_with_undefined_values:
+           key1: value1
+           key2: '{{ dict_value }}'
+           key3: '{{ undefined_dict_value }}'
 
 
 Command Line

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -97,11 +97,15 @@ class AnsibleJ2Vars(Mapping):
             try:
                 value = self._templar.template(variable)
             except AnsibleUndefinedVariable as e:
-                from ansible.template import AnsibleUndefined
-
-                # Instead of failing here prematurely, return AnsibleUndefined which will
-                # fail on the first usage allowing us to do lazy evaluation.
-                return AnsibleUndefined(name=varname, hint=f"{variable}: {e.message}")
+                # Instead of failing here prematurely, return an Undefined
+                # object which fails only after its first usage allowing us to
+                # do lazy evaluation and passing it into filters/tests that
+                # operate on such objects.
+                return self._templar.environment.undefined(
+                    hint=f"{variable}: {e.message}",
+                    name=varname,
+                    exc=AnsibleUndefinedVariable,
+                )
             except Exception as e:
                 msg = getattr(e, 'message', None) or to_native(e)
                 raise AnsibleError("An unhandled exception occurred while templating '%s'. "

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -97,7 +97,11 @@ class AnsibleJ2Vars(Mapping):
             try:
                 value = self._templar.template(variable)
             except AnsibleUndefinedVariable as e:
-                raise AnsibleUndefinedVariable("%s: %s" % (to_native(variable), e.message))
+                from ansible.template import AnsibleUndefined
+
+                # Instead of failing here prematurely, return AnsibleUndefined which will
+                # fail on the first usage allowing us to do lazy evaluation.
+                return AnsibleUndefined(name=varname, hint=f"{variable}: {e.message}")
             except Exception as e:
                 msg = getattr(e, 'message', None) or to_native(e)
                 raise AnsibleError("An unhandled exception occurred while templating '%s'. "

--- a/test/integration/targets/template/lazy_eval.yml
+++ b/test/integration/targets/template/lazy_eval.yml
@@ -1,20 +1,24 @@
 - hosts: testhost
-  gather_facts: no
+  gather_facts: false
   vars:
-    foo: "{{ nested_undefined_variable }}"
+    deep_undefined: "{{ nested_undefined_variable }}"
   tasks:
-    - name: Test lazy eval, evaluation of foo is not needed here
+    - name: These do not throw an error, deep_undefined is just evaluated to undefined, since 2.13
       assert:
         that:
-          - True or foo
+          - lazy_eval or deep_undefined
+          - deep_undefined is undefined
+          - deep_undefined|default('defaulted') == 'defaulted'
+      vars:
+        lazy_eval: true
 
-    - name: EXPECTED FAILURE Test lazy eval, this will fail on evaluation of foo
+    - name: EXPECTED FAILURE actually using deep_undefined fails
       debug:
-      when:
-        - foo or True
-      register: fail_output
-      ignore_errors: yes
+        msg: "{{ deep_undefined }}"
+      ignore_errors: true
+      register: res
 
     - assert:
         that:
-          - "\"'nested_undefined_variable' is undefined\" in fail_output.msg"
+          - res.failed
+          - res.msg is contains("'nested_undefined_variable' is undefined")

--- a/test/integration/targets/template/lazy_eval.yml
+++ b/test/integration/targets/template/lazy_eval.yml
@@ -1,0 +1,20 @@
+- hosts: testhost
+  gather_facts: no
+  vars:
+    foo: "{{ nested_undefined_variable }}"
+  tasks:
+    - name: Test lazy eval, evaluation of foo is not needed here
+      assert:
+        that:
+          - True or foo
+
+    - name: EXPECTED FAILURE Test lazy eval, this will fail on evaluation of foo
+      debug:
+      when:
+        - foo or True
+      register: fail_output
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - "\"'nested_undefined_variable' is undefined\" in fail_output.msg"

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -41,5 +41,4 @@ ansible-playbook unsafe.yml -v "$@"
 # ensure Jinja2 overrides from a template are used
 ansible-playbook in_template_overrides.yml -v "$@"
 
-# lazy eval
 ansible-playbook lazy_eval.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -40,3 +40,6 @@ ansible-playbook unsafe.yml -v "$@"
 
 # ensure Jinja2 overrides from a template are used
 ansible-playbook in_template_overrides.yml -v "$@"
+
+# lazy eval
+ansible-playbook lazy_eval.yml -i ../../inventory -v "$@"

--- a/test/units/playbook/test_conditional.py
+++ b/test/units/playbook/test_conditional.py
@@ -121,19 +121,6 @@ class TestConditional(unittest.TestCase):
                                self._eval_con,
                                when, variables)
 
-    def test_dict_undefined_values_is_defined(self):
-        variables = {'dict_value': 1,
-                     'some_defined_dict_with_undefined_values': {'key1': 'value1',
-                                                                 'key2': '{{ dict_value }}',
-                                                                 'key3': '{{ undefined_dict_value }}'
-                                                                 }}
-
-        when = [u"some_defined_dict_with_undefined_values is defined"]
-        self.assertRaisesRegex(errors.AnsibleError,
-                               "The conditional check 'some_defined_dict_with_undefined_values is defined' failed.",
-                               self._eval_con,
-                               when, variables)
-
     def test_is_defined(self):
         variables = {'some_defined_thing': True}
         when = [u"some_defined_thing is defined"]


### PR DESCRIPTION
##### SUMMARY

This will allow for:

```yaml
- hosts: localhost
  gather_facts: no
  vars:
    foo: "{{ nested_undefined_variable }}"
  tasks:
    - debug:
      when: True or foo
```

Now, the conditional is evaluated to `True`. Before, this would fail on `foo` being undefined although it wasn't necessary to evaluate it.

Also, this changes behavior(!):

```yaml
- hosts: localhost
  gather_facts: no
  vars:
    foo: "{{ nested_undefined_variable }}"
  tasks:
    - assert:
        that:
          - foo is undefined
```

Before:
```
TASK [assert] *****************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'foo is undefined' failed. The error was: error while evaluating conditional (foo is undefined): 'nested_undefined_variable' is undefined"}
```

Now:
```
TASK [assert] *******************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}
```

Fixes #56017

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/vars.py`
