### PR TITLE
Update gcp_compute_instance_facts.py (#56581)

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance_facts.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance_facts.py
@@ -42,7 +42,7 @@ requirements:
 options:
   filters:
     description:
-    - A list of filter value pairs. Available filters are listed here U(https://cloud.google.com/sdk/gcloud/reference/topic/filters.)
+    - A list of filter value pairs. Available filters are listed here U(https://cloud.google.com/sdk/gcloud/reference/topic/filters).
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
   zone:


### PR DESCRIPTION
swapped dot inside brackets leading to wrong url

(cherry picked from commit 2a90cbd247b3202bfb37b76add62040eb915381a)

##### SUMMARY
Backports #56581, fixing a link.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
