### PR TITLE
ACI: Do not encode query_string (backport)

### DIFF
--- a/changelogs/fragments/56784-aci-do_not_encode_query_string.yaml
+++ b/changelogs/fragments/56784-aci-do_not_encode_query_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ACI - DO not encode query_string

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -37,7 +37,6 @@ import os
 from copy import deepcopy
 
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils._text import to_bytes, to_native
 
@@ -419,7 +418,7 @@ class ACIModule(object):
                 self.filter_string += '&'
             else:
                 self.filter_string = '?'
-            self.filter_string += urlencode(accepted_params)
+            self.filter_string += '&'.join(['%s=%s' % (k, v) for (k, v) in accepted_params.items()])
 
     # TODO: This could be designed to accept multiple obj_classes and keys
     def build_filter(self, obj_class, params):

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -103,9 +103,6 @@
     ap: "{{ fakevar | default(omit) }}"
   register: query_all
 
-- debug:
-    msg: '{{ query_ap_ap.filter_string|urldecode }}'
-
 - name: query assertions
   assert:
     that:
@@ -121,7 +118,7 @@
       - query_ap_ap is not changed
       - query_ap_ap.current != []
       - query_ap_ap.current.0.fvAp is defined
-      - '"query-target-filter=eq(fvAp.name, \"anstest\")" in query_ap_ap.filter_string|urldecode'
+      - '"query-target-filter=eq(fvAp.name, \"anstest\")" in query_ap_ap.filter_string'
       - '"class/fvAp.json" in query_ap_ap.url'
       - query_all is not changed
       - query_all.current | length > 1

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -133,22 +133,22 @@
       - query_all is not changed
       - query_all.current | length > 1
       - query_all.current.0.fvBD is defined
-      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_all.filter_string|urldecode'
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_all.filter_string'
       - '"class/fvBD.json" in query_all.url'
       - query_tenant is not changed
       - query_tenant.current | length == 1
       - query_tenant.current.0.fvTenant.children | length == 2
-      - '"rsp-subtree-class=fvRsBdToEpRet,fvBD,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_tenant.filter_string|urldecode'
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvBD,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_bd_bd is not changed
       - query_bd_bd.current != []
-      - '"query-target-filter=eq(fvBD.name, \"anstest\")" in query_bd_bd.filter_string|urldecode'
-      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_bd_bd.filter_string|urldecode'
+      - '"query-target-filter=eq(fvBD.name, \"anstest\")" in query_bd_bd.filter_string'
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_bd_bd.filter_string'
       - '"class/fvBD.json" in query_bd_bd.url'
       - query_bd is not changed
       - query_bd.current | length == 1
       - query_bd.current.0.fvBD.attributes.name == "anstest"
-      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_bd.filter_string|urldecode'
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_bd.filter_string'
       - '"tn-anstest/BD-anstest.json" in query_bd.url'
 
 - name: delete bd - check mode works

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -174,23 +174,23 @@
       - get_all_tenant is not changed
       - '"tn-anstest.json" in get_all_tenant.url'
       - get_all_bd is not changed
-      - '"query-target-filter=eq(fvBD.name, \"anstest\")" in get_all_bd.filter_string|urldecode'
+      - '"query-target-filter=eq(fvBD.name, \"anstest\")" in get_all_bd.filter_string'
       - '"class/fvBD.json" in get_all_bd.url'
       - get_all_tenant_bd is not changed
       - '"tn-anstest/BD-anstest.json" in get_all_tenant_bd.url'
       - get_all_tenant_bd.current.0.fvBD.children | length > 1
       - get_subnet_tenant is not changed
-      - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_tenant.filter_string|urldecode'
+      - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_tenant.filter_string'
       - '"tn-anstest.json" in get_subnet_tenant.url'
       - get_subnet_bd is not changed
-      - '"query-target-filter=eq(fvBD.name, \"anstest\")"|urldecode'
-      - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_bd.filter_string|urldecode'
+      - '"query-target-filter=eq(fvBD.name, \"anstest\")"'
+      - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_bd.filter_string'
       - '"class/fvBD.json" in get_subnet_bd.url'
       - get_subnet is not changed
       - get_subnet.current | length == 1
       - '"tn-anstest/BD-anstest/subnet-[10.100.100.1/24].json" in get_subnet.url'
       - get_subnets_gateway is not changed
