### PR TITLE
Make second group match of ufw status output optional

### DIFF
--- a/changelogs/fragments/56678-ufw-status-change-detection.yaml
+++ b/changelogs/fragments/56678-ufw-status-change-detection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ufw - correctly check status when logging is off (https://github.com/ansible/ansible/issues/56674)

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -450,7 +450,9 @@ def main():
                 current_level = extract.group(2)
                 current_on_off_value = extract.group(1)
                 if value != "off":
-                    if value != "on" and (value != current_level or current_on_off_value == "off"):
+                    if current_on_off_value == "off":
+                        changed = True
+                    elif value != "on" and value != current_level:
                         changed = True
                 elif current_on_off_value != "off":
                     changed = True

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -445,7 +445,7 @@ def main():
                 execute(cmd + [['-f'], [states[value]]])
 
         elif command == 'logging':
-            extract = re.search(r'Logging: (on|off) \(([a-z]+)\)', pre_state)
+            extract = re.search(r'Logging: (on|off)(?: \(([a-z]+)\))?', pre_state)
             if extract:
                 current_level = extract.group(2)
                 current_on_off_value = extract.group(1)


### PR DESCRIPTION
Fixes #56674

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Second group match does not always exist. In cases where it is missing, like when logging is set to `off`, allow regex to still succeed to return first group match such that `current_on_off_value` will be defined.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ufw