### PR TITLE
meraki_network - Rework present state for compatibility with net_id

### DIFF
--- a/changelogs/fragments/meraki_network_boolean.yml
+++ b/changelogs/fragments/meraki_network_boolean.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - meraki_network - Parameter check had improper logic for absent or present.

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -240,7 +240,7 @@ def main():
     if not meraki.params['org_name'] and not meraki.params['org_id']:
         meraki.fail_json(msg='org_name or org_id parameters are required')
     if meraki.params['state'] != 'query':
-        if not meraki.params['net_name'] or meraki.params['net_id']:
+        if not meraki.params['net_name'] and not meraki.params['net_id']:
             meraki.fail_json(msg='net_name or net_id is required for present or absent states')
     if meraki.params['net_name'] and meraki.params['net_id']:
         meraki.fail_json(msg='net_name and net_id are mutually exclusive')

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -197,12 +197,15 @@
   - debug:
       msg: '{{create_net_tags}}'
 
+  - set_fact:
+      tag_net_id: create_net_tags.data.id
+
   - name: Modify network
     meraki_network:
       auth_key: '{{ auth_key }}'
       state: present
       org_name: '{{test_org_name}}'
-      net_name: IntTestNetworkTags
+      net_id: tag_net_id
       type: switch
       timezone: America/Chicago
       tags: 


### PR DESCRIPTION
##### SUMMARY
The parameter checks within `meraki_network` were not correct. Specifically, it required both `net_name` and `net_id` which isn't correct. This breaks `absent` state or any updates, but won't break creating a network.

**Update:** This bug has uncovered a problem with the execution of the module. It will likely require a more significant refactoring than I thought.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_network
