### PR TITLE
vmware: fix the test-suite

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/main.yml
@@ -52,9 +52,6 @@
     - name: add the hosts in the inventory
       add_host:
         hostname: '{{ item | basename }}'
-        ansible_host: '{{ item | basename }}'
-        ansible_user: 'root'
-        ansible_password: 'pass'
         groups:
           - 'esxi-lab'
       with_items: '{{ vcsim_host_list.json }}'

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -5,7 +5,7 @@
     password: '{{ vcenter_password }}'
     datacenter_name: '{{ dc1 }}'
     cluster_name: '{{ ccr1 }}'
-    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    esxi_hostname: '{{ item }}'
     esxi_username: '{{ hostvars[item].ansible_user }}'
     esxi_password: '{{ hostvars[item].ansible_password }}'
     state: present
@@ -18,6 +18,6 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    esxi_hostname: '{{ item }}'
     state: absent
   with_items: "{{ groups['esxi-lab'] }}"

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
@@ -2,7 +2,7 @@
 - debug: var=datastores
 - name: Mount NFS (ds1) datastores to ESXi
   vmware_host_datastore:
-    hostname: '{{ hostvars[item].ansible_host }}'
+    hostname: '{{ item }}'
     username: '{{ hostvars[item].ansible_user }}'
     password: '{{ hostvars[item].ansible_password }}'
     datastore_name: '{{ ds1 }}'
@@ -10,14 +10,14 @@
     nfs_server: '{{ infra.datastores[ds1].server }}'
     nfs_path: '{{ infra.datastores[ds1].path }}'
     nfs_ro: '{{ infra.datastores[ds2].ro }}'
-    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    esxi_hostname: '{{ item }}'
     state: present
     validate_certs: no
   with_items: "{{ groups['esxi-lab'] }}"
 
 - name: Mount NFS (ds2) datastores on the ESXi
   vmware_host_datastore:
-    hostname: '{{ hostvars[item].ansible_host }}'
+    hostname: '{{ item }}'
     username: '{{ hostvars[item].ansible_user }}'
     password: '{{ hostvars[item].ansible_password }}'
     datastore_name: '{{ ds2 }}'
@@ -25,7 +25,7 @@
     nfs_server: '{{ infra.datastores[ds2].server }}'
     nfs_path: '{{ infra.datastores[ds2].path }}'
     nfs_ro: '{{ infra.datastores[ds2].ro }}'
-    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    esxi_hostname: '{{ item }}'
     state: present
     validate_certs: no
   with_items: "{{ groups['esxi-lab'] }}"

--- a/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -26,7 +26,7 @@
 - name: Remove the vSwitches
   vmware_vswitch:
     validate_certs: no
-    hostname: '{{ hostvars[item].ansible_host }}'
+    hostname: '{{ item }}'
     username: '{{ hostvars[item].ansible_user }}'
     password: '{{ hostvars[item].ansible_password }}'
     switch_name: "{{ switch1 }}"
@@ -40,7 +40,7 @@
     password: '{{ vcenter_password }}'
     datacenter_name: '{{ dc1 }}'
     cluster_name: ccr1
-    esxi_hostname: '{{ hostvars[item].ansible_host }}'
+    esxi_hostname: '{{ item }}'
     esxi_username: '{{ hostvars[item].ansible_user }}'
     esxi_password: '{{ hostvars[item].ansible_password }}'
     state: absent
@@ -60,7 +60,7 @@
 
 - name: Umount NFS datastores to ESXi (1/2)
   vmware_host_datastore:
-      hostname: '{{ hostvars[item].ansible_host }}'
+      hostname: '{{ item }}'
       username: '{{ hostvars[item].ansible_user }}'
       password: '{{ hostvars[item].ansible_password }}'
       datastore_name: '{{ ds1 }}'
@@ -76,7 +76,7 @@
 
 - name: Umount NFS datastores to ESXi (2/2)
   vmware_host_datastore:
-      hostname: '{{ hostvars[item].ansible_host }}'
+      hostname: '{{ item }}'
       username: '{{ hostvars[item].ansible_user }}'
       password: '{{ hostvars[item].ansible_password }}'
       datastore_name: '{{ ds2 }}'
@@ -93,7 +93,7 @@
 # - name: get a final list of the datastore
 #   vmware_datastore_facts:
 #     validate_certs: False
-#     hostname: '{{ hostvars[item].ansible_host }}'
+#     hostname: '{{ item }}'
 #     username: '{{ hostvars[item].ansible_user }}'
 #     password: '{{ hostvars[item].ansible_password }}'
 #   register: datastore_facts

