### PR TITLE
[2.8] XenServer: Minor changes and fixes in xenserver_guest (#55678)

### DIFF
--- a/changelogs/fragments/55678-xenserver_guest-change-wait_for_ip_address-behaviour-and-other.yaml
+++ b/changelogs/fragments/55678-xenserver_guest-change-wait_for_ip_address-behaviour-and-other.yaml
@@ -1,0 +1,6 @@
+minor_changes:
+  - xenserver_guest - wait_for_ip_address is now ignored when state=absent (https://github.com/ansible/ansible/issues/55348).
+
+bugfixes:
+  - xenserver_guest - proper error message is shown when maximum number of network interfaces is reached and multiple network interfaces are added at once.
+  - xenserver_guest - fixed an issue where VM whould be powered off even though check mode is used if reconfiguration requires VM to be powered off.

--- a/lib/ansible/modules/cloud/xenserver/xenserver_guest.py
+++ b/lib/ansible/modules/cloud/xenserver/xenserver_guest.py
@@ -169,7 +169,7 @@ options:
     type: list
   wait_for_ip_address:
     description:
-    - Wait until XenServer detects an IP address for the VM.
+    - Wait until XenServer detects an IP address for the VM. If C(state) is set to C(absent), this parameter is ignored.
     - This requires XenServer Tools to be preinstalled on the VM to work properly.
     type: bool
     default: no
@@ -597,15 +597,15 @@ class XenServerVM(XenServerObject):
 
         vm_power_state_save = self.vm_params['power_state'].lower()
 
-        if "need_poweredoff" in config_changes and vm_power_state_save != 'halted':
-            if self.module.params['force']:
-                self.set_power_state("shutdownguest")
-            else:
-                self.module.fail_json(msg="VM reconfigure: VM has to be in powered off state to reconfigure but force was not specified!")
+        if "need_poweredoff" in config_changes and vm_power_state_save != 'halted' and not self.module.params['force']:
+            self.module.fail_json(msg="VM reconfigure: VM has to be in powered off state to reconfigure but force was not specified!")
 
         # Support for Ansible check mode.
         if self.module.check_mode:
             return config_changes
+
+        if "need_poweredoff" in config_changes and vm_power_state_save != 'halted' and self.module.params['force']:
+            self.set_power_state("shutdownguest")
 
         try:
             for change in config_changes:
@@ -1632,6 +1632,7 @@ class XenServerVM(XenServerObject):
                         if vif_device not in vif_devices_allowed:
                             self.module.fail_json(msg="VM check networks[%s]: new network interface position %s is out of bounds!" % (position, vif_device))
 
+                        vif_devices_allowed.remove(vif_device)
                         vif_device_highest = vif_device
 
                         # For new VIFs we only track their position.
@@ -1911,7 +1912,7 @@ def main():
         vm.deploy()
         result['changed'] = True
 
-    if module.params['wait_for_ip_address']:
+    if module.params['wait_for_ip_address'] and module.params['state'] != "absent":
         vm.wait_for_ip_address()
 
     result['instance'] = vm.gather_facts()


### PR DESCRIPTION
Backport of #55678 to stable-2.8.

* XenServer: Minor changes and fixes in xenserver_guest

 - xenserver_guest module: ignore wait_for_ip_address when
   state=absent (fixes #55348). Module docs are updated to reflect this.
 - xenserver_guest module: show proper error message when maximum number
   of network interfaces is reached and multiple network interfaces are
   added at once (fix for changes introduced in #54697).
 - xenserver_guest module: fixed a bug in reconfigure() where VM would
   be powered off even though check mode is used when reconfiguration
   needs VM to be powered off.

* Added changelog fragment

(cherry picked from commit 2a39dc84b75599db0891398ccb7716601c56b139)

##### SUMMARY
Minor changes in module behaviour and fixes for minor bugs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xenserver_guest

##### ADDITIONAL INFORMATION
No additional info.