### PR TITLE
Add SHA1 to password_hash filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -265,6 +265,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=Non
     passlib_mapping = {
         'md5': 'md5_crypt',
         'blowfish': 'bcrypt',
+        'sha1': 'sha1_crypt',
         'sha256': 'sha256_crypt',
         'sha512': 'sha512_crypt',
     }

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -107,7 +107,7 @@ class CryptHash(BaseHash):
             saltstring = "$%s$%s" % (self.algo_data.crypt_id, salt)
         else:
             saltstring = "$%s$rounds=%d$%s" % (self.algo_data.crypt_id, rounds, salt)
-        result = crypt.crypt(to_bytes(secret), saltstring)
+        result = crypt.crypt(secret, saltstring)
 
         # crypt.crypt returns None if it cannot parse saltstring
         # None as result would be interpreted by the some modules (user module)

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -107,7 +107,11 @@ class CryptHash(BaseHash):
             saltstring = "$%s$%s" % (self.algo_data.crypt_id, salt)
         else:
             saltstring = "$%s$rounds=%d$%s" % (self.algo_data.crypt_id, rounds, salt)
-        result = crypt.crypt(to_bytes(secret), saltstring)
+
+        try:
+            result = crypt.crypt(to_bytes(secret), saltstring)
+        except TypeError:
+            result = crypt.crypt(secret, saltstring)
 
         # crypt.crypt returns None if it cannot parse saltstring
         # None as result would be interpreted by the some modules (user module)

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -107,7 +107,7 @@ class CryptHash(BaseHash):
             saltstring = "$%s$%s" % (self.algo_data.crypt_id, salt)
         else:
             saltstring = "$%s$rounds=%d$%s" % (self.algo_data.crypt_id, rounds, salt)
-        result = crypt.crypt(secret, saltstring)
+        result = crypt.crypt(to_bytes(secret), saltstring)
 
         # crypt.crypt returns None if it cannot parse saltstring
         # None as result would be interpreted by the some modules (user module)

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -65,6 +65,7 @@ class BaseHash(object):
     algorithms = {
         'md5_crypt': algo(crypt_id='1', salt_size=8, implicit_rounds=None),
         'bcrypt': algo(crypt_id='2a', salt_size=22, implicit_rounds=None),
+        'sha1_crypt': algo(crypt_id='7', salt_size=16, implicit_rounds=80),
         'sha256_crypt': algo(crypt_id='5', salt_size=16, implicit_rounds=5000),
         'sha512_crypt': algo(crypt_id='6', salt_size=16, implicit_rounds=5000),
     }

--- a/test/integration/targets/filters/aliases
+++ b/test/integration/targets/filters/aliases
@@ -1,1 +1,3 @@
 shippable/posix/group2
+needs/file/requirements.txt
+needs/file/test/runner/requirements/constraints.txt

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -4,11 +4,9 @@ set -eux
 
 source virtualenv.sh
 
-pip install bcrypt
-
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
 
-pip install jmespath netaddr
+pip install jmespath netaddr bcrypt
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -13,3 +13,11 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i ../../inventory -e @../..
 
 pip install "passlib<1.7"
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -t password_hash -i ../../inventory -e @../../integration_config.yml "$@"
+
+# Required to test against CryptHash class
+
+source virtualenv-isolated.sh
+
+pip install jmespath netaddr bcrypt -r ../../../../requirements.txt
+
+ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -e crypt_skip=True -t password_hash -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -16,7 +16,7 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -t password_hash -i ../../in
 
 # Required to test against CryptHash class
 
-source virtualenv-isolated.sh
+source virtualenv.sh
 
 pip install jmespath netaddr bcrypt -r ../../../../requirements.txt
 

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -4,6 +4,8 @@ set -eux
 
 source virtualenv.sh
 
+pip install bcrypt
+
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
 

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -20,4 +20,4 @@ source virtualenv-isolated.sh
 
 pip install jmespath netaddr bcrypt -r ../../../../requirements.txt
 
-ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -e crypt_skip=True -t password_hash -i ../../inventory -e @../../integration_config.yml "$@"
+ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -e crypt_run=False -t password_hash -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -7,6 +7,9 @@ source virtualenv.sh
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
 
