### PR TITLE
Improvement on setting VALID_INCLUDE_KEYWORDS on HandlerTaskInclude

### DIFF
--- a/lib/ansible/playbook/handler_task_include.py
+++ b/lib/ansible/playbook/handler_task_include.py
@@ -26,7 +26,7 @@ from ansible.playbook.task_include import TaskInclude
 
 class HandlerTaskInclude(Handler, TaskInclude):
 
-    VALID_INCLUDE_KEYWORDS = frozenset(('listen',) + tuple(TaskInclude.VALID_INCLUDE_KEYWORDS))
+    VALID_INCLUDE_KEYWORDS = TaskInclude.VALID_INCLUDE_KEYWORDS.union(('listen',))
 
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):


### PR DESCRIPTION
##### SUMMARY
Improvement on setting VALID_INCLUDE_KEYWORDS on HandlerTaskInclude
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbooks/handler_task_include.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```