### PR TITLE
Fix cli_config junos integration test failures

### DIFF
--- a/test/integration/targets/junos_config/tests/cli_config/cli_backup.yaml
+++ b/test/integration/targets/junos_config/tests/cli_config/cli_backup.yaml
@@ -24,7 +24,6 @@
 - name: take config backup
   cli_config:
     backup: yes
-  become: yes
   register: result
 
 - assert:
@@ -48,7 +47,6 @@
     backup_options:
       filename: backup.cfg
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
   register: result
 
 - assert:
@@ -70,7 +68,6 @@
     backup: yes
     backup_options:
       filename: backup.cfg
-  become: yes
   register: result
 
 - assert:
@@ -92,7 +89,6 @@
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/junos_config/tests/cli_config/cli_basic.yaml
+++ b/test/integration/targets/junos_config/tests/cli_config/cli_basic.yaml
@@ -4,12 +4,10 @@
 - name: setup
   cli_config: &rm1
     config: delete interfaces ge-0/0/1
-  become: yes
 
 - name: setup
   cli_config: &rm2
     config: delete interfaces ge-0/0/2
-  become: yes
 
 - name: configure device with config
   cli_config: &conf1


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Priviledge escalation is not required for junos
   cli_config backup opeation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/targets/junos_config/tests/cli_config/cli_backup.yaml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
