### PR TITLE
Bugfix: Creating two IPs in single run of netbox_ip_address

### DIFF
--- a/changelogs/fragments/netbox_ip_address-fix-duplicate-ip.yaml
+++ b/changelogs/fragments/netbox_ip_address-fix-duplicate-ip.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+- >
+  netbox_ip_address - Fixed issue where it would create duplicate IP addresses when trying to serialize the IP address object
+  which doesn't have the `.serialize()` method. This should also prevent future duplicate objects being created if they don't
+  have the `.serialize()` method as well.

--- a/changelogs/fragments/netbox_ip_address-fix-duplicate-ip.yaml
+++ b/changelogs/fragments/netbox_ip_address-fix-duplicate-ip.yaml
@@ -2,5 +2,5 @@
 bugfixes:
 - >
   netbox_ip_address - Fixed issue where it would create duplicate IP addresses when trying to serialize the IP address object
-  which doesn't have the `.serialize()` method. This should also prevent future duplicate objects being created if they don't
-  have the `.serialize()` method as well.
+  which doesn't have the ``.serialize()`` method. This should also prevent future duplicate objects being created if they don't
+  have the ``.serialize()`` method as well.

--- a/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
+++ b/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
@@ -197,10 +197,11 @@ def create_netbox_object(nb_endpoint, data, check_mode):
     if check_mode:
         serialized_nb_obj = data
     else:
+        nb_obj = nb_endpoint.create(data)
         try:
-            serialized_nb_obj = nb_endpoint.create(data).serialize()
+            serialized_nb_obj = nb_obj.serialize()
         except AttributeError:
-            serialized_nb_obj = nb_endpoint.create(data)
+            serialized_nb_obj = nb_obj
 
     diff = _build_diff(before={"state": "absent"}, after={"state": "present"})
     return serialized_nb_obj, diff


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes #56451 

The issue was attempting to use the `serialize()` function during the creation of the netbox object, which not all objects currently support. Changed it to create the object and then use `try/except` block to use the `serialize()` function or else just return the created data (already serialized)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netbox_ip_address.py
netbox_utils.py