### PR TITLE
Fix junos_config backup testcase

### DIFF
--- a/test/integration/targets/junos_config/tests/netconf/backup.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/backup.yaml
@@ -59,7 +59,6 @@
     backup_options:
       filename: backup.cfg
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
   register: result
 
 - assert:
@@ -81,7 +80,6 @@
     backup: yes
     backup_options:
       filename: backup.cfg
-  become: yes
   register: result
 
 - assert:
@@ -103,7 +101,6 @@
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
   register: result
 
 - assert:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* For junos_config taking backup of running configuration
  does not required priviledge escalation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/targets/junos_config/tests/netconf/backup.yaml 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
