### PR TITLE
Adding loop_control.notify_scope

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -402,6 +402,45 @@ Variable                    Description
       loop_control:
         extended: yes
 
+Notification scope in the loop
+------------------------------
+.. versionadded:: 2.9
+
+By default, if each loop item triggers different notification target, all targets for all items get triggered even if
+only single item has changed. In the following task, only the first item is marked as changed but both handlers get
+triggered anyway::
+
+    - shell: "{{ item.cmd }}"
+      notify: "{{ item.notify }}"
+      changed_when: ansible_loop.first
+      loop:
+        - cmd: echo ONE
+          notify:
+            - Handler one
+        - cmd: echo TWO
+          notify:
+            - Handler two
+      loop_control:
+        extended: yes
+
+It's possible to change this behaviour by adding the ``notify_scope`` parameter with the value of ``per_loop_item``
+(default value of ``notify_scope`` is ``task``) into the ``loop_control``. The following task will trigger only the
+``Handler one``::
+
+    - shell: "{{ item.cmd }}"
+      notify: "{{ item.notify }}"
+      changed_when: ansible_loop.first
+      loop:
+        - cmd: echo ONE
+          notify:
+            - Handler one
+        - cmd: echo TWO
+          notify:
+            - Handler two
+      loop_control:
+        extended: yes
+        notify_scope: per_loop_item
+
 Accessing the name of your loop_var
 -----------------------------------
 .. versionadded:: 2.8

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -323,7 +323,6 @@ class TaskExecutor:
         items_len = len(items)
         for item_index, item in enumerate(items):
             task_vars['ansible_loop_var'] = loop_var
-            task_vars['notify_scope'] = notify_scope
 
             task_vars[loop_var] = item
             if index_var:
@@ -371,7 +370,7 @@ class TaskExecutor:
             # execute, and swap them back so we can do the next iteration cleanly
             (self._task, tmp_task) = (tmp_task, self._task)
             (self._play_context, tmp_play_context) = (tmp_play_context, self._play_context)
-            res = self._execute(variables=task_vars)
+            res = self._execute(variables=task_vars, notify_scope=notify_scope)
             task_fields = self._task.dump_attrs()
             (self._task, tmp_task) = (tmp_task, self._task)
             (self._play_context, tmp_play_context) = (tmp_play_context, self._play_context)
@@ -500,7 +499,7 @@ class TaskExecutor:
                 self._task.args['name'] = name
         return items
 
-    def _execute(self, variables=None):
+    def _execute(self, variables=None, notify_scope='task'):
         '''
         The primary workhorse of the executor system, this runs the task
         on the specified host (which may be the delegated_to host) and handles
@@ -761,9 +760,8 @@ class TaskExecutor:
         # notification targets only from items which changed if loop_control.notify_scope='per_loop_item'
         if (
                 self._task.notify is not None and (
-                    'notify_scope' not in variables or
-                    variables['notify_scope'] != 'per_loop_item' or (
-                        variables['notify_scope'] == 'per_loop_item' and
+                    notify_scope != 'per_loop_item' or (
+                        notify_scope == 'per_loop_item' and
                         result['changed']))):
             result['_ansible_notify'] = self._task.notify
 

--- a/lib/ansible/playbook/loop_control.py
+++ b/lib/ansible/playbook/loop_control.py
@@ -26,6 +26,7 @@ from ansible.playbook.base import FieldAttributeBase
 class LoopControl(FieldAttributeBase):
 
     _loop_var = FieldAttribute(isa='str', default='item')
+    _notify_scope = FieldAttribute(isa='str', default='task')
     _index_var = FieldAttribute(isa='str')
     _label = FieldAttribute(isa='str')
     _pause = FieldAttribute(isa='float', default=0)

--- a/test/integration/targets/loops/handlers/main.yaml
+++ b/test/integration/targets/loops/handlers/main.yaml
@@ -1,0 +1,13 @@
+---
+
+- name: Handler one
+  debug:
+    msg: Handler one
+  register:
+    handler_one
+
+- name: Handler two
+  debug:
+    msg: Handler two
+  register:
+    handler_two

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -390,3 +390,31 @@
     that:
       - handler_one != None
       - handler_two == None
+
+- name: Set handler variables to known value
+  set_fact:
+    handler_one: null
+    handler_two: null
+
+- name: Test loop_control.notify_scope=wrong_value
+  shell: "{{ item.cmd }}"
+  notify: "{{ item.notify }}"
+  changed_when: ansible_loop.first
+  loop:
+    - cmd: echo ONE
+      notify:
+        - Handler one
+    - cmd: echo TWO
+      notify:
+        - Handler two
+  loop_control:
+    extended: yes
+    notify_scope: wrong_value
+
+- meta: flush_handlers
+
+- name: Test all handlers were run
+  assert:
+    that:
+      - handler_one != None
+      - handler_two != None

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -334,3 +334,59 @@
     - 1
   loop_control:
     loop_var: alvin
+
+
+- name: Set handler variables to known value
+  set_fact:
+    handler_one: null
+    handler_two: null
+
+- name: Test loop_control.notify_scope=task
+  shell: "{{ item.cmd }}"
+  notify: "{{ item.notify }}"
+  changed_when: ansible_loop.first
+  loop:
+    - cmd: echo ONE
+      notify:
+        - Handler one
+    - cmd: echo TWO
+      notify:
+        - Handler two
+  loop_control:
+    extended: yes
+
+- meta: flush_handlers
+
+- name: Test all handlers were run
+  assert:
+    that:
+      - handler_one != None
+      - handler_two != None
+
+- name: Set handler variables to known value
+  set_fact:
+    handler_one: null
+    handler_two: null
+
+- name: Test loop_control.notify_scope=per_loop_item
+  shell: "{{ item.cmd }}"
+  notify: "{{ item.notify }}"
+  changed_when: ansible_loop.first
+  loop:
+    - cmd: echo ONE
+      notify:
+        - Handler one
+    - cmd: echo TWO
+      notify:
+        - Handler two
+  loop_control:
+    extended: yes
+    notify_scope: per_loop_item
+
+- meta: flush_handlers
+
+- name: Test only one handler was run
+  assert:
+    that:
+      - handler_one != None
+      - handler_two == None

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -165,7 +165,7 @@ class TestTaskExecutor(unittest.TestCase):
             final_q=mock_queue,
         )
 
-        def _execute(variables):
+        def _execute(variables, notify_scope='task'):
             return dict(item=variables.get('item'))
 
         te._squash_items = MagicMock(return_value=items)


### PR DESCRIPTION
##### SUMMARY
When using `notify` in a loop, notification targets for all loop items are triggered even if only single loop item has been changed. This PR is adding a `loop_control` toggle which allows to trigger notification targets only for changed items of the loop.

To the attention of @bcoca.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
`loop_control`

##### ADDITIONAL INFORMATION
See more details and examples in the documentation included in the PR.