### PR TITLE
[2.8] VMware: remove duplicate implementation of memory reservation

### DIFF
--- a/changelogs/fragments/54335-vmware_guest-memory_reservation.yml
+++ b/changelogs/fragments/54335-vmware_guest-memory_reservation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Remove duplicate implementation of memory reservation parameter in vmware_guest (https://github.com/ansible/ansible/issues/54335).


### PR DESCRIPTION
##### SUMMARY
mem_reservation and memory_reservation has redundant implementation.
Combining them together.

Fixes: #54335

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 193f69064fb40a83e3e7d2112ef24868b45233b3)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/54335-vmware_guest-memory_reservation.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
