### PR TITLE
postgresql_db: added tablespace support

### DIFF
--- a/lib/ansible/module_utils/database.py
+++ b/lib/ansible/module_utils/database.py
@@ -38,7 +38,7 @@ class UnclosedQuoteError(SQLParseError):
 # maps a type of identifier to the maximum number of dot levels that are
 # allowed to specify that identifier.  For example, a database column can be
 # specified by up to 4 levels: database.schema.table.column
-_PG_IDENTIFIER_TO_DOT_LEVEL = dict(database=1, schema=2, table=3, column=4, role=1)
+_PG_IDENTIFIER_TO_DOT_LEVEL = dict(database=1, schema=2, table=3, column=4, role=1, tablespace=1)
 _MYSQL_IDENTIFIER_TO_DOT_LEVEL = dict(database=1, table=2, column=3, role=1, vars=1)
 
 

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -820,6 +820,9 @@
 # Test postgresql_tablespace module
 - include: postgresql_tablespace.yml
 
+# Test postgresql_db module, specific options:
+- include: postgresql_db.yml
+
 # Test postgresql_privs
 - include: postgresql_privs.yml
 

--- a/test/integration/targets/postgresql/tasks/postgresql_db.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_db.yml
@@ -1,0 +1,169 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# The file for testing new options for postgresql_db module.
+
+- vars:
+    db_tablespace: bar
+    tblspc_location: /ssd
+    db_name: acme
+    block_parameters: &block_parameters
+      become_user: "{{ pg_user }}"
+      become: True
+    task_parameters: &task_parameters
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: "{{ pg_user }}"
+
+  # Start tablespace option tests:
+  block:
+  # create tablespace for tests
+  - name: postgresql_db_tablespace - Create tablespace
+    <<: *task_parameters
+    postgresql_tablespace:
+      <<: *pg_parameters
+      login_db: postgres
+      name: "{{ db_tablespace }}"
+      location: "{{ tblspc_location }}"
+
+  # Check mode for DB creation with tablespace option:
+  - name: postgresql_db_tablespace - Create DB with tablespace option in check mode
+    <<: *task_parameters
+    check_mode: yes
+    postgresql_db:
+      <<: *pg_parameters
+      maintenance_db: postgres
+      name: "{{ db_name }}"
+      tablespace: "{{ db_tablespace }}"
+
+  - assert:
+      that:
+      - result.changed == true
+
+  - name: postgresql_db_tablespace - Check actual DB tablespace, rowcount must be 0 because actually nothing changed
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      login_db: postgres
+      query: >
+        SELECT 1 FROM pg_database AS d JOIN pg_tablespace AS t
+        ON d.dattablespace = t.oid WHERE d.datname = '{{ db_name }}'
+        AND t.spcname = '{{ db_tablespace }}'
+
+  - assert:
+      that:
+      - result.rowcount == 0
+
+  # Actual mode for creation with tablespace option:
+  - name: postgresql_db_tablespace - Create DB with tablespace option
+    <<: *task_parameters
+    postgresql_db:
+      <<: *pg_parameters
+      maintenance_db: postgres
+      name: "{{ db_name }}"
+      tablespace: "{{ db_tablespace }}"
+
+  - assert:
+      that:
+      - result.changed == true
+
+  - name: postgresql_db_tablespace - Check actual DB tablespace, rowcount must be 1
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      login_db: postgres
+      query: >
+        SELECT 1 FROM pg_database AS d JOIN pg_tablespace AS t
+        ON d.dattablespace = t.oid WHERE d.datname = '{{ db_name }}'
+        AND t.spcname = '{{ db_tablespace }}'
+
+  - assert:
+      that:
+      - result.rowcount == 1
+ 
+  # Try to change tablespace to the same:
+  - name: postgresql_db_tablespace - The same DB with tablespace option again
+    <<: *task_parameters
+    postgresql_db:
+      <<: *pg_parameters
+      maintenance_db: postgres
+      name: "{{ db_name }}"
+      tablespace: "{{ db_tablespace }}"
+
+  - assert:
+      that:
+      - result.changed == false
+
+  # Try to change tablespace in check_mode:
+  - name: postgresql_db_tablespace - Change tablespace in check_mode
+    <<: *task_parameters
+    check_mode: yes
+    postgresql_db:
+      <<: *pg_parameters
+      maintenance_db: postgres
+      name: "{{ db_name }}"
+      tablespace: pg_default
+
+  - assert:
+      that:
+      - result.changed == true
+
+  - name: postgresql_db_tablespace - Check actual DB tablespace, rowcount must be 1 because actually nothing changed
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      login_db: postgres
+      query: >
+        SELECT 1 FROM pg_database AS d JOIN pg_tablespace AS t
+        ON d.dattablespace = t.oid WHERE d.datname = '{{ db_name }}'
+        AND t.spcname = '{{ db_tablespace }}'
+
+  - assert:
+      that:
+      - result.rowcount == 1
+
+  # Try to change tablespace to pg_default in actual mode:
+  - name: postgresql_db_tablespace - Change tablespace in actual mode
+    <<: *task_parameters
+    postgresql_db:
+      <<: *pg_parameters
+      maintenance_db: postgres
+      name: "{{ db_name }}"
+      tablespace: pg_default
+
+  - assert:
+      that:
+      - result.changed == true
+
+  - name: postgresql_db_tablespace - Check actual DB tablespace, rowcount must be 1
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      login_db: postgres
+      query: >
+        SELECT 1 FROM pg_database AS d JOIN pg_tablespace AS t
+        ON d.dattablespace = t.oid WHERE d.datname = '{{ db_name }}'
+        AND t.spcname = 'pg_default'
+
+  - assert:
+      that:
+      - result.rowcount == 1
+
+  # Cleanup:
+  - name: postgresql_db_tablespace - Drop test DB
+    <<: *task_parameters
+    postgresql_db:
+      <<: *pg_parameters
+      maintenance_db: postgres
+      name: "{{ db_name }}"
+      state: absent
+
+  - name: postgresql_db_tablespace - Remove tablespace
+    <<: *task_parameters
+    postgresql_tablespace:
+      <<: *pg_parameters
+      login_db: postgres
+      name: "{{ db_tablespace }}"
+      state: absent
+
+  <<: *block_parameters
+  # End of tablespace block


### PR DESCRIPTION
##### SUMMARY
Added tablespace support for postgresql_db module

Instead of #37953 No feedback from the author

```
  tablespace:
    description:
      - The tablespace to set for the database https://www.postgresql.org/docs/current/sql alterdatabase.html.
      - If you want to move the database back to the default tablespace, explicitly set this to pg_default.
    type: path
    version_added: '2.9'
```

##### EXAMPLE
```
# Note: In the example below, if database foo exists and has another tablespace
# the tablespace will be changed to foo. Access to the database will be locked
# until the copying of database files is finished.
- name: Create a new database called foo in tablespace bar
  postgresql_db:
    name: foo
    tablespace: bar
```