### PR TITLE
[Doc-Release-2.8] move too old version to 2.3

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -52,7 +52,7 @@ from ansible.utils._build_helpers import update_file_if_different
 
 # if a module is added in a version of Ansible older than this, don't print the version added information
 # in the module documentation because everyone is assumed to be running something newer than this already.
-TOO_OLD_TO_BE_NOTABLE = 2.0
+TOO_OLD_TO_BE_NOTABLE = 2.3
 
 # Get parent directory of the directory this script lives in
 MODULEDIR = os.path.abspath(os.path.join(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the 'too old version' parameter to 2.3.  Future changes should be +1 for each major release (aka 2.9 should change this parameter to 2.4).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Related to #56539
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
