### PR TITLE
[2.8] VMware: Add examples of folder in vmware_deploy_ovf

### DIFF
--- a/changelogs/fragments/51825-vmware_deploy_ovf-add_folder_doc.yml
+++ b/changelogs/fragments/51825-vmware_deploy_ovf-add_folder_doc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added documentation about the folder parameter with examples in vmware_deploy_ovf (https://github.com/ansible/ansible/issues/51825).

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -65,6 +65,16 @@ options:
         description:
         - Absolute path of folder to place the virtual machine.
         - If not specified, defaults to the value of C(datacenter.vmFolder).
+        - 'Examples:'
+        - '   folder: /ha-datacenter/vm'
+        - '   folder: ha-datacenter/vm'
+        - '   folder: /datacenter1/vm'
+        - '   folder: datacenter1/vm'
+        - '   folder: /datacenter1/vm/folder1'
+        - '   folder: datacenter1/vm/folder1'
+        - '   folder: /folder1/datacenter1/vm'
+        - '   folder: folder1/datacenter1/vm'
+        - '   folder: /folder1/datacenter1/vm/folder2'
     inject_ovf_env:
         description:
         - Force the given properties to be inserted into an OVF Environment and injected through VMware Tools.


### PR DESCRIPTION
##### SUMMARY
Fixes: #51825

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 748cfd89ab087bdfe1eab98de164c7c226705911)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/51825-vmware_deploy_ovf-add_folder_doc.yml
lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py