### PR TITLE
Make ansible adhoc work with include_role

### DIFF
--- a/changelogs/fragments/ansible-adhoc.yaml
+++ b/changelogs/fragments/ansible-adhoc.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - allow include_role to work with ansible command

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -69,7 +69,7 @@ class AdHocCLI(CLI):
         mytask = {'action': {'module': context.CLIARGS['module_name'], 'args': parse_kv(context.CLIARGS['module_args'], check_raw=check_raw)}}
 
         # avoid adding to tasks that don't support it, unless set, then give user an error
-        if context.CLIARGS['module_name'] not in ('include_role', 'include_tasks') or any(frozenset((async_val, poll))):
+        if context.CLIARGS['module_name'] not in ('include_role', 'include_tasks') and any(frozenset((async_val, poll))):
             mytask['async_val'] = async_val
             mytask['poll'] = poll
 

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -10,6 +10,10 @@ function gen_task_files() {
     done
 }
 
+## Adhoc
+
+ansible -m include_role -a name=role1 localhost
+
 ## Import (static)
 
 # Playbook


### PR DESCRIPTION
##### SUMMARY

Fix logic condition so that include_role works
without

```
ERROR! 'async_val' is not a valid attribute for a IncludeRole

The error appears to be in 'None': line 0, column 0, but may
be elsewhere in the file depending on the exact syntax problem.

(could not open file to display line)
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible cli

##### ADDITIONAL INFORMATION

Before
```paste below
$ ansible -m include_role -a name=test -vv localhost
ansible 2.9.0.dev0
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
No config file found; using defaults
 [WARNING]: No inventory was parsed, only implicit localhost is available

ERROR! 'async_val' is not a valid attribute for a IncludeRole

The error appears to be in 'None': line 0, column 0, but may
be elsewhere in the file depending on the exact syntax problem.

(could not open file to display line)
```

After
```
$ ansible -m include_role -a name=test -vv localhost
ansible 2.9.0.dev0
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
No config file found; using defaults
 [WARNING]: No inventory was parsed, only implicit localhost is available

META: ran handlers
localhost | SUCCESS => {
    "changed": false, 
    "include_args": {
        "name": "test"
    }
}
localhost | SUCCESS => {
    "msg": "Hello, world!"
}
META: ran handlers
META: ran handlers
```
