### PR TITLE
Fix rds_instance module…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -212,7 +212,7 @@ options:
         type: bool
     iops:
         description:
-          - The Provisioned IOPS (I/O operations per second) value. Is only set when when using I(storage_type) is set to io1.
+          - The Provisioned IOPS (I/O operations per second) value. Is only set when using I(storage_type) is set to io1.
         type: int
     kms_key_id:
         description:

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -842,6 +842,9 @@ def get_options_with_changing_values(client, module, parameters):
     apply_immediately = parameters.pop('ApplyImmediately', None)
     cloudwatch_logs_enabled = module.params['enable_cloudwatch_logs_exports']
 
+    # Iops can't be updated
+    parameters.pop('Iops', None)
+
     if port:
         parameters['DBPortNumber'] = port
     if not force_update_password:
@@ -892,7 +895,8 @@ def get_current_attributes_with_inconsistent_keys(instance):
     options['DBParameterGroupName'] = [parameter_group['DBParameterGroupName'] for parameter_group in instance['DBParameterGroups']]
     options['AllowMajorVersionUpgrade'] = None
     options['EnableIAMDatabaseAuthentication'] = instance['IAMDatabaseAuthenticationEnabled']
-    options['EnablePerformanceInsights'] = instance['PerformanceInsightsEnabled']
+    # PerformanceInsightsEnabled is not returned on older RDS instances it seems
+    options['EnablePerformanceInsights'] = instance.get('PerformanceInsightsEnabled', False)
     options['MasterUserPassword'] = None
     options['NewDBInstanceIdentifier'] = instance['DBInstanceIdentifier']
 

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -212,7 +212,7 @@ options:
         type: bool
     iops:
         description:
-          - The Provisioned IOPS (I/O operations per second) value. Only set when when using I(storage_type: io1)
+          - The Provisioned IOPS (I/O operations per second) value. Is only set when when using I(storage_type) is set to io1.
         type: int
     kms_key_id:
         description:

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -212,7 +212,7 @@ options:
         type: bool
     iops:
         description:
-          - The Provisioned IOPS (I/O operations per second) value.
+          - The Provisioned IOPS (I/O operations per second) value. Only set when when using I(storage_type: io1)
         type: int
     kms_key_id:
         description:
@@ -842,15 +842,14 @@ def get_options_with_changing_values(client, module, parameters):
     apply_immediately = parameters.pop('ApplyImmediately', None)
     cloudwatch_logs_enabled = module.params['enable_cloudwatch_logs_exports']
 
-    # Iops can't be updated
-    parameters.pop('Iops', None)
-
     if port:
         parameters['DBPortNumber'] = port
     if not force_update_password:
         parameters.pop('MasterUserPassword', None)
     if cloudwatch_logs_enabled:
         parameters['CloudwatchLogsExportConfiguration'] = cloudwatch_logs_enabled
+    if not module.params['storage_type']:
+        parameters.pop('Iops')
 
     instance = get_instance(client, module, instance_id)
     updated_parameters = get_changing_options_with_inconsistent_keys(parameters, instance, purge_cloudwatch_logs)


### PR DESCRIPTION
##### SUMMARY
… to run against an existing RDS instance successfully

Fixes tow issues I experienced when trying to run this module against an already existing RDS instance (created 2016). See details below.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rds_instance module

##### ADDITIONAL INFORMATION

Fixes two errors (relevant exception snippets):

1. [...] `line 903, in get_current_attributes_with_inconsistent_keys KeyError: 'PerformanceInsightsEnabled'` [...]
2. [...] `line 948, in get_changing_options_with_consistent_keys KeyError: 'Iops'` [...]
