### PR TITLE
adds 2.9 roadmap, reverses local TOC order

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_9.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_9.rst
@@ -1,0 +1,38 @@
+===========
+Ansible 2.9
+===========
+
+.. contents::
+   :local:
+
+Release Schedule
+----------------
+
+Expected
+========
+
+PRs must be raised well in advance of the dates below to have a chance of being included in this Ansible release.
+
+- TBD 2019-??-?? Alpha 1 **Core freeze**
+  No new features to ``support:core`` code.
+  Includes no new options to existing Core modules
+
+- TBD 2019-??-?? Beta 1 **Feature freeze**
+  No new functionality (including modules/plugins) to any code
+
+- 2019-??-?? Release Candidate 1
+- 2019-??-?? Release Candidate 2 (if needed)
+- 2019-??-?? Release Candidate 3 (if needed)
+- 2019-??-?? Release
+
+
+
+Release Manager
+---------------
+
+Toshio Kuratomi (IRC: abadger1999; GitHub: @abadger)
+
+Planned work
+============
+
+See the `Ansible 2.9 Project Board <https://github.com/ansible/ansible/projects/34>`_

--- a/docs/docsite/rst/roadmap/index.rst
+++ b/docs/docsite/rst/roadmap/index.rst
@@ -22,6 +22,7 @@ See :ref:`Ansible communication channels <communication>` for details on how to 
 .. toctree::
    :maxdepth: 1
    :glob:
+   :reversed:
    :caption: Ansible Release Roadmaps
 
    ROADMAP*


### PR DESCRIPTION
##### SUMMARY
To prepare for the release of Ansible 2.8, adds a roadmap page for Ansible 2.9 to the `devel` documentation. Dates can be filled in later. 

Also uses the `:reversed:` parameter to create a better `:glob:` TOC for the Roadmaps section.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

