### PR TITLE
Asa fix changes

### DIFF
--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -279,9 +279,9 @@ def run(module, result):
         contents = module.params['config']
         if not contents:
             contents = get_config(module)
-            config = NetworkConfig(indent=1, contents=contents)
-            configobjs = candidate.difference(config, path=path, match=match,
-                                              replace=replace)
+        config = NetworkConfig(indent=1, contents=contents)
+        configobjs = candidate.difference(config, path=path, match=match,
+                                          replace=replace)
 
     else:
         configobjs = candidate.items


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes#56314
- It seems for  asa_config module when "config" parameters are provided  and "match" is set to not "none" a trace back is produced.
- root cause for this was that ,  diff handling between candidate config and provided content when "match"  is  not "none"  was missing.
 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/asa/asa_config.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
when contents are provided in that case candidate config should be compared with the 
provided one.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