-pip install jmespath netaddr bcrypt
+pip install jmespath netaddr bcrypt passlib
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i ../../inventory -e @../../integration_config.yml "$@"
+
+pip install "passlib<1.7"
+ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -t password_hash -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -146,6 +146,7 @@
       - pass: 'hash'
         algo: 'bcrypt'
         result: '$2b$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
+        result_alt: '$2a$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
         salt: 'saltWith22Characters00'
       - pass: '*%!)0café'
         algo: 'md5'
@@ -165,19 +166,21 @@
         salt: 'somesaltsomesalt'
       - pass: '*%!)0café'
         result: '$2b$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
+        result_alt: '$2a$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
         algo: 'bcrypt'
         salt: 'saltWith22Characters00'
   block:
     - name: Test using static salt
       assert:
         that:
-          - '"{{ item.pass | password_hash(item.algo, item.salt) }}" == "{{ item.result }}"'
+          - "{{ ( item.pass | password_hash(item.algo, item.salt) ) == item.result or ( item.pass | password_hash(item.algo, item.salt) ) == ( item.result_alt | default('') ) }}"
       loop: "{{ passwords }}"
     - name: Passwords default to random salt
       assert:
         that:
           - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
       loop: "{{ passwords }}"
+  tags: 'password_hash'
 
 - debug:
     var: "'http://mary:MySecret@www.acme.com:9000/dir/index.html?query=term#fragment' | urlsplit"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -173,6 +173,11 @@
         that:
           - '"{{ item.pass | password_hash(item.algo, item.salt) }}" == "{{ item.result }}"'
       loop: "{{ passwords }}"
+    - name: Passwords default to random salt
+      assert:
+        that:
+          - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
+      loop: "{{ passwords }}"
 
 - debug:
     var: "'http://mary:MySecret@www.acme.com:9000/dir/index.html?query=term#fragment' | urlsplit"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -128,6 +128,9 @@
   setup: filter=ansible_system
   tags: password_hash
 
+- name: Report ansible_system value
+  debug: var=ansible_system
+
 - name: Test password_hash filter
   vars:
     crypt_skip: '{{ True if ansible_system == "Darwin" else False }}'
@@ -179,6 +182,8 @@
         salt: 'saltWith22Characters00'
         crypt_skip: '{{ crypt_skip | default(False) }}'
   block:
+    - name: Debug crypt_skip var
+      debug: var=crypt_skip
     - name: Test using static salt
       assert:
         that:

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -124,6 +124,10 @@
       - '"{{ "hash" | hash("sha1") }}" == "2346ad27d7568ba9896f1b7da6b5991251debdf2"'
       - '"{{ "café" | hash("sha1") }}" == "f424452a9673918c6f09b0cdd35b20be8e6ae7d7"'
 
+- name: Get ansible_system fact
+  setup: filter=ansible_system
+  tags: password_hash
+
 - name: Test password_hash filter
   vars:
     crypt_skip: '{{ True if ansible_system == "Darwin" else False }}'

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -124,6 +124,56 @@
       - '"{{ "hash" | hash("sha1") }}" == "2346ad27d7568ba9896f1b7da6b5991251debdf2"'
       - '"{{ "café" | hash("sha1") }}" == "f424452a9673918c6f09b0cdd35b20be8e6ae7d7"'
 
