### PR TITLE
nxos_interface: Fix admin_state check for n6k (#55673)

### DIFF
--- a/changelogs/fragments/nxos_interface_28.yaml
+++ b/changelogs/fragments/nxos_interface_28.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_interface Fix admin_state check for n6k (https://github.com/ansible/ansible/pull/55673).

--- a/test/integration/targets/nxos_interface/tests/common/intent.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/intent.yaml
@@ -26,11 +26,16 @@
     that:
       - "result.failed == false"
 
+- name: "Clear interface {{ testint2 }} counters before next task"
+  nxos_command:
+    commands: "clear counters interface {{ testint2 }}"
+  ignore_errors: yes
+
 - name: Check intent arguments (failed condition)
   nxos_interface:
     name: "{{ testint2 }}"
     admin_state: down
-    tx_rate: gt(0)
+    tx_rate: gt(10000)
     rx_rate: lt(0)
     provider: "{{ connection }}"
   ignore_errors: yes
@@ -39,7 +44,7 @@
 - assert:
     that:
       - "result.failed == true"
-      - "'tx_rate gt(0)' in result.failed_conditions"
+      - "'tx_rate gt(10000)' in result.failed_conditions"
       - "'rx_rate lt(0)' in result.failed_conditions"
 
 - name: aggregate definition of interface


### PR DESCRIPTION
* Fix admin_state check for n6k

* Fix rx and tx_rate intent check test

(cherry picked from commit bceca72eb7f4714a64c6ebee310e005633de1f71)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
