### PR TITLE
In tower_credential module, add credential_type parameter

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -53,9 +53,21 @@ options:
       description:
         - Type of credential being added.
         - The ssh choice refers to a Tower Machine credential.
-      required: True
+      required: False
       type: str
       choices: ["ssh", "vault", "net", "scm", "aws", "vmware", "satellite6", "cloudforms", "gce", "azure_rm", "openstack", "rhv", "insights", "tower"]
+    credential_type:
+      description:
+        - Name of credential type.
+      required: False
+      version_added: "2.9"
+    inputs:
+      description:
+        - >-
+          Enter inputs using either JSON or YAML syntax. Refer to the Ansible
+          Tower documentation for example syntax.
+      required: False
+      version_added: "2.9"
     host:
       description:
         - Host for this credential.
@@ -176,6 +188,15 @@ EXAMPLES = '''
     tower_host: https://localhost
   run_once: true
   delegate_to: localhost
+
+- name: Add Credential with Custom Credential Type
+  tower_credential:
+    name: Workshop Credential
+    credential_type: MyCloudCredential
+    organization: Default
+    tower_username: admin
+    tower_password: ansible
+    tower_host: https://localhost
 '''
 
 import os
@@ -210,7 +231,7 @@ KIND_CHOICES = {
 }
 
 
-def credential_type_for_v1_kind(params, module):
+def credential_type_for_kind(params):
     credential_type_res = tower_cli.get_resource('credential_type')
     kind = params.pop('kind')
     arguments = {'managed_by_tower': True}
@@ -235,8 +256,9 @@ def main():
         name=dict(required=True),
         user=dict(),
         team=dict(),
-        kind=dict(required=True,
-                  choices=KIND_CHOICES.keys()),
+        kind=dict(choices=KIND_CHOICES.keys()),
+        credential_type=dict(),
+        inputs=dict(type='dict'),
         host=dict(),
         username=dict(),
         password=dict(no_log=True),
@@ -289,10 +311,23 @@ def main():
                 # /api/v1/ backwards compat
                 # older versions of tower-cli don't *have* a credential_type
                 # resource
-                params['kind'] = module.params['kind']
+                params['kind'] = module.params.get('kind')
             else:
-                credential_type = credential_type_for_v1_kind(module.params, module)
-                params['credential_type'] = credential_type['id']
+                if module.params.get('credential_type') and module.params.get('kind'):
+                    module.fail_json(msg='cannot specify both credential_type and kind', changed=False)
+                if module.params.get('credential_type'):
+                    credential_type_res = tower_cli.get_resource('credential_type')
+                    credential_type = credential_type_res.get(name=module.params['credential_type'])
+                    params['credential_type'] = credential_type['id']
+
+                    if module.params.get('inputs'):
+                        params['inputs'] = module.params.get('inputs')
+
+                elif module.params.get('kind'):
+                    credential_type = credential_type_for_kind(module.params)
+                    params['credential_type'] = credential_type['id']
+                else:
+                    module.fail_json(msg='must either specify credential_type or kind', changed=False)
 
             if module.params.get('description'):
                 params['description'] = module.params.get('description')

--- a/test/integration/targets/tower_credential_type/tasks/main.yml
+++ b/test/integration/targets/tower_credential_type/tasks/main.yml
@@ -12,6 +12,29 @@
     that:
       - "result is changed"
 
+- name: Create credential from custom credential type
+  tower_credential:
+    name: test-custom-cred
+    organization: Default
+    credential_type: test-credential-type
+    state: present
+    inputs: '{"username": "my-username", "password": "my-password"}'
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Remove credential
+  tower_credential:
+    name: test-custom-cred
+    organization: Default
+    credential_type: test-credential-type
+    state: absent
+
+- assert:
+    that:
+      - "result is changed"
+
 - name: Remove a Tower credential type
   tower_credential_type:
     name: test-credential-type


### PR DESCRIPTION
##### SUMMARY
Adds the `credential_type` parameter to the `tower_credential` module. This will allow users to create credentials that use custom credential types.

The `kind` parameter is still supported for backwards compatibility.

Fixes https://github.com/ansible/ansible/issues/54493

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower_credential module