### PR TITLE
[docker] support the lookup of images by digest

### DIFF
--- a/changelogs/fragments/56649-docker-image-lookup-by-digest.yml
+++ b/changelogs/fragments/56649-docker-image-lookup-by-digest.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - docker_container - Add support for image lookups by digest. Fixes the detection of digest changes.
+  - docker_image - Add support for image lookups by digest. Fixes the detection of digest changes.
+  - docker_image_info - Add support for image lookups by digest. Fixes the detection of digest changes.

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -639,10 +639,12 @@ class AnsibleDockerClient(Client):
         images = response
         if tag:
             lookup = "%s:%s" % (name, tag)
+            lookup_digest = "%s@%s" % (name, tag)
             images = []
             for image in response:
                 tags = image.get('RepoTags')
-                if tags and lookup in tags:
+                digests = image.get('RepoDigests')
+                if tags and lookup in tags or digests and lookup_digest in digests:
                     images = [image]
                     break
         return images

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -644,7 +644,7 @@ class AnsibleDockerClient(Client):
             for image in response:
                 tags = image.get('RepoTags')
                 digests = image.get('RepoDigests')
-                if tags and lookup in tags or digests and lookup_digest in digests:
+                if (tags and lookup in tags) or (digests and lookup_digest in digests):
                     images = [image]
                     break
         return images

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -76,3 +76,45 @@
       - create_2 is not changed
       - create_3 is changed
       - create_4 is not changed
+
+- name: set Digests
+  set_fact:
+    digest_hello_world_2016: 0256e8a36e2070f7bf2d0b0763dbabdd67798512411de4cdcf9431a1feb60fd9
+    digest_hello_world_2019: 2557e3c07ed1e38f26e389462d03ed943586f744621577a99efb77324b0fe535
+
+- name: Create container with hello-world image via old digest
+  docker_container:
+    image: "hello-world@sha256:{{ digest_hello_world_2016 }}"
+    name: "{{ cname }}"
+    state: present
+    force_kill: yes
+  register: digest_1
+
+- name: Create container with hello-world image via old digest (idempotent)
+  docker_container:
+    image: "hello-world@sha256:{{ digest_hello_world_2016 }}"
+    name: "{{ cname }}"
+    state: present
+    force_kill: yes
+  register: digest_2
+
+- name: Update container with hello-world image via new digest
+  docker_container:
+    image: "hello-world@sha256:{{ digest_hello_world_2019 }}"
+    name: "{{ cname }}"
+    state: present
+    force_kill: yes
+  register: digest_3
+
+- name: Cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    force_kill: yes
+  diff: no
+
+- assert:
+    that:
+      - digest_1 is changed
+      - digest_2 is not changed
+      - digest_3 is changed


### PR DESCRIPTION
##### SUMMARY

As docker image tags are not immutable, one may want to lock deployment to a specific image specified by its' sha256 digest.

Initial container creation works with an sha, but further changes are not detected.

The image change detection is some what flawed, as it ignores a missing image and silently marks the image as not changed [0]. But a patch should go into another PR.

This PR extends the parsing of the lookup response from the docker-api, in adding support for the digest matching.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION

[0] https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/docker/docker_container.py#L2423..L2429