### PR TITLE
nxos_ospf_vrf:sanity: ignore no default-metric idempotence tests when I7 images (#55615)

### DIFF
--- a/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
@@ -3,6 +3,10 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: def_met_default="default"
+  # CSCvi74876 Cannot remove default-metric
+  when: imagetag is not search("I7")
+
 - name: "Setup: disable feature OSPF for initial cleanup"
   nxos_feature:
     feature: ospf
@@ -73,7 +77,7 @@
     nxos_ospf_vrf: &config2
       ospf: 2
       auto_cost: default
-      default_metric: default
+      default_metric: "{{def_met_default|default(omit)}}"
       log_adjacency: default
       timer_throttle_spf_hold: default
       passive_interface: false
@@ -105,6 +109,7 @@
     register: result
 
   - assert: *false
+    when: def_met_default is defined
 
   - name: Unconfigure ospf vrf
     nxos_ospf_vrf: &unconfig
@@ -121,6 +126,7 @@
     register: result
 
   - assert: *false
+    when: def_met_default is defined
 
   always:
   - name: "Disable feature OSPF"


### PR DESCRIPTION
##### SUMMARY
* nxos_ospf_vrf:sanity: ignore no default-metric idempotence tests when I7 images

This is a sanity test cleanup to handle a known image bug with (N9K) I7 images.
The I7 image rejects 'no default-metric' configs, so we're skipping the idempotence
tests that involve this bug.

Tested on N9K images: 9.2(2), 7.0(3)I7, 7.0(3)I2

* simplify check for I7

(cherry picked from commit a568e018be0138e24b86a60de418b60c0da83195)


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request