### PR TITLE
[2.8] Clarify that GPLv3+ module_utils need core team approval

### DIFF
--- a/docs/docsite/rst/dev_guide/shared_snippets/licensing.txt
+++ b/docs/docsite/rst/dev_guide/shared_snippets/licensing.txt
@@ -2,7 +2,8 @@
    **LICENSING REQUIREMENTS**  Ansible enforces the following licensing requirements:
 
    * Utilities (files in ``lib/ansible/module_utils/``) may have one of two licenses:
-      * A ``module_util`` used **only** for a specific vendor's hardware, provider, or service may be licensed under GPLv3+.
+      * A file in ``module_utils`` used **only** for a specific vendor's hardware, provider, or service may be licensed under GPLv3+.
+        Adding a new file under ``module_utils`` with GPLv3+ needs to be approved by the core team.
       * All other ``module_utils`` must be licensed under BSD, so GPL-licensed third-party and Galaxy modules can use them.
-      * If there's doubt about the appropriate license for a ``module_util``, the Ansible Core Team will decide during an Ansible Core Community Meeting.
+      * If there's doubt about the appropriate license for a file in ``module_utils``, the Ansible Core Team will decide during an Ansible Core Community Meeting.
    * All other files shipped with Ansible, including all modules, must be licensed under the GPL license (GPLv3 or later).


### PR DESCRIPTION
##### SUMMARY
Backport of #56740 to stable-2.8.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/shared_snippets/licensing.txt
