### PR TITLE
VMware: standardized states between 'vmware_guest' & 'vmware_guest_powerstate'

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -49,25 +49,25 @@ options:
        configurations conforms to task arguments.'
     - 'If C(state) is set to C(absent) and virtual machine exists, then the specified virtual machine
       is removed with its associated components.'
-    - 'If C(state) is set to one of the following C(poweredon), C(poweredoff), C(present), C(restarted), C(suspended)
+    - 'If C(state) is set to one of the following C(powered-off), C(powered-on), C(present), C(restarted), C(suspended)
       and virtual machine does not exists, then virtual machine is deployed with given parameters.'
-    - 'If C(state) is set to C(poweredon) and virtual machine exists with powerstate other than powered on,
-      then the specified virtual machine is powered on.'
-    - 'If C(state) is set to C(poweredoff) and virtual machine exists with powerstate other than powered off,
+    - 'If C(state) is set to C(powered-off) and virtual machine exists with powerstate other than powered off,
       then the specified virtual machine is powered off.'
+    - 'If C(state) is set to C(powered-on) and virtual machine exists with powerstate other than powered on,
+      then the specified virtual machine is powered on.'
+    - 'If C(state) is set to C(reboot-guest) and virtual machine exists, then the virtual machine is rebooted.'
     - 'If C(state) is set to C(restarted) and virtual machine exists, then the virtual machine is restarted.'
+    - 'If C(state) is set to C(shutdown-guest) and virtual machine exists, then the virtual machine is shutdown.'
     - 'If C(state) is set to C(suspended) and virtual machine exists, then the virtual machine is set to suspended mode.'
-    - 'If C(state) is set to C(shutdownguest) and virtual machine exists, then the virtual machine is shutdown.'
-    - 'If C(state) is set to C(rebootguest) and virtual machine exists, then the virtual machine is rebooted.'
     default: present
-    choices: [ present, absent, poweredon, poweredoff, restarted, suspended, shutdownguest, rebootguest ]
+    choices: [ present, absent, powered-off, poweredoff, powered-on, poweredon, reboot-guest, rebootguest, restarted, shutdown-guest, shutdownguest, suspended ]
   name:
     description:
     - Name of the virtual machine to work with.
     - Virtual machine names in vCenter are not necessarily unique, which may be problematic, see C(name_match).
     - 'If multiple virtual machines with same name exists, then C(folder) is required parameter to
        identify uniqueness of the virtual machine.'
-    - This parameter is required, if C(state) is set to C(poweredon), C(poweredoff), C(present), C(restarted), C(suspended)
+    - This parameter is required, if C(state) is set to C(powered-off), C(powered-on), C(present), C(restarted), C(suspended)
       and virtual machine does not exists.
     - This parameter is case sensitive.
     required: yes
@@ -223,8 +223,8 @@ options:
     version_added: '2.8'
   state_change_timeout:
     description:
-    - If the C(state) is set to C(shutdownguest), by default the module will return immediately after sending the shutdown signal.
-    - If this argument is set to a positive integer, the module will instead wait for the virtual machine to reach the poweredoff state.
+    - If the C(state) is set to C(shutdown-guest), by default the module will return immediately after sending the shutdown signal.
+    - If this argument is set to a positive integer, the module will instead wait for the virtual machine to reach the powered-off state.
     - The value sets a timeout in seconds for the module to wait for the state change.
     default: 0
     version_added: '2.6'
@@ -374,7 +374,7 @@ EXAMPLES = r'''
     validate_certs: no
     folder: /DC1/vm/
     name: test_vm_0001
-    state: poweredon
+    state: powered-on
     guest_id: centos64Guest
     # This is hostname of particular ESXi server on which user wants VM to be deployed
     esxi_hostname: "{{ esxi_hostname }}"
@@ -404,7 +404,7 @@ EXAMPLES = r'''
     validate_certs: no
     folder: /testvms
     name: testvm_2
