### PR TITLE
DOCS: Fix typo in aws log group return documentation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group.py
@@ -83,7 +83,7 @@ EXAMPLES = '''
 
 RETURN = '''
 log_groups:
-    description: Return the list of complex objetcs representing log groups
+    description: Return the list of complex objects representing log groups
     returned: success
     type: complex
     contains:


### PR DESCRIPTION
##### SUMMARY
Fix typo in aws log group return documentation

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
cloudwatchlogs_log_group

##### ADDITIONAL INFORMATION
N/A
