### PR TITLE
apt_repository: support repos as list

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -573,8 +573,17 @@ def main():
         try:
             sourceslist.save()
             if update_cache:
-                cache = apt.Cache()
-                cache.update()
+                err = ''
+                for retry in range(3):
+                    try:
+                        cache = apt.Cache()
+                        cache.update()
+                        break
+                    except apt.cache.FetchFailedException as e:
+                        err = to_native(e)
+                else:
+                    module.fail_json(msg='Failed to update apt cache: %s' % err)
+
         except OSError as err:
             module.fail_json(msg=to_native(err))
 

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -1,13 +1,15 @@
 ---
-
-- set_fact:
+- name: set test vars
+  set_fact:
     test_ppa_name: 'ppa:git-core/ppa'
     test_ppa_filename: 'git-core'
-    test_ppa_spec: 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu {{ansible_distribution_release}} main'
+    test_ppa_spec: 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu {{ ansible_distribution_release }} main'
+    test_ppa_spec_src: 'deb-src http://ppa.launchpad.net/git-core/ppa/ubuntu {{ ansible_distribution_release }} main'
     test_ppa_key: 'E1DF1F24' # http://keyserver.ubuntu.com:11371/pks/lookup?search=0xD06AAF4C11DAB86DF421421EFE6B20ECA7AD98A1&op=index
 
 - name: show python version
-  debug: var=ansible_python_version
+  debug:
+    var: ansible_python_version
 
 - name: use python-apt
   set_fact:
@@ -20,102 +22,125 @@
   when: ansible_python_version is version('3', '>=')
 
 # UNINSTALL 'python-apt'
-#  The `apt_repository` module has the smarts to auto-install `python-apt`.  To
-# test, we will first uninstall `python-apt`.
+# The `apt_repository` module has the smarts to auto-install `python-apt`.
+# To test, we will first uninstall `python-apt`.
 - name: check {{ python_apt }} with dpkg
   shell: dpkg -s {{ python_apt }}
   register: dpkg_result
   ignore_errors: true
 
 - name: uninstall {{ python_apt }} with apt
-  apt: pkg={{ python_apt }} state=absent purge=yes
+  apt:
+    pkg: '{{ python_apt }}'
+    state: absent
+    purge: yes
   register: apt_result
   when: dpkg_result is successful
 
 #
 # TEST: apt_repository: repo=<name>
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: 'name=<name> (expect: pass)'
-  apt_repository: repo='{{test_ppa_name}}' state=present
+  apt_repository:
+    repo: '{{ test_ppa_name }}'
+    state: present
   register: result
 
-- name: 'assert the apt cache did *NOT* change'
+- name: assert the apt cache did *NOT* change
   assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_name}}"'
+      - 'result.repo == "{{ test_ppa_name }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did change'
+- name: assert the apt cache did change
   assert:
     that:
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 - name: 'ensure ppa key is installed (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=present
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: present
 
 #
 # TEST: apt_repository: repo=<name> update_cache=no
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: 'name=<name> update_cache=no (expect: pass)'
-  apt_repository: repo='{{test_ppa_name}}' state=present update_cache=no
+  apt_repository:
+    repo: '{{ test_ppa_name }}'
+    state: present
+    update_cache: no
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_name}}"'
+      - 'result.repo == "{{ test_ppa_name }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did *NOT* change'
+- name: assert the apt cache did *NOT* change
   assert:
     that:
       - 'cache_before.stat.mtime == cache_after.stat.mtime'
 
 - name: 'ensure ppa key is installed (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=present
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: present
 
 #
 # TEST: apt_repository: repo=<name> update_cache=yes
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: 'name=<name> update_cache=yes (expect: pass)'
-  apt_repository: repo='{{test_ppa_name}}' state=present update_cache=yes
+  apt_repository:
+    repo: '{{ test_ppa_name }}'
+    state: present
+    update_cache: yes
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_name}}"'
+      - 'result.repo == "{{ test_ppa_name }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
 - name: 'assert the apt cache did change'
@@ -124,86 +149,157 @@
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 - name: 'ensure ppa key is installed (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=present
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: present
 
 #
 # TEST: apt_repository: repo=<spec>
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: ensure ppa key is present before adding repo that requires authentication
-  apt_key: keyserver=keyserver.ubuntu.com id='{{test_ppa_key}}' state=present
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: '{{ test_ppa_key }}'
+    state: present
 
 - name: 'name=<spec> (expect: pass)'
