### PR TITLE
[stable-2.8] Don't detect update if vrf not set. (#56235)

### DIFF
--- a/changelogs/fragments/56235-eapi-vrf.yaml
+++ b/changelogs/fragments/56235-eapi-vrf.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- eos_eapi: fix idempotency issues when vrf was unspecified.
+- "eos_eapi: fix idempotency issues when vrf was unspecified."

--- a/changelogs/fragments/56235-eapi-vrf.yaml
+++ b/changelogs/fragments/56235-eapi-vrf.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- eos_eapi: fix idempotency issues when vrf was unspecified.

--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -299,7 +299,7 @@ def map_config_to_obj(module):
         'local_http': out[0]['localHttpServer']['configured'],
         'local_http_port': out[0]['localHttpServer']['port'],
         'socket': out[0]['unixSocketServer']['configured'],
-        'vrf': out[0]['vrf'],
+        'vrf': out[0]['vrf'] or "default",
         'state': parse_state(out)
     }
 


### PR DESCRIPTION
(cherry picked from commit ea41bbc)

Co-authored-by: Nathaniel Case <ncase@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_eapi