### PR TITLE
k8s minor bug fixes

### DIFF
--- a/changelogs/fragments/k8s-raw-minor-fixes.yml
+++ b/changelogs/fragments/k8s-raw-minor-fixes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - k8s - ensure wait_condition works when Status is Unknown
+  - k8s - ensure k8s returns result of a resource update as it is at the end of the wait period

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -347,7 +347,6 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             if wait:
                 success, result['result'], result['duration'] = self.wait(resource, definition, wait_timeout, condition=wait_condition)
             match, diffs = self.diff_objects(existing.to_dict(), result['result'])
-            result['result'] = k8s_obj
             result['changed'] = not match
             result['method'] = 'patch'
             result['diff'] = diffs
@@ -437,6 +436,11 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             # There should never be more than one condition of a specific type
             match = match[0]
             if match.status == 'Unknown':
+                if match.status == condition['status']:
+                    if 'reason' not in condition:
+                        return True
+                    if condition['reason']:
+                        return match.reason == condition['reason']
                 return False
             status = True if match.status == 'True' else False
             if status == condition['status']:

--- a/test/integration/targets/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/tasks/waiter.yml
@@ -265,7 +265,7 @@
           - condition.reason == "DeploymentPaused"
           - condition.status == "Unknown"
       vars:
-        condition: '{{ pause_deploy.result.status.conditions | selectattr("type", "Progressing")).0 }}'
+        condition: '{{ pause_deploy.result.status.conditions | json_query("[?type==`Progressing`]") | first }}'
 
     - name: add a service based on the deployment
       k8s:


### PR DESCRIPTION
##### SUMMARY

Ensure `wait_condition`s with `Status: Unknown` actually
complete

Return k8s object after wait rather than k8s object before
wait when object is patched.



##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/k8s/raw

##### ADDITIONAL INFORMATION
Candidate for 2.8 backport. 