### PR TITLE
Create digital_ocean inventory's cache_path if doesn't exist

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -265,6 +265,9 @@ class DigitalOceanInventory(object):
         self.cache_filename = self.cache_path + "/ansible-digital_ocean.cache"
         self.cache_refreshed = False
 
+        if not os.path.exists(self.cache_path):
+            os.makedirs(os.path.abspath(self.cache_path), 0x1C0)
+
         if self.is_cache_valid():
             self.load_from_cache()
             if len(self.data) == 0:


### PR DESCRIPTION
Allows one to execute the inventory script directly without being in the top-level directory of ansible.cfg and playbooks.

Thereby avoiding this scenario:
```
 ✘  ~/dev/infra/inventory [master ✭|● 2✚ 31… 76]
kevin@example  ➤  ./digital_ocean.py  --list
Traceback (most recent call last):
  File "./digital_ocean.py", line 555, in <module>
    DigitalOceanInventory()
  File "./digital_ocean.py", line 314, in __init__
    self.write_to_cache()
  File "./digital_ocean.py", line 533, in write_to_cache
    with open(self.cache_filename, 'w') as cache:
FileNotFoundError: [Errno 2] No such file or directory: '~/.ansible/tmp/ansible-digital_ocean.cache'
```