### PR TITLE
Fix for issue #56137 - problem with Chassis/Power URI

### DIFF
--- a/changelogs/fragments/56185-problem-with-redfish-chassis-power-uri.yml
+++ b/changelogs/fragments/56185-problem-with-redfish-chassis-power-uri.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Instead of building the Redfish Power URI from assumptions about URI structure, assemble from @odata.id information in the Chassis resource (https://github.com/ansible/ansible/issues/56137).
+  - Redfish - Instead of building the Power URI from assumptions about URI structure, assemble from @odata.id information in the Chassis resource (https://github.com/ansible/ansible/issues/56137).

--- a/changelogs/fragments/56185-problem-with-redfish-chassis-power-uri.yml
+++ b/changelogs/fragments/56185-problem-with-redfish-chassis-power-uri.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Instead of building the Redfish Power URI from assumptions about URI structure, assemble from @odata.id information in the Chassis resource (https://github.com/ansible/ansible/issues/56137).

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -1043,7 +1043,7 @@ class RedfishUtils(object):
             result['ret'] = True
             data = response['data']
             if key in data:
-                response = self.get_request(self.root_uri+data[key]['@odata.id'])
+                response = self.get_request(self.root_uri + data[key]['@odata.id'])
                 data = response['data']
                 if 'PowerControl' in data:
                     if len(data['PowerControl']) > 0:

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -1043,8 +1043,7 @@ class RedfishUtils(object):
             result['ret'] = True
             data = response['data']
             if key in data:
-                response = self.get_request(self.root_uri + chassis_uri +
-                                            "/" + key)
+                response = self.get_request(self.root_uri+data[key]['@odata.id'])
                 data = response['data']
                 if 'PowerControl' in data:
                     if len(data['PowerControl']) > 0:


### PR DESCRIPTION
##### SUMMARY
Assemble the Power URI from @odata.id information in the Chassis resource

Fixes #56137 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_facts

##### ADDITIONAL INFORMATION
Test against HPE ProLiant servers with iLO 5

BEFORE CHANGE
<!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
The following output:

```
TASK [Get Chassis Power] ********************************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'data'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1557169030.74096-151454169883598/AnsiballZ_redfish_facts.py\", line 125, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1557169030.74096-151454169883598/AnsiballZ_redfish_facts.py\", line 117, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1557169030.74096-151454169883598/AnsiballZ_redfish_facts.py\", line 51, in invoke_module\n    spec.loader.exec_module(module)\n  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_redfish_facts_payload_vijwehp0/__main__.py\", line 346, in <module>\n  File \"/tmp/ansible_redfish_facts_payload_vijwehp0/__main__.py\", line 303, in main\n  File \"/tmp/ansible_redfish_facts_payload_vijwehp0/ansible_redfish_facts_payload.zip/ansible/module_utils/redfish_utils.py\", line 1048, in get_chassis_power\nKeyError: 'data'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
AFTER CHANGE
<!--- Describe what you expected to happen when running the steps above -->
Output like this:
```
TASK [Get Chassis Power] ********************************************************************************************************************************************************************************************************************
ok: [localhost] => {"ansible_facts": {"redfish_facts": {"chassis_power": {"entries": [{"PowerCapacityWatts": 500, "PowerConsumedWatts": 0, "PowerMetrics": {"AverageConsumedWatts": 0, "IntervalInMin": 20, "MaxConsumedWatts": 0, "MinConsumedWatts": 0}}], "ret": true}}}, "changed": false}
```

