### PR TITLE
Revert nxos, ios, iosxr return_timestamps (#56206)

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2674,7 +2674,3 @@ class AnsibleModule(object):
 
 def get_module_path():
     return os.path.dirname(os.path.realpath(__file__))
-
-
-def get_timestamp():
-    return datetime.datetime.now().replace(microsecond=0).isoformat()

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -129,10 +129,10 @@ def get_config(module, flags=None):
         return cfg
 
 
-def run_commands(module, commands, check_rc=True, return_timestamps=False):
+def run_commands(module, commands, check_rc=True):
     connection = get_connection(module)
     try:
-        return connection.run_commands(commands=commands, check_rc=check_rc, return_timestamps=return_timestamps)
+        return connection.run_commands(commands=commands, check_rc=check_rc)
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))
 

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -477,10 +477,10 @@ def load_config(module, command_filter, commit=False, replace=False,
     return diff
 
 
-def run_commands(module, commands, check_rc=True, return_timestamps=False):
+def run_commands(module, commands, check_rc=True):
     connection = get_connection(module)
     try:
-        return connection.run_commands(commands=commands, check_rc=check_rc, return_timestamps=return_timestamps)
+        return connection.run_commands(commands=commands, check_rc=check_rc)
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))
 

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -33,7 +33,7 @@ import json
 import re
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import env_fallback, get_timestamp
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.network.common.utils import to_list, ComplexList
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.module_utils.common._collections_compat import Mapping
@@ -154,13 +154,13 @@ class Cli:
             self._device_configs[cmd] = cfg
             return cfg
 
-    def run_commands(self, commands, check_rc=True, return_timestamps=False):
+    def run_commands(self, commands, check_rc=True):
         """Run list of commands on remote device and return results
         """
         connection = self._get_connection()
 
         try:
-            out, timestamps = connection.run_commands(commands, check_rc)
+            out = connection.run_commands(commands, check_rc)
             if check_rc == 'retry_json':
                 capabilities = self.get_capabilities()
                 network_api = capabilities.get('network_api')
@@ -170,11 +170,8 @@ class Cli:
                         if ('Invalid command at' in resp or 'Ambiguous command at' in resp) and 'json' in resp:
                             if commands[index]['output'] == 'json':
                                 commands[index]['output'] = 'text'
-                                out, timestamps = connection.run_commands(commands, check_rc)
-            if return_timestamps:
-                return out, timestamps
-            else:
-                return out
+                                out = connection.run_commands(commands, check_rc)
+            return out
         except ConnectionError as exc:
             self._module.fail_json(msg=to_text(exc))
 
@@ -344,7 +341,6 @@ class LocalNxapi:
 
         headers = {'Content-Type': 'application/json'}
         result = list()
-        timestamps = list()
         timeout = self._module.params['timeout']
         use_proxy = self._module.params['provider']['use_proxy']
 
@@ -352,7 +348,6 @@ class LocalNxapi:
             if self._nxapi_auth:
                 headers['Cookie'] = self._nxapi_auth
 
