### PR TITLE
command and shell: moved chdir block after creates check

### DIFF
--- a/changelogs/fragments/50409-command_chdir_after_creates_check.yml
+++ b/changelogs/fragments/50409-command_chdir_after_creates_check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "command and shell module with existant creates path no longer fails when chdir path is non-existent"

--- a/changelogs/fragments/50409-command_chdir_after_creates_check.yml
+++ b/changelogs/fragments/50409-command_chdir_after_creates_check.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "command and shell module with existant creates path no longer fails when chdir path is non-existent"
+- "command and shell module with existent creates path no longer fails when chdir path is non-existent"

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -258,10 +258,6 @@ def main():
     if is_iterable(args, include_strings=False):
         args = [to_native(arg, errors='surrogate_or_strict', nonstring='simplerepr') for arg in args]
 
-    if chdir:
-        chdir = os.path.abspath(chdir)
-        os.chdir(chdir)
-
     if creates:
         # do not run the command if the line contains creates=filename
         # and the filename already exists.  This allows idempotence
@@ -285,6 +281,10 @@ def main():
                 changed=False,
                 rc=0
             )
+
+    if chdir:
+        chdir = os.path.abspath(chdir)
+        os.chdir(chdir)
 
     if warn:
         check_command(module, args)


### PR DESCRIPTION
##### SUMMARY
Fixes #50409 Command and shell module with existent creates path no longer fails when chdir path is non-existent.

##### ISSUE TYPE

- Bugfix Pull Request
##### COMPONENT NAME
command
shell
