### PR TITLE
iam_managed_policy: add check & diff mode support, cover with unit tests

### DIFF
--- a/changelogs/fragments/56736-iam-managed-policy-check-diff-mode.yaml
+++ b/changelogs/fragments/56736-iam-managed-policy-check-diff-mode.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - iam_managed_policy - add support for check & diff modes and cover module with unit tests.

--- a/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
@@ -278,6 +278,18 @@ def detach_all_entities(module, iam, policy, **kwargs):
         detach_all_entities(module, iam, policy, marker=entities['Marker'])
 
 
+def diff(module, policy_document_before, policy_document_after):
+    if module._diff:
+        return {
+            'diff': {
+                'before': policy_document_before,
+                'after': policy_document_after,
+            }
+        }
+    else:
+        return {}
+
+
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
@@ -305,10 +317,12 @@ def main():
     default = module.params.get('make_default')
     only = module.params.get('only_version')
 
-    policy = None
-
     if module.params.get('policy') is not None:
-        policy = json.dumps(json.loads(module.params.get('policy')))
+        policy_document_after = json.loads(module.params.get('policy'))
+        policy_document = json.dumps(policy_document_after)
+    else:
+        policy_document_after = None
+        policy_document = None
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
@@ -319,26 +333,37 @@ def main():
                          exceptions=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     p = get_policy_by_name(module, iam, name)
+    policy_document_before = None
+
+    if p:
+        try:
+            policy_document_before = iam.get_policy_version(
+                PolicyArn=p['Arn'], VersionId=p['DefaultVersionId'])['PolicyVersion']['Document']
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg="Couldn't get policy version %s: %s" % (p['DefaultVersionId'], str(e)),
+                             exception=traceback.format_exc(),
+                             **camel_dict_to_snake_dict(e.response))
+
     if state == 'present':
         if p is None:
             if not module.check_mode:
                 # No Policy so just create one
                 try:
-                    rvalue = iam.create_policy(PolicyName=name, Path='/',
-                                               PolicyDocument=policy, Description=description)
+                    p = iam.create_policy(PolicyName=name, Path='/',
+                                          PolicyDocument=policy_document, Description=description)['Policy']
                 except Exception as e:
                     module.fail_json(msg="Couldn't create policy %s: %s" % (name, to_native(e)),
                                      exception=traceback.format_exc(),
                                      **camel_dict_to_snake_dict(e.response))
 
-                module.exit_json(changed=True, policy=camel_dict_to_snake_dict(rvalue['Policy']))
-            else:
-                module.exit_json(changed=True, policy=None)
+            module.exit_json(changed=True, policy=p and camel_dict_to_snake_dict(p),
+                             **diff(module, policy_document_before, policy_document_after))
         else:
-            policy_version, changed = get_or_create_policy_version(module, iam, p, policy)
+            policy_version, changed = get_or_create_policy_version(module, iam, p, policy_document)
             changed = set_if_default(module, iam, p, policy_version, default) or changed
             changed = set_if_only(module, iam, p, policy_version, only) or changed
-            # If anything has changed we needto refresh the policy
+
+            # If anything has changed we need to refresh the policy
             if changed:
                 try:
                     p = iam.get_policy(PolicyArn=p['Arn'])['Policy']
@@ -347,7 +372,8 @@ def main():
                                      exception=traceback.format_exc(),
                                      **camel_dict_to_snake_dict(e.response))
 
-            module.exit_json(changed=changed, policy=camel_dict_to_snake_dict(p))
+            module.exit_json(changed=changed, policy=camel_dict_to_snake_dict(p),
+                             **diff(module, policy_document_before, policy_document_after))
     else:
         # Check for existing policy
         if p:
@@ -379,9 +405,10 @@ def main():
                                      **camel_dict_to_snake_dict(e.response))
 
             # This is the one case where we will return the old policy
-            module.exit_json(changed=True, policy=camel_dict_to_snake_dict(p))
+            module.exit_json(changed=True, policy=camel_dict_to_snake_dict(p),
+                             **diff(module, policy_document_before, None))
         else:
-            module.exit_json(changed=False, policy=None)
+            module.exit_json(changed=False, policy=None, **diff(module, None, None))
 # end main
 
 

