### PR TITLE
Add virt facts module for networks

### DIFF
--- a/lib/ansible/module_utils/virt.py
+++ b/lib/ansible/module_utils/virt.py
@@ -1,0 +1,127 @@
+# Copyright: (c) 2019, Chris Redit, github.com/chrisred
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.six import string_types
+from collections import defaultdict
+import traceback
+
+LXML_IMPORT_ERROR = None
+try:
+    from lxml import etree
+    HAS_LXML = True
+except ImportError:
+    LXML_IMPORT_ERROR = traceback.format_exc()
+    HAS_LXML = False
+
+
+class Config():
+    '''Represents the XML configuration of a libvirt resource. This should provide a simple interface
+    for accessing the configuration.'''
+    def __init__(self, module, xml):
+        if not HAS_LXML:
+            module.fail_json(msg=missing_required_lib('lxml'), exception=LXML_IMPORT_ERROR)
+
+        try:
+            self._etree = etree.fromstring(xml)
+        except etree.XMLSyntaxError as e:
+            module.fail_json(
+                msg='Error parsing libvirt XML config. ' + str(e),
+                exception=traceback.format_exc()
+            )
+
+    def __str__(self):
+        return etree.tostring(self._etree, encoding='utf-8')
+
+
+def etree_to_dict(element):
+    '''Convert an ElementTree object into a dictonary. The tag/attribute/text content of the XML
+    document is converted (in most cases) into key/value pairs in the resulting dictonary. For
+    duplicate tag names a list of dictionaries is generated.'''
+    parent = {element.tag: {} if element.attrib else ''}
+    children = list(element)
+    if children:
+        # create default dict using a list to deal with duplicate tags
+        dd = defaultdict(list)
+        for child in map(etree_to_dict, children):
+            for k, v in child.items():
+                # Append each child item to the list in the defaultdict, duplicate keys/tags get
+                # grouped together in the same list.
+                dd[k].append(v)
+        # Add the child dicts to the parent, the one item lists have the only value added,
+        # otherwise the whole list is added representing multiple elements with the same tag.
+        parent = {element.tag: dict([(k, v[0] if len(v) == 1 else v) for k, v in dd.items()])}
+    if element.attrib:
+        parent[element.tag].update(('@' + k, v) for k, v in element.attrib.items())
+    if element.text:
+        text = element.text.strip()
+        if children or element.attrib:
+            if text:
+                parent[element.tag]['#' + element.tag] = text
+        else:
+            # add only a text string if this is all the element contains
+            parent[element.tag] = text
+    return parent
+
+
+def flatten_dict(d, parent_key='', seperator='_'):
+    '''Convert nested dictonaries into a single "flat" dictonary by generating new concatenated keys
+    that combine the nested dictonaries into one. This will also handle list objects contained in the
+    dictonaries.'''
+    items = list()
+    for k, v in d.items():
+        # modify some of the key names to make the flattened key cleaner
+        if k[:1] == '#':
+            new_key = parent_key if parent_key else k[1:]
+        elif k[:1] == '@':
+            new_key = parent_key + seperator + k[1:] if parent_key else k[1:]
+        else:
+            new_key = parent_key + seperator + k if parent_key else k
+
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, seperator=seperator).items())
+        elif isinstance(v, list):
+            # Process a list of dicts, this occurs when there are elements with duplicate names
+            # in the source XML docuemnt the dictionary was generated from. If the duplicates are
+            # elements containing only a text node this can also be a list of strings.
+            items.append((new_key, [flatten_dict(i) if isinstance(i, dict) else i for i in v]))
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+def get_facts(config, wanted):
+    '''Access the properties of a Config object selected by the "wanted" parameter and process them to
+    be returned as facts. ElementTree objects are converted to dictonaries and flattened so that clean
+    JSON output can be generated.'''
+    facts = dict()
+    for key in wanted:
+        config_item = getattr(config, key)
+        if isinstance(config_item, string_types) or isinstance(config_item, int):
+            facts[key] = config_item
+        elif isinstance(config_item, list):
+            new_items = list()
+            for item in config_item:
+                if isinstance(item, etree._Element):
+                    # The first key in the output from etree_to_dict is the tag name for the current
+                    # element. This is not required as we use the oft identical property name from the
+                    # Config object, so select only the value here.
+                    item_value = list(etree_to_dict(item).values())[0]
+                    # An empty element selected by a property of the Config object won't return a dict
+                    # as it's value. Only run flatten_dict if we have a dict.
+                    if isinstance(item_value, dict):
+                        new_items.append(flatten_dict(item_value))
+                    else:
+                        new_items.append(item_value)
+                else:
+                    raise TypeError('Unexpected type when reading config property list.')
+            facts[key] = new_items
+        elif isinstance(config_item, etree._Element):
+            key_value = list(etree_to_dict(config_item).values())[0]
+            facts[key] = flatten_dict(key_value) if isinstance(key_value, dict) else key_value
+        else:
+            facts[key] = None
+    return facts

