### PR TITLE
VMware: add facts about tags in vmware_cluster_facts

### DIFF
--- a/changelogs/fragments/46458-vmware_cluster_facts-show_tag.yml
+++ b/changelogs/fragments/46458-vmware_cluster_facts-show_tag.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_cluster_facts now supports tag facts (https://github.com/ansible/ansible/issues/46458).

--- a/lib/ansible/modules/cloud/vmware/vmware_cluster_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cluster_facts.py
@@ -24,7 +24,7 @@ version_added: '2.6'
 author:
     - Abhijeet Kasurde (@Akasurde)
 notes:
-    - Tested on vSphere 6.5
+    - Tested on vSphere 6.5, 6.7
 requirements:
     - "python >= 2.6"
     - PyVmomi
@@ -42,6 +42,12 @@ options:
      - This parameter is required, if C(datacenter) is not supplied.
      required: False
      type: str
+   show_tag:
+    description:
+    - Tags related to cluster are shown if set to C(True).
+    default: False
+    type: bool
+    version_added: 2.9
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -62,6 +68,16 @@ EXAMPLES = '''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: DC0_C0
+  delegate_to: localhost
+  register: cluster_facts
+
+- name: Gather facts from datacenter about specific cluster with tags
+  vmware_cluster_facts:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    cluster_name: DC0_C0
+    show_tag: True
   delegate_to: localhost
   register: cluster_facts
 '''
@@ -89,7 +105,16 @@ clusters:
             "ha_vm_min_up_time": null,
             "ha_vm_monitoring": null,
             "ha_vm_tools_monitoring": null,
-            "vsan_auto_claim_storage": false
+            "vsan_auto_claim_storage": false,
+            "tags": [
+                {
+                    "category_id": "urn:vmomi:InventoryServiceCategory:9fbf83de-7903-442e-8004-70fd3940297c:GLOBAL",
+                    "category_name": "sample_cluster_cat_0001",
+                    "description": "",
+                    "id": "urn:vmomi:InventoryServiceTag:93d680db-b3a6-4834-85ad-3e9516e8fee8:GLOBAL",
+                    "name": "sample_cluster_tag_0001"
+                }
+            ],
         },
     }
 """
@@ -99,6 +124,11 @@ try:
 except ImportError:
     pass
 
+from ansible.module_utils.vmware_rest_client import VmwareRestClient
+try:
+    from com.vmware.vapi.std_client import DynamicID
+except ImportError:
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, find_datacenter_by_name, find_cluster_by_name
@@ -124,7 +154,7 @@ class VmwreClusterFactsManager(PyVmomi):
 
     def get_all_cluster_objs(self, parent):
         """
-        Function to get all cluster managed objects from given parent object
+        Get all cluster managed objects from given parent object
         Args:
             parent: Managed objected of datacenter or host folder
 
@@ -144,9 +174,36 @@ class VmwreClusterFactsManager(PyVmomi):
                 cluster_objs.append(child)
         return cluster_objs
 
+    def get_tags_for_object(self, dobj):
+        """
+        Return tags associated with an object
+        Args:
+            dobj: Dynamic object
+        Returns: List of tags associated with the given object
+        """
+        vmware_client = VmwareRestClient(self.module)
+
+        cluster_dynamic_obj = DynamicID(type='ClusterComputeResource', id=dobj._moId)
+        self.tag_service = vmware_client.api_client.tagging.Tag
+        self.tag_association_svc = vmware_client.api_client.tagging.TagAssociation
+        self.category_service = vmware_client.api_client.tagging.Category
+
+        tag_ids = self.tag_association_svc.list_attached_tags(cluster_dynamic_obj)
+        tags = []
+        for tag_id in tag_ids:
+            tag_obj = self.tag_service.get(tag_id)
+            tags.append({
+                'id': tag_obj.id,
+                'category_name': self.category_service.get(tag_obj.category_id).name,
+                'name': tag_obj.name,
+                'description': tag_obj.description,
+                'category_id': tag_obj.category_id,
+            })
+        return tags
+
     def gather_cluster_facts(self):
         """
-        Function to gather facts about cluster
+        Gather facts about cluster
 
         """
         results = dict(changed=False, clusters=dict())
@@ -183,6 +240,10 @@ class VmwreClusterFactsManager(PyVmomi):
                 enabled_vsan = vsan_config.enabled,
                 vsan_auto_claim_storage = vsan_config.defaultConfig.autoClaimStorage,
 