+- name: Test password_hash filter
+  vars:
+    passwords:
+      - pass: 'hash'
+        algo: 'md5'
+        result: '$1$somesalt$O6svGriNmsz3R1fF/cFvh1'
+        salt: 'somesalt'
+      - pass: 'hash'
+        algo: 'sha1'
+        result: '$sha1$80$somesaltsomesalt$h7lwE0gVsklfEnUUth/XHjatn1DG'
+        salt: 'somesaltsomesalt'
+      - pass: 'hash'
+        algo: 'sha256'
+        result: '$5$somesaltsomesalt$htweuBbEINJNtSRltQ3nKa.yr/K64Nor4cqL526jaO1'
+        salt: 'somesaltsomesalt'
+      - pass: 'hash'
+        algo: 'sha512'
+        result: '$6$somesaltsomesalt$UXKSWGnhsHpsLOTx.Qe.Mi7qryzThIYDEaOYuD1izD7iPltWrZ2V57YxPNHACKVrvNH1hDmNBjQixoc6v2Bnv.'
+        salt: 'somesaltsomesalt'
+      - pass: 'hash'
+        algo: 'bcrypt'
+        result: '$2b$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
+        salt: 'saltWith22Characters00'
+      - pass: '*%!)0café'
+        algo: 'md5'
+        result: '$1$somesalt$H9oy8N8y2EQRPsOX2QAxq.'
+        salt: 'somesalt'
+      - pass: '*%!)0café'
+        result: '$sha1$80$somesaltsomesalt$D6BUIhnXSmk/OoWKOW9eI6UU.uFC'
+        algo: 'sha1'
+        salt: 'somesaltsomesalt'
+      - pass: '*%!)0café'
+        result: '$5$somesaltsomesalt$qt./ksLHkPeS6hbcL0apHqmZ237bu/9zgPHbE14b0Y8'
+        algo: 'sha256'
+        salt: 'somesaltsomesalt'
+      - pass: '*%!)0café'
+        result: '$6$somesaltsomesalt$A9Few/s0L/ZMntbQiAAHo.VN8bGjyFtgBHVURiPuyumhAldz0DpQu69KMR.5gJ4FAo.SLHLdfoffO.60w4yB61'
+        algo: 'sha512'
+        salt: 'somesaltsomesalt'
+      - pass: '*%!)0café'
+        result: '$2b$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
+        algo: 'bcrypt'
+        salt: 'saltWith22Characters00'
+  block:
+    - name: Test using static salt
+      assert:
+        that:
+          - '"{{ item.pass | password_hash(item.algo, item.salt) }}" == "{{ item.result }}"'
+      loop: "{{ passwords }}"
+
 - debug:
     var: "'http://mary:MySecret@www.acme.com:9000/dir/index.html?query=term#fragment' | urlsplit"
     verbosity: 1

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -133,7 +133,7 @@
 
 - name: Test password_hash filter
   vars:
-    crypt_skip: '{{ True if ansible_system == "Darwin" else False }}'
+    crypt_skip_all: '{{ True if ansible_system == "Darwin" else False }}'
     passwords:
       - pass: 'hash'
         algo: 'md5'
@@ -182,20 +182,18 @@
         salt: 'saltWith22Characters00'
         crypt_skip: '{{ crypt_skip | default(False) }}'
   block:
-    - name: Debug crypt_skip var
-      debug: var=crypt_skip
     - name: Test using static salt
       assert:
         that:
           - "{{ ( item.pass | password_hash(item.algo, item.salt) ) == item.result or ( item.pass | password_hash(item.algo, item.salt) ) == ( item.result_alt | default('') ) }}"
       loop: "{{ passwords }}"
-      when: not item.crypt_skip | default(False)
+      when: not item.crypt_skip or not crypt_skip_all | default(False)
     - name: Passwords default to random salt
       assert:
         that:
           - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
       loop: "{{ passwords }}"
-      when: not item.crypt_skip | default(False)
+      when: not item.crypt_skip or not crypt_skip_all | default(False)
     - name: Register results of the algorithm error
       debug:
         var: "{{ item.pass | password_hash('fake_algo') }}"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -203,6 +203,7 @@
         that:
           - "'does not support' in algo_error.msg"
   tags: 'password_hash'
+  when: crypt_run|bool == true or crypt_run|bool == False and ansible_facts['os_family'] != 'Darwin'
 
 - debug:
     var: "'http://mary:MySecret@www.acme.com:9000/dir/index.html?query=term#fragment' | urlsplit"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -184,15 +184,15 @@
         that:
           - "{{ ( item.pass | password_hash(item.algo, item.salt) ) == item.result or ( item.pass | password_hash(item.algo, item.salt) ) == ( item.result_alt | default('') ) }}"
       with_flattened:
-        - "{{ passwords }}"
-        - "{{ no_crypt_passwords if crypt_run|bool == true else omit }}"
+        - - "{{ passwords }}"
+          - "{{ no_crypt_passwords if crypt_run|bool == true else [] }}"
     - name: Passwords default to random salt
       assert:
         that:
           - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
       with_flattened:
-        - "{{ passwords }}"
-        - "{{ no_crypt_passwords if crypt_run|bool == true else omit }}"
+        - - "{{ passwords }}"
+          - "{{ no_crypt_passwords if crypt_run|bool == true else [] }}"
     - name: Register results of the algorithm error
       debug:
         var: "{{ item.pass | password_hash('fake_algo') }}"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -126,6 +126,7 @@
 
 - name: Test password_hash filter
   vars:
