### PR TITLE
GCP instance templates should look for the metadata under the "properties" key

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance_template.py
@@ -1090,14 +1090,16 @@ def raise_if_errors(response, err_path, module):
 
 
 def encode_request(request, module):
-    if 'metadata' in request and request['metadata'] is not None:
-        request['metadata'] = metadata_encoder(request['metadata'])
+    if ('properties' in request and request['properties'] is not None and
+            'metadata' in request['properties'] and request['properties']['metadata'] is not None):
+        request['properties']['metadata'] = metadata_encoder(request['properties']['metadata'])
     return request
 
 
 def decode_response(response, module):
-    if 'metadata' in response and response['metadata'] is not None:
-        response['metadata'] = metadata_decoder(response['metadata'])
+    if ('properties' in response and response['properties'] is not None and
+            'metadata' in response['properties'] and response['properties']['metadata'] is not None):
+        response['properties']['metadata'] = metadata_decoder(response['properties']['metadata'])
     return response
 
 

--- a/test/units/modules/cloud/google/test_gcp_compute_instance_template.py
+++ b/test/units/modules/cloud/google/test_gcp_compute_instance_template.py
@@ -3,7 +3,8 @@ import copy
 
 from ansible.modules.cloud.google.gcp_compute_instance_template import encode_request, decode_response
 
-class TestTestGCPComputeInstanceTemplate(unittest.TestCase):
+
+class TestGCPComputeInstanceTemplate(unittest.TestCase):
     """Unit tests for gcp_compute_instance_template module."""
     request_without_metadata = {
         u'kind': 'compute#instanceTemplate',
@@ -18,7 +19,7 @@ class TestTestGCPComputeInstanceTemplate(unittest.TestCase):
         u'description': 'instance template description',
         u'name': 'my-instance-template',
         u'properties': {
-            u'machineType': 'n1-standard-1', 
+            u'machineType': 'n1-standard-1',
             u'metadata': {
                 'startup-script': '#!/bin/bash\necho hello',
                 'ssh-keys': 'not-an-ssh-key'
@@ -26,39 +27,39 @@ class TestTestGCPComputeInstanceTemplate(unittest.TestCase):
         }
     }
     response_without_metadata = {
-        u'kind': u'compute#instanceTemplate', 
+        u'kind': u'compute#instanceTemplate',
         u'description': 'instance template description',
         u'properties': {
-            u'machineType': u'n1-standard-1', 
+            u'machineType': u'n1-standard-1',
             u'metadata': {
-                u'kind': u'compute#metadata', 
+                u'kind': u'compute#metadata',
                 u'fingerprint': u'ZmluZ2VycHJpbnQK'
             }
-        }, 
-        u'creationTimestamp': u'2019-05-22T06:58:43.884-07:00', 
-        u'id': u'0000000000000000001', 
-        u'selfLink': u'https://www.googleapis.com/compute/v1/projects/my-fake-gcp-project/global/instanceTemplates/my-instance-template', 
+        },
+        u'creationTimestamp': u'2019-05-22T06:58:43.884-07:00',
+        u'id': u'0000000000000000001',
+        u'selfLink': u'https://www.googleapis.com/compute/v1/projects/my-fake-gcp-project/global/instanceTemplates/my-instance-template',
         u'name': u'my-instance-template'
     }
     response_with_metadata = {
-        u'kind': u'compute#instanceTemplate', 
+        u'kind': u'compute#instanceTemplate',
         u'description': 'instance template description',
         u'properties': {
-            u'machineType': u'n1-standard-1', 
+            u'machineType': u'n1-standard-1',
             u'metadata': {
                 u'items': [
                     {
-                        u'value': u'#!/bin/bash\necho hello', 
+                        u'value': u'#!/bin/bash\necho hello',
                         u'key': u'startup-script'
                     }
-                ], 
-                u'kind': u'compute#metadata', 
+                ],
+                u'kind': u'compute#metadata',
                 u'fingerprint': u'ZmluZ2VycHJpbnQK'
             }
-        }, 
-        u'creationTimestamp': u'2019-05-22T06:58:43.884-07:00', 
-        u'id': u'0000000000000000001', 
-        u'selfLink': u'https://www.googleapis.com/compute/v1/projects/my-fake-gcp-project/global/instanceTemplates/my-instance-template', 
+        },
+        u'creationTimestamp': u'2019-05-22T06:58:43.884-07:00',
+        u'id': u'0000000000000000001',
+        u'selfLink': u'https://www.googleapis.com/compute/v1/projects/my-fake-gcp-project/global/instanceTemplates/my-instance-template',
         u'name': u'my-instance-template'
     }
 
