### PR TITLE
Fix VyOS cli prompt issues

### DIFF
--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -81,10 +81,9 @@ class ActionModule(ActionNetworkModule):
 
         conn = Connection(socket_path)
         out = conn.get_prompt()
-        while to_text(out, errors='surrogate_then_replace').strip().endswith('#'):
+        if to_text(out, errors='surrogate_then_replace').strip().endswith('#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
             conn.send_command('exit discard')
-            out = conn.get_prompt()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -109,6 +109,8 @@ class Cliconf(CliconfBase):
                 self.discard_changes()
         else:
             self.send_command('exit')
+            if to_text(self._connection.get_prompt(), errors='surrogate_or_strict').strip().endswith('#'):
+                self.discard_changes()
 
         if diff_config:
             resp['diff'] = diff_config


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Related to #55589
- Open bug in VyOS - https://phabricator.vyos.net/T1372
- It appears that handling prompt check only at action plugin level doesn't work when the task iterates over a loop of items.
- For example a task like the one below would fail while iterating over the second item:
```yaml
---
- name: Remove Config
  cli_config:
    config: "{{ lines }}"
  vars:
    lines: |
      delete interfaces ethernet "{{ intf }}" description
      delete interfaces ethernet "{{ intf }}" speed
      delete interfaces ethernet "{{ intf }}" duplex
      delete interfaces ethernet "{{ intf }}" mtu
      delete interfaces ethernet "{{ intf }}" disable
      delete interfaces ethernet "{{ intf }}" vif
  loop:
    - eth1
    - eth2
    - eth3
  loop_control:
    loop_var: intf
```
- This PR adds the patch in cliconf/edit_config too.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cliconf/vyos.py
