### PR TITLE
[stable-2.6] win_get_url: ignore defender false positive in tests

### DIFF
--- a/test/integration/targets/win_get_url/library/win_defender_exclusion.ps1
+++ b/test/integration/targets/win_get_url/library/win_defender_exclusion.ps1
@@ -1,0 +1,40 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+$params = Parse-Args $args -supports_check_mode $true
+
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent", "present"
+
+$result = @{
+    changed = $false
+}
+
+# This is a test module, just skip instead of erroring out if we cannot set the rule
+if ($null -eq (Get-Command -Name Get-MpPreference -ErrorAction SilentlyContinue)) {
+    $result.skipped = $true
+    $result.msg = "Skip as cannot set exclusion rule"
+    Exit-Json -obj $result
+}
+
+$exclusions = (Get-MpPreference).ExclusionPath
+if ($null -eq $exclusions) {
+    $exclusions = @()
+}
+
+if ($state -eq "absent") {
+    if ($path -in $exclusions) {
+        Remove-MpPreference -ExclusionPath $path
+        $result.changed = $true
+    }
+} else {
+    if ($path -notin $exclusions) {
+        Add-MpPreference -ExclusionPath $path
+        $result.changed = $true
+    }
+}
+
+Exit-Json -obj $result

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -9,6 +9,13 @@
     src: files/
     dest: '{{test_win_get_url_path}}\'
 
+# False positive in Windows Defender is flagging the file as a virus and removing it. We need to add an exclusion so
+# the tests continue to work
+- name: add exclusion for the SlimFTPd binary
+  win_defender_exclusion:
+    path: '{{ remote_tmp_dir | win_dirname }}'
+    state: present
+
 - name: download SlimFTPd binary
   win_get_url:
     url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_get_url/SlimFTPd.exe
@@ -56,4 +63,9 @@
   - name: remove testing folder
     win_file:
       path: '{{test_win_get_url_path}}'
+      state: absent
+
+  - name: remove exclusion for the SlimFTPd binary
+    win_defender_exclusion:
+      path: '{{ remote_tmp_dir | win_dirname }}'
       state: absent

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -13,7 +13,7 @@
 # the tests continue to work
 - name: add exclusion for the SlimFTPd binary
   win_defender_exclusion:
-    path: '{{ remote_tmp_dir | win_dirname }}'
+    path: '{{ test_win_get_url_path | win_dirname }}'
     state: present
 
 - name: download SlimFTPd binary
@@ -67,5 +67,5 @@
 
   - name: remove exclusion for the SlimFTPd binary
     win_defender_exclusion:
-      path: '{{ remote_tmp_dir | win_dirname }}'
+      path: '{{ test_win_get_url_path | win_dirname }}'
       state: absent


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] win_get_url: ignore defender false positive in tests (#56812)

(cherry picked from commit 124400f319e7dab576b0c1417afbabde5fa44331)

Co-authored-by: Jordan Borean <jborean93@gmail.com>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_get_url integration test
