### PR TITLE
[stable-2.7] Changing the license to Apache 2

### DIFF
--- a/test/units/modules/network/radware/ct.vm
+++ b/test/units/modules/network/radware/ct.vm
@@ -1,0 +1,32 @@
+##Copyright 2019 Radware
+##
+##Licensed under the Apache License, Version 2.0 (the "License");
+##you may not use this file except in compliance with the License.
+##You may obtain a copy of the License at
+##
+##    http://www.apache.org/licenses/LICENSE-2.0
+##
+##Unless required by applicable law or agreed to in writing, software
+##distributed under the License is distributed on an "AS IS" BASIS,
+##WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##See the License for the specific language governing permissions and
+##limitations under the License.
+
+#property('description', 'Ansible Test mock')
+
+#param($p1, 'int', 'in')
+#param($p2, 'int[]', 'out')
+
+#set($p2 = [])
+#set($start = 2)
+#set($end = 1024)
+#set($range = [$start..$end])
+
+#foreach($i in $range)
+        #set($j = $adc.readBean('MOCK', $i))
+        #if ($adc.isEmpty($j))
+                #set($dummy = $p2.add($i))
+        #if ($p2.size() == $p1)
+                #break
+        #end
+#end


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Changing the license to Apache 2

Backport of https://github.com/ansible/ansible/pull/56614

(cherry picked from commit ea4842c0d3312e941e0d0feac11f3ce0b9925759)

Co-authored-by: EvgenyF <evgenyf@radware.com>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/units/modules/network/radware/ct.vm
