### PR TITLE
remove unused and incorrect inventory manager method

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -158,9 +158,6 @@ class InventoryManager(object):
     def hosts(self):
         return self._inventory.hosts
 
-    def get_vars(self, *args, **kwargs):
-        return self._inventory.get_vars(args, kwargs)
-
     def add_host(self, host, group=None, port=None):
         return self._inventory.add_host(host, group, port)
 


### PR DESCRIPTION
The InventoryData class does not have a get_vars method and Inventory Manager's get_vars never appears to have been used.

##### SUMMARY
Trying to use InventoryManager.get_vars() causes an AttributeError since self._inventory has no such method.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/manager.py
