### PR TITLE
meraki_network - Restructure execution logic

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -212,20 +212,19 @@ class MerakiModule(object):
             self.nets.append(t)
         return self.nets
 
-    # def get_net(self, org_name, net_name, data=None):
-    #     path = self.construct_path('get_all', function='network', org_id=org_id)
-    #     r = self.request(path, method='GET')
-    #     return r
-
-    def get_net(self, org_name, net_name, org_id=None, data=None):
+    def get_net(self, org_name, net_name=None, org_id=None, data=None, net_id=None):
         ''' Return network information '''
         if not data:
             if not org_id:
                 org_id = self.get_org_id(org_name)
             data = self.get_nets(org_id=org_id)
         for n in data:
-            if n['name'] == net_name:
-                return n
+            if net_id:
+                if n['id'] == net_id:
+                    return n
+            elif net_name:
+                if n['name'] == net_name:
+                    return n
         return False
 
     def get_net_id(self, org_name=None, net_name=None, data=None):

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -287,7 +287,6 @@ def main():
     net_exists = False
     if net_id is not None:
         if is_net_valid(nets, net_id=net_id) is False:
-            # meraki.fail_json(msg="nets", net_id=net_id, nets=nets)
             meraki.fail_json(msg="Network specified by net_id does not exist.")
         net_exists = True
     elif meraki.params['net_name']:
@@ -305,6 +304,8 @@ def main():
                                                    )
     elif meraki.params['state'] == 'present':
         if net_exists is False:  # Network needs to be created
+            if 'type' not in meraki.params or meraki.params['type'] is None:
+                meraki.fail_json(msg="type parameter is required when creating a network.")
             path = meraki.construct_path('create',
                                          org_id=org_id
                                          )

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -175,10 +175,16 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 
-def is_net_valid(meraki, net_name, data):
+def is_net_valid(data, net_name=None, net_id=None):
+    if net_name is None and net_id is None:
+        return False
     for n in data:
-        if n['name'] == net_name:
-            return True
+        if net_name:
+            if n['name'] == net_name:
+                return True
+        elif net_id:
+            if n['id'] == net_id:
+                return True
     return False
 
 
@@ -240,7 +246,7 @@ def main():
     if not meraki.params['org_name'] and not meraki.params['org_id']:
         meraki.fail_json(msg='org_name or org_id parameters are required')
     if meraki.params['state'] != 'query':
-        if not meraki.params['net_name'] or meraki.params['net_id']:
+        if not meraki.params['net_name'] and not meraki.params['net_id']:
             meraki.fail_json(msg='net_name or net_id is required for present or absent states')
     if meraki.params['net_name'] and meraki.params['net_id']:
         meraki.fail_json(msg='net_name and net_id are mutually exclusive')
@@ -277,12 +283,17 @@ def main():
     nets = meraki.get_nets(org_id=org_id)
 
     # check if network is created
-    net_id = None
-    if meraki.params['net_name']:
-        if is_net_valid(meraki, meraki.params['net_name'], nets) is True:
+    net_id = meraki.params['net_id']
+    net_exists = False
+    if net_id is not None:
+        if is_net_valid(nets, net_id=net_id) is False:
+            # meraki.fail_json(msg="nets", net_id=net_id, nets=nets)
+            meraki.fail_json(msg="Network specified by net_id does not exist.")
+        net_exists = True
+    elif meraki.params['net_name']:
+        if is_net_valid(nets, net_name=meraki.params['net_name']) is True:
             net_id = meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
-    elif meraki.params['net_id']:
-        net_id = meraki.params['net_id']
+            net_exists = True
 
     if meraki.params['state'] == 'query':
         if not meraki.params['net_name'] and not meraki.params['net_id']:
@@ -293,7 +304,7 @@ def main():
                                                    data=nets
                                                    )
     elif meraki.params['state'] == 'present':
-        if net_id is None:
+        if net_exists is False:  # Network needs to be created
             path = meraki.construct_path('create',
                                          org_id=org_id
                                          )
@@ -304,51 +315,40 @@ def main():
             if meraki.status == 201:
                 meraki.result['data'] = r
                 meraki.result['changed'] = True
