### PR TITLE
gitlab_group: fix sample code that used 'parent_path' which does not exists

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -114,7 +114,7 @@ EXAMPLES = '''
     name: my_first_group
     path: my_first_group
     state: present
-    parent_path: "super_parent/parent"
+    parent: "super_parent/parent"
 '''
 
 RETURN = '''


### PR DESCRIPTION

##### SUMMARY

Fix `gilab_group` sample documentation that use an invalid parameter.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

gitlab_group.py

##### ADDITIONAL INFORMATION

The sample refers to `parent_path` which is not supportted by the module.