### PR TITLE
Backport/2.8/55954

### DIFF
--- a/changelogs/fragments/55954-cnos-coverity-bugfix.yaml
+++ b/changelogs/fragments/55954-cnos-coverity-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixing bug came up after running cnos_vrf module against coverity.

--- a/lib/ansible/modules/network/cnos/cnos_vrf.py
+++ b/lib/ansible/modules/network/cnos/cnos_vrf.py
@@ -228,9 +228,6 @@ def map_obj_to_commands(updates, module):
 def map_config_to_obj(module):
     objs = []
     output = run_commands(module, {'command': 'show vrf'})
-<<<<<<< HEAD
-    if output is None:
-=======
     if output is not None:
         vrfText = output[0].strip()
         vrfList = vrfText.split('VRF')
@@ -251,7 +248,6 @@ def map_config_to_obj(module):
                             obj['interfaces'].append(intName.strip().lower())
                 objs.append(obj)
     else:
->>>>>>> ac546457c8... Update cnos_vrf.py
         module.fail_json(msg='Could not fetch VRF details from device')
     vrfText = output[0].strip()
     vrfList = vrfText.split('VRF')

--- a/lib/ansible/modules/network/cnos/cnos_vrf.py
+++ b/lib/ansible/modules/network/cnos/cnos_vrf.py
@@ -228,7 +228,30 @@ def map_obj_to_commands(updates, module):
 def map_config_to_obj(module):
     objs = []
     output = run_commands(module, {'command': 'show vrf'})
+<<<<<<< HEAD
     if output is None:
+=======
+    if output is not None:
+        vrfText = output[0].strip()
+        vrfList = vrfText.split('VRF')
+        for vrfItem in vrfList:
+            if 'FIB ID' in vrfItem:
+                obj = dict()
+                list_of_words = vrfItem.split()
+                vrfName = list_of_words[0]
+                obj['name'] = vrfName[:-1]
+                obj['rd'] = list_of_words[list_of_words.index('RD') + 1]
+                start = False
+                obj['interfaces'] = []
+                for intName in list_of_words:
+                    if 'Interfaces' in intName:
+                        start = True
+                    if start is True:
+                        if '!' not in intName and 'Interfaces' not in intName:
+                            obj['interfaces'].append(intName.strip().lower())
+                objs.append(obj)
+    else:
+>>>>>>> ac546457c8... Update cnos_vrf.py
         module.fail_json(msg='Could not fetch VRF details from device')
     vrfText = output[0].strip()
     vrfList = vrfText.split('VRF')


### PR DESCRIPTION
(cherry picked from commit ac54645)
##### SUMMARY
Cherry-pick #55954 to 2.8.x
This changes are pertaining to fix for coverity bugs ran against cnos modules

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
lib//ansible/modules/network/cnos/cnos_vrf.py

##### ADDITIONAL INFORMATION
Pasted below is the coverity issue which I am trying address

def map_config_to_obj(module):
229 objs = []
230 output = run_commands(module, {'command': 'show vrf'})
Condition output === None, taking true branch.
null_check: Comparing output to a null-like value implies that output might be null-like.
231 if output is None:
232 module.fail_json(msg='Could not fetch VRF details from device')
CID 80685 (#1 of 1): Bad use of null-like value (FORWARD_NULL)3. property_access: Accessing a property of null-like value output.
233 vrfText = output[0].strip()