-    state: poweredon
+    state: powered-on
     template: template_el7
     disk:
     - size_gb: 10
@@ -543,7 +543,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     validate_certs: no
     uuid: "{{ vm_uuid }}"
-    state: poweredoff
+    state: powered-off
   delegate_to: localhost
 
 - name: Deploy a virtual machine in a datastore different from the datastore of the template
@@ -855,7 +855,7 @@ class PyVmomiHelper(PyVmomi):
 
     def remove_vm(self, vm):
         # https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.ManagedEntity.html#destroy
-        if vm.summary.runtime.powerState.lower() == 'poweredon':
+        if vm.summary.runtime.powerState.lower() == 'powered-on':
             self.module.fail_json(msg="Virtual machine %s found in 'powered on' state, "
                                       "please use 'force' parameter to remove or poweroff VM "
                                       "and try removing VM again." % vm.name)
@@ -2295,8 +2295,8 @@ class PyVmomiHelper(PyVmomi):
                 if task.info.state == 'error':
                     return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'customvalues'}
 
-            if self.params['wait_for_ip_address'] or self.params['wait_for_customization'] or self.params['state'] in ['poweredon', 'restarted']:
-                set_vm_power_state(self.content, vm, 'poweredon', force=False)
+            if self.params['wait_for_ip_address'] or self.params['wait_for_customization'] or self.params['state'] in ['powered-on', 'restarted']:
+                set_vm_power_state(self.content, vm, 'powered-on', force=False)
 
                 if self.params['wait_for_ip_address']:
                     self.wait_for_vm_ip(vm)
@@ -2455,7 +2455,7 @@ class PyVmomiHelper(PyVmomi):
             return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'customize_exist'}
 
         if self.params['wait_for_customization']:
-            set_vm_power_state(self.content, self.current_vm_obj, 'poweredon', force=False)
+            set_vm_power_state(self.content, self.current_vm_obj, 'powered-on', force=False)
             is_customization_ok = self.wait_for_customization(self.current_vm_obj)
             if not is_customization_ok:
                 return {'changed': self.change_applied, 'failed': True, 'op': 'wait_for_customize_exist'}
@@ -2530,7 +2530,8 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         state=dict(type='str', default='present',
-                   choices=['absent', 'poweredoff', 'poweredon', 'present', 'rebootguest', 'restarted', 'shutdownguest', 'suspended']),
+                   choices=['absent', 'powered-off', 'poweredoff', 'powered-on', 'poweredon', 'present', 'reboot-guest',
+                            'rebootguest', 'restarted', 'shutdown-guest', 'shutdownguest', 'suspended']),
         template=dict(type='str', aliases=['template_src']),
         is_template=dict(type='bool', default=False),
         annotation=dict(type='str', aliases=['notes']),
@@ -2574,6 +2575,15 @@ def main():
 
     result = {'failed': False, 'changed': False}
 
+    # Display deprecation warning for deprecated 'state' choices
+    if module.params['state'] in ('poweredoff', 'poweredon', 'rebootguest', 'shutdownguest'):
+        deprecated_state = module.params['state']
+        module.params['state'] = deprecated_state.replace('powered', 'powered-').replace('guest', '-guest')
+        module.deprecate(
+            msg="the use of '{0}' is deprecated, please switch to the new format, '{1}')".format(deprecated_state, module.params['state']),
+            version='2.13'
+        )
+
     pyv = PyVmomiHelper(module)
 
     # Check if the VM exists before continuing
@@ -2592,8 +2602,8 @@ def main():
                 )
                 module.exit_json(**result)
             if module.params['force']:
-                # has to be poweredoff first
-                set_vm_power_state(pyv.content, vm, 'poweredoff', module.params['force'])
+                # has to be powered-off first
+                set_vm_power_state(pyv.content, vm, 'powered-off', module.params['force'])
             result = pyv.remove_vm(vm)
         elif module.params['state'] == 'present':
             if module.check_mode:
