### PR TITLE
docs: gcp_compute_target_proxy does not exist, update deprecated redirect

### DIFF
--- a/lib/ansible/modules/cloud/google/_gcp_target_proxy.py
+++ b/lib/ansible/modules/cloud/google/_gcp_target_proxy.py
@@ -29,7 +29,7 @@ requirements:
 deprecated:
     removed_in: "2.12"
     why: Updated modules released with increased functionality
-    alternative: Use M(gcp_compute_target_proxy) instead.
+    alternative: Use M(gcp_compute_target_http_proxy) instead.
 notes:
   - Currently only supports global HTTP proxy.
 author:


### PR DESCRIPTION
##### SUMMARY

The docs for the deprecated module `_gcp_target_proxy` were directing users to a non-existent module called `gcp_compute_target_proxy`. The new modules include the protocol in their names. The old module only supported `http`, so redirecting users to the `gcp_compute_target_http_proxy` module.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
