### PR TITLE
Autodecryption does not work with remote_src=yes

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -89,6 +89,7 @@ options:
     - If C(yes) it will search for C(src) on the managed (remote) node.
     - C(remote_src) supports recursive copying as of version 2.8.
     - C(remote_src) only works with C(mode=preserve) as of version 2.6.
+    - Autodecryption of files does not work when C(remote_src=yes).
     type: bool
     default: no
     version_added: '2.0'


### PR DESCRIPTION
This is in reference to the issue: https://github.com/ansible/ansible/issues/41130 (Cannot decrypt with copy module when remote_src: yes)

Autodecryption of the vaulted files does not work when we want to copy files with remote_src=yes.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
