### PR TITLE
2.8: yum: fix false error msg about autoremove support (#56459)

### DIFF
--- a/changelogs/fragments/56458-yum-fix-false-error-msg-autoremove.yaml
+++ b/changelogs/fragments/56458-yum-fix-false-error-msg-autoremove.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yum - Fix false error message about autoremove not being supported (https://github.com/ansible/ansible/issues/56458)

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1067,9 +1067,8 @@ class YumModule(YumDnf):
             res['msg'] = err
 
             if rc != 0:
-                if self.autoremove:
-                    if 'No such command' not in out:
-                        self.module.fail_json(msg='Version of YUM too old for autoremove: Requires yum 3.4.3 (RHEL/CentOS 7+)')
+                if self.autoremove and 'No such command' in out:
+                    self.module.fail_json(msg='Version of YUM too old for autoremove: Requires yum 3.4.3 (RHEL/CentOS 7+)')
                 else:
                     self.module.fail_json(**res)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/56459

(cherry picked from commit a68ac729ea3a090553f9bec40992135337c4146b)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
yum