-        else:
-            net = meraki.get_net(meraki.params['org_name'], meraki.params['net_name'], data=nets)
-            if meraki.is_update_required(net, payload):
-                path = meraki.construct_path('update',
-                                             net_id=meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
-                                             )
-                r = meraki.request(path,
-                                   method='PUT',
-                                   payload=json.dumps(payload))
-                if meraki.status == 200:
-                    meraki.result['data'] = r
-                    meraki.result['changed'] = True
-            else:  # Update existing network
-                net = meraki.get_net(meraki.params['org_name'], meraki.params['net_name'], data=nets)
-                if meraki.params['enable_vlans'] is not None:
-                    status_path = meraki.construct_path('status_vlans', net_id=meraki.get_net_id(net_name=meraki.params['net_name'], data=nets))
-                    status = meraki.request(status_path, method='GET')
-                    payload = {'enabled': meraki.params['enable_vlans']}
-                    if meraki.is_update_required(status, payload):
-                        path = meraki.construct_path('enable_vlans',
-                                                     net_id=meraki.get_net_id(net_name=meraki.params['net_name'], data=nets))
-                        r = meraki.request(path,
-                                           method='PUT',
-                                           payload=json.dumps(payload))
-                        if meraki.status == 200:
-                            meraki.result['data'] = r
-                            meraki.result['changed'] = True
-                    else:
-                        meraki.result['data'] = status
-                elif meraki.is_update_required(net, payload):
-                    path = meraki.construct_path('update',
-                                                 net_id=meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
-                                                 )
+        else:  # Network exists, make changes
+            # meraki.fail_json(msg="nets", nets=nets, net_id=net_id)
+            # meraki.fail_json(msg="compare", original=net, payload=payload)
+            if meraki.params['enable_vlans'] is not None:  # Modify VLANs configuration
+                status_path = meraki.construct_path('status_vlans', net_id=net_id)
+                status = meraki.request(status_path, method='GET')
+                payload = {'enabled': meraki.params['enable_vlans']}
+                # meraki.fail_json(msg="here", payload=payload)
+                if meraki.is_update_required(status, payload):
+                    path = meraki.construct_path('enable_vlans', net_id=net_id)
                     r = meraki.request(path,
                                        method='PUT',
                                        payload=json.dumps(payload))
                     if meraki.status == 200:
                         meraki.result['data'] = r
                         meraki.result['changed'] = True
+                        meraki.exit_json(**meraki.result)
                 else:
-                    meraki.result['data'] = net
+                    meraki.result['data'] = status
+                    meraki.exit_json(**meraki.result)
+            net = meraki.get_net(meraki.params['org_name'], net_id=net_id, data=nets)
+            if meraki.is_update_required(net, payload):
+                path = meraki.construct_path('update', net_id=net_id)
+                # meraki.fail_json(msg="Payload", path=path, payload=payload)
+                r = meraki.request(path,
+                                   method='PUT',
+                                   payload=json.dumps(payload))
+                if meraki.status == 200:
+                    meraki.result['data'] = r
+                    meraki.result['changed'] = True
+            else:
+                meraki.result['data'] = net
     elif meraki.params['state'] == 'absent':
-        if is_net_valid(meraki, meraki.params['net_name'], nets) is True:
-            net_id = meraki.get_net_id(net_name=meraki.params['net_name'],
-                                       data=nets)
+        if is_net_valid(nets, net_id=net_id) is True:
             path = meraki.construct_path('delete', net_id=net_id)
             r = meraki.request(path, method='DELETE')
             if meraki.status == 204:

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -4,26 +4,26 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
-  - name: Create network without type
-    meraki_network:
-      auth_key: '{{ auth_key }}'
-      state: present
-      org_name: '{{test_org_name}}'
-      net_name: IntTestNetwork
-      timezone: America/Chicago
-    delegate_to: localhost
-    register: create_net_no_type
-    ignore_errors: yes
+  # - name: Create network without type
+  #   meraki_network:
+  #     auth_key: '{{ auth_key }}'
+  #     state: present
+  #     org_name: '{{test_org_name}}'
+  #     net_name: IntTestNetwork
+  #     timezone: America/Chicago
+  #   delegate_to: localhost
+  #   register: create_net_no_type
+  #   ignore_errors: yes
 