@@ -75,14 +76,11 @@ class TestTestGCPComputeInstanceTemplate(unittest.TestCase):
             self.request_with_metadata
         )
 
-        self.assertIn('properties', encoded_request_with_metadata)
-        self.assertIn('metadata', encoded_request_with_metadata['properties'])
-        self.assertIn('items', encoded_request_with_metadata['properties']['metadata'])
+        self.assertTrue('properties' in encoded_request_with_metadata)
+        self.assertTrue('metadata' in encoded_request_with_metadata['properties'])
+        self.assertTrue('items' in encoded_request_with_metadata['properties']['metadata'])
         for metadata_key, metadata_value in self.request_with_metadata['properties']['metadata'].items():
-            self.assertIn(
-                { 'key': metadata_key, 'value': metadata_value },
-                encoded_request_with_metadata['properties']['metadata']['items']
-            )
+            self.assertTrue({'key': metadata_key, 'value': metadata_value} in encoded_request_with_metadata['properties']['metadata']['items'])
 
     def test_decode_request(self):
         self.maxDiff = None
@@ -108,15 +106,11 @@ class TestTestGCPComputeInstanceTemplate(unittest.TestCase):
             response_with_metadata_cleared
         )
 
-        self.assertIn('properties', decoded_response_with_metadata)
-        self.assertIn('metadata', decoded_response_with_metadata['properties'])
+        self.assertTrue('properties' in decoded_response_with_metadata)
+        self.assertTrue('metadata' in decoded_response_with_metadata['properties'])
         for metadata_object in self.response_with_metadata['properties']['metadata']['items']:
-            self.assertIn(
-                metadata_object['key'], 
-                decoded_response_with_metadata['properties']['metadata']
-            )
+            self.assertTrue(metadata_object['key'] in decoded_response_with_metadata['properties']['metadata'])
             self.assertEqual(
                 metadata_object['value'],
                 decoded_response_with_metadata['properties']['metadata'][metadata_object['key']]
             )
-

