### PR TITLE
Keep machinectl from parsing options of cmd

### DIFF
--- a/lib/ansible/plugins/become/machinectl.py
+++ b/lib/ansible/plugins/become/machinectl.py
@@ -84,4 +84,4 @@ class BecomeModule(BecomeBase):
         become = self._get_option('become_exe') or self.name
         flags = self.get_option('flags') or ''
         user = self.get_option('become_user') or ''
-        return '%s shell -q %s %s@ %s' % (become, flags, user, cmd)
+        return '%s shell -q %s %s@ -- %s' % (become, flags, user, cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is needed on machinectl versions prior to v231 (https://github.com/systemd/systemd/pull/3095/commits/d6c3537ea91e33d7c87ffe73851e87d366e2a39d to be precise).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #56571

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
become

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #56571
