### PR TITLE
vmware: check the SSL certification

### DIFF
--- a/changelogs/fragments/vmware_check_ssl_cert.yaml
+++ b/changelogs/fragments/vmware_check_ssl_cert.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware - The VMware modules now enable the SSL certificate check unless ``validate_certs`` is ``false``.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -514,10 +514,11 @@ def connect_to_api(module, disconnect_atexit=True):
         module.fail_json(msg='pyVim does not support changing verification mode with python < 2.7.9. Either update '
                              'python or use validate_certs=false.')
 
-    ssl_context = None
-    if not validate_certs and hasattr(ssl, 'SSLContext'):
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        ssl_context.verify_mode = ssl.CERT_NONE
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+    if validate_certs:
+        ssl_context.verify_mode = ssl.CERT_REQUIRED
+        ssl_context.check_hostname = True
+        ssl_context.load_default_certs()
 
     service_instance = None
     try:


### PR DESCRIPTION
##### SUMMARY

If `validate_certs` is enable, we now validate the server SSL
certificate.

(cherry picked from commit 23e63c9237299dfbb9300899d6c36cbea8155bc0)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->