### PR TITLE
In tower_credential module, add credential_type parameter

### DIFF
--- a/test/integration/targets/tower_credential_type/tasks/main.yml
+++ b/test/integration/targets/tower_credential_type/tasks/main.yml
@@ -12,6 +12,29 @@
     that:
       - "result is changed"
 
+- name: Create credential from custom credential type
+  tower_credential:
+    name: test-custom-cred
+    organization: Default
+    credential_type: test-credential-type
+    state: present
+    inputs: '{"username": "my-username", "password": "my-password"}'
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Remove credential
+  tower_credential:
+    name: test-custom-cred
+    organization: Default
+    credential_type: test-credential-type
+    state: absent
+
+- assert:
+    that:
+      - "result is changed"
+
 - name: Remove a Tower credential type
   tower_credential_type:
     name: test-credential-type


### PR DESCRIPTION
##### SUMMARY
Adds the `credential_type` parameter to the `tower_credential` module. This will allow users to create credentials that use custom credential types.

The `kind` parameter is still supported for backwards compatibility.

Fixes https://github.com/ansible/ansible/issues/54493

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower_credential module