### PR TITLE
[backport 2.7] Expose timeout option to Redfish modules (#54130)

### DIFF
--- a/changelogs/fragments/54130-fix-missing-timeout-in-redfish_utils.yaml
+++ b/changelogs/fragments/54130-fix-missing-timeout-in-redfish_utils.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_utils - expose timeout option for redfish implementations that exceed the 10 second default

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -19,9 +19,10 @@ DELETE_HEADERS = {'accept': 'application/json', 'OData-Version': '4.0'}
 
 class RedfishUtils(object):
 
-    def __init__(self, creds, root_uri):
+    def __init__(self, creds, root_uri, timeout):
         self.root_uri = root_uri
         self.creds = creds
+        self.timeout = timeout
         self._init_session()
         return
 
@@ -33,7 +34,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
             data = json.loads(resp.read())
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -52,7 +53,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
         except URLError as e:
@@ -70,7 +71,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
         except URLError as e:
@@ -88,7 +89,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False)
+                            use_proxy=False, timeout=self.timeout)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
         except URLError as e:

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -63,6 +63,12 @@ options:
     required: false
     description:
       - bootdevice when setting boot configuration
+  timeout:
+    description:
+      - Timeout in seconds for URL requests to OOB controller
+    default: 10
+    type: int
+    version_added: '2.7.11'
 
 author: "Jose Delarosa (github: jose-delarosa)"
 '''
@@ -116,13 +122,14 @@ EXAMPLES = '''
       userid: "{{ userid }}"
       userpswd: "{{ userpswd }}"
 
-  - name: Clear Manager Logs
+  - name: Clear Manager Logs with a timeout of 20 seconds
     redfish_command:
       category: Manager
       command: ClearLogs
       baseuri: "{{ baseuri }}"
       user: "{{ user }}"
       password: "{{ password }}"
+      timeout: 20
 '''
 
 RETURN = '''
@@ -163,6 +170,7 @@ def main():
             userpswd=dict(no_log=True),
             userrole=dict(),
             bootdevice=dict(),
+            timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False
     )
@@ -180,10 +188,13 @@ def main():
             'userpswd': module.params['userpswd'],
             'userrole': module.params['userrole']}
 
+    # timeout
+    timeout = module.params['timeout']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri)
+    rf_utils = RedfishUtils(creds, root_uri, timeout)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -62,6 +62,12 @@ options:
     description:
       - value of Manager attribute to update
     default: 'null'
+  timeout:
+    description:
+      - Timeout in seconds for URL requests to OOB controller
+    default: 10
+    type: int
+    version_added: "2.7.11"
 
 author: "Jose Delarosa (github: jose-delarosa)"
 '''
@@ -97,7 +103,7 @@ EXAMPLES = '''
       user: "{{ user }}"
       password: "{{ password }}"
 
-  - name: Set BIOS default settings
+  - name: Set BIOS default settings with a timeout of 20 seconds
     redfish_config:
       category: Systems
       command: SetBiosDefaultSettings
@@ -134,6 +140,7 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       user: "{{ user}}"
       password: "{{ password }}"
+      timeout: 20
 '''
 
 RETURN = '''
@@ -169,6 +176,7 @@ def main():
             mgr_attr_value=dict(default='null'),
             bios_attr_name=dict(default='null'),
             bios_attr_value=dict(default='null'),
+            timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False
     )
@@ -183,6 +191,10 @@ def main():
     # Manager attributes to update
     mgr_attributes = {'mgr_attr_name': module.params['mgr_attr_name'],
                       'mgr_attr_value': module.params['mgr_attr_value']}
+
+    # timeout
+    timeout = module.params['timeout']
+
     # BIOS attributes to update
     bios_attributes = {'bios_attr_name': module.params['bios_attr_name'],
                        'bios_attr_value': module.params['bios_attr_value']}
@@ -190,7 +202,7 @@ def main():
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_uri = "/redfish/v1/"
-    rf_utils = RedfishUtils(creds, root_uri)
+    rf_utils = RedfishUtils(creds, root_uri, timeout)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -42,6 +42,12 @@ options:
     required: true
     description:
       - Password for authentication with OOB controller
+  timeout:
+    description:
+      - Timeout in seconds for URL requests to OOB controller
+    default: 10
+    type: int
+    version_added: '2.7.11'
 
 author: "Jose Delarosa (github: jose-delarosa)"
 '''
@@ -55,13 +61,14 @@ EXAMPLES = '''
       user: "{{ user }}"
       password: "{{ password }}"
 
-  - name: Get fan inventory
+  - name: Get fan inventory with a timeout of 20 seconds
     redfish_facts:
       category: Chassis
       command: GetFanInventory
       baseuri: "{{ baseuri }}"
       user: "{{ user }}"
       password: "{{ password }}"
+      timeout: 20
 
   - name: Get default inventory information
     redfish_facts:
@@ -149,6 +156,7 @@ def main():
             baseuri=dict(required=True),
             user=dict(required=True),
             password=dict(required=True, no_log=True),
+            timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False
     )
@@ -157,10 +165,13 @@ def main():
     creds = {'user': module.params['user'],
              'pswd': module.params['password']}
 
+    # timeout
+    timeout = module.params['timeout']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_uri = "/redfish/v1"
-    rf_utils = RedfishUtils(creds, root_uri)
+    rf_utils = RedfishUtils(creds, root_uri, timeout)
 
     # Build Category list
     if "all" in module.params['category']:


### PR DESCRIPTION
(cherry picked from commit d8536e47d3fe1d31412f192ce567a9780ae0d521)

##### SUMMARY
Backport request of #54130 to 2.7. This PR fixes #52332 which addresses timeouts that occur when a Redfish response takes longer than the default 10 second open_url() timeout.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils
redfish_facts
redfish_config
redfish_command

##### ADDITIONAL INFORMATION
I wasn't sure what was appropriate for the `version_added` fields for this `timeout` option. I guessed at `2.7.11` but can change (or omit) this.

```
(venv) [jyundt@donuc ansible]$ ansible --version
ansible 2.7.10.post0 (backport/2.7/54130 bcb2b2827a) last updated 2019/05/13 19:56:15 (GMT -400)
  config file = None
  configured module search path = [u'/home/jyundt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jyundt/git/ansible/lib/ansible
  executable location = /home/jyundt/git/ansible/bin/ansible
  python version = 2.7.5 (default, Apr  9 2019, 14:30:50) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
(venv) [jyundt@donuc ansible]$ 
```

cc @nlopez @jose-delarosa 
