### PR TITLE
When not using file_per_task, make sure we don't prematurely close the perf files

### DIFF
--- a/changelogs/fragments/cgroup-perf-recap-fix-open-files.yaml
+++ b/changelogs/fragments/cgroup-perf-recap-fix-open-files.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- cgroup_perf_recap - When not using file_per_task, make sure we don't prematurely close the perf files

--- a/lib/ansible/plugins/callback/cgroup_perf_recap.py
+++ b/lib/ansible/plugins/callback/cgroup_perf_recap.py
@@ -394,13 +394,14 @@ class CallbackModule(CallbackBase):
     def _profile(self, obj=None):
         prev_task = None
         results = dict.fromkeys(self._features)
-        for dummy, f in self._files.items():
-            if f is None:
-                continue
-            try:
-                f.close()
-            except Exception:
-                pass
+        if not obj or self._file_per_task:
+            for dummy, f in self._files.items():
+                if f is None:
+                    continue
+                try:
+                    f.close()
+                except Exception:
+                    pass
 
         try:
             for name, prof in self._profilers.items():
@@ -420,7 +421,7 @@ class CallbackModule(CallbackBase):
                     pass
 
         if obj is not None:
-            if self._file_per_task:
+            if self._file_per_task or self._counter == 0:
                 self._open_files(task_uuid=obj._uuid)
 
             for feature in self._features:


### PR DESCRIPTION
##### SUMMARY
When not using `file_per_task`, make sure we don't prematurely close the perf files

When adding `file_per_task` functionality, a bug was introduced that caused the perf files to be prematurely closed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/cgroup_perf_recap.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```