### PR TITLE
Properly handle check for session support on eos

### DIFF
--- a/changelogs/fragments/56407_eos_use_sessions.yaml
+++ b/changelogs/fragments/56407_eos_use_sessions.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - eos_use_sessions is now type boolean instead of int.

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -226,8 +226,10 @@ class Cliconf(CliconfBase):
             if self._session_support:
                 return self._session_support
 
-            response = self.get('show configuration sessions')
-            self._session_support = 'error' not in response
+            try:
+                self.get('show configuration sessions')
+            except AnsibleConnectionFailure:
+                self._session_support = False
 
         return self._session_support
 

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -30,8 +30,8 @@ description:
 version_added: "2.4"
 options:
   eos_use_sessions:
-    type: int
-    default: 1
+    type: boolean
+    default: yes
     description:
       - Specifies if sessions should be used on remote host or not
     env:
@@ -214,13 +214,7 @@ class Cliconf(CliconfBase):
         return diff
 
     def supports_sessions(self):
-        use_session = self.get_option('eos_use_sessions')
-        try:
-            use_session = int(use_session)
-        except ValueError:
-            pass
-
-        if not bool(use_session):
+        if not self.get_option('eos_use_sessions'):
             self._session_support = False
         else:
             if self._session_support:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #19586

Presumably this check was correct once, and cliconf `get()` calls were changed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_config