### PR TITLE
iam_role.py remove_policies should remove all absent policies

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -220,7 +220,7 @@ def remove_policies(connection, module, policies_to_remove, params):
         except BotoCoreError as e:
             module.fail_json(msg="Unable to detach policy {0} from {1}: {2}".format(policy, params['RoleName'], to_native(e)),
                              exception=traceback.format_exc())
-        return True
+    return True
 
 
 def create_or_update_role(connection, module):


### PR DESCRIPTION
The remove_policies function in iam_role.py enumerates a list of policies to remove. However, due to an indentation issue on the return True line, only the first such policy would be removed.

This change outdents the return True so that all of the the requested policies are removed.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #56329

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iam_role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```