### PR TITLE
VMware: support folder param in vmware_vm_facts

### DIFF
--- a/changelogs/fragments/56125-vmware_vm_facts-use_folder.yml
+++ b/changelogs/fragments/56125-vmware_vm_facts-use_folder.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_facts supports folder as a filter to gather fact for VM (https://github.com/ansible/ansible/issues/56125).

--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -10,8 +10,8 @@
     setup_datastore: true
     setup_virtualmachines: true
 
-
-- name: Get facts about available vms
+- &vm_data
+  name: Get facts about available vms
   vmware_vm_facts:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
@@ -21,7 +21,8 @@
 
 - debug: var=vm_facts_0001
 
-- name: Verify if VM facts exist
+- &vm_fact_check
+  name: Verify if VM facts exist
   assert:
     that:
       - "item.esxi_hostname is defined"
@@ -36,17 +37,37 @@
   vars:
     query: "[?guest_name=='DC0_H0_VM0']"
 
+- <<: *vm_data
+  name: Get facts about available vms in check mode
+  check_mode: yes
 
-- name: Get facts about available vms in check mode
-  vmware_vm_facts:
+- <<: *vm_fact_check
+  name: Verify if VM facts exist in check mode
+
+- name: Get folder name from VM
+  vmware_guest_find:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-  register: vm_facts_0001
-  check_mode: yes
+    name: "DC0_H0_VM0"
+  register: folder_path_info
 
-- name: Verify if VM facts exist in check mode
+- set_fact:
+    folder_path: "{{ folder_path_info.folders[0] }}"
+  when: folder_path_info.folders is defined
+
+- name: Gather facts about VM using folder
+  vmware_vm_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    folder: "{{ folder_path }}"
+  register: vm_facts
+  when: folder_path_info.folders is defined
+
+- name: Check if facts are returned for VM with folder specified
   assert:
     that:
       - "item.esxi_hostname is defined"
@@ -56,8 +77,7 @@
       - "item.power_state is defined"
       - "item.uuid is defined"
       - "item.vm_network is defined"
-      - "item.attributes is defined"
   with_items:
-    - "{{ vm_facts_0001.virtual_machines | json_query(query) }}"
+    - "{{ vm_facts.virtual_machines | json_query(query) }}"
   vars:
     query: "[?guest_name=='DC0_H0_VM0']"


### PR DESCRIPTION
##### SUMMARY
folder can be used as a filter while gathering facts about VMs.

Fixes: #56125

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/56125-vmware_vm_facts-use_folder.yml
lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
test/integration/targets/vmware_vm_facts/tasks/main.yml
