### PR TITLE
VMware: Add folder option for vmware_dvswitch

### DIFF
--- a/changelogs/fragments/54986-vmware_dvswitch-use_folder.yml
+++ b/changelogs/fragments/54986-vmware_dvswitch-use_folder.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add folder option in vmware_dvswitch to place distributed switch in a network specific folder (https://github.com/ansible/ansible/issues/54986).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -66,7 +66,8 @@ No notable changes
 Noteworthy module changes
 -------------------------
 
-No notable changes
+* `vmware_dvswitch <vmware_dvswitch_module>` accepts `folder` parameter to place dvswitch in user defined folder.
+   This option makes `datacenter` as optional parameter.
 
 
 Plugins

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -170,8 +170,8 @@ def find_datastore_by_name(content, datastore_name):
     return find_object_by_name(content, datastore_name, [vim.Datastore])
 
 
-def find_dvs_by_name(content, switch_name):
-    return find_object_by_name(content, switch_name, [vim.DistributedVirtualSwitch])
+def find_dvs_by_name(content, switch_name, folder=None):
+    return find_object_by_name(content, switch_name, [vim.DistributedVirtualSwitch], folder=folder)
 
 
 def find_hostsystem_by_name(content, hostname):

--- a/test/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -5,9 +5,8 @@
 - import_role:
     name: prepare_vmware_tests
 
-# Testcase 0001: Add Distributed vSwitch
 - &dvs_data
-  name: add distributed vSwitch
+  name: Add distributed vSwitch
   vmware_dvswitch:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
@@ -22,12 +21,31 @@
     discovery_operation: both
   register: dvs_result_0001
 
-- name: ensure distributed vswitch is present
+- name: Ensure distributed vswitch is present
   assert:
     that:
       - dvs_result_0001.changed
 
-# Testcase 0002: Add Distributed vSwitch again
+- name: Add distributed vSwitch using folder
+  vmware_dvswitch:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: "/F0/{{ dc1 }}/network/F0"
+    state: present
+    switch_name: dvswitch_0002
+    mtu: 9000
+    uplink_quantity: 2
+    discovery_proto: lldp
+    discovery_operation: both
+  register: dvs_result_0002
+
+- name: Ensure distributed vswitch is present
+  assert:
+    that:
+      - dvs_result_0002.changed
+
 # vcsim doesn't support ldp check (self.dvs.config.linkDiscoveryProtocolConfig.protocol)
 - when: vcsim is not defined
   block:
@@ -39,7 +57,6 @@
     assert:
       that:
         - not dvs_result_0002.changed
-
 
 # FIXME: Remove this testcase from block once vcsim supports distributed vswitch delete method
 # Currently, vcsim does not support distributed vswitch delete option,


### PR DESCRIPTION
##### SUMMARY
* Added folder param
* Mark datacenter as optional parameter
* Updated docs
* Updated tests

Fixes: #54986

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/54986-vmware_dvswitch-use_folder.yml
docs/docsite/rst/porting_guides/porting_guide_2.9.rst
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
test/integration/targets/vmware_dvswitch/tasks/main.yml