### PR TITLE
Fix typo that breaks invocation of os_stack

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -249,7 +249,7 @@ def main():
             if not stack:
                 stack = _create_stack(module, stack, cloud, sdk)
             else:
-                if module.params['tags']:
+                if module.params['tag']:
                     from distutils.version import StrictVersion
                     min_version = '0.28.0'
                     if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -154,16 +154,15 @@ from ansible.module_utils.openstack import openstack_full_argument_spec, opensta
 from ansible.module_utils._text import to_native
 
 
-def _create_stack(module, stack, cloud, sdk):
+def _create_stack(module, stack, cloud, sdk, parameters):
     try:
         stack = cloud.create_stack(module.params['name'],
-                                   tags=module.params['tag'],
                                    template_file=module.params['template'],
                                    environment_files=module.params['environment'],
                                    timeout=module.params['timeout'],
                                    wait=True,
                                    rollback=module.params['rollback'],
-                                   **module.params['parameters'])
+                                   **parameters)
 
         stack = cloud.get_stack(stack.id, None)
         if stack.stack_status == 'CREATE_COMPLETE':
@@ -177,17 +176,16 @@ def _create_stack(module, stack, cloud, sdk):
             module.fail_json(msg=to_native(e))
 
 
-def _update_stack(module, stack, cloud, sdk):
+def _update_stack(module, stack, cloud, sdk, parameters):
     try:
         stack = cloud.update_stack(
             module.params['name'],
-            tags=module.params['tag'],
             template_file=module.params['template'],
             environment_files=module.params['environment'],
             timeout=module.params['timeout'],
             rollback=module.params['rollback'],
             wait=module.params['wait'],
-            **module.params['parameters'])
+            **parameters)
 
         if stack['stack_status'] == 'UPDATE_COMPLETE':
             return stack
@@ -242,24 +240,24 @@ def main():
         stack = cloud.get_stack(name)
 
         if module.check_mode:
-            module.exit_json(changed=_system_state_change(module, stack,
-                                                          cloud))
+            module.exit_json(changed=_system_state_change(module, stack, cloud))
 
         if state == 'present':
+            parameters = module.params['parameters']
+            if module.params['tag']:
+                parameters['tags'] = module.params['tag']
+                from distutils.version import StrictVersion
+                min_version = '0.28.0'
+                if StrictVersion(sdk.version.__version__) < StrictVersion(min_version) and stack:
+                    module.warn("To update tags using os_stack module, the"
+                                "installed version of the openstacksdk"
+                                "library MUST be >={min_version}"
+                                "".format(min_version=min_version))
             if not stack:
-                stack = _create_stack(module, stack, cloud, sdk)
+                stack = _create_stack(module, stack, cloud, sdk, parameters)
             else:
-                if module.params['tag']:
-                    from distutils.version import StrictVersion
-                    min_version = '0.28.0'
-                    if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):
-                        module.warn("To update tags using os_stack module, the"
-                                    "installed version of the openstacksdk"
-                                    "library MUST be >={min_version}"
-                                    "".format(min_version=min_version))
-                stack = _update_stack(module, stack, cloud, sdk)
-            changed = True
-            module.exit_json(changed=changed,
+                stack = _update_stack(module, stack, cloud, sdk, parameters)
+            module.exit_json(changed=True,
                              stack=stack,
                              id=stack.id)
         elif state == 'absent':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_stack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Invoke os_stack update with openstacksdk less than 0.28.0, the module breaks:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'tags'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/opt/bharat/.ansible/tmp/ansible-tmp-1558096175.82-77808391248578/An
siballZ_os_stack.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/opt/bharat/.ansible/tmp/ansible-tmp-1558096175.82-77808391248578/AnsiballZ_os_stack.py\", line 106, in
 _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/opt/bharat/.ansible/tmp/ansible-tmp-1558096175.82-77808391248578/AnsiballZ_os_stack.py\", lin
e 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_os_stack_payload_5ywH_k/__main__.py\", line 278, in <module>\n  File \"/tmp/ans
ible_os_stack_payload_5ywH_k/__main__.py\", line 252, in main\nKeyError: 'tags'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

After fixing the typo, unless we are using openstack==0.28.0, we still get the following error:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "BadRequestException: 400: Client Error for url: http://10.60.253.1:8004/v1/5638e8577bc84379baba4bfb66177086/stacks/kata/a07
0f76b-cc84-417f-81c3-392c874fbc5c, {\"explanation\": \"The server could not comply with the request since it is either malformed or otherwise incorrect.\", \"code\": 400, \"error\":
 {\"message\": \"The Parameter (tags) was not defined in template.\", \"traceback\": null, \"type\": \"UnknownUserParameter\"}, \"title\": \"Bad Request\"}", "response": {"code": 40
0, "error": {"message": "The Parameter (tags) was not defined in template.", "traceback": null, "type": "UnknownUserParameter"}, "explanation": "The server could not comply with the
 request since it is either malformed or otherwise incorrect.", "title": "Bad Request"}}
```

Additional changes only supply `tags` argument if it is provided  for backward compatibility.