### PR TITLE
Update java_cert module

### DIFF
--- a/changelogs/fragments/43249-java_cert.yaml
+++ b/changelogs/fragments/43249-java_cert.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "Update java_cert module to change `state: present` to check certificates by hash, not just alias name (https://github.com/ansible/ansible/issues/43249)"

--- a/changelogs/fragments/43249-java_cert.yaml
+++ b/changelogs/fragments/43249-java_cert.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+        - Update java_cert module to change 'state: present' to check certificates by hash, not just alias name (https://github.com/ansible/ansible/issues/43249) 

--- a/changelogs/fragments/43249-java_cert.yaml
+++ b/changelogs/fragments/43249-java_cert.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-        - Update java_cert module to change 'state: present' to check certificates by hash, not just alias name (https://github.com/ansible/ansible/issues/43249) 
+  - "Update java_cert module to change `state: present` to check certificates by hash, not just alias name (https://github.com/ansible/ansible/issues/43249)"

--- a/changelogs/fragments/java_cert-state_changes.yml
+++ b/changelogs/fragments/java_cert-state_changes.yml
@@ -1,6 +1,5 @@
 minor_changes:
-        - "Java_cert: Change `state: present` to check certificates by hash, not just alias name (https://github.com/ansible/ansible/issues/43249)"
+  - "Java_cert: Change `state: present` to check certificates by hash, not just alias name (https://github.com/ansible/ansible/issues/43249)"
 bugfixes:
-        - "Java_cert: Allow setting `state: absent` by providing just the cert_alias - (https://github.com/ansible/ansible/issues/27982)"
-        - "Java_cert: Properly handle proxy arguments when the scheme is provided - (https://github.com/ansible/ansible/issues/54481)"
-
+  - "Java_cert: Allow setting `state: absent` by providing just the cert_alias - (https://github.com/ansible/ansible/issues/27982)"
+  - "Java_cert: Properly handle proxy arguments when the scheme is provided - (https://github.com/ansible/ansible/issues/54481)"

--- a/changelogs/fragments/java_cert-state_changes.yml
+++ b/changelogs/fragments/java_cert-state_changes.yml
@@ -1,0 +1,6 @@
+minor_changes:
+        - "Java_cert: Change `state: present` to check certificates by hash, not just alias name (https://github.com/ansible/ansible/issues/43249)"
+bugfixes:
+        - "Java_cert: Allow setting `state: absent` by providing just the cert_alias - (https://github.com/ansible/ansible/issues/27982)"
+        - "Java_cert: Properly handle proxy arguments when the scheme is provided - (https://github.com/ansible/ansible/issues/54481)"
+

--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -171,7 +171,7 @@ from ansible.module_utils.crypto import load_certificate
 try:
     from urlparse import urlparse
     from urllib import getproxies
-except ModuleNotFoundError:
+except ImportError:
     from urllib.parse import urlparse
     from urllib.request import getproxies
 

--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -165,7 +165,7 @@ import string
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.crypto import  load_certificate
+from ansible.module_utils.crypto import load_certificate
 
 
 def get_keystore_type(keystore_type):
@@ -186,39 +186,44 @@ def check_cert_present(module, executable, keystore_path, keystore_pass, alias, 
         return True
     return False
 
+
 def export_cert(module, executable, keystore_path, keystore_pass, alias, keystore_type):
     """ Uses keytool to export the certificate with the specified alias in PEM.
           The certificate is returned as a PEM formatted string """
     export_cmd = ("%s -noprompt -rfc -export -keystore '%s' -storepass '%s' "
-                "-alias '%s' %s") % (executable, keystore_path, keystore_pass, alias, get_keystore_type(keystore_type))
-    (_,stdout,_) = module.run_command(export_cmd)
+                  "-alias '%s' %s") % (executable, keystore_path, keystore_pass, alias, get_keystore_type(keystore_type))
+    (_, stdout, _) = module.run_command(export_cmd)
     return stdout
 
-def  convert_pem_string_to_x509_object(pem_string):
-  """ Takes a string containing a PEM formatted certificate and
-        returns an OpenSSL.crypto.x509 object """
-  try:
-    (_, tmp) = tempfile.mkstemp()
-    with open(tmp, 'w') as f:
-      f.write(pem_string)
-    cert = load_certificate(tmp)
-  finally:
-    os.remove(tmp)
-  return cert
+
+def convert_pem_string_to_x509_object(pem_string):
+    """ Takes a string containing a PEM formatted certificate and
+          returns an OpenSSL.crypto.x509 object """
+    try:
+        (_, tmp) = tempfile.mkstemp()
+        with open(tmp, 'w') as f:
+            f.write(pem_string)
+        cert = load_certificate(tmp)
+    finally:
+        os.remove(tmp)
+    return cert
+
 
 def convert_jks_to_pkcs12(module, executable, keystore_path, keystore_pass, alias, pkcs12_dest):
-  """ Creates a PKCS12 archive from an existing keystore """
-  convert_cmd = ("'%s' -importkeystore -srckeystore '%s' -srcstorepass '%s' "
-                "-srcalias '%s'  -deststoretype PKCS12 "
-                "-destalias '%s' -destkeystore '%s' -deststorepass '%s' -noprompt") % (executable, keystore_path, keystore_pass, alias, 
-                                                  alias, pkcs12_dest, keystore_pass)
-  module.run_command(convert_cmd)
-    
-def export_public_cert_from_pkcs12(module, pkcs_file,  alias, password, dest):
-  """ Runs Openssl to extract the public cert from a PKCS12 archive and write it to a file. """
-  export_cmd = ("openssl pkcs12 -in '%s' -nokeys -password pass:'%s' "
-                           " -name '%s' -out '%s'") %(pkcs_file, password, alias, dest )
-  module.run_command(export_cmd)
+    """ Creates a PKCS12 archive from an existing keystore """
+    convert_cmd = ("'%s' -importkeystore -srckeystore '%s' -srcstorepass '%s' "
+                   "-srcalias '%s'  -deststoretype PKCS12 "
+                   "-destalias '%s' -destkeystore '%s' -deststorepass '%s' -noprompt") % (executable, keystore_path, keystore_pass, alias,
+                                                                                          alias, pkcs12_dest, keystore_pass)
+    module.run_command(convert_cmd)
+
+
+def export_public_cert_from_pkcs12(module, pkcs_file, alias, password, dest):
+    """ Runs Openssl to extract the public cert from a PKCS12 archive and write it to a file. """
+    export_cmd = ("openssl pkcs12 -in '%s' -nokeys -password pass:'%s' "
+                  " -name '%s' -out '%s'") % (pkcs_file, password, alias, dest)
+    module.run_command(export_cmd)
+
 
 def import_cert_url(module, executable, url, port, keystore_path, keystore_pass, alias, keystore_type):
     ''' Import certificate from URL into keystore located at keystore_path '''
@@ -307,7 +312,7 @@ def import_pkcs12_path(module, executable, path, keystore_path, keystore_pass, p
         module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd)
 
 
-def delete_cert(module, executable, keystore_path, keystore_pass, alias, keystore_type, exit_after = True):
+def delete_cert(module, executable, keystore_path, keystore_pass, alias, keystore_type, exit_after=True):
     ''' Delete certificate identified with alias from keystore on keystore_path '''
     del_cmd = ("%s -delete -keystore '%s' -storepass '%s' "
                "-alias '%s' %s") % (executable, keystore_path, keystore_pass, alias, get_keystore_type(keystore_type))
@@ -316,11 +321,11 @@ def delete_cert(module, executable, keystore_path, keystore_pass, alias, keystor
     (del_rc, del_out, del_err) = module.run_command(del_cmd, check_rc=True)
 
     if exit_after:
-      diff = {'before': '%s\n' % alias, 'after': None}
+        diff = {'before': '%s\n' % alias, 'after': None}
 
-      module.exit_json(changed=True, msg=del_out,
-                     rc=del_rc, cmd=del_cmd, stdout=del_out,
-                     error=del_err, diff=diff)
+        module.exit_json(changed=True, msg=del_out,
+                         rc=del_rc, cmd=del_cmd, stdout=del_out,
+                         error=del_err, diff=diff)
 
 
 def test_keytool(module, executable):
@@ -398,53 +403,53 @@ def main():
                                       keystore_pass, cert_alias, keystore_type)
 
     if not alias_exists:
-      cert_present = False
+        cert_present = False
     else:
-      # The alias exists in the keystore so we must now compare the SHA1 hash of the
-      # public certificate already in the keystore, and the certificate we  are wanting to add
-      if cert_type == 'PKCS12':
-          # To get the digest of the PKCS12 file we need to convert the JKS
-          # format to PKCS12. Then we can run OpenSSL to print out only the 
-          # public cert. We can then load the public cert and get the digest
+        # The alias exists in the keystore so we must now compare the SHA1 hash of the
+        # public certificate already in the keystore, and the certificate we  are wanting to add
+        if cert_type == 'PKCS12':
+            # To get the digest of the PKCS12 file we need to convert the JKS
+            # format to PKCS12. Then we can run OpenSSL to print out only the
+            # public cert. We can then load the public cert and get the digest
 
-        # We need temporary places to store the transformations from JKS -> PKCS12 -> X509
-        # The keytool program wont create a keystore if a file already exists, so we can't use a tmpfile
-        # for the pkcs12 transformation
-        random_name = "".join(random.choice(string.ascii_letters + string.digits) for _ in range(12))
-        tmp_pkcs12_store = os.path.join(tempfile.gettempdir(), random_name)
-        (_, tmp_pem_cert) = tempfile.mkstemp()
-        (_, tmp_pem_cert2) = tempfile.mkstemp()
-        try:
-          convert_jks_to_pkcs12(module, executable, keystore_path,
-                                            keystore_pass, cert_alias, tmp_pkcs12_store)
+            # We need temporary places to store the transformations from JKS -> PKCS12 -> X509
+            # The keytool program wont create a keystore if a file already exists, so we can't use a tmpfile
+            # for the pkcs12 transformation
+            random_name = "".join(random.choice(string.ascii_letters + string.digits) for _ in range(12))
+            tmp_pkcs12_store = os.path.join(tempfile.gettempdir(), random_name)
+            (_, tmp_pem_cert) = tempfile.mkstemp()
+            (_, tmp_pem_cert2) = tempfile.mkstemp()
+            try:
+                convert_jks_to_pkcs12(module, executable, keystore_path,
+                                      keystore_pass, cert_alias, tmp_pkcs12_store)
 
-          export_public_cert_from_pkcs12(module, tmp_pkcs12_store, cert_alias, keystore_pass, tmp_pem_cert)
-          keystore_cert_digest = load_certificate(tmp_pem_cert).digest(digest)
+                export_public_cert_from_pkcs12(module, tmp_pkcs12_store, cert_alias, keystore_pass, tmp_pem_cert)
+                keystore_cert_digest = load_certificate(tmp_pem_cert).digest(digest)
 
-          export_public_cert_from_pkcs12(module, pkcs12_path, cert_alias, keystore_pass, tmp_pem_cert2)
-          new_cert_digest = load_certificate(tmp_pem_cert2).digest(digest)
-        finally:
-          try:
-            os.remove(tmp_pkcs12_store)
-          except OSError:
-            pass
-          os.remove(tmp_pem_cert)
-          os.remove(tmp_pem_cert2)
-      else:
-        # Extracting the X509 digest is a bit easier. Keytool will print the PEM 
-        # certificate to stdout so we don't need to do any transformations.
-        keystore_cert_pem = export_cert(module, executable, keystore_path,
-                                                  keystore_pass, cert_alias, keystore_type)
-        keystore_cert_digest = convert_pem_string_to_x509_object(keystore_cert_pem).digest(digest)
-        new_cert_digest = load_certificate(path).digest(digest)
+                export_public_cert_from_pkcs12(module, pkcs12_path, cert_alias, keystore_pass, tmp_pem_cert2)
+                new_cert_digest = load_certificate(tmp_pem_cert2).digest(digest)
+            finally:
+                try:
+                    os.remove(tmp_pkcs12_store)
+                except OSError:
+                    pass
+                os.remove(tmp_pem_cert)
+                os.remove(tmp_pem_cert2)
+        else:
+            # Extracting the X509 digest is a bit easier. Keytool will print the PEM
+            # certificate to stdout so we don't need to do any transformations.
+            keystore_cert_pem = export_cert(module, executable, keystore_path,
+                                            keystore_pass, cert_alias, keystore_type)
+            keystore_cert_digest = convert_pem_string_to_x509_object(keystore_cert_pem).digest(digest)
+            new_cert_digest = load_certificate(path).digest(digest)
 
     # Perform the comparison between digests. If they are the same then
     # we know that the correct cert is present
 
-    if alias_exists and keystore_cert_digest == new_cert_digest: 
-      cert_present = True
-    else: 
-      cert_present = False
+    if alias_exists and keystore_cert_digest == new_cert_digest:
+        cert_present = True
+    else:
+        cert_present = False
 
     if state == 'absent' and alias_exists:
         if module.check_mode:
@@ -459,7 +464,7 @@ def main():
         # The certificate in the keystore does not match with the one we want to be present
         # The existing certificate must first be deleted before we insert the correct one
         if alias_exists:
-          delete_cert(module, executable, keystore_path, keystore_pass, cert_alias, keystore_type, False)
+            delete_cert(module, executable, keystore_path, keystore_pass, cert_alias, keystore_type, False)
 
         if pkcs12_path:
             import_pkcs12_path(module, executable, pkcs12_path, keystore_path,

--- a/test/integration/targets/java_cert/defaults/main.yml
+++ b/test/integration/targets/java_cert/defaults/main.yml
@@ -1,3 +1,13 @@
 ---
 test_pkcs12_path: testpkcs.p12
 test_keystore_path: keystore.jks
+test_keystore2_path: "{{ output_dir }}/keystore2.jks"
+test_keystore2_password: changeit
+test_cert_path: "{{ output_dir }}/cert.pem"
+test_key_path: "{{ output_dir }}/key.pem"
+test_cert2_path: "{{ output_dir }}/cert2.pem"
+test_key2_path: "{{ output_dir }}/key2.pem"
+test_pkcs_path: "{{ output_dir }}/cert.p12"
+test_pkcs2_path: "{{ output_dir }}/cert2.p12"
+test_ssl: setupSSLServer.py
+test_ssl_port: 21500

--- a/test/integration/targets/java_cert/files/setupSSLServer.py
+++ b/test/integration/targets/java_cert/files/setupSSLServer.py
@@ -1,0 +1,14 @@
+import BaseHTTPServer
+import SimpleHTTPServer
+import ssl
+import os
+import sys
+
+root_dir = sys.argv[1]
+port = int(sys.argv[2])
+
+httpd = BaseHTTPServer.HTTPServer(('localhost', port), SimpleHTTPServer.SimpleHTTPRequestHandler)
+httpd.socket = ssl.wrap_socket(httpd.socket, server_side=True,
+                               certfile=os.path.join(root_dir, 'cert.pem'),
+                               keyfile=os.path.join(root_dir, 'key.pem'))
+httpd.handle_request()

--- a/test/integration/targets/java_cert/tasks/main.yml
+++ b/test/integration/targets/java_cert/tasks/main.yml
@@ -4,50 +4,52 @@
 
 - name: import pkcs12
   java_cert:
-     pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
-     pkcs12_password: changeit
-     pkcs12_alias: default
-     cert_alias: default
-     keystore_path: "{{output_dir}}/{{ test_keystore_path }}"
-     keystore_pass: changeme_keystore
-     keystore_create: yes
-     state: present
+    pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
+    pkcs12_password: changeit
+    pkcs12_alias: default
+    cert_alias: default
+    keystore_path: "{{output_dir}}/{{ test_keystore_path }}"
+    keystore_pass: changeme_keystore
+    keystore_create: yes
+    state: present
   register: result_success
 - name: verify success
   assert:
     that:
-    - result_success is successful
+      - result_success is successful
 
 - name: import pkcs12 with wrong password
   java_cert:
-     pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
-     pkcs12_password: wrong_pass
-     pkcs12_alias: default
-     cert_alias: default_new
-     keystore_path: "{{output_dir}}/{{ test_keystore_path }}"
-     keystore_pass: changeme_keystore
-     keystore_create: yes
-     state: present
+    pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
+    pkcs12_password: wrong_pass
+    pkcs12_alias: default
+    cert_alias: default_new
+    keystore_path: "{{output_dir}}/{{ test_keystore_path }}"
+    keystore_pass: changeme_keystore
+    keystore_create: yes
+    state: present
   ignore_errors: true
   register: result_wrong_pass
 
 - name: verify fail with wrong import password
   assert:
     that:
-    - result_wrong_pass is failed
+      - result_wrong_pass is failed
 
 - name: test fail on mutually exclusive params
   java_cert:
-     cert_path: ca.crt
-     pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
-     cert_alias: default
-     keystore_path: "{{output_dir}}/{{ test_keystore_path }}"
-     keystore_pass: changeme_keystore
-     keystore_create: yes
-     state: present
+    cert_path: ca.crt
+    pkcs12_path: "{{output_dir}}/{{ test_pkcs12_path }}"
+    cert_alias: default
+    keystore_path: "{{output_dir}}/{{ test_keystore_path }}"
+    keystore_pass: changeme_keystore
+    keystore_create: yes
+    state: present
   ignore_errors: true
   register: result_excl_params
 - name: verify failed exclusive params
   assert:
     that:
-    - result_excl_params is failed
+      - result_excl_params is failed
+
+- import_tasks: state_change.yml

--- a/test/integration/targets/java_cert/tasks/state_change.yml
+++ b/test/integration/targets/java_cert/tasks/state_change.yml
@@ -1,0 +1,167 @@
+---
+- name: Generate the self signed cert used as a place holder to create the java keystore
+  command: openssl req -x509 -newkey rsa:4096 -keyout {{ test_key_path }} -out {{ test_cert_path }} -days 365 -nodes -subj '/CN=localhost'
+  args:
+    creates: "{{ test_key_path }}"
+
+- name: Create the test keystore
+  java_keystore:
+    name: placeholder
+    dest: "{{ test_keystore2_path }}"
+    password: "{{ test_keystore2_password }}"
+    private_key: "{{ lookup('file', '{{ test_key_path }}') }}"
+    certificate: "{{ lookup('file', '{{ test_cert_path }}') }}"
+
+- name: Generate the self signed cert we will use for testing
+  command: openssl req -x509 -newkey rsa:4096 -keyout '{{ test_key2_path }}' -out '{{ test_cert2_path }}' -days 365 -nodes -subj '/CN=localhost'
+  args:
+    creates: "{{ test_key2_path }}"
+
+- name: |
+    Import the newly created certificate. This is our main test.
+    If the java_cert has been updated properly, then this task will report changed each time
+    since the module will be comparing the hash of the certificate instead of validating that the alias
+    simply exists
+  java_cert:
+    cert_alias: test_cert
+    cert_path: "{{ test_cert2_path }}"
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+    state: present
+  register: result_x509_changed
+
+- name: Verify the x509 status has changed
+  assert:
+    that:
+      - result_x509_changed is changed
+
+- name: |
+    We also want to make sure that the status doesnt change if we import the same cert
+  java_cert:
+    cert_alias: test_cert
+    cert_path: "{{ test_cert2_path }}"
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+    state: present
+  register: result_x509_succeeded
+
+- name: Verify the x509 status is ok
+  assert:
+    that:
+      - result_x509_succeeded is succeeded
+
+- name: Create the pkcs12 archive from the test x509 cert
+  command: >
+    openssl pkcs12
+    -in {{ test_cert_path }}
+    -inkey {{ test_key_path }}
+    -export
+    -name test_pkcs12_cert
+    -out {{ test_pkcs_path }}
+    -passout pass:"{{ test_keystore2_password }}"
+
+- name: Create the pkcs12 archive from the certificate we will be trying to add to the keystore
+  command: >
+    openssl pkcs12
+    -in {{ test_cert2_path }}
+    -inkey {{ test_key2_path }}
+    -export
+    -name test_pkcs12_cert
+    -out {{ test_pkcs2_path }}
+    -passout pass:"{{ test_keystore2_password }}"
+
+- name: >
+    Ensure the original pkcs12 cert is in the keystore
+  java_cert:
+    cert_alias: test_pkcs12_cert
+    pkcs12_alias: test_pkcs12_cert
+    pkcs12_path: "{{ test_pkcs_path }}"
+    pkcs12_password: "{{ test_keystore2_password }}"
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+    state: present
+
+- name: |
+    Perform the same test, but we will now be testing the pkcs12 functionality
+    If we add a different pkcs12 cert with the same alias, we should have a chnaged result, NOT the same
+  java_cert:
+    cert_alias: test_pkcs12_cert
+    pkcs12_alias: test_pkcs12_cert
+    pkcs12_path: "{{ test_pkcs2_path }}"
+    pkcs12_password: "{{ test_keystore2_password }}"
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+    state: present
+  register: result_pkcs12_changed
+
+- name: Verify the pkcs12 status has changed
+  assert:
+    that:
+      - result_pkcs12_changed is changed
+
+- name: |
+    We are requesting the same cert now, so the status should show OK
+  java_cert:
+    cert_alias: test_pkcs12_cert
+    pkcs12_alias: test_pkcs12_cert
+    pkcs12_path: "{{ test_pkcs2_path }}"
+    pkcs12_password: "{{ test_keystore2_password }}"
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+  register: result_pkcs12_succeeded
+
+- name: Verify the pkcs12 status is ok
+  assert:
+    that:
+      - result_pkcs12_succeeded is succeeded
+
+- name: Copy the ssl server script
+  copy: src="setupSSLServer.py" dest="{{output_dir}}"
+
+- name: Create an SSL server that we will use for testing URL imports
+  command: python {{ output_dir }}/setupSSLServer.py {{ output_dir }} {{ test_ssl_port }}
+  async: 5
+  poll: 0
+
+- name: |
+    Download the original cert.pem from our temporary server. The current cert should contain
+     cert2.pem. Importing this cert should return a status of changed
+  java_cert:
+    cert_alias: test_cert
+    cert_url: google.com
+    cert_port: 443
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+    state: present
+  register: result_url_changed
+
+- name: Verify that the url status is changed
+  assert:
+    that:
+      - result_url_changed is changed
+
+- name: Ensure we can remove the x509 cert
+  java_cert:
+    cert_alias: test_cert
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+    state: absent
+  register: result_x509_absent
+
+- name: Verify the x509 cert is absent
+  assert:
+    that:
+      - result_x509_absent is changed
+
+- name: Ensure we can remove the pkcs12 archive
+  java_cert:
+    cert_alias: test_pkcs12_cert
+    keystore_path: "{{ test_keystore2_path }}"
+    keystore_pass: "{{ test_keystore2_password }}"
+    state: absent
+  register: result_pkcs12_absent
+
+- name: Verify the pkcs12 archive is absent
+  assert:
+    that:
+      - result_pkcs12_absent is changed


### PR DESCRIPTION
The module previously compared certificates based on the alias name. It will now compare the SHA1 digest of the public certificates to determine if the certificate is present or absent. If the digests are not the same, then the module will overwrite the existing alias in the keystore

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #43249 
Fixes #27982
Fixes #54481
The issue goes into detail as to why this change is neccessary.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
java_cert