### PR TITLE
Add sanity test to check for unwanted files.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/no-unwanted-files.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-unwanted-files.rst
@@ -1,0 +1,13 @@
+Sanity Tests » no-unwanted-files
+================================
+
+Specific file types are allowed in certain directories:
+
+- ``lib`` - All content must reside in the ``lib/ansible`` directory.
+
+- ``lib/ansible`` - Only source code with one of the following extensions is allowed:
+
+  - ``*.cs`` - C#
+  - ``*.ps1`` - PowerShell
+  - ``*.psm1`` - PowerShell
+  - ``*.py`` - Python

--- a/test/sanity/code-smell/no-unwanted-files.json
+++ b/test/sanity/code-smell/no-unwanted-files.json
@@ -1,0 +1,6 @@
+{
+    "prefixes": [
+        "lib/"
+    ],
+    "output": "path-message"
+}

--- a/test/sanity/code-smell/no-unwanted-files.py
+++ b/test/sanity/code-smell/no-unwanted-files.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Prevent unwanted files from being added to the source tree."""
+import os
+import sys
+
+
+def main():
+    """Main entry point."""
+    paths = sys.argv[1:] or sys.stdin.read().splitlines()
+
+    allowed_extensions = (
+        '.cs',
+        '.ps1',
+        '.psm1',
+        '.py',
+    )
+
+    skip = (
+        # allowed special cases
+        'lib/ansible/config/base.yml',
+        'lib/ansible/config/module_defaults.yml',
+        # temporary skip, relocate these to docs
+        'lib/ansible/modules/cloud/amazon/GUIDELINES.md',
+        'lib/ansible/modules/cloud/openstack/README.md',
+        'lib/ansible/modules/cloud/ovirt/README.rst',
+    )
+
+    skip_directories = (
+        'lib/ansible.egg-info/',
+        'lib/ansible/galaxy/data/',
+    )
+
+    for path in paths:
+        if path in skip:
+            continue
+
+        if any(path.startswith(skip_directory) for skip_directory in skip_directories):
+            continue
+
+        if path.startswith('lib/') and not path.startswith('lib/ansible/'):
+            print('%s: all "lib" content must reside in the "lib/ansible" directory' % path)
+            continue
+
+        ext = os.path.splitext(path)[1]
+
+        if ext not in allowed_extensions:
+            print('%s: extension must be one of: %s' % (path, ', '.join(allowed_extensions)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY

Prevent unwanted files from being added to the repository. Current checks are:

- Prevent files in the `lib` directory unless they reside under `lib/ansible`.
- Limit the files under `lib/ansible` to expected source file types:
  - `*.cs` - C#
  - `*.ps1` - PowerShell
  - `*.psm1` - PowerShell
  - `*.py` - Python

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

sanity test

##### ADDITIONAL INFORMATION

This would have detected the unwanted file `lib/ansible/module_utils/oracle/oci_logging.yaml` in https://github.com/ansible/ansible/pull/53156 before merge.