### PR TITLE
VMware: add facts about tags in vmware_host_facts

### DIFF
--- a/changelogs/fragments/46461-vmware_host_facts-show_tag.yml
+++ b/changelogs/fragments/46461-vmware_host_facts-show_tag.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_facts now supports tag facts (https://github.com/ansible/ansible/issues/46461).


### PR DESCRIPTION
##### SUMMARY
Fixes: #46461

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/46461-vmware_host_facts-show_tag.yml
lib/ansible/modules/cloud/vmware/vmware_host_facts.py
