### PR TITLE
Refactor service_root variable

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -20,12 +20,13 @@ DELETE_HEADERS = {'accept': 'application/json', 'OData-Version': '4.0'}
 
 class RedfishUtils(object):
 
-    def __init__(self, creds, root_uri, timeout):
+    def __init__(self, creds, root_uri, timeout, module):
         self.root_uri = root_uri
         self.creds = creds
         self.timeout = timeout
+        self.module = module
+        self.service_root = '/redfish/v1/'
         self._init_session()
-        return
 
     # The following functions are to send GET/POST/PATCH/DELETE requests
     def get_request(self, uri):
@@ -154,8 +155,8 @@ class RedfishUtils(object):
     def _init_session(self):
         pass
 
-    def _find_accountservice_resource(self, uri):
-        response = self.get_request(self.root_uri + uri)
+    def _find_accountservice_resource(self):
+        response = self.get_request(self.root_uri + self.service_root)
         if response['ret'] is False:
             return response
         data = response['data']
@@ -173,8 +174,8 @@ class RedfishUtils(object):
             self.accounts_uri = accounts
         return {'ret': True}
 
-    def _find_sessionservice_resource(self, uri):
-        response = self.get_request(self.root_uri + uri)
+    def _find_sessionservice_resource(self):
+        response = self.get_request(self.root_uri + self.service_root)
         if response['ret'] is False:
             return response
         data = response['data']
@@ -192,8 +193,8 @@ class RedfishUtils(object):
             self.sessions_uri = sessions
         return {'ret': True}
 
-    def _find_systems_resource(self, uri):
-        response = self.get_request(self.root_uri + uri)
+    def _find_systems_resource(self):
+        response = self.get_request(self.root_uri + self.service_root)
         if response['ret'] is False:
             return response
         data = response['data']
@@ -210,8 +211,8 @@ class RedfishUtils(object):
                 'msg': "ComputerSystem's Members array is either empty or missing"}
         return {'ret': True}
 
-    def _find_updateservice_resource(self, uri):
-        response = self.get_request(self.root_uri + uri)
+    def _find_updateservice_resource(self):
+        response = self.get_request(self.root_uri + self.service_root)
         if response['ret'] is False:
             return response
         data = response['data']
@@ -228,9 +229,9 @@ class RedfishUtils(object):
             self.firmware_uri = firmware_inventory
             return {'ret': True}
 
-    def _find_chassis_resource(self, uri):
+    def _find_chassis_resource(self):
         chassis_service = []
-        response = self.get_request(self.root_uri + uri)
+        response = self.get_request(self.root_uri + self.service_root)
         if response['ret'] is False:
             return response
         data = response['data']
@@ -247,8 +248,8 @@ class RedfishUtils(object):
             self.chassis_uri_list = chassis_service
             return {'ret': True}
 
-    def _find_managers_resource(self, uri):
-        response = self.get_request(self.root_uri + uri)
+    def _find_managers_resource(self):
+        response = self.get_request(self.root_uri + self.service_root)
         if response['ret'] is False:
             return response
         data = response['data']

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
@@ -149,8 +149,7 @@ def main():
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_uri = "/redfish/v1/"
-    rf_utils = IdracRedfishUtils(creds, root_uri, timeout)
+    rf_utils = IdracRedfishUtils(creds, root_uri, timeout, module)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:
@@ -166,14 +165,14 @@ def main():
 
     if category == "Systems":
         # execute only if we find a System resource
-        result = rf_utils._find_systems_resource(rf_uri)
+        result = rf_utils._find_systems_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 
         for command in command_list:
             if command == "CreateBiosConfigJob":
                 # execute only if we find a Managers resource
-                result = rf_utils._find_managers_resource(rf_uri)
+                result = rf_utils._find_managers_resource()
                 if result['ret'] is False:
                     module.fail_json(msg=to_native(result['msg']))
                 result = rf_utils.create_bios_config_job()

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -100,7 +100,6 @@ msg:
 '''
 
 import json
-import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.redfish_utils import RedfishUtils
 from ansible.module_utils._text import to_native
@@ -184,8 +183,7 @@ def main():
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_uri = "/redfish/v1/"
-    rf_utils = IdracRedfishUtils(creds, root_uri, timeout)
+    rf_utils = IdracRedfishUtils(creds, root_uri, timeout, module)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:
@@ -201,7 +199,7 @@ def main():
 
     if category == "Manager":
         # execute only if we find a Manager resource
-        result = rf_utils._find_managers_resource(rf_uri)
+        result = rf_utils._find_managers_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_facts.py
@@ -69,7 +69,6 @@ msg:
     sample: List of Manager attributes
 '''
 
-import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.redfish_utils import RedfishUtils
 from ansible.module_utils._text import to_native
