### PR TITLE
add add/remove_members states to ipa_hostgroup

### DIFF
--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -191,6 +191,32 @@ class IPAClient(object):
                 result.append(key)
         return result
 
+    def add_if_missing(self, name, ipa_list, module_list, add_method, item=None):
+        changed = False
+        diff = list(set(module_list) - set(ipa_list))
+        if len(diff) > 0:
+            changed = True
+            if not self.module.check_mode:
+                if item:
+                    add_method(name=name, item={item: diff})
+                else:
+                    add_method(name=name, item=diff)
+
+        return changed
+
+    def remove_if_present(self, name, ipa_list, module_list, remove_method, item=None):
+        changed = False
+        common = list(set(ipa_list).intersection(set(module_list)))
+        if len(common) > 0:
+            changed = True
+            if not self.module.check_mode:
+                if item:
+                    remove_method(name=name, item={item: common})
+                else:
+                    remove_method(name=name, item=common)
+
+        return changed
+
     def modify_if_diff(self, name, ipa_list, module_list, add_method, remove_method, item=None):
         changed = False
         diff = list(set(ipa_list) - set(module_list))

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -204,21 +204,23 @@ def ensure(module, client):
 
 def main():
     argument_spec = ipa_argument_spec()
-    argument_spec.update(cn=dict(type='str', required=True, aliases=['name']),
-                         description=dict(type='str'),
-                         host=dict(type='list'),
-                         hostgroup=dict(type='list'),
-                         state=dict(type='str', default='present',
-                                    choices=[
-                                        'present',
-                                        'absent',
-                                        'add_members',
-                                        'remove_members',
-                                        'enabled',
-                                        'disabled'
-                                    ]
-                                   )
-                         )
+    argument_spec.update(
+        cn=dict(type='str', required=True, aliases=['name']),
+        description=dict(type='str'),
+        host=dict(type='list'),
+        hostgroup=dict(type='list'),
+        state=dict(
+            type='str', default='present',
+            choices=[
+                'present',
+                'absent',
+                'add_members',
+                'remove_members',
+                'enabled',
+                'disabled'
+            ]
+        )
+    )
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -218,7 +218,8 @@ def main():
                                         'enabled',
                                         'disabled'
                                     ]
-                         ))
+                                   )
+                         )
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -160,7 +160,6 @@ def ensure(module, client):
                     for key in diff:
                         data[key] = module_hostgroup.get(key)
                     client.hostgroup_mod(name=name, item=data)
-
     else:
         if ipa_hostgroup:
             changed = True
@@ -189,7 +188,7 @@ def ensure(module, client):
             changed = client.add_if_missing(name, ipa_hostgroup.get('member_hostgroup', []),
                                             [item.lower() for item in hostgroup],
                                             client.hostgroup_add_hostgroup) or changed
-    if state == 'remove_members':
+    elif state == 'remove_members':
         if host is not None:
             changed = client.remove_if_present(name, ipa_hostgroup.get('member_host', []),
                                                [item.lower() for item in host],


### PR DESCRIPTION
##### SUMMARY
Add two new states to ipa_hostgroup, add_members and remove_members.  These would allow adding or removing members without requiring knowledge of every host or hostgroup currently in the hostgroup, as is currently the case with the "present" state.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ipa_hostgroup module