### PR TITLE
win_pester path behavior changed to match Pester behavior

### DIFF
--- a/lib/ansible/modules/windows/win_pester.ps1
+++ b/lib/ansible/modules/windows/win_pester.ps1
@@ -3,64 +3,59 @@
 # Copyright: (c) 2017, Erwan Quelin (@equelin) <erwan.quelin@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -CSharpUtil Ansible.Basic
 
-$ErrorActionPreference = 'Stop'
-
-$params = Parse-Args -arguments $args -supports_check_mode $true
-$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
-$diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
-
-# Modules parameters
-
-$path = Get-AnsibleParam -obj $params -name "path" -type "str" -failifempty $true
-$minimum_version = Get-AnsibleParam -obj $params -name "minimum_version" -type "str" -failifempty $false
-
-$result = @{
-    changed = $false
+$spec = @{
+    options = @{
+        path = @{ type = "str"; required = $true }
+        version = @{ type = "str"; required = $false }
+    }
+    supports_check_mode = $true
 }
 
-if ($diff_mode) {
-    $result.diff = @{}
-}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 
-# CODE
+$path = $module.Params.path
+$version = $module.Params.version
+
+$module.result.changed = $false
+
 # Test if parameter $version is valid
 Try {
-    $minimum_version = [version]$minimum_version
+    $version = [version]$version
 }
 Catch {
-    Fail-Json -obj $result -message "Value '$minimum_version' for parameter 'minimum_version' is not a valid version format"
+    $module.FailJson("Value '$version' for parameter 'version' is not a valid version format")
 }
 
 # Import Pester module if available
-$Module = 'Pester'
+$Pester = 'Pester'
 
-If (-not (Get-Module -Name $Module -ErrorAction SilentlyContinue)) {
-    If (Get-Module -Name $Module -ListAvailable -ErrorAction SilentlyContinue) {
-        Import-Module $Module
+If (-not (Get-Module -Name $Pester -ErrorAction SilentlyContinue)) {
+    If (Get-Module -Name $Pester -ListAvailable -ErrorAction SilentlyContinue) {
+        Import-Module $Pester
     } else {
-        Fail-Json -obj $result -message "Cannot find module: $Module. Check if pester is installed, and if it is not, install using win_psmodule or win_chocolatey."
+        $module.FailJson("Cannot find module: $Pester. Check if pester is installed, and if it is not, install using win_psmodule or win_chocolatey.")
     }
 }
 
 # Add actual pester's module version in the ansible's result variable
-$Pester_version = (Get-Module -Name $Module).Version.ToString()
-$result.pester_version = $Pester_version
+$Pester_version = (Get-Module -Name $Pester).Version.ToString()
+$module.result.pester_version = $Pester_version
 
 # Test if the Pester module is available with a version greater or equal than the one specified in the $version parameter
-If ((-not (Get-Module -Name $Module -ErrorAction SilentlyContinue | Where-Object {$_.Version -ge $minimum_version})) -and ($minimum_version)) {
-    Fail-Json -obj $result -message "$Module version is not greater or equal to $minimum_version"
+If ((-not (Get-Module -Name $Pester -ErrorAction SilentlyContinue | Where-Object {$_.Version -ge $version})) -and ($version)) {
+    $module.FailJson("$Pester version is not greater or equal to $version")
 }
 
 # Testing if test file or directory exist
 If (-not (Test-Path -LiteralPath $path)) {
-    Fail-Json -obj $result -message "Cannot find file or directory: '$path' as it does not exist"
+    $module.FailJson("Cannot find file or directory: '$path' as it does not exist")
 }
 
 #Prepare Invoke-Pester parameters depending of the Pester's version.
 #Invoke-Pester output deactivation behave differently depending on the Pester's version
-If ($result.pester_version -ge "4.0.0") {
+If ($module.result.pester_version -ge "4.0.0") {
     $Parameters = @{
         "show" = "none"
         "PassThru" = $True
@@ -75,12 +70,12 @@ If ($result.pester_version -ge "4.0.0") {
 # Run Pester tests
 If (Test-Path -LiteralPath $path -PathType Leaf) {
     if ($check_mode) {
-        $result.output = "Run pester test in the file: $path"
+        $module.result.output = "Run pester test in the file: $path"
     } else {
         try {
-            $result.output = Invoke-Pester $path @Parameters
+            $module.result.output = Invoke-Pester $path @Parameters
         } catch {
-            Fail-Json -obj $result -message $_.Exception
+            $module.FailJson($_.Exception)
         }
     }
 } else {
@@ -88,16 +83,16 @@ If (Test-Path -LiteralPath $path -PathType Leaf) {
     $files = Get-ChildItem -Path $path | Where-Object {$_.extension -eq ".ps1"}
 
     if ($check_mode) {
-        $result.output = "Run pester test(s) who are in the folder: $path"
+        $module.result.output = "Run pester test(s) who are in the folder: $path"
     } else {
         try {
-            $result.output = Invoke-Pester $files.FullName @Parameters
+            $module.result.output = Invoke-Pester $files.FullName @Parameters
         } catch {
-            Fail-Json -obj $result -message $_.Exception
+            $module.FailJson($_.Exception)
         }
     }
 }
 
-$result.changed = $true
+$module.result.changed = $true
 
-Exit-Json -obj $result
+$module.ExitJson()

--- a/lib/ansible/modules/windows/win_pester.ps1
+++ b/lib/ansible/modules/windows/win_pester.ps1
@@ -68,7 +68,7 @@ If ($module.result.pester_version -ge "4.0.0") {
 }
 
 # Run Pester tests
-If (Test-Path -LiteralPath $path -PathType Leaf) {
+if (Test-Path -LiteralPath $path -PathType Leaf) {
     if ($check_mode) {
         $module.result.output = "Run pester test in the file: $path"
     } else {
@@ -90,6 +90,17 @@ If (Test-Path -LiteralPath $path -PathType Leaf) {
         } catch {
             $module.FailJson($_.Exception)
         }
+    }
+}
+
+# Run Pester tests
+if ($check_mode) {
+    $module.result.output = "Run pester tests: $path"
+} else {
+    try {
+        $module.result.output = Invoke-Pester $path @Parameters
+    } catch {
+        $module.FailJson($_.Exception)
     }
 }
 

--- a/lib/ansible/modules/windows/win_pester.ps1
+++ b/lib/ansible/modules/windows/win_pester.ps1
@@ -30,6 +30,7 @@ Catch {
 
 # Make sure path is a real path
 Try {
+    $path = $path.TrimEnd("\")
     $path = (Get-item -LiteralPath $path).FullName
     Test-Path $path
 }

--- a/lib/ansible/modules/windows/win_pester.ps1
+++ b/lib/ansible/modules/windows/win_pester.ps1
@@ -81,8 +81,7 @@ if ($check_mode) {
     } catch {
         $module.FailJson($_.Exception)
     }
+    $module.result.changed = $true
 }
-
-$module.result.changed = $true
 
 $module.ExitJson()

--- a/test/integration/targets/win_pester/tasks/test.yml
+++ b/test/integration/targets/win_pester/tasks/test.yml
@@ -14,7 +14,7 @@
 - name: Run Pester test(s) specifying a test file and a higher pester version
   win_pester:
     path: '{{test_win_pester_path}}\test01.test.ps1'
-    minimum_version: '6.0.0'
+    version: '6.0.0'
   register: invalid_version
   failed_when: '"Pester version is not greater or equal to 6.0.0" not in invalid_version.msg'
 
@@ -33,7 +33,7 @@
 - name: Run Pester test(s) specifying a test file and with a minimum mandatory Pester version
   win_pester:
     path: '{{test_win_pester_path}}\test01.test.ps1'
-    minimum_version: 3.0.0
+    version: 3.0.0
   register: file_result_with_version
 
 - name: assert Run Pester test(s) specifying a test file and a minimum mandatory Pester version
@@ -70,7 +70,7 @@
 - name: Run Pester test(s) located in a folder and with a minimum mandatory Pester version
   win_pester:
     path: '{{test_win_pester_path}}'
-    minimum_version: 3.0.0
+    version: 3.0.0
   register: dir_with_version
 
 - name: assert Run Pester test(s) located in a folder and with a minimum mandatory Pester version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix supplying directory path to only execute *.tests.ps1 files, using Pester's built-in test searching functionality.

Fixes #55736

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bug Fix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_pester

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Previously, win_pester would search for '*.ps1' files in the directory supplied to 'Path:', and then execute 'Invoke-Pester' against each file. This is different from Pester's behavior, which only executes against '*.tests.ps1' files. Due to this divergent behavior, the win_pester module could inadvertently execute code that changes your system state when you are attempting to execute tests.

Pester also will search supplied paths itself, so searching for the files to execute within the win_pester module was unnecessary.

Also, I converted the module from using 'Ansible.ModuleUtils.Legacy' to using 'Ansible.Basic'

The behavior when a single test file is passed has not changed.