+    crypt_skip: '{{ True if ansible_system == "Darwin" else False }}'
     passwords:
       - pass: 'hash'
         algo: 'md5'

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -180,6 +180,18 @@
         that:
           - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
       loop: "{{ passwords }}"
+    - name: Register results of the password_hash filter
+      debug:
+        var: "{{ item.pass | password_hash('fake_algo') }}"
+      register: algo_error
+      ignore_errors: yes
+    - name: Error dialog shows for missing crypto algorithm
+      assert:
+        that:
+          - "'passlib does not support' in algo_error.msg"
+    - name: Rounds get set if defined in filter
+      debug:
+        msg: '{{ "supersecret" | password_hash("sha256_crypt", "somesalt", 8, 5000) }}'
   tags: 'password_hash'
 
 - debug:

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -135,6 +135,7 @@
         algo: 'sha1'
         result: '$sha1$80$somesaltsomesalt$h7lwE0gVsklfEnUUth/XHjatn1DG'
         salt: 'somesaltsomesalt'
+        crypt_skip: '{{ crypt_skip | default(False) }}'
       - pass: 'hash'
         algo: 'sha256'
         result: '$5$somesaltsomesalt$htweuBbEINJNtSRltQ3nKa.yr/K64Nor4cqL526jaO1'
@@ -148,6 +149,7 @@
         result: '$2b$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
         result_alt: '$2a$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
         salt: 'saltWith22Characters00'
+        crypt_skip: '{{ crypt_skip | default(False) }}'
       - pass: '*%!)0café'
         algo: 'md5'
         result: '$1$somesalt$H9oy8N8y2EQRPsOX2QAxq.'
@@ -156,6 +158,7 @@
         result: '$sha1$80$somesaltsomesalt$D6BUIhnXSmk/OoWKOW9eI6UU.uFC'
         algo: 'sha1'
         salt: 'somesaltsomesalt'
+        crypt_skip: '{{ crypt_skip | default(False) }}'
       - pass: '*%!)0café'
         result: '$5$somesaltsomesalt$qt./ksLHkPeS6hbcL0apHqmZ237bu/9zgPHbE14b0Y8'
         algo: 'sha256'
@@ -169,17 +172,20 @@
         result_alt: '$2a$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
         algo: 'bcrypt'
         salt: 'saltWith22Characters00'
+        crypt_skip: '{{ crypt_skip | default(False) }}'
   block:
     - name: Test using static salt
       assert:
         that:
           - "{{ ( item.pass | password_hash(item.algo, item.salt) ) == item.result or ( item.pass | password_hash(item.algo, item.salt) ) == ( item.result_alt | default('') ) }}"
       loop: "{{ passwords }}"
+      when: not item.crypt_skip | default(False)
     - name: Passwords default to random salt
       assert:
         that:
           - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
       loop: "{{ passwords }}"
+      when: not item.crypt_skip | default(False)
     - name: Register results of the password_hash filter
       debug:
         var: "{{ item.pass | password_hash('fake_algo') }}"
@@ -189,6 +195,7 @@
       assert:
         that:
           - "'passlib does not support' in algo_error.msg"
+      when: not crypt_skip | default(False)
     - name: Rounds get set if defined in filter
       debug:
         msg: '{{ "supersecret" | password_hash("sha256_crypt", "somesalt", 8, 5000) }}'

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -194,11 +194,7 @@
     - name: Error dialog shows for missing crypto algorithm
       assert:
         that:
-          - "'passlib does not support' in algo_error.msg"
-      when: not crypt_skip | default(False)
-    - name: Rounds get set if defined in filter
-      debug:
-        msg: '{{ "supersecret" | password_hash("sha256_crypt", "somesalt", 8, 5000) }}'
+          - "'does not support' in algo_error.msg"
   tags: 'password_hash'
 
 - debug:

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -133,17 +133,31 @@
 
 - name: Test password_hash filter
   vars:
