### PR TITLE
Docs: cron example would raise a warning.

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -185,9 +185,9 @@ EXAMPLES = r'''
 - name: Creates a cron file under /etc/cron.d
   cron:
     name: yum autoupdate
-    weekday: 2
-    minute: 0
-    hour: 12
+    weekday: "2"
+    minute: "0"
+    hour: "12"
     user: root
     job: "YUMINTERACTIVE=0 /usr/sbin/yum-autoupdate"
     cron_file: ansible_yum-autoupdate


### PR DESCRIPTION
The following one:

    The value 2 (type int) in a string field was converted to '2'


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
