### PR TITLE
acme_certificate: allow to download alternate certificate chains

### DIFF
--- a/changelogs/fragments/56334-acme_certificate-alternate-chains.yml
+++ b/changelogs/fragments/56334-acme_certificate-alternate-chains.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - "acme_certificate - all alternate chains can be retrieved using the new ``retrieve_all_alternates`` option."

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -30,6 +30,7 @@ import traceback
 from ansible.module_utils._text import to_native, to_text, to_bytes
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.compat import ipaddress as compat_ipaddress
+from ansible.module_utils.six.moves.urllib.parse import unquote
 
 try:
     import cryptography
@@ -930,3 +931,13 @@ def set_crypto_backend(module):
         module.debug('Using cryptography backend (library version {0})'.format(CRYPTOGRAPHY_VERSION))
     else:
         module.debug('Using OpenSSL binary backend')
+
+
+def process_links(info, callback):
+    '''
+    Process link header, calls callback for every link header with the URL and relation as options.
+    '''
+    if 'link' in info:
+        link = info['link']
+        for url, relation in re.findall(r'<([^>]+)>;rel="(\w+)"', link):
+            callback(unquote(url), relation)

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -412,6 +412,7 @@ from ansible.module_utils.acme import (
     openssl_get_csr_identifiers,
     cryptography_get_cert_days,
     set_crypto_backend,
+    process_links,
 )
 
 import base64
@@ -427,14 +428,6 @@ from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.compat import ipaddress as compat_ipaddress
-from ansible.module_utils.six.moves.urllib.parse import unquote
-
-
-def process_links(info, callback):
-    if 'link' in info:
-        link = info['link']
-        for url, relation in re.findall(r'<([^>]+)>;rel="(\w+)"', link):
-            callback(unquote(url), relation)
 
 
 def get_cert_days(module, cert_file):

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -934,12 +934,12 @@ class ACMEClient(object):
                 def _append_all_chains(chain):
                     self.all_chains.append(dict(
                         chain=("\n".join(chain)).encode('utf8'),
-                        full_chain=(pem_cert + "\n".join(chain)).encode('utf8'),
+                        full_chain=(cert['cert'] + "\n".join(chain)).encode('utf8'),
                     ))
 
-                _append_all_chains(cert)
+                _append_all_chains(cert.get('chain', []))
                 for alt_chain in alternate_chains:
-                    _append_all_chains(alt_chain)
+                    _append_all_chains(alt_chain.get('chain', []))
 
         if cert['cert'] is not None:
             pem_cert = cert['cert']

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -200,9 +200,9 @@ options:
   retrieve_all_alternates:
     description:
       - "When set to C(yes), will retrieve all alternate chains offered by the ACME CA.
-         These will not be written to disk, be returned together with the main chain as
-         C(all_chains). See the documentation for the C(all_chains) return value for
-         details."
+         These will not be written to disk, but will be returned together with the main
+         chain as C(all_chains). See the documentation for the C(all_chains) return
+         value for details."
     type: bool
     default: no
     version_added: "2.9"

--- a/test/integration/targets/acme_certificate/tasks/impl.yml
+++ b/test/integration/targets/acme_certificate/tasks/impl.yml
@@ -57,6 +57,10 @@
     remaining_days: 10
     terms_agreed: yes
     account_email: "example@example.org"
+    retrieve_all_alternates: yes
+- name: Store obtain results for cert 1
+  set_fact:
+    cert_1_obtain_results: "{{ certificate_obtain_result }}"
 - name: Obtain cert 2
   include_tasks: obtain-cert.yml
   vars:
@@ -73,6 +77,9 @@
     remaining_days: 10
     terms_agreed: no
     account_email: ""
+- name: Store obtain results for cert 2
+  set_fact:
+    cert_2_obtain_results: "{{ certificate_obtain_result }}"
 - name: Obtain cert 3
   include_tasks: obtain-cert.yml
   vars:

--- a/test/integration/targets/acme_certificate/tests/validate.yml
+++ b/test/integration/targets/acme_certificate/tests/validate.yml
@@ -13,8 +13,8 @@
       - "'all_chains' in cert_1_obtain_results"
       - "'chain' in cert_1_obtain_results.all_chains[0]"
       - "'full_chain' in cert_1_obtain_results.all_chains[0]"
