### PR TITLE
Update apt.py

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -137,8 +137,9 @@ requirements:
 author: "Matthew Williams (@mgwilliams)"
 notes:
    - Three of the upgrade modes (C(full), C(safe) and its alias C(yes)) required C(aptitude) up to 2.3, since 2.4 C(apt-get) is used as a fall-back.
-   - apt starts newly installed services by default, this is what the underlying tooling does,
-     to avoid this you can set the ``RUNLEVEL`` environment variable to 1.
+   - In most cases, packages installed with apt will start newly installed services by default. Most distributions have mechanisms to avoid this.
+     For example when installing Postgresql-9.5 in Debian 9, creating an excutable shell script (/usr/sbin/policy-rc.d) that throws 
+     a return code of 101 will stop Postgresql 9.5 starting up after install. Remove the file or remove its execute permission afterwards.
    - The apt-get commandline supports implicit regex matches here but we do not because it can let typos through easier
      (If you typo C(foo) as C(fo) apt-get would install packages that have "fo" in their name with a warning and a prompt for the user.
      Since we don't have warnings and prompts before installing we disallow this.Use an explicit fnmatch pattern if you want wildcarding)
@@ -146,17 +147,15 @@ notes:
 '''
 
 EXAMPLES = '''
+- name: Install apache httpd  (state=present is optional)
+  apt:
+    name: apache2
+    state: present
+
 - name: Update repositories cache and install "foo" package
   apt:
     name: foo
     update_cache: yes
-
-- name: Install apache httpd but avoid starting it immediately (state=present is optional)
-  apt:
-    name: apache2
-    state: present
-  environment:
-    RUNLEVEL: 1
 
 - name: Remove "foo" package
   apt:

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -138,7 +138,7 @@ author: "Matthew Williams (@mgwilliams)"
 notes:
    - Three of the upgrade modes (C(full), C(safe) and its alias C(yes)) required C(aptitude) up to 2.3, since 2.4 C(apt-get) is used as a fall-back.
    - In most cases, packages installed with apt will start newly installed services by default. Most distributions have mechanisms to avoid this.
-     For example when installing Postgresql-9.5 in Debian 9, creating an excutable shell script (/usr/sbin/policy-rc.d) that throws 
+     For example when installing Postgresql-9.5 in Debian 9, creating an excutable shell script (/usr/sbin/policy-rc.d) that throws
      a return code of 101 will stop Postgresql 9.5 starting up after install. Remove the file or remove its execute permission afterwards.
    - The apt-get commandline supports implicit regex matches here but we do not because it can let typos through easier
      (If you typo C(foo) as C(fo) apt-get would install packages that have "fo" in their name with a warning and a prompt for the user.


### PR DESCRIPTION
##### SUMMARY
Setting the environment variable 'RUNLEVEL' to 1 when using apt no longer inhibits starting of daemons when a package is installed.

Tested under Debian 9 with installation of Apache2 and PostgreSQL.
In both cases the daemons are started immediately upon installation.

https://www.alextomkins.com/2018/03/runlevel-apt-get-install-package-alternative/
https://major.io/2014/06/26/install-debian-packages-without-starting-daemons/

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
apt package manager