### PR TITLE
cloudformation_facts multi-stack support

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
@@ -26,6 +26,7 @@ options:
     stack_names:
         description:
           - The name(s) or id(s) of the CloudFormation stacks. Gathers facts for all stacks by default.
+        type: list
     all_facts:
         description:
             - Get all stack information for the stack
@@ -65,7 +66,7 @@ EXAMPLES = '''
 
 # Get summary information about multiple stacks
 - cloudformation_facts:
-    stack_name:
+    stack_names:
       - my-cloudformation-stack
       - my-other-cloudformation-stacks
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
@@ -288,7 +288,7 @@ def main():
 
     result = {'ansible_facts': {'cloudformation': {}}}
 
-    for stack_name in module.params.get('stack_names'):
+    for stack_name in module.params.get('stack_name'):
         for stack_description in service_mgr.describe_stacks(stack_name):
             facts = {'stack_description': stack_description}
             stack_name = stack_description.get('StackName')

--- a/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
@@ -66,7 +66,7 @@ EXAMPLES = '''
 
 # Get summary information about multiple stacks
 - cloudformation_facts:
-    stack_names:
+    stack_name:
       - my-cloudformation-stack
       - my-other-cloudformation-stacks
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
@@ -23,7 +23,7 @@ requirements:
 version_added: "2.2"
 author: Justin Menga (@jmenga)
 options:
-    stack_names:
+    stack_name:
         description:
           - The name(s) or id(s) of the CloudFormation stacks. Gathers facts for all stacks by default.
         type: list
@@ -271,7 +271,7 @@ def to_dict(items, key, value):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        stack_names=dict(type='list', aliases=['stack_name']),
+        stack_name=dict(type='list', aliases=['stack_names']),
         all_facts=dict(required=False, default=False, type='bool'),
         stack_policy=dict(required=False, default=False, type='bool'),
         stack_events=dict(required=False, default=False, type='bool'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I have a use case where I often want information on multiple Cloudformation stacks in one invocation, and it is just simpler to get them all at once.

The parameter name `stack_name` is changed to `stack_names` to reflect the true functionality, though `stack_name` is added as an alias for backwards compatibility.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudformation_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
$ ansible localhost -m "cloudformation_facts" -a "region=us-west-2 stack_name={{['emiller01','emiller02']}}"
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (ValidationError) when calling the DescribeStacks operation: 1 validation error detected: Value '['emiller01', 'emiller02']' at 'stackName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/._+]*
localhost | FAILED! => {
    "changed": false, 
    "msg": "Error describing stack - An error occurred (ValidationError) when calling the DescribeStacks operation: 1 validation error detected: Value '['emiller01', 'emiller02']' at 'stackName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/._+]*"
}
```

After
```
ANSIBLE_LIBRARY=lib/ansible/modules ansible localhost -m "cloudformation_facts" -a "region=us-west-2 stack_name={{['emiller01','emiller02']}}"
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

localhost | SUCCESS => {
    "ansible_facts": {
        "cloudformation": {}
    }, 
    "changed": false
}
```