### PR TITLE
nxos_acl: some platforms/versions raise when no ACLs are present (#55609)

### DIFF
--- a/changelogs/fragments/nxos_acl_28.yaml
+++ b/changelogs/fragments/nxos_acl_28.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_acl some platforms/versions raise when no ACLs are present (https://github.com/ansible/ansible/pull/55609).

--- a/test/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
   when: ansible_connection == "local"
 
 - set_fact: time_range="ans-range"
-  when: not (platform is match("N5K")) and not (platform is match("N35"))
+  when: platform is not search('N35|N5K|N6K')
 
 - name: "Setup: Cleanup possibly existing acl."
   nxos_acl: &remove


### PR DESCRIPTION
nxos_acl: some platforms/versions raise when no ACLs are present (#55609)

* `nxos_acl` may fail with `IndexError: list index out of range` while attempting to delete a non-existent ACL.

The failure occurs when the `acl` var is an empty list.

* nxos_acl: catch 501 'Structured output unsupported' when no ACLs present

With some older image versions, `show ip access-list | json` will raise a 501 error indicating `'Structured output unsupported'` when there are no access-lists configured. This change turns off the `check_rc` and then looks for the failure condition.

* Fix kwarg

* Fix lint issues

(cherry picked from commit 869fdcd7d4911ad456c38a38c9e24793cfc1f71c)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