--- a/test/units/modules/cloud/amazon/test_iam_managed_policy.py
+++ b/test/units/modules/cloud/amazon/test_iam_managed_policy.py
@@ -1,0 +1,297 @@
+import functools
+
+from ansible.modules.cloud.amazon import iam_managed_policy
+from units.compat import unittest
+from units.compat.mock import patch
+from units.modules.utils import AnsibleExitJson, ModuleTestCase, set_module_args
+
+
+def check_mode_flag(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        func(check_mode=True, *args, **kwargs)
+        func(check_mode=False, *args, **kwargs)
+    return wrapper
+
+
+@patch.object(iam_managed_policy, 'HAS_BOTO3', new=True)
+class TestIAMManagedPolicyModule(ModuleTestCase):
+    @check_mode_flag
+    @patch.object(iam_managed_policy, 'get_aws_connection_info', return_value=('eu-central-1', None, {}))
+    @patch.object(iam_managed_policy, 'get_policy_by_name', return_value=None)
+    @patch.object(iam_managed_policy, 'boto3_conn')
+    def test_create_policy(self, boto3_conn_mock, *args, check_mode):
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                'secret_key': 'SECRET_KEY',
+                'access_key': 'ACCESS_KEY',
+                'region': 'eu-central-1',
+                'policy_name': 'test-policy',
+                'policy_description': 'This is a new description',
+                'policy': '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}',
+                'state': 'present',
+                '_ansible_check_mode': check_mode,
+            })
+            iam_managed_policy.main()
+
+        if check_mode:
+            boto3_conn_mock.return_value.create_policy.assert_not_called()
+        else:
+            boto3_conn_mock.return_value.create_policy.assert_called_once_with(
+                Description='This is a new description',
+                Path='/',
+                PolicyDocument='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}',
+                PolicyName='test-policy',
+            )
+
+        self.assertTrue('policy' in exec_info.exception.args[0])
+        self.assertEqual(exec_info.exception.args[0]['changed'], True)
+
+    @check_mode_flag
+    @patch.object(iam_managed_policy, 'get_aws_connection_info', return_value=('eu-central-1', None, {}))
+    @patch.object(iam_managed_policy, 'get_policy_by_name', return_value={
+        'PolicyName': 'test-policy',
+        'PolicyId': 'POL_ID',
+        'Arn': 'arn:policy',
+        'Path': '/',
+        'DefaultVersionId': 'v1',
+        'AttachmentCount': 0,
+        'PermissionsBoundaryUsageCount': 0,
+        'IsAttachable': True,
+    })
+    @patch.object(iam_managed_policy, 'boto3_conn')
+    def test_create_default_policy_version(self, boto3_conn_mock, *args, check_mode):
+        boto3_conn_mock.return_value.list_policy_versions.return_value = {
+            'Versions': [{'VersionId': 'v1', 'IsDefaultVersion': True}],
+        }
+
+        boto3_conn_mock.return_value.get_policy_version.return_value = {
+            'PolicyVersion': {
+                'Document': {'Version': '2012-10-17',
+                             'Statement': [{'Effect': 'Allow', 'Action': ['s3:Get*', 's3:List*'], 'Resource': '*'}]},
+                'VersionId': 'v1',
+                'IsDefaultVersion': True,
+            },
+        }
+
+        boto3_conn_mock.return_value.create_policy_version.return_value = {
+            'PolicyVersion': {
+                'VersionId': 'v2',
+                'IsDefaultVersion': False,
+            }
+        }
+
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                'secret_key': 'SECRET_KEY',
+                'access_key': 'ACCESS_KEY',
+                'region': 'eu-central-1',
+                'policy_name': 'test-policy',
+                'policy_description': 'This is a new description',
+                'policy': '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}',
+                'state': 'present',
+                '_ansible_check_mode': check_mode,
+            })
+            iam_managed_policy.main()
+
+        if check_mode:
+            boto3_conn_mock.return_value.create_policy_version.assert_not_called()
+        else:
+            boto3_conn_mock.return_value.create_policy_version.assert_called_once_with(
+                PolicyArn='arn:policy',
+                PolicyDocument='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}',
+            )
+            boto3_conn_mock.return_value.set_default_policy_version.assert_called_once()
+
+        self.assertTrue('policy' in exec_info.exception.args[0])
+        self.assertEqual(exec_info.exception.args[0]['changed'], True)
+
+    @check_mode_flag
+    @patch.object(iam_managed_policy, 'get_aws_connection_info', return_value=('eu-central-1', None, {}))
+    @patch.object(iam_managed_policy, 'get_policy_by_name', return_value={
+        'PolicyName': 'test-policy',
+        'PolicyId': 'POL_ID',
+        'Arn': 'arn:policy',
+        'Path': '/',
+        'DefaultVersionId': 'v1',
+        'AttachmentCount': 0,
+        'PermissionsBoundaryUsageCount': 0,
+        'IsAttachable': True,
+    })
+    @patch.object(iam_managed_policy, 'boto3_conn')
+    def test_only_policy_version(self, boto3_conn_mock, *args, check_mode):
+        boto3_conn_mock.return_value.list_policy_versions.side_effect = [{
+            'Versions': [{'VersionId': 'v1', 'IsDefaultVersion': True}],
+        }, {
+            'Versions': [
+                {'VersionId': 'v1', 'IsDefaultVersion': False},
+                {'VersionId': 'v2', 'IsDefaultVersion': True},
+            ],
+        }]
+
+        boto3_conn_mock.return_value.get_policy_version.return_value = {
+            'PolicyVersion': {
+                'Document': {'Version': '2012-10-17',
+                             'Statement': [{'Effect': 'Allow', 'Action': ['s3:Get*', 's3:List*'], 'Resource': '*'}]},
+                'VersionId': 'v1',
+                'IsDefaultVersion': True,
+            },
+        }
+
+        boto3_conn_mock.return_value.create_policy_version.return_value = {
+            'PolicyVersion': {
+                'VersionId': 'v2',
+                'IsDefaultVersion': False,
+            }
+        }
+
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                'secret_key': 'SECRET_KEY',
+                'access_key': 'ACCESS_KEY',
+                'region': 'eu-central-1',
+                'policy_name': 'test-policy',
+                'policy_description': 'This is a new description',
+                'policy': '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}',
+                'make_default': False,
+                'only_version': True,
+                'state': 'present',
+                '_ansible_check_mode': check_mode,
+            })
+            iam_managed_policy.main()
+
+        if check_mode:
+            boto3_conn_mock.return_value.create_policy_version.assert_not_called()
+        else:
+            boto3_conn_mock.return_value.create_policy_version.assert_called_once_with(
+                PolicyArn='arn:policy',
+                PolicyDocument='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}',
+            )
+            boto3_conn_mock.return_value.set_default_policy_version.assert_not_called()
+            boto3_conn_mock.return_value.delete_policy_version.assert_called_once_with(
+                PolicyArn='arn:policy',
+                VersionId='v1',
+            )
+
+        self.assertTrue('policy' in exec_info.exception.args[0])
+        self.assertEqual(exec_info.exception.args[0]['changed'], True)
+
+    @patch.object(iam_managed_policy, 'get_aws_connection_info', return_value=('eu-central-1', None, {}))
+    @patch.object(iam_managed_policy, 'get_policy_by_name', return_value={
+        'PolicyName': 'test-policy',
+        'PolicyId': 'POL_ID',
+        'Arn': 'arn:policy',
+        'Path': '/',
+        'DefaultVersionId': 'v1',
+        'AttachmentCount': 0,
+        'PermissionsBoundaryUsageCount': 0,
+        'IsAttachable': True,
+    })
+    @patch.object(iam_managed_policy, 'boto3_conn')
+    def test_create_policy_version_no_changes(self, boto3_conn_mock, *args):
+        boto3_conn_mock.return_value.list_policy_versions.return_value = {
+            'Versions': [{'VersionId': 'v1', 'IsDefaultVersion': True}],
+        }
+
+        boto3_conn_mock.return_value.get_policy_version.return_value = {
+            'PolicyVersion': {
+                'Document': {'Version': '2012-10-17',
+                             'Statement': [{'Effect': 'Allow', 'Action': '*', 'Resource': '*'}]},
+                'VersionId': 'v1',
+                'IsDefaultVersion': True,
+            },
+        }
+
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                'secret_key': 'SECRET_KEY',
+                'access_key': 'ACCESS_KEY',
+                'region': 'eu-central-1',
+                'policy_name': 'test-policy',
+                'policy_description': 'This is a new description',
+                'policy': '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}',
+                'state': 'present',
+            })
+            iam_managed_policy.main()
+
+        boto3_conn_mock.return_value.create_policy_version.assert_not_called()
+        boto3_conn_mock.return_value.set_default_policy_version.assert_not_called()
+        boto3_conn_mock.return_value.delete_policy_version.assert_not_called()
+
+        self.assertTrue('policy' in exec_info.exception.args[0])
+        self.assertEqual(exec_info.exception.args[0]['changed'], False)
+
+    @check_mode_flag
+    @patch.object(iam_managed_policy, 'get_aws_connection_info', return_value=('eu-central-1', None, {}))
+    @patch.object(iam_managed_policy, 'get_policy_by_name', return_value={
+        'PolicyName': 'test-policy',
+        'PolicyId': 'POL_ID',
+        'Arn': 'arn:policy',
+        'Path': '/',
+        'DefaultVersionId': 'v1',
+        'AttachmentCount': 0,
+        'PermissionsBoundaryUsageCount': 0,
+        'IsAttachable': True,
+    })
+    @patch.object(iam_managed_policy, 'boto3_conn')
+    def test_delete_policy(self, boto3_conn_mock, *args, check_mode):
+        boto3_conn_mock.return_value.list_entities_for_policy.return_value = {
+            'PolicyGroups': [{'GroupName': 'group'}],
+            'PolicyUsers': [{'UserName': 'user'}],
+            'PolicyRoles': [{'RoleName': 'role'}],
+            'IsTruncated': False,
+        }
+
+        boto3_conn_mock.return_value.list_policy_versions.return_value = {
+            'Versions': [
+                {'VersionId': 'v1', 'IsDefaultVersion': False},
+                {'VersionId': 'v2', 'IsDefaultVersion': True},
+            ],
+        }
+
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                'secret_key': 'SECRET_KEY',
+                'access_key': 'ACCESS_KEY',
+                'region': 'eu-central-1',
+                'policy_name': 'test-policy',
+                'state': 'absent',
+                '_ansible_check_mode': check_mode,
+            })
+            iam_managed_policy.main()
+
+        if check_mode:
+            boto3_conn_mock.return_value.create_policy_version.assert_not_called()
+        else:
+            client = boto3_conn_mock.return_value
+
+            client.detach_group_policy.assert_called_once_with(PolicyArn='arn:policy', GroupName='group')
+            client.detach_user_policy.assert_called_once_with(PolicyArn='arn:policy', UserName='user')
+            client.detach_role_policy.assert_called_once_with(PolicyArn='arn:policy', RoleName='role')
+            client.delete_policy_version.assert_called_once_with(PolicyArn='arn:policy', VersionId='v1')
+            client.delete_policy.assert_called_once_with(PolicyArn='arn:policy')
+
+        self.assertTrue('policy' in exec_info.exception.args[0])
+        self.assertEqual(exec_info.exception.args[0]['changed'], True)
+
+    @patch.object(iam_managed_policy, 'get_aws_connection_info', return_value=('eu-central-1', None, {}))
+    @patch.object(iam_managed_policy, 'get_policy_by_name', return_value=None)
+    @patch.object(iam_managed_policy, 'boto3_conn')
+    def test_delete_policy_no_changes(self, boto3_conn_mock, *args):
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                'secret_key': 'SECRET_KEY',
+                'access_key': 'ACCESS_KEY',
+                'region': 'eu-central-1',
+                'policy_name': 'test-policy',
+                'state': 'absent',
+            })
+            iam_managed_policy.main()
+
+        boto3_conn_mock.return_value.delete_policy.assert_not_called()
+        self.assertTrue('policy' in exec_info.exception.args[0])
+        self.assertEqual(exec_info.exception.args[0]['changed'], False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
This PR adds check & diff mode support to `iam_managed_policy`, which comes in very handy, because you can then see what changes exactly are going to be applied, almost like in Terraform ;-)

On top of that, we have covered the module with unit test to make sure future changes won't break existing logic.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iam_managed_policy
