### PR TITLE
[stable-2.8] Don't fail trying to read boot image without enable (#56126)

### DIFF
--- a/changelogs/fragments/56126-eos-without-become.yaml
+++ b/changelogs/fragments/56126-eos-without-become.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- eos: don't fail modules without become set, instead show message and continue
+- "eos: don't fail modules without become set, instead show message and continue"

--- a/changelogs/fragments/56126-eos-without-become.yaml
+++ b/changelogs/fragments/56126-eos-without-become.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- eos: don't fail modules without become set, instead show message and continue

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -247,10 +247,15 @@ class Cliconf(CliconfBase):
 
         device_info['network_os_hostname'] = data['hostname']
 
-        reply = self.get('bash timeout 5 cat /mnt/flash/boot-config')
-        match = re.search(r'SWI=(.+)$', reply, re.M)
-        if match:
-            device_info['network_os_image'] = match.group(1)
+        try:
+            reply = self.get('bash timeout 5 cat /mnt/flash/boot-config')
+
+            match = re.search(r'SWI=(.+)$', reply, re.M)
+            if match:
+                device_info['network_os_image'] = match.group(1)
+        except AnsibleConnectionFailure:
+            # This requires enable mode to run
+            self._connection.queue_message('vvv', "Unable to gather network_os_image without enable mode")
 
         return device_info
 


### PR DESCRIPTION
Also add a message when network_os_image can't be acquired.
(cherry picked from commit 3d9da0c)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf/eos