### PR TITLE
a bug fix for elastic pool name

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
@@ -195,6 +195,7 @@ status:
 '''
 
 import time
+import pdb
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
@@ -434,6 +435,7 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
         self.log("Creating / Updating the SQL Database instance {0}".format(self.name))
 
         try:
+            pdb.set_trace()
             response = self.sql_client.databases.create_or_update(resource_group_name=self.resource_group,
                                                                   server_name=self.server_name,
                                                                   database_name=self.name,

--- a/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
@@ -196,7 +196,7 @@ status:
 
 import time
 import pdb
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
 
 try:
     from msrestazure.azure_exceptions import CloudError
@@ -358,6 +358,9 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
         if "location" not in self.parameters:
             self.parameters["location"] = resource_group.location
 
+        if "elastic_pool_id" in self.parameters:
+            self.format_elastic_pool_id()
+
         old_response = self.get_sqldatabase()
 
         if not old_response:
@@ -486,6 +489,14 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
             return response.as_dict()
 
         return False
+
+    def format_elastic_pool_id(self):
+        parrent_id = format_resource_id(val=self.server_name,
+                                        subscription_id=self.subscription_id,
+                                        namespace="Microsoft.Sql",
+                                        types="servers",
+                                        resource_group=self.resource_group)
+        self.parameters['elastic_pool_id'] = parrent_id + "/elasticPools/" + self.parameters['elastic_pool_id']
 
 def _snake_to_camel(snake, capitalize_first=False):
     if capitalize_first:

--- a/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
@@ -339,7 +339,7 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
                 elif key == "max_size_bytes":
                     self.parameters["max_size_bytes"] = kwargs[key]
                 elif key == "elastic_pool_name":
-                    self.parameters["elastic_pool_name"] = kwargs[key]
+                    self.parameters["elastic_pool_id"] = kwargs[key]
                 elif key == "read_scale":
                     self.parameters["read_scale"] = 'Enabled' if kwargs[key] else 'Disabled'
                 elif key == "sample_name":
@@ -486,7 +486,6 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
             return response.as_dict()
 
         return False
-
 
 def _snake_to_camel(snake, capitalize_first=False):
     if capitalize_first:

--- a/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
@@ -496,6 +496,7 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
                                         resource_group=self.resource_group)
         self.parameters['elastic_pool_id'] = parrent_id + "/elasticPools/" + self.parameters['elastic_pool_id']
 
+
 def _snake_to_camel(snake, capitalize_first=False):
     if capitalize_first:
         return ''.join(x.capitalize() or '_' for x in snake.split('_'))

--- a/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
@@ -195,7 +195,6 @@ status:
 '''
 
 import time
-import pdb
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
 
 try:
@@ -438,7 +437,6 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
         self.log("Creating / Updating the SQL Database instance {0}".format(self.name))
 
         try:
-            pdb.set_trace()
             response = self.sql_client.databases.create_or_update(resource_group_name=self.resource_group,
                                                                   server_name=self.server_name,
                                                                   database_name=self.name,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Python SDK changed the parameter `elastic_pool_name` to the `elastic_pool_id` and cause the small bug for this module.
Ref:https://github.com/Azure/azure_preview_modules/issues/268
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_sqldatabase

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
