### PR TITLE
some logging fixes

### DIFF
--- a/changelogs/fragments/logging_updates.yml
+++ b/changelogs/fragments/logging_updates.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - several minor fixes to ansible logging, allow deterministic log name, better level matching, leaner setup.

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -63,7 +63,7 @@ if getattr(C, 'DEFAULT_LOG_PATH'):
     path = C.DEFAULT_LOG_PATH
     if path and (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
         logging.basicConfig(filename=path, level=logging.INFO, format='%(asctime)s p=%(user)s u=%(process)d | %(message)s')
-        logger = logging.LoggerAdapter(logging.getLogger(__name__), {'user': getpass.getuser()})
+        logger = logging.LoggerAdapter(logging.getLogger('ansible'), {'user': getpass.getuser()})
         for handler in logging.root.handlers:
             handler.addFilter(FilterBlackList(getattr(C, 'DEFAULT_LOG_FILTER', [])))
     else:

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -34,7 +34,7 @@ from struct import unpack, pack
 from termios import TIOCGWINSZ
 
 from ansible import constants as C
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.six import with_metaclass
 from ansible.utils.color import stringc
@@ -185,7 +185,7 @@ class Display(with_metaclass(Singleton, object)):
                     lvl = color_to_log_level[color]
                 except KeyError:
                     # this should not happen, but JIC
-                    AnsibleError('Invalid color supplied to display: %s' % color)
+                    raise AnsibleAssertionError('Invalid color supplied to display: %s' % color)
             # actually log
             logger.log(lvl, msg2)
 

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -185,7 +185,7 @@ class Display(with_metaclass(Singleton, object)):
                     lvl = color_to_log_level[color]
                 except KeyError:
                     # this should not happen, but JIC
-                    pass
+                    AnsibleError('Invalid color supplied to display: %s' % color)
             # actually log
             logger.log(lvl, msg2)
 


### PR DESCRIPTION
  fixes #25757, #25758, #25761
  alternative to #41859 and #25765

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
display

before:
```
2019-05-10 12:52:31,375 p=27869 u=bcoca |   [WARNING]: No inventory was parsed, only implicit localhost is available

2019-05-10 12:52:31,537 passlib.registry registered 'md5_crypt' handler: <class 'passlib.handlers.md5_crypt.md5_crypt'>
2019-05-10 12:52:31,774 p=27869 u=bcoca |  localhost | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```

after:
```
2019-05-10 12:49:01,788 p=bcoca u=26808 |  [WARNING]: No inventory was parsed, only implicit localhost is available

2019-05-10 12:49:02,176 p=bcoca u=26808 | localhost | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```

not sure it is worth passing levels if they are not reflected in file (well, we do error/warning/deprecation ..)