### PR TITLE
nxos_snmp_traps:sanity: skip idempotency tests for I7 image bug (#55618)

### DIFF
--- a/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
@@ -54,15 +54,16 @@
   - assert: *true
 
   - block:
-    # On I2, link command does not work properly
+    # On I2/I7, link command does not work properly
     # On D1, callhome command does not work properly
     # skip for these older platforms
     - name: Idempotence Check
       nxos_snmp_traps: *config1
       register: result
+      when: imagetag is not search("I2|I7|D1")
 
     - assert: *false
-    when: imagetag is not search("I2|I7|D1")
+      when: imagetag is not search("I2|I7|D1")
 
   - name: Cleanup
     nxos_snmp_traps: *remove


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
nxos_snmp_traps:sanity: skip idempotency tests for I7 image bug
cherry-picked from https://github.com/ansible/ansible/commit/4d46f44ff21d36197ea8f2e54b3ebff15a78f986
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request
