### PR TITLE
gcp_compute_target_proxy does not exist, update deprecated redirect (…

### DIFF
--- a/lib/ansible/modules/cloud/google/_gcp_target_proxy.py
+++ b/lib/ansible/modules/cloud/google/_gcp_target_proxy.py
@@ -29,7 +29,7 @@ requirements:
 deprecated:
     removed_in: "2.12"
     why: Updated modules released with increased functionality
-    alternative: Use M(gcp_compute_target_proxy) instead.
+    alternative: Use M(gcp_compute_target_http_proxy) instead.
 notes:
   - Currently only supports global HTTP proxy.
 author:


### PR DESCRIPTION
…#56496)

(cherry picked from commit 7636f36a8a1fce40c57c257d13a4e14b4cb9e62b)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_target_proxy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
