### PR TITLE
Update gcp_compute_instance_facts.py

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance_facts.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance_facts.py
@@ -42,7 +42,7 @@ requirements:
 options:
   filters:
     description:
-    - A list of filter value pairs. Available filters are listed here U(https://cloud.google.com/sdk/gcloud/reference/topic/filters.)
+    - A list of filter value pairs. Available filters are listed here U(https://cloud.google.com/sdk/gcloud/reference/topic/filters).
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
   zone:


### PR DESCRIPTION
##### SUMMARY
Typo in filters URL


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Swapped dot character inside brackets leads to wrong URL for gcloud topic filters
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute_instance_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
[...] (https://cloud.google.com/sdk/gcloud/reference/topic/filters).
instead of (https://cloud.google.com/sdk/gcloud/reference/topic/filters.).
```
