### PR TITLE
apt: honor cache_update=false on auto-install deps

### DIFF
--- a/changelogs/fragments/51489-apt-not-honor-update-cache.yml
+++ b/changelogs/fragments/51489-apt-not-honor-update-cache.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
 - apt - Fixed the issue the cache being updated while auto-installing its
-  dependencies even ``update_cache`` is set to false.
+  dependencies even when ``update_cache`` is set to false.

--- a/changelogs/fragments/51489-apt-not-honor-update-cache.yml
+++ b/changelogs/fragments/51489-apt-not-honor-update-cache.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- apt - Fixed the issue the cache being updated while auto-installing its
+  dependencies even ``update_cache`` is set to false.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -61,7 +61,7 @@ Modules
 =======
 
 * The ``win_get_url`` and ``win_uri`` module now sends requests with a default ``User-Agent`` of ``ansible-httpget``. This can be changed by using the ``http_agent`` key.
-
+* The ``apt`` module now honors ``update_cache=false`` while installing its own dependency and skips the cache update. Explicitly set ``update_cache=true` or omitting the param ``update_cache`` will result in a cache update while installing its own dependency.
 
 Writing modules
 ---------------

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -61,7 +61,7 @@ Modules
 =======
 
 * The ``win_get_url`` and ``win_uri`` module now sends requests with a default ``User-Agent`` of ``ansible-httpget``. This can be changed by using the ``http_agent`` key.
-* The ``apt`` module now honors ``update_cache=false`` while installing its own dependency and skips the cache update. Explicitly set ``update_cache=true` or omitting the param ``update_cache`` will result in a cache update while installing its own dependency.
+* The ``apt`` module now honors ``update_cache=false`` while installing its own dependency and skips the cache update. Explicitly setting ``update_cache=true`` or omitting the param ``update_cache`` will result in a cache update while installing its own dependency.
 
 Writing modules
 ---------------

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1031,8 +1031,14 @@ def main():
             module.fail_json(msg="%s must be installed to use check mode. "
                                  "If run normally this module can auto-install it." % PYTHON_APT)
         try:
-            module.warn("Updating cache and auto-installing missing dependency: %s" % PYTHON_APT)
-            module.run_command(['apt-get', 'update'], check_rc=True)
+            # We skip cache update in auto install the dependency if the
+            # user explicitly declared it with update_cache=no.
+            if module.params.get('update_cache') is False:
+                module.warn("Auto-installing missing dependency without updating cache: %s" % PYTHON_APT)
+            else:
+                module.warn("Updating cache and auto-installing missing dependency: %s" % PYTHON_APT)
+                module.run_command(['apt-get', 'update'], check_rc=True)
+
             module.run_command(['apt-get', 'install', '--no-install-recommends', PYTHON_APT, '-y', '-q'], check_rc=True)
             global apt, apt_pkg
             import apt

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -31,6 +31,57 @@
   register: apt_result
   when: dpkg_result is successful
 
+# In check mode, auto-install of `python-apt` must fail
+- name: test fail uninstall hello without required apt deps in check mode
+  apt:
+    pkg: hello
+    state: absent
+    purge: yes
+  register: apt_result
+  check_mode: yes
+  ignore_errors: yes
+
+- name: verify fail uninstall hello without required apt deps in check mode
+  assert:
+    that:
+    - apt_result is failed
+    - '"If run normally this module can auto-install it." in apt_result.msg'
+
+- name: check {{ python_apt }} with dpkg
+  shell: dpkg -s {{ python_apt }}
+  register: dpkg_result
+  ignore_errors: true
+
+# UNINSTALL 'hello'
+#   With 'python-apt' uninstalled, the first call to 'apt' should install
+#   python-apt without updating the cache.
+- name: uninstall hello with apt and prevent updating the cache
+  apt:
+    pkg: hello
+    state: absent
+    purge: yes
+    update_cache: no
+  register: apt_result
+
+- name: check hello with dpkg
+  shell: dpkg-query -l hello
+  failed_when: False
+  register: dpkg_result
+
+- name: verify uninstall hello with apt and prevent updating the cache
+  assert:
+    that:
+    - "'changed' in apt_result"
+    - apt_result is not changed
+    - "dpkg_result.rc == 1"
+    - "'Auto-installing missing dependency without updating cache: {{ python_apt }}' in apt_result.warnings"
+
+- name: uninstall {{ python_apt }} with apt again
+  apt:
+    pkg: "{{ python_apt }}"
+    state: absent
+    purge: yes
+
 # UNINSTALL 'hello'
 #   With 'python-apt' uninstalled, the first call to 'apt' should install
 #   python-apt.
@@ -46,8 +97,10 @@
 - name: verify uninstallation of hello
   assert:
     that:
-        - "'changed' in apt_result"
-        - "dpkg_result.rc == 1"
+    - "'changed' in apt_result"
+    - apt_result is not changed
+    - "dpkg_result.rc == 1"
+    - "'Updating cache and auto-installing missing dependency: {{ python_apt }}' in apt_result.warnings"
 
 # UNINSTALL AGAIN
 - name: uninstall hello with apt
@@ -259,7 +312,7 @@
     that:
       - apt_result is not changed
 
-# check policy_rc_d parameter 
+# check policy_rc_d parameter
 
 - name: Install unscd but forbid service start
   apt:


### PR DESCRIPTION
##### SUMMARY
 Fixed the issue the cache being updated while auto-installing its
  dependencies even ``update_cache`` is set to false. Fixes #51489

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
