### PR TITLE
WIP: Drop tox.ini for ansible-test to 1.4.2

### DIFF
--- a/test/runner/tox.ini
+++ b/test/runner/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-minversion = 2.5.0
+minversion = 1.4.2
 
 [testenv]
 changedir = {toxinidir}/../../


### PR DESCRIPTION
##### SUMMARY
Lower the tox requirement to 1.4.2 so we can run against centos-7. This is the default version of tox that ships with centos-7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ADDITIONAL INFORMATION
This is for python2.7 testing using centos-7 as controller.