### PR TITLE
[WIP] [2.8] connection/docker: add support for privilege escalation

### DIFF
--- a/changelogs/fragments/53385-docker-privilege-escalation.yml
+++ b/changelogs/fragments/53385-docker-privilege-escalation.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+ - Fix privilege escalation support for the docker connection plugin when
+   credentials needs to be supplied (e.g. sudo with password).

--- a/changelogs/fragments/53385-docker-privilege-escalation.yml
+++ b/changelogs/fragments/53385-docker-privilege-escalation.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
  - Fix privilege escalation support for the docker connection plugin when
-   credentials needs to be supplied (e.g. sudo with password).
+   credentials need to be supplied (e.g. sudo with password).


### PR DESCRIPTION
##### SUMMARY
Backport of #55816 and #56288 to stable-2.8. Fixes privilege escalation for `docker` connection plugin if a passphrase is required.

CC @larsks 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/docker.py
