### PR TITLE
Add type: for options in docs for Redfish modules

### DIFF
--- a/changelogs/fragments/56809-add-options-type-info-for-redfish-modules.yaml
+++ b/changelogs/fragments/56809-add-options-type-info-for-redfish-modules.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "add options type info for Redfish modules (https://github.com/ansible/ansible/issues/54688)"

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
@@ -25,22 +25,27 @@ options:
     required: true
     description:
       - Category to execute on OOB controller
+    type: str
   command:
     required: true
     description:
       - List of commands to execute on OOB controller
+    type: list
   baseuri:
     required: true
     description:
       - Base URI of OOB controller
+    type: str
   username:
     required: true
     description:
       - User for authentication with OOB controller
+    type: str
   password:
     required: true
     description:
       - Password for authentication with OOB controller
+    type: str
   timeout:
     description:
       - Timeout in seconds for URL requests to OOB controller

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -30,28 +30,34 @@ options:
     required: true
     description:
       - List of commands to execute on iDRAC
+    type: list
   baseuri:
     required: true
     description:
       - Base URI of iDRAC
+    type: str
   username:
     required: true
     description:
       - User for authentication with iDRAC
+    type: str
   password:
     required: true
     description:
       - Password for authentication with iDRAC
+    type: str
   manager_attribute_name:
     required: false
     description:
       - name of iDRAC attribute to update
     default: 'null'
+    type: str
   manager_attribute_value:
     required: false
     description:
       - value of iDRAC attribute to update
     default: 'null'
+    type: str
   timeout:
     description:
       - Timeout in seconds for URL requests to iDRAC controller

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_facts.py
@@ -25,22 +25,27 @@ options:
     required: true
     description:
       - Category to execute on iDRAC controller
+    type: str
   command:
     required: true
     description:
       - List of commands to execute on iDRAC controller
+    type: list
   baseuri:
     required: true
     description:
       - Base URI of iDRAC controller
+    type: str
   username:
     required: true
     description:
       - User for authentication with iDRAC controller
+    type: str
   password:
     required: true
     description:
       - Password for authentication with iDRAC controller
+    type: str
   timeout:
     description:
       - Timeout in seconds for URL requests to OOB controller

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -27,47 +27,57 @@ options:
     required: true
     description:
       - Category to execute on OOB controller
+    type: str
   command:
     required: true
     description:
       - List of commands to execute on OOB controller
+    type: list
   baseuri:
     required: true
     description:
       - Base URI of OOB controller
+    type: str
   username:
     required: true
     description:
       - User for authentication with OOB controller
+    type: str
     version_added: "2.8"
   password:
     required: true
     description:
       - Password for authentication with OOB controller
+    type: str
   id:
     required: false
     description:
       - ID of user to add/delete/modify
+    type: str
     version_added: "2.8"
   new_username:
     required: false
     description:
       - name of user to add/delete/modify
+    type: str
     version_added: "2.8"
   new_password:
     required: false
     description:
       - password of user to add/delete/modify
+    type: str
     version_added: "2.8"
   roleid:
     required: false
     description:
       - role of user to add/delete/modify
+    type: str
     version_added: "2.8"
   bootdevice:
     required: false
     description:
       - bootdevice when setting boot configuration
+    type: str
   timeout:
     description:
       - Timeout in seconds for URL requests to OOB controller
@@ -78,11 +88,13 @@ options:
     required: false
     description:
       - UEFI target when bootdevice is "UefiTarget"
+    type: str
     version_added: "2.9"
   boot_next:
     required: false
     description:
       - BootNext target when bootdevice is "UefiBootNext"
+    type: str
     version_added: "2.9"
 
 author: "Jose Delarosa (@jose-delarosa)"

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -26,34 +26,41 @@ options:
     required: true
     description:
       - Category to execute on OOB controller
+    type: str
   command:
     required: true
     description:
       - List of commands to execute on OOB controller
+    type: list
   baseuri:
     required: true
     description:
       - Base URI of OOB controller
+    type: str
   username:
     required: true
     description:
       - User for authentication with OOB controller
+    type: str
     version_added: "2.8"
   password:
     required: true
     description:
       - Password for authentication with OOB controller
+    type: str
   bios_attribute_name:
     required: false
     description:
       - name of BIOS attribute to update
     default: 'null'
+    type: str
     version_added: "2.8"
   bios_attribute_value:
     required: false
     description:
       - value of BIOS attribute to update
     default: 'null'
+    type: str
     version_added: "2.8"
   timeout:
     description:

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -26,23 +26,28 @@ options:
     description:
       - List of categories to execute on OOB controller
     default: ['Systems']
+    type: list
   command:
     required: false
     description:
       - List of commands to execute on OOB controller
+    type: list
   baseuri:
     required: true
     description:
       - Base URI of OOB controller
+    type: str
   username:
     required: true
     description:
       - User for authentication with OOB controller
+    type: str
     version_added: "2.8"
   password:
     required: true
     description:
       - Password for authentication with OOB controller
+    type: str
   timeout:
     description:
       - Timeout in seconds for URL requests to OOB controller


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As described in issue #54688, the DOCUMENTATION section the Redfish modules did not include `type` information for all the options. This PR adds `type:` entries for each option.

Fixes #54688

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts.py
redfish_command.py
redfish_config.py
idrac_redfish_facts.py
idrac_redfish_command.py
idrac_redfish_config.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example DOCUMENTATION string update (snippet):

Before:
```paste below
options:
  category:
    required: false
    description:
      - List of categories to execute on OOB controller
    default: ['Systems']
```

After:
```paste below
options:
  category:
    required: false
    description:
      - List of categories to execute on OOB controller
    default: ['Systems']
    type: list
```