--- a/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -164,7 +164,7 @@
     #template: "{{ item|basename }}"
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     hardware:
         num_cpus: 1
         memory_mb: 512

--- a/test/integration/targets/vmware_host/tasks/main.yml
+++ b/test/integration/targets/vmware_host/tasks/main.yml
@@ -12,7 +12,7 @@
         password: '{{ vcenter_password }}'
         datacenter_name: '{{ dc1 }}'
         cluster_name: '{{ ccr1 }}'
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         esxi_username: '{{ hostvars[esxi1].ansible_user }}'
         esxi_password: '{{ hostvars[esxi1].ansible_password }}'
         state: present
@@ -26,7 +26,7 @@
         password: '{{ vcenter_password }}'
         datacenter_name: '{{ dc1 }}'
         cluster_name: '{{ ccr1 }}'
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         esxi_username: '{{ hostvars[esxi1].ansible_user }}'
         esxi_password: '{{ hostvars[esxi1].ansible_password }}'
         state: present
@@ -44,7 +44,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_hostname: '{{ esxi2 }}'
         esxi_username: '{{ hostvars[esxi2].ansible_user }}'
         esxi_password: '{{ hostvars[esxi2].ansible_password }}'
         datacenter_name: "{{ dc1 }}"
@@ -65,7 +65,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_hostname: '{{ esxi2 }}'
         datacenter_name: "{{ dc1 }}"
         cluster_name: "{{ ccr1 }}"
         fetch_ssl_thumbprint: False
@@ -77,7 +77,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_hostname: '{{ esxi2 }}'
         datacenter_name: "{{ dc1 }}"
         cluster_name: "{{ ccr1 }}"
         state: absent
@@ -118,7 +118,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_hostname: '{{ esxi2 }}'
         esxi_username: '{{ hostvars[esxi2].ansible_user }}'
         esxi_password: '{{ hostvars[esxi2].ansible_password }}'
         datacenter_name: "{{ dc1 }}"
@@ -138,7 +138,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_hostname: '{{ esxi2 }}'
         esxi_username: '{{ hostvars[esxi2].ansible_user }}'
         esxi_password: '{{ hostvars[esxi2].ansible_password }}'
         datacenter_name: "{{ dc1 }}"
@@ -157,7 +157,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+        esxi_hostname: '{{ esxi2 }}'
         esxi_username: '{{ hostvars[esxi2].ansible_user }}'
         esxi_password: '{{ hostvars[esxi2].ansible_password }}'
         datacenter_name: "{{ dc1 }}"

--- a/test/integration/targets/vmware_host_acceptance/tasks/main.yml
+++ b/test/integration/targets/vmware_host_acceptance/tasks/main.yml
@@ -15,7 +15,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
       validate_certs: no
       acceptance_level: vmware_certified
       state: present
@@ -30,7 +30,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
       validate_certs: no
       acceptance_level: vmware_certified
       state: present

--- a/test/integration/targets/vmware_host_active_directory/tasks/main.yml
+++ b/test/integration/targets/vmware_host_active_directory/tasks/main.yml
@@ -13,7 +13,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         ad_domain: '{{ active_directory_domain }}'
         ad_user: '{{ active_directory_user }}'
         ad_password: '{{ active_directory_password }}'
@@ -34,7 +34,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         ad_domain: example.local
         ad_user: adjoin
         ad_password: Password123$
@@ -55,7 +55,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         ad_state: absent
         validate_certs: no
       register: host_active_directory_facts_2_check_mode
@@ -73,7 +73,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         ad_state: absent
         validate_certs: no
       register: host_active_directory_facts_2

--- a/test/integration/targets/vmware_host_capability_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_capability_facts/tasks/main.yml
@@ -30,7 +30,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       validate_certs: False
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
     register: capability_0002_results
   - assert:
       that:

--- a/test/integration/targets/vmware_host_config_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_facts/tasks/main.yml
@@ -46,7 +46,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       validate_certs: no
-      esxi_hostname: "{{ hostvars[esxi1].ansible_host }}"
+      esxi_hostname: "{{ esxi1 }}"
     register: single_hosts_result_check_mode
     check_mode: yes
   - name: ensure facts are gathered for all hosts
@@ -60,7 +60,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       validate_certs: no
-      esxi_hostname: "{{ hostvars[esxi1].ansible_host }}"
+      esxi_hostname: "{{ esxi1 }}"
     register: single_hosts_result
   - name: ensure facts are gathered for all hosts
     assert:

--- a/test/integration/targets/vmware_host_config_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_manager/tasks/main.yml
@@ -42,7 +42,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
       options:
         'Config.HostAgent.log.level': 'info'
       validate_certs: no
