### PR TITLE
Fix netconf_config backup string issue 

### DIFF
--- a/changelogs/fragments/netconf_config_backup_issue.yaml
+++ b/changelogs/fragments/netconf_config_backup_issue.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix netconf_config backup string issue (https://github.com/ansible/ansible/issues/56022)

--- a/lib/ansible/module_utils/network/netconf/netconf.py
+++ b/lib/ansible/module_utils/network/netconf/netconf.py
@@ -76,7 +76,7 @@ def locked_config(module, target=None):
         unlock_configuration(module, target=target)
 
 
-def get_config(module, source, filter, lock=False):
+def get_config(module, source, filter=None, lock=False):
     conn = get_connection(module)
     try:
         locked = False

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -252,6 +252,11 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.module_utils.network.netconf.netconf import get_capabilities, get_config, sanitize_xml
 
+try:
+    from lxml.etree import tostring
+except ImportError:
+    from xml.etree.ElementTree import tostring
+
 
 def main():
     """ main entry point for module execution
@@ -365,7 +370,7 @@ def main():
     try:
         if module.params['backup']:
             response = get_config(module, target, lock=execute_lock)
-            before = to_text(response, errors='surrogate_then_replace').strip()
+            before = to_text(tostring(response), errors='surrogate_then_replace').strip()
             result['__backup__'] = before.strip()
         if validate:
             conn.validate(target)

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -381,7 +381,7 @@ def main():
             if not module.check_mode:
                 conn.commit()
             result['changed'] = True
-        else:
+        elif config:
             if module.check_mode and not supports_commit:
                 module.warn("check mode not supported as Netconf server doesn't support candidate capability")
                 result['changed'] = True

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -1,0 +1,13 @@
+---
+- debug: msg="START netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"
+
+- name: save config test
+  netconf_config:
+    backup: yes
+  register: result
+
+- assert:
+    that:
+      - "'backup_path' in result"
+
+- debug: msg="END netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/netconf_config/tests/junos/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/junos/basic.yaml
@@ -52,4 +52,13 @@
     lines:
     - delete system syslog file test_netconf_config
 
+- name: save config
+  netconf_config:
+    backup: yes
+    register: result
+
+- assert:
+    that:
+      - "'backup_path' in result"
+
 - debug: msg="END netconf_config junos/basic.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #56022

*  Convert the ElementTree object to string
    before dumping the configuration in the file.
*   Fixed get_config to not require multiple parameters to just run a backup
*  Add Integration test for netconf_config

Cherry pick from 647ed207afaa662cb700eee95f50f1a3a016b550 and 9c5745ad2133549c7fcdd21411c98c7223e19200
Merged to devel 
https://github.com/ansible/ansible/pull/56175
https://github.com/ansible/ansible/pull/56138

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
