### PR TITLE
ansible_hostname_f: a platform fact mimicking `hostname -f`

### DIFF
--- a/lib/ansible/module_utils/facts/system/platform.py
+++ b/lib/ansible/module_utils/facts/system/platform.py
@@ -53,6 +53,11 @@ class PlatformFactCollector(BaseFactCollector):
 
         platform_facts['domain'] = '.'.join(platform_facts['fqdn'].split('.')[1:])
 
+        # this is what `hostname -f` returns
+        platform_facts['hostname_f'] = socket.getaddrinfo(socket.gethostname(), None, 0, socket.SOCK_DGRAM, 0, socket.AI_CANONNAME)[0][3]
+        # this is what `hostname -d` returns
+        platform_facts['hostname_d'] = '.'.join(platform_facts['hostname_f'].split('.')[1:])
+
         arch_bits = platform.architecture()[0]
 
         platform_facts['userspace_bits'] = arch_bits.replace('bit', '')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are some issues with ansible_fqdn platform fact (#38777, #9972, maybe others). I recently stuck into another one: if you have multiple PTR records with different names for one IP address, ansible_fqdn value is randomly set to one of those names. For example, [Mikrotik](http://www.mikrotik.com) built-in DNS server lets you have multiple names resolving to the same IP, but it gives you no option to choose which name to resolve that IP into via PTR record — it just creates as many PTRs for that IP as many names you give it. Nevertheless, `hostname -f` always returns the same, there [was](https://github.com/ansible/ansible/issues/9972#issuecomment-69468592) a hint about it.

Due to this, I propose a new fact, ansible_hostname_f, which value is populated the same way `hostname -f` works:
``
Technically: The FQDN is the name getaddrinfo(3) returns for the host name returned by gethostname(2).  The DNS domain name is the part after the first dot.
``
(from `man hostname`). I also propose ansible_hostname_d mimicking `hostname -d`.

In order not to break the backwards compatibility with existing setups, I don't replace any existing facts but add new ones instead.

In order to maintain cross-platform portability this implementation does not call hostname(1) binary but implements the same algo on python using the already-utilised socket module.

Please consider applying.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/facts/system/platform.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
