### PR TITLE
Revert "inventory: virtualbox: fix typo in examples (#56328)"

### DIFF
--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -43,7 +43,7 @@ simple_config_file:
     query:
       logged_in_users: /VirtualBox/GuestInfo/OS/LoggedInUsersList
     compose:
-      ansible_connection: ('windows' in vbox_Guest_OS)|ternary('winrm', 'ssh')
+      ansible_connection: ('indows' in vbox_Guest_OS)|ternary('winrm', 'ssh')
 '''
 
 import os


### PR DESCRIPTION
Turns out, this typo is by intention. 
This reverts commit 099917ddc8744fa1fb864600c966b69901778b7b. 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
virtualbox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
