### PR TITLE
Missed change to dev_guide documenting-modules page

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -117,7 +117,7 @@ Module documentation should briefly and accurately define what each module and o
     * Descriptions should always start with a capital letter and end with a full stop. Consistency always helps.
     * Verify that arguments in doc and module spec dict are identical.
     * For password / secret arguments no_log=True should be set.
-    * If an optional parameter is sometimes required, reflect this fact in the documentation, e.g. "Required when I(state=present)."
+    * If an option is only sometimes required, describe the conditions. For example, "Required when I(state=present)."
     * If your module allows ``check_mode``, reflect this fact in the documentation.
 
 Each documentation field is described below. Before committing your module documentation, please test it at the command line and as HTML:


### PR DESCRIPTION
##### SUMMARY

This makes the wording match in both places where we tell people to add "Required when" conditions to the module documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
