### PR TITLE
nxos_interface_ospf: Add bfd support

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -55,10 +55,11 @@ options:
     required: true
   bfd:
     description:
-      - Enables bfd at interface level. This overrides the bfd variable set at the ospf router level. Valid values are 'true', 'false' (disable bfd on this interface), or 'default'.
+      - Enables bfd at interface level. This overrides the bfd variable set at the ospf router level.
+      - Valid values are 'true', 'false' (disable bfd on this interface), or 'default'.
       - "Dependency: 'feature bfd'"
     version_added: "2.9"
-    type: bool
+    type: str
   cost:
     description:
       - The cost associated with this cisco_interface_ospf instance.

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -56,8 +56,9 @@ options:
   bfd:
     description:
       - Enables bfd at interface level. This overrides the bfd variable set at the ospf router level.
-      - Valid values are 'true', 'false' (disable bfd on this interface), or 'default'.
+      - Valid values are 'enable', 'disable' or 'default'.
       - "Dependency: 'feature bfd'"
+    default: Not configured
     version_added: "2.9"
     type: str
   cost:
@@ -119,14 +120,14 @@ EXAMPLES = '''
     interface: ethernet1/32
     ospf: 1
     area: 1
-    bfd: false
+    bfd: disable
     cost: default
 
 - nxos_interface_ospf:
     interface: loopback0
     ospf: prod
     area: 0.0.0.0
-    bfd: true
+    bfd: enable
     network: point-to-point
     state: present
 '''
@@ -136,7 +137,7 @@ commands:
     description: commands sent to the device
     returned: always
     type: list