--- a/test/units/modules/cloud/google/test_gcp_compute_instance_template.py
+++ b/test/units/modules/cloud/google/test_gcp_compute_instance_template.py
@@ -1,0 +1,122 @@
+import unittest
+import copy
+
+from ansible.modules.cloud.google.gcp_compute_instance_template import encode_request, decode_response
+
+class TestTestGCPComputeInstanceTemplate(unittest.TestCase):
+    """Unit tests for gcp_compute_instance_template module."""
+    request_without_metadata = {
+        u'kind': 'compute#instanceTemplate',
+        u'description': 'instance template description',
+        u'name': 'my-instance-template',
+        u'properties': {
+            u'machineType': 'n1-standard-1'
+        }
+    }
+    request_with_metadata = {
+        u'kind': 'compute#instanceTemplate',
+        u'description': 'instance template description',
+        u'name': 'my-instance-template',
+        u'properties': {
+            u'machineType': 'n1-standard-1', 
+            u'metadata': {
+                'startup-script': '#!/bin/bash\necho hello',
+                'ssh-keys': 'not-an-ssh-key'
+            }
+        }
+    }
+    response_without_metadata = {
+        u'kind': u'compute#instanceTemplate', 
+        u'description': 'instance template description',
+        u'properties': {
+            u'machineType': u'n1-standard-1', 
+            u'metadata': {
+                u'kind': u'compute#metadata', 
+                u'fingerprint': u'ZmluZ2VycHJpbnQK'
+            }
+        }, 
+        u'creationTimestamp': u'2019-05-22T06:58:43.884-07:00', 
+        u'id': u'0000000000000000001', 
+        u'selfLink': u'https://www.googleapis.com/compute/v1/projects/my-fake-gcp-project/global/instanceTemplates/my-instance-template', 
+        u'name': u'my-instance-template'
+    }
+    response_with_metadata = {
+        u'kind': u'compute#instanceTemplate', 
+        u'description': 'instance template description',
+        u'properties': {
+            u'machineType': u'n1-standard-1', 
+            u'metadata': {
+                u'items': [
+                    {
+                        u'value': u'#!/bin/bash\necho hello', 
+                        u'key': u'startup-script'
+                    }
+                ], 
+                u'kind': u'compute#metadata', 
+                u'fingerprint': u'ZmluZ2VycHJpbnQK'
+            }
+        }, 
+        u'creationTimestamp': u'2019-05-22T06:58:43.884-07:00', 
+        u'id': u'0000000000000000001', 
+        u'selfLink': u'https://www.googleapis.com/compute/v1/projects/my-fake-gcp-project/global/instanceTemplates/my-instance-template', 
+        u'name': u'my-instance-template'
+    }
+
+    def test_encode_request(self):
+        encoded_request_without_metadata = encode_request(copy.deepcopy(self.request_without_metadata), None)
+        self.assertEqual(
+            encoded_request_without_metadata,
+            self.request_without_metadata
+        )
+
+        encoded_request_with_metadata = encode_request(copy.deepcopy(self.request_with_metadata), None)
+        self.assertNotEqual(
+            encoded_request_with_metadata,
+            self.request_with_metadata
+        )
+
+        self.assertIn('properties', encoded_request_with_metadata)
+        self.assertIn('metadata', encoded_request_with_metadata['properties'])
+        self.assertIn('items', encoded_request_with_metadata['properties']['metadata'])
+        for metadata_key, metadata_value in self.request_with_metadata['properties']['metadata'].items():
+            self.assertIn(
+                { 'key': metadata_key, 'value': metadata_value },
+                encoded_request_with_metadata['properties']['metadata']['items']
+            )
+
+    def test_decode_request(self):
+        self.maxDiff = None
+
+        # Even if there's no metadata items, decode_response will clear out the other
+        # stuff in the metadata object.
+        response_without_metadata_cleared = copy.deepcopy(self.response_without_metadata)
+        response_without_metadata_cleared['properties']['metadata'].pop('kind')
+        response_without_metadata_cleared['properties']['metadata'].pop('fingerprint')
+        response_with_metadata_cleared = copy.deepcopy(self.response_with_metadata)
+        response_with_metadata_cleared['properties']['metadata'].pop('kind')
+        response_with_metadata_cleared['properties']['metadata'].pop('fingerprint')
+
+        decoded_response_without_metadata = decode_response(copy.deepcopy(self.response_without_metadata), None)
+        self.assertEqual(
+            decoded_response_without_metadata,
+            response_without_metadata_cleared
+        )
+
+        decoded_response_with_metadata = decode_response(copy.deepcopy(self.response_with_metadata), None)
+        self.assertNotEqual(
+            decoded_response_with_metadata,
+            response_with_metadata_cleared
+        )
+
+        self.assertIn('properties', decoded_response_with_metadata)
+        self.assertIn('metadata', decoded_response_with_metadata['properties'])
+        for metadata_object in self.response_with_metadata['properties']['metadata']['items']:
+            self.assertIn(
+                metadata_object['key'], 
+                decoded_response_with_metadata['properties']['metadata']
+            )
+            self.assertEqual(
+                metadata_object['value'],
+                decoded_response_with_metadata['properties']['metadata'][metadata_object['key']]
+            )
+


### PR DESCRIPTION
##### SUMMARY
[The gcp_compute_instance_template documentation](https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_template_module.html) specifies that metadata for instance templates should be included under the `properties` key. However, the metadata encode/decode functions in `gcp_compute_instance_template.py` look for `metadata` on the root of the request/response instead. This PR changes the encode/decode functions to instead look under `properties`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_compute_instance_template

