### PR TITLE
module_utils/docker/swarm.py: change license from GPLv3+ to BSD.

### DIFF
--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -1,6 +1,6 @@
 # (c) 2019 Piotr Wojciechowski (@wojciechowskipiotr) <piotr@it-playground.pl>
 # (c) Thierry Bouvet (@tbouvet)
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 import json
 from time import sleep


### PR DESCRIPTION
##### SUMMARY
It has recently be clarified that while modules in module_utils can be GPLv3+ licensed, they shouldn't be if possible. Since module_utils/docker/swarm.py is relatively new and has been based on module code (which was GPLv3+ in the first place), I'm trying to change the license.

For this, everyone who participated in changes to this file needs to explicitly approve the license change. These are (next to me) @WojciechowskiPiotr and @hannseman (see [history 1](https://github.com/ansible/ansible/commits/devel/lib/ansible/module_utils/docker/swarm.py), [history 2](https://github.com/felixfontein/ansible/commits/4a5d38b55a88864185bf4b00f2967cc466fde371/lib/ansible/module_utils/docker_swarm.py)).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker/swarm.py
