### PR TITLE
Prevent vars premature templating (#56117)

### DIFF
--- a/changelogs/fragments/vars_prematurely_template.yaml
+++ b/changelogs/fragments/vars_prematurely_template.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - we don't really need to template vars on definition as we do this on demand in templating.

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -353,7 +353,9 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
 
             if attribute.static:
                 value = getattr(self, name)
-                if templar.is_template(value):
+
+                # we don't template 'vars' but allow template as values for later use
+                if name not in ('vars',) and templar.is_template(value):
                     display.warning('"%s" is not templatable, but we found: %s, '
                                     'it will not be templated and will be used "as is".' % (name, value))
                 continue
@@ -597,7 +599,7 @@ class Base(FieldAttributeBase):
     _remote_user = FieldAttribute(isa='string', default=context.cliargs_deferred_get('remote_user'))
 
     # variables
-    _vars = FieldAttribute(isa='dict', priority=100, inherit=False)
+    _vars = FieldAttribute(isa='dict', priority=100, inherit=False, static=True)
 
     # module default params
     _module_defaults = FieldAttribute(isa='list', extend=True, prepend=True)

--- a/test/integration/targets/var_templating/aliases
+++ b/test/integration/targets/var_templating/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/var_templating/runme.sh
+++ b/test/integration/targets/var_templating/runme.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# this should succeed since we override the undefined variable
+ansible-playbook undefined.yml -i inventory -v "$@" -e '{"mytest": False}'
+
+# this should still work, just show that var is undefined in debug
+ansible-playbook undefined.yml -i inventory -v "$@"
+
+# this should work since we dont use the variable
+ansible-playbook undall.yml -i inventory -v "$@"

--- a/test/integration/targets/var_templating/undall.yml
+++ b/test/integration/targets/var_templating/undall.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+      vars:
+        mytest: '{{ und }}'

--- a/test/integration/targets/var_templating/undefined.yml
+++ b/test/integration/targets/var_templating/undefined.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: show defined/undefined var
+      debug: var=mytest
+      vars:
+        mytest: '{{ und }}'
+      register: var_undefined
+
+    - name: ensure either mytest is defined or debug finds it to be undefined
+      assert:
+        that:
+          - mytest is defined or 'VARIABLE IS NOT DEFINED!' in var_undefined['mytest']


### PR DESCRIPTION
Avoid premature vars templating
  * added tests
  * avoid 'is template' warning in vars, since we want them for latter templating

(cherry picked from commit 1da47bfa8c6711e19902e4a1460d3276d33664e1)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
playbook