@@ -77,7 +77,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
       options:
         'Config.HostAgent.log.level': 'info'
       validate_certs: no

--- a/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
@@ -27,7 +27,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     validate_certs: no
   register: all_hosts_dns_result
 
@@ -58,7 +58,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     validate_certs: no
   register: all_hosts_dns_result_check_mode
   check_mode: yes

--- a/test/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_facts/tasks/main.yml
@@ -10,7 +10,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
       register: facts
     - debug: var=facts
     - name: verify some data,like ansible_processor
@@ -22,7 +22,7 @@
     - name: get host facts through from a host
       vmware_host_facts:
         validate_certs: False
-        hostname: '{{ hostvars[esxi1].ansible_host }}'
+        hostname: '{{ esxi1 }}'
         username: '{{ hostvars[esxi1].ansible_user }}'
         password: '{{ hostvars[esxi1].ansible_password }}'
       register: facts

--- a/test/integration/targets/vmware_host_feature_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_feature_facts/tasks/main.yml
@@ -48,7 +48,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
   register: capability_0002_results
 
 - debug: var=capability_0002_results
@@ -65,7 +65,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
   register: capability_0002_results
   check_mode: yes
 

--- a/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
@@ -12,7 +12,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
   register: firewall_0004_results
   check_mode: yes
 
@@ -49,7 +49,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       validate_certs: no
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
     register: firewall_0002_results
 
   - assert:

--- a/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -44,8 +44,8 @@
             - all_hosts_result.rule_set_state[item]['vvold']['desired_state'] == True
             - all_hosts_result.rule_set_state[item]['vvold']['previous_state'] == False
       with_items:
-        - '{{ hostvars[esxi1].ansible_host }}'
-        - '{{ hostvars[esxi2].ansible_host }}'
+        - '{{ esxi1 }}'
+        - '{{ esxi2 }}'
 
     - name: Disable vvold for {{ host1 }}
       vmware_host_firewall_manager:
@@ -53,7 +53,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         rules:
           - name: vvold
             enabled: False
@@ -72,7 +72,7 @@
             - host_result.rule_set_state[item]['vvold']['desired_state'] == False
             - host_result.rule_set_state[item]['vvold']['previous_state'] == True
       with_items:
-        - '{{ hostvars[esxi1].ansible_host }}'
+        - '{{ esxi1 }}'
 
     - name: Enable vvold rule set on all hosts of {{ ccr1 }} in check mode
       vmware_host_firewall_manager:
@@ -96,9 +96,9 @@
     - name: ensure facts are gathered for all hosts of {{ ccr1 }}
       assert:
         that:
-            - all_hosts_result_check_mode.rule_set_state[hostvars[esxi1].ansible_host]['vvold']['current_state'] == True
-            - all_hosts_result_check_mode.rule_set_state[hostvars[esxi2].ansible_host]['vvold']['current_state'] == True
-            - all_hosts_result_check_mode.rule_set_state[hostvars[esxi2].ansible_host]['vvold']['desired_state'] == True
+            - all_hosts_result_check_mode.rule_set_state[esxi1]['vvold']['current_state'] == True
+            - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['current_state'] == True
+            - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['desired_state'] == True
 
     - name: Disable vvold for {{ host1 }} in check mode
       vmware_host_firewall_manager:
@@ -106,7 +106,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         rules:
           - name: vvold
             enabled: False
@@ -126,4 +126,4 @@
             - host_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == False
             - host_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
       with_items:
-        - '{{ hostvars[esxi1].ansible_host }}'
+        - '{{ esxi1 }}'

--- a/test/integration/targets/vmware_host_hyperthreading/tasks/main.yml
+++ b/test/integration/targets/vmware_host_hyperthreading/tasks/main.yml
@@ -27,7 +27,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
       validate_certs: no
       state: disabled
     register: host_hyperthreading_facts
@@ -44,7 +44,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
       validate_certs: no
       state: disabled
     register: host_hyperthreading_facts_check_mode

--- a/test/integration/targets/vmware_host_ipv6/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ipv6/tasks/main.yml
@@ -23,7 +23,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
         state: enabled
       register: host_ipv6_facts
@@ -38,7 +38,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
         state: enabled
       register: host_ipv6_facts_check_mode

--- a/test/integration/targets/vmware_host_kernel_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_kernel_manager/tasks/main.yml
@@ -15,7 +15,7 @@
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
         validate_certs: False
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         kernel_module_name: "tcpip4"
         kernel_module_option: "ipv6=0"
       register: my_results_01
@@ -23,8 +23,8 @@
     - name: Check that the provided kernel_module_name has kernel_module_option set
       assert:
         that:
