### PR TITLE
gcp_container_cluster_facts: Fix loop possibilites over items.

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_container_cluster_facts.py
+++ b/lib/ansible/modules/cloud/google/gcp_container_cluster_facts.py
@@ -62,8 +62,8 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-items:
-  description: List of items
+clusters:
+  description: List of clusters
   returned: always
   type: complex
   contains:
@@ -406,12 +406,12 @@ def main():
     if not module.params['scopes']:
         module.params['scopes'] = ['https://www.googleapis.com/auth/cloud-platform']
 
-    items = fetch_list(module, collection(module))
-    if items.get('clusters'):
-        items = items.get('clusters')
+    clusters = fetch_list(module, collection(module))
+    if clusters.get('clusters'):
+        clusters = clusters.get('clusters')
     else:
-        items = []
-    return_value = {'items': items}
+        clusters = []
+    return_value = {'clusters': clusters}
     module.exit_json(**return_value)
 
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To add the possibilities to loop over items.
The string `items` is a built-in operations in ansible
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

gcp_container_cluster_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

To fix this issue: https://github.com/ansible/ansible/issues/56639

I have tested localy. It worked:

```
-
    name: "Get clusters facts"
    gcp_container_cluster_facts:
        location: "{{ cluster.zone | default(cluster_config.default_config.zone) }}"
        project: "{{ cluster.gke_project | default(cluster_config.default_config.gke_project) }}"
        auth_kind: "{{ cluster.auth_kind | default(cluster_config.default_config.auth_kind) }}"
        service_account_file: "{{ cluster.service_account_file | default(cluster_config.default_config.service_account_file) }}"
    delegate_to: "{{ worker.container.name }}"
    register: cluster_facts

-
    name: "Check if cluster still existing"
    set_fact:
        cluster_present: true
    when: cluster.project ~ "-" ~ cluster.env == item.name
    loop: "{{ cluster_facts.clusters }}"
```