-    crypt_skip_all: '{{ True if ansible_system == "Darwin" else False }}'
+    crypt_run: True
+    no_crypt_passwords:
+      - pass: 'hash'
+        algo: 'sha1'
+        result: '$sha1$80$somesaltsomesalt$h7lwE0gVsklfEnUUth/XHjatn1DG'
+        salt: 'somesaltsomesalt'
+      - pass: 'hash'
+        algo: 'bcrypt'
+        result: '$2b$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
+        result_alt: '$2a$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
+        salt: 'saltWith22Characters00'
+      - pass: '*%!)0café'
+        result: '$sha1$80$somesaltsomesalt$D6BUIhnXSmk/OoWKOW9eI6UU.uFC'
+        algo: 'sha1'
+        salt: 'somesaltsomesalt'
+      - pass: '*%!)0café'
+        result: '$2b$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
+        result_alt: '$2a$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
+        algo: 'bcrypt'
+        salt: 'saltWith22Characters00'
     passwords:
       - pass: 'hash'
         algo: 'md5'
         result: '$1$somesalt$O6svGriNmsz3R1fF/cFvh1'
         salt: 'somesalt'
-      - pass: 'hash'
-        algo: 'sha1'
-        result: '$sha1$80$somesaltsomesalt$h7lwE0gVsklfEnUUth/XHjatn1DG'
-        salt: 'somesaltsomesalt'
-        crypt_skip: '{{ crypt_skip | default(False) }}'
       - pass: 'hash'
         algo: 'sha256'
         result: '$5$somesaltsomesalt$htweuBbEINJNtSRltQ3nKa.yr/K64Nor4cqL526jaO1'
@@ -152,21 +166,10 @@
         algo: 'sha512'
         result: '$6$somesaltsomesalt$UXKSWGnhsHpsLOTx.Qe.Mi7qryzThIYDEaOYuD1izD7iPltWrZ2V57YxPNHACKVrvNH1hDmNBjQixoc6v2Bnv.'
         salt: 'somesaltsomesalt'
-      - pass: 'hash'
-        algo: 'bcrypt'
-        result: '$2b$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
-        result_alt: '$2a$12$saltWith22Characters0u1uXyJT.dsFdme5PqlljM0R59E1XCwC2'
-        salt: 'saltWith22Characters00'
-        crypt_skip: '{{ crypt_skip | default(False) }}'
       - pass: '*%!)0café'
         algo: 'md5'
         result: '$1$somesalt$H9oy8N8y2EQRPsOX2QAxq.'
         salt: 'somesalt'
-      - pass: '*%!)0café'
-        result: '$sha1$80$somesaltsomesalt$D6BUIhnXSmk/OoWKOW9eI6UU.uFC'
-        algo: 'sha1'
-        salt: 'somesaltsomesalt'
-        crypt_skip: '{{ crypt_skip | default(False) }}'
       - pass: '*%!)0café'
         result: '$5$somesaltsomesalt$qt./ksLHkPeS6hbcL0apHqmZ237bu/9zgPHbE14b0Y8'
         algo: 'sha256'
@@ -175,25 +178,21 @@
         result: '$6$somesaltsomesalt$A9Few/s0L/ZMntbQiAAHo.VN8bGjyFtgBHVURiPuyumhAldz0DpQu69KMR.5gJ4FAo.SLHLdfoffO.60w4yB61'
         algo: 'sha512'
         salt: 'somesaltsomesalt'
-      - pass: '*%!)0café'
-        result: '$2b$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
-        result_alt: '$2a$12$saltWith22Characters0udO85cENMyXfRbDHfY.b0bJEQrfUeMuO'
-        algo: 'bcrypt'
-        salt: 'saltWith22Characters00'
-        crypt_skip: '{{ crypt_skip | default(False) }}'
   block:
     - name: Test using static salt
       assert:
         that:
           - "{{ ( item.pass | password_hash(item.algo, item.salt) ) == item.result or ( item.pass | password_hash(item.algo, item.salt) ) == ( item.result_alt | default('') ) }}"
-      loop: "{{ passwords }}"
-      when: not item.crypt_skip or not crypt_skip_all | default(False)
+      with_flattened:
+        - "{{ passwords }}"
+        - "{{ no_crypt_passwords if crypt_run|bool == true else omit }}"
     - name: Passwords default to random salt
       assert:
         that:
           - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
-      loop: "{{ passwords }}"
-      when: not item.crypt_skip or not crypt_skip_all | default(False)
+      with_flattened:
+        - "{{ passwords }}"
+        - "{{ no_crypt_passwords if crypt_run|bool == true else omit }}"
     - name: Register results of the algorithm error
       debug:
         var: "{{ item.pass | password_hash('fake_algo') }}"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -186,7 +186,7 @@
           - '"{{ item.pass | password_hash(item.algo) }}" != "{{ item.pass | password_hash(item.algo) }}"'
       loop: "{{ passwords }}"
       when: not item.crypt_skip | default(False)
