### PR TITLE
VMware: add timezone and hwclockUTC customize parameters for Linux guest in vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -320,10 +320,9 @@ options:
           and minus, rest of the characters are dropped as per RFC 952.'
     - 'Parameters related to Linux customization:'
     - ' - C(timezone) (string): Timezone (See List of supported time zones for different vSphere versions in Linux/Unix
-          systems (2145518) U(https://kb.vmware.com/s/article/2145518)).'
+          systems (2145518) U(https://kb.vmware.com/s/article/2145518)). version_added: 2.9'
     - ' - C(hwclockUTC) (bool): Specifies whether the hardware clock is in UTC or local time.
-          True when the hardware clock is in UTC, False when the hardware clock is in local time.'
-    version_added: '2.9'
+          True when the hardware clock is in UTC, False when the hardware clock is in local time. version_added: 2.9'
     - 'Parameters related to Windows customization:'
     - ' - C(autologon) (bool): Auto logon after virtual machine customization (default: False).'
     - ' - C(autologoncount) (int): Number of autologon after reboot (default: 1).'

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -318,6 +318,12 @@ options:
     - ' - C(domain) (string): DNS domain name to use.'
     - ' - C(hostname) (string): Computer hostname (default: shorted C(name) parameter). Allowed characters are alphanumeric (uppercase and lowercase)
           and minus, rest of the characters are dropped as per RFC 952.'
+    - 'Parameters related to Linux customization:'
+    - ' - C(timezone) (string): Timezone (See List of supported time zones for different vSphere versions in Linux/Unix
+          systems (2145518) U(https://kb.vmware.com/s/article/2145518)).'
+    - ' - C(hwclockUTC) (bool): Specifies whether the hardware clock is in UTC or local time.
+          True when the hardware clock is in UTC, False when the hardware clock is in local time.'
+    version_added: '2.9'
     - 'Parameters related to Windows customization:'
     - ' - C(autologon) (bool): Auto logon after virtual machine customization (default: False).'
     - ' - C(autologoncount) (int): Number of autologon after reboot (default: 1).'
@@ -1649,6 +1655,13 @@ class PyVmomiHelper(PyVmomi):
             # Remove all characters except alphanumeric and minus which is allowed by RFC 952
             valid_hostname = re.sub(r"[^a-zA-Z0-9\-]", "", hostname)
             ident.hostName.name = valid_hostname
+
+            # List of supported time zones for different vSphere versions in Linux/Unix systems
+            # https://kb.vmware.com/s/article/2145518
+            if 'timezone' in self.params['customization']:
+                ident.timeZone = str(self.params['customization']['timezone'])
+            if 'hwclockUTC' in self.params['customization']:
+                ident.hwClockUTC = self.params['customization']['hwclockUTC']
 
         self.customspec = vim.vm.customization.Specification()
         self.customspec.nicSettingMap = adaptermaps


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #56296
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add support of "timezone" and "hwclockUTC" guest customization parameters for Linux
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Tested on vSphere 6.7 GA and 6.5 Update2, Ubuntu 18.04 server, open-vm-tools 10.3.0 and 10.3.2.
customize guest OS of an existing VM example playbook:
- hosts: localhost
  tasks:
    - name: "customize the linux VM"
      vmware_guest:
        validate_certs: False
        hostname: xx.xx.xx.xx
        username: xxxxxx
        password: xxxxxx
        folder: ""
        esxi_hostname: xx.test.com
        datacenter: Datacenter
        name: ubuntu18.04.2_test_cus
        customization:
          dns_servers:
            - 192.168.1.1
            - 192.168.1.2
          dns_suffix:
            - test.com
            - test2.com
          domain: my_domain
          hostname: cus_test
          timezone: "Africa/Freetown"
          hwclockUTC: yes
          existing_vm: True
        networks:
          - name: 'VM Network'
            type: static
            ip: 192.168.xx.xx
            netmask: 255.255.255.0
            gateway: 192.168.1.1
            dns_servers: 192.168.1.2
        wait_for_customization: True
      register: test_vm
```
