### PR TITLE
Backport/2.7/docs default lists

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -11,6 +11,7 @@ __metaclass__ = type
 
 import datetime
 import glob
+import json
 import optparse
 import os
 import re
@@ -364,6 +365,10 @@ def jinja2_environment(template_dir, typ, plugin_type):
     if 'max' not in env.filters:
         # Jinja < 2.10
         env.filters['max'] = do_max
+
+    if 'tojson' not in env.filters:
+        # Jinja < 2.9
+        env.filters['tojson'] = json.dumps
 
     templates = {}
     if typ == 'rst':

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -155,7 +155,7 @@ Parameters
                     {% endif %}
                     {# Show default value, when multiple choice or no choices #}
                     {% if value.default is defined and value.default not in value.choices %}
-                        <b>Default:</b><br/><div style="color: blue">@{ value.default | escape }@</div>
+                        <b>Default:</b><br/><div style="color: blue">@{ value.default | tojson | escape }@</div>
                     {% endif %}
                 </td>
                 {# configuration #}


### PR DESCRIPTION
##### SUMMARY
Backports #56041 and #56596 to improve the way lists of defaults are rendered in the docs, with support for older Jinja2 versions.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
