### PR TITLE
[facts] iscsi fixes, add/fix solaris discovery for iscsi iqn

### DIFF
--- a/changelogs/fragments/solaris_iscsi_iqn.yaml
+++ b/changelogs/fragments/solaris_iscsi_iqn.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - facts - fix ISCSI IQN discovery on solaris OS and strip whitespaces from IQN (https://github.com/ansible/ansible/pull/56603)

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -72,7 +72,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
 
         iscsi_facts = {}
         iscsi_facts['iscsi_iqn'] = ""
-        if sys.platform.startswith('linux') or sys.platform.startswith('sunos'):
+        if sys.platform.startswith('linux'):
             for line in get_file_content('/etc/iscsi/initiatorname.iscsi', '').splitlines():
                 if line.startswith('#') or line.startswith(';') or line.strip() == '':
                     continue
@@ -96,6 +96,14 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 if out:
                     line = self.findstr(out, 'Initiator Name')
                     iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].strip()
+        elif sys.platform.startswith('sunos'):
+            cmd = get_bin_path('iscsiadm')
+            if cmd:
+                cmd += " list initiator-node"
+                rc, out, err = module.run_command(cmd)
+                if rc == 0 and out:
+                    line = self.findstr(out, 'Initiator node name')
+                    iscsi_facts['iscsi_iqn'] = line.split()[3].strip()
         return iscsi_facts
 
     def findstr(self, text, match):

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -86,7 +86,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 rc, out, err = module.run_command(cmd)
                 if rc == 0 and out:
                     line = self.findstr(out, 'initiator_name')
-                    iscsi_facts['iscsi_iqn'] = line.split()[1].rstrip()
+                    iscsi_facts['iscsi_iqn'] = line.split()[1].strip()
         elif sys.platform.startswith('hp-ux'):
             # try to find it in the default PATH and opt_dirs
             cmd = get_bin_path('iscsiutil', opt_dirs=['/opt/iscsi/bin'])
@@ -95,7 +95,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 rc, out, err = module.run_command(cmd)
                 if out:
                     line = self.findstr(out, 'Initiator Name')
-                    iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].rstrip()
+                    iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].strip()
         return iscsi_facts
 
     def findstr(self, text, match):

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -103,7 +103,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                 rc, out, err = module.run_command(cmd)
                 if rc == 0 and out:
                     line = self.findstr(out, 'Initiator node name')
-                    iscsi_facts['iscsi_iqn'] = line.split()[3].strip()
+                    iscsi_facts['iscsi_iqn'] = line.split(":", 1)[1].strip()
         return iscsi_facts
 
     def findstr(self, text, match):

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -50,5 +50,5 @@ def test_get_iscsi_info(mocker):
     mocker.patch('sys.platform', 'hp-ux')
     mocker.patch('ansible.module_utils.facts.network.iscsi.get_bin_path', return_value='/opt/iscsi/bin/iscsiutil')
     mocker.patch.object(module, 'run_command', return_value=(0, ISCSIUTIL_OUTPUT, ''))
-    hpux_iscsi_expected = {"iscsi_iqn": " iqn.2001-04.com.hp.stor:svcio"}
+    hpux_iscsi_expected = {"iscsi_iqn": "iqn.2001-04.com.hp.stor:svcio"}
     assert hpux_iscsi_expected == inst.collect(module=module)

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -36,6 +36,24 @@ Data Digest                : None,CRC32C (default)
 SLP Scope list for iSLPD   :
 """
 
+# Solaris # iscsiadm list initiator-node
+ISCSIADM_OUTPUT = """
+Initiator node name: iqn.1986-03.com.sun:01:00144ffafe39.578e4635
+Initiator node alias: solaris11.nvglabs.local
+        Login Parameters (Default/Configured):
+                Header Digest: NONE/-
+                Data Digest: NONE/-
+                Max Connections: 65535/-
+        Authentication Type: NONE
+        RADIUS Server: NONE
+        RADIUS Access: unknown
+        Tunable Parameters (Default/Configured):
+                Session Login Response Time: 60/-
+                Maximum Connection Retry Time: 180/-
+                Login Retry Time Interval: 60/-
+        Configured Sessions: 1
+"""
+
 
 def test_get_iscsi_info(mocker):
     module = Mock()
@@ -52,3 +70,9 @@ def test_get_iscsi_info(mocker):
     mocker.patch.object(module, 'run_command', return_value=(0, ISCSIUTIL_OUTPUT, ''))
     hpux_iscsi_expected = {"iscsi_iqn": "iqn.2001-04.com.hp.stor:svcio"}
     assert hpux_iscsi_expected == inst.collect(module=module)
+
+    mocker.patch('sys.platform', 'sunos5')
+    mocker.patch('ansible.module_utils.facts.network.iscsi.get_bin_path', return_value='/usr/sbin/iscsiadm')
+    mocker.patch.object(module, 'run_command', return_value=(0, ISCSIADM_OUTPUT, ''))
+    sunos_iscsi_expected = {"iscsi_iqn": "iqn.1986-03.com.sun:01:00144ffafe39.578e4635"}
+    assert sunos_iscsi_expected == inst.collect(module=module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add/fix solaris iscsi iqn discovery. Strip leading whitespace from HP-UX iscsi iqn. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
facts module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There's no `/etc/iscsi/initiatorname.iscsi` on solaris (checked on solaris 10 and solaris 11, besides no mentions of this file in Solaris documentation), so use `iscsiadm` for discovery.


Before:
```
$ ansible -m setup solaris10 -a "filter=ansible_iscsi*"   
solaris10 | SUCCESS => {
    "ansible_facts": {
        "ansible_iscsi_iqn": "", 
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false
}
```
after:
```
$ ansible -m setup solaris10 -a "filter=ansible_iscsi*"
solaris10 | SUCCESS => {
    "ansible_facts": {
        "ansible_iscsi_iqn": "iqn.1986-03.com.sun:01:7a8102f8ffff.50fedbb9", 
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false
}
```