### PR TITLE
docs: display 'string' instead of '-' when 'type' isn't set

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -119,7 +119,7 @@ Parameters
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <div style="font-size: small">
-                        <span style="color: purple">@{ value.type | documented_type }@</span>
+                        <span style="color: purple">@{ value.type | default('string') | documented_type }@</span>
                         {% if value.get('required', False) %} / <span style="color: red">required</span>{% endif %}
                     </div>
                     {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}


### PR DESCRIPTION
##### SUMMARY
[docs] default type is `str`: display `string` instead of `-` when `type` isn't set

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
* without this change ([`zabbix_action` doc](https://docs.ansible.com/ansible/devel/modules/zabbix_action_module.html))
![Screenshot_2019-05-10_19-04-22](https://user-images.githubusercontent.com/1356830/57544483-fbbec800-7346-11e9-9947-78fe45a0036f.png)
* with this change
![Screenshot_2019-05-10_19-05-10](https://user-images.githubusercontent.com/1356830/57544492-02e5d600-7347-11e9-8e7c-190dde48d20b.png)
