### PR TITLE
Update na_ontap_volume.py

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_volume.py
@@ -78,7 +78,9 @@ options:
   type:
     description:
     - The volume type, either read-write (RW) or data-protection (DP).
-
+    choices: ['rw', 'dp']
+    default: rw
+    
   policy:
     description:
     - Name of the export policy.


### PR DESCRIPTION
Specify the valid choices and default for the type parameter

+label: docsite_pr

##### SUMMARY

Added the specific options available for the "type" field

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
na_ontap_volume

##### ADDITIONAL INFORMATION
Current documentation is not clear which syntax should be used, as "read-write" and "data-protection" are mentioned as the valid options and the Choices field is blank. I'm just filling in the choices field with the options that actually work correctly (after first using "data-protection" instead of "dp" in my playbook and getting errors!)