### PR TITLE
docs: Update scopes value example - guide_gce

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -95,7 +95,7 @@ you can use the following configuration:
        project: my-project
        auth_kind: serviceaccount
        scopes:
-         - www.googleapis.com/auth/compute
+         - https://www.googleapis.com/auth/compute
 
      tasks:
 


### PR DESCRIPTION
<!--- Your description here -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update scopes value example because return : invalid_scope.
"error_description": "www.googleapis.com/auth/compute is not a valid audience string."

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If you try to execute this [example Providing Credentials as Module Parameters](https://docs.ansible.com/ansible/latest/scenario_guides/guide_gce.html#providing-credentials-as-module-parameters) 
you get this error output : ('invalid_scope: www.googleapis.com/auth/compute is not a valid audience string.', u'{\n  "error": "invalid_scope",\n  "error_description": "www.googleapis.com/auth/compute is not a valid audience string."\n}')
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
