### PR TITLE
Create requirements-netaddr.txt

### DIFF
--- a/packaging/requirements/requirements-netaddr.txt
+++ b/packaging/requirements/requirements-netaddr.txt
@@ -1,0 +1,1 @@
+netaddr


### PR DESCRIPTION
##### SUMMARY
Python import cache is not being reloaded for each task, and as discussed in IRC it doesn't make any sense to do so. I faced the problem where I had to run ansible twice in order to install dependencies for the ipaddr filter, and only then run the main playbook (see #49139). In this PR I propose adding an extra to simplify ansible installation with the ipaddr filter. I suppose this would be enough

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ipaddr filter
