### PR TITLE
Make ansible adhoc work with include_role (#56163)

### DIFF
--- a/changelogs/fragments/ansible-adhoc.yaml
+++ b/changelogs/fragments/ansible-adhoc.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - allow include_role to work with ansible command

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -73,7 +73,7 @@ class AdHocCLI(CLI):
         mytask = {'action': {'module': context.CLIARGS['module_name'], 'args': parse_kv(context.CLIARGS['module_args'], check_raw=check_raw)}}
 
         # avoid adding to tasks that don't support it, unless set, then give user an error
-        if context.CLIARGS['module_name'] not in ('include_role', 'include_tasks') or any(frozenset((async_val, poll))):
+        if context.CLIARGS['module_name'] not in ('include_role', 'include_tasks') and any(frozenset((async_val, poll))):
             mytask['async_val'] = async_val
             mytask['poll'] = poll
 

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -10,6 +10,10 @@ function gen_task_files() {
     done
 }
 
+## Adhoc
+
+ansible -m include_role -a name=role1 localhost
+
 ## Import (static)
 
 # Playbook


### PR DESCRIPTION
##### SUMMARY

* Make ansible adhoc work with include_role

Fix logic condition so that include_role works
without

```
ERROR! 'async_val' is not a valid attribute for a IncludeRole

The error appears to be in 'None': line 0, column 0, but may
be elsewhere in the file depending on the exact syntax problem.

(could not open file to display line)
```

* Add include_role test for adhoc

(cherry picked from commit cd95843ea5f1bff40225b0430cfbb379cbe53661)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cli/ansible

##### ADDITIONAL INFORMATION
Backport of 56163
