### PR TITLE
Fixes Netconf_config single parameter bug

### DIFF
--- a/lib/ansible/module_utils/network/netconf/netconf.py
+++ b/lib/ansible/module_utils/network/netconf/netconf.py
@@ -76,7 +76,7 @@ def locked_config(module, target=None):
         unlock_configuration(module, target=target)
 
 
-def get_config(module, source, filter, lock=False):
+def get_config(module, source, filter=None, lock=False):
     conn = get_connection(module)
     try:
         locked = False

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -381,7 +381,7 @@ def main():
             if not module.check_mode:
                 conn.commit()
             result['changed'] = True
-        else:
+        elif config:
             if module.check_mode and not supports_commit:
                 module.warn("check mode not supported as Netconf server doesn't support candidate capability")
                 result['changed'] = True

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -11,4 +11,3 @@
       - "'backup_path' in result"
 
 - debug: msg="END netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"
-

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -1,0 +1,14 @@
+---
+- hosts: junos
+  connection: netconf
+  gather_facts: no
+  tasks:
+  - name: save config
+    netconf_config:
+      backup: yes
+    register: result
+
+  - assert:
+      that:
+        - "'backup_path' in result"
+

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -1,14 +1,14 @@
 ---
-- hosts: junos
-  connection: netconf
-  gather_facts: no
-  tasks:
-  - name: save config
-    netconf_config:
-      backup: yes
-    register: result
+- debug: msg="START netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"
 
-  - assert:
-      that:
-        - "'backup_path' in result"
+- name: save config test
+  netconf_config:
+    backup: yes
+  register: result
+
+- assert:
+    that:
+      - "'backup_path' in result"
+
+- debug: msg="END netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"
 

--- a/test/integration/targets/netconf_config/tests/junos/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/junos/basic.yaml
@@ -53,3 +53,17 @@
     - delete system syslog file test_netconf_config
 
 - debug: msg="END netconf_config junos/basic.yaml on connection={{ ansible_connection }}"
+
+- hosts: junos
+  connection: netconf
+  gather_facts: no
+  tasks:
+  - name: save config
+    netconf_config:
+      backup: yes
+    register: result
+
+  - assert:
+      that:
+        - "'backup_path' in result"
+

--- a/test/integration/targets/netconf_config/tests/junos/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/junos/basic.yaml
@@ -52,18 +52,13 @@
     lines:
     - delete system syslog file test_netconf_config
 
-- debug: msg="END netconf_config junos/basic.yaml on connection={{ ansible_connection }}"
-
-- hosts: junos
-  connection: netconf
-  gather_facts: no
-  tasks:
-  - name: save config
-    netconf_config:
-      backup: yes
+- name: save config
+  netconf_config:
+    backup: yes
     register: result
 
-  - assert:
-      that:
-        - "'backup_path' in result"
+- assert:
+    that:
+      - "'backup_path' in result"
 
+- debug: msg="END netconf_config junos/basic.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #56022

fixed get_config to not require multiple parameters to just run a backup

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
