### PR TITLE
slack: fix thread_id type

### DIFF
--- a/lib/ansible/modules/notification/slack.py
+++ b/lib/ansible/modules/notification/slack.py
@@ -58,7 +58,7 @@ options:
   thread_id:
     version_added: 2.8
     description:
-      - Optional. Timestamp of message to thread this message to as a float. https://api.slack.com/docs/message-threading
+      - Optional. Timestamp-style identifier of message to thread this message to. https://api.slack.com/docs/message-threading
   username:
     description:
       - This is the sender of the message.
@@ -114,7 +114,7 @@ EXAMPLES = """
     token: thetoken/generatedby/slack
     msg: '{{ inventory_hostname }} completed'
     channel: '#ansible'
-    thread_id: 1539917263.000100
+    thread_id: '1539917263.000100'
     username: 'Ansible on {{ inventory_hostname }}'
     icon_url: http://www.example.com/some-image-file.png
     link_names: 0
@@ -270,7 +270,7 @@ def main():
             token=dict(type='str', required=True, no_log=True),
             msg=dict(type='str', required=False, default=None),
             channel=dict(type='str', default=None),
-            thread_id=dict(type='float', default=None),
+            thread_id=dict(type='str', default=None),
             username=dict(type='str', default='Ansible'),
             icon_url=dict(type='str', default='https://www.ansible.com/favicon.ico'),
             icon_emoji=dict(type='str', default=None),

--- a/test/units/modules/notification/test_slack.py
+++ b/test/units/modules/notification/test_slack.py
@@ -68,7 +68,7 @@ class TestSlackModule(ModuleTestCase):
         set_module_args({
             'token': 'XXXX/YYYY/ZZZZ',
             'msg': 'test',
-            'thread_id': 100.00
+            'thread_id': '100.00'
         })
 
         with patch.object(slack, "fetch_url") as fetch_url_mock:
@@ -80,7 +80,7 @@ class TestSlackModule(ModuleTestCase):
             call_data = json.loads(fetch_url_mock.call_args[1]['data'])
             assert call_data['username'] == "Ansible"
             assert call_data['text'] == "test"
-            assert call_data['thread_ts'] == 100.00
+            assert call_data['thread_ts'] == "100.00"
             assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
 
     def test_message_with_invalid_color(self):


### PR DESCRIPTION
##### SUMMARY
Changed type of `thread_id` from `float` to `str`.  This fixes an issue where `thread_id` ends in any `0`s

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
slack

##### ADDITIONAL INFORMATION
The field merely _looks like_ UNIX/epoch timestamps per https://api.slack.com/docs/message-threading#finding_message_threads_in_the_wild
