### PR TITLE
Give open_url the same default user-agent as fetch_url

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1314,7 +1314,7 @@ class Request:
 
 def open_url(url, data=None, headers=None, method=None, use_proxy=True,
              force=False, last_mod_time=None, timeout=10, validate_certs=True,
-             url_username=None, url_password=None, http_agent=None,
+             url_username=None, url_password=None, http_agent='ansible-httpget',
              force_basic_auth=False, follow_redirects='urllib2',
              client_cert=None, client_key=None, cookies=None,
              use_gssapi=False, unix_socket=None):


### PR DESCRIPTION
after debugging de difference between `get_url` and `lookup('url'` the difference seems to be the User-Agent.
This sync's the user-agent in both function

##### SUMMARY
While automating the configuration of our loadbalancer with an ip whitelist of cloudflare. had an issue that `get_url` could fetch the list of ip's and `lookup('url',..)` gave an 403, because cloudflare blocks the default python request user-agent.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
urls

##### ADDITIONAL INFORMATION
Broken url example:
`ansible -mdebug -a"msg={{lookup('url','https://cloudflare.com/ips-v4')}}" localhost`

More verbose output doesn't add any information
```
url lookup connecting to https://cloudflare.com/ips-v4
localhost | FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'url'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Received HTTP error for https://cloudflare.com/ips-v4 : HTTP Error 403: Forbidden"
}
```

Working get_url
`ansible -v -m get_url -a "url=https://cloudflare.com/ips-v4 dest=/tmp/foo" localhost`