-      - "lookup('file', output_dir ~ '/cert-1-chain.pem') | b64decode == cert_1_obtain_results.all_chains[0].chain"
-      - "lookup('file', output_dir ~ '/cert-1-fullchain.pem') | b64decode == cert_1_obtain_results.all_chains[0].full_chain"
+      - "lookup('file', output_dir ~ '/cert-1-chain.pem', rstrip=False) == cert_1_obtain_results.all_chains[0].chain"
+      - "lookup('file', output_dir ~ '/cert-1-fullchain.pem', rstrip=False) == cert_1_obtain_results.all_chains[0].full_chain"
 
 - name: Check that certificate 2 is valid
   assert:

--- a/test/integration/targets/acme_certificate/tests/validate.yml
+++ b/test/integration/targets/acme_certificate/tests/validate.yml
@@ -7,6 +7,14 @@
   assert:
     that:
       - "'DNS:example.com' in cert_1_text.stdout"
+- name: Check that certificate 1 retrieval got all chains
+  assert:
+    that:
+      - "'all_chains' in cert_1_obtain_results"
+      - "'chain' in cert_1_obtain_results.all_chains[0]"
+      - "'full_chain' in cert_1_obtain_results.all_chains[0]"
+      - "lookup('file', output_dir ~ '/cert-1-chain.pem') | b64decode == cert_1_obtain_results.all_chains[0].chain"
+      - "lookup('file', output_dir ~ '/cert-1-fullchain.pem') | b64decode == cert_1_obtain_results.all_chains[0].full_chain"
 
 - name: Check that certificate 2 is valid
   assert:
@@ -17,6 +25,10 @@
     that:
       - "'DNS:*.example.com' in cert_2_text.stdout"
       - "'DNS:example.com' in cert_2_text.stdout"
+- name: Check that certificate 2 retrieval did not get all chains
+  assert:
+    that:
+      - "'all_chains' not in cert_2_obtain_results"
 
 - name: Check that certificate 3 is valid
   assert:

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -111,6 +111,8 @@
     terms_agreed: "{{ terms_agreed }}"
     account_email: "{{ account_email }}"
     data: "{{ challenge_data }}"
+    retrieve_all_alternates: "{{ retrieve_all_alternates | default(omit) }}"
+  register: certificate_obtain_result
   when: challenge_data is changed
 - name: ({{ certgen_title }}) Deleting HTTP challenges
   uri:

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -111,6 +111,7 @@
     terms_agreed: "{{ terms_agreed }}"
     account_email: "{{ account_email }}"
     data: "{{ challenge_data }}"
+  when: challenge_data is changed
 - name: ({{ certgen_title }}) Deleting HTTP challenges
   uri:
     url: "http://{{ acme_host }}:5000/http/{{ item.key }}/{{ item.value['http-01'].resource[('.well-known/acme-challenge/'|length):] }}"

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -26,7 +26,8 @@
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
-    account_key: "{{ output_dir }}/{{ account_key }}.pem"
+    account_key: "{{ (output_dir ~ '/' ~ account_key ~ '.pem') if account_key_content is not defined else omit }}"
+    account_key_content: "{{ account_key_content | default(omit) }}"
     modify_account: "{{ modify_account }}"
     csr: "{{ output_dir }}/{{ certificate_name }}.csr"
     dest: "{{ output_dir }}/{{ certificate_name }}.pem"
@@ -39,31 +40,6 @@
     terms_agreed: "{{ terms_agreed }}"
     account_email: "{{ account_email }}"
   register: challenge_data
-  when: account_key_content is not defined
-- name: ({{ certgen_title }}) Obtain cert, step 1 (using account key data)
-  acme_certificate:
-    select_crypto_backend: "{{ select_crypto_backend }}"
-    acme_version: 2
-    acme_directory: https://{{ acme_host }}:14000/dir
-    validate_certs: no
-    account_key_content: "{{ account_key_content }}"
-    modify_account: "{{ modify_account }}"
-    csr: "{{ output_dir }}/{{ certificate_name }}.csr"
-    dest: "{{ output_dir }}/{{ certificate_name }}.pem"
-    fullchain_dest: "{{ output_dir }}/{{ certificate_name }}-fullchain.pem"
-    chain_dest: "{{ output_dir }}/{{ certificate_name }}-chain.pem"
-    challenge: "{{ challenge }}"
-    deactivate_authzs: "{{ deactivate_authzs }}"
-    force: "{{ force }}"
-    remaining_days: "{{ remaining_days }}"
-    terms_agreed: "{{ terms_agreed }}"
-    account_email: "{{ account_email }}"
-  register: challenge_data_content
-  when: account_key_content is defined
-- name: ({{ certgen_title }}) Copy challenge data (when using account key data)
-  set_fact:
-    challenge_data: "{{ challenge_data_content }}"
-  when: account_key_content is defined
 - name: ({{ certgen_title }}) Print challenge data
   debug:
     var: challenge_data
