### PR TITLE
Add msg parameter to the mandatory filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -280,7 +280,7 @@ def to_uuid(string):
     return str(uuid.uuid5(UUID_NAMESPACE_ANSIBLE, str(string)))
 
 
-def mandatory(a):
+def mandatory(a, msg=None):
     from jinja2.runtime import Undefined
 
     ''' Make a variable mandatory '''
@@ -289,7 +289,12 @@ def mandatory(a):
             name = "'%s' " % to_text(a._undefined_name)
         else:
             name = ''
-        raise AnsibleFilterError("Mandatory variable %s not defined." % name)
+
+        if msg is not None:
+            raise AnsibleFilterError(str(msg))
+        else:
+            raise AnsibleFilterError("Mandatory variable %s not defined." % name)
+
     return a
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -291,7 +291,7 @@ def mandatory(a, msg=None):
             name = ''
 
         if msg is not None:
-            raise AnsibleFilterError(str(msg))
+            raise AnsibleFilterError(to_native(msg))
         else:
             raise AnsibleFilterError("Mandatory variable %s not defined." % name)
 


### PR DESCRIPTION
The `mandatory` filter would be more useful, particularly when dealing with nested dictionaries, with the simple addition of a `msg` parameter for supplying it with a custom failure message.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change would make it possible to pass a custom failure message to be displayed when the `mandatory` filter catches an undefined variable.

The mandatory filter is great, but its failure message sometimes lacks enough context to be helpful with more complex templates and nested dictionaries.

This PR will let template designers add more context with custom error messages via a `msg` parameter.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mandatory

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
{% set current_prefix = source_details['prefixes'][neighbor['uplink_name']]|mandatory %}
```
```
fatal: [mpr01.xxx]: FAILED! => {"changed": false, "msg": "AnsibleFilterError: Mandatory variable 'verizon'  not defined."}
```
After:
```
{% set current_prefix = source_details['prefixes'][neighbor['uplink_name']]|mandatory(neighbor['uplink_name'] ~ ' not properly defined in source_details dictionary.') %}
```
```
fatal: [mpr01.xxx]: FAILED! => {"changed": false, "msg": "AnsibleFilterError: verizon not properly defined in source_details dictionary."}
```