### PR TITLE
Galaxy install warning should include the version of the dependency so we can better understand the problem

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -437,8 +437,8 @@ class GalaxyCLI(CLI):
                                     dep_role.remove()
                                     roles_left.append(dep_role)
                                 else:
-                                    display.warning('- dependency %s from role %s differs from already installed version (%s), skipping' %
-                                                    (to_text(dep_role), role.name, dep_role.install_info['version']))
+                                    display.warning('- dependency %s (%s) from role %s differs from already installed version (%s), skipping' %
+                                                    (to_text(dep_role), dep_role.version, role.name, dep_role.install_info['version']))
                             else:
                                 if force_deps:
                                     roles_left.append(dep_role)


### PR DESCRIPTION
##### SUMMARY
When I get messages like this, I'm still not sure what is going on! I get it all the time. The role versions are up to date... 

Put aside the confusion as to why this is happening, I saw a chance to improve the error message.

```
 [WARNING]: - dependency geerlingguy.php from role geerlingguy.php-mysql differs from already installed version
(3.7.0), skipping
```

There's a bit of information here that isn't being displayed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
galaxy cli

##### ADDITIONAL INFORMATION

To reproduce:

roles.yml
```
- name: geerlingguy.php
  version: 3.7.0

- name: geerlingguy.php-mysql
  version: 2.0.2
```

```sh
$ ansible-galaxy install -r roles.yml
- downloading role 'php', owned by geerlingguy
- downloading role from https://github.com/geerlingguy/ansible-role-php/archive/3.7.0.tar.gz
- extracting geerlingguy.php to /home/jon/Projects/devshop/deps/geerlingguy.php
- geerlingguy.php (3.7.0) was installed successfully
- downloading role 'php-mysql', owned by geerlingguy
- downloading role from https://github.com/geerlingguy/ansible-role-php-mysql/archive/2.0.2.tar.gz
- extracting geerlingguy.php-mysql to /home/jon/Projects/devshop/deps/geerlingguy.php-mysql
- geerlingguy.php-mysql (2.0.2) was installed successfully
 [WARNING]: - dependency geerlingguy.php from role geerlingguy.php-mysql differs from already installed version
(3.7.0), skipping
```

What's really happening is that `geerlingguy.php` is required `geerlingguy.php-mysql` already, so adding it to the playbook is redundant, but I think it's useful to keep it in the playbook because it pins the version, and Galaxy roles can't declare dependency to specific versions.

