### PR TITLE
Ansible galaxy role download should not have to perform aditionnal ch…

### DIFF
--- a/docs/docsite/rst/reference_appendices/galaxy.rst
+++ b/docs/docsite/rst/reference_appendices/galaxy.rst
@@ -120,7 +120,15 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
 
     # from a webserver, where the role is packaged in a tar.gz
     - src: https://some.webserver.example.com/files/master.tar.gz
-      name: http-role
+      name: http-role-gz
+
+    # from a webserver, where the role is packaged in a tar.bz2
+    - src: https://some.webserver.example.com/files/master.tar.bz2
+      name: http-role-bz2
+
+    # from a webserver, where the role is packaged in a tar.xz (Python 3.x only)
+    - src: https://some.webserver.example.com/files/master.tar.xz
+      name: http-role-xz
 
     # from Bitbucket
     - src: git+https://bitbucket.org/willthames/git-ansible-galaxy

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -319,7 +319,7 @@ class GalaxyCLI(CLI):
     def execute_install(self):
         """
         uses the args list of roles to be installed, unless -f was specified. The list of roles
-        can be a name (which will be downloaded via the galaxy API and github), or it can be a local .tar.gz file.
+        can be a name (which will be downloaded via the galaxy API and github), or it can be a local tar archive file.
         """
         role_file = context.CLIARGS['role_file']
 

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -256,12 +256,9 @@ class GalaxyRole(object):
             display.debug("installing from %s" % tmp_file)
 
             if not tarfile.is_tarfile(tmp_file):
-                raise AnsibleError("the file downloaded was not a tar.gz")
+                raise AnsibleError("the downloaded file does not appear to be a valid tar archive.")
             else:
-                if tmp_file.endswith('.gz'):
-                    role_tar_file = tarfile.open(tmp_file, "r:gz")
-                else:
-                    role_tar_file = tarfile.open(tmp_file, "r")
+                role_tar_file = tarfile.open(tmp_file, "r")
                 # verify the role's meta file
                 meta_file = None
                 members = role_tar_file.getmembers()


### PR DESCRIPTION
…eck against tar archive file extension #56616.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Ansible galaxy role download performs unnecessary check against file extension and specifically against `.tar.gz`.
Tarfile `tarfile.is_tarfile(...)` method seems sufficient to identify if the file is a valid tarfile and if tarfile is able to open it.
This allows to open file by using transparent stream compression of tarfile. This makes `.tar.gz` and `.tar.bz2` formats valid with python 2.6.x/2.7.x (as well as `.tar.xz` with python 3.x).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
