### PR TITLE
nxos_snmp_user: platform fixes for get_snmp_user (#55832)

### DIFF
--- a/changelogs/fragments/nxos_snmp_user28.yaml
+++ b/changelogs/fragments/nxos_snmp_user28.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_snmp_user fix platform fixes for get_snmp_user (https://github.com/ansible/ansible/pull/55832).

--- a/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -4,10 +4,21 @@
   when: ansible_connection == "local"
 
 - name: Remove snmp user
-  nxos_snmp_user: &remove
+  nxos_snmp_user: &remove_snmp_user
     user: ntc
     provider: "{{ connection }}"
     state: absent
+  ignore_errors: yes
+  when: platform is not search('N5K|N6K|N9K-F')
+
+- name: Remove user workaround
+  # Some platforms will not allow snmp_user to remove the last role
+  nxos_user: &workaround_remove_user
+    name: ntc
+    provider: "{{ connection }}"
+    state: absent
+  ignore_errors: yes
+  when: platform is search('N5K|N6K|N9K-F')
 
 - pause:
     seconds: 5
@@ -64,27 +75,35 @@
 
   - assert: *false
 
-  - name: delete snmp user
-    nxos_snmp_user: &remove1
-      user: ntc
-      group: network-operator
-      provider: "{{ connection }}"
-      state: absent
-    register: result
+  - block:
+    # Some platforms will not allow snmp_user to remove the last role
+    - name: delete snmp user
+      nxos_snmp_user: &remove1
+        user: ntc
+        group: network-operator
+        provider: "{{ connection }}"
+        state: absent
+      register: result
 
-  - assert: *true
+    - assert: *true
 
-  - pause:
-      seconds: 5
+    - pause:
+        seconds: 5
 
-  - name: "Remove Idempotence"
-    nxos_snmp_user: *remove1
-    register: result
+    - name: "Remove Idempotence"
+      nxos_snmp_user: *remove1
+      register: result
 
-  - assert: *false
+    - assert: *false
+    when: platform is not search('N5K|N6K|N9K-F')
 
   always:
     - name: delete snmp user
-      nxos_snmp_user: *remove
+      nxos_snmp_user: *remove_snmp_user
+      when: platform is not search('N5K|N6K|N9K-F')
+
+    - name: remove user workaround
+      nxos_user: *workaround_remove_user
+      when: platform is search('N5K|N6K|N9K-F')
 
 - debug: msg="END connection={{ ansible_connection }} nxos_snmp_user sanity test"


### PR DESCRIPTION
##### SUMMARY
* nxos_snmp_user: platform fixes for get_snmp_user

snmp user output behavior varies quite a bit for the different nxos platforms and required several workarounds:

- N5K/N6k
 - These platforms do not support structured output for `show snmp user`.
 - The current code lands in an `except` clause when the output is not structured; so I added a new `get_non_structured_snmp_user` method to scrape the state from the regular cli output if it's present.

- N9K-F
 - The `group` data in the JSON output is different for this platform; it has a different key (just `group` instead of `TABLE_groups` or `group_names`) and it is not indexed
 - For a single group the value is a string, for multiple groups it's a list

- sanity
 - N5K/N6K/N9K-F platforms will reject `no snmp user <name> <role>` when it's the last role defined for the user.
 - workaround is to use `nxos_user` to remove the user

- Changes validated on:
 - `N3K, N3K-F, N35, N6K, N7K, N9K, N9K-F`
 - `6.0(2)A8`
 - `7.0(3)I2, 7.0(3)I4, 7.0(3)I5, 7.0(3)I6, 7.0(3)I7`
 - `7.3(2)D1`
 - `7.3(3)N1, 7.3(4)N1`
 - `8.3(2)`
 - `9.2(2), 9.2(3)`

* fix lint warning

(cherry picked from commit 8c56c116e5eed1726b6012640d05d70ab108350b)


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request