### PR TITLE
Update ovirt_vnic_profile.py

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vnic_profile.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vnic_profile.py
@@ -217,7 +217,7 @@ class EntityVnicPorfileModule(BaseModule):
             equal(self.param('pass_through'), entity.pass_through.mode.name) and
             equal(self.param('description'), entity.description) and
             equal(self.param('network_filter'), getattr(entity.network_filter, 'name', None)) and
-            equal(self.param('qos'), entity.qos.name) and
+            equal(self.param('qos'), getattr(entity.qos, 'name', None)) and
             equal(self.param('port_mirroring'), getattr(entity, 'port_mirroring', None))
         )
 


### PR DESCRIPTION
##### SUMMARY
qos is not defined when port_mirroring is enabled, a NoneType is returned for entity.qos in this case
getattr is safer to use than using a direct call to entity.qos.name


##### ISSUE TYPE
- Bugfix Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
