### PR TITLE
vmware_vm_facts: fix the support with regular ESXi

### DIFF
--- a/changelogs/fragments/56073-vmware_vm_facts_fix_the_support_with_regular_ESXi.yaml
+++ b/changelogs/fragments/56073-vmware_vm_facts_fix_the_support_with_regular_ESXi.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_vm_facts - fix the support with regular ESXi

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -805,6 +805,9 @@ class PyVmomi(object):
         self.si = None
         self.current_vm_obj = None
         self.content = connect_to_api(self.module)
+        self.custom_field_mgr = []
+        if self.content.customFieldsManager:  # not an ESXi
+            self.custom_field_mgr = self.content.customFieldsManager.field
 
     def is_vcenter(self):
         """

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attribute_defs.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attribute_defs.py
@@ -91,7 +91,6 @@ except ImportError:
 class VmAttributeDefManager(PyVmomi):
     def __init__(self, module):
         super(VmAttributeDefManager, self).__init__(module)
-        self.custom_field_mgr = self.content.customFieldsManager.field
 
     def remove_custom_def(self, field):
         changed = False

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -139,7 +139,6 @@ from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
 class VmAttributeManager(PyVmomi):
     def __init__(self, module):
         super(VmAttributeManager, self).__init__(module)
-        self.custom_field_mgr = self.content.customFieldsManager.field
 
     def set_custom_field(self, vm, user_fields):
         result_fields = dict()

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -18,9 +18,9 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = r'''
 ---
 module: vmware_vm_facts
-short_description: Return basic facts pertaining to a vSphere virtual machine guest
+short_description: Return basic facts pertaining to a VMware machine guest
 description:
-- Return basic facts pertaining to a vSphere virtual machine guest.
+- Return basic facts pertaining to a vSphere or ESXi virtual machine guest.
 - Cluster name as fact is added in version 2.7.
 version_added: '2.0'
 author:
@@ -28,7 +28,7 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 - Fedor Vompe (@sumkincpp)
 notes:
-- Tested on vSphere 5.5 and vSphere 6.5
+- Tested on ESXi 6.7, vSphere 5.5 and vSphere 6.5
 - From 2.8 and onwards, facts are returned as list of dict instead of dict.
 requirements:
 - python >= 2.6
@@ -150,7 +150,6 @@ from ansible.module_utils.vmware import PyVmomi, get_all_objs, vmware_argument_s
 class VmwareVmFacts(PyVmomi):
     def __init__(self, module):
         super(VmwareVmFacts, self).__init__(module)
-        self.custom_field_mgr = self.content.customFieldsManager.field
 
     def get_vm_attributes(self, vm):
         return dict((x.name, v.value) for x in self.custom_field_mgr

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -473,7 +473,9 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             'runtime.maxMemoryUsage',
             'customValue',
         ]
-        field_mgr = self.pyv.content.customFieldsManager.field
+        field_mgr = []
+        if self.pyv.content.customFieldsManager:
+            field_mgr = self.pyv.content.customFieldsManager.field
 
         for vm_prop in vm_properties:
             if vm_prop == 'customValue':

--- a/test/units/module_utils/test_vmware.py
+++ b/test/units/module_utils/test_vmware.py
@@ -89,7 +89,9 @@ class FakeAnsibleModule:
 
 
 def fake_connect_to_api(module):
-    pass
+    class MyContent():
+        customFieldsManager = None
+    return MyContent
 
 
 def test_pyvmomi_lib_exists(mocker, fake_ansible_module):


### PR DESCRIPTION
##### SUMMARY

Ensure the module still work with the ESXi where CustomFieldsManager
does not exist.

From: https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.CustomFieldsManager.html

    The CustomFieldsManager object is used to add and remove custom fields to
    managed entities.
    The custom fields values set on managed entities are available through the
    customValue property and through the summary objects for VirtualMachine
    and HostSystem. They are not available directly through this managed object.
    This functionality is only available through VirtualCenter.

Fixes: #56071

(cherry picked from commit cf78759f5bdbab5ebe77a8f9999a52cfae1155de)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_vm_facts