-    sample: ["interface Ethernet1/32", "ip router ospf 1 area 0.0.0.1"]
+    sample: ["interface Ethernet1/32", "ip router ospf 1 area 0.0.0.1", "ip ospf bfd disable"]
 '''
 
 
@@ -211,9 +212,9 @@ def get_value(arg, config, module):
     elif arg == 'bfd':
         m = re.search(r'\s*ip ospf bfd(?P<disable> disable)?', config)
         if m:
-            value = False if m.group('disable') else True
+            value = 'disable' if m.group('disable') else 'enable'
         else:
-            value = None
+            value = 'default'
     elif arg in BOOL_PARAMS:
         value = bool(has_command)
     else:
@@ -329,11 +330,13 @@ def state_present(module, existing, proposed, candidate):
         if key == 'ip ospf network' and value == 'broadcast' and module.params.get('interface').upper().startswith('LO'):
             module.fail_json(msg='loopback interface does not support ospf network type broadcast')
 
-        if key == 'ip ospf bfd' and value is not True:
-            if value is False:
-                commands.append('ip ospf bfd disable')
+        if key == 'ip ospf bfd':
+            cmd = key
+            if 'disable' in value:
+                cmd += ' disable'
             elif 'default' in value and existing.get('bfd') is not None:
-                commands.append('no ip ospf bfd')
+                cmd = 'no ' + cmd
+            commands.append(cmd)
             continue
 
         if value is True:
@@ -365,9 +368,10 @@ def state_absent(module, existing, proposed, candidate):
     existing_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, existing)
 
     for key, value in existing_commands.items():
-        if 'ip ospf bfd' in key and value is not None:
-            # cli is present for both enabled or disabled; this removes either
-            commands.append('no ip ospf bfd')
+        if 'ip ospf bfd' in key:
+            if 'default' not in value:
+                # cli is present when enabled or disabled; this removes either case
+                commands.append('no ip ospf bfd')
             continue
         if 'ip ospf passive-interface' in key and value is not None:
             # cli is present for both enabled or disabled; 'no' will not remove
@@ -418,7 +422,7 @@ def main():
         interface=dict(required=True, type='str'),
         ospf=dict(required=True, type='str'),
         area=dict(required=True, type='str'),
-        bfd=dict(required=False, type='str'),
+        bfd=dict(choices=['enable', 'disable', 'default'], default='default', required=False, type='str'),
         cost=dict(required=False, type='str'),
         hello_interval=dict(required=False, type='str'),
         dead_interval=dict(required=False, type='str'),
@@ -478,9 +482,11 @@ def main():
                 value = False
             elif str(value).lower() == 'default':
                 value = 'default'
+            elif key == 'bfd':
+                value = str(value).lower()
             if existing.get(key) or (not existing.get(key) and value):
                 proposed[key] = value
-            elif re.search(r'bfd|passive_interface', key) and existing.get(key) is None and value is False:
+            elif 'passive_interface' in key and existing.get(key) is None and value is False:
                 proposed[key] = value
 
     proposed['area'] = normalize_area(proposed['area'], module)

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -58,9 +58,9 @@ options:
       - Enables bfd at interface level. This overrides the bfd variable set at the ospf router level.
       - Valid values are 'enable', 'disable' or 'default'.
       - "Dependency: 'feature bfd'"
-    default: Not configured
     version_added: "2.9"
     type: str
+    choices: ['enable', 'disable', 'default']
   cost:
     description:
       - The cost associated with this cisco_interface_ospf instance.
@@ -422,7 +422,7 @@ def main():
         interface=dict(required=True, type='str'),
         ospf=dict(required=True, type='str'),
         area=dict(required=True, type='str'),
-        bfd=dict(choices=['enable', 'disable', 'default'], default='default', required=False, type='str'),
+        bfd=dict(choices=['enable', 'disable', 'default'], required=False, type='str'),
         cost=dict(required=False, type='str'),
         hello_interval=dict(required=False, type='str'),
         dead_interval=dict(required=False, type='str'),

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -5,18 +5,24 @@
 
 - set_fact: testint="{{ nxos_int1 }}"
 
-- name: "Setup - Disable feature OSPF"
-  nxos_feature: &disable
-    feature: ospf
+- name: Setup - Disable features
+  nxos_feature:
+    feature: "{{ item }}"
     provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
+  loop:
+    - ospf
+    - bfd
 
-- name: "Setup - Enable feature OSPF"
-  nxos_feature: &enable
-    feature: ospf
+- name: Setup - Enable features
+  nxos_feature:
+    feature: "{{ item }}"
     provider: "{{ connection }}"
     state: enabled
+  loop:
+    - ospf
+    - bfd
   ignore_errors: yes
 
 - name: "Put interface into default state"
@@ -51,6 +57,7 @@
       interface: "{{ nxos_int1|upper }}"
       ospf: 1
       area: 12345678
+      bfd: True
       cost: 55
       passive_interface: true
       hello_interval: 15
@@ -99,6 +106,7 @@
       interface: "{{ testint }}"
       ospf: 1
       area: 12345678
+      bfd: default
       cost: default
       hello_interval: 10
       dead_interval: default
@@ -266,6 +274,7 @@
       interface: "{{ testint }}"
       ospf: 1
       area: 12345678
+      bfd: False
       cost: 55
       passive_interface: true
       hello_interval: 15
@@ -282,22 +291,26 @@
 
   - assert: *false
 
-  - name: "Disable feature OSPF"
-    nxos_feature: *disable
+  - name: "Interface cleanup"
+    nxos_config: *intdefault
+
+  always:
+  - name: Disable features
+    nxos_feature:
+      feature: "{{ item }}"
+      provider: "{{ connection }}"
+      state: disabled
     ignore_errors: yes
+    loop:
+      - ospf
+      - bfd
 
   - name: "Interface cleanup"
     nxos_config: *intdefault
-
-  rescue:
-  - name: "Disable feature OSPF"
-    nxos_feature: *disable
-
-  - name: "Interface cleanup"
-    nxos_config: *intdefault
+    ignore_errors: yes
 
   - name: "Remove port-channel and loopback ints"
     nxos_config: *removepcandlb
+    ignore_errors: yes
 
-  always:
   - debug: msg="END connection={{ ansible_connection }} nxos_interface_ospf sanity test"

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -52,7 +52,7 @@
       interface: "{{ nxos_int1|upper }}"
       ospf: 1
       area: 12345678
-      bfd: True
+      bfd: enable
       cost: 55
       passive_interface: true
       hello_interval: 15
@@ -269,7 +269,7 @@
       interface: "{{ testint }}"
       ospf: 1
       area: 12345678
-      bfd: False
+      bfd: disable
       cost: 55
       passive_interface: true
       hello_interval: 15
@@ -285,9 +285,6 @@
     register: result
 
   - assert: *false
-
-  - name: "Interface cleanup"
-    nxos_config: *intdefault
 
   always:
   - name: Disable features

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -10,20 +10,15 @@
     feature: "{{ item }}"
     provider: "{{ connection }}"
     state: disabled
+  loop: ['ospf', 'bfd']
   ignore_errors: yes
-  loop:
-    - ospf
-    - bfd
 
 - name: Setup - Enable features
   nxos_feature:
     feature: "{{ item }}"
     provider: "{{ connection }}"
     state: enabled
-  loop:
-    - ospf
-    - bfd
-  ignore_errors: yes
+  loop: ['ospf', 'bfd']
 
 - name: "Put interface into default state"
   nxos_config: &intdefault
@@ -300,10 +295,8 @@
       feature: "{{ item }}"
       provider: "{{ connection }}"
       state: disabled
+    loop: ['ospf', 'bfd']
     ignore_errors: yes
-    loop:
-      - ospf
-      - bfd
 
   - name: "Interface cleanup"
     nxos_config: *intdefault

--- a/test/units/modules/network/nxos/fixtures/nxos_interface_ospf/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_interface_ospf/config.cfg
@@ -1,7 +1,17 @@
 interface Ethernet1/33
+interface Ethernet1/33.101
+  ip router ospf 1 area 0.0.0.1
 interface Ethernet1/34
   ip router ospf 1 area 0.0.0.1
   ip ospf passive-interface
 interface Ethernet1/35
   ip router ospf 1 area 0.0.0.1
   no ip ospf passive-interface
+
+interface Ethernet1/36
+  ip router ospf 1 area 0.0.0.1
+  ip ospf bfd
+
+interface Ethernet1/37
+  ip router ospf 1 area 0.0.0.1
+  ip ospf bfd disable

--- a/test/units/modules/network/nxos/test_nxos_interface_ospf.py
+++ b/test/units/modules/network/nxos/test_nxos_interface_ospf.py
@@ -52,12 +52,12 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
         self.execute_module(changed=True, commands=['interface Ethernet1/32', 'ip router ospf 1 area 0.0.0.1'])
 
     def test_bfd_1(self):
-        # default -> True
-        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, bfd=True))
+        # default -> enable
+        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, bfd='enable'))
         self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1', 'ip ospf bfd'])
 
-        # default -> False (disable)
-        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, bfd=False))
+        # default -> disable
+        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, bfd='disable'))
         self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1', 'ip ospf bfd disable'])
 
     def test_bfd_2(self):
@@ -65,21 +65,21 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
         set_module_args(dict(interface='ethernet1/33.101', ospf=1, area=1, bfd='default'))
         self.execute_module(changed=False)
 
-        # True -> default
+        # enable -> default
         set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd='default'))
         self.execute_module(changed=True, commands=['interface Ethernet1/36', 'no ip ospf bfd'])
 
-        # False (disable) -> default
+        # disable -> default
         set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd='default'))
         self.execute_module(changed=True, commands=['interface Ethernet1/37', 'no ip ospf bfd'])
 
     def test_bfd_3(self):
-        # True -> idempotence
-        set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd=True))
+        # enable -> idempotence
+        set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd='enable'))
         self.execute_module(changed=False)
 
-        # False (disable) -> idempotence
-        set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd=False))
+        # disable -> idempotence
+        set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd='disable'))
         self.execute_module(changed=False)
 
     def test_bfd_4(self):
@@ -87,12 +87,12 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
         set_module_args(dict(interface='ethernet1/33.101', ospf=1, area=1, state='absent'))
         self.execute_module(changed=True, commands=['interface Ethernet1/33.101', 'no ip router ospf 1 area 0.0.0.1'])
 
-        # True -> absent
-        set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd=True, state='absent'))
+        # enable -> absent
+        set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd='enable', state='absent'))
         self.execute_module(changed=True, commands=['interface Ethernet1/36', 'no ip router ospf 1 area 0.0.0.1', 'no ip ospf bfd'])
 
-        # False (disable) -> absent
-        set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd=False, state='absent'))
+        # disable -> absent
+        set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd='disable', state='absent'))
         self.execute_module(changed=True, commands=['interface Ethernet1/37', 'no ip router ospf 1 area 0.0.0.1', 'no ip ospf bfd'])
 
     def test_absent_1(self):

--- a/test/units/modules/network/nxos/test_nxos_interface_ospf.py
+++ b/test/units/modules/network/nxos/test_nxos_interface_ospf.py
@@ -51,6 +51,59 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
         set_module_args(dict(interface='ethernet1/32', ospf=1, area=1))
         self.execute_module(changed=True, commands=['interface Ethernet1/32', 'ip router ospf 1 area 0.0.0.1'])
 
+    def test_bfd_1(self):
+        # default -> True
+        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, bfd=True))
+        self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1', 'ip ospf bfd'])
+
+        # default -> False (disable)
+        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, bfd=False))
+        self.execute_module(changed=True, commands=['interface Ethernet1/33', 'ip router ospf 1 area 0.0.0.1', 'ip ospf bfd disable'])
+
+    def test_bfd_2(self):
+        # default -> default
+        set_module_args(dict(interface='ethernet1/33.101', ospf=1, area=1, bfd='default'))
+        self.execute_module(changed=False)
+
+        # True -> default
+        set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd='default'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/36', 'no ip ospf bfd'])
+
+        # False (disable) -> default
+        set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd='default'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/37', 'no ip ospf bfd'])
+
+    def test_bfd_3(self):
+        # True -> idempotence
+        set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd=True))
+        self.execute_module(changed=False)
+
+        # False (disable) -> idempotence
+        set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd=False))
+        self.execute_module(changed=False)
+
+    def test_bfd_4(self):
+        # None -> absent
+        set_module_args(dict(interface='ethernet1/33.101', ospf=1, area=1, state='absent'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/33.101', 'no ip router ospf 1 area 0.0.0.1'])
+
+        # True -> absent
+        set_module_args(dict(interface='ethernet1/36', ospf=1, area=1, bfd=True, state='absent'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/36', 'no ip router ospf 1 area 0.0.0.1', 'no ip ospf bfd'])
+
+        # False (disable) -> absent
+        set_module_args(dict(interface='ethernet1/37', ospf=1, area=1, bfd=False, state='absent'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/37', 'no ip router ospf 1 area 0.0.0.1', 'no ip ospf bfd'])
+
+    def test_absent_1(self):
+        # area only -> absent
+        set_module_args(dict(interface='ethernet1/33.101', ospf=1, area=1, state='absent'))
+        self.execute_module(changed=True, commands=['interface Ethernet1/33.101', 'no ip router ospf 1 area 0.0.0.1'])
+
+        # None -> absent
+        set_module_args(dict(interface='ethernet1/33', ospf=1, area=1, state='absent'))
+        self.execute_module(changed=False)
+
     def test_loopback_interface_failed(self):
         set_module_args(dict(interface='loopback0', ospf=1, area=0, passive_interface=True))
         self.execute_module(failed=True, changed=False)


### PR DESCRIPTION
##### SUMMARY
*edit: Updated to reflect new tri-stage values*

Add support for `bfd` state in `nxos_interface_ospf`

- `bfd` is a tri-state value because it nvgens a `disable` state:
 - `enable`  = `ip ospf bfd`
 - `disable` = `ip ospf bfd disable`
 - `default` = `None`   

(note: `no ip ospf bfd` removes both forms of the enable/disable states)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`nxos_interface_ospf`

##### ADDITIONAL INFORMATION
Tested on N9K & N6K h/w platforms
