### PR TITLE
Small typo fix in documentation

### DIFF
--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -48,7 +48,7 @@ options:
         description:
             - Forces the use of "local" command alternatives on platforms that implement it.
             - This is useful in environments that use centralized authentication when you want to manipulate the local groups.
-              (e.g. it uses C(lgroupadd) instead of C(useradd)).
+              (e.g. it uses C(lgroupadd) instead of C(groupadd)).
             - This requires that these commands exist on the targeted host, otherwise it will be a fatal error.
         type: bool
         default: no


### PR DESCRIPTION
##### SUMMARY
Fixes a small error, probably leftover from a mistakenly C&P.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
group

##### ADDITIONAL INFORMATION
The documentation was probably C&P'd from the `user` module, leaving a "useradd" mention where a "groupadd" should be.
