### PR TITLE
openssl_pkcs12: fix crash due to wrong path used for loading key in check mode

### DIFF
--- a/changelogs/fragments/56808-openssl_pkcs12-passphrase-crash.yml
+++ b/changelogs/fragments/56808-openssl_pkcs12-passphrase-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_pkcs12 - fixes crash when private key has a passphrase and the module is run a second time."

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -227,7 +227,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
         def _check_pkey_passphrase():
             if self.privatekey_passphrase:
                 try:
-                    crypto_utils.load_privatekey(self.path,
+                    crypto_utils.load_privatekey(self.privatekey_path,
                                                  self.privatekey_passphrase)
                 except crypto.Error:
                     return False


### PR DESCRIPTION
##### SUMMARY
Fixes #56792.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12
