### PR TITLE
vmware_datastore_maintenancemode: check datastore params

### DIFF
--- a/changelogs/fragments/vmware_maintenance_mode_params.yaml
+++ b/changelogs/fragments/vmware_maintenance_mode_params.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - vmware_datastore_maintenancemode - Raise an error if the datastore does not exist.  

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_maintenancemode.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_maintenancemode.py
@@ -120,7 +120,10 @@ class VmwareDatastoreMaintenanceMgr(PyVmomi):
         datastore_cluster = self.params.get('datastore_cluster')
         self.datastore_objs = []
         if datastore_name:
-            self.datastore_objs = [self.find_datastore_by_name(datastore_name=datastore_name)]
+            ds = self.find_datastore_by_name(datastore_name=datastore_name)
+            if not ds:
+                self.module.fail_json(msg='Failed to find datastore "%(datastore)s".' % self.params)
+            self.datastore_objs = [ds]
         elif cluster_name:
             cluster = find_cluster_by_name(self.content, cluster_name)
             if not cluster:


### PR DESCRIPTION
##### SUMMARY

Check the `datastore` parameter and raise an error if nothing has been
found. This instead of raising a backtrace later during the evaluation
of the module.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_datastore_maintenancemode