### PR TITLE
[stable-2.8] Disable failing hcloud integration tests.

### DIFF
--- a/test/integration/targets/hcloud_server/aliases
+++ b/test/integration/targets/hcloud_server/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_ssh_key/aliases
+++ b/test/integration/targets/hcloud_ssh_key/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Disable failing hcloud integration tests.

Backport of https://github.com/ansible/ansible/pull/56272

(cherry picked from commit 87d42ca11ca20af8fb30a1873619261c62e52364)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

hcloud integration tests
