### PR TITLE
resizefs for extX and XFS filesystems

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -196,7 +196,7 @@ class XFS(Filesystem):
         mount = self.module.get_bin_path('mount', required=True)
         mnt = self.module.params['mountpoint']
         if not os.path.exists(mnt):
-            os.mkdir(mnt, 0755)
+            os.mkdir(mnt, 755)
         self.module.run_command([mount, str(dev), mnt], check_rc=True)
         cmd = self.module.get_bin_path('xfs_growfs', required=True)
         _, size, _ = self.module.run_command([cmd, '-n', str(dev)], check_rc=True, environ_update=self.LANG_ENV)

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -163,7 +163,7 @@ class Ext(Filesystem):
 
     def get_fs_size(self, dev):
         fsck = self.module.get_bin_path('e2fsck', required=True)
-        self.module.run_command([fsck, '-fy', str(dev)], check_rc=True, environ_update=self.LANG_ENV)
+        self.module.run_command([fsck, '-fy', str(dev)], check_rc=False, environ_update=self.LANG_ENV)
         cmd = self.module.get_bin_path('tune2fs', required=True)
         # Get Block count and Block size
         _, size, _ = self.module.run_command([cmd, '-l', str(dev)], check_rc=True, environ_update=self.LANG_ENV)

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -53,6 +53,9 @@ options:
     type: bool
     default: 'no'
     version_added: "2.0"
+  mountpoint:
+    description:
+    - required when wanting to resize an xfs filesystem, which requires to be mounted first.
   opts:
     description:
     - List of options to be passed to mkfs command.
@@ -360,7 +363,7 @@ def main():
             mountpoint=dict(type='str', default=''),
         ),
         required_if=[
-            ['fstype', 'xfs',[ 'mountpoint' ]]
+            ['fstype', 'xfs', ['mountpoint']]
         ],
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -56,6 +56,7 @@ options:
   mountpoint:
     description:
     - required when wanting to resize an xfs filesystem, which requires to be mounted first.
+    version_added: "2.9"
   opts:
     description:
     - List of options to be passed to mkfs command.


### PR DESCRIPTION
##### SUMMARY
While using the filesystem module I noticed that for ext{1,2,3} and XFS filesystems the parameter `resizefs: true` was leading to error.
for extX filesystems the error normally is:
```results: [
  {
    "_ansible_no_log": false,
    "err": "resize2fs 1.42.9 (28-Dec-2013)
Please run 'e2fsck -f /dev/sdc' first.

"
```

while for XFS it is a requirement to have the filesystem mounted to operate changes.
So I am proposing these few lines to address the specific needs of these two filesystem families, by adding a 'mountpoint' parameter mandatory only in case of xfs, plus the fsck command and mount command in the relevant classes.
Hopefully this will enrich the module, for now I take my chance to thank everybody for the good work so far.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
filesystem.py module 
 