-  apt_repository: repo='{{test_ppa_spec}}' state=present
+  apt_repository:
+    repo: '{{ test_ppa_spec }}'
+    state: present
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_spec}}"'
+      - 'result.repo == "{{ test_ppa_spec }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did change'
+- name: assert the apt cache did change
   assert:
     that:
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 # When installing a repo with the spec, the key is *NOT* added
 - name: 'ensure ppa key is absent (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=absent
+  apt_key:
+    id: '{{ test_ppa_key }}'
+    state: absent
+
+#
+# TEST: apt_repository: repo=<spec>,<spec>
+#
+- include: cleanup.yml
+
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
+  register: cache_before
+
+- name: ensure ppa key is present before adding repo that requires authentication
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: '{{ test_ppa_key }}'
+    state: present
+
+- name: 'test repos as list (expect: pass)'
+  apt_repository:
+    repos:
+    - '{{ test_ppa_spec }}'
+    - '{{ test_ppa_spec_src }}'
+    state: present
+  register: result
+
+- name: verify
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+      - 'result.repos == [ test_ppa_spec, test_ppa_spec_src ]'
+
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
+  register: cache_after
+
+- name: assert the apt cache did change
+  assert:
+    that:
+      - 'cache_before.stat.mtime != cache_after.stat.mtime'
+
+# When installing a repo with the spec, the key is *NOT* added
+- name: 'ensure ppa key is absent (expect: pass)'
+  apt_key:
+    id: '{{ test_ppa_key }}'
+    state: absent
 
 #
 # TEST: apt_repository: repo=<spec> filename=<filename>
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: ensure ppa key is present before adding repo that requires authentication
-  apt_key: keyserver=keyserver.ubuntu.com id='{{test_ppa_key}}' state=present
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: '{{ test_ppa_key }}'
+    state: present
 
 - name: 'name=<spec> filename=<filename> (expect: pass)'
-  apt_repository: repo='{{test_ppa_spec}}' filename='{{test_ppa_filename}}' state=present
+  apt_repository:
+    repo: '{{ test_ppa_spec }}'
+    filename: '{{ test_ppa_filename }}'
+    state: present
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_spec}}"'
+      - 'result.repo == "{{ test_ppa_spec }}"'
 
-- name: 'examine source file'
-  stat: path='/etc/apt/sources.list.d/{{test_ppa_filename}}.list'
+- name: examine source file
+  stat:
+    path: /etc/apt/sources.list.d/{{ test_ppa_filename }}.list
   register: source_file
 
-- name: 'assert source file exists'
+- name: assert source file exists
   assert:
     that:
       - 'source_file.stat.exists == True'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did change'
+- name: assert the apt cache did change
   assert:
     that:
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 # When installing a repo with the spec, the key is *NOT* added
 - name: 'ensure ppa key is absent (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=absent
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: absent
 
 - name: Test apt_repository with a null value for repo
   apt_repository:
@@ -211,7 +307,8 @@
   register: result
   ignore_errors: yes
 
-- assert:
+- name: verify
+  assert:
     that:
       - result is failed
       - result.msg == "Please set argument 'repos' to a non-empty value"
@@ -222,7 +319,8 @@
   register: result
   ignore_errors: yes
 
-- assert:
+- name: verify
+  assert:
     that:
       - result is failed
       - result.msg == "Please set argument 'repos' to a non-empty value"
@@ -230,4 +328,4 @@
 #
 # TEARDOWN
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -214,7 +214,7 @@
 - assert:
     that:
       - result is failed
-      - result.msg == 'Please set argument \'repo\' to a non-empty value'
+      - result.msg == "Please set argument 'repos' to a non-empty value"
 
 - name: Test apt_repository with an empty value for repo
   apt_repository:
@@ -225,7 +225,7 @@
 - assert:
     that:
       - result is failed
-      - result.msg == 'Please set argument \'repo\' to a non-empty value'
+      - result.msg == "Please set argument 'repos' to a non-empty value"
 
 #
 # TEARDOWN


### PR DESCRIPTION
##### SUMMARY
Currently the update cache runs once for every repo added. This simple change allows to add multiple repos and running the cache once.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt_repository

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