--- a/lib/ansible/modules/cloud/misc/virt_net_facts.py
+++ b/lib/ansible/modules/cloud/misc/virt_net_facts.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2019, Chris Redit, github.com/chrisred
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+module: virt_net_facts
+short_description: Retrieve facts about a libvirt virtual network.
+description: Retrieve facts about a libvirt virtual network. Facts from the file config and live config
+  are both retrieved when applicable.
+version_added: "2.9"
+author: Chris Redit (@chrisred)
+options:
+  name:
+    description: Defines the name of the virtual network(s) to retrieve facts for. If no I(name)
+      parameter is provided all virtual networks on the host will be retrieved.
+    type: list
+  uri:
+    description: The libvirt connection URI.
+    default: qemu:///system
+    type: str
+notes:
+  - Facts are generated from the XML configuration of the virtual network. The keys returned for each
+    of the items listed in the return values can vary based on the network configuration.
+requirements:
+  - python >= 2.6
+  - python-lxml
+  - libvirt-python
+'''
+
+EXAMPLES = '''
+- name: Retrieve facts for all the networks on a host
+  virt_net_facts:
+
+- name: Retrieve facts for the networks mynet1 and mynet2
+  virt_net_facts: name=mynet1,mynet2
+
+- name: Retrieve the name of the associated bridge device for each network on the host
+  virt_net_facts:
+- debug:
+    msg: "{{item.key}}: {{item.value.bridge.name}}"
+  loop: "{{virt_networks | dict2items}}"
+  loop_control:
+    label: "{{item.key}}"
+'''
+
+RETURN = '''
+virt_networks:
+  description: Facts retrieved from the persistent virtual network config, with the virtual network
+    name as a key.
+  returned: always
+  type: complex
+  contains:
+    active:
+      description: Defines whether the network is active or stopped.
+      returned: success
+      type: bool
+    autostart:
+      description: Defines whether the network will start automatically after the host has booted.
+      returned: success
+      type: bool
+    connections:
+      description: The number of network interfaces currently connected via this network from a domain.
+      returned: success
+      type: str
+    mac_address:
+      description: The MAC address assigned to the bridge device defined for the network.
+      returned: success
+      type: str
+    name:
+      description: The short name for the network.
+      returned: success
+      type: str
+    persistent:
+      description: Defines whether the network is persistent or transient.
+      returned: success
+      type: bool
+    uuid:
+      description: The globally unique identifier for the network.
+      returned: success
+      type: str
+    bridge:
+      description: The bridge device defined for the network.
+      returned: success
+      type: complex
+    dns:
+      description: The DNS server defined for the network.
+      returned: success
+      type: complex
+    domain:
+      description: The DNS domain defined for the network's DHCP server.
+      returned: success
+      type: complex
+    forward:
+      description: The forwarding defined for the network.
+      returned: success
+      type: complex
+    mtu:
+      description: The maximum transmission unit (MTU) defined for the network.
+      returned: success
+      type: complex
+    virtualport:
+      description: The virtual ports (VEPA) defined for the network.
+      returned: success
+      type: complex
+    vlan:
+      description: The guest-transparent VLAN tagging defined for the network.
+      returned: success
+      type: complex
+    ip:
+      description: The IPv4 or IPv6 address assigned to the bridge device defined for the network.
+      returned: success
+      type: complex
+    portgroup:
+      description: The port group defined for the network.
+      returned: success
+      type: complex
+    static_route:
+      description: The static route definitions provided to the host for the network.
+      returned: success
+      type: complex
+virt_networks_live:
+  description: Facts retrieved from the live virtual network config, with the virtual network name
+    as a key. This contains an identical set of return values as the C(virt_networks) key.
+  returned: always
+  type: complex
+  contains: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.virt import Config, etree_to_dict, flatten_dict, get_facts
+import traceback
+
+LIBVIRT_IMPORT_ERROR = None
+try:
+    import libvirt
+    HAS_LIBVIRT = True
+except ImportError:
+    LIBVIRT_IMPORT_ERROR = traceback.format_exc()
+    HAS_LIBVIRT = False
+
+
+class NetworkConfig(Config):
+    @property
+    def connections(self):
+        return self._etree.find('.').attrib.get('connections')
+
+    @property
+    def mac_address(self):
+        return self._etree.find('./mac').attrib.get('address')
+
+    @property
+    def name(self):
+        return self._etree.findtext('./name')
+
+    @property
+    def uuid(self):
+        return self._etree.findtext('./uuid')
+
+    @property
+    def bridge(self):
+        return self._etree.find('./bridge')
+
+    @property
+    def dns(self):
+        return self._etree.find('./dns')
+
+    @property
+    def domain(self):
+        return self._etree.find('./domain')
+
+    @property
+    def forward(self):
+        return self._etree.find('./forward')
+
+    @property
+    def mtu(self):
+        return self._etree.find('./mtu')
+
+    @property
+    def virtualport(self):
+        return self._etree.find('./virtualport')
+
+    @property
+    def vlan(self):
+        return self._etree.find('./vlan')
+
+    @property
+    def ip(self):
+        return self._etree.findall('./ip')
+
+    @property
+    def portgroup(self):
+        return self._etree.findall('./portgroup')
+
+    @property
+    def static_route(self):
+        return self._etree.findall('./route')
+
+
+def main():
+    module_args = dict(
+        name=dict(type='list'),
+        uri=dict(type='str', default='qemu:///system'),
+    )
+
+    host = None
+    config_live = None
+    config_file = None
+    active = False
+    autostart = None
+    persistent = True
+    facts_file = dict()
+    facts_live = dict()
+    networks = list()
+    module = AnsibleModule(module_args, supports_check_mode=True)
+    name = module.params['name']
+
+    if not HAS_LIBVIRT:
+        module.fail_json(msg=missing_required_lib('libvirt'), exception=LIBVIRT_IMPORT_ERROR)
+
+    try:
+        host = libvirt.open(module.params['uri'])
+        try:
+            if name is not None and isinstance(name, list):
+                networks = [host.networkLookupByName(item) for item in name]
+            else:
+                networks = host.listAllNetworks(
+                    libvirt.VIR_CONNECT_LIST_NETWORKS_PERSISTENT |
+                    libvirt.VIR_CONNECT_LIST_NETWORKS_TRANSIENT
+                )
+        except libvirt.libvirtError:
+            module.fail_json(msg='Network(s) not found on this host.')
+
+        # the properties of the Config object that will be returned as facts
+        wanted_properties = [
+            'connections', 'mac_address', 'name', 'uuid', 'bridge', 'dns', 'domain', 'forward', 'mtu',
+            'virtualport', 'vlan', 'ip', 'portgroup', 'static_route'
+        ]
+
+        for network in networks:
+            if network.isPersistent():
+                config_file = NetworkConfig(module, network.XMLDesc(libvirt.VIR_NETWORK_XML_INACTIVE))
+                autostart = True if network.autostart() else False
+
+                if network.isActive():
+                    config_live = NetworkConfig(module, network.XMLDesc())
+                    active = True
+            else:
+                # a transient network only has a "live" configuration
+                config_live = NetworkConfig(module, network.XMLDesc())
+                active = True
+                persistent = False
+
+            if config_file:
+                facts_file[config_file.name] = get_facts(config_file, wanted_properties)
+                facts_file[config_file.name]['active'] = active
+                facts_file[config_file.name]['autostart'] = autostart
+                facts_file[config_file.name]['persistent'] = persistent
+
+            if config_live:
+                facts_live[config_live.name] = get_facts(config_live, wanted_properties)
+                facts_live[config_live.name]['active'] = active
+                facts_live[config_live.name]['autostart'] = autostart
+                facts_live[config_live.name]['persistent'] = persistent
+
+        module.exit_json(
+            changed=False,
+            ansible_facts=dict(
+                virt_networks=facts_file if len(facts_file) > 0 else None,
+                virt_networks_live=facts_live if len(facts_live) > 0 else None,
+            ),
+        )
+
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        if host is not None:
+            host.close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
A facts module for libvirt virtual networks. Facts are (mostly) generated from the XML configuration of the network, the XML document is loaded through a Config object to allow selected elements to be returned keeping the JSON output clean.

