### PR TITLE
nxos_snmp_traps: fix 'group: all' for N35 platforms (#55995)

### DIFF
--- a/changelogs/fragments/nxos_snmp_traps_28.yaml
+++ b/changelogs/fragments/nxos_snmp_traps_28.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_snmp_traps fix group all for N35 platforms (https://github.com/ansible/ansible/pull/55995).

--- a/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
@@ -78,7 +78,13 @@ commands:
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.network.nxos.nxos import get_capabilities
 from ansible.module_utils.basic import AnsibleModule
+
+
+def get_platform_id(module):
+    info = get_capabilities(module).get('device_info', {})
+    return (info.get('network_os_platform', ''))
 
 
 def execute_show_command(command, module):
@@ -110,6 +116,11 @@ def get_snmp_traps(group, module):
                     'rf', 'rmon', 'snmp', 'storm-control', 'stpx',
                     'switchfabric', 'syslog', 'sysmgr', 'system', 'upgrade',
                     'vtp']
+
+    if 'all' in group and 'N3K-C35' in get_platform_id(module):
+        module.warn("Platform does not support bfd traps; bfd ignored for 'group: all' request")
+        feature_list.remove('bfd')
+
     for each in feature_list:
         for line in body:
             if each == 'ospf':

--- a/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
@@ -5,14 +5,14 @@
 
 - name: Setup - Remove snmp_traps if configured
   nxos_snmp_traps: &remove
-    group: all 
+    group: all
     provider: "{{ connection }}"
     state: disabled
 
 - block:
-  - name: Configure one snmp trap group 
+  - name: Configure one snmp trap group
     nxos_snmp_traps: &config
-      group: bridge 
+      group: bridge
       provider: "{{ connection }}"
       state: enabled
     register: result
@@ -60,10 +60,9 @@
     - name: Idempotence Check
       nxos_snmp_traps: *config1
       register: result
-      when: imagetag is not search("I2|D1")
 
     - assert: *false
-      when: imagetag is not search("I2|D1")
+    when: imagetag is not search("I2|I7|D1")
 
   - name: Cleanup
     nxos_snmp_traps: *remove


### PR DESCRIPTION
##### SUMMARY
* nxos_snmp_traps: fix 'group: all' for N35 platforms

- `group: all` attempts to enable traps for all features defined in the module's `feature_list`

- `N35` platforms do not support `snmp-server enable traps bfd`; so removing `bfd` from the `feature_list` for that platform

- Minor cleanup in `sanity.yaml` test file

* whitespace lint fix

(cherry picked from commit 0e0c2a7db7670133bf2f4e762bc46ae8c4efc6be)


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