-    - name: Register results of the password_hash filter
+    - name: Register results of the algorithm error
       debug:
         var: "{{ item.pass | password_hash('fake_algo') }}"
       register: algo_error

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -118,7 +118,6 @@ def test_password_hash_filter_passlib():
     assert get_encrypted_password("123", "pbkdf2_sha256")
 
 
-
 def test_random_salt():
     res = encrypt.random_salt()
     expected_salt_candidate_chars = u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./'

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -106,50 +106,17 @@ def test_password_hash_filter_passlib():
     if not encrypt.PASSLIB_AVAILABLE:
         pytest.skip("passlib not available")
 
-    with pytest.raises(AnsibleFilterError):
-        get_encrypted_password("123", "sha257", salt="12345678")
-
-    # Uses 5000 rounds by default for sha256 matching crypt behaviour
-    assert get_encrypted_password("123", "sha256", salt="12345678") == "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
-    assert get_encrypted_password("123", "sha256", salt="12345678", rounds=5000) == "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
-
     assert (get_encrypted_password("123", "sha256", salt="12345678", rounds=10000) ==
             "$5$rounds=10000$12345678$JBinliYMFEcBeAXKZnLjenhgEhTmJBvZn3aR8l70Oy/")
 
     assert (get_encrypted_password("123", "sha512", salt="12345678", rounds=6000) ==
             "$6$rounds=6000$12345678$l/fC67BdJwZrJ7qneKGP1b6PcatfBr0dI7W6JLBrsv8P1wnv/0pu4WJsWq5p6WiXgZ2gt9Aoir3MeORJxg4.Z/")
 
-    assert (get_encrypted_password("123", "sha512", salt="12345678", rounds=5000) ==
-            "$6$12345678$LcV9LQiaPekQxZ.OfkMADjFdSO2k9zfbDQrHPVcYjSLqSdjLYpsgqviYvTEP/R41yPmhH3CCeEDqVhW1VHr3L.")
-
     assert get_encrypted_password("123", "crypt16", salt="12") == "12pELHK2ME3McUFlHxel6uMM"
 
     # Try algorithm that uses a raw salt
     assert get_encrypted_password("123", "pbkdf2_sha256")
 
-
-def test_do_encrypt_no_passlib():
-    with passlib_off():
-        assert not encrypt.PASSLIB_AVAILABLE
-        assert encrypt.do_encrypt("123", "md5_crypt", salt="12345678") == "$1$12345678$tRy4cXc3kmcfRZVj4iFXr/"
-
-        with pytest.raises(AnsibleError):
-            encrypt.do_encrypt("123", "crypt16", salt="12")
-
-
-def test_do_encrypt_passlib():
-    if not encrypt.PASSLIB_AVAILABLE:
-        pytest.skip("passlib not available")
-
-    with pytest.raises(AnsibleError):
-        encrypt.do_encrypt("123", "sha257_crypt", salt="12345678")
-
-    # Uses 5000 rounds by default for sha256 matching crypt behaviour.
-    assert encrypt.do_encrypt("123", "sha256_crypt", salt="12345678") == "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
-
-    assert encrypt.do_encrypt("123", "md5_crypt", salt="12345678") == "$1$12345678$tRy4cXc3kmcfRZVj4iFXr/"
-
-    assert encrypt.do_encrypt("123", "crypt16", salt="12") == "12pELHK2ME3McUFlHxel6uMM"
 
 
 def test_random_salt():
@@ -158,3 +125,7 @@ def test_random_salt():
     assert len(res) == 8
     for res_char in res:
         assert res_char in expected_salt_candidate_chars
+
+
+def test_password_hash_filter_no_passlib():
+    with passlib_off():

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -129,3 +129,6 @@ def test_random_salt():
 
 def test_password_hash_filter_no_passlib():
     with passlib_off():
+        if sys.platform.startswith('darwin'):
+            with pytest.raises(AnsibleError):
+                get_encrypted_password("123", "crypt16", salt="12")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add sha1 support for the password_hash jinja2 filter

Also replace most unit tests with integration tests for password_hash.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #26322 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
password_hash filter
