### PR TITLE
creates reversed glob TOCs for porting guide and roadmap index pages

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guides.rst
+++ b/docs/docsite/rst/porting_guides/porting_guides.rst
@@ -10,10 +10,7 @@ Please note that this is not a complete list. If you believe any extra informati
 
 .. toctree::
    :maxdepth: 2
-  
-   porting_guide_2.0
-   porting_guide_2.3
-   porting_guide_2.4
-   porting_guide_2.5
-   porting_guide_2.6
-   porting_guide_2.7
+   :glob:
+   :reversed:
+
+   porting_guide_*

--- a/docs/docsite/rst/roadmap/index.rst
+++ b/docs/docsite/rst/roadmap/index.rst
@@ -22,6 +22,7 @@ See :ref:`Ansible communication channels <communication>` for details on how to 
 .. toctree::
    :maxdepth: 1
    :glob:
+   :reversed:
    :caption: Ansible Release Roadmaps
 
    ROADMAP*


### PR DESCRIPTION
##### SUMMARY
Backports relevant parts of #56373 and #56371. Once we implement the version-changer for the docsite, it would be distracting at best to have local TOCs change direction when switching from 2.8 to 2.7 (or 2.6).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
