### PR TITLE
Update azure_rm_appgateway.py

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
@@ -294,7 +294,7 @@ options:
             authentication_certificates:
                 description:
                     - List of references to application gateway authentication certificates.
-                    - Applicable only when cookie_based_affinity is enabled, otherwise quietly ignored.
+                    - Applicable only when C(cookie_based_affinity) is enabled, otherwise quietly ignored.
                 suboptions:
                     id:
                         description:

--- a/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
@@ -294,6 +294,7 @@ options:
             authentication_certificates:
                 description:
                     - List of references to application gateway authentication certificates.
+                    - Applicable only when cookie_based_affinity is enabled, otherwise quietly ignored.
                 suboptions:
                     id:
                         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
backend_http_settings_collection allows to set authentication_certificates regardless of the cookie_based_affinity state , but UI does not allow to save that configuration if affinity is disabled. Module accepts that configuration but does not set the authentication_certificates element at all. 

I think the documentation should explain the dependency of authentication_certificates on cookie_based_affinity being enabled to avoid confusion.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