-      - '"query-target-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnets_gateway.filter_string|urldecode'
+      - '"query-target-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnets_gateway.filter_string'
       - '"class/fvSubnet.json" in get_subnets_gateway.url'
 
 - name: delete subnet - check mode works

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -103,7 +103,7 @@
       - query_snapshot is not failed
       - query_snapshot is not changed
       - '"class/configSnapshot.json" in query_snapshot.url'
-      - '"configSnapshot.name, \"{{ test_snapshot }}\"" in query_snapshot.filter_string|urldecode'
+      - '"configSnapshot.name, \"{{ test_snapshot }}\"" in query_snapshot.filter_string'
       - query_all is not failed
       - query_all is not changed
       - '"class/configSnapshot.json" in query_all.url'

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -109,7 +109,7 @@
       - '"tn-anstest.json" in query_tenant.url'
       - query_name is not changed
       - query_name.current != []
-      - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_name.filter_string|urldecode'
+      - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_name.filter_string'
       - '"class/vzBrCP.json" in query_name.url'
       - query_all is not changed
       - query_all.current | length > 1

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -156,30 +156,30 @@
       - query_tenant_subject.current.0.fvTenant.attributes.name == "anstest"
       - query_tenant_subject.current.0.fvTenant.children.0.vzBrCP.children | length == 1
       - query_tenant_subject.current.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"
-      - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_tenant_subject.filter_string|urldecode'
+      - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_tenant_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_tenant_subject.filter_string'
       - '"tn-anstest.json" in query_tenant_subject.url'
       - query_contract_subject is not changed
       - query_contract_subject.current.0.vzBrCP.attributes.name == "anstest"
       - query_contract_subject.current.0.vzBrCP.children | length == 1
       - query_contract_subject.current.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"
-      - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract_subject.filter_string|urldecode'
-      - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_contract_subject.filter_string|urldecode'
+      - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract_subject.filter_string'
+      - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract_subject.filter_string'
       - '"class/vzBrCP.json" in query_contract_subject.url'
       - query_tenant is not changed
       - query_tenant.current | length == 1
       - query_tenant.current.0.fvTenant.attributes.name == "anstest"
-      - '"rsp-subtree-class=vzBrCP,vzSubj" in query_tenant.filter_string|urldecode'
+      - '"rsp-subtree-class=vzBrCP,vzSubj" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_contract is not changed
       - query_contract.current.0.vzBrCP.attributes.name == "anstest"
-      - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract.filter_string|urldecode'
+      - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract.filter_string'
       - '"class/vzBrCP.json" in query_contract.url'
       - query_subject is not changed
       - query_subject.current.0.vzSubj.attributes.name == "anstest"
-      - '"query-target-filter=eq(vzSubj.name, \"anstest\")" in query_subject.filter_string|urldecode'
+      - '"query-target-filter=eq(vzSubj.name, \"anstest\")" in query_subject.filter_string'
       - '"class/vzSubj.json" in query_subject.url'
       - query_all is not changed
       - query_all.current > 1

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -228,9 +228,9 @@
     that:
       - range_query_from_to_name is not changed
       - range_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_to_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_from_to_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_from_to_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_from_to_name.filter_string'
       - range_query_from_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - range_query_from_to_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
       - range_query_from_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
@@ -246,8 +246,8 @@
     that:
       - range_query_from_name is not changed
       - range_query_from_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_from_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_from_name.filter_string'
       - range_query_from_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - range_query_from_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
 
@@ -262,8 +262,8 @@
     that:
       - range_query_to_name is not changed
       - range_query_to_name.url.endswith('class/fvnsEncapBlk.json')
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_to_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_to_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_to_name.filter_string'
       - range_query_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - range_query_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
@@ -279,7 +279,7 @@
     that:
       - range_query_name is not changed
       - range_query_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_name.filter_string'
       - range_query_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: query vlan pool range - from and to are filtered
@@ -293,8 +293,8 @@
     that:
       - range_query_from_to is not changed
       - range_query_from_to.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_to.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_from_to.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_to.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_from_to.filter_string'
       - range_query_from_to.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
       - range_query_from_to.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -195,13 +195,13 @@
       - query_filter_entry is not changed
       - query_filter_entry.current.0.vzFilter.attributes.name == "anstest"
       - query_filter_entry.current.0.vzFilter.children | length == 1
-      - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter_entry.filter_string|urldecode'
-      - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_filter_entry.filter_string|urldecode'
+      - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter_entry.filter_string'
+      - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"class/vzFilter.json" in query_filter_entry.url'
       - query_tenant_entry is not changed
       - query_tenant_entry.current | length == 1
       - query_tenant_entry.current.0.fvTenant.attributes.name == "anstest"
-      - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_tenant_entry.filter_string|urldecode'
+      - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_tenant_entry.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_tenant_entry.filter_string'
       - '"tn-anstest.json" in query_tenant_entry.url'
       - query_tenant_filter is not changed
@@ -212,17 +212,17 @@
       - '"tn-anstest/flt-anstest.json" in query_tenant_filter.url'
       - query_entry is not changed
       - query_entry.current.0.vzEntry.attributes.name == "anstest"
-      - '"query-target-filter=eq(vzEntry.name, \"anstest\")" in query_entry.filter_string|urldecode'
+      - '"query-target-filter=eq(vzEntry.name, \"anstest\")" in query_entry.filter_string'
       - '"class/vzEntry.json" in query_entry.url'
       - query_filter is not changed
       - query_filter.current.0.vzFilter.attributes.name == "anstest"
-      - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter.filter_string|urldecode'
+      - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_filter.filter_string'
       - '"class/vzFilter.json" in query_filter.url'
       - query_tenant is not changed
       - query_tenant.current | length == 1
       - query_tenant.current.0.fvTenant.attributes.name == "anstest"
-      - '"rsp-subtree-class=vzEntry,vzFilter" in query_tenant.filter_string|urldecode'
+      - '"rsp-subtree-class=vzEntry,vzFilter" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_all is not changed
       - query_all.current | length > 1

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -224,9 +224,9 @@
     that:
       - encap_block_query_from_to_name is not changed
       - encap_block_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_to_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_from_to_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_from_to_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_from_to_name.filter_string'
       - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
       - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
@@ -242,8 +242,8 @@
     that:
       - encap_block_query_from_name is not changed
       - encap_block_query_from_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_from_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_from_name.filter_string'
       - encap_block_query_from_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - encap_block_query_from_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
 
@@ -258,8 +258,8 @@
     that:
       - encap_block_query_to_name is not changed
       - encap_block_query_to_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_to_name.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_to_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_to_name.filter_string'
       - encap_block_query_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - encap_block_query_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
@@ -275,7 +275,7 @@
     that:
       - encap_block_query_name is not changed
       - encap_block_query_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_name.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_name.filter_string'
       - encap_block_query_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from and to are filtered
@@ -289,8 +289,8 @@
     that:
       - encap_block_query_from_to is not changed
       - encap_block_query_from_to.url.endswith("class/fvnsEncapBlk.json")
-      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_to.filter_string|urldecode'
-      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_from_to.filter_string|urldecode'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_to.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_from_to.filter_string'
       - encap_block_query_from_to.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
       - encap_block_query_from_to.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -119,7 +119,7 @@
       - query_vrf_vrf is not changed
       - query_vrf_vrf.current != []
       - query_vrf_vrf.current.0.fvCtx.attributes.name == "anstest"
-      - '"query-target-filter=eq(fvCtx.name, \"anstest\")" in query_vrf_vrf.filter_string|urldecode'
+      - '"query-target-filter=eq(fvCtx.name, \"anstest\")" in query_vrf_vrf.filter_string'
       - '"class/fvCtx.json" in query_vrf_vrf.url'
       - query_vrf is not changed
       - query_vrf.current | length == 1


### PR DESCRIPTION
##### SUMMARY
It appears ACI fails signature authentication when commas are encoded
in the URL. It expects its signature to be created with commas intact.

This is a backport of #56783 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ACI