-          - "'original_options' in my_results_01['ansible_module_results']['{{ hostvars[esxi1].ansible_host }}']"
-          - "my_results_01['ansible_module_results']['{{ hostvars[esxi1].ansible_host }}'].original_options == 'ipv6=0'"
+          - "'original_options' in my_results_01['ansible_module_results']['{{ esxi1 }}']"
+          - "my_results_01['ansible_module_results']['{{ esxi1 }}'].original_options == 'ipv6=0'"
 
     - name: host connected, module exists, same options for idempotence test
       vmware_host_kernel_manager:
@@ -32,7 +32,7 @@
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
         validate_certs: False
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         kernel_module_name: "tcpip4"
         kernel_module_option: "ipv6=0"
       register: my_results_02

--- a/test/integration/targets/vmware_host_ntp/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ntp/tasks/main.yml
@@ -15,7 +15,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: present
         ntp_servers:
           - 0.pool.ntp.org
@@ -28,7 +28,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: present
         ntp_servers:
           - 1.pool.ntp.org
@@ -41,7 +41,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: absent
         ntp_servers:
           - 1.pool.ntp.org
@@ -54,7 +54,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: present
         ntp_servers:
           - 1.pool.ntp.org
@@ -67,7 +67,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: present
         ntp_servers:
           - 2.pool.ntp.org
@@ -82,7 +82,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: absent
         ntp_servers:
           - 0.pool.ntp.org
@@ -100,7 +100,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         ntp_servers:
           - 0.pool.ntp.org
           - 1.pool.ntp.org
@@ -114,7 +114,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         ntp_servers:
           - 3.pool.ntp.org
           - 4.pool.ntp.org
@@ -129,7 +129,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: present
         ntp_servers:
           - 0.pool.ntp.org
@@ -143,7 +143,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         state: absent
         ntp_servers:
           - 0.pool.ntp.org
@@ -157,7 +157,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         ntp_servers:
           - 0.pool.ntp.org
           - 1.pool.ntp.org

--- a/test/integration/targets/vmware_host_ntp_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ntp_facts/tasks/main.yml
@@ -15,7 +15,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
       register: host_ntp
     - debug: var=host_ntp

--- a/test/integration/targets/vmware_host_package_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_package_facts/tasks/main.yml
@@ -15,7 +15,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
       register: host_packages
     - debug: var=host_packages

--- a/test/integration/targets/vmware_host_powermgmt_policy/tasks/main.yml
+++ b/test/integration/targets/vmware_host_powermgmt_policy/tasks/main.yml
@@ -15,7 +15,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         policy: high-performance
         validate_certs: no
       register: host_result
@@ -23,7 +23,7 @@
     - name: Ensure Power Management Policy for esxi1
       assert:
         that:
-            - host_result.result['{{ hostvars[esxi1].ansible_host }}'].current_state == "high-performance"
+            - host_result.result['{{ esxi1 }}'].current_state == "high-performance"
 
     - name: Set the Power Management Policy on all hosts of {{ ccr1 }}
       vmware_host_powermgmt_policy:
@@ -46,7 +46,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         policy: high-performance
         validate_certs: no
       register: host_result
@@ -73,5 +73,5 @@
       assert:
         that:
             - not (all_hosts_result is changed)
-            - "all_hosts_result.result['{{ hostvars[esxi1].ansible_host }}']current_state == 'balanced'"
-            - "all_hosts_result.result['{{ hostvars[esxi2].ansible_host }}']current_state == 'balanced'"
+            - "all_hosts_result.result['{{ esxi1 }}']current_state == 'balanced'"
+            - "all_hosts_result.result['{{ esxi2 }}']current_state == 'balanced'"

--- a/test/integration/targets/vmware_host_powerstate/tasks/main.yml
+++ b/test/integration/targets/vmware_host_powerstate/tasks/main.yml
@@ -23,7 +23,7 @@
       password: "{{ vcenter_password }}"
       validate_certs: False
       state: power-down-to-standby
-      esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+      esxi_hostname: '{{ esxi1 }}'
       force: True
     register: host_powerstate
 

--- a/test/integration/targets/vmware_host_service_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_facts/tasks/main.yml
@@ -16,7 +16,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
       register: host_services
 

--- a/test/integration/targets/vmware_host_service_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_manager/tasks/main.yml
@@ -29,7 +29,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         service_name: ntpd
         state: absent
       register: single_hosts_result
@@ -60,7 +60,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         service_name: ntpd
         state: absent
       register: single_hosts_result_check_mode

