### PR TITLE
[backport] ec2_instance fix name idempotency (#55224)

### DIFF
--- a/changelogs/fragments/55224-ec2_instance-idempotent-tags.yaml
+++ b/changelogs/fragments/55224-ec2_instance-idempotent-tags.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_instance - make Name tag idempotent (https://github.com/ansible/ansible/pull/55224)

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1686,7 +1686,11 @@ def main():
         for match in existing_matches:
             warn_if_public_ip_assignment_changed(match)
             warn_if_cpu_options_changed(match)
-            changed |= manage_tags(match, (module.params.get('tags') or {}), module.params.get('purge_tags', False), ec2)
+            tags = module.params.get('tags') or {}
+            name = module.params.get('name')
+            if name:
+                tags['Name'] = name
+            changed |= manage_tags(match, tags, module.params.get('purge_tags', False), ec2)
 
     if state in ('present', 'running', 'started'):
         ensure_present(existing_matches=existing_matches, changed=changed, ec2=ec2, state=state)


### PR DESCRIPTION
Backport #55224 to 2.8.x
(cherry picked from commit 1462fd740b279ebe7dd791c8cac338a36ad413f6)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance