### PR TITLE
Added Link and IO C# utils

### DIFF
--- a/lib/ansible/module_utils/csharp/Ansible.IO.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.IO.cs
@@ -1,0 +1,1034 @@
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Text;
+using Ansible.Privilege;
+
+namespace Ansible.IO
+{
+    internal static class Win32Errors
+    {
+        public const Int32 ERROR_SUCCESS = 0x00000000;
+        public const Int32 ERROR_FILE_NOT_FOUND = 0x00000002;
+        public const Int32 ERROR_PATH_NOT_FOUND = 0x00000003;
+        public const Int32 ERROR_ACCESS_DENIED = 0x00000005;
+        public const Int32 ERROR_NO_MORE_FILES = 0x00000012;
+        public const Int32 ERROR_NOT_READY = 0x00000015;
+        public const Int32 ERROR_SHARING_VIOLATION = 0x00000020;
+        public const Int32 ERROR_HANDLE_EOF = 0x00000026;
+        public const Int32 ERROR_FILE_EXISTS = 0x00000050;
+        public const Int32 ERROR_INVALID_PARAMETER = 0x00000057;
+        public const Int32 ERROR_INVALID_NAME = 0x0000007B;
+        public const Int32 ERROR_DIR_NOT_EMPTY = 0x00000091;
+        public const Int32 ERROR_ALREADY_EXISTS = 0x000000B7;
+        public const Int32 ERROR_FILENAME_EXCED_RANGE = 0x000000CE;
+        public const Int32 ERROR_MORE_DATA = 0x000000EA;
+        public const Int32 ERROR_OPERATION_ABORTED = 0x000003E3;
+    }
+
+    internal class NativeHelpers
+    {
+        public enum GET_FILEEX_INFO_LEVELS
+        {
+            GetFileExInfoStandard,
+            GetFileExMaxInfoLevel
+        }
+
+        [Flags]
+        public enum FlagsAndAttributes : uint
+        {
+            NONE = 0x00000000,
+            FILE_ATTRIBUTE_READONLY = 0x00000001,
+            FILE_ATTRIBUTE_HIDDEN = 0x00000002,
+            FILE_ATTRIBUTE_SYSTEM = 0x00000004,
+            FILE_ATTRIBUTE_ARCHIVE = 0x00000020,
+            FILE_ATTRIBUTE_NORMAL = 0x00000080,
+            FILE_ATTRIBUTE_TEMPORARY = 0x00000100,
+            FILE_ATTRIBUTE_OFFLINE = 0x00001000,
+            FILE_ATTRIBUTE_ENCRYPTED = 0x00004000,
+            FILE_FLAG_OPEN_NO_RECALL = 0x00100000,
+            FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000,
+            FILE_FLAG_SESSION_AWARE = 0x00800000,
+            FILE_FLAG_BACKUP_SEMANTICS = 0x02000000,
+            FILE_FLAG_DELETE_ON_CLOSE = 0x04000000,
+            FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000,
+            FILE_FLAG_RANDOM_ACCESS = 0x10000000,
+            FILE_FLAG_NO_BUFFERING = 0x20000000,
+            FILE_FLAG_OVERLAPPED = 0x40000000,
+            FILE_FLAG_WRITE_THROUGH = 0x80000000,
+        }
+
+        [Flags]
+        public enum ReplaceFlags : uint
+        {
+            REPLACEFILE_WRITE_THROUGH = 0x00000001,
+            REPLACEFILE_IGNORE_MERGE_ERRORS = 0x00000002,
+            REAPLCEFILE_IGNORE_ACL_ERRORS = 0x00000004,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FILETIME
+        {
+            internal UInt32 dwLowDateTime;
+            internal UInt32 dwHighDateTime;
+
+            public static implicit operator Int64(FILETIME v) { return ((Int64)v.dwHighDateTime << 32) + v.dwLowDateTime; }
+            public static explicit operator DateTimeOffset(FILETIME v) { return DateTimeOffset.FromFileTime(v); }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WIN32_FILE_ATTRIBUTE_DATA
+        {
+            public Int32 dwFileAttributes;
+            public FILETIME ftCreationTime;
+            public FILETIME ftLastAccessTime;
+            public FILETIME ftLastWriteTime;
+            public UInt32 nFileSizeHigh;
+            public UInt32 nFileSizeLow;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct WIN32_FIND_DATA
+        {
+            public FileAttributes dwFileAttributes;
+            public FILETIME ftCreationTime;
+            public FILETIME ftLastAccessTime;
+            public FILETIME ftLastWriteTime;
+            public UInt32 nFileSizeHigh;
+            public UInt32 nFileSizeLow;
+            public UInt32 dwReserved0;
+            public UInt32 dwReserved1;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)] public string cFileName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)] public string cAlternateFileName;
+        }
+    }
+
+    internal class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool CopyFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpExistingFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpNewFileName,
+            [MarshalAs(UnmanagedType.Bool)] bool bFailIfExists);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool CreateDirectoryW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpPathName,
+            IntPtr lpSecurityAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern SafeFileHandle CreateFileW(
+             [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+             [MarshalAs(UnmanagedType.U4)] FileSystemRights dwDesiredAccess,
+             [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
+             IntPtr lpSecurityAttributes,
+             [MarshalAs(UnmanagedType.U4)] FileMode dwCreationDisposition,
+             NativeHelpers.FlagsAndAttributes dwFlagsAndAttributes,
+             IntPtr hTemplateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool DeleteFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool FindClose(
+            IntPtr hFindFile);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern SafeFindHandle FindFirstFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            out NativeHelpers.WIN32_FIND_DATA lpFindFileData);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool FindNextFileW(
+            SafeFindHandle hFindFile,
+            out NativeHelpers.WIN32_FIND_DATA lpFindFileData);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool GetFileAttributesExW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            NativeHelpers.GET_FILEEX_INFO_LEVELS fInfoLevelId,
+            out NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern UInt32 GetFullPathNameW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            UInt32 nBufferLength,
+            StringBuilder lpBuffer,
+            out IntPtr lpFilePart);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool MoveFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpExistingFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpNewFileName);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool RemoveDirectoryW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpPathName);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool ReplaceFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpReplacedFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpReplacementFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpBackupFileName,
+            NativeHelpers.ReplaceFlags dwReplaceFlags,
+            IntPtr lpExclude,
+            IntPtr lpReserved);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool SetFileAttributesW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            FileAttributes dwFileAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool SetFileTime(
+            SafeFileHandle hFile,
+            ref Int64 lpCreationTime,
+            ref Int64 lpLastAccessTime,
+            ref Int64 lpLastWriteTime);
+    }
+
+    internal class SafeFindHandle : SafeHandleMinusOneIsInvalid
+    {
+        public SafeFindHandle() : base(true) { }
+        public SafeFindHandle(IntPtr handle) : base(true) { this.handle = handle; }
+
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        protected override bool ReleaseHandle()
+        {
+            return NativeMethods.FindClose(handle);
+        }
+    }
+
+    internal static class Win32Marshal
+    {
+        internal static Exception GetExceptionForLastWin32Error(string path = "") { return GetExceptionForWin32Error(Marshal.GetLastWin32Error(), path); }
+
+        internal static Exception GetExceptionForWin32Error(int errorCode, string path = "")
+        {
+            switch (errorCode)
+            {
+                case Win32Errors.ERROR_FILE_NOT_FOUND:
+                    return new FileNotFoundException(
+                        string.IsNullOrEmpty(path) ? "Unable to find the specified file." : String.Format("Could not find file '{0}'", path), path);
+                case Win32Errors.ERROR_PATH_NOT_FOUND:
+                    return new DirectoryNotFoundException(
+                        string.IsNullOrEmpty(path) ? "Could not find a part of the path." : String.Format("Could not find a part of the path '{0}'.", path));
+                case Win32Errors.ERROR_ACCESS_DENIED:
+                    return new UnauthorizedAccessException(
+                        string.IsNullOrEmpty(path) ? "Access to the path is denied." : String.Format("Access to the path '{0}' is denied.", path));
+                case Win32Errors.ERROR_ALREADY_EXISTS:
+                    if (string.IsNullOrEmpty(path))
+                        goto default;
+                    return new IOException(
+                        String.Format("Cannot create '{0}' because a file or directory with the same name already exists.", path), MakeHRFromErrorCode(errorCode));
+                case Win32Errors.ERROR_SHARING_VIOLATION:
+                    return new IOException(string.IsNullOrEmpty(path) ?
+                        "The process cannot access the file because it is being used by another process." :
+                        String.Format("The process cannot access the file '{0}' because it is being used by another process.", path),
+                        MakeHRFromErrorCode(errorCode));
+                case Win32Errors.ERROR_FILE_EXISTS:
+                    if (string.IsNullOrEmpty(path))
+                        goto default;
+                    return new IOException(
+                        String.Format("The file '{0}' already exists.", path), MakeHRFromErrorCode(errorCode));
+                case Win32Errors.ERROR_OPERATION_ABORTED:
+                    return new OperationCanceledException();
+                case Win32Errors.ERROR_INVALID_NAME:
+                    return new NotSupportedException("Illegal characters in path.");
+                case Win32Errors.ERROR_INVALID_PARAMETER:
+                default:
+                    string msg = new System.ComponentModel.Win32Exception(errorCode).Message;
+                    return new IOException(
+                        string.IsNullOrEmpty(path) ? msg : String.Format("{0}: '{1}'", msg, path), MakeHRFromErrorCode(errorCode));
+            }
+        }
+
+        internal static int MakeHRFromErrorCode(int errorCode)
+        {
+            // Don't convert it if it is already an HRESULT
+            if ((0xFFFF0000 & errorCode) != 0)
+                return errorCode;
+            return unchecked(((int)0x80070000) | errorCode);
+        }
+    }
+
+    public class FileAttributeData
+    {
+        public FileAttributes FileAttributes;
+        public DateTimeOffset CreationTime;
+        public DateTimeOffset LastAccessTime;
+        public DateTimeOffset LastWriteTime;
+        public Int64 FileSize;
+    }
+
+    public static class FileSystem
+    {
+        /// <summary>
+        /// Copies the whole directory to another directory. Links and their contents are copied as normal files to
+        /// the dest path, broken links are copied as an empty dir or file.
+        /// </summary>
+        /// <param name="sourceFullPath">The path to the directory to copy.</param>
+        /// <param name="destFullPath">The path to the directory to copy to.</param>
+        /// <param name="recurse">Whether to copy the contents of the directory.</param>
+        /// <param name="overwrite">Whether to overwrite any files in the dest path.</param>
+        public static void CopyDirectory(string sourceFullPath, string destFullPath, bool recurse, bool overwrite)
+        {
+            // Validate the input parameters
+            if (FileExists(sourceFullPath))
+                throw new IOException(String.Format("The source path '{0}' is a file, not a directory.", sourceFullPath),
+                    Win32Marshal.MakeHRFromErrorCode(Win32Errors.ERROR_ACCESS_DENIED));
+            else if (FileExists(destFullPath))
+                throw new IOException(String.Format("The target path '{0}' is a file, not a directory.", destFullPath),
+                    Win32Marshal.MakeHRFromErrorCode(Win32Errors.ERROR_ACCESS_DENIED));
+            else if (!DirectoryExists(sourceFullPath))
+                throw Win32Marshal.GetExceptionForWin32Error(Win32Errors.ERROR_PATH_NOT_FOUND, sourceFullPath);
+            if (!DirectoryExists(destFullPath))
+                throw Win32Marshal.GetExceptionForWin32Error(Win32Errors.ERROR_PATH_NOT_FOUND, destFullPath);
+
+            // Create the initial destination directory
+            string destDirPath = Path.Combine(destFullPath, Path.GetFileName(sourceFullPath));
+            if (!DirectoryExists(destDirPath))
+                CreateDirectory(destDirPath);
+
+            if (recurse)
+            {
+                foreach (Tuple<string, NativeHelpers.WIN32_FIND_DATA> find in EnumerateFolderInternal(sourceFullPath, "*",
+                    SearchOption.TopDirectoryOnly, false))
+                {
+                    if (find.Item2.dwFileAttributes.HasFlag(FileAttributes.Directory))
+                        CopyDirectory(find.Item1, destDirPath, true, overwrite);
+                    else
+                        CopyFile(find.Item1, Path.Combine(destDirPath, find.Item2.cFileName), overwrite);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies a file from the source to dest path.
+        /// </summary>
+        /// <param name="sourceFullPath">The source file to copy.</param>
+        /// <param name="destFullPath">The destination path.</param>
+        /// <param name="overwrite">Whether to overwrite the file at destFullPath if it already exists.</param>
+        public static void CopyFile(string sourceFullPath, string destFullPath, bool overwrite)
+        {
+            CopyFileInternal(sourceFullPath, destFullPath, overwrite);
+        }
+
+        /// <summary>
+        /// Creates a directory at the path specified. Will create parent directories if they do not already exist.
+        /// </summary>
+        /// <param name="fullPath">The path to create the directory at.</param>
+        public static void CreateDirectory(string fullPath)
+        {
+            if (DirectoryExists(fullPath))
+                return;
+
+            Stack<string> dirsToCreate = new Stack<string>();
+            string directoryRoot = Path.GetPathRoot(fullPath);
+            string dir = fullPath;
+            while (directoryRoot != dir)
+            {
+                if (DirectoryExists(dir))
+                    break;
+                dirsToCreate.Push(dir);
+                dir = Path.GetDirectoryName(dir);
+            }
+
+            using (new PrivilegeEnabler(false, "SeRestorePrivilege", "SeTakeOwnershipPrivilege"))
+            {
+                while (dirsToCreate.Count > 0)
+                {
+                    dir = dirsToCreate.Pop();
+                    if (!NativeMethods.CreateDirectoryW(dir, IntPtr.Zero))
+                    {
+                        int errorCode = Marshal.GetLastWin32Error();
+
+                        // Do no fail if the error is ERROR_ALREADY_EXISTS and it is already a dir
+                        if (!(errorCode == Win32Errors.ERROR_ALREADY_EXISTS && DirectoryExists(dir)))
+                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, dir);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates or opens a handle to the file specified. The way the system is opened is based on the mode set.
+        /// </summary>
+        /// <param name="path">The path to open the handle at.</param>
+        /// <param name="mode">The System.IO.FileMode enum that specifies how the system should open a file.</param>
+        /// <param name="access">The System.IO.FileAccess enum flags that specifies the access required.</param>
+        /// <param name="share">The System.IO.FileShare enum flags that define the allowed access for newer handles on the same file.</param>
+        /// <param name="options">The System.IO.FileOptions enum flags that specifies advanced options when opening a file.</param>
+        /// <returns>SafeFileHandle of the file opened. Call .Dispose() to close the handle.</returns>
+        public static SafeFileHandle CreateFile(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options)
+        {
+            FileSystemRights accessRights;
+            if (access == FileAccess.Read)
+                accessRights = FileSystemRights.Read;
+            else if (access == FileAccess.Write)
+                accessRights = FileSystemRights.WriteData;
+            else
+                accessRights = FileSystemRights.ReadData | FileSystemRights.WriteData;
+
+            NativeHelpers.FlagsAndAttributes attr = (NativeHelpers.FlagsAndAttributes)options;
+            SafeFileHandle fileHandle = NativeMethods.CreateFileW(path, accessRights, share, IntPtr.Zero, mode, attr, IntPtr.Zero);
+            if (fileHandle.IsInvalid)
+                throw Win32Marshal.GetExceptionForLastWin32Error(path);
+            return fileHandle;
+        }
+
+        /// <summary>
+        /// Deletes the file at the path specified.
+        /// </summary>
+        /// <param name="fullPath">The file to delete.</param>
+        public static void DeleteFile(string fullPath)
+        {
+            DeleteFileInternal(fullPath, retry: false);
+        }
+
+        /// <summary>
+        /// Checks whether a directory already exists. 
+        /// </summary>
+        /// <param name="fullPath">The path to the directory to check.</param>
+        /// <returns>System.Boolean that is true when a directory exists and false when it doesn't.</returns>
+        public static bool DirectoryExists(string fullPath)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            int lastError = FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
+            return (lastError == 0) && (data.dwFileAttributes != -1) && ((data.dwFileAttributes & (int)FileAttributes.Directory) != 0);
+        }
+
+        /// <summary>
+        /// Enumerates the contents of the folder specified.
+        /// </summary>
+        /// <param name="path">The path to the directory to search in.</param>
+        /// <param name="searchPattern">The search pattern, '?' is a wildcard for an individual char and '*' is a wildcard for multiple chars.</param>
+        /// <param name="searchOption">The System.IO.SearchOption enum that states whether to search recursively or not.</param>
+        /// <param name="returnFolders">Whether to return folders found in the search.</param>
+        /// <param name="returnFiles">Whether to return files found in the search.</param>
+        /// <returns>IEnumerable<string> of the path of each folder child item.</string></returns>
+        public static IEnumerable<string> EnumerateFolder(string path, string searchPattern, SearchOption searchOption, bool returnFolders, bool returnFiles)
+        {
+            foreach (Tuple<string, NativeHelpers.WIN32_FIND_DATA> find in EnumerateFolderInternal(path, searchPattern, searchOption, false))
+            {
+                bool isDir = find.Item2.dwFileAttributes.HasFlag(FileAttributes.Directory);
+                if (!returnFolders && isDir)
+                    continue;
+                else if (!returnFiles && !isDir)
+                    continue;
+
+                yield return find.Item1;
+            }
+        }
+
+        /// <summary>
+        /// Checks whether a file or directory already exists. 
+        /// </summary>
+        /// <param name="fullPath">The path to the file or directory to check.</param>
+        /// <returns>System.Boolean that is true when a file or directory exists and false when it doesn't.</returns>
+        public static bool Exists(string fullPath)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            int errorCode = FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
+            return (errorCode == 0) && (data.dwFileAttributes != -1);
+        }
+
+        /// <summary>
+        /// Checks whether a file already exists. 
+        /// </summary>
+        /// <param name="fullPath">The path to the file to check.</param>
+        /// <returns>System.Boolean that is true when a file exists and false when it doesn't.</returns>
+        public static bool FileExists(string fullPath)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            int errorCode = FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
+            return (errorCode == 0) && (data.dwFileAttributes != -1) && ((data.dwFileAttributes & (int)FileAttributes.Directory) == 0);
+        }
+
+        /// <summary>
+        /// Returns info on the file or directory specified.
+        /// </summary>
+        /// <param name="fullPath">The path to the file or directory to get the info on.</param>
+        /// <returns>Ansible.IO.FileAttributeData that contains the attributes, size, and date stamps of the file or directory.</returns>
+        public static FileAttributeData GetFileAttributeData(string fullPath)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: false);
+
+            return new FileAttributeData()
+            {
+                FileAttributes = (FileAttributes)data.dwFileAttributes,
+                CreationTime = (DateTimeOffset)data.ftCreationTime,
+                LastAccessTime = (DateTimeOffset)data.ftLastAccessTime,
+                LastWriteTime = (DateTimeOffset)data.ftLastWriteTime,
+                FileSize = (Int64)((data.nFileSizeHigh) << 32 | data.nFileSizeLow & 0xFFFFFFFFL),
+            };
+        }
+
+        /// <summary>
+        /// Moves the file or directory to the path specified.
+        /// </summary>
+        /// <param name="sourceFullPath">The source path.</param>
+        /// <param name="destFullPath">The destination path.</param>
+        public static void MoveFile(string sourceFullPath, string destFullPath)
+        {
+            using (new PrivilegeEnabler(false, "SeBackupPrivilege", "SeRestorePrivilege", "SeTakeOwnershipPrivilege"))
+            {
+                if (!NativeMethods.MoveFileW(sourceFullPath, destFullPath))
+                    RaiseExceptionForFileCopy(sourceFullPath, destFullPath);
+            }
+        }
+
+        /// <summary>
+        /// Removes the directory at the path specified.
+        /// </summary>
+        /// <param name="fullPath">The path to the directory to remove.</param>
+        /// <param name="recursive">Set to true to delete a directory that is not empty.</param>
+        public static void RemoveDirectory(string fullPath, bool recursive)
+        {
+            // Typically we only set this when actually doing the native call but this has a lot of recursive
+            // functions that can rely on these privileges so we just set it at the parent level.
+            using (new PrivilegeEnabler(false, "SeBackupPrivilege", "SeRestorePrivilege", "SeTakeOwnershipPrivilege"))
+            {
+                if (!recursive)
+                {
+                    RemoveDirectoryInternal(fullPath, topLevel: true);
+                    return;
+                }
+
+                NativeHelpers.WIN32_FIND_DATA findData = new NativeHelpers.WIN32_FIND_DATA();
+                GetFindData(fullPath, ref findData);
+                if (IsNameSurrogateReparsePoint(findData))
+                    // Don't recurse
+                    RemoveDirectoryInternal(fullPath, topLevel: true);
+                else
+                    RemoveDirectoryRecursive(fullPath, ref findData, topLevel: true);
+            }
+        }
+
+        /// <summary>
+        /// Replaces and creates an optional backup of a file.
+        /// </summary>
+        /// <param name="sourceFullPath">The path to the file that will replace the file.</param>
+        /// <param name="destFullPath">The path to the file that will be replaced.</param>
+        /// <param name="destBackupFullPath">An optional path that will be a backup of destFullPath is set.</param>
+        /// <param name="ignoreMetadataErrors">Whether to ignore metadata merging from source to dest on replacement.</param>
+        public static void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
+        {
+            // Make sure destBackupFullPath is null, PowerShell marshaling changes $null to "" which we don't want.
+            destBackupFullPath = String.IsNullOrEmpty(destBackupFullPath) ? null : destBackupFullPath;
+            NativeHelpers.ReplaceFlags flags = ignoreMetadataErrors ? NativeHelpers.ReplaceFlags.REPLACEFILE_IGNORE_MERGE_ERRORS : 0;
+
+            using (new PrivilegeEnabler(false, "SeBackupPrivilege", "SeRestorePrivilege", "SeTakeOwnershipPrivilege"))
+            {
+                if (!NativeMethods.ReplaceFileW(destFullPath, sourceFullPath, destBackupFullPath, flags, IntPtr.Zero, IntPtr.Zero))
+                    RaiseExceptionForFileCopy(sourceFullPath, destFullPath);
+            }
+        }
+
+        /// <summary>
+        /// Sets the attributes of the file or directory specified.
+        /// </summary>
+        /// <param name="fullPath">The path of the file or directory to set the attributes for.</param>
+        /// <param name="attributes">The System.IO.FileAttributes to set, some attributes cannot be set this way.</param>
+        public static void SetAttributes(string fullPath, FileAttributes attributes)
+        {
+            using (new PrivilegeEnabler(false, "SeRestorePrivilege"))
+            {
+                if (!NativeMethods.SetFileAttributesW(fullPath, attributes))
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+                    if (errorCode == Win32Errors.ERROR_INVALID_PARAMETER)
+                        throw new ArgumentException("Invalid File or Directory attributes value.", "attributes");
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the datestamps of the file or directory specified.
+        /// </summary>
+        /// <param name="fullPath">The path of the file or directory to set the datestamps for.</param>
+        /// <param name="creationTime">The creation time of the file, set to null to not set/change.</param>
+        /// <param name="lastAccessTime">The last access time of the file, set to null to not set/change.</param>
+        /// <param name="lastWriteTime">The last write time of the file, set to null to not set/change.</param>
+        public static void SetFileTime(string fullPath, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime)
+        {
+            using (new PrivilegeEnabler(false, "SeRestorePrivilege"))
+            using (SafeFileHandle handle = NativeMethods.CreateFileW(fullPath, FileSystemRights.WriteAttributes, FileShare.ReadWrite | FileShare.Delete,
+                IntPtr.Zero, FileMode.Open, NativeHelpers.FlagsAndAttributes.FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero))
+            {
+                if (handle.IsInvalid)
+                    throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
+                Int64 creation = creationTime.HasValue ? creationTime.Value.ToFileTimeUtc() : 0;
+                Int64 access = lastAccessTime.HasValue ? lastAccessTime.Value.ToFileTimeUtc() : 0;
+                Int64 write = lastWriteTime.HasValue ? lastWriteTime.Value.ToFileTimeUtc() : 0;
+
+                if (!NativeMethods.SetFileTime(handle, ref creation, ref access, ref write))
+                    throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
+            }
+        }
+
+        private static void CopyFileInternal(string sourceFullPath, string destFullPath, bool overwrite, bool retry = false)
+        {
+            bool res = NativeMethods.CopyFileW(sourceFullPath, destFullPath, !overwrite);
+            int errorCode = Marshal.GetLastWin32Error();
+
+            if (!res)
+            {
+                if (FileExists(sourceFullPath) && FileExists(destFullPath) && errorCode == Win32Errors.ERROR_ACCESS_DENIED)
+                {
+                    RemoveReadOnlyAndHidden(destFullPath, errorCode, retry);
+                    CopyFileInternal(sourceFullPath, destFullPath, overwrite, retry: true);
+                }
+                else if (FileExists(sourceFullPath) && errorCode == Win32Errors.ERROR_FILE_NOT_FOUND)
+                {
+                    // Source file is a broken file symlink, we just create an empty file as a placeholder.
+                    FileMode createMode = overwrite ? FileMode.Create : FileMode.CreateNew;
+                    SafeFileHandle handle = CreateFile(destFullPath, createMode, FileAccess.Write,
+                        FileShare.None, FileOptions.None);
+                    handle.Dispose();
+                }
+                else
+                {
+                    RaiseExceptionForFileCopy(sourceFullPath, destFullPath, errorCode: errorCode);
+                }
+            }
+        }
+
+        private static void DeleteFileInternal(string fullPath, bool retry = false)
+        {
+            bool res;
+            int errorCode = 0;
+            using (new PrivilegeEnabler(false, "SeRestorePrivilege", "SeTakeOwnershipPrivilege"))
+            {
+                res = NativeMethods.DeleteFileW(fullPath);
+                errorCode = Marshal.GetLastWin32Error();
+            }
+
+            if (!res)
+            {
+                if (errorCode == Win32Errors.ERROR_ACCESS_DENIED)
+                {
+                    RemoveReadOnlyAndHidden(fullPath, errorCode, retry);
+                    DeleteFileInternal(fullPath, retry: true);
+                }
+                else if (errorCode != Win32Errors.ERROR_FILE_NOT_FOUND)
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+        }
+
+        private static IEnumerable<Tuple<string, NativeHelpers.WIN32_FIND_DATA>> EnumerateFolderInternal(string path, string searchPattern,
+            SearchOption searchOption, bool strict)
+        {
+            Queue<string> dirs = new Queue<string>();
+            dirs.Enqueue(path);
+
+            while (dirs.Count > 0)
+            {
+                string currentPath = dirs.Dequeue();
+
+                // We need to manually get all directories if AllDirectories is specified. We can't rely on the
+                // enumeration below as the searchPattern may not be '*'.
+                if (searchOption == SearchOption.AllDirectories)
+                {
+                    foreach (var directory in EnumerateFolderInternal(currentPath, "*", SearchOption.TopDirectoryOnly, strict))
+                    {
+                        if (directory.Item2.dwFileAttributes.HasFlag(FileAttributes.Directory))
+                            dirs.Enqueue(directory.Item1);
+                    }
+                }
+
+                // Now search the directory based on the actual input search pattern.
+                string searchPath = Path.Combine(currentPath, Path.TrimEndingDirectorySeparator(searchPattern));
+
+                NativeHelpers.WIN32_FIND_DATA findData = new NativeHelpers.WIN32_FIND_DATA();
+                using (new PrivilegeEnabler(false, "SeBackupPrivilege"))
+                using (SafeFindHandle findHandle = NativeMethods.FindFirstFileW(searchPath, out findData))
+                {
+                    if (findHandle.IsInvalid)
+                    {
+                        if (strict)
+                            throw Win32Marshal.GetExceptionForLastWin32Error(path);
+                        else
+                            continue;
+                    }
+
+                    do
+                    {
+                        string fileName = findData.cFileName;
+                        string filePath = Path.Combine(currentPath, fileName);
+                        FileAttributes attr = findData.dwFileAttributes;
+
+                        if (attr.HasFlag(FileAttributes.Directory) && (fileName == "." || fileName == ".."))
+                            continue;
+
+                        yield return Tuple.Create<string, NativeHelpers.WIN32_FIND_DATA>(filePath, findData);
+                    } while (NativeMethods.FindNextFileW(findHandle, out findData));
+
+                    int lastErr = Marshal.GetLastWin32Error();
+                    if (lastErr != Win32Errors.ERROR_NO_MORE_FILES)
+                        throw Win32Marshal.GetExceptionForWin32Error(lastErr);
+                }
+            }
+        }
+
+        private static int FillAttributeInfo(string path, ref NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data, bool returnErrorOnNotFound)
+        {
+            // Remove any trailing separators
+            path = Path.TrimEndingDirectorySeparator(path);
+            int errorCode = Win32Errors.ERROR_SUCCESS;
+            using (new PrivilegeEnabler(false, "SeBackupPrivilege"))
+            {
+                if (!NativeMethods.GetFileAttributesExW(path, NativeHelpers.GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, out data))
+                {
+                    errorCode = Marshal.GetLastWin32Error();
+                    // special system files like pagefile.sys returns
+                    // ERROR_SHARING_VIOLATION but FindFirstFileW works so we try
+                    // that here
+                    if (errorCode == Win32Errors.ERROR_SHARING_VIOLATION)
+                    {
+                        NativeHelpers.WIN32_FIND_DATA findData;
+                        using (SafeFindHandle findHandle = NativeMethods.FindFirstFileW(path, out findData))
+                        {
+                            if (findHandle.IsInvalid)
+                                errorCode = Marshal.GetLastWin32Error();
+                            else
+                            {
+                                errorCode = Win32Errors.ERROR_SUCCESS;
+                                data.dwFileAttributes = (int)findData.dwFileAttributes;
+                                data.ftCreationTime = findData.ftCreationTime;
+                                data.ftLastAccessTime = findData.ftLastAccessTime;
+                                data.ftLastWriteTime = findData.ftLastWriteTime;
+                                data.nFileSizeHigh = findData.nFileSizeHigh;
+                                data.nFileSizeLow = findData.nFileSizeLow;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (errorCode != Win32Errors.ERROR_SUCCESS && !returnErrorOnNotFound)
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, path);
+
+            return errorCode;
+        }
+
+        private static void GetFindData(string fullPath, ref NativeHelpers.WIN32_FIND_DATA findData)
+        {
+            using (new PrivilegeEnabler(false, "SeBackupPrivilege"))
+            using (SafeFindHandle handle = NativeMethods.FindFirstFileW(fullPath, out findData))
+            {
+                if (handle.IsInvalid)
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+                    // File not found doesn't make much sense coming from a directory delete.
+                    if (errorCode == Win32Errors.ERROR_FILE_NOT_FOUND)
+                        errorCode = Win32Errors.ERROR_PATH_NOT_FOUND;
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+                }
+            }
+        }
+
+        private static bool IsNameSurrogateReparsePoint(NativeHelpers.WIN32_FIND_DATA data)
+        {
+            // Reparse points that are not name surrogates should be treated like any other directory
+            return data.dwFileAttributes.HasFlag(FileAttributes.ReparsePoint) && (data.dwReserved0 & 0x20000000) != 0;
+        }
+
+        private static void RemoveDirectoryRecursive(string fullPath, ref NativeHelpers.WIN32_FIND_DATA findData, bool topLevel)
+        {
+            Exception exception = null;
+
+            foreach (Tuple<string, NativeHelpers.WIN32_FIND_DATA> find in EnumerateFolderInternal(fullPath, "*", SearchOption.TopDirectoryOnly, true))
+            {
+                string filePath = find.Item1;
+                findData = find.Item2;
+
+                bool isDir = findData.dwFileAttributes.HasFlag(FileAttributes.Directory);
+                if (isDir)
+                {
+                    try
+                    {
+                        if (IsNameSurrogateReparsePoint(findData))
+                            RemoveDirectoryInternal(filePath, false, false);
+                        else
+                            RemoveDirectoryRecursive(filePath, ref findData, false);
+                    }
+                    catch (Exception e)
+                    {
+                        if (exception == null)
+                            exception = e;
+                    }
+                }
+                else
+                    DeleteFile(filePath);
+            }
+
+            if (exception != null)
+                throw exception;
+
+            RemoveDirectoryInternal(fullPath, topLevel: topLevel, allowDirectoryNotEmpty: true);
+        }
+
+        private static void RaiseExceptionForFileCopy(string sourcePath, string destPath, int? errorCode = null)
+        {
+            // Copy and move operations have 2 paths where the problem could lie, we default to having the destPath
+            // being the problematic one but still check for cases where sourcePath is a better file.
+            int win32Error = errorCode == null ? Marshal.GetLastWin32Error() : (int)errorCode;
+
+            string fileName = destPath;
+            if (errorCode != Win32Errors.ERROR_FILE_EXISTS)
+            {
+                // For some error codes we don't know if the problem was source or dest, try reading source to
+                // rule it out.
+                using (SafeFileHandle handle = NativeMethods.CreateFileW(sourcePath, FileSystemRights.Read,
+                    FileShare.Read, IntPtr.Zero, FileMode.Open, 0, IntPtr.Zero))
+                {
+                    if (handle.IsInvalid)
+                        fileName = sourcePath;
+                }
+
+                // Special case when trying to copy/move a file to a dir
+                if (errorCode == Win32Errors.ERROR_ACCESS_DENIED)
+                {
+                    string msg = null;
+                    if (FileSystem.DirectoryExists(sourcePath))
+                        msg = String.Format("The source file '{0}' is a directory, not a file.", sourcePath);
+                    else if (FileSystem.DirectoryExists(destPath))
+                        msg = String.Format("The target file '{0}' is a directory, not a file.", destPath);
+
+                    if (msg != null)
+                        throw new IOException(msg, Win32Marshal.MakeHRFromErrorCode(win32Error));
+                }
+            }
+
+            throw Win32Marshal.GetExceptionForWin32Error(win32Error, fileName);
+        }
+
+        private static void RemoveDirectoryInternal(string fullPath, bool topLevel, bool allowDirectoryNotEmpty = false, bool retry = false)
+        {
+            if (!NativeMethods.RemoveDirectoryW(fullPath))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                switch (errorCode)
+                {
+                    case Win32Errors.ERROR_FILE_NOT_FOUND:
+                        errorCode = Win32Errors.ERROR_PATH_NOT_FOUND;
+                        goto case Win32Errors.ERROR_PATH_NOT_FOUND;
+                    case Win32Errors.ERROR_PATH_NOT_FOUND:
+                        // we only throw for the top level directory not found, not for any contents.
+                        if (!topLevel)
+                            return;
+                        break;
+                    case Win32Errors.ERROR_DIR_NOT_EMPTY:
+                        if (allowDirectoryNotEmpty)
+                            return;
+                        break;
+                    case Win32Errors.ERROR_ACCESS_DENIED:
+                        RemoveReadOnlyAndHidden(fullPath, errorCode, retry);
+                        RemoveDirectoryInternal(fullPath, topLevel, allowDirectoryNotEmpty, retry: true);
+                        return;
+                }
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+        }
+
+        private static void RemoveReadOnlyAndHidden(string fullPath, int errorCode, bool retry)
+        {
+            // Delete operations can fail if ReadOnly is set as an attribute on the object. We try and this attribute
+            // before trying the deletion again.
+            try
+            {
+                FileAttributes existingAttributes = GetFileAttributeData(fullPath).FileAttributes;
+
+                bool isUnset = (existingAttributes & FileAttributes.ReadOnly) == 0 &&
+                    (existingAttributes & FileAttributes.Hidden) == 0;
+                if (retry || isUnset)
+                    // This is the 2nd call to the delete operation or ReadOnly/Hidden is not set,
+                    // raise the original excep.
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+
+                SetAttributes(fullPath, existingAttributes & ~FileAttributes.ReadOnly & ~FileAttributes.Hidden);
+            }
+            catch (Exception)
+            {
+                // Failed to perform the prepartion task, just raise the original exception.
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Meant to be a very close copy of System.IO.Path but support paths exceeding MAX_PATH.
+    /// </summary>
+    public static class Path
+    {
+        internal const char DirectorySeparatorChar = '\\';
+        internal const char AltDirectorySeparatorChar = '/';
+
+        public static string ChangeExtension(string path, string extension) { return System.IO.Path.ChangeExtension(path, extension); }
+        public static string Combine(params string[] paths) { return System.IO.Path.Combine(paths); }
+        public static string GetDirectoryName(string path)
+        {
+            if (path == null || IsEffectivelyEmpty(path))
+                return null;
+
+            int end = GetDirectoryNameOffset(path);
+            return end >= 0 ? NormalizeDirectorySeparators(path.Substring(0, end)) : null;
+        }
+        public static string GetExtension(string path) { return System.IO.Path.GetExtension(path); }
+        public static string GetFileName(string path) { return System.IO.Path.GetFileName(path); }
+        public static string GetFileNameWithoutExtension(string path) { return System.IO.Path.GetFileNameWithoutExtension(path); }
+        public static string GetFullPath(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("The path is not of a legal form.");
+            else if (IsEffectivelyEmpty(path))
+                throw new ArgumentException("The path is not of a legal form.");
+
+            if (path.IndexOf('\0') != -1)
+                throw new ArgumentException("The path is not of a legal form.", "path");
+
+            // Actual .NET returns the path if \\?\ is used, this is different from the behaviour of GetFullPathNameW which resolves relative paths which we want
+            UInt32 bufferLength = 0;
+            StringBuilder lpBuffer = new StringBuilder();
+            IntPtr lpFilePart = IntPtr.Zero;
+            UInt32 returnLength = NativeMethods.GetFullPathNameW(path, bufferLength, lpBuffer, out lpFilePart);
+
+            lpBuffer.EnsureCapacity((int)returnLength);
+            returnLength = NativeMethods.GetFullPathNameW(path, returnLength, lpBuffer, out lpFilePart);
+            if (returnLength == 0)
+                throw Win32Marshal.GetExceptionForLastWin32Error(path);
+
+            return lpBuffer.ToString();
+        }
+        public static char[] GetInvalidFileNameChars() { return System.IO.Path.GetInvalidFileNameChars(); }
+        public static char[] GetInvalidPathChars() { return System.IO.Path.GetInvalidPathChars(); }
+        public static string GetPathRoot(string path)
+        {
+            // Strip the extended length path prefix if present
+            string pathPrefix = "";
+            if (path.StartsWith(@"\\?\UNC\", true, System.Globalization.CultureInfo.InvariantCulture))
+            {
+                path = @"\\" + path.Substring(8);
+                pathPrefix = @"\\?\UNC\";
+            }
+            else if (path.StartsWith(@"\\?\"))
+            {
+                path = path.Substring(4);
+                pathPrefix = @"\\?\";
+            }
+
+            // Make sure we don't exceed 256 chars and get the root from there
+            // the extra path info isn't needed 
+            if (path.Length > 256)
+                path = path.Substring(0, 256);
+            string pathRoot = System.IO.Path.GetPathRoot(path);
+
+            // Make sure the \\server is changed back to \\?\UNC\server
+            if (pathPrefix == @"\\?\UNC\")
+                return pathPrefix + pathRoot.Substring(2);
+            else
+                return pathPrefix + pathRoot;
+        }
+        public static string GetRandomFileName() { return System.IO.Path.GetRandomFileName(); }
+        public static string GetTempFileName() { return System.IO.Path.GetTempFileName(); }
+        public static string GetTempPath() { return System.IO.Path.GetTempPath(); }
+        public static bool HasExtension(string path) { return System.IO.Path.HasExtension(path); }
+        public static bool IsPathRooted(string path) { return System.IO.Path.IsPathRooted(path); }
+
+        internal static int GetDirectoryNameOffset(string path)
+        {
+            int rootLength = GetPathRoot(path).Length;
+            int end = path.Length;
+            if (end <= rootLength)
+                return -1;
+
+            while (end > rootLength && !IsDirectorySeparator(path[--end])) ;
+
+            // Trim off any remaining separators (to deal with C:\foo\\bar)
+            while (end > rootLength && IsDirectorySeparator(path[end - 1]))
+                end--;
+
+            return end;
+        }
+        internal static bool IsDirectorySeparator(char c) { return c == DirectorySeparatorChar || c == AltDirectorySeparatorChar; }
+        internal static bool IsEffectivelyEmpty(string path)
+        {
+            if (path.Length == 0)
+                return true;
+
+            foreach (char c in path)
+                if (c != ' ')
+                    return false;
+            return true;
+        }
+        internal static string NormalizeDirectorySeparators(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return path;
+            if (path.StartsWith(@"\\?\"))
+                return path;
+
+            char current;
+
+            // Make a pass to see if we need to normalize so we can potentially skip allocating
+            bool normalized = true;
+
+            for (int i = 0; i < path.Length; i++)
+            {
+                current = path[i];
+                if (IsDirectorySeparator(current)
+                    && (current != DirectorySeparatorChar
+                        // Check for sequential separators past the first position (we need to keep initial two for UNC/extended)
+                        || (i > 0 && i + 1 < path.Length && IsDirectorySeparator(path[i + 1]))))
+                {
+                    normalized = false;
+                    break;
+                }
+            }
+
+            if (normalized)
+                return path;
+
+            StringBuilder builder = new StringBuilder(path.Length);
+            int start = 0;
+            if (IsDirectorySeparator(path[start]))
+            {
+                start++;
+                builder.Append(DirectorySeparatorChar);
+            }
+
+            for (int i = start; i < path.Length; i++)
+            {
+                current = path[i];
+
+                // If we have a separator
+                if (IsDirectorySeparator(current))
+                {
+                    // If the next is a separator, skip adding this
+                    if (i + 1 < path.Length && IsDirectorySeparator(path[i + 1]))
+                        continue;
+
+                    // Ensure it is the primary separator
+                    current = DirectorySeparatorChar;
+                }
+                builder.Append(current);
+            }
+            return builder.ToString();
+        }
+        internal static string TrimEndingDirectorySeparator(string path)
+        {
+            return (path.Length > 0 && IsDirectorySeparator(path[path.Length - 1])) && !(GetPathRoot(path) == path)
+                ? path.Substring(0, path.Length - 1)
+                : path;
+        }
+    }
+}
+

--- a/lib/ansible/module_utils/csharp/Ansible.Link.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Link.cs
@@ -1,0 +1,441 @@
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Text;
+using Ansible.IO;
+using Ansible.Privilege;
+
+namespace Ansible.Link
+{
+    internal class NativeHelpers
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct REPARSE_DATA_BUFFER
+        {
+            public UInt32 ReparseTag;
+            public UInt16 ReparseDataLength;
+            public UInt16 Reserved;
+            public UInt16 SubstituteNameOffset;
+            public UInt16 SubstituteNameLength;
+            public UInt16 PrintNameOffset;
+            public UInt16 PrintNameLength;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = LinkUtil.MAXIMUM_REPARSE_DATA_BUFFER_SIZE)]
+            public byte[] PathBuffer;
+        }
+    }
+
+    internal class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool CreateHardLinkW(
+            string lpFileName,
+            string lpExistingFileName,
+            IntPtr lpSecurityAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static extern bool CreateSymbolicLinkW(
+            string lpSymlinkFileName,
+            string lpTargetFileName,
+            UInt32 dwFlags);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool DeviceIoControl(
+            SafeFileHandle hDevice,
+            UInt32 dwIoControlCode,
+            Ansible.Privilege.SafeMemoryBuffer lpInBuffer,
+            UInt32 nInBufferSize,
+            Ansible.Privilege.SafeMemoryBuffer lpOutBuffer,
+            UInt32 nOutBufferSize,
+            out UInt32 lpBytesReturned,
+            IntPtr lpOverlapped);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern SafeFindHandle FindFirstFileNameW(
+            string lpFileName,
+            UInt32 dwFlags,
+            ref UInt32 StringLength,
+            StringBuilder LinkName);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool FindNextFileNameW(
+            SafeFindHandle hFindStream,
+            ref UInt32 StringLength,
+            StringBuilder LinkName);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool GetVolumePathNameW(
+            string lpszFileName,
+            StringBuilder lpszVolumePathName,
+            ref UInt32 cchBufferLength);
+    }
+
+    public enum LinkType
+    {
+        SymbolicLink,
+        JunctionPoint,
+        HardLink
+    }
+
+    public class LinkInfo
+    {
+        public LinkType Type { get; internal set; }
+
+        // Part of REPARSE_DATA_BUFFER, this is just a label of the target
+        public string PrintName { get; internal set; }
+
+        // Part of REPARSE_DATA_BUFFER, this is the actual target using the NT Kernel path (differs from the Win32 path)
+        public string SubstituteName { get; internal set; }
+
+        // Converts the SubstituteName value to the Win32 path, this is the absolute path
+        public string AbsolutePath { get; internal set; }
+
+        // Converts the SubstituteName value to the Win32 path, this is not resolved to the absolute path and can be related to the path of the link itself
+        public string TargetPath { get; internal set; }
+
+        // If LinkType is HardLink, this is an array of paths that are linked together
+        public string[] HardTargets { get; internal set; }
+    }
+
+    public class LinkUtil
+    {
+        public const int MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16384 - 16;  // 16 KiB - 16 bytes for the REPARSE_DATA_BUFFER headers
+
+        private const UInt32 FSCTL_GET_REPARSE_POINT = 0x000900A8;
+        private const UInt32 FSCTL_SET_REPARSE_POINT = 0x000900A4;
+
+        private const UInt32 IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
+        private const UInt32 IO_REPARSE_TAG_SYMLINK = 0xA000000C;
+
+        private const UInt32 SYMLINK_FLAG_RELATIVE = 0x00000001;
+
+        private const UInt32 SYMBOLIC_LINK_FLAG_FILE = 0x00000000;
+        private const UInt32 SYMBOLIC_LINK_FLAG_DIRECTORY = 0x00000001;
+        private const UInt32 SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 0x00000002;
+
+
+        /// <summary>
+        /// Gets the link info for the path specified.
+        /// </summary>
+        /// <param name="linkPath">The path of the link to check.</param>
+        /// <returns>Ansible.Link.LinkInfo if the file is a link, null if it is not.</returns>
+        public static LinkInfo GetLinkInfo(string linkPath)
+        {
+            FileAttributeData attrData = FileSystem.GetFileAttributeData(linkPath);
+            if (attrData.FileAttributes.HasFlag(FileAttributes.ReparsePoint))
+                return GetReparsePointInfo(linkPath);
+
+            if (!attrData.FileAttributes.HasFlag(FileAttributes.Directory))
+                return GetHardLinkInfo(linkPath);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Deletes the link at the path specified.
+        /// </summary>
+        /// <param name="linkPath">The path to the link to delete.</param>
+        public static void DeleteLink(string linkPath)
+        {
+            FileAttributeData attrData = FileSystem.GetFileAttributeData(linkPath);
+            if (attrData.FileAttributes.HasFlag(FileAttributes.Directory))
+                FileSystem.RemoveDirectory(linkPath, false);
+            else
+                FileSystem.DeleteFile(linkPath);
+        }
+
+        /// <summary>
+        /// Creates a link.
+        /// </summary>
+        /// <param name="linkPath">The path to create the link at.</param>
+        /// <param name="linkTarget">The target of the link, must be absolute unless LinkType is SymbolicLink.</param>
+        /// <param name="linkType">The Ansible.Link.LinkType that specifies the type of link to create.</param>
+        public static void CreateLink(string linkPath, string linkTarget, LinkType linkType)
+        {
+            switch (linkType)
+            {
+                case LinkType.SymbolicLink:
+                    CreateSymbolicLink(linkPath, linkTarget);
+                    break;
+                case LinkType.JunctionPoint:
+                    CreateJunctionPoint(linkPath, linkTarget);
+                    break;
+                case LinkType.HardLink:
+                    using (new PrivilegeEnabler(false, "SeRestorePrivilege", "SeTakeOwnershipPrivilege"))
+                    {
+                        if (!NativeMethods.CreateHardLinkW(linkPath, linkTarget, IntPtr.Zero))
+                            RaiseCreateLinkException(linkPath, linkTarget);
+                    }
+                    break;
+            }
+        }
+
+        private static LinkInfo GetHardLinkInfo(string linkPath)
+        {
+            // GetVolumePathNameW requires a buffer length to be set for the output path. To be safe we just get the
+            // length of the full path as the root will always be less than this.
+            StringBuilder volumePathName = new StringBuilder(Ansible.IO.Path.GetFullPath(linkPath).Length);
+            UInt32 bufferLength = (UInt32)volumePathName.Capacity;
+            if (!NativeMethods.GetVolumePathNameW(linkPath, volumePathName, ref bufferLength))
+                throw Ansible.IO.Win32Marshal.GetExceptionForLastWin32Error(linkPath);
+            string volume = volumePathName.ToString();
+
+            UInt32 stringLength = 0;
+            StringBuilder linkName = new StringBuilder();
+            NativeMethods.FindFirstFileNameW(linkPath, 0, ref stringLength, linkName);
+            linkName.EnsureCapacity((int)stringLength);
+
+            // No use setting SeBackupPrivilege as FindFirstFileNameW does not open the file with the backup flag
+            List<string> result = new List<string>();
+            using (SafeFindHandle findHandle = NativeMethods.FindFirstFileNameW(linkPath, 0, ref stringLength, linkName))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                if (findHandle.IsInvalid)
+                {
+                    // ERROR_NOT_SUPPORTED - Cannot enumerate network paths, so just return null, otherwise throw exp
+                    if (errorCode == 0x00000032 && linkPath.StartsWith(@"\\"))
+                        return null;
+                    else
+                        throw Ansible.IO.Win32Marshal.GetExceptionForLastWin32Error(linkPath);
+                }    
+
+                while (true)
+                {
+                    string hardLinkPath = linkName.ToString();
+                    hardLinkPath = hardLinkPath.StartsWith(@"\") ? hardLinkPath.Substring(1) : hardLinkPath;
+                    result.Add(Ansible.IO.Path.Combine(volume, hardLinkPath));
+
+                    // get the buffer size for the next file
+                    linkName = new StringBuilder();
+                    stringLength = 0;
+                    NativeMethods.FindNextFileNameW(findHandle, ref stringLength, linkName);
+                    linkName.Capacity = (int)stringLength;
+
+                    if (!NativeMethods.FindNextFileNameW(findHandle, ref stringLength, linkName))
+                    {
+                        errorCode = Marshal.GetLastWin32Error();
+                        if (errorCode == 38)  // ERROR_HANDLE_EOF
+                            break;
+                        throw Ansible.IO.Win32Marshal.GetExceptionForWin32Error(errorCode);
+                    }
+                }
+            }
+
+            if (result.Count > 1)
+                return new LinkInfo
+                {
+                    Type = LinkType.HardLink,
+                    HardTargets = result.ToArray()
+                };
+
+            return null;
+        }
+
+        private static LinkInfo GetReparsePointInfo(string linkPath)
+        {
+            Ansible.IO.NativeHelpers.FlagsAndAttributes flagsAndAttr =
+                Ansible.IO.NativeHelpers.FlagsAndAttributes.FILE_FLAG_OPEN_REPARSE_POINT |
+                Ansible.IO.NativeHelpers.FlagsAndAttributes.FILE_FLAG_BACKUP_SEMANTICS;
+
+            using (SafeMemoryBuffer outBuffer = new Ansible.Privilege.SafeMemoryBuffer(MAXIMUM_REPARSE_DATA_BUFFER_SIZE))
+            using (new PrivilegeEnabler(false, "SeBackupPrivilege"))
+            using (SafeFileHandle handle = Ansible.IO.NativeMethods.CreateFileW(linkPath, FileSystemRights.Read,
+                FileShare.None, IntPtr.Zero, FileMode.Open, flagsAndAttr, IntPtr.Zero))
+            {
+                if (handle.IsInvalid)
+                    throw Ansible.IO.Win32Marshal.GetExceptionForLastWin32Error(linkPath);
+
+                UInt32 bytesReturned;
+                if (!NativeMethods.DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, new SafeMemoryBuffer(0), 0, outBuffer,
+                    MAXIMUM_REPARSE_DATA_BUFFER_SIZE, out bytesReturned, IntPtr.Zero))
+                {
+                    throw Ansible.IO.Win32Marshal.GetExceptionForLastWin32Error(linkPath);
+                }
+                NativeHelpers.REPARSE_DATA_BUFFER buffer = (NativeHelpers.REPARSE_DATA_BUFFER)Marshal.PtrToStructure(outBuffer.DangerousGetHandle(),
+                    typeof(NativeHelpers.REPARSE_DATA_BUFFER));
+
+                bool isRelative = false;
+                LinkType linkType;
+                int offset = 0;
+                if (buffer.ReparseTag == IO_REPARSE_TAG_SYMLINK)
+                {
+                    linkType = LinkType.SymbolicLink;
+                    UInt32 bufferFlags = BitConverter.ToUInt32(buffer.PathBuffer, 0);
+                    if (bufferFlags == SYMLINK_FLAG_RELATIVE)
+                        isRelative = true;
+                    offset = 4;
+                }
+                else if (buffer.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT)
+                    linkType = LinkType.JunctionPoint;
+                else
+                    throw new Exception(String.Format("Unsupported Reparse Tag: 0x{0}", buffer.ReparseTag.ToString("X8")));
+
+                string printName = Encoding.Unicode.GetString(buffer.PathBuffer, buffer.PrintNameOffset + offset, buffer.PrintNameLength);
+                string substituteName = Encoding.Unicode.GetString(buffer.PathBuffer, buffer.SubstituteNameOffset + offset, buffer.SubstituteNameLength);
+                string targetPath = substituteName;
+                string absolutePath;
+
+                if (isRelative)
+                    absolutePath = Ansible.IO.Path.GetFullPath(Ansible.IO.Path.Combine(Ansible.IO.Path.GetDirectoryName(linkPath), targetPath));
+                else
+                {
+                    // Remove the NT object namespace \??\, \DosDevices\ and get a normal Win32 path
+                    if (targetPath.StartsWith(@"\??\UNC") && (linkPath.StartsWith(@"\\?\") || printName.Length > 250))
+                        targetPath = @"\\?\" + targetPath.Substring(4, targetPath.Length - 4);
+                    else if (targetPath.StartsWith(@"\??\UNC"))
+                        targetPath = @"\" + targetPath.Substring(7, targetPath.Length - 7);
+                    else if (targetPath.StartsWith(@"\??\") && (linkPath.StartsWith(@"\\?\") || printName.Length > 250))
+                        targetPath = @"\\?\" + targetPath.Substring(4, targetPath.Length - 4);
+                    else if (targetPath.StartsWith(@"\??\"))
+                        targetPath = targetPath.Substring(4, targetPath.Length - 4);
+                    else if (targetPath.StartsWith(@"\DosDevices\") && (linkPath.StartsWith(@"\\?\") || printName.Length > 250))
+                        targetPath = @"\\?\" + targetPath.Substring(12, targetPath.Length - 12);
+                    else if (targetPath.StartsWith(@"\DosDevices\"))
+                        targetPath = targetPath.Substring(12, targetPath.Length - 12);
+                    absolutePath = targetPath;
+                }
+
+                return new LinkInfo
+                {
+                    Type = linkType,
+                    PrintName = printName,  // raw PrintName from buffer
+                    SubstituteName = substituteName,  // raw SubstituteName from buffer (contains NT obj namespace)
+                    AbsolutePath = absolutePath,  // The absolute path of TargetPath
+                    TargetPath = targetPath  // SubstituteName but without the obj namespace
+                };
+            }
+        }
+
+        private static void CreateSymbolicLink(string linkPath, string linkTarget)
+        {
+            string absoluteTarget = linkTarget;
+            if (!Ansible.IO.Path.IsPathRooted(linkTarget))
+            {
+                string parentDir = Ansible.IO.Path.GetDirectoryName(linkPath);
+                absoluteTarget = Ansible.IO.Path.GetFullPath(Ansible.IO.Path.Combine(parentDir, linkTarget));
+            }
+
+            UInt32 linkFlags = 0;
+            try
+            {
+                FileAttributeData attrData = FileSystem.GetFileAttributeData(absoluteTarget);
+                if (attrData.FileAttributes.HasFlag(FileAttributes.Directory))
+                    linkFlags = SYMBOLIC_LINK_FLAG_DIRECTORY;
+                else
+                    linkFlags = SYMBOLIC_LINK_FLAG_FILE;
+            }
+            catch (Exception e)
+            {
+                if (e is FileNotFoundException || e is DirectoryNotFoundException)
+                    // Cannot determine link type based on the target as it does not exist, use dir if no extension is present otherwise file
+                    linkFlags = Ansible.IO.Path.GetExtension(absoluteTarget) == "" && Ansible.IO.Path.GetExtension(linkPath) == ""
+                        ? SYMBOLIC_LINK_FLAG_DIRECTORY
+                        : SYMBOLIC_LINK_FLAG_FILE;
+            }
+
+            // Try and run with the new flag that allows non elevated processes to create symlinks
+            // will return ERROR_INVALID_PARAMETER if on an unsupported host
+            // added in Windows 10 build 14972
+            linkFlags |= SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+
+            using (new PrivilegeEnabler(false, "SeRestorePrivilege"))
+            {
+                if (!NativeMethods.CreateSymbolicLinkW(linkPath, linkTarget, linkFlags))
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+                    if (errorCode == Ansible.IO.Win32Errors.ERROR_INVALID_PARAMETER)  // try again without flag
+                        if (NativeMethods.CreateSymbolicLinkW(linkPath, linkTarget, linkFlags &= ~SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
+                            errorCode = 0;
+                        else
+                            errorCode = Marshal.GetLastWin32Error();
+
+                    if (errorCode != 0)
+                        RaiseCreateLinkException(linkPath, linkTarget, errorCode: errorCode);
+                }
+            }
+        }
+
+        private static void CreateJunctionPoint(string linkPath, string linkTarget)
+        {
+            if (!Ansible.IO.Path.IsPathRooted(linkTarget))
+                throw new ArgumentException(String.Format("Cannot create junction point because target '{0}' is not an absolute path.", linkTarget));
+            else if (Ansible.IO.FileSystem.FileExists(linkTarget))
+                throw new ArgumentException(String.Format("Cannot create junction point because target '{0}' is a file.", linkTarget));
+
+            string substituteName;
+            if (linkTarget.StartsWith(@"\\?\"))
+                substituteName = @"\??\" + Ansible.IO.Path.GetFullPath(linkTarget).Substring(4);
+            else
+                substituteName = @"\??\" + Ansible.IO.Path.GetFullPath(linkTarget);
+            string printName = linkTarget;
+
+            UInt16 substituteNameLength = (UInt16)Encoding.Unicode.GetByteCount(substituteName);
+            UInt16 printNameLength = (UInt16)Encoding.Unicode.GetByteCount(printName);
+            byte[] pathBuffer = Encoding.Unicode.GetBytes(substituteName + "\0" + printName + "\0");
+
+            NativeHelpers.REPARSE_DATA_BUFFER buffer = new NativeHelpers.REPARSE_DATA_BUFFER();
+            buffer.ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
+            buffer.SubstituteNameOffset = 0;
+            buffer.SubstituteNameLength = substituteNameLength;
+            buffer.PrintNameOffset = (UInt16)(substituteNameLength + sizeof(char));  // offset include the null unicode terminator
+            buffer.PrintNameLength = printNameLength;
+            buffer.PathBuffer = new byte[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+            Array.Copy(pathBuffer, buffer.PathBuffer, pathBuffer.Length);
+            buffer.ReparseDataLength = (UInt16)(pathBuffer.Length + (4 * sizeof(UInt16)));  // sizeof fields past Reserved in REPARSE_DATA_BUFFER
+            UInt32 reparseHeaderSize = sizeof(UInt32) + (2 * sizeof(UInt16));  // sizof ReparseTag + ReparseDataLength + Reserved
+
+            // We need to create the link as a dir beforehand
+            FileSystem.CreateDirectory(linkPath);
+
+            Ansible.IO.NativeHelpers.FlagsAndAttributes flagsAndAttr =
+                Ansible.IO.NativeHelpers.FlagsAndAttributes.FILE_FLAG_OPEN_REPARSE_POINT |
+                Ansible.IO.NativeHelpers.FlagsAndAttributes.FILE_FLAG_BACKUP_SEMANTICS;
+
+            // Open a handle to the new dir and write the reparse buffer data
+            using (SafeMemoryBuffer inBuffer = new SafeMemoryBuffer(Marshal.SizeOf(typeof(NativeHelpers.REPARSE_DATA_BUFFER))))
+            using (new PrivilegeEnabler(false, "SeRestorePrivilege"))
+            using (SafeFileHandle handle = Ansible.IO.NativeMethods.CreateFileW(linkPath, FileSystemRights.Write,
+                FileShare.Read | FileShare.Write | FileShare.None, IntPtr.Zero, FileMode.Open,
+                flagsAndAttr, IntPtr.Zero))
+            {
+                if (handle.IsInvalid)
+                    throw Ansible.IO.Win32Marshal.GetExceptionForLastWin32Error(linkPath);
+
+                Marshal.StructureToPtr(buffer, inBuffer.DangerousGetHandle(), false);
+                UInt32 bytesReturned;
+                if (!NativeMethods.DeviceIoControl(handle, FSCTL_SET_REPARSE_POINT, inBuffer,
+                    reparseHeaderSize + buffer.ReparseDataLength, new SafeMemoryBuffer(0), 0, out bytesReturned, IntPtr.Zero))
+                {
+                    throw Ansible.IO.Win32Marshal.GetExceptionForLastWin32Error(linkPath);
+                }
+            }
+        }
+
+        private static void RaiseCreateLinkException(string linkPath, string linkTarget, int? errorCode = null)
+        {
+            // Some smarter logic when it comes to raising exceptions and the paths they are about.
+            if (errorCode == null)
+                errorCode = Marshal.GetLastWin32Error();
+
+            string fileName = linkPath;
+            if (errorCode == Ansible.IO.Win32Errors.ERROR_FILE_NOT_FOUND || errorCode == Ansible.IO.Win32Errors.ERROR_PATH_NOT_FOUND)
+            {
+                if (!Ansible.IO.FileSystem.Exists(linkTarget))
+                    fileName = linkTarget;
+            }
+            else if (errorCode == Ansible.IO.Win32Errors.ERROR_ACCESS_DENIED && Ansible.IO.FileSystem.DirectoryExists(linkTarget))
+            {
+                // Hard link with target pointing to a directory
+                throw new IOException(String.Format("The target file '{0}' is a directory, not a file.", linkTarget),
+                    Ansible.IO.Win32Marshal.MakeHRFromErrorCode((int)errorCode));
+            }
+
+
+            throw Ansible.IO.Win32Marshal.GetExceptionForWin32Error((int)errorCode, fileName);
+        }
+    }
+}

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
@@ -1,454 +1,133 @@
 # Copyright (c) 2017 Ansible Project
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
-#Requires -Module Ansible.ModuleUtils.PrivilegeUtil
+#AnsibleRequires -CSharpUtil Ansible.IO
+#AnsibleRequires -CSharpUtil Ansible.Link
 
-Function Load-LinkUtils() {
-    $link_util = @'
-using Microsoft.Win32.SafeHandles;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
+Function Load-LinkUtils {
+    <#
+    .SYNOPSIS
+    No-op, as the C# types are automatically loaded.
+    #>
+    Param ()
 
-namespace Ansible
-{
-    public enum LinkType
-    {
-        SymbolicLink,
-        JunctionPoint,
-        HardLink
-    }
-
-    public class LinkUtilWin32Exception : System.ComponentModel.Win32Exception
-    {
-        private string _msg;
-
-        public LinkUtilWin32Exception(string message) : this(Marshal.GetLastWin32Error(), message) { }
-
-        public LinkUtilWin32Exception(int errorCode, string message) : base(errorCode)
-        {
-            _msg = String.Format("{0} ({1}, Win32ErrorCode {2})", message, base.Message, errorCode);
+    $msg = "Load-LinkUtils is deprecated and no longer needed. this cmdlet will be removed in a future version"
+    $result = Get-Variable -Name result -ErrorAction SilentlyContinue
+    if ((Get-Command -Name Add-DeprecationWarning -ErrorAction SilentlyContinue) -and $null -ne $result) {
+        Add-DeprecationWarning -obj $result.Value -message $msg -version 2.13
+    } else {
+        $module = Get-Variable -Name module -ErrorAction SilentlyContinue
+        if ($null -ne $module -and $module.Value.GetType().FullName -eq "Ansible.Basic.AnsibleModule") {
+            $module.Value.Deprecate($msg, "2.13")
         }
-
-        public override string Message { get { return _msg; } }
-        public static explicit operator LinkUtilWin32Exception(string message) { return new LinkUtilWin32Exception(message); }
     }
+}
 
-    public class LinkInfo
-    {
-        public LinkType Type { get; internal set; }
-        public string PrintName { get; internal set; }
-        public string SubstituteName { get; internal set; }
-        public string AbsolutePath { get; internal set; }
-        public string TargetPath { get; internal set; }
-        public string[] HardTargets { get; internal set; }
-    }
+Function Get-Link {
+    <#
+    .SYNOPSIS
+    Gets information about the link at the path specified. If the object specified by Path is not a link then it will
+    return $null.
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    public struct REPARSE_DATA_BUFFER
-    {
-        public UInt32 ReparseTag;
-        public UInt16 ReparseDataLength;
-        public UInt16 Reserved;
-        public UInt16 SubstituteNameOffset;
-        public UInt16 SubstituteNameLength;
-        public UInt16 PrintNameOffset;
-        public UInt16 PrintNameLength;
+    .PARAMETER Path
+    The path to get the link info for.
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$true)]
+        [Alias("link_path")]
+        [System.String]$Path
+    )
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = LinkUtil.MAXIMUM_REPARSE_DATA_BUFFER_SIZE)]
-        public char[] PathBuffer;
-    }
+    [Ansible.Link.LinkUtil]::GetLinkInfo($Path)
+}
 
-    public class LinkUtil
-    {
-        public const int MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 1024 * 16;
+Function Remove-Link {
+    <#
+    .SYNOPSIS
+    Removes the link file or directory specified by Path.
 
-        private const UInt32 FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
-        private const UInt32 FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
+    .PARAMETER Path
+    The path to the link to remove.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    Param (
+        [Parameter(Mandatory=$true)]
+        [Alias("link_path")]
+        [System.String]$Path
+    )
 
-        private const UInt32 FSCTL_GET_REPARSE_POINT = 0x000900A8;
-        private const UInt32 FSCTL_SET_REPARSE_POINT = 0x000900A4;
-        private const UInt32 FILE_DEVICE_FILE_SYSTEM = 0x00090000;
-
-        private const UInt32 IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
-        private const UInt32 IO_REPARSE_TAG_SYMLINK = 0xA000000C;
-
-        private const UInt32 SYMLINK_FLAG_RELATIVE = 0x00000001;
-
-        private const Int64 INVALID_HANDLE_VALUE = -1;
-
-        private const UInt32 SIZE_OF_WCHAR = 2;
-
-        private const UInt32 SYMBOLIC_LINK_FLAG_FILE = 0x00000000;
-        private const UInt32 SYMBOLIC_LINK_FLAG_DIRECTORY = 0x00000001;
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-        private static extern SafeFileHandle CreateFile(
-            string lpFileName,
-            [MarshalAs(UnmanagedType.U4)] FileAccess dwDesiredAccess,
-            [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
-            IntPtr lpSecurityAttributes,
-            [MarshalAs(UnmanagedType.U4)] FileMode dwCreationDisposition,
-            UInt32 dwFlagsAndAttributes,
-            IntPtr hTemplateFile);
-
-        // Used by GetReparsePointInfo()
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool DeviceIoControl(
-            SafeFileHandle hDevice,
-            UInt32 dwIoControlCode,
-            IntPtr lpInBuffer,
-            UInt32 nInBufferSize,
-            out REPARSE_DATA_BUFFER lpOutBuffer,
-            UInt32 nOutBufferSize,
-            out UInt32 lpBytesReturned,
-            IntPtr lpOverlapped);
-
-        // Used by CreateJunctionPoint()
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool DeviceIoControl(
-            SafeFileHandle hDevice,
-            UInt32 dwIoControlCode,
-            REPARSE_DATA_BUFFER lpInBuffer,
-            UInt32 nInBufferSize,
-            IntPtr lpOutBuffer,
-            UInt32 nOutBufferSize,
-            out UInt32 lpBytesReturned,
-            IntPtr lpOverlapped);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool GetVolumePathName(
-            string lpszFileName,
-            StringBuilder lpszVolumePathName,
-            ref UInt32 cchBufferLength);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern IntPtr FindFirstFileNameW(
-            string lpFileName,
-            UInt32 dwFlags,
-            ref UInt32 StringLength,
-            StringBuilder LinkName);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool FindNextFileNameW(
-            IntPtr hFindStream,
-            ref UInt32 StringLength,
-            StringBuilder LinkName);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool FindClose(
-            IntPtr hFindFile);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool RemoveDirectory(
-            string lpPathName);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool DeleteFile(
-            string lpFileName);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool CreateSymbolicLink(
-            string lpSymlinkFileName,
-            string lpTargetFileName,
-            UInt32 dwFlags);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool CreateHardLink(
-            string lpFileName,
-            string lpExistingFileName,
-            IntPtr lpSecurityAttributes);
-
-        public static LinkInfo GetLinkInfo(string linkPath)
-        {
-            FileAttributes attr = File.GetAttributes(linkPath);
-            if (attr.HasFlag(FileAttributes.ReparsePoint))
-                return GetReparsePointInfo(linkPath);
-
-            if (!attr.HasFlag(FileAttributes.Directory))
-                return GetHardLinkInfo(linkPath);
-
-            return null;
-        }
-
-        public static void DeleteLink(string linkPath)
-        {
-            bool success;
-            FileAttributes attr = File.GetAttributes(linkPath);
-            if (attr.HasFlag(FileAttributes.Directory))
-            {
-                success = RemoveDirectory(linkPath);
-            }
-            else
-            {
-                success = DeleteFile(linkPath);
-            }
-
-            if (!success)
-                throw new LinkUtilWin32Exception(String.Format("Failed to delete link at {0}", linkPath));
-        }
-
-        public static void CreateLink(string linkPath, String linkTarget, LinkType linkType)
-        {
-            switch (linkType)
-            {
-                case LinkType.SymbolicLink:
-                    UInt32 linkFlags;
-                    FileAttributes attr = File.GetAttributes(linkTarget);
-                    if (attr.HasFlag(FileAttributes.Directory))
-                        linkFlags = SYMBOLIC_LINK_FLAG_DIRECTORY;
-                    else
-                        linkFlags = SYMBOLIC_LINK_FLAG_FILE;
-
-                    if (!CreateSymbolicLink(linkPath, linkTarget, linkFlags))
-                        throw new LinkUtilWin32Exception(String.Format("CreateSymbolicLink({0}, {1}, {2}) failed", linkPath, linkTarget, linkFlags));
-                    break;
-                case LinkType.JunctionPoint:
-                    CreateJunctionPoint(linkPath, linkTarget);
-                    break;
-                case LinkType.HardLink:
-                    if (!CreateHardLink(linkPath, linkTarget, IntPtr.Zero))
-                        throw new LinkUtilWin32Exception(String.Format("CreateHardLink({0}, {1}) failed", linkPath, linkTarget));
-                    break;
-            }
-        }
-
-        private static LinkInfo GetHardLinkInfo(string linkPath)
-        {
-            UInt32 maxPath = 260;
-            List<string> result = new List<string>();
-
-            StringBuilder sb = new StringBuilder((int)maxPath);
-            UInt32 stringLength = maxPath;
-            if (!GetVolumePathName(linkPath, sb, ref stringLength))
-                throw new LinkUtilWin32Exception("GetVolumePathName() failed");
-            string volume = sb.ToString();
-
-            stringLength = maxPath;
-            IntPtr findHandle = FindFirstFileNameW(linkPath, 0, ref stringLength, sb);
-            if (findHandle.ToInt64() != INVALID_HANDLE_VALUE)
-            {
-                try
-                {
-                    do
-                    {
-                        string hardLinkPath = sb.ToString();
-                        if (hardLinkPath.StartsWith("\\"))
-                            hardLinkPath = hardLinkPath.Substring(1, hardLinkPath.Length - 1);
-
-                        result.Add(Path.Combine(volume, hardLinkPath));
-                        stringLength = maxPath;
-
-                    } while (FindNextFileNameW(findHandle, ref stringLength, sb));
+    Process {
+        if ([Ansible.IO.FileSystem]::Exists($Path)) {
+            $link_info = Get-Link -Path $Path
+            if ($null -ne $link_Info) {
+                if ($PSCmdlet.ShouldProcess($Path, "Delete $($link_info.Type)")) {
+                    [Ansible.Link.LinkUtil]::DeleteLink($Path)
                 }
-                finally
-                {
-                    FindClose(findHandle);
-                }                
-            }
-
-            if (result.Count > 1)
-                return new LinkInfo
-                {
-                    Type = LinkType.HardLink,
-                    HardTargets = result.ToArray()
-                };
-
-            return null;
-        }
-
-        private static LinkInfo GetReparsePointInfo(string linkPath)
-        {
-            SafeFileHandle fileHandle = CreateFile(
-                linkPath,
-                FileAccess.Read,
-                FileShare.None,
-                IntPtr.Zero,
-                FileMode.Open,
-                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
-                IntPtr.Zero);
-
-            if (fileHandle.IsInvalid)
-                throw new LinkUtilWin32Exception(String.Format("CreateFile({0}) failed", linkPath));            
-
-            REPARSE_DATA_BUFFER buffer = new REPARSE_DATA_BUFFER();
-            UInt32 bytesReturned;
-            try
-            {
-                if (!DeviceIoControl(
-                    fileHandle,
-                    FSCTL_GET_REPARSE_POINT,
-                    IntPtr.Zero,
-                    0,
-                    out buffer,
-                    MAXIMUM_REPARSE_DATA_BUFFER_SIZE,
-                    out bytesReturned,
-                    IntPtr.Zero))
-                    throw new LinkUtilWin32Exception(String.Format("DeviceIoControl() failed for file at {0}", linkPath));
-            }
-            finally
-            {
-                fileHandle.Dispose();
-            }
-
-            bool isRelative = false;
-            int pathOffset = 0;
-            LinkType linkType;
-            if (buffer.ReparseTag == IO_REPARSE_TAG_SYMLINK)
-            {
-                UInt32 bufferFlags = Convert.ToUInt32(buffer.PathBuffer[0]) + Convert.ToUInt32(buffer.PathBuffer[1]);
-                if (bufferFlags == SYMLINK_FLAG_RELATIVE)
-                    isRelative = true;
-                pathOffset = 2;
-                linkType = LinkType.SymbolicLink;
-            }
-            else if (buffer.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT)
-            {
-                linkType = LinkType.JunctionPoint;
-            }
-            else
-            {
-                string errorMessage = String.Format("Invalid Reparse Tag: {0}", buffer.ReparseTag.ToString());
-                throw new Exception(errorMessage);
-            }
-
-            string printName = new string(buffer.PathBuffer, (int)(buffer.PrintNameOffset / SIZE_OF_WCHAR) + pathOffset, (int)(buffer.PrintNameLength / SIZE_OF_WCHAR));
-            string substituteName = new string(buffer.PathBuffer, (int)(buffer.SubstituteNameOffset / SIZE_OF_WCHAR) + pathOffset, (int)(buffer.SubstituteNameLength / SIZE_OF_WCHAR));
-
-            // TODO: should we check for \?\UNC\server for convert it to the NT style \\server path
-            // Remove the leading Windows object directory \?\ from the path if present
-            string targetPath = substituteName;
-            if (targetPath.StartsWith("\\??\\"))
-                targetPath = targetPath.Substring(4, targetPath.Length - 4);
-
-            string absolutePath = targetPath;
-            if (isRelative)
-                absolutePath = Path.GetFullPath(Path.Combine(new FileInfo(linkPath).Directory.FullName, targetPath));
-
-            return new LinkInfo
-            {
-                Type = linkType,
-                PrintName = printName,
-                SubstituteName = substituteName,
-                AbsolutePath = absolutePath,
-                TargetPath = targetPath
-            };
-        }
-
-        private static void CreateJunctionPoint(string linkPath, string linkTarget)
-        {
-            // We need to create the link as a dir beforehand
-            Directory.CreateDirectory(linkPath);
-            SafeFileHandle fileHandle = CreateFile(
-                linkPath,
-                FileAccess.Write,
-                FileShare.Read | FileShare.Write | FileShare.None,
-                IntPtr.Zero,
-                FileMode.Open,
-                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
-                IntPtr.Zero);
-
-            if (fileHandle.IsInvalid)
-                throw new LinkUtilWin32Exception(String.Format("CreateFile({0}) failed", linkPath));
-
-            try
-            {
-                string substituteName = "\\??\\" + Path.GetFullPath(linkTarget);
-                string printName = linkTarget;
-
-                REPARSE_DATA_BUFFER buffer = new REPARSE_DATA_BUFFER();
-                buffer.SubstituteNameOffset = 0;
-                buffer.SubstituteNameLength = (UInt16)(substituteName.Length * SIZE_OF_WCHAR);
-                buffer.PrintNameOffset = (UInt16)(buffer.SubstituteNameLength + 2);
-                buffer.PrintNameLength = (UInt16)(printName.Length * SIZE_OF_WCHAR);
-
-                buffer.ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
-                buffer.ReparseDataLength = (UInt16)(buffer.SubstituteNameLength + buffer.PrintNameLength + 12);
-                buffer.PathBuffer = new char[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
-
-                byte[] unicodeBytes = Encoding.Unicode.GetBytes(substituteName + "\0" + printName);
-                char[] pathBuffer = Encoding.Unicode.GetChars(unicodeBytes);
-                Array.Copy(pathBuffer, buffer.PathBuffer, pathBuffer.Length);
-
-                UInt32 bytesReturned;
-                if (!DeviceIoControl(
-                    fileHandle,
-                    FSCTL_SET_REPARSE_POINT,
-                    buffer,
-                    (UInt32)(buffer.ReparseDataLength + 8),
-                    IntPtr.Zero, 0,
-                    out bytesReturned,
-                    IntPtr.Zero))
-                    throw new LinkUtilWin32Exception(String.Format("DeviceIoControl() failed to create junction point at {0} to {1}", linkPath, linkTarget));
-            }
-            finally
-            {
-                fileHandle.Dispose();
             }
         }
     }
 }
-'@
 
-    # FUTURE: find a better way to get the _ansible_remote_tmp variable
-    $original_tmp = $env:TMP
+Function New-Link {
+    <#
+    .SYNOPSIS
+    Creates a link at the path specified.
 
-    $remote_tmp = $original_tmp
-    $module_params = Get-Variable -Name complex_args -ErrorAction SilentlyContinue
-    if ($module_params) {
-        if ($module_params.Value.ContainsKey("_ansible_remote_tmp") ) {
-            $remote_tmp = $module_params.Value["_ansible_remote_tmp"]
-            $remote_tmp = [System.Environment]::ExpandEnvironmentVariables($remote_tmp)
-        }
-    }
+    .PARAMETER Path
+    The path to create the link at.
 
-    $env:TMP = $remote_tmp
-    Add-Type -TypeDefinition $link_util
-    $env:TMP = $original_tmp
+    .PARAMETER TargetPath
+    The target of the link to create.
 
-    # enable the SeBackupPrivilege if it is disabled
-    $state = Get-AnsiblePrivilege -Name SeBackupPrivilege
-    if ($state -eq $false) {
-        Set-AnsiblePrivilege -Name SeBackupPrivilege -Value $true
-    }
-}
+    .PARAMETER Type
+    The type of link to create, can be;
+        symbolic - A file or directory symbolic link that can span across volumes.
+        junction - A directory junction point that must target a dir on the same volume.
+        hard - A file hard link that must target a file on the same volume.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param (
+        [Parameter(Mandatory=$true)]
+        [Alias("link_path")]
+        [System.String]$Path,
 
-Function Get-Link($link_path) {
-    $link_info = [Ansible.LinkUtil]::GetLinkInfo($link_path)
-    return $link_info
-}
+        [Parameter(Mandatory=$true)]
+        [Alias("link_target")]
+        [System.String]$TargetPath,
 
-Function Remove-Link($link_path) {
-    [Ansible.LinkUtil]::DeleteLink($link_path)
-}
+        [Parameter(Mandatory=$true)]
+        [Alias("link_type")]
+        [ValidateSet("link", "junction", "hard")]
+        [System.String]$Type
+    )
 
-Function New-Link($link_path, $link_target, $link_type) {
-    if (-not (Test-Path -LiteralPath $link_target)) {
-        throw "link_target '$link_target' does not exist, cannot create link"
-    }
-    
-    switch($link_type) {
-        "link" {
-            $type = [Ansible.LinkType]::SymbolicLink
-        }
-        "junction" {
-            if (Test-Path -LiteralPath $link_target -PathType Leaf) {
-                throw "cannot set the target for a junction point to a file"
+    Process {
+        switch ($Type) {
+            "link" {
+                $link_type = [Ansible.Link.LinkType]::SymbolicLink
             }
-            $type = [Ansible.LinkType]::JunctionPoint
-        }
-        "hard" {
-            if (Test-Path -LiteralPath $link_target -PathType Container) {
-                throw "cannot set the target for a hard link to a directory"
+            "junction" {
+                if ([Ansible.IO.FileSystem]::FileExists($TargetPath)) {
+                    throw "cannot set the target for a junction point to a file"
+                }
+                $link_type = [Ansible.Link.LinkType]::JunctionPoint
             }
-            $type = [Ansible.LinkType]::HardLink
+            "hard" {
+                if ([Ansible.IO.FileSystem]::DirectoryExists($TargetPath)) {
+                    throw "cannot set the target for a hard link to a directory"
+                } elseif (-not ([Ansible.IO.FileSystem]::FileExists($TargetPath))) {
+                    throw "link target '$TargetPath' does not exist, cannot create hard link"
+                }
+                $link_type = [Ansible.Link.LinkType]::HardLink
+            }
         }
-        default { throw "invalid link_type option $($link_type): expecting link, junction, hard" }
+
+        if ($PSCmdlet.ShouldProcess($Path, "Create $($link_type.ToString()) targeting $TargetPath")) {
+            [Ansible.Link.LinkUtil]::CreateLink($Path, $TargetPath, $link_type)
+        }
     }
-    [Ansible.LinkUtil]::CreateLink($link_path, $link_target, $type)
 }
 
 # this line must stay at the bottom to ensure all defined module parts are exported
-Export-ModuleMember -Alias * -Function * -Cmdlet *
+Export-ModuleMember -Function Get-Link, Load-LinkUtils, New-Link, Remove-Link

--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -75,7 +75,6 @@ $follow = $module.Params.follow
 
 $module.Result.stat = @{ exists=$false }
 
-Load-LinkUtils
 $info, $link_info = Get-FileInfo -Path $path -Follow:$follow
 If ($null -ne $info) {    
     $epoch_date = Get-Date -Date "01/01/1970"

--- a/test/integration/targets/win_csharp_utils/library/ansible_io_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_io_tests.ps1
@@ -1498,6 +1498,7 @@ $tests = [Ordered]@{
             $_.Exception.InnerException.Message | Assert-Equals -Expected "The directory is not empty: '$dir_path'"
             $failed = $true
         }
+        $failed | Assert-Equals -Expected $true
 
         [Ansible.IO.FileSystem]::Exists($nested_dir) | Assert-Equals -Expected $true
         [Ansible.IO.FileSystem]::DirectoryExists($nested_dir) | Assert-Equals -Expected $true
@@ -2108,7 +2109,7 @@ $path_tests = [Ordered]@{
         [Ansible.IO.Path]::GetPathRoot("\\server\share") | Assert-Equals -Expected "\\server\share"
         [Ansible.IO.Path]::GetPathRoot("\\?\UNC\server\share") | Assert-Equals -Expected "\\?\UNC\server\share"
         [Ansible.IO.Path]::GetPathRoot("\\server\share\path") | Assert-Equals -Expected "\\server\share"
-        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\server\share\path") | Assert-Equals -Expected "\\?\UNC\server\share" 
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\server\share\path") | Assert-Equals -Expected "\\?\UNC\server\share"
     }
 }
 

--- a/test/integration/targets/win_csharp_utils/library/ansible_io_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_io_tests.ps1
@@ -1,0 +1,2126 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -CSharpUtil Ansible.Link
+#AnsibleRequires -CSharpUtil Ansible.IO
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, @{})
+
+Function Assert-Equals {
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)][AllowNull()]$Actual,
+        [Parameter(Mandatory=$true, Position=0)][AllowNull()]$Expected
+    )
+
+    $matched = $false
+    if ($Actual -is [System.Collections.ArrayList] -or $Actual -is [Array]) {
+        $Actual.Count | Assert-Equals -Expected $Expected.Count
+        for ($i = 0; $i -lt $Actual.Count; $i++) {
+            $actual_value = $Actual[$i]
+            $expected_value = $Expected[$i]
+            Assert-Equals -Actual $actual_value -Expected $expected_value
+        }
+        $matched = $true
+    } else {
+        $matched = $Actual -ceq $Expected
+    }
+
+    if (-not $matched) {
+        if ($Actual -is [PSObject]) {
+            $Actual = $Actual.ToString()
+        }
+
+        $call_stack = (Get-PSCallStack)[1]
+        $module.Result.test = $test
+        $module.Result.actual = $Actual
+        $module.Result.expected = $Expected
+        $module.Result.line = $call_stack.ScriptLineNumber
+        $module.Result.method = $call_stack.Position.Text
+
+        $module.FailJson("AssertionError: actual != expected")
+    }
+}
+
+Function Clear-Directory {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$true)][System.String]$Path
+    )
+
+    if ([Ansible.IO.FileSystem]::DirectoryExists($Path)) {
+        [Ansible.IO.FileSystem]::RemoveDirectory($Path, $true)
+    }
+    [Ansible.IO.FileSystem]::CreateDirectory($Path)
+}
+
+Function Set-AnsibleContent {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$true)][System.String]$Path,
+        [Parameter(Mandatory=$true)][System.String]$Value
+    )
+
+    $file_h = [Ansible.IO.FileSystem]::CreateFile($Path, "Create", "Write", "None", "None")
+
+    try {
+        $fs = New-Object -TypeName System.IO.FileStream -ArgumentList $file_h, "Write"
+
+        try {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
+            $fs.Write($bytes, 0, $bytes.Length)
+        } finally {
+            $fs.Dispose()
+        }
+    } finally {
+        $file_h.Dispose()
+    }
+}
+
+Function Get-AnsibleContent {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$true)][System.String]$Path
+    )
+
+    $file_h = [Ansible.IO.FileSystem]::CreateFile($Path, "Open", "Read", "None", "None")
+
+    try {
+        $fs = New-Object -TypeName System.IO.FileStream -ArgumentList $file_h, "Read"
+
+        try {
+            $bytes = New-Object -TypeName byte[] -ArgumentList $fs.Length
+            $fs.Read($bytes, 0, $bytes.Length)
+            [System.Text.Encoding]::UTF8.GetString($bytes)
+        } finally {
+            $fs.Dispose()
+        }
+    } finally {
+        $file_h.Dispose()
+    }
+}
+
+Function Get-Pagefile {
+    $pagefile = $null
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem
+    if ($cs.AutomaticManagedPagefile) {
+        $pagefile = "$($env:SystemRoot.Substring(0, 1)):\pagefile.sys"
+    } else {
+        $pf = Get-CimInstance -ClassName Win32_PageFileSetting
+        if ($null -ne $pf) {
+            $pagefile = $pf[0].Name
+        }
+    }
+    return $pagefile
+}
+
+Function Set-RestrictedSD {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$true)][System.String]$Path
+    )
+
+    # Sets a an empty DACL (no permissions) and a different group/owner from the current user.
+    $system_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-18"
+    $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+    $acl.SetGroup($system_sid)
+    $acl.SetOwner($system_sid)
+    $acl.SetAccessRuleProtection($true, $false)
+    [System.IO.Directory]::SetAccessControl($Path, $acl)
+}
+
+$tests = [Ordered]@{
+    "Copy a directory that does not exist" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $false, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$source'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy an directory to non-existing dest" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $false, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$target'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy a directory, source is a file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+        Set-AnsibleContent -Path $source -Value "Hi"
+
+        $failed = $true
+        try {
+            [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $false, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The source path '$source' is a file, not a directory."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy a directory, dest is a file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        Set-AnsibleContent -Path $target -Value "Hi"
+
+        $failed = $true
+        try {
+            [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $false, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The target path '$target' is a file, not a directory."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy an empty directory without recurse" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $false, $false)
+
+        [Ansible.IO.FileSystem]::DirectoryExists([Ansible.IO.Path]::Combine($target, "source")) | Assert-Equals -Expected $true
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach ($path in [Ansible.IO.FileSystem]::EnumerateFolder($target, "*", "AllDirectories", $true, $true)) {
+            $actual.Add($path)
+        }
+        $actual.Count | Assert-Equals -Expected 1
+        $actual[0] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source"))
+    }
+
+    "Copy an empty directory with recurse" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        [Ansible.IO.FileSystem]::DirectoryExists([Ansible.IO.Path]::Combine($target, "source")) | Assert-Equals -Expected $true
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach ($path in [Ansible.IO.FileSystem]::EnumerateFolder($target, "*", "AllDirectories", $true, $true)) {
+            $actual.Add($path)
+        }
+        $actual.Count | Assert-Equals -Expected 1
+        $actual[0] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source"))
+    }
+
+    "Copy a directory with files without recurse" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "file.txt")) -Value "foo"
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $false, $false)
+
+        [Ansible.IO.FileSystem]::DirectoryExists([Ansible.IO.Path]::Combine($target, "source")) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists([Ansible.IO.Path]::Combine($target, "source", "file.txt")) | Assert-Equals -Expected $false
+    }
+
+    "Copy a directory with files with recurse" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "file.txt")) -Value "foo"
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        [Ansible.IO.FileSystem]::DirectoryExists([Ansible.IO.Path]::Combine($target, "source")) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists([Ansible.IO.Path]::Combine($target, "source", "file.txt")) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "file.txt")) | Assert-Equals -Expected "foo"
+    }
+
+    "Copy a directory with files and folders without recurse" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        $sub_folder = [Ansible.IO.Path]::Combine($source, "folder")
+        [Ansible.IO.FileSystem]::CreateDirectory($sub_folder)
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "file.txt")) -Value "foo"
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($sub_folder, "file.txt")) -Value "bar"
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $false, $false)
+
+        [Ansible.IO.FileSystem]::DirectoryExists([Ansible.IO.Path]::Combine($target, "source")) | Assert-Equals -Expected $true
+        $dir_contents = [System.Collections.Generic.List`1[String]]@()
+        foreach ($path in [Ansible.IO.FileSystem]::EnumerateFolder($target, "*", "AllDirectories", $true, $true)) {
+            $dir_contents.Add($path)
+        }
+        $dir_contents.Count | Assert-Equals -Expected 1
+        $dir_contents[0] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source"))
+    }
+
+    "Copy a directory with files and folders with recurse" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        $sub_folder = [Ansible.IO.Path]::Combine($source, "folder")
+        [Ansible.IO.FileSystem]::CreateDirectory($sub_folder)
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "file.txt")) -Value "foo"
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($sub_folder, "file.txt")) -Value "bar"
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        [Ansible.IO.FileSystem]::DirectoryExists([Ansible.IO.Path]::Combine($target, "source")) | Assert-Equals -Expected $true
+        $dir_contents = [System.Collections.Generic.List`1[String]]@()
+        foreach ($path in [Ansible.IO.FileSystem]::EnumerateFolder($target, "*", "AllDirectories", $true, $true)) {
+            $dir_contents.Add($path)
+        }
+        $dir_contents = $dir_contents | Sort-Object
+        $dir_contents.Count | Assert-Equals -Expected 4
+        $dir_contents[0] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source"))
+        $dir_contents[1] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "file.txt"))
+        $dir_contents[2] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "folder"))
+        $dir_contents[3] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "folder", "file.txt"))
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "file.txt")) | Assert-Equals -Expected "foo"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "folder", "file.txt")) | Assert-Equals -Expected "bar"
+    }
+
+    "Copy a directory with a link" = {
+        # This verifies it doesn't choke on links and replicates the behaviour of Copy-Item
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        $sub_folder = [Ansible.IO.Path]::Combine($source, "folder")
+        [Ansible.IO.FileSystem]::CreateDirectory($sub_folder)
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "file.txt")) -Value "foo"
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "folder", "file.txt")) -Value "bar"
+        [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "sym-link"), $sub_folder, "SymbolicLink")
+        [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "sym-link-missing"), "missing", "SymbolicLink")
+        [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "sym-link.txt"), [Ansible.IO.Path]::Combine($sub_folder, "file.txt"), "SymbolicLink")
+        [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "sym-link-missing.txt"), "missing.txt", "SymbolicLink")
+        [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "hard.txt"), [Ansible.IO.Path]::Combine($sub_folder, "file.txt"), "HardLink")
+
+        # Junction points don't work over UNC paths, adjust the test slightly for this scenario
+        $expected_count = 10
+        if (-not ($test_path.StartsWith("\\") -or $test_path.StartsWith("\\?\UNC"))) {
+            $expected_count = 12
+            [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "zzjunction"), $sub_folder, "JunctionPoint")
+        }
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        [Ansible.IO.FileSystem]::DirectoryExists([Ansible.IO.Path]::Combine($target, "source")) | Assert-Equals -Expected $true
+        $dir_contents = [System.Collections.Generic.List`1[String]]@()
+        foreach ($path in [Ansible.IO.FileSystem]::EnumerateFolder($target, "*", "AllDirectories", $true, $true)) {
+            $dir_contents.Add($path)
+        }
+        $dir_contents = $dir_contents | Sort-Object
+        $dir_contents.Count | Assert-Equals -Expected $expected_count
+        $dir_contents[0] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source"))
+        $dir_contents[1] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "file.txt"))
+        $dir_contents[2] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "folder"))
+        $dir_contents[3] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "folder", "file.txt"))
+        $dir_contents[4] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "hard.txt"))
+        $dir_contents[5] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "sym-link"))
+        $dir_contents[6] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "sym-link.txt"))
+        $dir_contents[7] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "sym-link", "file.txt"))
+        $dir_contents[8] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "sym-link-missing"))
+        $dir_contents[9] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "sym-link-missing.txt"))
+
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "file.txt")) | Assert-Equals -Expected "foo"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "folder", "file.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "hard.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "sym-link.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "sym-link", "file.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "folder", "file.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "sym-link", "file.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "sym-link-missing.txt")) | Assert-Equals -Expected ""
+
+        # Change contents of original link sources to ensure the copies are not actual links
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "file.txt")) -Value "foo2"
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "folder", "file.txt")) -Value "bar2"
+
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "hard.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "sym-link.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "sym-link", "file.txt")) | Assert-Equals -Expected "bar"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "sym-link", "file.txt")) | Assert-Equals -Expected "bar"
+
+        if (-not ($test_path.StartsWith("\\") -or $test_path.StartsWith("\\?\UNC"))) {
+            $dir_contents[10] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "zzjunction"))
+            $dir_contents[11] | Assert-Equals -Expected ([Ansible.IO.Path]::Combine($target, "source", "zzjunction", "file.txt"))
+            Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "zzjunction", "file.txt")) | Assert-Equals -Expected "bar"
+        }
+    }
+
+    "Copy directory without overwrite" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        $sub_folder = [Ansible.IO.Path]::Combine($source, "folder")
+        [Ansible.IO.FileSystem]::CreateDirectory($sub_folder)
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "file.txt")) -Value "foo"
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "folder", "file.txt")) -Value "bar"
+
+        # Create dest dir structure to ensure it doesn't fail if only dirs are there
+        [Ansible.IO.FileSystem]::CreateDirectory([Ansible.IO.Path]::Combine($target, "source", "folder"))
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        # Now that the files have been copied, it should fail without overwrite
+        try {
+            [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+        } catch {
+            $target_file = [Ansible.IO.Path]::Combine($target, "source", "file.txt")
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The file '$target_file' already exists."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy directory with broken file symlink without overwrite" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+        [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "sym-link.txt"), "missing", "SymbolicLink")
+
+        # Copy it once
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        # Set the content of the copied blank symlink so we can test it wasn't changed in the next call
+        $target_file = [Ansible.IO.Path]::Combine($target, "source", "sym-link.txt")
+        [Ansible.IO.FileSystem]::FileExists($target_file) | Assert-Equals -Expected $true
+        Set-AnsibleContent -Path $target_file -Value "foo"
+
+        try {
+            # Copy it again expecting a failure
+            [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The file '$target_file' already exists."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target_file | Assert-Equals -Expected "foo"
+    }
+
+    "Copy directory with broken file symlink with overwrite" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+        [Ansible.Link.LinkUtil]::CreateLink([Ansible.IO.Path]::Combine($source, "sym-link.txt"), "missing", "SymbolicLink")
+
+        # Copy it once
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        # Set the content of the copied blank symlink so we can test it was changed in the next call
+        $target_file = [Ansible.IO.Path]::Combine($target, "source", "sym-link.txt")
+        [Ansible.IO.FileSystem]::FileExists($target_file) | Assert-Equals -Expected $true
+        Set-AnsibleContent -Path $target_file -Value "foo"
+
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $true)
+        Get-AnsibleContent -Path $target_file | Assert-Equals -Expected ""
+    }
+
+    "Copy directory with overwrite" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        $sub_folder = [Ansible.IO.Path]::Combine($source, "folder")
+        [Ansible.IO.FileSystem]::CreateDirectory($sub_folder)
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "file.txt")) -Value "foo"
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($source, "folder", "file.txt")) -Value "bar"
+
+        # Copy once
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $false)
+
+        # Edit copied file to ensure the next operation overwrites it
+        Set-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "file.txt")) -Value "foo2"
+
+        # Copy again with overwrite
+        [Ansible.IO.FileSystem]::CopyDirectory($source, $target, $true, $true)
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "file.txt")) | Assert-Equals -Expected "foo"
+        Get-AnsibleContent -Path ([Ansible.IO.Path]::Combine($target, "source", "folder", "file.txt")) | Assert-Equals -Expected "bar"
+    }
+
+    "Copy a file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        Set-AnsibleContent -Path $source -Value "Hello World"
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        $actual = Get-AnsibleContent -Path $target
+        $actual | Assert-Equals -Expected "Hello World"
+    }
+
+    "Copy a file fail to overwrite" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        Set-AnsibleContent -Path $source -Value "Hello World"
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The file '$target' already exists."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy a file with overwrite" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        Set-AnsibleContent -Path $source -Value "Hello World"
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        Set-AnsibleContent -Path $source -Value "Hello back"
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $true)
+
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        $actual = Get-AnsibleContent -Path $target
+        $actual | Assert-Equals -Expected "Hello back"
+    }
+
+    "Copy a file fail with dir source" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The source file '$source' is a directory, not a file."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy a file fail with dir target" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        Set-AnsibleContent -Path $source -Value "abc"
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The target file '$target' is a directory, not a file."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy a file fail with missing source" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$source'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Copy a file with custom attributes" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        Set-AnsibleContent -Path $source -Value "a"
+        Set-AnsibleContent -Path $target -Value "b"
+        [Ansible.IO.FileSystem]::SetAttributes($source, "Hidden, ReadOnly")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $true)
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "a"
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($target)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $true
+    }
+
+    "Copy a file with read only attribute as dest" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        Set-AnsibleContent -Path $source -Value "a"
+        Set-AnsibleContent -Path $target -Value "b"
+        [Ansible.IO.FileSystem]::SetAttributes($target, "ReadOnly")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $true)
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "a"
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($target)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $false
+    }
+
+    "Copy a file with a hidden attribute as dest" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        Set-AnsibleContent -Path $source -Value "a"
+        Set-AnsibleContent -Path $target -Value "b"
+        [Ansible.IO.FileSystem]::SetAttributes($target, "Hidden")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $true)
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "a"
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($target)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $false
+    }
+
+    "Copy a symbolic link file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link-target.txt")
+        Set-AnsibleContent -Path $link_target -Value "abc"
+        [Ansible.Link.LinkUtil]::CreateLink($source, $link_target, "SymbolicLink")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "abc"
+
+        # Verify the copied file is a copy of the original target and not an actual symlink
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($target)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReparsePoint) | Assert-Equals -Expected $false
+    }
+
+    "Copy a broken symbolic link file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link-target.txt")
+        [Ansible.Link.LinkUtil]::CreateLink($source, $link_target, "SymbolicLink")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected ""
+
+        # Verify the copied file is a copy of the original target and not an actual symlink
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($target)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReparsePoint) | Assert-Equals -Expected $false
+    }
+
+    "Copy a hard link" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link-target.txt")
+        Set-AnsibleContent -Path $link_target -Value "abc"
+        [Ansible.Link.LinkUtil]::CreateLink($source, $link_target, "HardLink")
+
+        [Ansible.IO.FileSystem]::CopyFile($source, $target, $false)
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "abc"
+
+        # Verify the copied file is a copy of the original target and not an actual hard link
+        Set-AnsibleContent -Path $link_target -Value "def"
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "abc"
+    }
+
+    "Create directory" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $true
+    }
+
+    "Create nested directory" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory", "nested")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $true
+    }
+
+    "Create directory with file path" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        Set-AnsibleContent -Path $dir_path -Value "abc"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Cannot create '$dir_path' because a file or directory with the same name already exists."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Create directory that exists" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+    }
+
+    "Create directory with no permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $base_dir = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($base_dir)
+        Set-RestrictedSD -Path $base_dir
+
+        $dir_path = [Ansible.IO.Path]::Combine($base_dir, "nested")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $true
+    }
+
+    "Create new file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "CreateNew", "Read", "None", "None")
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CreateFile($file_path, "CreateNew", "Read", "None", "None")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The file '$file_path' already exists."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Create new file over existing file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Create", "Read", "None", "None")
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Create", "Read", "None", "None")
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+
+        # Getting a handle with Create will create a new file, erasing the existing one
+        Get-AnsibleContent -Path $file_path | Assert-Equals -Expected ""
+    }
+
+    "Open existing file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "Read", "None", "None")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$file_path'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "Read", "None", "None")
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+    }
+
+    "Open existing file or create new" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "OpenOrCreate", "Read", "None", "None")
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "OpenOrCreate", "Read", "None", "None")
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+
+        Get-AnsibleContent -Path $file_path | Assert-Equals -Expected "abc"
+    }
+
+    "Open file without any sharing" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Create", "Read", "None", "None")
+        try {
+            $failed = $true
+            try {
+                [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "Read", "Read", "None")
+            } catch {
+                $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+                $_.Exception.InnerException.Message | Assert-Equals -Expected "The process cannot access the file '$file_path' because it is being used by another process."
+                $failed = $true
+            }
+            $failed | Assert-Equals -Expected $true
+        } finally {
+            $handle.Dispose()
+        }
+    }
+
+    "Open file with read sharing" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Create", "Read", "Read", "None")
+        try {
+            $sub_handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "Read", "Read", "None")
+            try {
+                $sub_handle.IsInvalid | Assert-Equals -Expected $false
+                $sub_handle.IsClosed | Assert-Equals -Expected $false
+            } finally {
+                $sub_handle.Dispose()
+            }
+            $sub_handle.IsClosed | Assert-Equals -Expected $true
+
+            $failed = $true
+            try {
+                [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "Write", "Read", "None")
+            } catch {
+                $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+                $_.Exception.InnerException.Message | Assert-Equals -Expected "The process cannot access the file '$file_path' because it is being used by another process."
+                $failed = $true
+            }
+            $failed | Assert-Equals -Expected $true
+        } finally {
+            $handle.Dispose()
+        }
+    }
+
+    "Open file with read/write sharing" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Create", "Read", "ReadWrite", "None")
+        try {
+            $sub_handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "ReadWrite", "ReadWrite", "None")
+            try {
+                $sub_handle.IsInvalid | Assert-Equals -Expected $false
+                $sub_handle.IsClosed | Assert-Equals -Expected $false
+            } finally {
+                $sub_handle.Dispose()
+            }
+            $sub_handle.IsClosed | Assert-Equals -Expected $true
+        } finally {
+            $handle.Dispose()
+        }
+    }
+
+    "Open file with delete on close" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Create", "Read", "None", "DeleteOnClose")
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+            [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $true
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Create file in directory with no permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $base_dir = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $file_path = [Ansible.IO.Path]::Combine($base_dir, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($base_dir)
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        Set-RestrictedSD -Path $base_dir
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "Read", "None", "None")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.UnauthorizedAccessException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Access to the path '$file_path' is denied."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+
+        $priv_enabler = New-Object -TypeName Ansible.Privilege.PrivilegeEnabler -ArgumentList $true, "SeBackupPrivilege"
+        try {
+            $handle = [Ansible.IO.FileSystem]::CreateFile($file_path, "Open", "Read", "None", 0x02000000)  # FILE_FLAG_BACKUP_SEMANTICS
+            try {
+                $handle.IsInvalid | Assert-Equals -Expected $false
+                $handle.IsClosed | Assert-Equals -Expected $false
+            } finally {
+                $handle.Dispose()
+            }
+            $handle.IsClosed | Assert-Equals -Expected $true
+        } finally {
+            $priv_enabler.Dispose()
+        }
+    }
+
+    "CreateFile with directory" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        $handle = [Ansible.IO.FileSystem]::CreateFile($dir_path, "Open", "Read", "None", 0x02000000)
+        try {
+            $handle.IsInvalid | Assert-Equals -Expected $false
+            $handle.IsClosed | Assert-Equals -Expected $false
+        } finally {
+            $handle.Dispose()
+        }
+        $handle.IsClosed | Assert-Equals -Expected $true
+    }
+
+    "Delete file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Delete file that does not exist" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Delete file in a dir that does not exist" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "missing", "file.txt")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::DeleteFile($file_path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$file_path'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Delete file that is a folder" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "folder")
+        [Ansible.IO.FileSystem]::CreateDirectory($file_path)
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::DeleteFile($file_path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.UnauthorizedAccessException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Access to the path '$file_path' is denied."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Delete file that is hidden" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden")
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Delete file that is read only" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "ReadOnly")
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Delete file with no permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $base_dir = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($base_dir)
+
+        $file_path = [Ansible.IO.Path]::Combine($base_dir, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        Set-RestrictedSD -Path $base_dir
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Delete file that is a symlink" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link_target.txt")
+        Set-AnsibleContent -Path $link_target -Value "abc"
+        [Ansible.Link.LinkUtil]::CreateLink($file_path, $link_target, "SymbolicLink")
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Delete file that is a broken symlink" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link_target.txt")
+        [Ansible.Link.LinkUtil]::CreateLink($file_path, $link_target, "SymbolicLink")
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Delete file that is a hard link" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link_target.txt")
+        Set-AnsibleContent -Path $link_target -Value "abc"
+        [Ansible.Link.LinkUtil]::CreateLink($file_path, $link_target, "HardLink")
+
+        [Ansible.IO.FileSystem]::DeleteFile($file_path)
+
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "Directory exists for dir" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $true
+    }
+
+    "Directory exists for file" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $dir_path -Value "abc"
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $false
+    }
+
+    "Directory exists for missing dir" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $false
+    }
+
+    "Directory exists for missing nested dir" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory", "nested")
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $false
+    }
+
+    "Directory exists for dir with no permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir_path = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir_path)
+        Set-RestrictedSD -Path $dir_path
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::Exists($nested_dir_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::DirectoryExists($nested_dir_path) | Assert-Equals -Expected $true
+    }
+
+    "Enumerate directory that is empty" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach($e in [Ansible.IO.FileSystem]::EnumerateFolder($dir_path, "*", "TopDirectoryOnly", $true, $true)) {
+            $actual.Add($e)
+        }
+        $actual.Count | Assert-Equals -Expected 0
+    }
+
+    "Enumerate directory non recursively" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir_path = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        $file_path = [Ansible.IO.Path]::Combine($nested_dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir_path)
+        Set-AnsibleContent $file_path -Value "abc"
+
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach($e in [Ansible.IO.FileSystem]::EnumerateFolder($dir_path, "*", "TopDirectoryOnly", $true, $true)) {
+            $actual.Add($e)
+        }
+        $actual.Count | Assert-Equals -Expected 1
+        $actual[0] | Assert-Equals -Expected $nested_dir_path
+    }
+
+    "Enumerate directory recursively" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir_path = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        $file_path = [Ansible.IO.Path]::Combine($nested_dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir_path)
+        Set-AnsibleContent $file_path -Value "abc"
+
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach($e in [Ansible.IO.FileSystem]::EnumerateFolder($dir_path, "*", "AllDirectories", $true, $true)) {
+            $actual.Add($e)
+        }
+        $actual.Count | Assert-Equals -Expected 2
+        $actual[0] | Assert-Equals -Expected $nested_dir_path
+        $actual[1] | Assert-Equals -Expected $file_path
+    }
+
+    "Enumerate directory recursively with pattern" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir_path = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        $file_path1 = [Ansible.IO.Path]::Combine($nested_dir_path, "file1.txt")
+        $file_path2 = [Ansible.IO.Path]::Combine($nested_dir_path, "files2.txt")
+        $file_path3 = [Ansible.IO.Path]::Combine($nested_dir_path, "file3.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir_path)
+        Set-AnsibleContent $file_path1 -Value "abc"
+        Set-AnsibleContent $file_path2 -Value "abc"
+        Set-AnsibleContent $file_path3 -Value "abc"
+
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach($e in [Ansible.IO.FileSystem]::EnumerateFolder($dir_path, "file?.txt", "AllDirectories", $true, $true)) {
+            $actual.Add($e)
+        }
+        $actual.Count | Assert-Equals -Expected 2
+        $actual[0] | Assert-Equals -Expected $file_path1
+        $actual[1] | Assert-Equals -Expected $file_path3
+    }
+
+    "Enumerate directory return directories" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir_path = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        $file_path = [Ansible.IO.Path]::Combine($nested_dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir_path)
+        Set-AnsibleContent $file_path -Value "abc"
+
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach($e in [Ansible.IO.FileSystem]::EnumerateFolder($dir_path, "*", "AllDirectories", $true, $false)) {
+            $actual.Add($e)
+        }
+        $actual.Count | Assert-Equals -Expected 1
+        $actual[0] | Assert-Equals -Expected $nested_dir_path
+    }
+
+    "Enumerate directory return files" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir_path = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        $file_path = [Ansible.IO.Path]::Combine($nested_dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir_path)
+        Set-AnsibleContent $file_path -Value "abc"
+
+        $actual = [System.Collections.Generic.List`1[String]]@()
+        foreach($e in [Ansible.IO.FileSystem]::EnumerateFolder($dir_path, "*", "AllDirectories", $false, $true)) {
+            $actual.Add($e)
+        }
+        $actual.Count | Assert-Equals -Expected 1
+        $actual[0] | Assert-Equals -Expected $file_path
+    }
+
+    "File exists for file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        [Ansible.IO.FileSystem]::Exists($file_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $true
+    }
+
+    "File exists for dir" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($file_path)
+
+        [Ansible.IO.FileSystem]::Exists($file_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "File exists for missing file in missing dir" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $file_path = [Ansible.IO.Path]::Combine($dir_path, "file.txt")
+
+        [Ansible.IO.FileSystem]::Exists($file_path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $false
+    }
+
+    "File exists for file with no permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $file_path = [Ansible.IO.Path]::Combine($dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        Set-RestrictedSD -Path $dir_path
+
+        [Ansible.IO.FileSystem]::Exists($file_path) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists($file_path) | Assert-Equals -Expected $true
+    }
+
+    "File exists for pagefile.sys" = {
+        if ($test_path.StartsWith("\\")) {
+            # We only need to test this once
+            return
+        }
+
+        # The pagefile.sys is a special file that usually is locked. It requires special handling to check if it exists
+        $pagefile = Get-Pagefile
+        if ($null -eq $pagefile) {
+            return
+        }
+
+        [Ansible.IO.FileSystem]::Exists($pagefile) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists($pagefile) | Assert-Equals -Expected $true
+    }
+
+    "Get file attribute data for file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.IO.FileAttributeData"
+        $actual.FileAttributes.GetType().FullName | Assert-Equals -Expected "System.IO.FileAttributes"
+        $actual.CreationTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.LastAccessTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.LastWriteTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.FileSize | Assert-Equals -Expected 3
+    }
+
+    "Get file attribute data for directory" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($dir_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Directory) | Assert-Equals -Expected $true
+        $actual.CreationTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.LastAccessTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.LastWriteTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.FileSize | Assert-Equals -Expected 0
+    }
+
+    "Get file attribute data for missing file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "missing")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$file_path'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Get file attribute data for file in missing directory" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "missing", "file.txt")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$file_path'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Get file attribute data for hidden, system, and read only file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden, ReadOnly, System")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::System) | Assert-Equals -Expected $true
+    }
+
+    "Get file attribute data for symbolic link" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link_target.txt")
+        Set-AnsibleContent -Path $link_target -Value "abc"
+
+        [Ansible.Link.LinkUtil]::CreateLink($file_path, $link_target, "SymbolicLink")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReparsePoint) | Assert-Equals -Expected $true
+        $actual.FileSize | Assert-Equals -Expected 0
+
+        # Delete the target and try again
+        [Ansible.IO.FileSystem]::DeleteFile($link_target)
+        $actual2 = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual2.FileAttributes | Assert-Equals -Expected $actual.FileAttributes
+        $actual2.CreationTime | Assert-Equals -Expected $actual.CreationTime
+        $actual2.LastAccessTime | Assert-Equals -Expected $actual.LastAccessTime
+        $actual2.LastWriteTime | Assert-Equals -Expected $actual.LastWriteTime
+        $actual2.FileSize | Assert-Equals -Expected $actual.FileSize
+    }
+
+    "Get file attribute data for junction point" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "dir")
+        $link_target = [Ansible.IO.Path]::Combine($test_path, "link_target")
+        [Ansible.IO.FileSystem]::CreateDirectory($link_target)
+
+        [Ansible.Link.LinkUtil]::CreateLink($dir_path, $link_target, "JunctionPoint")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($dir_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Directory) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReparsePoint) | Assert-Equals -Expected $true
+        $actual.FileSize | Assert-Equals -Expected 0
+
+        # Delete the target and try again
+        [Ansible.IO.FileSystem]::RemoveDirectory($link_target, $false)
+        $actual2 = [Ansible.IO.FileSystem]::GetFileAttributeData($dir_path)
+        $actual2.FileAttributes | Assert-Equals -Expected $actual.FileAttributes
+        $actual2.CreationTime | Assert-Equals -Expected $actual.CreationTime
+        $actual2.LastAccessTime | Assert-Equals -Expected $actual.LastAccessTime
+        $actual2.LastWriteTime | Assert-Equals -Expected $actual.LastWriteTime
+        $actual2.FileSize | Assert-Equals -Expected $actual.FileSize
+    }
+
+    "Get file attribute data for pagefile.sys" = {
+        if ($test_path.StartsWith("\\")) {
+            # We only need to test this once
+            return
+        }
+
+        # The pagefile.sys is a special file that usually is locked. It requires special handling to check if it exists
+        $pagefile = Get-Pagefile
+        if ($null -eq $pagefile) {
+            return
+        }
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($pagefile)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Archive) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::System) | Assert-Equals -Expected $true
+    }
+
+    "Get file attribute data for file and dir without permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $file_path = [Ansible.IO.Path]::Combine($dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        Set-RestrictedSD -Path $dir_path
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.IO.FileAttributeData"
+        $actual.FileAttributes.GetType().FullName | Assert-Equals -Expected "System.IO.FileAttributes"
+        $actual.CreationTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.LastAccessTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.LastWriteTime.GetType().FullName | Assert-Equals -Expected "System.DateTimeOffset"
+        $actual.FileSize | Assert-Equals -Expected 3
+    }
+
+    "Move file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+
+        [Ansible.IO.FileSystem]::MoveFile($source, $target)
+
+        [Ansible.IO.FileSystem]::FileExists($source) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "abc"
+    }
+
+    "Move directory" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $source_dir = [Ansible.IO.Path]::Combine($source, "directory")
+        $source_file = [Ansible.IO.Path]::Combine($source_dir, "file.txt")
+
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        $target_dir = [Ansible.IO.Path]::Combine($target, "directory")
+        $target_file = [Ansible.IO.Path]::Combine($target_dir, "file.txt")
+
+        [Ansible.IO.FileSystem]::CreateDirectory($source_dir)
+        Set-AnsibleContent -Path $source_file -Value "abc"
+
+        [Ansible.IO.FileSystem]::MoveFile($source, $target)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($source) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::DirectoryExists($target) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::DirectoryExists($target_dir) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists($target_file) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target_file | Assert-Equals -Expected "abc"
+    }
+
+    "Move missing file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::MoveFile($source, $target)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$source'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Move missing directory" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "missing", "target.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::MoveFile($source, $target)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$target'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Move file to existing path" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+        Set-AnsibleContent -Path $target -Value "def"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::MoveFile($source, $target)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Cannot create '$target' because a file or directory with the same name already exists."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+
+        [Ansible.IO.FileSystem]::FileExists($source) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $source | Assert-Equals -Expected "abc"
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "def"
+    }
+
+    "Remove directory" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        [Ansible.IO.FileSystem]::RemoveDirectory($dir_path, $false)
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $false
+    }
+
+    "Remove directory with contents and without recurse" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir)
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::RemoveDirectory($dir_path, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The directory is not empty: '$dir_path'"
+            $failed = $true
+        }
+
+        [Ansible.IO.FileSystem]::Exists($nested_dir) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::DirectoryExists($nested_dir) | Assert-Equals -Expected $true
+    }
+
+    "Remove directory with contents and with recurse" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $nested_dir = [Ansible.IO.Path]::Combine($dir_path, "nested")
+        [Ansible.IO.FileSystem]::CreateDirectory($nested_dir)
+
+        [Ansible.IO.FileSystem]::RemoveDirectory($dir_path, $true)
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $false
+    }
+
+    "Remove directory with file path" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $dir_path -Value "abc"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::RemoveDirectory($dir_path, $true)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The directory name is invalid: '$dir_path'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Remove directory without permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $parent_dir = [Ansible.IO.Path]::Combine($test_path, "parent directory")
+        $dir_path = [Ansible.IO.Path]::Combine($parent_dir, "directory")
+        $file_path = [Ansible.IO.Path]::Combine($dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        Set-RestrictedSD -Path $parent_dir
+
+        [Ansible.IO.FileSystem]::RemoveDirectory($dir_path, $true)
+
+        [Ansible.IO.FileSystem]::Exists($dir_path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::DirectoryExists($dir_path) | Assert-Equals -Expected $false
+    }
+
+    "Replace file without backup" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+        Set-AnsibleContent -Path $target -Value "def"
+
+        [Ansible.IO.FileSystem]::ReplaceFile($source, $target, $null, $false)
+
+        [Ansible.IO.FileSystem]::FileExists($source) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "abc"
+    }
+
+    "Replace file with backup" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $backup = [Ansible.IO.Path]::Combine($test_path, "backup.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+        Set-AnsibleContent -Path $target -Value "def"
+
+        [Ansible.IO.FileSystem]::ReplaceFile($source, $target, $backup, $false)
+
+        [Ansible.IO.FileSystem]::FileExists($source) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "abc"
+        [Ansible.IO.FileSystem]::FileExists($backup) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $backup | Assert-Equals -Expected "def"
+    }
+
+    "Replace file with backup that already exists" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $backup = [Ansible.IO.Path]::Combine($test_path, "backup.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+        Set-AnsibleContent -Path $target -Value "def"
+        Set-AnsibleContent -Path $backup -Value "ghi"
+
+        [Ansible.IO.FileSystem]::ReplaceFile($source, $target, $backup, $false)
+
+        [Ansible.IO.FileSystem]::FileExists($source) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $target | Assert-Equals -Expected "abc"
+        [Ansible.IO.FileSystem]::FileExists($backup) | Assert-Equals -Expected $true
+        Get-AnsibleContent -Path $backup | Assert-Equals -Expected "def"
+    }
+
+    "Replace directory with file" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+        Set-AnsibleContent -Path $source -Value "abc"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::ReplaceFile($source, $target, $null, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.UnauthorizedAccessException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Access to the path '$target' is denied."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Replace file with directory" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($source)
+        Set-AnsibleContent -Path $target -Value "abc"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::ReplaceFile($source, $target, $null, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.UnauthorizedAccessException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Access to the path '$source' is denied."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Replace file with dest in missing dir" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "missing", "target.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::ReplaceFile($source, $target, $null, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$target'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Replace file with missing dest" = {
+        $source = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        Set-AnsibleContent -Path $source -Value "abc"
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::ReplaceFile($source, $target, $null, $false)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$target'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Set attributes on file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden, System, ReadOnly")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::System) | Assert-Equals -Expected $true
+
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden, ReadOnly")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::System) | Assert-Equals -Expected $false
+    }
+
+    "Set attributes on directory" = {
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+
+        [Ansible.IO.FileSystem]::SetAttributes($dir_path, "Hidden, System, ReadOnly")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($dir_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Directory) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::System) | Assert-Equals -Expected $true
+
+        [Ansible.IO.FileSystem]::SetAttributes($dir_path, "Hidden, ReadOnly")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($dir_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Directory) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::System) | Assert-Equals -Expected $false
+    }
+
+    "Set same attributes on file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden, System, ReadOnly")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::ReadOnly) | Assert-Equals -Expected $true
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::System) | Assert-Equals -Expected $true
+
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden, System, ReadOnly")
+        $actual2 = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual2.FileAttributes | Assert-Equals -Expected $actual.FileAttributes
+    }
+
+    "Set attributes on missing file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$file_path'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Set attributes on missing directory" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "missing", "file.txt")
+
+        $failed = $false
+        try {
+            [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$file_path'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Set attributes in dir with no permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $file_path = [Ansible.IO.Path]::Combine($dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        Set-RestrictedSD -Path $dir_path
+
+        [Ansible.IO.FileSystem]::SetAttributes($file_path, "Hidden")
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.FileAttributes.HasFlag([System.IO.FileAttributes]::Hidden) | Assert-Equals -Expected $true
+    }
+
+    "Set creation time on file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        $file_info = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $cdate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 59 -Millisecond 999
+        $adate = $file_info.LastAccessTime
+        $wdate = $file_info.LastWriteTime
+
+        [Ansible.IO.FileSystem]::SetFileTime($file_path, $cdate, $null, $null)
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.CreationTime | Assert-Equals -Expected $cdate
+        $actual.LastAccessTime | Assert-Equals -Expected $adate
+        $actual.LastWriteTime | Assert-Equals -Expected $wdate
+    }
+
+    "Set access time on file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        $file_info = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $cdate = $file_info.CreationTime
+        $adate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 59 -Millisecond 999
+        $wdate = $file_info.LastWriteTime
+
+        [Ansible.IO.FileSystem]::SetFileTime($file_path, $null, $adate, $null)
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.CreationTime | Assert-Equals -Expected $cdate
+        $actual.LastAccessTime | Assert-Equals -Expected $adate
+        $actual.LastWriteTime | Assert-Equals -Expected $wdate
+    }
+
+    "Set write time on file" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        $file_info = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $cdate = $file_info.CreationTime
+        $adate = $file_info.LastAccessTime
+        $wdate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 59 -Millisecond 999
+
+        [Ansible.IO.FileSystem]::SetFileTime($file_path, $null, $null, $wdate)
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.CreationTime | Assert-Equals -Expected $cdate
+        $actual.LastAccessTime | Assert-Equals -Expected $adate
+        $actual.LastWriteTime | Assert-Equals -Expected $wdate
+    }
+
+    "Set time on directory" = {
+        $file_path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        Set-AnsibleContent -Path $file_path -Value "abc"
+
+        $cdate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 57 -Millisecond 999
+        $adate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 58 -Millisecond 999
+        $wdate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 59 -Millisecond 999
+
+        [Ansible.IO.FileSystem]::SetFileTime($file_path, $cdate, $adate, $wdate)
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.CreationTime | Assert-Equals -Expected $cdate
+        $actual.LastAccessTime | Assert-Equals -Expected $adate
+        $actual.LastWriteTime | Assert-Equals -Expected $wdate
+    }
+
+    "Set time on file with no permissions" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        $dir_path = [Ansible.IO.Path]::Combine($test_path, "directory")
+        $file_path = [Ansible.IO.Path]::Combine($dir_path, "file.txt")
+        [Ansible.IO.FileSystem]::CreateDirectory($dir_path)
+        Set-AnsibleContent -Path $file_path -Value "abc"
+        Set-RestrictedSD -Path $dir_path
+
+        $cdate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 57 -Millisecond 999
+        $adate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 58 -Millisecond 999
+        $wdate = Get-Date -Year 1999 -Month 12 -Day 31 -Hour 23 -Minute 59 -Second 59 -Millisecond 999
+
+        [Ansible.IO.FileSystem]::SetFileTime($file_path, $cdate, $adate, $wdate)
+
+        $actual = [Ansible.IO.FileSystem]::GetFileAttributeData($file_path)
+        $actual.CreationTime | Assert-Equals -Expected $cdate
+        $actual.LastAccessTime | Assert-Equals -Expected $adate
+        $actual.LastWriteTime | Assert-Equals -Expected $wdate
+    }
+}
+
+foreach ($test_impl in $tests.GetEnumerator()) {
+    # Run each test with
+    #     1. A normal path
+    #     2. A path that exceeds MAX_PATH
+    #     3. A UNC path
+    #     4. A UNC path that exceeds MAX_PATH
+
+    # Normal path
+    $test_path = [Ansible.IO.Path]::Combine($module.Tmpdir, "short")
+    Clear-Directory -Path $test_path
+    $test = $test_impl.Key
+    &$test_impl.Value
+
+    # Local MAX_PATH
+    $test_path = [Ansible.IO.Path]::Combine("\\?\$($module.Tmpdir)", "a" * 255)
+    Clear-Directory -Path $test_path
+    $test = "$($test_impl.Key) - MAX_PATH"
+    &$test_impl.Value
+
+    # UNC Path
+    $unc_path = [Ansible.IO.Path]::Combine("localhost", "$($module.Tmpdir.Substring(0, 1))$", $module.Tmpdir.Substring(3))
+    $test_path = [Ansible.IO.Path]::Combine("\\$unc_path", "short")
+    Clear-Directory -Path $test_path
+    $test = "$($test_impl.Key) - UNC Path"
+    &$test_impl.Value
+
+    # UNC MAX_PATH
+    $test_path = [Ansible.IO.Path]::Combine("\\?\UNC\$unc_path", "a" * 255)
+    Clear-Directory -Path $test_path
+    $test = "$($test_impl.Key) - UNC MAX_PATH"
+    &$test_impl.Value
+}
+
+# These tests are based on results when running on 2016 which has less restrictions when it comes to long paths.
+$path_tests = [Ordered]@{
+    "GetDirectoryName tests" = {
+        $long_path = "{0}\{0}\{0}\{0}\{0}\{0}\{0}\dir" -f ("a" * 250)
+
+        [Ansible.IO.Path]::GetDirectoryName("C:\path\dir") | Assert-Equals -Expected "C:\path"
+        [Ansible.IO.Path]::GetDirectoryName("C:/path/dir") | Assert-Equals -Expected "C:\path"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\dir") | Assert-Equals -Expected "\\?\C:\path"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\$long_path\dir") | Assert-Equals -Expected "\\?\C:\path\$long_path"
+        [Ansible.IO.Path]::GetDirectoryName("\\127.0.0.1\c$\path\dir") | Assert-Equals -Expected "\\127.0.0.1\c$\path"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\$long_path"
+
+        [Ansible.IO.Path]::GetDirectoryName("C:\path\dir\file.txt") | Assert-Equals -Expected "C:\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("C:/path/dir/file.txt") | Assert-Equals -Expected "C:\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\dir\file.txt") | Assert-Equals -Expected "\\?\C:\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\$long_path\dir\file.txt") | Assert-Equals -Expected "\\?\C:\path\$long_path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\127.0.0.1\c$\path\dir\file.txt") | Assert-Equals -Expected "\\127.0.0.1\c$\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir"
+
+        [Ansible.IO.Path]::GetDirectoryName("C:\path\dir\file.") | Assert-Equals -Expected "C:\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("C:/path/dir/file.") | Assert-Equals -Expected "C:\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\dir\file.") | Assert-Equals -Expected "\\?\C:\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\$long_path\dir\file.") | Assert-Equals -Expected "\\?\C:\path\$long_path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\127.0.0.1\c$\path\dir\file.") | Assert-Equals -Expected "\\127.0.0.1\c$\path\dir"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir"
+
+        [Ansible.IO.Path]::GetDirectoryName($null) | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("C") | Assert-Equals -Expected ""
+        [Ansible.IO.Path]::GetDirectoryName("C:") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("C:\") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("C:/") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("C:\a") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetDirectoryName("C:\a\") | Assert-Equals -Expected "C:\a"
+        [Ansible.IO.Path]::GetDirectoryName("C:\a\b") | Assert-Equals -Expected "C:\a"
+        [Ansible.IO.Path]::GetDirectoryName("C:/a") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetDirectoryName("\\?") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:/") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:\a") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:/a") | Assert-Equals -Expected "\\?\C:/"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:/a/") | Assert-Equals -Expected "\\?\C:/a"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\C:/a/b") | Assert-Equals -Expected "\\?\C:/a"
+
+        [Ansible.IO.Path]::GetDirectoryName("\\") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\server") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\server\") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\server\share") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\server\share\") | Assert-Equals -Expected "\\server\share"
+        [Ansible.IO.Path]::GetDirectoryName("\\server\share\path") | Assert-Equals -Expected "\\server\share"
+
+        [Ansible.IO.Path]::GetDirectoryName("//") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("//server") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("//server/") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("//server/share") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("//server/share/") | Assert-Equals -Expected "\\server\share"
+        [Ansible.IO.Path]::GetDirectoryName("//server/share/path") | Assert-Equals -Expected "\\server\share"
+
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\share") | Assert-Equals -Expected $null
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\share\") | Assert-Equals -Expected "\\?\UNC\server\share"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\share\path") | Assert-Equals -Expected "\\?\UNC\server\share"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server/share\path") | Assert-Equals -Expected "\\?\UNC\server/share"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server/share\path\") | Assert-Equals -Expected "\\?\UNC\server/share\path"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server/share\path/") | Assert-Equals -Expected "\\?\UNC\server/share\path"
+
+        [Ansible.IO.Path]::GetDirectoryName("\\?/UNC/server/share/") | Assert-Equals -Expected "\\?\UNC\server\share"
+        [Ansible.IO.Path]::GetDirectoryName("\\?/UNC/server/share/path") | Assert-Equals -Expected "\\?\UNC\server\share"
+
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC/") | Assert-Equals -Expected "\\?\UNC"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server") | Assert-Equals -Expected "\\?\UNC"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/") | Assert-Equals -Expected "\\?\UNC/server"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/share") | Assert-Equals -Expected "\\?\UNC/server"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/share/") | Assert-Equals -Expected "\\?\UNC/server/share"
+        [Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/share/path") | Assert-Equals -Expected "\\?\UNC/server/share"
+    }
+
+    "GetFullPath tests" = {
+        $long_path = "{0}\{0}\{0}\{0}\{0}\{0}\{0}\dir" -f ("a" * 250)
+
+        # GetFullPath - we differ a bit from the latest System.IO.Path.GetFullPath where we still resolve if the prefix starts with \\?\
+        [Ansible.IO.Path]::GetFullPath("C:\path\dir") | Assert-Equals -Expected "C:\path\dir"
+        [Ansible.IO.Path]::GetFullPath("C:/path/dir") | Assert-Equals -Expected "C:\path\dir"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\path\dir") | Assert-Equals -Expected "\\?\C:\path\dir"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\path/dir") | Assert-Equals -Expected "\\?\C:\path\dir"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\path\$long_path\dir") | Assert-Equals -Expected "\\?\C:\path\$long_path\dir"
+        [Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir") | Assert-Equals -Expected "\\127.0.0.1\c$\path\dir"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\$long_path\dir") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path/$long_path\dir") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir"
+
+        [Ansible.IO.Path]::GetFullPath("C:\path\dir\file.txt") | Assert-Equals -Expected "C:\path\dir\file.txt"
+        [Ansible.IO.Path]::GetFullPath("C:/path/dir/file.txt") | Assert-Equals -Expected "C:\path\dir\file.txt"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\path\dir\file.txt") | Assert-Equals -Expected "\\?\C:\path\dir\file.txt"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\path\$long_path\dir\file.txt") | Assert-Equals -Expected "\\?\C:\path\$long_path\dir\file.txt"
+        [Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir\file.txt") | Assert-Equals -Expected "\\127.0.0.1\c$\path\dir\file.txt"
+        [Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir/file.txt") | Assert-Equals -Expected "\\127.0.0.1\c$\path\dir\file.txt"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\$long_path\dir/file.txt") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt"
+
+        [Ansible.IO.Path]::GetFullPath("C:\path\dir\file.") | Assert-Equals -Expected "C:\path\dir\file"
+        [Ansible.IO.Path]::GetFullPath("C:/path/dir/file.") | Assert-Equals -Expected "C:\path\dir\file"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\path\dir\file.") | Assert-Equals -Expected "\\?\C:\path\dir\file"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\path\$long_path\dir\file.") | Assert-Equals -Expected "\\?\C:\path\$long_path\dir\file"
+        [Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir\file.") | Assert-Equals -Expected "\\127.0.0.1\c$\path\dir\file"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\dir\file.") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$\path\dir\file"
+
+        $failed = $false
+        try {
+            [Ansible.IO.Path]::GetFullPath($null)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.ArgumentException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The path is not of a legal form."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+
+        $failed = $false
+        try {
+            [Ansible.IO.Path]::GetFullPath("")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.ArgumentException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The path is not of a legal form."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+
+        [Ansible.IO.Path]::GetFullPath("C:\") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetFullPath("C:/") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetFullPath("C:\a") | Assert-Equals -Expected "C:\a"
+        [Ansible.IO.Path]::GetFullPath("C:\a\") | Assert-Equals -Expected "C:\a\"
+        [Ansible.IO.Path]::GetFullPath("C:\a\b") | Assert-Equals -Expected "C:\a\b"
+        [Ansible.IO.Path]::GetFullPath("C:/a") | Assert-Equals -Expected "C:\a"
+        [Ansible.IO.Path]::GetFullPath("\\?") | Assert-Equals -Expected "\\?\"
+        [Ansible.IO.Path]::GetFullPath("\\?\") | Assert-Equals -Expected "\\?\"
+        [Ansible.IO.Path]::GetFullPath("\\?\C") | Assert-Equals -Expected "\\?\C"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:") | Assert-Equals -Expected "\\?\C:"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:/") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:\a") | Assert-Equals -Expected "\\?\C:\a"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:/a") | Assert-Equals -Expected "\\?\C:\a"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:/a/") | Assert-Equals -Expected "\\?\C:\a\"
+        [Ansible.IO.Path]::GetFullPath("\\?\C:/a/b") | Assert-Equals -Expected "\\?\C:\a\b"
+
+        [Ansible.IO.Path]::GetFullPath("\\server\share") | Assert-Equals -Expected "\\server\share"
+        [Ansible.IO.Path]::GetFullPath("\\server\share\") | Assert-Equals -Expected "\\server\share\"
+        [Ansible.IO.Path]::GetFullPath("\\server\share\path") | Assert-Equals -Expected "\\server\share\path"
+
+        [Ansible.IO.Path]::GetFullPath("//server/share") | Assert-Equals -Expected "\\server\share"
+        [Ansible.IO.Path]::GetFullPath("//server/share/") | Assert-Equals -Expected "\\server\share\"
+        [Ansible.IO.Path]::GetFullPath("//server/share/path") | Assert-Equals -Expected "\\server\share\path"
+
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC") | Assert-Equals -Expected "\\?\UNC"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\") | Assert-Equals -Expected "\\?\UNC\"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server") | Assert-Equals -Expected "\\?\UNC\server"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server\") | Assert-Equals -Expected "\\?\UNC\server\"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server\share") | Assert-Equals -Expected "\\?\UNC\server\share"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server\share\") | Assert-Equals -Expected "\\?\UNC\server\share\"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server\share\path") | Assert-Equals -Expected "\\?\UNC\server\share\path"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server/share\path") | Assert-Equals -Expected "\\?\UNC\server\share\path"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server/share\path\") | Assert-Equals -Expected "\\?\UNC\server\share\path\"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC\server/share\path/") | Assert-Equals -Expected "\\?\UNC\server\share\path\"
+
+        [Ansible.IO.Path]::GetFullPath("\\?/UNC") | Assert-Equals -Expected "\\?\UNC"
+        [Ansible.IO.Path]::GetFullPath("\\?/UNC/") | Assert-Equals -Expected "\\?\UNC\"
+        [Ansible.IO.Path]::GetFullPath("\\?/UNC/server") | Assert-Equals -Expected "\\?\UNC\server"
+        [Ansible.IO.Path]::GetFullPath("\\?/UNC/server/") | Assert-Equals -Expected "\\?\UNC\server\"
+        [Ansible.IO.Path]::GetFullPath("\\?/UNC/server/share") | Assert-Equals -Expected "\\?\UNC\server\share"
+        [Ansible.IO.Path]::GetFullPath("\\?/UNC/server/share/") | Assert-Equals -Expected "\\?\UNC\server\share\"
+        [Ansible.IO.Path]::GetFullPath("\\?/UNC/server/share/path") | Assert-Equals -Expected "\\?\UNC\server\share\path"
+
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC") | Assert-Equals -Expected "\\?\UNC"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC/") | Assert-Equals -Expected "\\?\UNC\"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC/server") | Assert-Equals -Expected "\\?\UNC\server"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC/server/") | Assert-Equals -Expected "\\?\UNC\server\"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC/server/share") | Assert-Equals -Expected "\\?\UNC\server\share"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC/server/share/") | Assert-Equals -Expected "\\?\UNC\server\share\"
+        [Ansible.IO.Path]::GetFullPath("\\?\UNC/server/share/path") | Assert-Equals -Expected "\\?\UNC\server\share\path"
+    }
+
+    "GetPathRoot tests" = {
+        $long_path = "{0}\{0}\{0}\{0}\{0}\{0}\{0}\dir" -f ("a" * 250)
+
+        [Ansible.IO.Path]::GetPathRoot("C:\path\dir") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("C:/path/dir") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\path\dir") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\path\$long_path\dir") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\127.0.0.1\c$\path\dir") | Assert-Equals -Expected "\\127.0.0.1\c$"
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\127.0.0.1\c$\path\$long_path\dir") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$"
+
+        [Ansible.IO.Path]::GetPathRoot("C:\path\dir\file.txt") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("C:/path/dir/file.txt") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\path\dir\file.txt") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\path\$long_path\dir\file.txt") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\127.0.0.1\c$\path\dir\file.txt") | Assert-Equals -Expected "\\127.0.0.1\c$"
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$"
+
+        [Ansible.IO.Path]::GetPathRoot("C:\path\dir\file.") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("C:/path/dir/file.") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\path\dir\file.") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\path\$long_path\dir\file.") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\127.0.0.1\c$\path\dir\file.") | Assert-Equals -Expected "\\127.0.0.1\c$"
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.") | Assert-Equals -Expected "\\?\UNC\127.0.0.1\c$"
+
+        [Ansible.IO.Path]::GetPathRoot("test") | Assert-Equals -Expected ""
+        [Ansible.IO.Path]::GetPathRoot(".\test") | Assert-Equals -Expected ""
+        [Ansible.IO.Path]::GetPathRoot("C:") | Assert-Equals -Expected "C:"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:") | Assert-Equals -Expected "\\?\C:"
+        [Ansible.IO.Path]::GetPathRoot("C:\") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("C:\path") | Assert-Equals -Expected "C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\C:\path") | Assert-Equals -Expected "\\?\C:\"
+        [Ansible.IO.Path]::GetPathRoot("\\") | Assert-Equals -Expected "\\"
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\") | Assert-Equals -Expected "\\?\UNC\"
+        [Ansible.IO.Path]::GetPathRoot("\\server") | Assert-Equals -Expected "\\server"
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\server") | Assert-Equals -Expected "\\?\UNC\server"
+        [Ansible.IO.Path]::GetPathRoot("\\server\share") | Assert-Equals -Expected "\\server\share"
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\server\share") | Assert-Equals -Expected "\\?\UNC\server\share"
+        [Ansible.IO.Path]::GetPathRoot("\\server\share\path") | Assert-Equals -Expected "\\server\share"
+        [Ansible.IO.Path]::GetPathRoot("\\?\UNC\server\share\path") | Assert-Equals -Expected "\\?\UNC\server\share" 
+    }
+}
+
+foreach ($test_impl in $path_tests.GetEnumerator()) {
+    $test = $test_impl.Key
+    &$test_impl.Value
+}
+
+# Make sure a path that exceeds MAX_PATH is in the module tmpdir. This checks to make sure that the AnsibleModule
+# cleanup task is able to delete these folders when Ansible.IO has been imported.
+$max_folder = [Ansible.IO.Path]::Combine("\\?\$($module.Tmpdir)", "z" * 255)
+[Ansible.IO.FileSystem]::CreateDirectory($max_folder)
+
+$module.Result.data = "success"
+$module.ExitJson()

--- a/test/integration/targets/win_csharp_utils/library/ansible_link_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_link_tests.ps1
@@ -1,0 +1,772 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -CSharpUtil Ansible.IO
+#AnsibleRequires -CSharpUtil Ansible.Link
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, @{})
+
+Function Assert-Equals {
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)][AllowNull()]$Actual,
+        [Parameter(Mandatory=$true, Position=0)][AllowNull()]$Expected
+    )
+
+    $matched = $false
+    if ($Actual -is [System.Collections.ArrayList] -or $Actual -is [Array]) {
+        $Actual.Count | Assert-Equals -Expected $Expected.Count
+        for ($i = 0; $i -lt $Actual.Count; $i++) {
+            $actual_value = $Actual[$i]
+            $expected_value = $Expected[$i]
+            Assert-Equals -Actual $actual_value -Expected $expected_value
+        }
+        $matched = $true
+    } else {
+        $matched = $Actual -ceq $Expected
+    }
+
+    if (-not $matched) {
+        if ($Actual -is [PSObject]) {
+            $Actual = $Actual.ToString()
+        }
+
+        $call_stack = (Get-PSCallStack)[1]
+        $module.Result.test = $test
+        $module.Result.actual = $Actual
+        $module.Result.expected = $Expected
+        $module.Result.line = $call_stack.ScriptLineNumber
+        $module.Result.method = $call_stack.Position.Text
+
+        $module.FailJson("AssertionError: actual != expected")
+    }
+}
+
+Function Clear-Directory {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$true)][System.String]$Path
+    )
+
+    if ([Ansible.IO.FileSystem]::DirectoryExists($Path)) {
+        [Ansible.IO.FileSystem]::RemoveDirectory($Path, $true)
+    }
+    [Ansible.IO.FileSystem]::CreateDirectory($Path)
+}
+
+$tests = @{
+    "Get link info on non existent path" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "fake.txt")
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$path'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Get link info on missing parent dir" = {
+        $path = [System.IO.Path]::Combine($test_path, "fake folder", "fake")
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$path'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Get link info for normal file" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($path, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        $actual | Assert-Equals -Expected $null
+    }
+
+    "Get link info for normal directory" = {
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($test_path)
+        $actual | Assert-Equals -Expected $null
+    }
+
+    "Create a directory symbolic link to absolute target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a directory symbolic link to missing absolute target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a directory symbolic link to relative target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine(".", "target")
+        $target_abs = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target_abs)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $target
+        $actual.AbsolutePath | Assert-Equals -Expected $target_abs
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a directory symbolic link to missing relative target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine(".", "target")
+        $target_abs = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $target
+        $actual.AbsolutePath | Assert-Equals -Expected $target_abs
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a file symbolic link to absolute target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::FileExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a file symbolic link to missing absolute target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::FileExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a file symbolic link to missing absolute target dest no extension" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::FileExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a file symbolic link to relative target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine(".", "target.txt")
+        $target_abs = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target_abs, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        ([Ansible.IO.FileSystem]::FileExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $target
+        $actual.AbsolutePath | Assert-Equals -Expected $target_abs
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a file symbolic link to missing relative target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine(".", "target.txt")
+        $target_abs = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        ([Ansible.IO.FileSystem]::FileExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $target
+        $actual.AbsolutePath | Assert-Equals -Expected $target_abs
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create a symbolic link to network path" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+
+        if ($test_path.StartsWith("\\?\")) {
+            $target_unc = "\\?\UNC\localhost\c$" + $test_path.Substring(6)
+            $expected_sub_name = "\??\UNC\localhost\c`$$($test_path.Substring(6))\target"
+        } else {
+            $target_unc = "\\localhost\c$" + $test_path.Substring(2)
+            $expected_sub_name = "\??\UNC\localhost\c`$$($test_path.Substring(2))\target"
+        }
+        $target = [Ansible.IO.Path]::Combine($target_unc, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Read symbolic link with no rights to link" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        # Create parent path that we have no rights to
+        $parent_path = [Ansible.IO.Path]::Combine($test_path, "parent")
+        [Ansible.IO.FileSystem]::CreateDirectory($parent_path)
+
+        $path = [Ansible.IO.Path]::Combine($parent_path, "source")
+        $target = [Ansible.IO.Path]::Combine($parent_path, "target")
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+
+        # Sets a an empty DACL (no permissions) and a different group/owner from the current user.
+        $system_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-18"
+        $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+        $acl.SetGroup($system_sid)
+        $acl.SetOwner($system_sid)
+        $acl.SetAccessRuleProtection($true, $false)
+        [System.IO.Directory]::SetAccessControl($parent_path, $acl)
+
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::SymbolicLink)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected "\??\$target"
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Fail to create symbolic link with missing parent dir" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "parent", "link")
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::CreateLink($path, $test_path, "SymbolicLink")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.DirectoryNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find a part of the path '$path'."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Delete a link that does not exist" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::DeleteLink($path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$path'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Delete a link that is a normal directory" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        [Ansible.IO.FileSystem]::CreateDirectory($path)
+
+        # DeleteLink does not fail if the path is not a link, just calls the normal delete functions.
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+        [Ansible.IO.FileSystem]::DirectoryExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Delete a link that is a normal file" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($path, "CreateNew", "Read", "None", "None")
+        $file_h.Dispose()
+
+        # DeleteLink does not fail if the path is not a link, just calls the normal delete functions.
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+        [Ansible.IO.FileSystem]::FileExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Delete a directory symbolic link" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Delete a file symbolic link" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target, "CreateNew", "Read", "None", "None")
+        $file_h.Dispose()
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::FileExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Delete a relative directory symbolic link" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine(".", "target")
+        $target_abs = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target_abs)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Delete a relative file symbolic link" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine(".", "target.txt")
+        $target_abs = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target_abs, "CreateNew", "Read", "None", "None")
+        $file_h.Dispose()
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::FileExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Delete a directory symbolic link with missing target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Delete a file symbolic link with a missing target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "SymbolicLink")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::FileExists($path) | Assert-Equals -Expected $false
+    }
+
+    "Create junction point to relative path - failure" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine(".", "target")
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.ArgumentException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Cannot create junction point because target '$target' is not an absolute path."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Create junction point to file - failure" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "file.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.ArgumentException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Cannot create junction point because target '$target' is a file."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Create junction point to directory" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::JunctionPoint)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create junction point to missing directory" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::JunctionPoint)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create junction point that replaces empty directory" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        [Ansible.IO.FileSystem]::CreateDirectory($path)
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+
+        if ($test_path.StartsWith("\\?\")) {
+            # Need to remove the \\?\ from the target path
+            $expected_sub_name = "\??\$($target.Substring(4))"
+        } else {
+            $expected_sub_name = "\??\$target"
+        }
+
+        ([Ansible.IO.FileSystem]::DirectoryExists($path)) | Assert-Equals -Expected $true
+        $actual.GetType().FullName | Assert-Equals -Expected "Ansible.Link.LinkInfo"
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::JunctionPoint)
+        $actual.PrintName | Assert-Equals -Expected $target
+        $actual.SubstituteName | Assert-Equals -Expected $expected_sub_name
+        $actual.AbsolutePath | Assert-Equals -Expected $target
+        $actual.TargetPath | Assert-Equals -Expected $target
+        $actual.HardTargets.Length | Assert-Equals -Expected 0
+    }
+
+    "Create junction point that replaces non empty directory - fail" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        [Ansible.IO.FileSystem]::CreateDirectory([Ansible.IO.Path]::Combine($path, "orig"))
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The directory is not empty: '$path'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Delete junction point" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($patH) | Assert-Equals -Expected $false
+    }
+
+    "Delete junction point with missing target" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "JunctionPoint")
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::DirectoryExists($patH) | Assert-Equals -Expected $false
+    }
+
+    "Create hard link to directory - fail" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+        [Ansible.IO.FileSystem]::CreateDirectory($target)
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::CreateLink($path, $target, "HardLink")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.IOException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "The target file '$target' is a directory, not a file."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Create hard link to missing file - fail" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target")
+
+        $failed = $false
+        try {
+            [Ansible.Link.LinkUtil]::CreateLink($path, $target, "HardLink")
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.IO.FileNotFoundException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Could not find file '$target'"
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Create hard link" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "HardLink")
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::HardLink)
+        $actual.HardTargets.Length | Assert-Equals -Expected 2
+        ($actual.HardTargets | Sort-Object)[0] | Assert-Equals -Expected $path
+        ($actual.HardTargets | Sort-Object)[1] | Assert-Equals -Expected $target
+
+        # Create another link to the same target and verify the HardTarget array is 3
+        $new_link = [Ansible.IO.Path]::Combine($test_path, "source2.txt")
+        [Ansible.Link.LinkUtil]::CreateLink($new_link, $target, "HardLink")
+
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::HardLink)
+        $actual.HardTargets.Length | Assert-Equals -Expected 3
+        ($actual.HardTargets | Sort-Object)[0] | Assert-Equals -Expected $path
+        ($actual.HardTargets | Sort-Object)[1] | Assert-Equals -Expected $new_link
+        ($actual.HardTargets | Sort-Object)[2] | Assert-Equals -Expected $target
+    }
+
+    "Create hard link to relative target" = {
+        # Cannot change dir to path that exceeds MAX_PATH so skip that scenario
+        if ($test_path.StartsWith("\\?\")) {
+            return
+        }
+
+        $path = [Ansible.IO.Path]::Combine($test_path, "source")
+        $target = [Ansible.IO.Path]::Combine(".", "target")
+        $target_abs = [Ansible.IO.Path]::Combine($test_path, "target")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target_abs, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+
+        $orig_cwd = [System.Environment]::CurrentDirectory
+        try {
+            # Relative paths are resolved in creation based on the cwd not relative to the link path
+            [System.Environment]::CurrentDirectory = $test_path
+            [Ansible.Link.LinkUtil]::CreateLink($path, $target, "HardLink")
+        } finally {
+            [System.Environment]::CurrentDirectory = $orig_cwd
+        }
+
+        $actual = [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        $actual.Type | Assert-Equals -Expected ([Ansible.Link.LinkType]::HardLink)
+        $actual.HardTargets.Length | Assert-Equals -Expected 2
+        ($actual.HardTargets | Sort-Object)[0] | Assert-Equals -Expected $path
+        ($actual.HardTargets | Sort-Object)[1] | Assert-Equals -Expected $target_abs
+    }
+
+    "Read hard link with no rights to link" = {
+        if ($test_path.StartsWith("\\?\")) {
+            # We use some .NET APIs to set the permissions which fail on a long path. Just skip that test for now.
+            return
+        }
+
+        # Create parent path that we have no rights to
+        $parent_path = [Ansible.IO.Path]::Combine($test_path, "parent")
+        [Ansible.IO.FileSystem]::CreateDirectory($parent_path)
+
+        $path = [Ansible.IO.Path]::Combine($parent_path, "source.txt")
+        $target = [Ansible.IO.Path]::Combine($parent_path, "target.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "HardLink")
+
+        # Sets a an empty DACL (no permissions) and a different group/owner from the current user.
+        $system_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-18"
+        $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+        $acl.SetGroup($system_sid)
+        $acl.SetOwner($system_sid)
+        $acl.SetAccessRuleProtection($true, $false)
+        [System.IO.Directory]::SetAccessControl($parent_path, $acl)
+
+        $failed = $false
+        try {
+            # Even with SeBackupPrivilege we won't be able to get this info
+            [Ansible.Link.LinkUtil]::GetLinkInfo($path)
+        } catch {
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "System.UnauthorizedAccessException"
+            $_.Exception.InnerException.Message | Assert-Equals -Expected "Access to the path '$path' is denied."
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Delete hard link" = {
+        $path = [Ansible.IO.Path]::Combine($test_path, "source.txt")
+        $new_link = [Ansible.IO.Path]::Combine($test_path, "source2.txt")
+        $target = [Ansible.IO.Path]::Combine($test_path, "target.txt")
+        $file_h = [Ansible.IO.FileSystem]::CreateFile($target, "CreateNew", "Write", "None", "None")
+        $file_h.Dispose()
+
+        [Ansible.Link.LinkUtil]::CreateLink($path, $target, "HardLink")
+        [Ansible.Link.LinkUtil]::CreateLink($new_link, $target, "HardLink")
+
+        [Ansible.Link.LinkUtil]::DeleteLink($path)
+
+        [Ansible.IO.FileSystem]::FileExists($path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($new_link) | Assert-Equals -Expected $true
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+
+        [Ansible.Link.LinkUtil]::DeleteLink($new_link)
+
+        [Ansible.IO.FileSystem]::FileExists($path) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($new_link) | Assert-Equals -Expected $false
+        [Ansible.IO.FileSystem]::FileExists($target) | Assert-Equals -Expected $true
+    }
+}
+
+foreach ($test_impl in $tests.GetEnumerator()) {
+    # Run each test with a normal path and a path that exceeds MAX_PATH
+    $test_path = [Ansible.IO.Path]::Combine($module.Tmpdir, "short")
+    Clear-Directory -Path $test_path
+    $test = $test_impl.Key
+    &$test_impl.Value
+
+    $test_path = [Ansible.IO.Path]::Combine("\\?\$($module.Tmpdir)", "a" * 255)
+    Clear-Directory -Path $test_path
+    $test = "$($test_impl.Key) - MAX_PATH"
+    &$test_impl.Value
+}
+
+$module.Result.data = "success"
+$module.ExitJson()

--- a/test/integration/targets/win_csharp_utils/tasks/main.yml
+++ b/test/integration/targets/win_csharp_utils/tasks/main.yml
@@ -36,6 +36,24 @@
     that:
     - ansible_become_tests.data == "success"
 
+- name: test Ansible.IO.cs
+  ansible_io_tests:
+  register: ansible_io_tests
+
+- name: assert test Ansible.IO.cs
+  assert:
+    that:
+    - ansible_io_tests.data == "success"
+
+- name: test Ansible.Link.cs
+  ansible_link_tests:
+  register: ansible_link_tests
+
+- name: assert test Ansible.Link.cs
+  assert:
+    that:
+    - ansible_link_tests.data == "success"
+
 - name: test Ansible.Process.cs
   ansible_process_tests:
   register: ansible_process_tests

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -70,7 +70,7 @@ try {
     Test-AnsiblePath -Path C:\Windows\*.exe
 } catch {
     $failed = $true
-    Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"GetAttributes`" with `"1`" argument(s): `"Illegal characters in path.`""
+    Assert-Equals -actual $_.Exception.InnerException.Message -expected "Illegal characters in path."
 }
 Assert-Equals -actual $failed -expected $true
 

--- a/test/integration/targets/win_stat/library/test_symlink_file.ps1
+++ b/test/integration/targets/win_stat/library/test_symlink_file.ps1
@@ -15,13 +15,11 @@ $result = @{
 
 if ($state -eq "absent") {
     if (Test-Path -Path $src) {
-        Load-LinkUtils
         Remove-Link -link_path $src
         $result.changed = $true
     }
 } else {
     if (-not (Test-Path -Path $src)) {
-        Load-LinkUtils
         New-Link -link_path $src -link_target $target -link_type "link"
         $result.changed = $true
     }

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -13,11 +13,9 @@ lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CamelConversion.psm1 PSA
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1 PSProvideCommentHelp  # need to agree on best format for comment location
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1 PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1 PSCustomUseLiteralPath
-lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1 PSProvideCommentHelp
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSAvoidUsingWMICmdlet
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSCustomUseLiteralPath
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSUseApprovedVerbs
-lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1 PSAvoidTrailingWhitespace
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1 PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.SID.psm1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/async_status.ps1 PSCustomUseLiteralPath


### PR DESCRIPTION
##### SUMMARY
Adds a C# util for both IO and link operations. These utils are designed to overcome various shortcomings in the existing .NET library like;

* Interact with paths that exceed MAX_PATH when using the `\\?\` prefix
* Automatic privilege enablement when setting ACLs that require the relevant privileges
* Manage symbolic links, junction points, and hard links using a more standard library

This is change to the module_util side, once merged then it available for modules to use wherever it is needed.

Supersedes changes in https://github.com/ansible/ansible/pull/43666.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
windows file and link utils