### PR TITLE
Don't warn if local user is found in user database

### DIFF
--- a/changelogs/fragments/user-local-warning-fix.yaml
+++ b/changelogs/fragments/user-local-warning-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - do not warn when using ``local: yes`` if user already exists (https://github.com/ansible/ansible/issues/58063)

--- a/changelogs/fragments/user-local-warning-fix.yaml
+++ b/changelogs/fragments/user-local-warning-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - user - do not warn when using ``local: yes`` if user already exists (https://github.com/ansible/ansible/issues/58063)
+  - 'user - do not warn when using ``local: yes`` if user already exists (https://github.com/ansible/ansible/issues/58063)'

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -869,9 +869,10 @@ class User(object):
                         exists = True
                         break
 
-            self.module.warn(
-                "'local: true' specified and user was not found in {file}. "
-                "The local user account may already exist if the local account database exists somewhere other than {file}.".format(file=self.PASSWORDFILE))
+            if not exists:
+                self.module.warn(
+                    "'local: true' specified and user was not found in {file}. "
+                    "The local user account may already exist if the local account database exists somewhere other than {file}.".format(file=self.PASSWORDFILE))
 
             return exists
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -871,8 +871,9 @@ class User(object):
 
             if not exists:
                 self.module.warn(
-                    "'local: true' specified and user was not found in {file}. "
-                    "The local user account may already exist if the local account database exists somewhere other than {file}.".format(file=self.PASSWORDFILE))
+                    "'local: true' specified and user '{name}' was not found in {file}. "
+                    "The local user account may already exist if the local account database exists "
+                    "somewhere other than {file}.".format(file=self.PASSWORDFILE, name=self.name))
 
             return exists
 

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -872,6 +872,18 @@
   tags:
     - user_test_local_mode
 
+- name: Create local account that already exists to check for warning
+  user:
+    name: root
+    local: yes
+  register: local_existing
+
+- name: Ensure no warning was issued
+  assert:
+    msg: A warning was issued and it should not be
+    that:
+      - local_existing.warnings is not defined
+
 - name: Create local_ansibulluser
   user:
     name: local_ansibulluser
@@ -942,6 +954,8 @@
   assert:
     that:
       - local_user_test_1 is changed
+      - local_user_test_1.warnings is defined
+      - local_user_test_1.warnings | first is search('The local user account may already exist')
       - local_user_test_2 is not changed
       - local_user_test_3 is failed
       - "local_user_test_3['msg'] is search('parameters are mutually exclusive: groups|local')"

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -877,12 +877,8 @@
     name: root
     local: yes
   register: local_existing
-
-- name: Ensure no warning was issued
-  assert:
-    msg: A warning was issued and it should not be
-    that:
-      - local_existing.warnings is not defined
+  tags:
+    - user_test_local_mode
 
 - name: Create local_ansibulluser
   user:
@@ -954,8 +950,6 @@
   assert:
     that:
       - local_user_test_1 is changed
-      - local_user_test_1.warnings is defined
-      - local_user_test_1.warnings | first is search('The local user account may already exist')
       - local_user_test_2 is not changed
       - local_user_test_3 is failed
       - "local_user_test_3['msg'] is search('parameters are mutually exclusive: groups|local')"
@@ -966,10 +960,12 @@
   tags:
     - user_test_local_mode
 
-- name: Ensure warnings were displayed
+- name: Ensure warnings were displayed properly
   assert:
     that:
       - local_user_test_1['warnings'] | length > 0
-      - "'user was not found in /etc/passwd. The local user account may already exist if the local account
-        database exists somewhere other than /etc/passwd.' in local_user_test_1['warnings'][0]"
+      - local_user_test_1['warnings'] | first is search('The local user account may already exist')
+      - local_existing['warnings'] is not defined
   when: ansible_facts.system in ['Linux']
+  tags:
+    - user_test_local_mode


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #58063

If the 'local' parameter of the 'user' Ansible module is enabled, andthe user has been found in the local user database, don't emita warning, because this is an expected outcome.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
The user module