### PR TITLE
Add compat tojson filter for jinja2 versions missing it

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -11,6 +11,7 @@ __metaclass__ = type
 
 import datetime
 import glob
+import json
 import optparse
 import os
 import re
@@ -398,6 +399,10 @@ def jinja2_environment(template_dir, typ, plugin_type):
     if 'max' not in env.filters:
         # Jinja < 2.10
         env.filters['max'] = do_max
+
+    if 'tojson' not in env.filters:
+        # Jinja < 2.9
+        env.filters['tojson'] = json.dumps
 
     templates = {}
     if typ == 'rst':


### PR DESCRIPTION
##### SUMMARY
Add compat `tojson` filter for jinja2 versions missing it

The jinja2 version available on EL7 is missing the `tojson` filter, which was added in jinja2 2.9.

This PR adds a compat when missing.  It's not 100% equivalent, since jinja2 does extra escaping, but we are passing to the `escape` filter already, so there should be no problem.

jinja2 uses:
```
    if dumper is None:
        dumper = json.dumps
    rv = dumper(obj, **kwargs) \
        .replace(u'<', u'\\u003c') \
        .replace(u'>', u'\\u003e') \
        .replace(u'&', u'\\u0026') \
        .replace(u"'", u'\\u0027')
    return Markup(rv)
```

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docs/bin/plugin_formatter.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```