### PR TITLE
Backport/2.8/56357

### DIFF
--- a/changelogs/fragments/56357-ibm-storage-unwanted-args-cause-failure.yml
+++ b/changelogs/fragments/56357-ibm-storage-unwanted-args-cause-failure.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ibm_storage - Added a check for null fields in ibm_storage utils module.

--- a/lib/ansible/module_utils/ibm_sa_utils.py
+++ b/lib/ansible/module_utils/ibm_sa_utils.py
@@ -81,6 +81,8 @@ def build_pyxcli_command(fields):
     """ Builds the args for pyxcli using the exact args from ansible"""
     pyxcli_args = {}
     for field in fields:
+        if not fields[field]:
+            continue
         if field in AVAILABLE_PYXCLI_FIELDS and fields[field] != '':
             pyxcli_args[field] = fields[field]
     return pyxcli_args


### PR DESCRIPTION
##### SUMMARY
ibm_storage utils module fix for a bug where null args were being passed. This caused a failure in most of our modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ibm_sa_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.8.0rc3.post0
  config file = None
  configured module search path = [u'/Users/tzure/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tzure/git/ansible/lib/ansible
  executable location = /Users/tzure/git/ansible/bin/ansible
  python version = 2.7.10 (default, Aug 17 2018, 19:45:58) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.0.42)]
```
