### PR TITLE
Allow config commands in aireos_command to support prompts

### DIFF
--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -22,8 +22,8 @@ description:
     read from the device. This module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.
-  - This module does not support running commands in configuration mode.
-    Please use M(aireos_config) to configure WLC devices.
+  - Commands run with this module in configuration mode are not
+    idempotent. Please use M(aireos_config) to configure WLC devices.
 extends_documentation_fragment: aireos
 options:
   commands:
@@ -143,9 +143,9 @@ def parse_commands(module, warnings):
                 'executing `%s`' % item['command']
             )
         elif item['command'].startswith('conf'):
-            module.fail_json(
-                msg='aireos_command does not support running config mode '
-                    'commands.  Please use aireos_config instead'
+            warnings.append(
+                'commands run in config mode with aireos_command are not'
+                'idempotent.  Please use aireos_config instead'
             )
     return commands
 

--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -22,7 +22,7 @@ description:
     read from the device. This module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.
-  - Commands run with this module in configuration mode are not
+  - Commands run in configuration mode with this module are not
     idempotent. Please use M(aireos_config) to configure WLC devices.
 extends_documentation_fragment: aireos
 options:

--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -144,7 +144,7 @@ def parse_commands(module, warnings):
             )
         elif item['command'].startswith('conf'):
             warnings.append(
-                'commands run in config mode with aireos_command are not'
+                'commands run in config mode with aireos_command are not '
                 'idempotent.  Please use aireos_config instead'
             )
     return commands


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Alternative to #50634 which referenced fixing #35622 as generally alluded to by @ganeshrn in #41579.  Simply allow configuration commands so we can support prompts and warn that these commands are not idempotent.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aireos_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```Playbook command
- name: Configure Access Points to Reboot
  aireos_command:
    provider:
      host: '{{ inventory_hostname }}'
      timeout: 60
    commands:
      - command: config ap reset {{ item }}
        prompt: "Would you like to reset"
        answer: y
  with_items: "{{ ap_list }}"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
__Output before:__   
```
failed: [x.x.x.x] (item=AP_NAME) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "commands": [
                {
                    "answer": "y", 
                    "command": "config ap reset AP_NAME", 
                    "prompt": "Would you like to reset"
                }
            ], 
            "host": null, 
            "interval": 1, 
            "match": "all", 
            "password": null, 
            "port": null, 
            "provider": {
                "host": "x.x.x.x", 
                "password": null, 
                "port": null, 
                "ssh_keyfile": null, 
                "timeout": 60, 
                "username": null
            }, 
            "retries": 10, 
            "ssh_keyfile": null, 
            "timeout": null, 
            "username": null, 
            "wait_for": null
        }
    }, 
    "item": "AP_NAME", 
    "msg": "aireos_command does not support running config mode commands.  Please use aireos_config instead"
}

```
__Output after:__  
```
ok: [x.x.x.x] => (item=AP_NAME) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "commands": [
                {
                    "answer": "y", 
                    "command": "config ap reset AP_NAME", 
                    "prompt": "Would you like to reset"
                }
            ], 
            "host": null, 
            "interval": 1, 
            "match": "all", 
            "password": null, 
            "port": null, 
            "provider": {
                "host": "x.x.x.x", 
                "password": null, 
                "port": null, 
                "ssh_keyfile": null, 
                "timeout": 60, 
                "username": null
            }, 
            "retries": 10, 
            "ssh_keyfile": null, 
            "timeout": null, 
            "username": null, 
            "wait_for": null
        }
    }, 
    "item": "AP_NAME", 
    "stdout": [
        "Would you like to reset AP_NAME ? (y/n)y"
    ], 
    "stdout_lines": [
        [
            "Would you like to reset AP_NAME ? (y/n)y"
        ]
    ], 
    "warnings": [
        "commands run in config mode with aireos_command are not idempotent.  Please use aireos_config instead"
    ]
}
 [WARNING]: commands run in config mode with aireos_command are not idempotent.  Please use aireos_config instead



```