### PR TITLE
[doc] fix example: always trigger the handler

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -131,6 +131,7 @@ Another example is how to run handlers after an error occurred :
       block:
         - debug:
             msg: 'I execute normally'
+          changed_when: yes
           notify: run me even after an error
         - command: /bin/false
       rescue:


### PR DESCRIPTION
##### SUMMARY

Fix example in documentation: always trigger the handler. By default, `debug` task result isn't changed, then handler is never triggered.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Without this change handler is never executed because never triggered:
```paste
PLAY [localhost] ***

TASK [Gathering Facts] ***
ok: [localhost]

TASK [debug] ***
ok: [localhost] => {
    "msg": "I execute normally"
}

TASK [command] ***
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["/bin/false"], "delta": "0:00:00.001461", "end": "2019-05-14 09:27:04.753049", "msg": "non-zero return code", "rc": 1, "start": "2019-05-14 09:27:04.751588", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

PLAY RECAP ***
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=1    ignored=0   
```

With this change:
```paste
PLAY [localhost] ***

TASK [Gathering Facts] ***
ok: [localhost]

TASK [debug] ***
changed: [localhost] => {
    "msg": "I execute normally"
}

TASK [command] ***
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["/bin/false"], "delta": "0:00:00.001501", "end": "2019-05-14 09:28:32.175268", "msg": "non-zero return code", "rc": 1, "start": "2019-05-14 09:28:32.173767", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

RUNNING HANDLER [run me even after an error] ***
ok: [localhost] => {
    "msg": "This handler runs even on error"
}

PLAY RECAP ***
localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=1    ignored=0   
```