### PR TITLE
vsphere_copy: fix the E309 error

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -31,7 +31,7 @@ options:
     version_added: "2.9"
   username:
     version_added: "2.9"
-    aliases: [login']
+    aliases: ['login']
   src:
     description:
       - The file to push to vCenter.

--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -26,22 +26,12 @@ author:
 options:
   hostname:
     version_added: "2.9"
+    aliases: ['host']
   port:
     version_added: "2.9"
   username:
     version_added: "2.9"
-  host:
-    description:
-      - Use C(hostname) instead like the other VMware modules.
-      - The vCenter or ESXi server on which the datastore is available.
-      - This option is deprecated and will eventually be removed in 2.12.
-    aliases: ['hostname']
-  login:
-    description:
-      - Use C(username) instead like the other VMware modules.
-      - The login name to authenticate on the vCenter or ESXi server.
-      - This option is deprecated and will eventually be removed in 2.12.
-    aliases: ['username']
+    aliases: [login']
   src:
     description:
       - The file to push to vCenter.
@@ -143,8 +133,8 @@ def vmware_path(datastore, datacenter, path):
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(dict(
-        host=dict(required=False, removedin_version='2.12'),
-        login=dict(required=False, removedin_version='2.12'),
+        hostname=dict(required=False, aliases=['host']),
+        username=dict(required=False, aliases=['login']),
         src=dict(required=True, aliases=['name']),
         datacenter=dict(required=False),
         datastore=dict(required=True),
@@ -158,13 +148,13 @@ def main():
         supports_check_mode=False,
     )
 
-    if module.params['host'] is not None:
+    if module.params.get('host'):
         module.deprecate("The 'host' option is being replaced by 'hostname'", version='2.12')
-    if module.params['login'] is not None:
+    if module.params.get('login'):
         module.deprecate("The 'login' option is being replaced by 'username'", version='2.12')
 
-    hostname = module.params['hostname'] or module.params['host']
-    username = module.params['username'] or module.params['login']
+    hostname = module.params['hostname']
+    username = module.params['username']
     password = module.params.get('password')
     src = module.params.get('src')
     datacenter = module.params.get('datacenter')

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -307,7 +307,6 @@ lib/ansible/modules/cloud/vmware/vca_vapp.py E322
 lib/ansible/modules/cloud/vmware/vca_vapp.py E324
 lib/ansible/modules/cloud/vmware/vmware_guest.py E322
 lib/ansible/modules/cloud/vmware/vsphere_copy.py E322
-lib/ansible/modules/cloud/vmware/vsphere_copy.py E309
 lib/ansible/modules/clustering/consul.py E322
 lib/ansible/modules/clustering/consul.py E324
 lib/ansible/modules/clustering/consul_kv.py E322


### PR DESCRIPTION
##### SUMMARY

Resolve the two following errors:

ERROR: lib/ansible/modules/cloud/vmware/vsphere_copy.py:0:0: E309 version_added for new option (host) should be '2.9'. Currently None
ERROR: lib/ansible/modules/cloud/vmware/vsphere_copy.py:0:0: E309 version_added for new option (login) should be '2.9'. Currently None

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vsphere_copy