### PR TITLE
vmware_guest: clone VM with attached CDROM

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2228,7 +2228,6 @@ class PyVmomiHelper(PyVmomi):
                 # https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.RelocateSpec.html
                 # > pool: For a clone operation from a template to a virtual machine, this argument is required.
                 self.relospec.pool = resource_pool
-
                 linked_clone = self.params.get('linked_clone')
                 snapshot_src = self.params.get('snapshot_src', None)
                 if linked_clone:

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -4,7 +4,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "vm"
+    folder: vm
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
@@ -76,6 +76,19 @@
       - "cdrom_vm.failed == false"
       - "cdrom_vm.changed == true"
 
+- name: clone vm
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm2
+    template: test_vm1
+    datacenter: "{{ dc1 }}"
+    state: poweredoff
+    folder: vm
+    convert: thin
+
 - name: Update CDROM to none for the new VM
   vmware_guest:
     validate_certs: False
@@ -105,7 +118,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     folder: vm
-    name: test_vm2
+    name: test_vm3
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: Resources
@@ -148,7 +161,7 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         folder: "{{ f0 }}"
-        name: test_vm2
+        name: test_vm3
         datacenter: "{{ dc1 }}"
         cluster: "{{ ccr1 }}"
         resource_pool: Resources


### PR DESCRIPTION
##### SUMMARY

If a VM has an attached CDROM, `backing` attribute of the CDROM will
be defined.
As a result, we cannot just loop `vm_obj.config.hardware.device` and check
for the existance of the attribute to decide if the entry is a
harddrive.

Instead, we check the type of the device, and only keep the
`vim.vm.device.VirtualDisk` disk.

This issue is actually breaking our test-suite with regular environment
because we keep a Fedora ISO attached to the VM.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest