### PR TITLE
k8s_ssl_check_fix

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -180,6 +180,10 @@ class K8sAnsibleMixin(object):
                     setattr(configuration, key, {'authorization': "Bearer {0}".format(value)})
                 else:
                     setattr(configuration, key, value)
+                    aliases = AUTH_ARG_SPEC[key].get('aliases')
+                    if aliases:
+                        for alias in aliases:
+                            setattr(configuration, alias, value)
 
         kubernetes.client.Configuration.set_default(configuration)
         return DynamicClient(kubernetes.client.ApiClient(configuration))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AUTH_ARG_SPEC verify_ssl key change to validate_certs in https://github.com/ansible/ansible/blob/stable-2.8/lib/ansible/module_utils/k8s/common.py
breaks SSL check in kubernetes package https://github.com/kubernetes-client/python/blob/release-9.0/kubernetes/client/rest.py.

kubernetes rest.py expects "verify_ssl" key in config to toggle SSL check, however common.py only sets the keys defined AUTH_ARG_SPEC, which now uses "validate_certs" even though "verify_ssl" is included as an alias.

Updated configuration enrichment to use alias as well as keys from AUTH_ARG_SPEC.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s/common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://github.com/ansible/ansible/issues/56640
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