##### ADDITIONAL INFORMATION
The following playbook illustrates the problem:
```
- name: Test playbook
  hosts: localhost
  gather_facts: no
  connection: local
  vars:
    gcp_project: ...
    gcp_cred_kind: serviceaccount
    gcp_cred_file: ...
    region: "us-west1"
    zone: "us-west1-b"

  tasks:
  - name: delete the existing instance template
    gcp_compute_instance_template:
      name: 'my-instance-template'
      project: "{{ gcp_project }}"
      auth_kind: "{{ gcp_cred_kind }}"
      service_account_file: "{{ gcp_cred_file }}"
      state: absent
  - name: create the instance template
    gcp_compute_instance_template:
      name: 'my-instance-template'
      project: "{{ gcp_project }}"
      auth_kind: "{{ gcp_cred_kind }}"
      service_account_file: "{{ gcp_cred_file }}"
      properties:
        disks:
        - auto_delete: yes
          boot: true
          initialize_params:
            source_image: "projects/centos-cloud/global/images/centos-7-v20190213"
        machine_type: n1-standard-1
        metadata:
          startup-script: "#!/bin/bash\necho hello"
        network_interfaces:
        - network:
            selfLink: "global/networks/default"
      state: present
    register: disk
```

Running this playbook with the verbose flag shows the response, which does not have the metadata on it (it only has the `kind` and `fingerprint` keys, which are supposed to be filtered out by `decode_metadata`):
```
$ ansible-playbook -v gwdev-sdpibc.yml
[WARNING]: log file at /var/log/ansible is not writeable and we cannot create it, aborting

Using /etc/ansible/ansible.cfg as config file
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'


PLAY [Test playbook] *******************************************************************************************************

TASK [delete the existing instance template] *******************************************************************************
ok: [localhost] => {"changed": false}

TASK [create the instance template] ****************************************************************************************
changed: [localhost] => {"changed": true, "creationTimestamp": "2019-05-22T07:35:07.950-07:00", "description": "", "id": "4078127546305667316", "kind": "compute#instanceTemplate", "name": "my-instance-template", "properties": {"disks": [{"autoDelete": true, "boot": true, "deviceName": "persistent-disk-0", "index": 0, "initializeParams": {"sourceImage": "projects/centos-cloud/global/images/centos-7-v20190213"}, "kind": "compute#attachedDisk", "mode": "READ_WRITE", "type": "PERSISTENT"}], "machineType": "n1-standard-1", "metadata": {"fingerprint": "4OFH1G7MRBA=", "kind": "compute#metadata"}, "networkInterfaces": [{"kind": "compute#networkInterface", "network": "https://www.googleapis.com/compute/v1/projects/[PROJECT_ID]/global/networks/default"}]}, "selfLink": "https://www.googleapis.com/compute/v1/projects/[PROJECT_ID]/global/instanceTemplates/my-instance-template"}

PLAY RECAP *****************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

Checking the object in the GCP console similarly shows that there is no metadata.

When the playbook is run against this PR's branch, however, the response shows that metadata exists on the instance template:
```
$ ansible-playbook -v gwdev-sdpibc.yml
[WARNING]: log file at /var/log/ansible is not writeable and we cannot create it, aborting

Using /etc/ansible/ansible.cfg as config file
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'


PLAY [Test playbook] *******************************************************************************************************

TASK [delete the existing instance template] *******************************************************************************
changed: [localhost] => {"changed": true}

TASK [create the instance template] ****************************************************************************************
changed: [localhost] => {"changed": true, "creationTimestamp": "2019-05-22T07:38:08.063-07:00", "description": "", "id": "2215106857994346559", "kind": "compute#instanceTemplate", "name": "my-instance-template", "properties": {"disks": [{"autoDelete": true, "boot": true, "deviceName": "persistent-disk-0", "index": 0, "initializeParams": {"sourceImage": "projects/centos-cloud/global/images/centos-7-v20190213"}, "kind": "compute#attachedDisk", "mode": "READ_WRITE", "type": "PERSISTENT"}], "machineType": "n1-standard-1", "metadata": {"startup-script": "#!/bin/bash\necho hello"}, "networkInterfaces": [{"kind": "compute#networkInterface", "network": "https://www.googleapis.com/compute/v1/projects/[PROJECT_ID]/global/networks/default"}]}, "selfLink": "https://www.googleapis.com/compute/v1/projects/[PROJECT_ID]/global/instanceTemplates/my-instance-template"}

PLAY RECAP *****************************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

Checking in the GCP console now shows that there is metadata attached.