### PR TITLE
Don't change dictionary keys during iteration

### DIFF
--- a/docs/bin/dump_keywords.py
+++ b/docs/bin/dump_keywords.py
@@ -46,7 +46,7 @@ for aclass in class_list:
     oblist[name] = dict((x, aobj.__dict__['_attributes'][x]) for x in aobj.__dict__['_attributes'] if 'private' not in x or not x.private)
 
     # pick up docs if they exist
-    for a in oblist[name]:
+    for a in list(oblist[name]):
         if a in docs:
             oblist[name][a] = docs[a]
         else:

--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -252,13 +252,13 @@ class Interfaces(FactsBase):
         data = self.responses[0]
         interfaces = self.parse_interfaces(data)
 
-        for key in interfaces.keys():
+        for key in list(interfaces.keys()):
             if "ManagementEthernet" in key:
                 temp_parsed = interfaces[key]
                 del interfaces[key]
                 interfaces.update(self.parse_mgmt_interfaces(temp_parsed))
 
-        for key in interfaces.keys():
+        for key in list(interfaces.keys()):
             if "Vlan" in key:
                 temp_parsed = interfaces[key]
                 del interfaces[key]


### PR DESCRIPTION
##### SUMMARY

With Python 3.8.0a4+, we get the following RuntimeError in Fedora:

```
PYTHONPATH=../../lib ../bin/dump_keywords.py --template-dir=../templates --output-dir=rst/reference_appendices/ -d ./keyword_desc.yml
Traceback (most recent call last):
  File "../bin/dump_keywords.py", line 49, in <module>
    for a in oblist[name]:
RuntimeError: dictionary keys changed during iteration
```

Python change: https://github.com/python/cpython/pull/12596

Downstream bug: https://bugzilla.redhat.com/show_bug.cgi?id=1712531

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

docs?
