### PR TITLE
[stable-2.7] Ensure uri module always returns status even on failure (#56240)

### DIFF
--- a/changelogs/fragments/55897-uri-correct-return-values.yaml
+++ b/changelogs/fragments/55897-uri-correct-return-values.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - uri - always return a value for status even during failure (https://github.com/ansible/ansible/issues/55897)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1249,7 +1249,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     cookies = cookiejar.LWPCookieJar()
 
     r = None
-    info = dict(url=url)
+    info = dict(url=url, status=-1)
     try:
         r = open_url(url, data=data, headers=headers, method=method,
                      use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
@@ -1290,11 +1290,11 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except NoSSLError as e:
         distribution = get_distribution()
         if distribution is not None and distribution.lower() == 'redhat':
-            module.fail_json(msg='%s. You can also install python-ssl from EPEL' % to_native(e))
+            module.fail_json(msg='%s. You can also install python-ssl from EPEL' % to_native(e), **info)
         else:
-            module.fail_json(msg='%s' % to_native(e))
+            module.fail_json(msg='%s' % to_native(e), **info)
     except (ConnectionError, ValueError) as e:
-        module.fail_json(msg=to_native(e))
+        module.fail_json(msg=to_native(e), **info)
     except urllib_error.HTTPError as e:
         try:
             body = e.read()

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -241,7 +241,7 @@ msg:
   sample: OK (unknown bytes)
 redirected:
   description: Whether the request was redirected
-  returned: always
+  returned: on success
   type: bool
   sample: false
 status:

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -102,9 +102,12 @@
 - name: Assert that the file was not downloaded
   assert:
     that:
-      - "result.failed == true"
+      - result.failed == true
       - "'Failed to validate the SSL certificate' in result.msg or ( result.msg is match('hostname .* doesn.t match .*'))"
-      - "stat_result.stat.exists == false"
+      - stat_result.stat.exists == false
+      - result.status is defined
+      - result.status == -1
+      - result.url == 'https://' ~ badssl_host ~ '/'
 
 - name: Clean up any cruft from the results directory
   file:

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -157,6 +157,8 @@ def test_fetch_url_nossl(open_url_mock, fake_ansible_module, mocker):
         fetch_url(fake_ansible_module, 'http://ansible.com/')
 
     assert 'python-ssl' in excinfo.value.kwargs['msg']
+    assert'http://ansible.com/' == excinfo.value.kwargs['url']
+    assert excinfo.value.kwargs['status'] == -1
 
 
 def test_fetch_url_connectionerror(open_url_mock, fake_ansible_module):
@@ -165,12 +167,16 @@ def test_fetch_url_connectionerror(open_url_mock, fake_ansible_module):
         fetch_url(fake_ansible_module, 'http://ansible.com/')
 
     assert excinfo.value.kwargs['msg'] == 'TESTS'
+    assert'http://ansible.com/' == excinfo.value.kwargs['url']
+    assert excinfo.value.kwargs['status'] == -1
 
     open_url_mock.side_effect = ValueError('TESTS')
     with pytest.raises(FailJson) as excinfo:
         fetch_url(fake_ansible_module, 'http://ansible.com/')
 
     assert excinfo.value.kwargs['msg'] == 'TESTS'
+    assert'http://ansible.com/' == excinfo.value.kwargs['url']
+    assert excinfo.value.kwargs['status'] == -1
 
 
 def test_fetch_url_httperror(open_url_mock, fake_ansible_module):


### PR DESCRIPTION
##### SUMMARY
Backport of #56240 for Ansible 2.7

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/module_utils/urls.py`