### PR TITLE
show commit configuration diff for module iosxr_config

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -469,6 +469,8 @@ def load_config(module, command_filter, commit=False, replace=False,
                     )
 
             response = conn.edit_config(candidate=command_filter, commit=commit, admin=admin, replace=replace, comment=comment, label=label)
+
+            diff = response.get('show_commit_config_diff')
             if module._diff:
                 diff = response.get('diff')
         except ConnectionError as exc:

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -117,6 +117,7 @@ class Cliconf(CliconfBase):
             results.append(self.send_command(**line))
             requests.append(cmd)
 
+        resp['show_commit_config_diff'] = self.get('show commit changes diff')
         if commit:
             self.commit(comment=comment, label=label, replace=replace)
         else:


### PR DESCRIPTION
##### SUMMARY
Changes are for feature #54616 
IOS XR devices can calculate diff changes using `show commit changes diff` command unlike other cisco devices. Including commit diff changes for IOS XR Config.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ios xr config

##### ADDITIONAL INFORMATION
It adds commit diff in response dictionary of IOS XR cliconf plugin and use it again in iosxr load config function to show it on cli.