### PR TITLE
Move backport guide to 2.8 (#56578)

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -225,7 +225,7 @@ We do **not** backport features.
 
    These instructions assume that:
 
-    * ``stable-2.7`` is the targeted release branch for the backport
+    * ``stable-2.8`` is the targeted release branch for the backport
     * ``https://github.com/ansible/ansible.git`` is configured as a
       ``git remote`` named ``upstream``. If you do not use
       a ``git remote`` named ``upstream``, adjust the instructions accordingly.
@@ -238,7 +238,7 @@ We do **not** backport features.
    ::
 
        git fetch upstream
-       git checkout -b backport/2.7/[PR_NUMBER_FROM_DEVEL] upstream/stable-2.7
+       git checkout -b backport/2.8/[PR_NUMBER_FROM_DEVEL] upstream/stable-2.8
 
 #. Cherry pick the relevant commit SHA from the devel branch into your feature
    branch, handling merge conflicts as necessary:
@@ -253,10 +253,10 @@ We do **not** backport features.
 
    ::
 
-       git push origin backport/2.7/[PR_NUMBER_FROM_DEVEL]
+       git push origin backport/2.8/[PR_NUMBER_FROM_DEVEL]
 
-#. Submit the pull request for ``backport/2.7/[PR_NUMBER_FROM_DEVEL]``
-   against the ``stable-2.7`` branch
+#. Submit the pull request for ``backport/2.8/[PR_NUMBER_FROM_DEVEL]``
+   against the ``stable-2.8`` branch
 
 #. The Release Manager will decide whether to merge the backport PR before
    the next minor release. There isn't any need to follow up. Just ensure that the automated
@@ -264,7 +264,7 @@ We do **not** backport features.
 
 .. note::
 
-    The choice to use ``backport/2.7/[PR_NUMBER_FROM_DEVEL]`` as the
+    The choice to use ``backport/2.8/[PR_NUMBER_FROM_DEVEL]`` as the
     name for the feature branch is somewhat arbitrary, but conveys meaning
     about the purpose of that branch. It is not required to use this format,
     but it can be helpful, especially when making multiple backport PRs for


### PR DESCRIPTION
The backport guide should refer to Ansible 2.8 instead of 2.7 as the target branch, since 2.8 is out.

(cherry picked from commit 4742897635b6e7608f29ca9c49ed894abc51daa4)

##### SUMMARY
Updates the 2.8 documentation to show backports being created to 2.8, not to 2.7.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
