### PR TITLE
Backport: Fix vyos_command integration test (#56091)

### DIFF
--- a/test/integration/targets/vyos_command/tests/cli/cli_command.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/cli_command.yaml
@@ -2,25 +2,40 @@
 - debug:
     msg: "START cli/cli_command.yaml on connection={{ ansible_connection }}"
 
-- name: get output for single command
-  cli_command:
-    command: show version
-  register: result
+- block:
+  - name: get output for single command
+    cli_command:
+      command: show version
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
-      - "result.stdout is defined"
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.stdout is defined"
 
-- name: send invalid command
-  cli_command:
-    command: 'show foo'
-  register: result
-  ignore_errors: yes
+  - name: send invalid command
+    cli_command:
+      command: 'show foo'
+    register: result
+    ignore_errors: yes
 
-- assert:
-    that:
-      - "result.failed == true"
-      - "result.msg is defined"
+  - assert:
+      that:
+        - "result.failed == true"
+        - "result.msg is defined"
+  when: "ansible_connection == 'network_cli'"
+
+- block:
+  - name: test failure for local connection
+    cli_command:
+      command: show version
+    register: result
+    ignore_errors: yes
+
+  - assert:
+      that:
+        - 'result.failed == true'
+        - "'Connection type local is not valid for this module' in result.msg"
+  when: "ansible_connection == 'local'"
 
 - debug: msg="END cli/cli_command.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
This has been broken for some time, but only noticed recently.  Because
vyos_command isn't supported on ansible_connection=local, update our
testing to account for that.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>
(cherry picked from commit 59d20e004e0e76b7746bb2047dd3815d9bbfcdf1)

##### SUMMARY
- Cherry-Pick #56129 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
targets/vyos_command

