### PR TITLE
Bump erlang ping to 1:20.3.8.18-1

### DIFF
--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -5,7 +5,7 @@
     dest: /etc/apt/preferences.d/erlang
     content: |
         Package: erlang*
-        Pin: version 1:20.3.8.14-1
+        Pin: version 1:20.3.8.18-1
         Pin-Priority: 1000
 
         Package: esl-erlang


### PR DESCRIPTION
##### SUMMARY
CI is failing right now due to `erlang-inets` specifically not having an installation candidate matching the pin of `1:20.3.8.14-1`

```
$ apt-cache policy erlang-inets
erlang-inets:
  Installed: (none)
  Candidate: 1:22.0-1
  Version table:
[...]
     1:20.3.8.21-1 500
        500 https://packages.erlang-solutions.com/ubuntu xenial/contrib amd64 Packages
     1:20.3.8.20-1 500
        500 https://packages.erlang-solutions.com/ubuntu xenial/contrib amd64 Packages
     1:20.3.8.19-1 500
        500 https://packages.erlang-solutions.com/ubuntu xenial/contrib amd64 Packages
     1:20.3.8.18-1 500
        500 https://packages.erlang-solutions.com/ubuntu xenial/contrib amd64 Packages
     1:20.3.8.7-1 500
        500 https://packages.erlang-solutions.com/ubuntu xenial/contrib amd64 Packages
[...]
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```