### PR TITLE
Add a new "log_folder" option to the log_plays callback plugin.

### DIFF
--- a/changelogs/fragments/56717-log-plays-configuration-options.yml
+++ b/changelogs/fragments/56717-log-plays-configuration-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "log_plays - Add a new log_folder option to the log_plays callback plugin."

--- a/lib/ansible/plugins/callback/log_plays.py
+++ b/lib/ansible/plugins/callback/log_plays.py
@@ -30,6 +30,7 @@ import os
 import time
 import json
 
+from ansible.utils.path import makedirs_safe
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.parsing.ajson import AnsibleJSONEncoder
@@ -65,7 +66,7 @@ class CallbackModule(CallbackBase):
         self.log_folder = self.get_option("log_folder")
 
         if not os.path.exists(self.log_folder):
-            os.makedirs(self.log_folder)
+            makedirs_safe(self.log_folder)
 
     def log(self, host, category, data):
         if isinstance(data, MutableMapping):

--- a/lib/ansible/plugins/callback/log_plays.py
+++ b/lib/ansible/plugins/callback/log_plays.py
@@ -12,7 +12,6 @@ DOCUMENTATION = '''
     version_added: historical
     description:
       - This callback writes playbook output to a file per host in the `/var/log/ansible/hosts` directory
-      - "TODO: make this configurable"
     requirements:
      - Whitelist in configuration
      - A writeable /var/log/ansible/hosts directory by the user executing Ansible on the controller


### PR DESCRIPTION
Add a new option for the log_plays callback plugin which allows the user to
control where the callback creates log files.

The option can be set via the ANSIBLE_LOG_FOLDER environment variable or in the
Ansible configuration file, e.g.:

```
[callback_log_plays]
log_folder = /path/to/my/log/folder
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