-            timestamp = get_timestamp()
             response, headers = fetch_url(
                 self._module, self._url, data=req, headers=headers,
                 timeout=timeout, method='POST', use_proxy=use_proxy
@@ -380,13 +375,12 @@ class LocalNxapi:
                             self._error(output=output, **item)
                     elif 'body' in item:
                         result.append(item['body'])
-                        timestamps.append(timestamp)
                     # else:
                         # error in command but since check_status is disabled
                         # silently drop it.
                         # result.append(item['msg'])
 
-            return result, timestamps
+            return result
 
     def get_config(self, flags=None):
         """Retrieves the current config from the device or cache
@@ -400,18 +394,17 @@ class LocalNxapi:
         try:
             return self._device_configs[cmd]
         except KeyError:
-            out, out_timestamps = self.send_request(cmd)
+            out = self.send_request(cmd)
             cfg = str(out[0]).strip()
             self._device_configs[cmd] = cfg
             return cfg
 
-    def run_commands(self, commands, check_rc=True, return_timestamps=False):
+    def run_commands(self, commands, check_rc=True):
         """Run list of commands on remote device and return results
         """
         output = None
         queue = list()
         responses = list()
-        timestamps = list()
 
         def _send(commands, output):
             return self.send_request(commands, output, check_status=check_rc)
@@ -422,23 +415,16 @@ class LocalNxapi:
                 item['output'] = 'json'
 
             if all((output == 'json', item['output'] == 'text')) or all((output == 'text', item['output'] == 'json')):
-                out, out_timestamps = _send(queue, output)
-                responses.extend(out)
-                timestamps.extend(out_timestamps)
+                responses.extend(_send(queue, output))
                 queue = list()
 
             output = item['output'] or 'json'
             queue.append(item['command'])
 
         if queue:
-            out, out_timestamps = _send(queue, output)
-            responses.extend(out)
-            timestamps.extend(out_timestamps)
+            responses.extend(_send(queue, output))
 
-        if return_timestamps:
-            return responses, timestamps
-        else:
-            return responses
+        return responses
 
     def load_config(self, commands, return_error=False, opts=None, replace=None):
         """Sends the ordered set of commands to the device
@@ -450,8 +436,8 @@ class LocalNxapi:
             commands = 'config replace {0}'.format(replace)
 
         commands = to_list(commands)
-        msg, msg_timestamps = self.send_request(commands, output='config', check_status=True,
-                                                return_error=return_error, opts=opts)
+        msg = self.send_request(commands, output='config', check_status=True,
+                                return_error=return_error, opts=opts)
         if return_error:
             return msg
         else:
@@ -530,7 +516,7 @@ class HttpApi:
 
         return self._connection_obj
 
-    def run_commands(self, commands, check_rc=True, return_timestamps=False):
+    def run_commands(self, commands, check_rc=True):
         """Runs list of commands on remote device and returns results
         """
         try:
@@ -548,11 +534,7 @@ class HttpApi:
             if response[0] == '{':
                 out[index] = json.loads(response)
 
-        if return_timestamps:
-            # workaround until timestamps are implemented
-            return out, list()
-        else:
-            return out
+        return out
 
     def get_config(self, flags=None):
         """Retrieves the current config from the device or cache
@@ -726,9 +708,9 @@ def get_config(module, flags=None):
     return conn.get_config(flags=flags)
 
 
-def run_commands(module, commands, check_rc=True, return_timestamps=False):
+def run_commands(module, commands, check_rc=True):
     conn = get_connection(module)
-    return conn.run_commands(to_command(module, commands), check_rc, return_timestamps)
+    return conn.run_commands(to_command(module, commands), check_rc)
 
 
 def load_config(module, config, return_error=False, opts=None, replace=None):

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -198,7 +198,7 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses, timestamps = run_commands(module, commands, return_timestamps=True)
+        responses = run_commands(module, commands)
 
         for item in list(conditionals):
             if item(responses):
@@ -221,7 +221,6 @@ def main():
     result.update({
         'stdout': responses,
         'stdout_lines': list(to_lines(responses)),
-        'timestamps': timestamps
     })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -178,7 +178,7 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses, timestamps = run_commands(module, commands, return_timestamps=True)
+        responses = run_commands(module, commands)
 
         for item in list(conditionals):
             if item(responses):
@@ -201,7 +201,6 @@ def main():
     result.update({
         'stdout': responses,
         'stdout_lines': list(to_lines(responses)),
-        'timestamps': timestamps
     })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_command.py
+++ b/lib/ansible/modules/network/nxos/nxos_command.py
@@ -188,7 +188,8 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses, timestamps = run_commands(module, commands, return_timestamps=True)
+        responses = run_commands(module, commands)
+
         for item in list(conditionals):
             try:
                 if item(responses):
@@ -213,7 +214,6 @@ def main():
     result.update({
         'stdout': responses,
         'stdout_lines': list(to_lines(responses)),
-        'timestamps': timestamps
     })
 
     module.exit_json(**result)

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -38,7 +38,6 @@ from itertools import chain
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import get_timestamp
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
@@ -287,12 +286,11 @@ class Cliconf(CliconfBase):
 
         return resp
 
-    def run_commands(self, commands=None, check_rc=True, return_timestamps=False):
+    def run_commands(self, commands=None, check_rc=True):
         if commands is None:
             raise ValueError("'commands' value is required")
 
         responses = list()
-        timestamps = list()
         for cmd in to_list(commands):
             if not isinstance(cmd, Mapping):
                 cmd = {'command': cmd}
@@ -303,19 +301,14 @@ class Cliconf(CliconfBase):
 
             try:
                 out = self.send_command(**cmd)
-                timestamp = get_timestamp()
             except AnsibleConnectionFailure as e:
                 if check_rc:
                     raise
                 out = getattr(e, 'err', to_text(e))
 
             responses.append(out)
-            timestamps.append(timestamp)
 
-        if return_timestamps:
-            return responses, timestamps
-        else:
-            return responses
+        return responses
 
     def get_defaults_flag(self):
         """

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -35,7 +35,6 @@ import json
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import get_timestamp
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
@@ -184,11 +183,10 @@ class Cliconf(CliconfBase):
 
         self.send_command(**cmd_obj)
 
-    def run_commands(self, commands=None, check_rc=True, return_timestamps=False):
+    def run_commands(self, commands=None, check_rc=True):
         if commands is None:
             raise ValueError("'commands' value is required")
         responses = list()
-        timestamps = list()
         for cmd in to_list(commands):
             if not isinstance(cmd, Mapping):
                 cmd = {'command': cmd}
@@ -198,7 +196,6 @@ class Cliconf(CliconfBase):
                 raise ValueError("'output' value %s is not supported for run_commands" % output)
 
             try:
-                timestamp = get_timestamp()
                 out = self.send_command(**cmd)
             except AnsibleConnectionFailure as e:
                 if check_rc:
@@ -217,11 +214,7 @@ class Cliconf(CliconfBase):
                     pass
 
                 responses.append(out)
-                timestamps.append(timestamp)
-        if return_timestamps:
-            return responses, timestamps
-        else:
-            return responses
+        return responses
 
     def discard_changes(self):
         self.send_command('abort')

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -34,7 +34,6 @@ import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils.basic import get_timestamp
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.connection import ConnectionError
@@ -199,7 +198,6 @@ class Cliconf(CliconfBase):
             raise ValueError("'commands' value is required")
 
         responses = list()
-        timestamps = list()
         for cmd in to_list(commands):
             if not isinstance(cmd, Mapping):
                 cmd = {'command': cmd}
@@ -209,7 +207,6 @@ class Cliconf(CliconfBase):
                 cmd['command'] = self._get_command_with_output(cmd['command'], output)
 
             try:
-                timestamp = get_timestamp()
                 out = self.send_command(**cmd)
             except AnsibleConnectionFailure as e:
                 if check_rc is True:
@@ -228,8 +225,7 @@ class Cliconf(CliconfBase):
                     pass
 
                 responses.append(out)
-                timestamps.append(timestamp)
-        return responses, timestamps
+        return responses
 
     def get_device_operations(self):
         return {

--- a/test/units/modules/network/ios/test_ios_command.py
+++ b/test/units/modules/network/ios/test_ios_command.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from ansible.module_utils.basic import get_timestamp
 from ansible.modules.network.ios import ios_command
 from units.modules.utils import set_module_args
 from .ios_module import TestIosModule, load_fixture
@@ -47,7 +46,6 @@ class TestIosCommandModule(TestIosModule):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()
-            timestamps = list()
 
             for item in commands:
                 try:
@@ -57,8 +55,7 @@ class TestIosCommandModule(TestIosModule):
                     command = item['command']
                 filename = str(command).replace(' ', '_')
                 output.append(load_fixture(filename))
-                timestamps.append(get_timestamp())
-            return output, timestamps
+            return output
 
         self.run_commands.side_effect = load_from_file
 

--- a/test/units/modules/network/iosxr/test_iosxr_command.py
+++ b/test/units/modules/network/iosxr/test_iosxr_command.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
-from ansible.module_utils.basic import get_timestamp
 from ansible.modules.network.iosxr import iosxr_command
 from units.modules.utils import set_module_args
 from .iosxr_module import TestIosxrModule, load_fixture
@@ -46,7 +45,6 @@ class TestIosxrCommandModule(TestIosxrModule):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()
-            timestamps = list()
 
             for item in commands:
                 try:
@@ -55,8 +53,7 @@ class TestIosxrCommandModule(TestIosxrModule):
                     command = item
                 filename = str(command).replace(' ', '_')
                 output.append(load_fixture(filename))
-                timestamps.append(get_timestamp())
-            return output, timestamps
+            return output
 
         self.run_commands.side_effect = load_from_file
 

--- a/test/units/modules/network/nxos/test_nxos_command.py
+++ b/test/units/modules/network/nxos/test_nxos_command.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from ansible.module_utils.basic import get_timestamp
 from ansible.modules.network.nxos import nxos_command
 from .nxos_module import TestNxosModule, load_fixture, set_module_args
 
@@ -45,7 +44,6 @@ class TestNxosCommandModule(TestNxosModule):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()
-            timestamps = list()
 
             for item in commands:
                 try:
@@ -55,8 +53,7 @@ class TestNxosCommandModule(TestNxosModule):
                     command = item['command']
                 filename = '%s.txt' % str(command).replace(' ', '_')
                 output.append(load_fixture('nxos_command', filename))
-                timestamps.append(get_timestamp())
-            return output, timestamps
+            return output
 
         self.run_commands.side_effect = load_from_file
 


### PR DESCRIPTION
##### SUMMARY

* Revert "nxos_command:run_commands results failure when commands array size >1 (#52670)"
This reverts commit 0df5b92af37d43da20125dc418f1cb92390a8a25.
* Revert "added timestamps to nxos_command module (#50261)"
This reverts commit e1509433144572e5010d0ced72a2129600dd8bd4.
* Revert "added timestamps to ios_command module (#50323)"
This reverts commit 2a432a093b392e3f8babea6b760df6a5c8716b03.
* Revert "added response_timestamps to iosxr_command module (#50095)"
This reverts commit 2a0c356da9d18a98399f2802ea8a52eb421f87ac.

(cherry picked from commit 2e8a3efccb8f90ae03e61e3b08d238790fb50658)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Fixes #52671 

timestamps can be implemented in task using http://www.mydailytutorials.com/working-date-timestamp-ansible/ ansible_date_time fact value. The cliconf change made for timetsamps is very hacky for adding features in future. Also it was not implemented for httpapi. We should be very careful about what we introduce in cliconf.

