### PR TITLE
Fix workload profileId indexing in netapp_e_volume module

### DIFF
--- a/changelogs/fragments/56747-netapp_e_volume-fix-profileId-indexing.yaml
+++ b/changelogs/fragments/56747-netapp_e_volume-fix-profileId-indexing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - netapp_e_volumes - fix workload profileId indexing when no previous workload tags exist on the storage array.

--- a/lib/ansible/modules/storage/netapp/netapp_e_volume.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_volume.py
@@ -470,10 +470,14 @@ class NetAppESeriesVolume(NetAppESeriesModule):
                 self.module.fail_json(msg="Failed to retrieve storage array workload tags. Array [%s]" % self.ssid)
 
             # Generate common indexed Ansible workload tag
-            tag_index = max([int(pair["value"].replace("ansible_workload_", ""))
-                             for tag in workload_tags for pair in tag["workloadAttributes"]
-                             if pair["key"] == "profileId" and "ansible_workload_" in pair["value"] and
-                             str(pair["value"]).replace("ansible_workload_", "").isdigit()]) + 1
+            current_tag_index_list = [int(pair["value"].replace("ansible_workload_", ""))
+                                      for tag in workload_tags for pair in tag["workloadAttributes"]
+                                      if pair["key"] == "profileId" and "ansible_workload_" in pair["value"] and
+                                      str(pair["value"]).replace("ansible_workload_", "").isdigit()]
+
+            tag_index = 1
+            if current_tag_index_list:
+                tag_index = max(current_tag_index_list) + 1
 
             ansible_profile_id = "ansible_workload_%d" % tag_index
             request_body = dict(name=self.workload_name,


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_volume

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Module fails during the first volume creation due to a max() operation applied to and empty set.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.9.0.dev0
  config file = None
  configured module search path = [u'/home/swartzn/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/ansible-dev/lib/ansible
  executable location = /home/swartzn/ansible-dev/bin/ansible
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
```
