### PR TITLE
openssl_certificate: fix passphrase handling for cryptography backend

### DIFF
--- a/changelogs/fragments/56155-openssl_certificate-passphrase.yml
+++ b/changelogs/fragments/56155-openssl_certificate-passphrase.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_certificate - fix private key passphrase handling for ``cryptography`` backend."

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -168,7 +168,7 @@ def load_privatekey(path, passphrase=None, check_passphrase=True, content=None, 
         elif backend == 'cryptography':
             try:
                 result = load_pem_private_key(priv_key_detail,
-                                              passphrase,
+                                              None if passphrase is None else to_bytes(passphrase),
                                               cryptography_backend())
             except TypeError as dummy:
                 raise OpenSSLBadPassphraseError('Wrong or empty passphrase provided for private key')

--- a/test/integration/targets/openssl_certificate/tasks/ownca.yml
+++ b/test/integration/targets/openssl_certificate/tasks/ownca.yml
@@ -3,10 +3,29 @@
   openssl_privatekey:
     path: '{{ output_dir }}/ca_privatekey.pem'
 
+- name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey with passphrase
+  openssl_privatekey:
+    path: '{{ output_dir }}/ca_privatekey_pw.pem'
+    passphrase: hunter2
+    cipher: auto
+    select_crypto_backend: cryptography
+
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA CSR
   openssl_csr:
     path: '{{ output_dir }}/ca_csr.csr'
     privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
+    subject:
+      commonName: Example CA
+    useCommonNameForSAN: no
+    basic_constraints:
+    - 'CA:TRUE'
+    basic_constraints_critical: yes
+
+- name: (OwnCA, {{select_crypto_backend}}) Generate CA CSR (privatekey passphrase)
+  openssl_csr:
+    path: '{{ output_dir }}/ca_csr_pw.csr'
+    privatekey_path: '{{ output_dir }}/ca_privatekey_pw.pem'
+    privatekey_passphrase: hunter2
     subject:
       commonName: Example CA
     useCommonNameForSAN: no
@@ -19,6 +38,16 @@
     path: '{{ output_dir }}/ca_cert.pem'
     csr_path: '{{ output_dir }}/ca_csr.csr'
     privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
+    provider: selfsigned
+    selfsigned_digest: sha256
+    select_crypto_backend: '{{ select_crypto_backend }}'
+
+- name: (OwnCA, {{select_crypto_backend}}) Generate selfsigned CA certificate (privatekey passphrase)
+  openssl_certificate:
+    path: '{{ output_dir }}/ca_cert_pw.pem'
+    csr_path: '{{ output_dir }}/ca_csr_pw.csr'
+    privatekey_path: '{{ output_dir }}/ca_privatekey_pw.pem'
+    privatekey_passphrase: hunter2
     provider: selfsigned
     selfsigned_digest: sha256
     select_crypto_backend: '{{ select_crypto_backend }}'
@@ -163,6 +192,18 @@
     ownca_digest: sha256
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: ownca_certificate_ecc
+
+- name: (OwnCA, {{select_crypto_backend}}) Generate selfsigned certificate (privatekey passphrase)
+  openssl_certificate:
+    path: '{{ output_dir }}/ownca_cert_ecc_2.pem'
+    csr_path: '{{ output_dir }}/csr_ecc.csr'
+    ownca_path: '{{ output_dir }}/ca_cert_pw.pem'
+    ownca_privatekey_path: '{{ output_dir }}/ca_privatekey_pw.pem'
+    ownca_privatekey_passphrase: hunter2
+    provider: ownca
+    ownca_digest: sha256
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: selfsigned_certificate_passphrase
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate (failed passphrase 1)
   openssl_certificate:

--- a/test/integration/targets/openssl_certificate/tasks/ownca.yml
+++ b/test/integration/targets/openssl_certificate/tasks/ownca.yml
@@ -179,7 +179,7 @@
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate (failed passphrase 2)
   openssl_certificate:
-    path: '{{ output_dir }}/ownca_cert_pw1.pem'
+    path: '{{ output_dir }}/ownca_cert_pw2.pem'
     csr_path: '{{ output_dir }}/csr_ecc.csr'
     ownca_path: '{{ output_dir }}/ca_cert.pem'
     ownca_privatekey_path: '{{ output_dir }}/privatekeypw.pem'

--- a/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
@@ -176,6 +176,25 @@
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: selfsigned_certificate_ecc
 
+- name: (Selfsigned, {{select_crypto_backend}}) Generate CSR (privatekey passphrase)
+  openssl_csr:
+    path: '{{ output_dir }}/csr_pass.csr'
+    privatekey_path: '{{ output_dir }}/privatekeypw.pem'
+    privatekey_passphrase: hunter2
+    subject:
+      commonName: www.example.com
+
+- name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate (privatekey passphrase)
+  openssl_certificate:
+    path: '{{ output_dir }}/cert_pass.pem'
+    csr_path: '{{ output_dir }}/csr_pass.csr'
+    privatekey_path: '{{ output_dir }}/privatekeypw.pem'
+    privatekey_passphrase: hunter2
+    provider: selfsigned
+    selfsigned_digest: sha256
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: selfsigned_certificate_passphrase
+
 - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate (failed passphrase 1)
   openssl_certificate:
     path: '{{ output_dir }}/cert_pw1.pem'

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -257,7 +257,7 @@
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: passphrase_1
 
-- name: Generate publickey - PEM format
+- name: Generate CSR (failed passphrase 1)
   openssl_csr:
     path: '{{ output_dir }}/csr_pw1.csr'
     privatekey_path: '{{ output_dir }}/privatekey.pem'
@@ -266,7 +266,7 @@
   ignore_errors: yes
   register: passphrase_error_1
 
-- name: Generate publickey - PEM format
+- name: Generate CSR (failed passphrase 2)
   openssl_csr:
     path: '{{ output_dir }}/csr_pw2.csr'
     privatekey_path: '{{ output_dir }}/privatekeypw.pem'
@@ -275,7 +275,7 @@
   ignore_errors: yes
   register: passphrase_error_2
 
-- name: Generate publickey - PEM format
+- name: Generate CSR (failed passphrase 3)
   openssl_csr:
     path: '{{ output_dir }}/csr_pw3.csr'
     privatekey_path: '{{ output_dir }}/privatekeypw.pem'

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -249,6 +249,14 @@
     cipher: auto
     select_crypto_backend: cryptography
 
+- name: Generate CSR with privatekey passphrase
+  openssl_csr:
+    path: '{{ output_dir }}/csr_pw.csr'
+    privatekey_path: '{{ output_dir }}/privatekeypw.pem'
+    privatekey_passphrase: hunter2
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: passphrase_1
+
 - name: Generate publickey - PEM format
   openssl_csr:
     path: '{{ output_dir }}/csr_pw1.csr'


### PR DESCRIPTION
##### SUMMARY
When creating selfsigned certificates with a private key passphrase (or probably also OwnCA certificates where the OwnCA key is passphrase protected), the module fails incorrectly when used with the `cryptography` backend. Fixes #55495.

I've added tests to prevent this in the future (I also extended them for openssl_csr).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
