### PR TITLE
[stable-2.8] Whitelist listen as a valid keyword on TaskInclude (#56586)

### DIFF
--- a/changelogs/fragments/include_tasks_listen.yml
+++ b/changelogs/fragments/include_tasks_listen.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- include_tasks - whitelist ``listen`` as a valid keyword
+  (https://github.com/ansible/ansible/issues/56580)

--- a/lib/ansible/playbook/handler_task_include.py
+++ b/lib/ansible/playbook/handler_task_include.py
@@ -26,6 +26,8 @@ from ansible.playbook.task_include import TaskInclude
 
 class HandlerTaskInclude(Handler, TaskInclude):
 
+    VALID_INCLUDE_KEYWORDS = frozenset(('listen',) + tuple(TaskInclude.VALID_INCLUDE_KEYWORDS))
+
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         t = HandlerTaskInclude(block=block, role=role, task_include=task_include)

--- a/lib/ansible/playbook/handler_task_include.py
+++ b/lib/ansible/playbook/handler_task_include.py
@@ -26,7 +26,7 @@ from ansible.playbook.task_include import TaskInclude
 
 class HandlerTaskInclude(Handler, TaskInclude):
 
-    VALID_INCLUDE_KEYWORDS = frozenset(('listen',) + tuple(TaskInclude.VALID_INCLUDE_KEYWORDS))
+    VALID_INCLUDE_KEYWORDS = TaskInclude.VALID_INCLUDE_KEYWORDS.union(('listen',))
 
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -82,7 +82,7 @@ class TaskInclude(Task):
     def preprocess_data(self, ds):
         ds = super(TaskInclude, self).preprocess_data(ds)
 
-        diff = set(ds.keys()).difference(TaskInclude.VALID_INCLUDE_KEYWORDS)
+        diff = set(ds.keys()).difference(self.VALID_INCLUDE_KEYWORDS)
         for k in diff:
             # This check doesn't handle ``include`` as we have no idea at this point if it is static or not
             if ds[k] is not Sentinel and ds['action'] in ('include_tasks', 'include_role'):

--- a/test/integration/targets/include_import/valid_include_keywords/include_me.yml
+++ b/test/integration/targets/include_import/valid_include_keywords/include_me.yml
@@ -1,0 +1,6 @@
+- debug:
+    msg: include_me
+- assert:
+    that:
+      - loopy == 1
+      - baz == 'qux'

--- a/test/integration/targets/include_import/valid_include_keywords/include_me_listen.yml
+++ b/test/integration/targets/include_import/valid_include_keywords/include_me_listen.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: listen

--- a/test/integration/targets/include_import/valid_include_keywords/include_me_notify.yml
+++ b/test/integration/targets/include_import/valid_include_keywords/include_me_notify.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: notify

--- a/test/integration/targets/include_import/valid_include_keywords/playbook.yml
+++ b/test/integration/targets/include_import/valid_include_keywords/playbook.yml
@@ -1,0 +1,39 @@
+- hosts: localhost
+  gather_facts: false
+  handlers:
+    - include_tasks: include_me_listen.yml
+      listen:
+        - include_me_listen
+
+    - name: Include Me Notify
+      include_tasks: include_me_notify.yml
+
+  tasks:
+    - name: Include me
+      include_tasks: include_me.yml
+      args:
+        apply:
+          tags:
+            - bar
+      debugger: ~
+      ignore_errors: false
+      loop:
+        - 1
+      loop_control:
+        loop_var: loopy
+      no_log: false
+      register: this_isnt_useful
+      run_once: true
+      tags:
+        - foo
+      vars:
+        baz: qux
+      when: true
+
+    - command: "true"
+      notify:
+        - include_me_listen
+
+    - command: "true"
+      notify:
+        - Include Me Notify


### PR DESCRIPTION
* Whitelist listen as a valid keyword on TaskInclude. Fixes #56580

* Move 'listen' to HandlerTaskInclude

* Remove trailing newline
(cherry picked from commit 576593e)


Co-authored-by: Matt Martz <matt@sivel.net>