### PR TITLE
Move update_cache to after self.yum_baseurl definition

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1509,6 +1509,17 @@ class YumModule(YumDnf):
         if error_msgs:
             self.module.fail_json(msg='. '.join(error_msgs))
 
+        # fedora will redirect yum to dnf, which has incompatibilities
+        # with how this module expects yum to operate. If yum-deprecated
+        # is available, use that instead to emulate the old behaviors.
+        if self.module.get_bin_path('yum-deprecated'):
+            yumbin = self.module.get_bin_path('yum-deprecated')
+        else:
+            yumbin = self.module.get_bin_path('yum')
+
+        # need debug level 2 to get 'Nothing to do' for groupinstall.
+        self.yum_basecmd = [yumbin, '-d', '2', '-y']
+
         if self.update_cache and not self.names and not self.list:
             rc, stdout, stderr = self.module.run_command(self.yum_basecmd + ['clean', 'expire-cache'])
             if rc == 0:
@@ -1525,17 +1536,6 @@ class YumModule(YumDnf):
                     rc=rc,
                     results=[stderr],
                 )
-
-        # fedora will redirect yum to dnf, which has incompatibilities
-        # with how this module expects yum to operate. If yum-deprecated
-        # is available, use that instead to emulate the old behaviors.
-        if self.module.get_bin_path('yum-deprecated'):
-            yumbin = self.module.get_bin_path('yum-deprecated')
-        else:
-            yumbin = self.module.get_bin_path('yum')
-
-        # need debug level 2 to get 'Nothing to do' for groupinstall.
-        self.yum_basecmd = [yumbin, '-d', '2', '-y']
 
         repoquerybin = self.module.get_bin_path('repoquery', required=False)
 


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/pull/46183 allows the yum and dnf modules to update_cache without passing in any packages.  There is a bug where self.yum_basecmd is called before it is declared.  This patch moves the self.yum_basecmd declaration up several lines.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yum

##### ADDITIONAL INFORMATION

```shell
[user@server ~]$ ansible localhost -e ansible_python_interpreter=/usr/bin/python2.7 -m yum -a "disablerepo=\"*\" enablerepo=\"some-repo\" update_cache=yes" --become
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'YumModule' object has no attribute 'yum_basecmd'
localhost | FAILED! => {
    "ansible_facts": {
        "pkg_mgr": "yum"
    },
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/.ansible/tmp/ansible-tmp-1558243188.749404-268779056159653/AnsiballZ_yum.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/tmp/.ansible/tmp/ansible-tmp-1558243188.749404-268779056159653/AnsiballZ_yum.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/tmp/.ansible/tmp/ansible-tmp-1558243188.749404-268779056159653/AnsiballZ_yum.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_yum_payload_z85En8/__main__.py\", line 1608, in <module>\n  File \"/tmp/ansible_yum_payload_z85En8/__main__.py\", line 1604, in main\n  File \"/tmp/ansible_yum_payload_z85En8/__main__.py\", line 1498, in run\nAttributeError: 'YumModule' object has no attribute 'yum_basecmd'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

After patch:

```shell
[user@server ~]$ ansible localhost -e ansible_python_interpreter=/usr/bin/python2.7 -m yum -a "disablerepo=\"*\" enablerepo=\"some-repo\" update_cache=yes" --become
localhost | SUCCESS => {
    "ansible_facts": {
        "pkg_mgr": "yum"
    },
    "changed": false,
    "msg": "Cache updated",
    "rc": 0,
    "results": []
}
```
