### PR TITLE
hetzner changed image tag for server, so its working with ids and names

### DIFF
--- a/lib/ansible/modules/cloud/hcloud/hcloud_server.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_server.py
@@ -234,10 +234,14 @@ class AnsibleHcloudServer(Hcloud):
             "server_type": self.client.server_types.get_by_name(
                 self.module.params.get("server_type")
             ),
-            "image": self.client.images.get_by_name(self.module.params.get("image")),
             "user_data": self.module.params.get("user_data"),
             "labels": self.module.params.get("labels"),
         }
+        if self.client.images.get_by_name(self.module.params.get("image")) is not None:
+            # When image name is not available look for id instead
+            params["image"] = self.client.images.get_by_name(self.module.params.get("image"))
+        else: 
+            params["image"] = self.client.images.get_by_id(self.module.params.get("image"))
 
         if self.module.params.get("ssh_keys") is not None:
             params["ssh_keys"] = [

--- a/lib/ansible/modules/cloud/hcloud/hcloud_server.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_server.py
@@ -270,7 +270,7 @@ class AnsibleHcloudServer(Hcloud):
         if not self.module.check_mode:
             resp = self.client.servers.create(**params)
             self.result["root_password"] = resp.root_password
-            resp.action.wait_until_finished()
+            resp.action.wait_until_finished(max_retries=1000)
             [action.wait_until_finished() for action in resp.next_actions]
         self._mark_as_changed()
         self._get_server()

--- a/lib/ansible/modules/cloud/hcloud/hcloud_server.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_server.py
@@ -240,7 +240,7 @@ class AnsibleHcloudServer(Hcloud):
         if self.client.images.get_by_name(self.module.params.get("image")) is not None:
             # When image name is not available look for id instead
             params["image"] = self.client.images.get_by_name(self.module.params.get("image"))
-        else: 
+        else:
             params["image"] = self.client.images.get_by_id(self.module.params.get("image"))
 
         if self.module.params.get("ssh_keys") is not None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module is in its current form only able to use the standard images from Hetzner. If you want to use your own snapshots as an image for server creation, it is not working, since those can not be named and there is an id expected. 
The change looks if there is an image by the provided name, if not it tries to find it via the id. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_server
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Instead of defining the image directly in the parameters its checked if an image by that name is available at Hetzner. If not, the first check will fail and it will try to use the ID instead. 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
