### PR TITLE
VMware: Add folder param in vmware_datastore_cluster

### DIFF
--- a/changelogs/fragments/48010-vmware_datastore_cluster-add_folder.yml
+++ b/changelogs/fragments/48010-vmware_datastore_cluster-add_folder.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add folder option in vmware_datastore_cluster to place datastore cluster in specific folder (https://github.com/ansible/ansible/issues/48010).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -66,8 +66,8 @@ No notable changes
 Noteworthy module changes
 -------------------------
 
-* `vmware_dvswitch <vmware_dvswitch_module>` accepts `folder` parameter to place dvswitch in user defined folder.
-   This option makes `datacenter` as optional parameter.
+* `vmware_dvswitch <vmware_dvswitch_module>` accepts `folder` parameter to place dvswitch in user defined folder. This option makes `datacenter` as an optional parameter.
+* `vmware_datastore_cluster <vmware_datastore_cluster_module>` accepts `folder` parameter to place datastore cluster in user defined folder. This option makes `datacenter` as an optional parameter.
 
 
 Plugins

--- a/test/integration/targets/vmware_datastore_cluster/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_cluster/tasks/main.yml
@@ -37,6 +37,21 @@
     that:
      - not add_dsc.changed
 
+- name: Add a datastore cluster using folder
+  vmware_datastore_cluster:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: no
+    folder: "/F0/{{ dc1 }}/datastore/F0"
+    datastore_cluster_name: DSC2
+    state: present
+  register: add_dsc_folder_check
+
+- assert:
+    that:
+     - add_dsc_folder_check.changed
+
 - name: Delete a datastore cluster to datacenter (check-mode)
   vmware_datastore_cluster: &delete_datastore_cluster
     hostname: '{{ vcenter_hostname }}'


### PR DESCRIPTION
##### SUMMARY
* Make datacenter as alias and optional
* Add folder param to place datastore cluster in specific folder
* Updated examples
* Updated tests

Fixes: #48010

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/48010-vmware_datastore_cluster-add_folder.yml
docs/docsite/rst/porting_guides/porting_guide_2.9.rst
lib/ansible/modules/cloud/vmware/vmware_datastore_cluster.py
test/integration/targets/vmware_datastore_cluster/tasks/main.yml
