### PR TITLE
'NoneType' object is not callable when password is None

### DIFF
--- a/lib/ansible/modules/system/crypttab.py
+++ b/lib/ansible/modules/system/crypttab.py
@@ -280,7 +280,7 @@ class Line(object):
                 if self.password is not None:
                     fields.append(self.password)
                 else:
-                    self.password('none')
+                    fields.append('none')
             if self.opts:
                 fields.append(str(self.opts))
             return ' '.join(fields)


### PR DESCRIPTION
Use `fields.append('none')` instead of `self.password('none')` when appending to crypttab

##### SUMMARY
When using this module without a password, an exception occurs. This looks to have been broken in commit 8bd5757720d6855d958981582567b7ffc348d488 where a fields.append was replaced (accidentally?) with a call to self.password

Attempts to use the crypttab module without specifying a password file resulted in the following error:

```
Traceback (most recent call last):
  File "./__main__.py", line 365, in <module>
    main()
  File "./__main__.py", line 161, in main
    f.write(to_bytes(crypttab, errors='surrogate_or_strict'))
  File "/home/infraweavers/.ansible/tmp/ansible-tmp-1558512110.99-166034509721507/debug_dir/ansible/module_utils/_text.py", line 149, in to_bytes
    value = str(obj)
  File "./__main__.py", line 203, in __str__
    lines.append(str(line))
  File "./__main__.py", line 283, in __str__
    self.password('none')
TypeError: 'NoneType' object is not callable
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
crypttab

##### ADDITIONAL INFORMATION
Before Output:
```
Traceback (most recent call last):
  File "./__main__.py", line 365, in <module>
    main()
  File "./__main__.py", line 161, in main
    f.write(to_bytes(crypttab, errors='surrogate_or_strict'))
  File "/home/infraweavers/.ansible/tmp/ansible-tmp-1558512110.99-166034509721507/debug_dir/ansible/module_utils/_text.py", line 149, in to_bytes
    value = str(obj)
  File "./__main__.py", line 203, in __str__
    lines.append(str(line))
  File "./__main__.py", line 283, in __str__
    self.password('none')
TypeError: 'NoneType' object is not callable
```

After output:
```
{"group": "root", "name": "sda5_crypt", "backing_device": "UUID=5f41ada4-7c91-11e9-b979-e311b8ea0db8", "warnings": ["Module did not set no_log for password"], "changed": true, "invocation": {"module_args": {"name": "sda5_crypt", "backing
_device": "UUID=5f41ada4-7c91-11e9-b979-e311b8ea0db8", "state": "present", "path": "/etc/crypttab", "password": null, "opts": "luks"}}, "state": "file", "gid": 0, "mode": "0644", "msg": "added line", "owner": "root", "path": "/etc/cryptt
ab", "password": null, "uid": 0, "opts": "luks", "size": 126}
```
