### PR TITLE
fix module defaults (#56020)

### DIFF
--- a/changelogs/fragments/module_default_fixes.yaml
+++ b/changelogs/fragments/module_default_fixes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - refactored into function and use in some action plugins to match actual module used, made precedence very clear in code.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1051,3 +1051,32 @@ def modify_module(module_name, module_path, module_args, templar, task_vars=None
         b_module_data = b"\n".join(b_lines)
 
     return (b_module_data, module_style, shebang)
+
+
+def get_action_args_with_defaults(action, args, defaults, templar):
+
+    tmp_args = {}
+    module_defaults = {}
+
+    # Merge latest defaults into dict, since they are a list of dicts
+    if isinstance(defaults, list):
+        for default in defaults:
+            module_defaults.update(default)
+
+    # if I actually have defaults, template and merge
+    if module_defaults:
+        module_defaults = templar.template(module_defaults)
+
+        # deal with configured group defaults first
+        if action in C.config.module_defaults_groups:
+            for group in C.config.module_defaults_groups.get(action, []):
+                tmp_args.update((module_defaults.get('group/{0}'.format(group)) or {}).copy())
+
+        # handle specific action defaults
+        if action in module_defaults:
+            tmp_args.update(module_defaults[action].copy())
+
+    # direct args override all
+    tmp_args.update(args)
+
+    return tmp_args

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -8,6 +8,7 @@ import os
 import time
 
 from ansible import constants as C
+from ansible.executor.module_common import get_action_args_with_defaults
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import combine_vars
 
@@ -38,6 +39,9 @@ class ActionModule(ActionBase):
         # Strip out keys with ``None`` values, effectively mimicking ``omit`` behavior
         # This ensures we don't pass a ``None`` value as an argument expecting a specific type
         mod_args = dict((k, v) for k, v in mod_args.items() if v is not None)
+
+        # handle module defaults
+        mod_args = get_action_args_with_defaults(fact_module, mod_args, self._task.module_defaults, self._templar)
 
         return mod_args
 

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -18,6 +18,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleAction, AnsibleActionFail
+from ansible.executor.module_common import get_action_args_with_defaults
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
@@ -63,6 +64,9 @@ class ActionModule(ActionBase):
                     new_module_args = self._task.args.copy()
                     if 'use' in new_module_args:
                         del new_module_args['use']
+
+                    # get defaults for specific module
+                    new_module_args = get_action_args_with_defaults(module, new_module_args, self._task.module_defaults, self._templar)
 
                     display.vvvv("Running %s" % module)
                     result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 
 from ansible.errors import AnsibleAction, AnsibleActionFail
+from ansible.executor.module_common import get_action_args_with_defaults
 from ansible.plugins.action import ActionBase
 
 
@@ -70,6 +71,9 @@ class ActionModule(ActionBase):
                         if unused in new_module_args:
                             del new_module_args[unused]
                             self._display.warning('Ignoring "%s" as it is not used in "%s"' % (unused, module))
+
+                # get defaults for specific module
+                new_module_args = get_action_args_with_defaults(module, new_module_args, self._task.module_defaults, self._templar)
 
                 self._display.vvvv("Running %s" % module)
                 result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))


### PR DESCRIPTION
* fix module defaults

 - corrected precedence (specific module > group)
 - made into reusable function
 - use from gather_facts/service/package to match 'actual module used'



(cherry picked from commit 674a57c3fa9abe1ccc6a22d2d5cff4ba8a8ba0b8)

Backport of https://github.com/ansible/ansible/pull/56020

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_defaults