### PR TITLE
Allow python_requirements_facts to cope with packages with dashes

### DIFF
--- a/changelogs/fragments/python_requirements_facts_dashes.yml
+++ b/changelogs/fragments/python_requirements_facts_dashes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - allow python_requirements_facts to report on dependencies containing dashes

--- a/lib/ansible/modules/system/python_requirements_facts.py
+++ b/lib/ansible/modules/system/python_requirements_facts.py
@@ -123,7 +123,7 @@ def main():
             python_version=sys.version,
             python_system_path=sys.path,
         )
-    pkg_dep_re = re.compile(r'(^[a-zA-Z][a-zA-Z0-9_]+)(==|[><]=?)?([0-9.]+)?$')
+    pkg_dep_re = re.compile(r'(^[a-zA-Z][a-zA-Z0-9_-]+)(==|[><]=?)?([0-9.]+)?$')
 
     results = dict(
         not_found=[],

--- a/test/integration/targets/python_requirements_facts/aliases
+++ b/test/integration/targets/python_requirements_facts/aliases
@@ -1,1 +1,1 @@
-unsupported
+shippable/posix/group2


### PR DESCRIPTION
##### SUMMARY

```
python_requirements_facts:
  dependencies:
    - kubernetes-validate
```

should work as expected


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
python_requirements_facts

##### ADDITIONAL INFORMATION
2.8 backport candidate