### PR TITLE
cassandra_backup module

### DIFF
--- a/lib/ansible/modules/database/cassandra/cassandra_backup.py
+++ b/lib/ansible/modules/database/cassandra/cassandra_backup.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-ANSIBLE_METADATA =\{
+ANSIBLE_METADATA ={
     "metadata_version": "1.1",
     "status": ['preview'],
     "supported_by": "community"

--- a/lib/ansible/modules/database/cassandra/cassandra_backup.py
+++ b/lib/ansible/modules/database/cassandra/cassandra_backup.py
@@ -5,20 +5,18 @@
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
-import socket
-__metaclass__ = type
+
 
 ANSIBLE_METADATA =\
             {"metadata_version": "1.1",
-             "status": "['preview']",
+             "status": ['preview'],
              "supported_by": "community"}
 
 DOCUMENTATION = '''
 ---
 module: cassandra_backup
-author: "Rhys Campbell (rhys.james.campbell@googlemail.com)"
-version_added: 2.8
+author: "Rhys Campbell"
+version_added: 2.9
 short_description: Enables or disables incremental backup.
 requirements: [ nodetool ]
 description:
@@ -27,8 +25,7 @@ options:
   host:
     description:
       - The hostname.
-    type: string
-    default: "localhost"
+    type: str
   port:
     description:
       - The Cassandra TCP port.
@@ -37,23 +34,24 @@ options:
   password:
     description:
       - The password to authenticate with.
-    type: string
+    type: str
   password_file:
     description:
       - Path to a file containing the password.
-    type: string
+    type: str
   username:
     description:
       - The username to authenticate with.
-    type: string
+    type: str
   state:
     description:
       - The required status
-    type: choices [ "enabled", "disabled" ]
+    type: str
+    choices: [ "enabled", "disabled" ]
   nodetool_path:
     description:
       - The path to nodetool.
-    type: string
+    type: str
   debug:
     description:
       - Enable additional debug output.
@@ -76,6 +74,11 @@ cassandra_backup:
   returned: success
   type: str
 '''
+
+
+from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
+import socket
+__metaclass__ = type
 
 
 class NodeToolCmd(object):
@@ -188,7 +191,7 @@ def main():
             if out == status_active:
                 module.exit_json(changed=True, msg="check mode", **result)
             else:
-                module.exit_json(changed=False,  msg="check mode", **result)
+                module.exit_json(changed=False, msg="check mode", **result)
         if out == status_active:
             (rc, out, err) = n.disable_command()
             if out:

--- a/lib/ansible/modules/database/cassandra/cassandra_backup.py
+++ b/lib/ansible/modules/database/cassandra/cassandra_backup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# 2019 Rhys Campbell <rhys.james.campbell@googlemail.com>
+# 2019 Rhys Campbell (@rhysmeister) <rhys.james.campbell@googlemail.com>
 # https://github.com/rhysmeister
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -15,7 +15,7 @@ ANSIBLE_METADATA =\
 DOCUMENTATION = '''
 ---
 module: cassandra_backup
-author: "Rhys Campbell"
+author: Rhys Campbell (@rhysmeister)
 version_added: 2.9
 short_description: Enables or disables incremental backup.
 requirements: [ nodetool ]

--- a/lib/ansible/modules/database/cassandra/cassandra_backup.py
+++ b/lib/ansible/modules/database/cassandra/cassandra_backup.py
@@ -7,10 +7,11 @@
 from __future__ import absolute_import, division, print_function
 
 
-ANSIBLE_METADATA =\
-  {"metadata_version": "1.1",
-   "status": ['preview'],
-   "supported_by": "community"}
+ANSIBLE_METADATA =\{
+    "metadata_version": "1.1",
+    "status": ['preview'],
+    "supported_by": "community"
+}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/database/cassandra/cassandra_backup.py
+++ b/lib/ansible/modules/database/cassandra/cassandra_backup.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python
+
+# 2019 Rhys Campbell <rhys.james.campbell@googlemail.com>
+# https://github.com/rhysmeister
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
+import socket
+__metaclass__ = type
+
+ANSIBLE_METADATA =\
+            {"metadata_version": "1.1",
+             "status": "['preview']",
+             "supported_by": "community"}
+
+DOCUMENTATION = '''
+---
+module: cassandra_backup
+author: "Rhys Campbell (rhys.james.campbell@googlemail.com)"
+version_added: 2.8
+short_description: Enables or disables incremental backup.
+requirements: [ nodetool ]
+description:
+    Enables or disables incremental backup.
+options:
+  host:
+    description:
+      - The hostname.
+    type: string
+    default: "localhost"
+  port:
+    description:
+      - The Cassandra TCP port.
+    type: int
+    default: 7199
+  password:
+    description:
+      - The password to authenticate with.
+    type: string
+  password_file:
+    description:
+      - Path to a file containing the password.
+    type: string
+  username:
+    description:
+      - The username to authenticate with.
+    type: string
+  state:
+    description:
+      - The required status
+    type: choices [ "enabled", "disabled" ]
+  nodetool_path:
+    description:
+      - The path to nodetool.
+    type: string
+  debug:
+    description:
+      - Enable additional debug output.
+    type: bool
+'''
+
+EXAMPLES = '''
+- name: Ensure Cassandra incremental backup feature is enabled
+  cassandra_backup:
+    state: enabled
+
+- name: Ensure Cassandra incremental backup feature is disabled
+  cassandra_backup:
+    state: disabled
+'''
+
+RETURN = '''
+cassandra_backup:
+  description: The return state of the executed command.
+  returned: success
+  type: str
+'''
+
+
+class NodeToolCmd(object):
+    """
+    This is a generic NodeToolCmd class for building nodetool commands
+    """
+
+    def __init__(self, module):
+        self.module = module
+        self.host = module.params['host']
+        self.port = module.params['port']
+        self.password = module.params['password']
+        self.password_file = module.params['password_file']
+        self.username = module.params['username']
+        self.nodetool_path = module.params['nodetool_path']
+        self.debug = module.params['debug']
+        if self.host is None:
+                self.host = socket.getfqdn()
+
+    def execute_command(self, cmd):
+        return self.module.run_command(cmd)
+
+    def nodetool_cmd(self, sub_command):
+        if self.nodetool_path is not None and len(self.nodetool_path) > 0 and \
+                not self.nodetool_path.endswith('/'):
+            self.nodetool_path += '/'
+        else:
+                self.nodetool_path = ""
+        cmd = "{0}nodetool --host {1} --port {2}".format(self.nodetool_path,
+                                                         self.host,
+                                                         self.port)
+        if self.username is not None:
+            cmd += " --username {0}".format(self.username)
+            if self.password_file is not None:
+                cmd += " --password-file {0}".format(self.password_file)
+            else:
+                cmd += " --password '{0}'".format(self.password)
+        # The thing we want nodetool to execute
+        cmd += " {0}".format(sub_command)
+        if self.debug:
+            print(cmd)
+        return self.execute_command(cmd)
+
+
+class NodeTool3PairCommand(NodeToolCmd):
+
+    """
+    Inherits from the NodeToolCmd class. Adds the following methods;
+
+        - status_command
+        - enable_command
+        - disable_command
+    """
+
+    def __init__(self, module, status_cmd, enable_cmd, disable_cmd):
+        NodeToolCmd.__init__(self, module)
+        self.status_cmd = status_cmd
+        self.enable_cmd = enable_cmd
+        self.disable_cmd = disable_cmd
+
+    def status_command(self):
+        return self.nodetool_cmd(self.status_cmd)
+
+    def enable_command(self):
+        return self.nodetool_cmd(self.enable_cmd)
+
+    def disable_command(self):
+        return self.nodetool_cmd(self.disable_cmd)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(type='str', default=None),
+            port=dict(type='int', default=7199),
+            password=dict(type='str', no_log=True),
+            password_file=dict(type='str', no_log=True),
+            username=dict(type='str', no_log=True),
+            state=dict(required=True, choices=['enabled', 'disabled']),
+            nodetool_path=dict(type='str', default=None, required=False),
+            debug=dict(type='bool', default=False, required=False)),
+        supports_check_mode=True)
+
+    status_cmd = 'statusbackup'
+    enable_cmd = 'enablebackup'
+    disable_cmd = 'disablebackup'
+    status_active = 'running'
+    status_inactive = 'not running'
+
+    n = NodeTool3PairCommand(module, status_cmd, enable_cmd, disable_cmd)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+
+    (rc, out, err) = n.status_command()
+    out = out.strip()
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    if module.params['state'] == "disabled":
+
+        if rc != 0:
+            module.fail_json(name=status_cmd,
+                             msg="status command failed", **result)
+        if module.check_mode:
+            if out == status_active:
+                module.exit_json(changed=True, msg="check mode", **result)
+            else:
+                module.exit_json(changed=False,  msg="check mode", **result)
+        if out == status_active:
+            (rc, out, err) = n.disable_command()
+            if out:
+                result['stdout'] = out
+            if err:
+                result['stderr'] = err
+        if rc != 0:
+            module.fail_json(name=disable_cmd,
+                             msg="disable command failed", **result)
+        else:
+            result['changed'] = True
+
+    elif module.params['state'] == "enabled":
+
+        if rc != 0:
+            module.fail_json(name=status_cmd,
+                             msg="status command failed", **result)
+        if module.check_mode:
+            if out == status_inactive:
+                module.exit_json(changed=True, msg="check mode", **result)
+            else:
+                module.exit_json(changed=False, msg="check mode", **result)
+        if out == status_inactive:
+            (rc, out, err) = n.enable_command()
+            if out:
+                result['stdout'] = out
+            if err:
+                result['stderr'] = err
+        if rc is not None and rc != 0:
+            module.fail_json(name=enable_cmd,
+                             msg="enable command failed", **result)
+        else:
+            result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/cassandra/cassandra_backup.py
+++ b/lib/ansible/modules/database/cassandra/cassandra_backup.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-ANSIBLE_METADATA ={
+ANSIBLE_METADATA = {
     "metadata_version": "1.1",
     "status": ['preview'],
     "supported_by": "community"

--- a/lib/ansible/modules/database/cassandra/cassandra_backup.py
+++ b/lib/ansible/modules/database/cassandra/cassandra_backup.py
@@ -8,9 +8,9 @@ from __future__ import absolute_import, division, print_function
 
 
 ANSIBLE_METADATA =\
-            {"metadata_version": "1.1",
-             "status": ['preview'],
-             "supported_by": "community"}
+  {"metadata_version": "1.1",
+   "status": ['preview'],
+   "supported_by": "community"}
 
 DOCUMENTATION = '''
 ---
@@ -96,7 +96,7 @@ class NodeToolCmd(object):
         self.nodetool_path = module.params['nodetool_path']
         self.debug = module.params['debug']
         if self.host is None:
-                self.host = socket.getfqdn()
+            self.host = socket.getfqdn()
 
     def execute_command(self, cmd):
         return self.module.run_command(cmd)
@@ -106,7 +106,7 @@ class NodeToolCmd(object):
                 not self.nodetool_path.endswith('/'):
             self.nodetool_path += '/'
         else:
-                self.nodetool_path = ""
+            self.nodetool_path = ""
         cmd = "{0}nodetool --host {1} --port {2}".format(self.nodetool_path,
                                                          self.host,
                                                          self.port)

--- a/test/integration/targets/cassandra_backup/aliases
+++ b/test/integration/targets/cassandra_backup/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group1

--- a/test/integration/targets/cassandra_backup/aliases
+++ b/test/integration/targets/cassandra_backup/aliases
@@ -1,3 +1,4 @@
 destructive
 needs/privileged
 shippable/posix/group1
+skip/rhel

--- a/test/integration/targets/cassandra_backup/aliases
+++ b/test/integration/targets/cassandra_backup/aliases
@@ -1,1 +1,3 @@
+destructive
+needs/privileged
 shippable/posix/group1

--- a/test/integration/targets/cassandra_backup/meta/main.yml
+++ b/test/integration/targets/cassandra_backup/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_cassandra

--- a/test/integration/targets/cassandra_backup/tasks/main.yml
+++ b/test/integration/targets/cassandra_backup/tasks/main.yml
@@ -1,0 +1,136 @@
+# test code for the cassandra_backup module
+# (c) 2019,  Rhys Campbell <rhys.james.campbell@googlemail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ===========================================================
+- name: Get incremental backup status 1
+  shell: nodetool -h $(hostname) statusbackup
+  register: backup_status
+
+- name: Assert incremental backup is not running 1
+  assert:
+    that: "'not running' == backup_status.stdout"
+
+- name: Turn on incremental backup with module
+  cassandra_backup:
+    state: "enabled"
+
+- name: Get incremental backup status 2
+  shell: nodetool -h $(hostname) statusbackup
+  register: backup_status
+
+- name: Assert incremental backup is running
+  assert:
+    that: "'running' == backup_status.stdout"
+
+- name: Turn off incremental backup with module
+  cassandra_backup:
+    state: "disabled"
+
+- name: Get incremental backup status 3
+  shell: nodetool -h $(hostname) statusbackup
+  register: backup_status
+
+- name: Assert incremental backup is not running 2
+  assert:
+    that: "'not running' == backup_status.stdout"
+
+- name: Execute with check_mode = True
+  cassandra_backup:
+    state: "enabled"
+  check_mode: true
+  register: backup_status
+
+- name: Assert increment backup status has changed (check_mode)
+  assert:
+    that: backup_status.changed == True
+
+- name: Get incremental backup status 4
+  shell: nodetool -h $(hostname) statusbackup
+  register: backup_status
+
+- name: Assert incremental backup is not running (after check_mode)
+  assert:
+    that: "'not running' == backup_status.stdout"
+
+- include_tasks: ../../setup_cassandra/tasks/cassandra_auth.yml
+  when: cassandra_auth_tests == True
+
+- name: Turn on incremental backup with auth
+  cassandra_backup:
+    state: "enabled"
+    username: "{{ cassandra_admin_user }}"
+    password: "{{ cassandra_admin_pwd }}"
+  register: backup_status
+  when: cassandra_auth_tests == True
+
+- name: Get incremental backup status 5
+  shell: nodetool -u {{ cassandra_admin_user }} -pw {{ cassandra_admin_pwd }} -h $(hostname) statusbackup
+  register: backup_status
+  when: cassandra_auth_tests == True
+
+- name: Assert incremental backup is running
+  assert:
+    that: "'running' == backup_status.stdout"
+  when: cassandra_auth_tests == True
+
+- name: Turn off incremental backup using password file
+  cassandra_backup:
+    state: "disabled"
+    username: "{{ cassandra_admin_user }}"
+    password_file: /etc/cassandra/jmxremote.password
+  register: backup_status
+  when: cassandra_auth_tests == True
+
+- name: Get incremental backup status 6
+  shell: nodetool -u {{ cassandra_admin_user }} -pw {{ cassandra_admin_pwd }} -h $(hostname) statusbackup
+  register: backup_status
+  when: cassandra_auth_tests == True
+
+- name: Assert incremental backup is running
+  assert:
+    that: "'not running' == backup_status.stdout"
+  when: cassandra_auth_tests == True
+
+- name: Test login failure handling
+  cassandra_backup:
+    state: "disabled"
+    username: "{{ cassandra_admin_user }}"
+    password: XXXXXXXXXXXXXXXXXXXXX
+  register: login_status
+  ignore_errors: true
+  when: cassandra_auth_tests == True
+
+- name: Assert failed login
+  assert:
+    that:
+      - login_status.failed == True
+      - "\"nodetool: Failed to connect to 'localhost:7199' - FailedLoginException: 'Invalid username or password'.\" == login_status.stderr_lines[0]"
+  when: cassandra_auth_tests == True
+
+- name: Test incorrect nodetool_path handling
+  cassandra_backup:
+    state: "disabled"
+    nodetool_path: /tmp
+  register: nodetool_path_error
+  ignore_errors: true
+  when: cassandra_auth_tests == True
+
+- name: Assert no such file
+  assert:
+    that:
+      - "'No such file or directory' in nodetool_path_error.msg"

--- a/test/integration/targets/cassandra_backup/vars/main.yml
+++ b/test/integration/targets/cassandra_backup/vars/main.yml
@@ -1,0 +1,1 @@
+cassandra_auth_tests: True

--- a/test/integration/targets/setup_cassandra/defaults/main.yml
+++ b/test/integration/targets/setup_cassandra/defaults/main.yml
@@ -1,0 +1,26 @@
+openjdk: java-1.8.0-openjdk
+
+cassandra_yum:
+  description: "Apache Cassandra"
+  name: cassandra_yum
+  baseurl: "https://www.apache.org/dist/cassandra/redhat/311x/"
+  enabled: yes
+  gpgcheck: yes
+  gpgkey: "https://www.apache.org/dist/cassandra/KEYS"
+
+cassandra_deb:
+  repo: deb http://www.apache.org/dist/cassandra/debian 311x main
+
+cassandra_yum_pkg: cassandra
+cassandra_deb_pkg: cassandra
+cassandra_service: cassandra
+
+cassandra_yml_file: "/etc/cassandra/conf/cassandra.yaml"
+cassandra_env_file: "/etc/cassandra/conf/cassandra-env.sh"
+cassandra_regexp: '^authenticator:'
+cassandra_authenticator: "authenticator: PasswordAuthenticator"
+cassandra_regexp_auth: '^authorizer:'
+cassandra_authorizer: "authorizer: CassandraAuthorizer"
+
+cassandra_admin_user: cassandra
+cassandra_admin_pwd: cassandra

--- a/test/integration/targets/setup_cassandra/handlers/main.yml
+++ b/test/integration/targets/setup_cassandra/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: redhat_remove_cassandra
+  yum:
+    name: "{{ cassandra_yum_pkg }}"
+    state: absent
+
+- name: redhat_remove_python3
+  yum:
+    name: python34*
+    state: absent

--- a/test/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
+++ b/test/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
@@ -101,4 +101,4 @@
       - "'Invalid username or password' in bad_login.stderr"
 
 - name: Test nodetool authentication with passwordFile
-  command: nodetool -u {{ cassandra_admin_user }}	-pwf /etc/cassandra/jmxremote.password status
+  command: nodetool -u {{ cassandra_admin_user }} -pwf /etc/cassandra/jmxremote.password status

--- a/test/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
+++ b/test/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
@@ -1,0 +1,104 @@
+# (c) 2019,  Rhys Campbell <rhys.james.campbell@googlemail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+
+- name: Set authenticator in cassandra.yml
+  lineinfile:
+    path: "{{ cassandra_yml_file }}"
+    regexp: "{{ cassandra_regexp }}"
+    line: "{{ cassandra_authenticator }}"
+
+- name: Set authorizer in cassandra.yml
+  lineinfile:
+    path: "{{ cassandra_yml_file }}"
+    regexp: "{{ cassandra_regexp_auth }}"
+    line: "{{ cassandra_authorizer}}"
+
+- name: Add lines for nodetool auth to cassandra-env.sh
+  blockinfile:
+    dest: "{{ cassandra_env_file }}"
+    block: |
+      JVM_OPTS="$JVM_OPTS -Djava.security.auth.login.config=$CASSANDRA_HOME/cassandra-jaas.config"
+      JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"
+
+#- name: Create password file
+#  tempfile:
+#    state: file
+#    suffix: temp
+#  register: pwd_file TO REMOVE
+
+#- name: Set password in pwd file
+#  shell: "echo {{ cassandra_admin_pwd }} > {{ pwd_file.path }}" TO REMOVE
+
+- name: Activate local jmx
+  lineinfile:
+    path:  "{{ cassandra_env_file }}"
+    regexp: '^if \[ \"\$LOCAL_JMX\" \= \"yes\" \]\; then'
+    line: 'if [ "$LOCAL_JMX" = "no" ]; then'
+
+- name: Set jmx password file
+  copy:
+    dest: /etc/cassandra/jmxremote.password
+    content: |
+      {{ cassandra_admin_user }} {{ cassandra_admin_pwd }}
+    mode: 0400
+    owner: cassandra
+    group: cassandra
+
+- name: Set jmx access file
+  copy:
+    dest: /etc/cassandra/jmxremote.access
+    content: |
+      {{ cassandra_admin_user }} readwrite
+    mode: 0400
+    owner: cassandra
+    group: cassandra
+
+- name: Set jmx auth options
+  blockinfile:
+    path: "{{ cassandra_env_file }}"
+    block: |
+      JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
+      JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.password.file=/etc/cassandra/jmxremote.password"
+      JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.access.file=/etc/cassandra/jmxremote.access"
+
+- name: Restart cassandra
+  service:
+    name: "{{ cassandra_service }}"
+    state: "restarted"
+
+- name: Wait for Cassandra to become active
+  wait_for:
+    port: 9042
+    host: 0.0.0.0
+    delay: 10
+
+- name: Test nodetool authentication from shell
+  command: nodetool -u {{ cassandra_admin_user }} -pw {{ cassandra_admin_pwd }} status
+
+- name: Test login fails with bad password
+  command: nodetool -u {{ cassandra_admin_user }} -pw XXXXXXXXXXXXX status
+  register: bad_login
+  ignore_errors: true
+
+- assert:
+    that:
+      - "'Invalid username or password' in bad_login.stderr"
+
+- name: Test nodetool authentication with passwordFile
+  command: nodetool -u {{ cassandra_admin_user }}	-pwf /etc/cassandra/jmxremote.password status

--- a/test/integration/targets/setup_cassandra/tasks/main.yml
+++ b/test/integration/targets/setup_cassandra/tasks/main.yml
@@ -1,0 +1,85 @@
+# (c) 2019,  Rhys Campbell <rhys.james.campbell@googlemail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+
+- meta: end_play
+  when: ansible_os_family not in  ['RedHat', 'Debian' ]
+
+# CassandraDaemon.java:749 - Local host name unknown: java.net.UnknownHostException: localhost.localdomain: localhost.localdomain: Name or service not known
+- command: hostname localhost
+
+- name: Install OpenJDK package
+  yum:
+    name: "{{ openjdk }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- name: Setup Cassandra yum repo
+  yum_repository:
+    name: "{{ cassandra_yum.name }}"
+    description: "{{ cassandra_yum.description }}"
+    baseurl: "{{ cassandra_yum.baseurl }}"
+    enabled: "{{ cassandra_yum.enabled }}"
+    gpgcheck: "{{ cassandra_yum.gpgcheck }}"
+    gpgkey: "{{ cassandra_yum.gpgkey }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: Install cassandra yum package
+  yum:
+    name: "{{ cassandra_yum_pkg }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+  notify:
+    - redhat_remove_cassandra
+    - redhat_remove_python3
+
+- name: Setup Cassandra apt repo
+  apt_repository:
+    repo: "{{ cassandra_deb.repo }}"
+    state: present
+  when: ansible_os_family == 'Debian'
+
+- name: Run the equivalent of "apt-get update"
+  apt:
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
+
+- name: Install cassandra deb package
+  apt:
+    name: "{{ cassandra_deb_pkg }}"
+    state: present
+    force: yes
+  when: ansible_os_family == 'Debian'
+
+- name: Adjust heap size
+  lineinfile:
+    path: /etc/cassandra/default.conf/cassandra-env.sh
+    regexp: "^MAX_HEAP_SIZE="
+    line: "MAX_HEAP_SIZE=256M"
+
+- name: Start Cassandra service
+  service:
+    name: "{{ cassandra_service }}"
+    enabled: "yes"
+    state: "restarted"
+
+- name: Allow a little time for Cassandra to start listening on ports
+  wait_for:
+    port: 9042
+    host: 0.0.0.0
+    delay: 10

--- a/test/integration/targets/setup_cassandra/tasks/main.yml
+++ b/test/integration/targets/setup_cassandra/tasks/main.yml
@@ -22,6 +22,7 @@
 
 # CassandraDaemon.java:749 - Local host name unknown: java.net.UnknownHostException: localhost.localdomain: localhost.localdomain: Name or service not known
 - command: hostname localhost
+  become: yes
 
 - name: Install OpenJDK package
   yum:


### PR DESCRIPTION
##### SUMMARY

A simple module for the Apache Cassandra database that allows the incremental backup feature to be managed on the node.

```
- name: Turn on incremental backup with module
  cassandra_backup:
    state: "enabled"

- name: Turn off incremental backup with module
  cassandra_backup:
    state: "disabled"
```

This is the first PR for a series of modules for managing the Cassandra database. A further 10 have already been developed and each encapsulates a function of the nodetool utility provided by the Cassandra distribution.

A full suite of integration tests for all these Cassandra modules have been produced and will be submitted in a separate PR from the modules.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

cassandra_backup