@@ -2604,7 +2614,7 @@ def main():
                 )
                 module.exit_json(**result)
             result = pyv.reconfigure_vm()
-        elif module.params['state'] in ['poweredon', 'poweredoff', 'restarted', 'suspended', 'shutdownguest', 'rebootguest']:
+        elif module.params['state'] in ['powered-on', 'powered-off', 'restarted', 'suspended', 'shutdown-guest', 'reboot-guest']:
             if module.check_mode:
                 result.update(
                     vm_name=vm.name,
@@ -2617,7 +2627,7 @@ def main():
             tmp_result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'])
             if tmp_result['changed']:
                 result["changed"] = True
-                if module.params['state'] in ['poweredon', 'restarted', 'rebootguest'] and module.params['wait_for_ip_address']:
+                if module.params['state'] in ['powered-on', 'restarted', 'reboot-guest'] and module.params['wait_for_ip_address']:
                     wait_result = wait_for_vm_ip(pyv.content, vm)
                     if not wait_result:
                         module.fail_json(msg='Waiting for IP address timed out')
@@ -2633,7 +2643,7 @@ def main():
             raise AssertionError()
     # VM doesn't exist
     else:
-        if module.params['state'] in ['poweredon', 'poweredoff', 'present', 'restarted', 'suspended']:
+        if module.params['state'] in ['powered-on', 'powered-off', 'present', 'restarted', 'suspended']:
             if module.check_mode:
                 result.update(
                     changed=True,

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -20,7 +20,7 @@
     folder: '{{ f0 }}'
     cluster: '{{ ccr1 }}'
     name: '{{ item }}' 
-    state: poweredon
+    state: powered-on
     guest_id: debian8_64Guest
     disk:
     - size_gb: 1

--- a/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
@@ -19,7 +19,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
   with_items: "{{ vmlist['json'] }}"
   register: clone_d1_c1_f0
@@ -49,7 +49,7 @@
 #        - size: 1gb
 #          type: thin
 #          autoselect_datastore: True
-#    state: poweredoff
+#    state: powered-off
 #    folder: "{{ item|dirname }}"
 #  with_items: "{{ vmlist['json'] }}"
 #  register: clone_d1_c1_f0
@@ -78,7 +78,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
   with_items: "{{ vmlist['json'] }}"
   register: clone_d1_c1_f0
@@ -108,7 +108,7 @@
 #        - size: 1gb
 #          type: thin
 #          autoselect_datastore: True
-#    state: poweredoff
+#    state: powered-off
 #    folder: "{{ item|dirname }}"
 #  with_items: "{{ vmlist['json'] }}"
 #  register: clone_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/check_mode.yml
+++ b/test/integration/targets/vmware_guest/tasks/check_mode.yml
@@ -14,12 +14,16 @@
   with_items:
     - absent
     - present
+    - powered-off
     - poweredoff
+    - powered-on
     - poweredon
-    - restarted
-    - suspended
-    - shutdownguest
+    - reboot-guest
     - rebootguest
+    - restarted
+    - shutdown-guest
+    - shutdownguest
+    - suspended
   register: check_mode_state
   check_mode: yes
 
@@ -43,7 +47,9 @@
     state: "{{ item }}"
   with_items:
     - present
+    - powered-off
     - poweredoff
+    - powered-on
     - poweredon
     - restarted
     - suspended

--- a/test/integration/targets/vmware_guest/tasks/clone_customize_guest_test.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_customize_guest_test.yml
@@ -43,7 +43,7 @@
     name: "{{ 'net_customize_' + item|basename }}"
     template: "{{ item|basename }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
     convert: thin
   with_items: "{{ vmlist['json'] }}"
@@ -66,7 +66,7 @@
     name: "{{ 'net_customize_' + item|basename }}"
     template: "{{ item|basename }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
     convert: thin
   with_items: "{{ vmlist['json'] }}"

--- a/test/integration/targets/vmware_guest/tasks/clone_with_convert.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_with_convert.yml
@@ -11,7 +11,7 @@
     name: "{{ 'thin_' + item|basename }}"
     template: "{{ item|basename }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
     convert: thin
   with_items: "{{ vmlist['json'] }}"
@@ -33,7 +33,7 @@
     name: "{{ 'thick_' + item|basename }}"
     template: "{{ item|basename }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
     convert: thick
   with_items: "{{ vmlist['json'] }}"
@@ -55,7 +55,7 @@
     name: "{{ 'eagerzeroedthick_' + item|basename }}"
     template: "{{ item|basename }}"
     datacenter: "{{ (item|basename).split('_')[0] }}"
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
     convert: eagerzeroedthick
   with_items: "{{ vmlist['json'] }}"

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -33,7 +33,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: clone_d1_c1_f0
 
@@ -62,7 +62,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: clone_d1_c1_f0_recreate
 

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0_env.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0_env.yml
@@ -14,7 +14,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
   with_items: "{{ vmlist['json'] }}"
   register: clone_d1_c1_f0_env
@@ -38,7 +38,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
   with_items: "{{ vmlist['json'] }}"
   register: clone_d1_c1_f0_env
@@ -64,7 +64,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
   with_items: "{{ vmlist['json'] }}"
   register: clone_d1_c1_f0_env
@@ -91,7 +91,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: "{{ item|dirname }}"
   with_items: "{{ vmlist['json'] }}"
   register: clone_d1_c1_f0_env

--- a/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
@@ -26,7 +26,7 @@
           wake_on_lan: True
           start_connected: True
           allow_guest_control: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: clone_d1_c1_f0
 

--- a/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -16,7 +16,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: clone_rp_d1_c1_f0
 
@@ -67,7 +67,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: clone_rpc_d1_c1_f0
 
@@ -120,7 +120,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: clone_rpcp_d1_c1_f0
 
@@ -172,7 +172,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: clone_rph_d1_c1_f0
 

--- a/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
@@ -19,7 +19,7 @@
           type: eagerzeroedthick
           autoselect_datastore: True
           disk_mode: 'invalid_disk_mode'
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: disk_mode_d1_c1_f0
   ignore_errors: True
@@ -48,7 +48,7 @@
           type: eagerzeroedthick
           autoselect_datastore: True
           disk_mode: 'independent_persistent'
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: disk_mode_d1_c1_f0_2
 
@@ -79,7 +79,7 @@
           type: eagerzeroedthick
           autoselect_datastore: True
           disk_mode: 'independent_persistent'
-      state: poweredoff
+      state: powered-off
       folder: "{{ f0 }}"
     register: disk_mode_d1_c1_f0_2
   - debug: var=disk_mode_d1_c1_f0_2

--- a/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
@@ -18,7 +18,7 @@
         - size: 0gb
           type: eagerzeroedthick
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: disk_size_d1_c1_f0
   ignore_errors: True

--- a/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
@@ -21,7 +21,7 @@
         - size: 1gb
           type: thin
           autoselect_datastore: True
-    state: poweredoff
+    state: powered-off
     folder: F0
   register: disk_type_d1_c1_f0
 

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -24,7 +24,7 @@
           netmask: 255.255.255.0
           gateway: 192.168.10.254
           mac: aa:bb:cc:dd:aa:42
-    state: poweredoff
+    state: powered-off
     folder: vm
   register: clone_d1_c1_f0
 

--- a/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
@@ -22,7 +22,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: non_existent_network
   ignore_errors: yes
@@ -55,7 +55,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: no_netmask
   ignore_errors: yes
@@ -88,7 +88,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: no_ip
   ignore_errors: yes
@@ -121,7 +121,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: no_network_name
   ignore_errors: yes
@@ -154,7 +154,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: no_network
   ignore_errors: yes
@@ -188,7 +188,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: invalid_device_type
   ignore_errors: yes
@@ -223,7 +223,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: invalid_mac
   ignore_errors: yes
@@ -259,7 +259,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: invalid_network_type
   ignore_errors: yes
@@ -295,7 +295,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: invalid_dhcp_network_type
   ignore_errors: yes
@@ -326,7 +326,7 @@
     hardware:
         num_cpus: 3
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ f0 }}"
   register: no_network_type
   ignore_errors: yes

