### PR TITLE
win_service recovery actions support

### DIFF
--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -148,6 +148,14 @@ Function Get-ServiceInfo($name) {
         $description = ""
     }
 
+    $recovery = Get-RecoveryActions($svc.Name)
+
+    if ('' -ne $recovery) {
+        $recovery = RecoveryActionsToHuman($recovery)
+    } else {
+        $recovery = @{}
+    }
+
     $result.exists = $true
     $result.name = $svc.Name
     $result.display_name = $svc.DisplayName
@@ -160,7 +168,7 @@ Function Get-ServiceInfo($name) {
     $result.dependencies = $existing_dependencies
     $result.depended_by = $existing_depended_by
     $result.can_pause_and_continue = $svc.CanPauseAndContinue
-    $result.recovery = RecoveryActionsToHuman("2c010000000000000000000003000000140000000100000060ea00000100000060ea00000100000060ea0000")
+    $result.recovery = $recovery
 }
 
 Function Get-WmiErrorMessage($return_value) {

--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -97,12 +97,12 @@ Function RecoveryActionMapping ($a) {
 
 Function RecoveryActionsToHuman ($s) {
     $res = (("{0:x8}" -f $s) -split '(........)' | Where-Object { $_ }).split(" ")
-    
+
     for ($i=0; $i -lt $res.Length; $i++) {
         $res[$i]=DecValue($res[$i])
     }
 
-    $recovery_actions = @{ 
+    $recovery_actions = @{
                             'reset_fail_count_after' = $res[0];
                             'on_first_failure' = $res[5];
                             'first_failure_timeout' = $res[6];

--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -522,7 +522,9 @@ Function Set-ServiceRecovery($name, $actions) {
 
     if ($recovery_actions -ne $processed_actions) {
 
-            $cmd_output=sc.exe \\$env:computername failure $name reset= $reset actions= $actions_string
+            if (!$check_mode) {
+                $cmd_output=sc.exe failure $name reset= $reset actions= $actions_string
+            }
 
             if ($LASTEXITCODE -ne 0) {
                 Fail-Json $result ("Service recovery set failed." + $cmd_output)

--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -87,8 +87,12 @@ Function DecValue ($v) {
 Function RecoveryActionMapping ($a) {
 
     $res = switch($a) {
+        'no_action' { 0 }
         'restart' { 1 }
         'reboot' { 2 }
+        0 { 'no_action' }
+        1 { 'restart' }
+        2 { 'reboot' }
         default { 0 }
     }
 
@@ -104,11 +108,11 @@ Function RecoveryActionsToHuman ($s) {
 
     $recovery_actions = @{
                             'reset_fail_count_after' = $res[0];
-                            'on_first_failure' = $res[5];
+                            'on_first_failure' = RecoveryActionMapping($res[5]);
                             'first_failure_timeout' = $res[6];
-                            'on_second_failure' = $res[7];
+                            'on_second_failure' = RecoveryActionMapping($res[7]);
                             'second_failure_timeout' = $res[8];
-                            'on_subsequent_failure' = $res[9];
+                            'on_subsequent_failure' = RecoveryActionMapping($res[9]);
                             'subsequent_failure_timeout' = $res[10];
                         }
 

--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -524,10 +524,10 @@ Function Set-ServiceRecovery($name, $actions) {
 
             if (!$check_mode) {
                 $cmd_output=sc.exe failure $name reset= $reset actions= $actions_string
-            }
 
-            if ($LASTEXITCODE -ne 0) {
-                Fail-Json $result ("Service recovery set failed." + $cmd_output)
+                if ($LASTEXITCODE -ne 0) {
+                    Fail-Json $result ("Service recovery set failed." + $cmd_output)
+                }
             }
 
         $result.changed = $true

--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -500,19 +500,15 @@ Function Set-ServiceRecovery($name, $reset_interval, $actions) {
 
     $reset_fail_count_after = ReversedHexValue $reset_interval
 
-    if ($actions.Count -ge 1) {
+    if ($actions.Count -ge 3) {
       $on_first_failure = ReversedHexValue (RecoveryActionMapping($actions[0].action))
       $first_failure_timeout = ReversedHexValue $actions[0].delay
-    }
-
-    if ($actions.Count -ge 2) {
       $on_second_failure = ReversedHexValue (RecoveryActionMapping($actions[1].action))
       $second_failure_timeout = ReversedHexValue $actions[1].delay
-    }
-
-    if ($actions.Count -ge 3) {
       $on_subsequent_failure = ReversedHexValue (RecoveryActionMapping($actions[2].action))
       $subsequent_failure_timeout = ReversedHexValue $actions[2].delay
+    } else {
+      Fail-Json $result ("You need to specify the three states of recovery_actions.")
     }
 
     $processed_actions = ($reset_fail_count_after + $lp_reboot_msg + $lp_command + $ca_actions + $lpsaActions `
@@ -525,6 +521,7 @@ Function Set-ServiceRecovery($name, $reset_interval, $actions) {
     $actions_string=$actions[0].action + '/' + $actions[0].delay `
                 + '/' + $actions[1].action + '/' + $actions[1].delay `
                 + '/' + $actions[2].action + '/' + $actions[2].delay
+
     $reset=$reset_interval
 
     if ($recovery_actions -ne $processed_actions) {

--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -495,11 +495,11 @@ Function Set-ServiceRecovery($name, $reset_interval, $actions) {
     $reset_fail_count_after = ReversedHexValue $reset_interval
 
     if ($actions.Count -eq 3) {
-      $on_first_failure = ReversedHexValue ($recovery_actions_map.$actions[0].action)
+      $on_first_failure = ReversedHexValue ($recovery_actions_map.($actions[0].action))
       $first_failure_timeout = ReversedHexValue $actions[0].delay
-      $on_second_failure = ReversedHexValue ($recovery_actions_map.$actions[1].action)
+      $on_second_failure = ReversedHexValue ($recovery_actions_map.($actions[1].action))
       $second_failure_timeout = ReversedHexValue $actions[1].delay
-      $on_subsequent_failure = ReversedHexValue ($recovery_actions_map.$actions[2].action)
+      $on_subsequent_failure = ReversedHexValue ($recovery_actions_map.($actions[2].action))
       $subsequent_failure_timeout = ReversedHexValue $actions[2].delay
     } else {
       Fail-Json $result ("You need to specify the three states of recovery_actions.")

--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -30,15 +30,6 @@ $result = @{
     changed = $false
 }
 
-$recovery_actions_map = @{
-	no_action = 0
-	restart = 1
-	reboot = 2
-	0 = 'no_action'
-	1 = 'restart'
-	2 = 'reboot'
-}
-
 # parse the username to SID and back so we get the full username with domain in a way WMI understands
 if ($null -ne $username) {
     if ($username -eq "LocalSystem") {
@@ -94,6 +85,21 @@ Function DecValue ($v) {
   return $res
 }
 
+Function RecoveryActionMapping ($a) {
+
+    $res = switch($a) {
+        'no_action' { 0 }
+        'restart' { 1 }
+        'reboot' { 2 }
+        0 { 'no_action' }
+        1 { 'restart' }
+        2 { 'reboot' }
+        default { 0 }
+    }
+
+    return $res
+}
+
 Function Convert-RecoveryActionsToHuman ($s) {
     $res = (("{0:x8}" -f $s) -split '(........)' | Where-Object { $_ }).split(" ")
 
@@ -103,11 +109,11 @@ Function Convert-RecoveryActionsToHuman ($s) {
 
     $recovery_actions = @{
                             'reset_fail_count_after' = $res[0];
-                            'on_first_failure' = $recovery_actions_map.$res[5];
+                            'on_first_failure' = RecoveryActionMapping($res[5]);
                             'first_failure_timeout' = $res[6];
-                            'on_second_failure' = $recovery_actions_map.$res[7];
+                            'on_second_failure' = RecoveryActionMapping($res[7]);
                             'second_failure_timeout' = $res[8];
-                            'on_subsequent_failure' = $recovery_actions_map.$res[9];
+                            'on_subsequent_failure' = RecoveryActionMapping($res[9]);
                             'subsequent_failure_timeout' = $res[10];
                         }
 
@@ -495,11 +501,11 @@ Function Set-ServiceRecovery($name, $reset_interval, $actions) {
     $reset_fail_count_after = ReversedHexValue $reset_interval
 
     if ($actions.Count -eq 3) {
-      $on_first_failure = ReversedHexValue ($recovery_actions_map.($actions[0].action))
+      $on_first_failure = ReversedHexValue (RecoveryActionMapping($actions[0].action))
       $first_failure_timeout = ReversedHexValue $actions[0].delay
-      $on_second_failure = ReversedHexValue ($recovery_actions_map.($actions[1].action))
+      $on_second_failure = ReversedHexValue (RecoveryActionMapping($actions[1].action))
       $second_failure_timeout = ReversedHexValue $actions[1].delay
-      $on_subsequent_failure = ReversedHexValue ($recovery_actions_map.($actions[2].action))
+      $on_subsequent_failure = ReversedHexValue (RecoveryActionMapping($actions[2].action))
       $subsequent_failure_timeout = ReversedHexValue $actions[2].delay
     } else {
       Fail-Json $result ("You need to specify the three states of recovery_actions.")

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -119,39 +119,46 @@ options:
       - This needs to be defined for the recovery actions to be set/updated.
     type: int
     default: null
+    version_added: '2.9'
   first_failure_action:
     description:
       - The first failure action to take (can be 0, 1, 2, 3)
       - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
     type: int
     default: 0
+    version_added: '2.9'
   first_failure_timer:
     description:
       - The first timer to wait for your first action to take effect in miliseconds.
     type: int
     default: 60000
+    version_added: '2.9'
   second_failure_action:
     description:
       - The second failure action to take (can be 0, 1, 2, 3)
       - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
     type: int
     default: 0
+    version_added: '2.9'
   second_failure_timer:
     description:
       - The second timer to wait for your second action to take effect in miliseconds.
     type: int
     default: 60000
+    version_added: '2.9'
   subseq_failure_action:
     description:
       - The subsequent failures action to take (can be 0, 1, 2, 3)
       - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
     type: int
     default: 0
+    version_added: '2.9'
   subseq_failure_timer:
     description:
       - The subesquent timer to wait for your subsequent action to take effect in miliseconds.
     type: int
     default: 60000
+    version_added: '2.9'
   
 seealso:
 - module: service
@@ -270,16 +277,16 @@ EXAMPLES = r'''
     - service2
     dependency_action: remove
 
- - name: Set recovery actions
-   win_service:
-     name: service name
-     reset_period: 300
-     first_failure_action: 1
-     first_failure_timer: 60000
-     second_failure_action: 1
-     second_failure_timer: 60000
-     subseq_failure_action: 1
-     subseq_failure_timer: 60000
+- name: Set recovery actions
+  win_service:
+    name: service name
+    reset_period: 300
+    first_failure_action: 1
+    first_failure_timer: 60000
+    second_failure_action: 1
+    second_failure_timer: 60000
+    subseq_failure_action: 1
+    subseq_failure_timer: 60000
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -114,9 +114,9 @@ options:
     type: str
     version_added: '2.3'
   recovery:
-    descrption:
+    description:
       - A dictionary representing the recovery actions you want to set.
-    suboptions:
+    options:
       reset_fail_count_after:
         description:
           - Reset failure counter after this number of seconds.
@@ -345,4 +345,17 @@ depended_by:
     returned: success and service exists
     type: list
     sample: false
+recovery:
+    description: A dict of the recovery settings.
+    returned: success, changed
+    sample:
+      {
+        "first_failure_timeout": "60000",
+        "on_first_failure": "1",
+        "on_second_failure": "1",
+        "on_subsequent_failure": "1",
+        "reset_fail_count_after": "300",
+        "second_failure_timeout": "60000",
+        "subsequent_failure_timeout": "60000"
+      }
 '''

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -352,9 +352,9 @@ recovery:
     sample:
       {
         "first_failure_timeout": "60000",
-        "on_first_failure": "1",
-        "on_second_failure": "1",
-        "on_subsequent_failure": "1",
+        "on_first_failure": "restart",
+        "on_second_failure": "restart",
+        "on_subsequent_failure": "restart",
         "reset_fail_count_after": "300",
         "second_failure_timeout": "60000",
         "subsequent_failure_timeout": "60000"

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -159,7 +159,7 @@ options:
     type: int
     default: 60000
     version_added: '2.9'
-  
+ 
 seealso:
 - module: service
 - module: win_nssm

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -113,51 +113,45 @@ options:
     - A newly created service will default to C(LocalSystem).
     type: str
     version_added: '2.3'
-  reset_period:
-    description:
-      - The reset period for the service recovery actions in seconds.
-      - This needs to be defined for the recovery actions to be set/updated.
-    type: int
-    default: null
-    version_added: '2.9'
-  first_failure_action:
-    description:
-      - The first failure action to take (can be 0, 1, 2, 3)
-      - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
-    type: int
-    default: 0
-    version_added: '2.9'
-  first_failure_timer:
-    description:
-      - The first timer to wait for your first action to take effect in miliseconds.
-    type: int
-    default: 60000
-    version_added: '2.9'
-  second_failure_action:
-    description:
-      - The second failure action to take (can be 0, 1, 2, 3)
-      - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
-    type: int
-    default: 0
-    version_added: '2.9'
-  second_failure_timer:
-    description:
-      - The second timer to wait for your second action to take effect in miliseconds.
-    type: int
-    default: 60000
-    version_added: '2.9'
-  subseq_failure_action:
-    description:
-      - The subsequent failures action to take (can be 0, 1, 2, 3)
-      - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
-    type: int
-    default: 0
-    version_added: '2.9'
-  subseq_failure_timer:
-    description:
-      - The subesquent timer to wait for your subsequent action to take effect in miliseconds.
-    type: int
-    default: 60000
+  recovery:
+    descrption:
+      - A dictionary representing the recovery actions you want to set.
+    suboptions:
+      reset_fail_count_after:
+        description:
+          - Reset failure counter after this number of seconds.
+        type: int
+      on_first_failure:
+        description:
+          - Action to take on first failure of the service.
+          - Only restart and reboot are supported value.
+          - Defaults to Take no action.
+        type: str
+      first_failure_timeout:
+        description:
+          - Time to wait to execute first failure action in ms.
+        type: int
+      on_second_failure:
+        description:
+          - Action to take on second failure of the service.
+          - Only restart and reboot are supported value.
+          - Defaults to Take no action.
+        type: str
+      second_failure_timeout:
+        description:
+          - Time to wait to execute second failure action in ms.
+        type: int
+      on_subsequent_failure:
+        description:
+          - Action to take on subsequent failure of the service.
+          - Only restart and reboot are supported value.
+          - Defaults to Take no action.
+        type: str
+      subsequent_failure_timeout:
+        description:
+          - Time to wait to execute subsequent failure action in ms.
+        type: int
+    type: dict
     version_added: '2.9'
 
 seealso:
@@ -280,13 +274,14 @@ EXAMPLES = r'''
 - name: Set recovery actions
   win_service:
     name: service name
-    reset_period: 300
-    first_failure_action: 1
-    first_failure_timer: 60000
-    second_failure_action: 1
-    second_failure_timer: 60000
-    subseq_failure_action: 1
-    subseq_failure_timer: 60000
+    recovery:
+      reset_fail_count_after: 300
+      on_first_failure: restart
+      first_failure_timeout: 60000
+      on_second_failure: restart
+      second_failure_timeout: 60000
+      on_subsequent_failure: reboot
+      subsequent_failure_timeout: 60000
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -159,7 +159,7 @@ options:
     type: int
     default: 60000
     version_added: '2.9'
- 
+
 seealso:
 - module: service
 - module: win_nssm

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -125,7 +125,7 @@ options:
         description:
           - Action to take on first failure of the service.
           - Only restart and reboot are supported value.
-          - Defaults to Take no action.
+          - Defaults to no_action.
         type: str
       first_failure_timeout:
         description:
@@ -135,7 +135,7 @@ options:
         description:
           - Action to take on second failure of the service.
           - Only restart and reboot are supported value.
-          - Defaults to Take no action.
+          - Defaults to no_action.
         type: str
       second_failure_timeout:
         description:
@@ -145,7 +145,7 @@ options:
         description:
           - Action to take on subsequent failure of the service.
           - Only restart and reboot are supported value.
-          - Defaults to Take no action.
+          - Defaults to no_action.
         type: str
       subsequent_failure_timeout:
         description:

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -4,7 +4,7 @@
 # Copyright: (c) 2014, Chris Hoffman <choffman@chathamfinancial.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
+ANSIBLE_METADATA = {'metadata_version': '1.2',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
 
@@ -113,6 +113,46 @@ options:
     - A newly created service will default to C(LocalSystem).
     type: str
     version_added: '2.3'
+  reset_period:
+    description:
+      - The reset period for the service recovery actions in seconds.
+      - This needs to be defined for the recovery actions to be set/updated.
+    type: int
+    default: null
+  first_failure_action:
+    description:
+      - The first failure action to take (can be 0, 1, 2, 3)
+      - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
+    type: int
+    default: 0
+  first_failure_timer:
+    description:
+      - The first timer to wait for your first action to take effect in miliseconds.
+    type: int
+    default: 60000
+  second_failure_action:
+    description:
+      - The second failure action to take (can be 0, 1, 2, 3)
+      - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
+    type: int
+    default: 0
+  second_failure_timer:
+    description:
+      - The second timer to wait for your second action to take effect in miliseconds.
+    type: int
+    default: 60000
+  subseq_failure_action:
+    description:
+      - The subsequent failures action to take (can be 0, 1, 2, 3)
+      - https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_sc_action
+    type: int
+    default: 0
+  subseq_failure_timer:
+    description:
+      - The subesquent timer to wait for your subsequent action to take effect in miliseconds.
+    type: int
+    default: 60000
+  
 seealso:
 - module: service
 - module: win_nssm
@@ -229,6 +269,17 @@ EXAMPLES = r'''
     - service1
     - service2
     dependency_action: remove
+
+ - name: Set recovery actions
+   win_service:
+     name: service name
+     reset_period: 300
+     first_failure_action: 1
+     first_failure_timer: 60000
+     second_failure_action: 1
+     second_failure_timer: 60000
+     subseq_failure_action: 1
+     subseq_failure_timer: 60000
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -124,8 +124,8 @@ options:
       on_first_failure:
         description:
           - Action to take on first failure of the service.
-          - Only restart and reboot are supported value.
-          - Defaults to no_action.
+        choices: [ restart, reboot, no_action ]
+        default: no_action
         type: str
       first_failure_timeout:
         description:
@@ -134,8 +134,8 @@ options:
       on_second_failure:
         description:
           - Action to take on second failure of the service.
-          - Only restart and reboot are supported value.
-          - Defaults to no_action.
+        choices: [ restart, reboot, no_action ]
+        default: no_action
         type: str
       second_failure_timeout:
         description:
@@ -144,8 +144,8 @@ options:
       on_subsequent_failure:
         description:
           - Action to take on subsequent failure of the service.
-          - Only restart and reboot are supported value.
-          - Defaults to no_action.
+        choices: [ restart, reboot, no_action ]
+        default: no_action
         type: str
       subsequent_failure_timeout:
         description:

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -4,7 +4,7 @@
 # Copyright: (c) 2014, Chris Hoffman <choffman@chathamfinancial.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {'metadata_version': '1.2',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
 

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -116,7 +116,7 @@ options:
   recovery:
     description:
       - A dictionary representing the recovery actions you want to set.
-    options:
+    suboptions:
       reset_fail_count_after:
         description:
           - Reset failure counter after this number of seconds.
@@ -348,6 +348,7 @@ depended_by:
 recovery:
     description: A dict of the recovery settings.
     returned: success, changed
+    type: dict
     sample:
       {
         "first_failure_timeout": "60000",

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -113,45 +113,20 @@ options:
     - A newly created service will default to C(LocalSystem).
     type: str
     version_added: '2.3'
-  recovery:
+  recovery_reset_interval:
+		description:
+			- Reset failure counter after this number of seconds.
+		type: int
+		default: 1
+		version_added: '2.9'
+	recovery_actions:
     description:
-      - A dictionary representing the recovery actions you want to set.
-    suboptions:
-      reset_fail_count_after:
-        description:
-          - Reset failure counter after this number of seconds.
-        type: int
-      on_first_failure:
-        description:
-          - Action to take on first failure of the service.
-        choices: [ restart, reboot, no_action ]
-        default: no_action
-        type: str
-      first_failure_timeout:
-        description:
-          - Time to wait to execute first failure action in ms.
-        type: int
-      on_second_failure:
-        description:
-          - Action to take on second failure of the service.
-        choices: [ restart, reboot, no_action ]
-        default: no_action
-        type: str
-      second_failure_timeout:
-        description:
-          - Time to wait to execute second failure action in ms.
-        type: int
-      on_subsequent_failure:
-        description:
-          - Action to take on subsequent failure of the service.
-        choices: [ restart, reboot, no_action ]
-        default: no_action
-        type: str
-      subsequent_failure_timeout:
-        description:
-          - Time to wait to execute subsequent failure action in ms.
-        type: int
-    type: dict
+      - A list representing the recovery actions you want to set.
+			- First element of the list is the first failure actions/delay...
+			- This can go up to a count of three for subsequent failures.
+			- ie: - action: restart
+              delay: 60000
+		type: list
     version_added: '2.9'
 
 seealso:

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -114,19 +114,19 @@ options:
     type: str
     version_added: '2.3'
   recovery_reset_interval:
-		description:
-			- Reset failure counter after this number of seconds.
-		type: int
-		default: 1
-		version_added: '2.9'
-	recovery_actions:
+    description:
+      - Reset failure counter after this number of seconds.
+    type: int
+    default: 1
+    version_added: '2.9'
+  recovery_actions:
     description:
       - A list representing the recovery actions you want to set.
-			- First element of the list is the first failure actions/delay...
-			- This can go up to a count of three for subsequent failures.
-			- ie: - action: restart
+      - First element of the list is the first failure actions/delay...
+      - This can go up to a count of three for subsequent failures.
+      - ie: - action: restart
               delay: 60000
-		type: list
+    type: list
     version_added: '2.9'
 
 seealso:

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -118,14 +118,14 @@ options:
       - Reset failure counter after this number of seconds.
     type: int
     default: 1
-    version_added: '2.9'
+    version_added: '2.10'
   recovery_actions:
     description:
       - A list representing the recovery actions you want to set.
       - First element of the list is the first failure actions/delay...
       - This can go up to a count of three for subsequent failures.
     type: list
-    version_added: '2.9'
+    version_added: '2.10'
 
 seealso:
 - module: service

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -124,8 +124,6 @@ options:
       - A list representing the recovery actions you want to set.
       - First element of the list is the first failure actions/delay...
       - This can go up to a count of three for subsequent failures.
-      - ie: - action: restart
-              delay: 60000
     type: list
     version_added: '2.9'
 
@@ -249,14 +247,14 @@ EXAMPLES = r'''
 - name: Set recovery actions
   win_service:
     name: service name
-    recovery:
-      reset_fail_count_after: 300
-      on_first_failure: restart
-      first_failure_timeout: 60000
-      on_second_failure: restart
-      second_failure_timeout: 60000
-      on_subsequent_failure: reboot
-      subsequent_failure_timeout: 60000
+    recovery_reset_interval: 300
+    recovery_actions:
+      - action: restart
+        delay: 60000
+      - action: restart
+        delay: 60000
+      - action: reboot
+        delay: 60000
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -117,13 +117,13 @@ options:
     description:
       - Reset failure counter after this number of seconds.
     type: int
-    default: 1
+    default: 0
     version_added: '2.10'
   recovery_actions:
     description:
-      - A list representing the recovery actions you want to set.
+      - A list representing the recovery actions you want to set (3).
       - First element of the list is the first failure actions/delay...
-      - This can go up to a count of three for subsequent failures.
+      - Third element is for the subsequent failures.
     type: list
     version_added: '2.10'
 

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -924,19 +924,19 @@
       subsequent_failure_timeout: 60000
   register: win_service_recovery_settings
 
-- name: check that that enabling the service for delayed startup succeeded
+- name: check that that the recovery settings succeeded
   assert:
     that:
     - win_service_recovery_settings is changed
-    - win_service_recovery_settings.recovery.reset_fail_count_after == '300'
+    - win_service_recovery_settings.recovery.reset_fail_count_after == 300
     - win_service_recovery_settings.recovery.on_first_failure == 'restart'
-    - win_service_recovery_settings.recovery.first_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.first_failure_timeout == 60000
     - win_service_recovery_settings.recovery.on_second_failure == 'restart'
-    - win_service_recovery_settings.recovery.second_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.second_failure_timeout == 60000
     - win_service_recovery_settings.recovery.on_subsequent_failure == 'restart'
-    - win_service_recovery_settings.recovery.subsequent_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.subsequent_failure_timeout == 60000
 
-- name: enable the service for delayed startup from non automatic again
+- name: set recovery settings for the service again
   win_service:
     name: "{{test_win_service_name}}"
     recovery:
@@ -949,14 +949,14 @@
       subsequent_failure_timeout: 60000
   register: win_service_recovery_settings_again
 
-- name: check that enabling the service for delayed startup again no changes
+- name: check that that the recovery settings again no changes
   assert:
     that:
     - win_service_recovery_settings is not changed
-    - win_service_recovery_settings.recovery.reset_fail_count_after == '300'
+    - win_service_recovery_settings.recovery.reset_fail_count_after == 300
     - win_service_recovery_settings.recovery.on_first_failure == 'restart'
-    - win_service_recovery_settings.recovery.first_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.first_failure_timeout == 60000
     - win_service_recovery_settings.recovery.on_second_failure == 'restart'
-    - win_service_recovery_settings.recovery.second_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.second_failure_timeout == 60000
     - win_service_recovery_settings.recovery.on_subsequent_failure == 'restart'
-    - win_service_recovery_settings.recovery.subsequent_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.subsequent_failure_timeout == 60000

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -910,3 +910,53 @@
     state: paused
   register: fail_pause_stopped_service
   failed_when: "fail_pause_stopped_service.msg != 'failed to pause service ' + test_win_service_name + ': The service does not support pausing'"
+
+- name: set recovery settings for the service
+  win_service:
+    name: "{{test_win_service_name}}"
+    recovery:
+      reset_fail_count_after: 300
+      on_first_failure: restart
+      first_failure_timeout: 60000
+      on_second_failure: restart
+      second_failure_timeout: 60000
+      on_subsequent_failure: restart
+      subsequent_failure_timeout: 60000
+  register: win_service_recovery_settings
+
+- name: check that that enabling the service for delayed startup succeeded
+  assert:
+    that:
+    - win_service_recovery_settings is changed
+    - win_service_recovery_settings.recovery.reset_fail_count_after == '300'
+    - win_service_recovery_settings.recovery.on_first_failure == 'restart'
+    - win_service_recovery_settings.recovery.first_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.on_second_failure == 'restart'
+    - win_service_recovery_settings.recovery.second_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.on_subsequent_failure == 'restart'
+    - win_service_recovery_settings.recovery.subsequent_failure_timeout == '60000'
+
+- name: enable the service for delayed startup from non automatic again
+  win_service:
+    name: "{{test_win_service_name}}"
+    recovery:
+      reset_fail_count_after: 300
+      on_first_failure: restart
+      first_failure_timeout: 60000
+      on_second_failure: restart
+      second_failure_timeout: 60000
+      on_subsequent_failure: restart
+      subsequent_failure_timeout: 60000
+  register: win_service_recovery_settings_again
+
+- name: check that enabling the service for delayed startup again no changes
+  assert:
+    that:
+    - win_service_recovery_settings is not changed
+    - win_service_recovery_settings.recovery.reset_fail_count_after == '300'
+    - win_service_recovery_settings.recovery.on_first_failure == 'restart'
+    - win_service_recovery_settings.recovery.first_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.on_second_failure == 'restart'
+    - win_service_recovery_settings.recovery.second_failure_timeout == '60000'
+    - win_service_recovery_settings.recovery.on_subsequent_failure == 'restart'
+    - win_service_recovery_settings.recovery.subsequent_failure_timeout == '60000'

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -929,14 +929,6 @@
   assert:
     that:
     - check_win_service_recovery_settings is changed
-    - check_win_service_recovery_settings.recovery.reset_fail_count_after == 300
-    - check_win_service_recovery_settings.recovery.on_first_failure == 'restart'
-    - check_win_service_recovery_settings.recovery.first_failure_timeout == 60000
-    - check_win_service_recovery_settings.recovery.on_second_failure == 'restart'
-    - check_win_service_recovery_settings.recovery.second_failure_timeout == 60000
-    - check_win_service_recovery_settings.recovery.on_subsequent_failure == 'restart'
-    - check_win_service_recovery_settings.recovery.subsequent_failure_timeout == 60000
-
 
 - name: set recovery settings for the service
   win_service:

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -911,6 +911,33 @@
   register: fail_pause_stopped_service
   failed_when: "fail_pause_stopped_service.msg != 'failed to pause service ' + test_win_service_name + ': The service does not support pausing'"
 
+- name: check recovery settings for the service
+  win_service:
+    name: "{{test_win_service_name}}"
+    recovery:
+      reset_fail_count_after: 300
+      on_first_failure: restart
+      first_failure_timeout: 60000
+      on_second_failure: restart
+      second_failure_timeout: 60000
+      on_subsequent_failure: restart
+      subsequent_failure_timeout: 60000
+  register: check_win_service_recovery_settings
+  check_mode: yes
+
+- name: check that the recovery settings check mode succeeded
+  assert:
+    that:
+    - check_win_service_recovery_settings is changed
+    - check_win_service_recovery_settings.recovery.reset_fail_count_after == 300
+    - check_win_service_recovery_settings.recovery.on_first_failure == 'restart'
+    - check_win_service_recovery_settings.recovery.first_failure_timeout == 60000
+    - check_win_service_recovery_settings.recovery.on_second_failure == 'restart'
+    - check_win_service_recovery_settings.recovery.second_failure_timeout == 60000
+    - check_win_service_recovery_settings.recovery.on_subsequent_failure == 'restart'
+    - check_win_service_recovery_settings.recovery.subsequent_failure_timeout == 60000
+
+
 - name: set recovery settings for the service
   win_service:
     name: "{{test_win_service_name}}"
@@ -924,7 +951,7 @@
       subsequent_failure_timeout: 60000
   register: win_service_recovery_settings
 
-- name: check that that the recovery settings succeeded
+- name: check that the recovery settings succeeded
   assert:
     that:
     - win_service_recovery_settings is changed
@@ -949,7 +976,7 @@
       subsequent_failure_timeout: 60000
   register: win_service_recovery_settings_again
 
-- name: check that that the recovery settings again no changes
+- name: check that the recovery settings again brings no changes
   assert:
     that:
     - win_service_recovery_settings_again is not changed

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -952,11 +952,11 @@
 - name: check that that the recovery settings again no changes
   assert:
     that:
-    - win_service_recovery_settings is not changed
-    - win_service_recovery_settings.recovery.reset_fail_count_after == 300
-    - win_service_recovery_settings.recovery.on_first_failure == 'restart'
-    - win_service_recovery_settings.recovery.first_failure_timeout == 60000
-    - win_service_recovery_settings.recovery.on_second_failure == 'restart'
-    - win_service_recovery_settings.recovery.second_failure_timeout == 60000
-    - win_service_recovery_settings.recovery.on_subsequent_failure == 'restart'
-    - win_service_recovery_settings.recovery.subsequent_failure_timeout == 60000
+    - win_service_recovery_settings_again is not changed
+    - win_service_recovery_settings_again.recovery.reset_fail_count_after == 300
+    - win_service_recovery_settings_again.recovery.on_first_failure == 'restart'
+    - win_service_recovery_settings_again.recovery.first_failure_timeout == 60000
+    - win_service_recovery_settings_again.recovery.on_second_failure == 'restart'
+    - win_service_recovery_settings_again.recovery.second_failure_timeout == 60000
+    - win_service_recovery_settings_again.recovery.on_subsequent_failure == 'restart'
+    - win_service_recovery_settings_again.recovery.subsequent_failure_timeout == 60000

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -914,14 +914,14 @@
 - name: check recovery settings for the service
   win_service:
     name: "{{test_win_service_name}}"
-    recovery:
-      reset_fail_count_after: 300
-      on_first_failure: restart
-      first_failure_timeout: 60000
-      on_second_failure: restart
-      second_failure_timeout: 60000
-      on_subsequent_failure: restart
-      subsequent_failure_timeout: 60000
+    recovery_reset_interval: 300
+    recovery_actions:
+      - action: restart
+        delay: 60000
+      - action: restart
+        delay: 60000
+      - action: restart
+        delay: 60000
   register: check_win_service_recovery_settings
   check_mode: yes
 
@@ -933,14 +933,14 @@
 - name: set recovery settings for the service
   win_service:
     name: "{{test_win_service_name}}"
-    recovery:
-      reset_fail_count_after: 300
-      on_first_failure: restart
-      first_failure_timeout: 60000
-      on_second_failure: restart
-      second_failure_timeout: 60000
-      on_subsequent_failure: restart
-      subsequent_failure_timeout: 60000
+    recovery_reset_interval: 300
+    recovery_actions:
+      - action: restart
+        delay: 60000
+      - action: restart
+        delay: 60000
+      - action: restart
+        delay: 60000
   register: win_service_recovery_settings
 
 - name: check that the recovery settings succeeded
@@ -958,14 +958,14 @@
 - name: set recovery settings for the service again
   win_service:
     name: "{{test_win_service_name}}"
-    recovery:
-      reset_fail_count_after: 300
-      on_first_failure: restart
-      first_failure_timeout: 60000
-      on_second_failure: restart
-      second_failure_timeout: 60000
-      on_subsequent_failure: restart
-      subsequent_failure_timeout: 60000
+    recovery_reset_interval: 300
+    recovery_actions:
+      - action: restart
+        delay: 60000
+      - action: restart
+        delay: 60000
+      - action: restart
+        delay: 60000
   register: win_service_recovery_settings_again
 
 - name: check that the recovery settings again brings no changes


### PR DESCRIPTION
##### SUMMARY
This is a new feature for the win_service Ansible module.
I wanted to be able to set actions related to the "Recovery" part of the service management GUI.
What is set in the GUI translates to a REG_BINARY key in the registry.
My code builds a hexadecimal combination of all the value that you passed through Ansible.
I'm comparing the values if it was already set for idempotency, and check mode is supported.

These settings can also be set with the sc.exe program, but I wanted to have something that was idempotent.

As far as variables naming, etc... I'm open to making changes you deem necessary. I commented as much as I saw fit, but if you feel like it's lacking, please do tell.

I've seen two schools when it comes to passing stuff to Powershell modules, either separate variables or a string that represents an Ansible dictionary, I went with the former. (Although I wished we could just pass a dict to a powershell script, it'd be more readable)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_service.py

##### ADDITIONAL INFORMATION
I did this for a personal need, so I'm using it in my local Ansible library directory.
I wanted to contribute back to the community in case someone else wanted this.