### PR TITLE
nxos_bgp_neighbor_af:sanity:6k: skip soft-reconfig 'always' test (#55661)

### DIFF
--- a/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
   when: ansible_connection == "local"
 
 - set_fact: soft_reconfiguration_ina="always"
-  when: imagetag and (imagetag is version_compare('D1', 'ne'))
+  when: imagetag is not search("D1|N1")
 
 - name: "Disable feature BGP"
   nxos_feature: &disable_bgp


### PR DESCRIPTION
##### SUMMARY
N5K / N6K do not support the `always` keyword on the `soft-reconfig in` configuration.

(cherry picked from commit 4798368b135c7cb6c96a094e1e570477793985aa)


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request