As facts are parsed from the XML config the keys returned can differ slightly depending on the resource configuration. However a key for each main config "item" is always present to provide a stable set of return values.

`module_utils/virt.py` is also included in this commit and contains shared functions used in this module and intended for use in other virt "facts" modules which parse the XML config of a libvirt resource. Additional pull requests to be generated separately for domain (VM) and storage pool modules will use these "utils" functions.

Related to #27905 about issues with the existing virt modules.

_For reference #56085 has this network facts module along with the others for domains and pools. As per the guidelines they are being split into separate pull requests._

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
`virt_net_facts`

##### ADDITIONAL INFORMATION
Example output from a simple virtual network.
```
lab-ln-kvm1 | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python",
        "virt_networks": {
            "host-only": {
                "active": false,
                "autostart": true,
                "bridge": {
                    "delay": "0",
                    "name": "virbr1",
                    "stp": "on"
                },
                "connections": null,
                "dns": null,
                "domain": null,
                "forward": null,
                "ip": [
                    {
                        "address": "192.168.123.1",
                        "dhcp_range_end": "192.168.123.254",
                        "dhcp_range_start": "192.168.123.2",
                        "netmask": "255.255.255.0"
                    }
                ],
                "mac_address": "52:54:00:6f:7c:62",
                "mtu": null,
                "name": "host-only",
                "persistent": true,
                "portgroup": [],
                "static_route": [],
                "uuid": "40a77b1f-00a2-4464-9522-6bbcc74f5341",
                "virtualport": null,
                "vlan": null
            }
        },
        "virt_networks_live": null
    },
    "changed": false
}

```
