### PR TITLE
[stable-2.7] Bump erlang ping to 1:20.3.8.18-1

### DIFF
--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -6,7 +6,7 @@
     dest: /etc/apt/preferences.d/erlang
     content: |
         Package: erlang*
-        Pin: version 1:20.3.8.14-1
+        Pin: version 1:20.3.8.18-1
         Pin-Priority: 1000
 
         Package: esl-erlang


### PR DESCRIPTION
(cherry picked from commit 4b00141)

Co-authored-by: Matt Martz <matt@sivel.net>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