--- a/test/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -13,7 +13,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: False
     datacenter: "{{ dc1 }}"
-    state: poweredon
+    state: powered-on
     folder: "{{ f0 }}"
     name: network_with_device
     disk:
@@ -41,7 +41,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: False
     datacenter: "{{ dc1 }}"
-    state: poweredon
+    state: powered-on
     folder: "{{ f0 }}"
     name: network_with_device
     disk:

--- a/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -10,7 +10,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ (vm1|basename).split('_')[0] }}"
-    state: poweredon
+    state: powered-on
     folder: "{{ vm1 | dirname }}"
     template: "{{ vm1 | basename }}"
     name: "{{ vm_name }}"
@@ -44,7 +44,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ (vm1|basename).split('_')[0] }}"
-    state: poweredon
+    state: powered-on
     folder: "{{ vm1 | dirname }}"
     name: "{{ vm_name }}"
     disk:
@@ -71,7 +71,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ (vm1|basename).split('_')[0] }}"
-    state: poweredon
+    state: powered-on
     folder: "{{ vm1 | dirname }}"
     name: "{{ vm_name }}"
     disk:

--- a/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -49,7 +49,7 @@
     hardware:
         num_cpus: 1
         memory_mb: 512
-    state: poweredoff
+    state: powered-off
     folder: "{{ vm1 | dirname }}"
   register: vm_with_portgroup
   ignore_errors: no

