### PR TITLE
Meraki - Add check for auth_key parameter

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -37,7 +37,7 @@ from ansible.module_utils._text import to_native, to_bytes, to_text
 
 
 def meraki_argument_spec():
-    return dict(auth_key=dict(type='str', no_log=True, fallback=(env_fallback, ['MERAKI_KEY'])),
+    return dict(auth_key=dict(type='str', no_log=True, fallback=(env_fallback, ['MERAKI_KEY']), required=True),
                 host=dict(type='str', default='api.meraki.com'),
                 use_proxy=dict(type='bool', default=False),
                 use_https=dict(type='bool', default=True),

--- a/lib/ansible/plugins/doc_fragments/meraki.py
+++ b/lib/ansible/plugins/doc_fragments/meraki.py
@@ -15,6 +15,7 @@ options:
         description:
         - Authentication key provided by the dashboard. Required if environmental variable C(MERAKI_KEY) is not set.
         type: str
+        required: yes
     host:
         description:
         - Hostname for Meraki dashboard.

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -36,6 +36,14 @@
         - '"Failed to connect to" in invalid_domain.msg'
         - '"http" in http.url'
 
+  - name: Test play without auth_key
+    meraki_network:
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      type: appliance
+    delegate_to: localhost
+
   - name: Create test network
     meraki_network:
       auth_key: '{{auth_key}}'

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -59,6 +59,15 @@
       type: appliance
     delegate_to: localhost
 
+  - name: Enable VLANs on network
+    meraki_network:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      enable_vlans: yes
+    delegate_to: localhost
+
   - name: Create VLAN
     meraki_vlan:
       auth_key: '{{auth_key}}'

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -43,6 +43,12 @@
       net_name: '{{test_net_name}}'
       type: appliance
     delegate_to: localhost
+    ignore_errors: yes
+    register: no_key
+
+  - assert:
+      that:
+        - '"missing required arguments" in no_key.msg'
 
   - name: Create test network
     meraki_network:


### PR DESCRIPTION
##### SUMMARY
`auth_key` is now a required parameter. This will need to change when I move to httpapi but in the meantime, this makes the field mandatory.

This PR also adds a test for this in the `meraki_vlan` integration test and adds a task to enable VLANs on the network, now that the enable VLAN feature is available in `devel`.

Fixes #56142 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki
