### PR TITLE
winrm - fix failure parsing for send input errors

### DIFF
--- a/changelogs/fragments/winrm-input-failures.yaml
+++ b/changelogs/fragments/winrm-input-failures.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - Fix issue when attempting to parse CLIXML on send input failure

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -481,8 +481,8 @@ class Connection(ConnectionBase):
                 except ValueError:
                     # stdout does not contain a return response, stdin input was a fatal error
                     stderr = to_bytes(response.std_err, encoding='utf-8')
-                    if self.is_clixml(stderr):
-                        stderr = self.parse_clixml_stream(stderr)
+                    if stderr.startswith(b"#< CLIXML"):
+                        stderr = _parse_clixml(stderr)
 
                     raise AnsibleError('winrm send_input failed; \nstdout: %s\nstderr %s'
                                        % (to_native(response.std_out), to_native(stderr)))


### PR DESCRIPTION
##### SUMMARY
When moving the clixml stuff outside of winrm.py, this section was missed causing a stacktrace to occur when parsing a send input failure.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
winrm