### PR TITLE
Aws ec2 instance

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -736,6 +736,12 @@ def manage_tags(match, new_tags, purge_tags, ec2):
         old_tags, new_tags,
         purge_tags=purge_tags,
     )
+
+    if module.check_mode:
+        if tags_to_set or tags_to_delete:
+            changed |= True
+        return changed
+
     if tags_to_set:
         ec2.create_tags(
             Resources=[match['InstanceId']],


### PR DESCRIPTION
##### SUMMARY
This bugfix repairs bug in ec2_instance module during check_mode.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
cloud/aws/ec2_instance

##### ADDITIONAL INFORMATION
When I run a step with ec2_instance module, there is a bug in check_mode. The step will rename all the tags in matched ec2 instances even in check_mode. This bugfix repairs this bug.