+            tag_info = []
+            if self.params.get('show_tag'):
+                tag_info = self.get_tags_for_object(cluster)
+
             results['clusters'][cluster.name] = dict(
                 enable_ha=das_config.enabled,
                 ha_failover_level=ha_failover_level,
@@ -201,6 +262,7 @@ class VmwreClusterFactsManager(PyVmomi):
                 drs_vmotion_rate=drs_config.vmotionRate,
                 enabled_vsan=enabled_vsan,
                 vsan_auto_claim_storage=vsan_auto_claim_storage,
+                tags=tag_info,
             )
 
         self.module.exit_json(**results)
@@ -210,7 +272,8 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         datacenter=dict(type='str'),
-        cluster_name=dict(type='str')
+        cluster_name=dict(type='str'),
+        show_tag=dict(type='bool', default=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/test/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
@@ -21,3 +21,7 @@
       when: setup_dvswitch is defined
     - include_tasks: setup_resource_pool.yml
       when: setup_resource_pool is defined
+    - include_tasks: setup_category.yml
+      when: setup_category is defined
+    - include_tasks: setup_tag.yml
+      when: setup_tag is defined

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_category.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_category.yml
@@ -1,0 +1,9 @@
+- name: Create a category for cluster
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+    category_name: '{{ cluster_category }}'
+    category_description: '{{ cluster_category }} description'
+    state: present

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_tag.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_tag.yml
@@ -1,0 +1,27 @@
+- name: Get Category facts
+  vmware_category_facts:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+  register: cat_info
+
+- name: Get Category id for {{ cluster_category }}
+  set_fact:
+    cluster_category_id: "{{ item.category_id }}"
+  with_items:
+    - "{{ cat_info.tag_category_facts | json_query(query) }}"
+  vars:
+    query: "[?category_name=='{{ cluster_category }}']"
+
+- name: Create a tag for cluster
+  vmware_tag:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+    category_id: '{{ cluster_category_id }}'
+    tag_name: '{{ cluster_tag }}'
+    tag_description: '{{ cluster_tag }} Description'
+    state: present
+  when: cluster_category_id is defined

--- a/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
@@ -29,3 +29,5 @@ virtual_machines_in_cluster:
   - name: DC0_C0_RP0_VM1
     folder: '{{ f0 }}'
     cluster: '{{ ccr1 }}'
+cluster_tag: test_cluster_tag_0001
+cluster_category: test_cluster_cat_0001

--- a/test/integration/targets/vmware_cluster_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster_facts/tasks/main.yml
@@ -28,9 +28,8 @@
 
 - debug: msg=all_cluster_result
 
-# vmware_cluster_facts does not support check mode
-# - <<: *ensure_vc_all_data
-#   name: Ensure facts are gathered for all clusters in check mode
+- <<: *ensure_vc_all_data
+  name: Ensure facts are gathered for all clusters in check mode
 
 - &vc_cluster_data
   name: Gather facts about the given cluster
@@ -53,6 +52,41 @@
   name: Gather facts about the given cluster in check mode
   check_mode: yes
 
-# vmware_cluster_facts does not support check mode
-# - <<: *ensure_vc_cluster_data
-#   name: Ensure facts are gathered for the given cluster in check mode
+- <<: *ensure_vc_cluster_data
+  name: Ensure facts are gathered for the given cluster in check mode
+
+
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_category: true
+      setup_tag: true
+
+  - name: Apply tag to cluster
+    vmware_tag_manager:
+      hostname: "{{ vcenter_server }}"
+      username: "{{ vcenter_user }}"
+      password: "{{ vcenter_pass }}"
+      validate_certs: no
+      tag_names:
+        - '{{ cluster_category }}:{{ cluster_tag }}'
+      state: present
+      object_name: '{{ cluster_name }}'
+      object_type: ClusterComputeResource
+
+  - name: Get facts about cluster
+    vmware_cluster_facts:
+      hostname: "{{ vcenter_server }}"
+      username: "{{ vcenter_user }}"
+      password: "{{ vcenter_pass }}"
+      validate_certs: no
+      show_tag: True
+      cluster_name: "{{ cluster_name }}"
+    register: cluster_info
+
+  - assert:
+      that:
+        - cluster_info is defined
+        - cluster_info.clusters[cluster_name].tags is defined


### PR DESCRIPTION
##### SUMMARY
Fixes: #46458

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/46458-vmware_cluster_facts-show_tag.yml
lib/ansible/modules/cloud/vmware/vmware_cluster_facts.py
test/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
test/integration/targets/prepare_vmware_tests/tasks/setup_category.yml
test/integration/targets/prepare_vmware_tests/tasks/setup_tag.yml
test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
test/integration/targets/vmware_cluster_facts/tasks/main.yml