--- a/test/integration/targets/vmware_host_ssl_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ssl_facts/tasks/main.yml
@@ -12,7 +12,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     validate_certs: no
   register: ssl_facts
 
@@ -42,7 +42,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     validate_certs: no
   check_mode: yes
   register: ssl_facts

--- a/test/integration/targets/vmware_host_vmhba_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_vmhba_facts/tasks/main.yml
@@ -16,7 +16,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
       register: host_vmhbas
 

--- a/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
@@ -15,7 +15,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
       register: host_vmnics
     - debug: var=host_vmnics
@@ -28,7 +28,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
         capabilities: true
         directpath_io: true

--- a/test/integration/targets/vmware_maintenancemode/tasks/main.yml
+++ b/test/integration/targets/vmware_maintenancemode/tasks/main.yml
@@ -13,7 +13,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     state: present
-    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+    esxi_hostname: '{{ esxi2 }}'
     validate_certs: no
   register: test_result_0001
 
@@ -30,7 +30,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     state: present
-    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+    esxi_hostname: '{{ esxi2 }}'
     validate_certs: no
   register: test_result_0002
 
@@ -47,7 +47,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     state: absent
-    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+    esxi_hostname: '{{ esxi2 }}'
     validate_certs: no
   register: test_result_0003
 
@@ -64,7 +64,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     state: absent
-    esxi_hostname: '{{ hostvars[esxi2].ansible_host }}'
+    esxi_hostname: '{{ esxi2 }}'
     validate_certs: no
   register: test_result_0004
 

--- a/test/integration/targets/vmware_portgroup_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_portgroup_facts/tasks/main.yml
@@ -27,7 +27,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
   register: portgroup_0002_results
 
 - assert:
@@ -41,7 +41,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     policies: true
   register: portgroup_0003_results
 
@@ -56,7 +56,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     policies: true
   register: portgroup_0004_results
   check_mode: yes

--- a/test/integration/targets/vmware_target_canonical_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_target_canonical_facts/tasks/main.yml
@@ -29,7 +29,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: False
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
   register: target_0002_results
 
 - assert:

--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -20,22 +20,20 @@
   register: vm_facts_0001
 
 - debug: var=vm_facts_0001
+- set_fact:
+    first_vm: "{{ vm_facts_0001['virtual_machines'][0] }}"
 
 - &vm_fact_check
   name: Verify if VM facts exist
   assert:
     that:
-      - "item.esxi_hostname is defined"
-      - "item.guest_fullname is defined"
-      - "item.ip_address is defined"
-      - "item.mac_address is defined"
-      - "item.power_state is defined"
-      - "item.uuid is defined"
-      - "item.vm_network is defined"
-  with_items:
-    - "{{ vm_facts_0001.virtual_machines | json_query(query) }}"
-  vars:
-    query: "[?guest_name=='DC0_H0_VM0']"
+      - first_vm.esxi_hostname is defined
+      - first_vm.guest_fullname is defined
+      - first_vm.ip_address is defined
+      - first_vm.mac_address is defined
+      - first_vm.power_state is defined
+      - first_vm.uuid is defined
+      - first_vm.vm_network is defined
 
 - <<: *vm_data
   name: Get facts about available vms in check mode
@@ -50,7 +48,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: "DC0_H0_VM0"
+    name: "{{ first_vm.guest_name }}"
   register: folder_path_info
 
 - set_fact:

--- a/test/integration/targets/vmware_vmkernel/tasks/main.yml
+++ b/test/integration/targets/vmware_vmkernel/tasks/main.yml
@@ -29,7 +29,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         vswitch: "{{ switch1 }}"
         portgroup: vMotion
         mtu: 9000
@@ -55,7 +55,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         vswitch: "{{ switch1 }}"
         device: '{{ host_vmkernel.device }}'
         portgroup: vMotion

--- a/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
@@ -15,7 +15,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
       register: host_vmkernel
     - debug: var=host_vmkernel
@@ -28,7 +28,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+        esxi_hostname: '{{ esxi1 }}'
         validate_certs: no
       register: host_vmkernel_check_mode
       check_mode: yes

--- a/test/integration/targets/vmware_vswitch_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch_facts/tasks/main.yml
@@ -14,7 +14,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     validate_certs: no
   register: switch_facts
 
@@ -29,7 +29,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ hostvars[esxi1].ansible_host }}'
+    esxi_hostname: '{{ esxi1 }}'
     validate_certs: no
   register: switch_facts_check_mode
   check_mode: yes


### PR DESCRIPTION
##### SUMMARY

These two patches should improve the reliability of the test-suite with
`vcsim` as used by shippable. It will also simplify the use of real VMware
ESXi and vCenter.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vcenter