### PR TITLE
Add 'member_action' parameter to ipa_hostgroup and ipa_role to add/remove members without specifying complete list of members

### DIFF
--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -191,6 +191,32 @@ class IPAClient(object):
                 result.append(key)
         return result
 
+    def add_if_missing(self, name, ipa_list, module_list, add_method, item=None):
+        changed = False
+        diff = list(set(module_list) - set(ipa_list))
+        if len(diff) > 0:
+            changed = True
+            if not self.module.check_mode:
+                if item:
+                    add_method(name=name, item={item: diff})
+                else:
+                    add_method(name=name, item=diff)
+
+        return changed
+
+    def remove_if_present(self, name, ipa_list, module_list, remove_method, item=None):
+        changed = False
+        common = list(set(ipa_list).intersection(set(module_list)))
+        if len(common) > 0:
+            changed = True
+            if not self.module.check_mode:
+                if item:
+                    remove_method(name=name, item={item: common})
+                else:
+                    remove_method(name=name, item=common)
+
+        return changed
+
     def modify_if_diff(self, name, ipa_list, module_list, add_method, remove_method, item=None):
         changed = False
         diff = list(set(ipa_list) - set(module_list))

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -167,6 +167,40 @@ def ensure(module, client):
                     for key in diff:
                         data[key] = module_hostgroup.get(key)
                     client.hostgroup_mod(name=name, item=data)
+
+        if member_action == 'set':
+            if host is not None:
+                changed = client.modify_if_diff(name, ipa_hostgroup.get('member_host', []),
+                                                [item.lower() for item in host],
+                                                client.hostgroup_add_host,
+                                                client.hostgroup_remove_host) or changed
+
+            if hostgroup is not None:
+                changed = client.modify_if_diff(name, ipa_hostgroup.get('member_hostgroup', []),
+                                                [item.lower() for item in hostgroup],
+                                                client.hostgroup_add_hostgroup,
+                                                client.hostgroup_remove_hostgroup) or changed
+        elif member_action == 'add':
+            if host is not None:
+                changed = client.add_if_missing(name, ipa_hostgroup.get('member_host', []),
+                                                [item.lower() for item in host],
+                                                client.hostgroup_add_host) or changed
+
+            if hostgroup is not None:
+                changed = client.add_if_missing(name, ipa_hostgroup.get('member_hostgroup', []),
+                                                [item.lower() for item in hostgroup],
+                                                client.hostgroup_add_hostgroup) or changed
+        elif member_action == 'remove':
+            if host is not None:
+                changed = client.remove_if_present(name, ipa_hostgroup.get('member_host', []),
+                                                   [item.lower() for item in host],
+                                                   client.hostgroup_remove_host) or changed
+
+            if hostgroup is not None:
+                changed = client.remove_if_present(name, ipa_hostgroup.get('member_hostgroup', []),
+                                                   [item.lower() for item in hostgroup],
+                                                   client.hostgroup_remove_hostgroup) or changed
+
     elif state == 'absent':
         if ipa_hostgroup:
             changed = True
@@ -175,39 +209,6 @@ def ensure(module, client):
 
     else:
         raise NotImplementedError("Support for state '%s' has not yet been implemented." % state)
-
-    if member_action == 'set':
-        if host is not None:
-            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_host', []),
-                                            [item.lower() for item in host],
-                                            client.hostgroup_add_host,
-                                            client.hostgroup_remove_host) or changed
-
-        if hostgroup is not None:
-            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_hostgroup', []),
-                                            [item.lower() for item in hostgroup],
-                                            client.hostgroup_add_hostgroup,
-                                            client.hostgroup_remove_hostgroup) or changed
-    elif member_action == 'add':
-        if host is not None:
-            changed = client.add_if_missing(name, ipa_hostgroup.get('member_host', []),
-                                            [item.lower() for item in host],
-                                            client.hostgroup_add_host) or changed
-
-        if hostgroup is not None:
-            changed = client.add_if_missing(name, ipa_hostgroup.get('member_hostgroup', []),
-                                            [item.lower() for item in hostgroup],
-                                            client.hostgroup_add_hostgroup) or changed
-    elif member_action == 'remove':
-        if host is not None:
-            changed = client.remove_if_present(name, ipa_hostgroup.get('member_host', []),
-                                               [item.lower() for item in host],
-                                               client.hostgroup_remove_host) or changed
-
-        if hostgroup is not None:
-            changed = client.remove_if_present(name, ipa_hostgroup.get('member_hostgroup', []),
-                                               [item.lower() for item in hostgroup],
-                                               client.hostgroup_remove_hostgroup) or changed
 
     return changed, client.hostgroup_find(name=name)
 

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -48,7 +48,7 @@ options:
     - Removing members will remove the specified members if they are present.  Nonexistent members will be ignored.
     default: "set"
     choices: ["add", "remove", "set"]
-    version_added: "2.9"
+    version_added: "2.10"
   state:
     description:
     - State to ensure.

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -32,25 +32,31 @@ options:
     type: str
   host:
     description:
-    - List of hosts that belong to the host-group.
+    - If the state is set to 'present', any provided hosts will be added to the group.
     - If an empty list is passed all hosts will be removed from the group.
     - If option is omitted hosts will not be checked or changed.
     - If option is passed all assigned hosts that are not passed will be unassigned from the group.
+    - Any assigned hostgroups which are not passed will be unassigned from the group.
+    - If the state is set to 'add_members', any provided hosts not currently in the group will be added.
+    - If the state is set to 'remove_members', any provided hosts currently in the group will be removed.
     type: list
     elements: str
   hostgroup:
     description:
-    - List of host-groups than belong to that host-group.
+    - If the state is set to 'present', any provided host-groups will be added to the group.
     - If an empty list is passed all host-groups will be removed from the group.
     - If option is omitted host-groups will not be checked or changed.
     - If option is passed all assigned hostgroups that are not passed will be unassigned from the group.
+    - Any assigned hostgroups which are not passed will be unassigned from the group.
+    - If the state is set to 'add_members', any provided host-groups not currently in the group will be added.
+    - If the state is set to 'remove_members', any provided host-groups currently in the group will be removed.
     type: list
     elements: str
   state:
     description:
     - State to ensure.
     default: "present"
-    choices: ["absent", "disabled", "enabled", "present"]
+    choices: ["present", "absent", "enabled", "disabled"]
     type: str
 extends_documentation_fragment: ipa.documentation
 version_added: "2.3"
@@ -149,7 +155,7 @@ def ensure(module, client):
     module_hostgroup = get_hostgroup_dict(description=module.params['description'])
 
     changed = False
-    if state == 'present':
+    if state in ['present', 'add_members', 'remove_members']:
         if not ipa_hostgroup:
             changed = True
             if not module.check_mode:
@@ -163,33 +169,67 @@ def ensure(module, client):
                     for key in diff:
                         data[key] = module_hostgroup.get(key)
                     client.hostgroup_mod(name=name, item=data)
-
-        if host is not None:
-            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_host', []), [item.lower() for item in host],
-                                            client.hostgroup_add_host, client.hostgroup_remove_host) or changed
-
-        if hostgroup is not None:
-            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_hostgroup', []),
-                                            [item.lower() for item in hostgroup],
-                                            client.hostgroup_add_hostgroup,
-                                            client.hostgroup_remove_hostgroup) or changed
-
     else:
         if ipa_hostgroup:
             changed = True
             if not module.check_mode:
                 client.hostgroup_del(name=name)
 
+    if state == 'present':
+        if host is not None:
+            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_host', []),
+                                            [item.lower() for item in host],
+                                            client.hostgroup_add_host,
+                                            client.hostgroup_remove_host) or changed
+
+        if hostgroup is not None:
+            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_hostgroup', []),
+                                            [item.lower() for item in hostgroup],
+                                            client.hostgroup_add_hostgroup,
+                                            client.hostgroup_remove_hostgroup) or changed
+    elif state == 'add_members':
+        if host is not None:
+            changed = client.add_if_missing(name, ipa_hostgroup.get('member_host', []),
+                                            [item.lower() for item in host],
+                                            client.hostgroup_add_host) or changed
+
+        if hostgroup is not None:
+            changed = client.add_if_missing(name, ipa_hostgroup.get('member_hostgroup', []),
+                                            [item.lower() for item in hostgroup],
+                                            client.hostgroup_add_hostgroup) or changed
+    elif state == 'remove_members':
+        if host is not None:
+            changed = client.remove_if_present(name, ipa_hostgroup.get('member_host', []),
+                                               [item.lower() for item in host],
+                                               client.hostgroup_remove_host) or changed
+
+        if hostgroup is not None:
+            changed = client.remove_if_present(name, ipa_hostgroup.get('member_hostgroup', []),
+                                               [item.lower() for item in hostgroup],
+                                               client.hostgroup_remove_hostgroup) or changed
+
     return changed, client.hostgroup_find(name=name)
 
 
 def main():
     argument_spec = ipa_argument_spec()
-    argument_spec.update(cn=dict(type='str', required=True, aliases=['name']),
-                         description=dict(type='str'),
-                         host=dict(type='list', elements='str'),
-                         hostgroup=dict(type='list', elements='str'),
-                         state=dict(type='str', default='present', choices=['present', 'absent', 'enabled', 'disabled']))
+    argument_spec.update(
+        cn=dict(type='str', required=True, aliases=['name']),
+        description=dict(type='str'),
+        host=dict(type='list', elements='str'),
+        hostgroup=dict(type='list', elements='str'),
+        state=dict(
+            type='str', default='present',
+            choices=[
+                'present',
+                'absent',
+                'add_members',
+                'remove_members',
+                'enabled',
+                'disabled'
+            ]
+        )
+    )
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -49,6 +49,7 @@ options:
     default: "set"
     choices: ["add", "remove", "set"]
     version_added: "2.10"
+    type: str
   state:
     description:
     - State to ensure.

--- a/lib/ansible/modules/identity/ipa/ipa_role.py
+++ b/lib/ansible/modules/identity/ipa/ipa_role.py
@@ -53,7 +53,7 @@ options:
     - Removing members will remove the specified members if they are present.  Nonexistent members will be ignored.
     default: "set"
     choices: ["add", "remove", "set"]
-    version_added: "2.9"
+    version_added: "2.10"
   privilege:
     description:
     - Accepts a list of member privileges.  The action taken will depend on the value of "member_action."

--- a/lib/ansible/modules/identity/ipa/ipa_role.py
+++ b/lib/ansible/modules/identity/ipa/ipa_role.py
@@ -54,6 +54,7 @@ options:
     default: "set"
     choices: ["add", "remove", "set"]
     version_added: "2.10"
+    type: str
   privilege:
     description:
     - Accepts a list of member privileges.  The action taken will depend on the value of "member_action."


### PR DESCRIPTION
##### SUMMARY
Currently, when adding members to a host group or role using the IPA modules, a user must obtain the full list of current members for each host group or role, then append the new members to the list of current members.  This change would allow only the new members to be specified, rather than having to specify the complete list of all members.  In particular, this simplifies adding multiple members in the same play.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
ipa_hostgroup
ipa_role