### PR TITLE
azure_rm_securitygroup - fix delete error handling

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -741,7 +741,8 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
             poller = self.network_client.network_security_groups.delete(resource_group_name=self.resource_group, network_security_group_name=self.name)
             result = self.get_poller_result(poller)
         except CloudError as exc:
-            raise Exception("Error deleting security group {0} - {1}".format(self.name, str(exc)))
+            self.fail("Error deleting security group {0} - {1}".format(self.name, str(exc)))
+
         return result
 
     def convert_asg_to_id(self, rule):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If you attempt to delete a security group that is in use, it throws an exception off the top and causes a generic "MODULE FAILURE" result instead of calling self.fail(...)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_securitygroup
