### PR TITLE
[2.8] VMware: vmware_guest_disk support for use_instance_uuid

### DIFF
--- a/changelogs/fragments/56021-vmware_guest_disk-use_instance_uuid.yml
+++ b/changelogs/fragments/56021-vmware_guest_disk-use_instance_uuid.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest_disk module supports use_instance_uuid parameter since Ansible 2.8 (https://github.com/ansible/ansible/issues/56021).

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -880,10 +880,10 @@ class PyVmomi(object):
         """
         vm_obj = None
         user_desired_path = None
-
-        if self.params['uuid'] and not self.params['use_instance_uuid']:
+        use_instance_uuid = self.params.get('use_instance_uuid') or False
+        if self.params['uuid'] and not use_instance_uuid:
             vm_obj = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid")
-        elif self.params['uuid'] and self.params['use_instance_uuid']:
+        elif self.params['uuid'] and use_instance_uuid:
             vm_obj = find_vm_by_id(self.content,
                                    vm_id=self.params['uuid'],
                                    vm_id_type="instance_uuid")

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -60,6 +60,12 @@ options:
      description:
      - The datacenter name to which virtual machine belongs to.
      required: True
+   use_instance_uuid:
+     description:
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
+     type: bool
+     version_added: '2.8'
    disk:
      description:
      - A list of disks to add.
@@ -630,6 +636,7 @@ def main():
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
         disk=dict(type='list', default=[]),
+        use_instance_uuid=dict(type='bool', default=False),
     )
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=[['name', 'uuid']])


### PR DESCRIPTION
##### SUMMARY
All vmware_guest_* module support for use_instance_uuid from Ansible 2.8,
somehow vmware_guest_disk missed from this change.
This fix adds support for use_instance_uuid in vmware_guest_disk.

Fixes: #56021

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 7e6be4e634c08dfdc5fd9692533bcc52a5e25917)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/56021-vmware_guest_disk-use_instance_uuid.yml
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
