### PR TITLE
os_port allowed_address_pairs and extra_dhcp_opts list of dicts comparison fix

### DIFF
--- a/changelogs/fragments/47182-os_port_order_difference_should_not_trigger_changes.yml
+++ b/changelogs/fragments/47182-os_port_order_difference_should_not_trigger_changes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - os_port does no longer trigger change when allowed_address_pairs items is in different order

--- a/changelogs/fragments/47182-os_port_order_difference_should_not_trigger_changes.yml
+++ b/changelogs/fragments/47182-os_port_order_difference_should_not_trigger_changes.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - os_port does no longer trigger change when allowed_address_pairs items is in different order
+  - "os_port - no longer triggers change when ``allowed_address_pairs`` items are in different order."

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -60,8 +60,9 @@ options:
                   - ip_address: ..."
    extra_dhcp_opts:
      description:
-        - "Extra dhcp options to be assigned to this port.  Extra options are
-          supported with dictionary structure.
+        - "Extra dhcp options to be assigned to this port. Extra options are
+          supported with dictionary structure. Note that options cannot be removed
+          only updated.
           e.g.  extra_dhcp_opts:
                   - opt_name: opt name1
                     opt_value: value1

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -65,6 +65,7 @@ options:
           e.g.  extra_dhcp_opts:
                   - opt_name: opt name1
                     opt_value: value1
+                    ip_version: 4
                   - opt_name: ..."
    device_owner:
      description:

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -22,6 +22,9 @@ version_added: "2.0"
 description:
    - Add, Update or Remove ports from an OpenStack cloud. A I(state) of
      'present' will ensure the port is created or updated if required.
+requirements:
+    - "ordereddict unless python >= 2.7"
+    - "openstacksdk"
 options:
    network:
      description:
@@ -371,7 +374,7 @@ def main():
                            **module_kwargs)
 
     if not HAS_ORDEREDDICT:
-        module.fail_json(msg=missing_required_lib('orederddict'))
+        module.fail_json(msg=missing_required_lib('ordereddict'))
 
     name = module.params['name']
     state = module.params['state']

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -222,10 +222,7 @@ from ansible.module_utils.openstack import openstack_full_argument_spec, opensta
 try:
     from collections import OrderedDict
 except ImportError:
-    try:
-        from ordereddict import OrderedDict
-    except ImportError:
-        from ordereddict import OrderedDict
+    from ordereddict import OrderedDict
 
 
 def _needs_update(module, port, cloud):

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -225,7 +225,7 @@ except ImportError:
     try:
         from ordereddict import OrderedDict
     except ImportError:
-        pass
+        from ordereddict import OrderedDict
 
 
 def _needs_update(module, port, cloud):

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -215,7 +215,7 @@ port_security_enabled:
     type: bool
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -252,7 +252,7 @@ def _needs_update(module, port, cloud):
             return True
 
     for key in compare_list_dict:
-        if module.params[key] is not None:
+        if not module.params[key]:
             if not port[key]:
                 return True
 

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -221,8 +221,13 @@ from ansible.module_utils.openstack import openstack_full_argument_spec, opensta
 
 try:
     from collections import OrderedDict
+    HAS_ORDEREDDICT = True
 except ImportError:
-    from ordereddict import OrderedDict
+    try:
+        from ordereddict import OrderedDict
+        HAS_ORDEREDDICT = True
+    except ImportError:
+        HAS_ORDEREDDICT = False
 
 
 def _needs_update(module, port, cloud):
@@ -364,6 +369,9 @@ def main():
     module = AnsibleModule(argument_spec,
                            supports_check_mode=True,
                            **module_kwargs)
+
+    if not HAS_ORDEREDDICT:
+        module.fail_json(msg=missing_required_lib('orederddict'))
 
     name = module.params['name']
     state = module.params['state']


### PR DESCRIPTION
##### SUMMARY
Fixes #47182, previously the comparison of list dicts would blindly compare the lists and trigger a change if the order of both list and dicts didn't match exactly, this change tries to ignore order, by re-ordering before comparing.

I also updated the extra_dhcp_opts docs.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
os_port

##### ADDITIONAL INFORMATION