-  - name: Create network without organization
-    meraki_network:
-      auth_key: '{{ auth_key }}'
-      state: present
-      net_name: IntTestNetwork
-      timezone: America/Chicago
-    delegate_to: localhost
-    register: create_net_no_org
-    ignore_errors: yes
+  # - name: Create network without organization
+  #   meraki_network:
+  #     auth_key: '{{ auth_key }}'
+  #     state: present
+  #     net_name: IntTestNetwork
+  #     timezone: America/Chicago
+  #   delegate_to: localhost
+  #   register: create_net_no_org
+  #   ignore_errors: yes
 
   - name: Create network with type switch
     meraki_network:
@@ -194,12 +194,15 @@
     delegate_to: localhost
     register: create_net_tags
 
-  - name: Modify network
+  - set_fact:
+      tag_net_id: '{{create_net_tags.data.id}}'
+
+  - name: Modify network by net_id
     meraki_network:
       auth_key: '{{ auth_key }}'
       state: present
       org_name: '{{test_org_name}}'
-      net_name: IntTestNetworkTags
+      net_id: '{{tag_net_id}}'
       type: switch
       timezone: America/Chicago
       tags: 
@@ -231,11 +234,11 @@
   - name: Present assertions
     assert:
       that:
-        - create_net_no_type.status == 500
+        # - create_net_no_type.status == 500
         - create_net_combined.data.type == 'combined'
         - create_net_combined.data.disableMyMerakiCom == True
         - enable_meraki_com.data.disableMyMerakiCom == False
-        - '"org_name or org_id parameters are required" in create_net_no_org.msg'
+        # - '"org_name or org_id parameters are required" in create_net_no_org.msg'
         - '"IntTestNetworkAppliance" in create_net_appliance_no_tz.data.name'
         - create_net_appliance_no_tz.changed == True
         - '"IntTestNetworkSwitch" in create_net_switch.data.name'

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -4,26 +4,34 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
-  # - name: Create network without type
-  #   meraki_network:
-  #     auth_key: '{{ auth_key }}'
-  #     state: present
-  #     org_name: '{{test_org_name}}'
-  #     net_name: IntTestNetwork
-  #     timezone: America/Chicago
-  #   delegate_to: localhost
-  #   register: create_net_no_type
-  #   ignore_errors: yes
+  - name: Create network without type
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetwork
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_no_type
+    ignore_errors: yes
 
-  # - name: Create network without organization
-  #   meraki_network:
-  #     auth_key: '{{ auth_key }}'
-  #     state: present
-  #     net_name: IntTestNetwork
-  #     timezone: America/Chicago
-  #   delegate_to: localhost
-  #   register: create_net_no_org
-  #   ignore_errors: yes
+  - assert:
+      that:
+      - create_net_no_type.msg == 'type parameter is required when creating a network.'
+
+  - name: Create network without organization
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      net_name: IntTestNetwork
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_no_org
+    ignore_errors: yes
+
+  - assert:
+     that:
+     - create_net_no_org.msg == 'org_name or org_id parameters are required'
 
   - name: Create network with type switch
     meraki_network:

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -29,10 +29,6 @@
     register: create_net_no_org
     ignore_errors: yes
 
-  - assert:
-     that:
-     - create_net_no_org.msg == 'org_name or org_id parameters are required'
-
   - name: Create network with type switch
     meraki_network:
       auth_key: '{{ auth_key }}'
@@ -242,11 +238,10 @@
   - name: Present assertions
     assert:
       that:
-        # - create_net_no_type.status == 500
         - create_net_combined.data.type == 'combined'
         - create_net_combined.data.disableMyMerakiCom == True
         - enable_meraki_com.data.disableMyMerakiCom == False
-        # - '"org_name or org_id parameters are required" in create_net_no_org.msg'
+        - '"org_name or org_id parameters are required" in create_net_no_org.msg'
         - '"IntTestNetworkAppliance" in create_net_appliance_no_tz.data.name'
         - create_net_appliance_no_tz.changed == True
         - '"IntTestNetworkSwitch" in create_net_switch.data.name'


### PR DESCRIPTION
##### SUMMARY
`meraki_network` has a bug which causes network updates to fail when `net_id` is used instead of `net_name`. While investigating the bug, it uncovered some problems with the logic of the module. This PR fixes the logic and cleans it up.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_network
