### PR TITLE
winrm - fix failure parsing for send input errors (#56245) - 2.8

### DIFF
--- a/changelogs/fragments/winrm-input-failures.yaml
+++ b/changelogs/fragments/winrm-input-failures.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - Fix issue when attempting to parse CLIXML on send input failure

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -482,8 +482,8 @@ class Connection(ConnectionBase):
                 except ValueError:
                     # stdout does not contain a return response, stdin input was a fatal error
                     stderr = to_bytes(response.std_err, encoding='utf-8')
-                    if self.is_clixml(stderr):
-                        stderr = self.parse_clixml_stream(stderr)
+                    if stderr.startswith(b"#< CLIXML"):
+                        stderr = _parse_clixml(stderr)
 
                     raise AnsibleError('winrm send_input failed; \nstdout: %s\nstderr %s'
                                        % (to_native(response.std_out), to_native(stderr)))


### PR DESCRIPTION
(cherry picked from commit fd65f037f8c1f4ccd110454a40df15dcadd4cbb4)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/56245

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
winrm