### PR TITLE
Add If-Match ETag header to PATCH requests

### DIFF
--- a/changelogs/fragments/56150-add-if-match-header-to-patch-requests.yaml
+++ b/changelogs/fragments/56150-add-if-match-header-to-patch-requests.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_command - add If-Match etag header to Redfish PATCH requests (https://github.com/ansible/ansible/issues/56050)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -37,7 +37,7 @@ class RedfishUtils(object):
                             follow_redirects='all',
                             use_proxy=False, timeout=self.timeout)
             data = json.loads(resp.read())
-            info = resp.info()
+            headers = {k.lower(): v for k, v in resp.info().items()}
         except HTTPError as e:
             msg = self._get_extended_message(e)
             return {'ret': False,
@@ -50,7 +50,7 @@ class RedfishUtils(object):
         except Exception as e:
             return {'ret': False,
                     'msg': "Failed GET request to '%s': '%s'" % (uri, to_text(e))}
-        return {'ret': True, 'data': data, 'info': info}
+        return {'ret': True, 'data': data, 'headers': headers}
 
     def post_request(self, uri, pyld):
         try:
@@ -79,8 +79,8 @@ class RedfishUtils(object):
         headers = PATCH_HEADERS
         r = self.get_request(uri)
         if r['ret']:
-            # Get etag from ETag header or @odata.etag property
-            etag = r['info'].get('ETag')
+            # Get etag from etag header or @odata.etag property
+            etag = r['headers'].get('etag')
             if not etag:
                 etag = r['data'].get('@odata.etag')
             if etag:

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -37,7 +37,7 @@ class RedfishUtils(object):
                             follow_redirects='all',
                             use_proxy=False, timeout=self.timeout)
             data = json.loads(resp.read())
-            headers = {k.lower(): v for k, v in resp.info().items()}
+            headers = dict((k.lower(), v) for (k, v) in resp.info().items())
         except HTTPError as e:
             msg = self._get_extended_message(e)
             return {'ret': False,

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -37,6 +37,7 @@ class RedfishUtils(object):
                             follow_redirects='all',
                             use_proxy=False, timeout=self.timeout)
             data = json.loads(resp.read())
+            info = resp.info()
         except HTTPError as e:
             msg = self._get_extended_message(e)
             return {'ret': False,
@@ -49,7 +50,7 @@ class RedfishUtils(object):
         except Exception as e:
             return {'ret': False,
                     'msg': "Failed GET request to '%s': '%s'" % (uri, to_text(e))}
-        return {'ret': True, 'data': data}
+        return {'ret': True, 'data': data, 'info': info}
 
     def post_request(self, uri, pyld):
         try:
@@ -75,9 +76,20 @@ class RedfishUtils(object):
         return {'ret': True, 'resp': resp}
 
     def patch_request(self, uri, pyld):
+        headers = PATCH_HEADERS
+        r = self.get_request(uri)
+        if r['ret']:
+            # Get etag from ETag header or @odata.etag property
+            etag = r['info'].get('ETag')
+            if not etag:
+                etag = r['data'].get('@odata.etag')
+            if etag:
+                # Make copy of headers and add If-Match header
+                headers = dict(headers)
+                headers['If-Match'] = etag
         try:
             resp = open_url(uri, data=json.dumps(pyld),
-                            headers=PATCH_HEADERS, method="PATCH",
+                            headers=headers, method="PATCH",
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See issue #56050 for a description of the original problem. The module was updated to check for an ETag in the GET response (looking for `ETag` header or `@odata.etag` property) for resources that are about to be PATCHed. If the ETag is found, it is included in the PATCH request via an `If-Match` header.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #56050 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command.py
redfish_config.py
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
See issue #56050 for a description of the steps to reproduce the problem. After this change, the `HTTP 428 Precondition Required` error is eliminated.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