--- a/test/integration/targets/vmware_guest/tasks/non_existent_vm_ops.yml
+++ b/test/integration/targets/vmware_guest/tasks/non_existent_vm_ops.yml
@@ -11,7 +11,7 @@
     name: "non_existent_vm"
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
-    state: poweredoff
+    state: powered-off
   register: non_existent_vm_ops
   ignore_errors: yes
 - debug: var=non_existent_vm_ops

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
@@ -2,14 +2,14 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: set state to poweroff on all VMs
+- name: set state to powered-off on all VMs
   vmware_guest:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "{{ item }}"
-    state: poweredoff
+    state: powered-off
   with_items: "{{ infra.vm_list }}"
   register: poweroff_d1_c1_f0
 

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
@@ -8,14 +8,14 @@
 #
 # /F0/DC0/vm/F0/DC0_H0_VM0
 
-- name: set state to poweredoff on all VMs
+- name: set state to powered-off on all VMs
   vmware_guest:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "{{ item }}"
-    state: poweredoff
+    state: powered-off
     folder: "DC1/C1/F1"
   with_items: "{{ infra.vm_list }}"
   register: poweroff_d1_c1_f1


### PR DESCRIPTION
standardized states between `vmware_guest` & `vmware_guest_powerstate`

##### SUMMARY

Fixes #55653

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

`vmware_guest`

##### ADDITIONAL INFORMATION

See #55653

```
# example deprecation warnings

[DEPRECATION WARNING]: the use of 'poweredoff' is deprecated, please switch to the new format, 'powered-off'). This feature will be removed in version 2.13. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: the use of 'poweredon' is deprecated, please switch to the new format, 'powered-on'). This feature will be removed in version 2.13. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: the use of 'rebootguest' is deprecated, please switch to the new format, 'reboot-guest'). This feature will be removed in version 2.13. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: the use of 'shutdownguest' is deprecated, please switch to the new format, 'shutdown-guest'). This feature will be removed in version 2.13. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```