### PR TITLE
Raise error in case of empty hosts list in playbook

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -103,6 +103,8 @@ class Play(Base, Taggable, CollectionSearch):
     @staticmethod
     def load(data, variable_manager=None, loader=None, vars=None):
         if ('name' not in data or data['name'] is None) and 'hosts' in data:
+            if data['hosts'] is None or all(host is None for host in data['hosts']):
+                raise AnsibleParserError("Hosts list cannot be empty - please check your playbook")
             if isinstance(data['hosts'], list):
                 data['name'] = ','.join(data['hosts'])
             else:


### PR DESCRIPTION
##### SUMMARY
Currently in case of playbook contaiing:
````
- hosts:
  -
````
ansible-playbook will fail with:
```
ERROR! Unexpected Exception, this is probably a bug: sequence item 0: expected string, NoneType found
the full traceback was:

Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 118, in <module>
    exit_code = cli.run()
  File "/usr/lib/python2.7/dist-packages/ansible/cli/playbook.py", line 122, in run
    results = pbex.run()
  File "/usr/lib/python2.7/dist-packages/ansible/executor/playbook_executor.py", line 81, in run
    pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
  File "/usr/lib/python2.7/dist-packages/ansible/playbook/__init__.py", line 54, in load
    pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
  File "/usr/lib/python2.7/dist-packages/ansible/playbook/__init__.py", line 106, in _load_playbook_data
    entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader)
  File "/usr/lib/python2.7/dist-packages/ansible/playbook/play.py", line 110, in load
    data['name'] = ','.join(data['hosts'])
TypeError: sequence item 0: expected string, NoneType found
```
##### ISSUE TYPE
- Bugfix Pull Request


