### PR TITLE
clean backport of PR 56355 - ansible-config description

### DIFF
--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -42,7 +42,7 @@ class ConfigCLI(CLI):
         self.parser = CLI.base_parser(
             usage="usage: %%prog [%s] [--help] [options] [ansible.cfg]" % "|".join(self.VALID_ACTIONS),
             epilog="\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0]),
-            desc="View, edit, and manage ansible configuration.",
+            desc="View ansible configuration.",
         )
         self.parser.add_option('-c', '--config', dest='config_file', help="path to configuration file, defaults to first file found in precedence.")
 


### PR DESCRIPTION
##### SUMMARY
Backports #56355. The commit in `devel` won't backport cleanly, unfortunately, but the main idea is to align the description of the `ansible-config` tool with the current functionality on all branches.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
