### PR TITLE
[WIP] remove call to filecompare to fix issue with empty file exclusion fro…

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -160,6 +160,7 @@ expanded_exclude_paths:
 '''
 
 import bz2
+import filecmp
 import glob
 import gzip
 import io
@@ -386,15 +387,28 @@ def main():
                                 for filename in filenames:
                                     fullpath = dirpath + filename
                                     arcname = match_root.sub('', fullpath)
-                                    try:
-                                        if format == 'zip':
-                                            arcfile.write(fullpath, arcname)
-                                        else:
-                                            arcfile.add(fullpath, arcname, recursive=False)
 
-                                        successes.append(fullpath)
-                                    except Exception as e:
-                                        errors.append('Adding %s: %s' % (path, to_native(e)))
+                                    # # filcmp returns True for a file that is empty
+                                    # fullpath_size = os.stat(fullpath).st_size
+                                    # dest_size = os.stat(dest).st_size
+
+                                    # if fullpath_size
+
+                                    # write_conditions = [
+                                    #     fullpath_size != dest_size,
+
+                                    # ]
+                                    # import q; q(fullpath, dest, filecmp.cmp(fullpath, dest))
+                                    if not filecmp.cmp(fullpath, dest):
+                                        try:
+                                            if format == 'zip':
+                                                arcfile.write(fullpath, arcname)
+                                            else:
+                                                arcfile.add(fullpath, arcname, recursive=False)
+
+                                            successes.append(fullpath)
+                                        except Exception as e:
+                                            errors.append('Adding %s: %s' % (path, to_native(e)))
                         else:
                             if format == 'zip':
                                 arcfile.write(path, match_root.sub('', path))

--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -160,7 +160,6 @@ expanded_exclude_paths:
 '''
 
 import bz2
-import filecmp
 import glob
 import gzip
 import io
@@ -387,17 +386,15 @@ def main():
                                 for filename in filenames:
                                     fullpath = dirpath + filename
                                     arcname = match_root.sub('', fullpath)
+                                    try:
+                                        if format == 'zip':
+                                            arcfile.write(fullpath, arcname)
+                                        else:
+                                            arcfile.add(fullpath, arcname, recursive=False)
 
-                                    if not filecmp.cmp(fullpath, dest):
-                                        try:
-                                            if format == 'zip':
-                                                arcfile.write(fullpath, arcname)
-                                            else:
-                                                arcfile.add(fullpath, arcname, recursive=False)
-
-                                            successes.append(fullpath)
-                                        except Exception as e:
-                                            errors.append('Adding %s: %s' % (path, to_native(e)))
+                                        successes.append(fullpath)
+                                    except Exception as e:
+                                        errors.append('Adding %s: %s' % (path, to_native(e)))
                         else:
                             if format == 'zip':
                                 arcfile.write(path, match_root.sub('', path))

--- a/test/integration/targets/archive/tasks/main.yml
+++ b/test/integration/targets/archive/tasks/main.yml
@@ -68,11 +68,12 @@
   when: ansible_python_version.split('.')[0] == '2'
   register: backports_lzma_pip
 
-- name: prep our file
+- name: prep our files
   copy: src={{ item }} dest={{output_dir}}/{{ item }}
   with_items:
     - foo.txt
     - bar.txt
+    - empty.txt
 
 - name: archive using gz
   archive:
@@ -86,12 +87,12 @@
 - name: verify that the files archived
   file: path={{output_dir}}/archive_01.gz state=file
 
-- name: check if gz file exists
+- name: check if gz file exists and includes all text files
   assert:
     that:
       - "{{ archive_gz_result_01.changed }}"
       - "{{ 'archived' in archive_gz_result_01 }}"
-      - "{{ archive_gz_result_01['archived'] | length }} == 2"
+      - "{{ archive_gz_result_01['archived'] | length }} == 3"
 
 - name: archive using zip
   archive:
@@ -110,7 +111,7 @@
     that:
       - "{{ archive_zip_result_01.changed }}"
       - "{{ 'archived' in archive_zip_result_01 }}"
-      - "{{ archive_zip_result_01['archived'] | length }} == 2"
+      - "{{ archive_zip_result_01['archived'] | length }} == 3"
 
 - name: archive using bz2
   archive:
@@ -129,7 +130,7 @@
     that:
       - "{{ archive_bz2_result_01.changed }}"
       - "{{ 'archived' in archive_bz2_result_01 }}"
-      - "{{ archive_bz2_result_01['archived'] | length }} == 2"
+      - "{{ archive_bz2_result_01['archived'] | length }} == 3"
 
 - name: archive using xz
   archive:
@@ -148,7 +149,7 @@
     that:
       - "{{ archive_xz_result_01.changed }}"
       - "{{ 'archived' in archive_xz_result_01 }}"
-      - "{{ archive_xz_result_01['archived'] | length }} == 2"
+      - "{{ archive_xz_result_01['archived'] | length }} == 3"
 
 - name: archive and set mode to 0600
   archive:
@@ -171,7 +172,7 @@
       - "archive_02_gz_stat.changed == False "
       - "archive_02_gz_stat.stat.mode == '0600'"
       - "'archived' in archive_bz2_result_02"
-      - "{{ archive_bz2_result_02['archived']| length}} == 2"
+      - "{{ archive_bz2_result_02['archived']| length}} == 3"
 
 - name: remove our gz
   file: path="{{ output_dir }}/archive_02.gz" state=absent
@@ -196,7 +197,7 @@
       - "archive_02_zip_stat.changed == False"
       - "archive_02_zip_stat.stat.mode == '0600'"
       - "'archived' in archive_zip_result_02"
-      - "{{ archive_zip_result_02['archived']| length}} == 2"
+      - "{{ archive_zip_result_02['archived']| length}} == 3"
 
 - name: remove our zip
   file: path="{{ output_dir }}/archive_02.zip" state=absent
@@ -221,7 +222,7 @@
       - "archive_02_bz2_stat.changed == False"
       - "archive_02_bz2_stat.stat.mode == '0600'"
       - "'archived' in archive_bz2_result_02"
-      - "{{ archive_bz2_result_02['archived']| length}} == 2"
+      - "{{ archive_bz2_result_02['archived']| length}} == 3"
 
 - name: remove our bz2
   file: path="{{ output_dir }}/archive_02.bz2" state=absent
@@ -245,7 +246,7 @@
       - "archive_02_xz_stat.changed == False"
       - "archive_02_xz_stat.stat.mode == '0600'"
       - "'archived' in archive_xz_result_02"
-      - "{{ archive_xz_result_02['archived']| length}} == 2"
+      - "{{ archive_xz_result_02['archived']| length}} == 3"
 
 - name: remove our xz
   file: path="{{ output_dir }}/archive_02.xz" state=absent


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/34569 
Removes a call to `filecmp` that probably protected against adding the archive file to itself (but is unnecessary). This change fixes an issue where empty files were not being added to archives

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/files/archive.py`

