### PR TITLE
pkg5: wrap 'to modify' package list

### DIFF
--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -152,7 +152,7 @@ def ensure(module, state, packages, params):
     else:
         no_refresh = ['--no-refresh']
 
-    to_modify = filter(behaviour[state]['filter'], packages)
+    to_modify = list(filter(behaviour[state]['filter'], packages))
     if to_modify:
         rc, out, err = module.run_command(['pkg', behaviour[state]['subcommand']] + dry_run + accept_licenses + beadm + no_refresh + ['-q', '--'] + to_modify)
         response['rc'] = rc


### PR DESCRIPTION
##### SUMMARY
When executing against an OmniOS (r151030) node with only the Python 3.5.7 package installed, pkg5 module tasks fail due to differing behavior between Python 2.x and 3.x (if the Python 2 package is present, /usr/bin/python defaults to that, and everything works as expected). Wrapping filter() with a list() should cover both 2.x and 3.x.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pkg5

##### ADDITIONAL INFORMATION
The trace returned when the module fails:
> Traceback (most recent call last):
>   File "<stdin>", line 113, in <module>
>   File "<stdin>", line 105, in _ansiballz_main
>   File "<stdin>", line 48, in invoke_module
>   File "/usr/lib/python3.5/imp.py", line 235, in load_module
>     return load_source(name, filename, file)
>   File "/usr/lib/python3.5/imp.py", line 170, in load_source
>     module = _exec(spec, sys.modules[name])
>   File "<frozen importlib._bootstrap>", line 626, in _exec
>   File "<frozen importlib._bootstrap_external>", line 697, in exec_module
>   File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
>   File "/tmp/ansible_pkg5_payload_lw9t_kg5/__main__.py", line 154, in <module>
>   File "/tmp/ansible_pkg5_payload_lw9t_kg5/__main__.py", line 88, in main
>   File "/tmp/ansible_pkg5_payload_lw9t_kg5/__main__.py", line 129, in ensure
> TypeError: can only concatenate list (not "filter") to list