@@ -128,8 +127,7 @@ def main():
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_uri = "/redfish/v1/"
-    rf_utils = IdracRedfishUtils(creds, root_uri, timeout)
+    rf_utils = IdracRedfishUtils(creds, root_uri, timeout, module)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:
@@ -145,7 +143,7 @@ def main():
 
     if category == "Manager":
         # execute only if we find a Manager resource
-        result = rf_utils._find_managers_resource(rf_uri)
+        result = rf_utils._find_managers_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -238,8 +238,7 @@ def main():
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri, timeout)
+    rf_utils = RedfishUtils(creds, root_uri, timeout, module)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:
@@ -263,7 +262,7 @@ def main():
         }
 
         # execute only if we find an Account service resource
-        result = rf_utils._find_accountservice_resource(rf_uri)
+        result = rf_utils._find_accountservice_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 
@@ -272,7 +271,7 @@ def main():
 
     elif category == "Systems":
         # execute only if we find a System resource
-        result = rf_utils._find_systems_resource(rf_uri)
+        result = rf_utils._find_systems_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 
@@ -286,7 +285,7 @@ def main():
                     module.params['boot_next'])
 
     elif category == "Chassis":
-        result = rf_utils._find_chassis_resource(rf_uri)
+        result = rf_utils._find_chassis_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 
@@ -308,7 +307,7 @@ def main():
         }
 
         # execute only if we find a Manager service resource
-        result = rf_utils._find_managers_resource(rf_uri)
+        result = rf_utils._find_managers_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -157,8 +157,7 @@ def main():
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri, timeout)
+    rf_utils = RedfishUtils(creds, root_uri, timeout, module)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:
@@ -173,7 +172,7 @@ def main():
     # Organize by Categories / Commands
     if category == "Systems":
         # execute only if we find a System resource
-        result = rf_utils._find_systems_resource(rf_uri)
+        result = rf_utils._find_systems_resource()
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -235,7 +235,6 @@ CATEGORY_COMMANDS_DEFAULT = {
 
 def main():
     result = {}
-    resource = {}
     category_list = []
     module = AnsibleModule(
         argument_spec=dict(
@@ -258,8 +257,7 @@ def main():
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri, timeout)
+    rf_utils = RedfishUtils(creds, root_uri, timeout, module)
 
     # Build Category list
     if "all" in module.params['category']:
@@ -294,7 +292,7 @@ def main():
         # Organize by Categories / Commands
         if category == "Systems":
             # execute only if we find a Systems resource
-            resource = rf_utils._find_systems_resource(rf_uri)
+            resource = rf_utils._find_systems_resource()
             if resource['ret'] is False:
                 module.fail_json(msg=resource['msg'])
 
@@ -322,7 +320,7 @@ def main():
 
         elif category == "Chassis":
             # execute only if we find Chassis resource
-            resource = rf_utils._find_chassis_resource(rf_uri)
+            resource = rf_utils._find_chassis_resource()
             if resource['ret'] is False:
                 module.fail_json(msg=resource['msg'])
 
@@ -340,7 +338,7 @@ def main():
 
         elif category == "Accounts":
             # execute only if we find an Account service resource
-            resource = rf_utils._find_accountservice_resource(rf_uri)
+            resource = rf_utils._find_accountservice_resource()
             if resource['ret'] is False:
                 module.fail_json(msg=resource['msg'])
 
@@ -350,7 +348,7 @@ def main():
 
         elif category == "Update":
             # execute only if we find UpdateService resources
-            resource = rf_utils._find_updateservice_resource(rf_uri)
+            resource = rf_utils._find_updateservice_resource()
             if resource['ret'] is False:
                 module.fail_json(msg=resource['msg'])
 
@@ -362,7 +360,7 @@ def main():
 
         elif category == "Sessions":
             # excute only if we find SessionService resources
-            resource = rf_utils._find_sessionservice_resource(rf_uri)
+            resource = rf_utils._find_sessionservice_resource()
             if resource['ret'] is False:
                 module.fail_json(msg=resource['msg'])
 
@@ -372,7 +370,7 @@ def main():
 
         elif category == "Manager":
             # execute only if we find a Manager service resource
-            resource = rf_utils._find_managers_resource(rf_uri)
+            resource = rf_utils._find_managers_resource()
             if resource['ret'] is False:
                 module.fail_json(msg=resource['msg'])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Small enhancement includes the following changes:

1. Refactor to move the definition of the service root variable (value "/redfish/v1/") out of the individual modules and into the `redfish_utils.py` utility module. Service root is a Redfish protocol defined URI so defining it once in the utility module that needs it makes more sense that defining in every one of the top-level Redfish modules.

2. Added a `module` param to the `RedfishUtils.__init__()` constructor so that the `module` instance will be available in the `redfish_utils.py` utility module. This allows the utility module to make calls like `module.deprecate()`, `module.log()`, etc.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_facts.py
redfish_config.py
redfish_command.py
idrac_redfish_facts.py
idrac_redfish_config.py
idrac_redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

