### PR TITLE
Update get_certificate.py

### DIFF
--- a/lib/ansible/modules/crypto/get_certificate.py
+++ b/lib/ansible/modules/crypto/get_certificate.py
@@ -107,12 +107,12 @@ EXAMPLES = '''
   delegate_to: localhost
   run_once: true
   register: cert
-  
+
 - name: How many days until cert expires
   debug:
     msg: "cert expires in: {{ expire_days }} days."
   vars:
-    expire_days: "{{ (( get_certificate_result.not_after | to_datetime('%Y%m%d%H%M%SZ')) - (ansible_date_time.iso8601 | to_datetime('%Y-%m-%dT%H:%M:%SZ')) ).days }}"
+    expire_days: "{{ (( cert.not_after | to_datetime('%Y%m%d%H%M%SZ')) - (ansible_date_time.iso8601 | to_datetime('%Y-%m-%dT%H:%M:%SZ')) ).days }}"
 '''
 
 import traceback

--- a/lib/ansible/modules/crypto/get_certificate.py
+++ b/lib/ansible/modules/crypto/get_certificate.py
@@ -108,7 +108,7 @@ EXAMPLES = '''
   run_once: true
   register: cert
   
-- name: how many days until cert expires
+- name: How many days until cert expires
   debug:
     msg: "cert expires in: {{ expire_days }} days."
   vars:

--- a/lib/ansible/modules/crypto/get_certificate.py
+++ b/lib/ansible/modules/crypto/get_certificate.py
@@ -107,6 +107,12 @@ EXAMPLES = '''
   delegate_to: localhost
   run_once: true
   register: cert
+  
+- name: how many days until cert expires
+  debug:
+    msg: "cert expires in: {{ expire_days }} days."
+  vars:
+    expire_days: "{{ (( get_certificate_result.not_after | to_datetime('%Y%m%d%H%M%SZ')) - (ansible_date_time.iso8601 | to_datetime('%Y-%m-%dT%H:%M:%SZ')) ).days }}"
 '''
 
 import traceback


### PR DESCRIPTION
##### SUMMARY
provide example to calculate number of days until cert expires from get_certificate result.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
provide example to calculate number of days until cert expires from get_certificate result.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Calculating how long before a cert expires would seem to be a common task using the output of this module, but took me a while to figure out how to work with the datetime format produced by the module, so wanted to share a solution.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
