### PR TITLE
BUGFIX updating existing managed filters fails

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
@@ -440,7 +440,8 @@ class ManageIQgroup(object):
         norm_current_filters = self.manageiq_filters_to_sorted_dict(current_filters)
 
         if norm_current_filters == norm_managed_filters:
-            new_filters_resource['managed'] = current_filters['managed']
+            if 'managed' in current_filters:
+                new_filters_resource['managed'] = current_filters['managed']
         else:
             if managed_filters_merge_mode == 'merge':
                 merged_dict = self.merge_dict_values(norm_current_filters, norm_managed_filters)


### PR DESCRIPTION
##### SUMMARY
Fix a bug when updating an existing group with belongsto filters and the exisitng group does not have managed tags the module would fail on this line:

https://github.com/ansible/ansible/blob/8c29c78e221b21533882c6394811bf61abe8c4f9/lib/ansible/modules/remote_management/manageiq/manageiq_group.py#L443

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
manageiq_group

##### ADDITIONAL INFORMATION
Added simple check before reapply of current managed filters.
