### PR TITLE
win_get_url: ignore defender false positive in tests

### DIFF
--- a/test/integration/targets/win_get_url/library/win_defender_exclusion.ps1
+++ b/test/integration/targets/win_get_url/library/win_defender_exclusion.ps1
@@ -1,0 +1,40 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+$params = Parse-Args $args -supports_check_mode $true
+
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent", "present"
+
+$result = @{
+    changed = $false
+}
+
+# This is a test module, just skip instead of erroring out if we cannot set the rule
+if ($null -eq (Get-Command -Name Get-MpPreference -ErrorAction SilentlyContinue)) {
+    $result.skipped = $true
+    $result.msg = "Skip as cannot set exclusion rule"
+    Exit-Json -obj $result
+}
+
+$exclusions = (Get-MpPreference).ExclusionPath
+if ($null -eq $exclusions) {
+    $exclusions = @()
+}
+
+if ($state -eq "absent") {
+    if ($path -in $exclusions) {
+        Remove-MpPreference -ExclusionPath $path
+        $result.changed = $true
+    }
+} else {
+    if ($path -notin $exclusions) {
+        Add-MpPreference -ExclusionPath $path
+        $result.changed = $true
+    }
+}
+
+Exit-Json -obj $result

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -13,6 +13,13 @@
     src: files/
     dest: '{{ testing_dir }}'
 
+# False positive in Windows Defender is flagging the file as a virus and removing it. We need to add an exclusion so
+# the tests continue to work
+- name: add exclusion for the SlimFTPd binary
+  win_defender_exclusion:
+    path: '{{ testing_dir }}\SlimFTPd.exe'
+    state: present
+
 - name: download SlimFTPd binary
   win_get_url:
     url: https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_get_url/SlimFTPd.exe
@@ -39,10 +46,6 @@
       state: started
       dependencies:
       - tcpip
-    register: service_setup
-    until: service_setup is successful
-    retries: 5
-    delay: 3
 
   - name: run URL tests
     import_tasks: tests_url.yml
@@ -62,4 +65,9 @@
   - name: remove temp symlink
     win_file:
       path: '{{ slimftpd_link }}'
+      state: absent
+
+  - name: remove exclusion for the SlimFTPd binary
+    win_defender_exclusion:
+      path: '{{ testing_dir }}\SlimFTPd.exe'
       state: absent

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -39,6 +39,10 @@
       state: started
       dependencies:
       - tcpip
+    register: service_setup
+    until: service_setup is successful
+    retries: 5
+    delay: 3
 
   - name: run URL tests
     import_tasks: tests_url.yml

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -17,7 +17,7 @@
 # the tests continue to work
 - name: add exclusion for the SlimFTPd binary
   win_defender_exclusion:
-    path: '{{ testing_dir }}\SlimFTPd.exe'
+    path: '{{ remote_tmp_dir | win_dirname }}'
     state: present
 
 - name: download SlimFTPd binary
@@ -69,5 +69,5 @@
 
   - name: remove exclusion for the SlimFTPd binary
     win_defender_exclusion:
-      path: '{{ testing_dir }}\SlimFTPd.exe'
+      path: '{{ remote_tmp_dir | win_dirname }}'
       state: absent


### PR DESCRIPTION
##### SUMMARY
We are seeing more errors in trying to start this service that is intermittent https://app.shippable.com/github/ansible/ansible/runs/124053/14/tests. ~This adds a retry on this task to try again instead of failing straight away.~

It seems like the binary is being flagged as a false positive virus by Windows. This adds an exclusion for that binary until we get a better solution to replace it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_get_url tests