@@ -120,7 +96,8 @@
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
-    account_key: "{{ output_dir }}/{{ account_key }}.pem"
+    account_key: "{{ (output_dir ~ '/' ~ account_key ~ '.pem') if account_key_content is not defined else omit }}"
+    account_key_content: "{{ account_key_content | default(omit) }}"
     account_uri: "{{ challenge_data.account_uri }}"
     modify_account: "{{ modify_account }}"
     csr: "{{ output_dir }}/{{ certificate_name }}.csr"
@@ -134,28 +111,6 @@
     terms_agreed: "{{ terms_agreed }}"
     account_email: "{{ account_email }}"
     data: "{{ challenge_data }}"
-  when: challenge_data is changed and account_key_content is not defined
-- name: ({{ certgen_title }}) Obtain cert, step 2 (using account key data)
-  acme_certificate:
-    select_crypto_backend: "{{ select_crypto_backend }}"
-    acme_version: 2
-    acme_directory: https://{{ acme_host }}:14000/dir
-    validate_certs: no
-    account_key_content: "{{ account_key_content }}"
-    account_uri: "{{ challenge_data.account_uri }}"
-    modify_account: "{{ modify_account }}"
-    csr: "{{ output_dir }}/{{ certificate_name }}.csr"
-    dest: "{{ output_dir }}/{{ certificate_name }}.pem"
-    fullchain_dest: "{{ output_dir }}/{{ certificate_name }}-fullchain.pem"
-    chain_dest: "{{ output_dir }}/{{ certificate_name }}-chain.pem"
-    challenge: "{{ challenge }}"
-    deactivate_authzs: "{{ deactivate_authzs }}"
-    force: "{{ force }}"
-    remaining_days: "{{ remaining_days }}"
-    terms_agreed: "{{ terms_agreed }}"
-    account_email: "{{ account_email }}"
-    data: "{{ challenge_data }}"
-  when: challenge_data is changed and account_key_content is defined
 - name: ({{ certgen_title }}) Deleting HTTP challenges
   uri:
     url: "http://{{ acme_host }}:5000/http/{{ item.key }}/{{ item.value['http-01'].resource[('.well-known/acme-challenge/'|length):] }}"


### PR DESCRIPTION
##### SUMMARY
Background: Let's Encrypt [announced](https://letsencrypt.org/2019/04/15/transitioning-to-isrg-root.html) that they want to switch to the new ISRG root certificate this summer, i.e. they will start delivering the intermediate certificate signed by their own root and not by the IdenTrust root. The consequence is that Let's Encrypt certs using this chain won't be supported by a lot of older devices and browsers which support the IdenTrust root, but not the ISRG root. (Support for the IdenTrust root is listed [here](https://letsencrypt.org/docs/certificate-compatibility/), there is unfortunately no similar listing of devices/browsers supporting the new root, except the statement [here](https://letsencrypt.org/2018/08/06/trusted-by-all-major-root-programs.html).) There have been some discussions about this ([here](https://community.letsencrypt.org/t/please-reconsider-defaulting-to-the-isrg-root-its-unsupported-by-more-than-50-of-android-phones/91485), [here](https://community.letsencrypt.org/t/please-update-the-certificate-compatibility-page-to-include-information-about-the-new-isrg-roots/91436/19)). **Update:** the root change has been [delayed by one year](https://community.letsencrypt.org/t/transitioning-to-isrgs-root/94056/1).

Anyway, the ACME protocol offers [a way for CAs to offer alternative chains](https://tools.ietf.org/html/rfc8555#section-7.4.2), and my hope is that Let's Encrypt will use that feature of the protocol to still deliver the old intermediate certificate. That would allow ACME clients to offer the "old" chain to the users without ugly hacks (see [here](https://community.letsencrypt.org/t/please-update-the-certificate-compatibility-page-to-include-information-about-the-new-isrg-roots/91436/13) for an example).

This is an experimental branch to play around with downloading alternate chains. Works so far with letsencrypt/pebble#234

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acme_certificate
