### PR TITLE
Add MACAddress property to GetNicInventory

### DIFF
--- a/changelogs/fragments/56864-add-macaddress-to-get-nic-inventory.yaml
+++ b/changelogs/fragments/56864-add-macaddress-to-get-nic-inventory.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_facts - add MACAddress to properties fetched by Redfish GetNicInventory command

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -1364,8 +1364,8 @@ class RedfishUtils(object):
         key = "EthernetInterfaces"
         # Get these entries, but does not fail if not found
         properties = ['Description', 'FQDN', 'IPv4Addresses', 'IPv6Addresses',
-                      'NameServers', 'PermanentMACAddress', 'SpeedMbps', 'MTUSize',
-                      'AutoNeg', 'Status']
+                      'NameServers', 'MACAddress', 'PermanentMACAddress',
+                      'SpeedMbps', 'MTUSize', 'AutoNeg', 'Status']
 
         response = self.get_request(self.root_uri + resource_uri)
         if response['ret'] is False:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The GetNicInventory command fetches several key properties from the `EthernetInterface` resources. But it does not fetch the `MACAddress` property. This PR adds `MACAddress` to the list of properties to retrieve.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts.py
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Run a playbook that issues the GetNicInventory command. For example:

```
---
- hosts: myhosts
  connection: local
  name: NIC Inventory
  gather_facts: False

  vars:
    datatype: NicInventory

  tasks:

  - name: Define output file
    include_tasks: create_output_file.yml

  - name: Get NIC Information
    redfish_facts:
      category: Systems
      command: GetNicInventory
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
    register: result

  - name: Copy results to output file
    copy:
      content: "{{ result | to_nice_json }}"
      dest: "{{ template }}.json"
``` 
<!--- Paste verbatim command output below, e.g. before and after your change -->

**Before** the change, a snippet of the inventory looks like this:
```
{
    "ansible_facts": {
        "redfish_facts": {
            "nic": {
                "entries": [
                    [
                        {
                            "resource_uri": "/redfish/v1/Systems/437XR1138R2"
                        },
                        [
                            {
                                "Description": "System NIC 1",
                                "FQDN": "web483.contoso.com",
                                "IPv4Addresses": [
                                    {
                                        "Address": "192.168.0.10",
                                        "AddressOrigin": "Static",
                                        "Gateway": "192.168.0.1",
                                        "SubnetMask": "255.255.252.0"
                                    }
                                ],
                                "IPv6Addresses": [
                                    {
                                        "Address": "fe80::1ec1:deff:fe6f:1e24",
                                        "AddressOrigin": "Static",
                                        "AddressState": "Preferred",
                                        "PrefixLength": 64
                                    }
                                ],
                                "NameServers": [
                                    "names.contoso.com"
                                ],  
                                "PermanentMACAddress": "12:44:6A:3B:04:11",
                                "SpeedMbps": 1000,
                                "Status": {
                                    "Health": "OK",
                                    "State": "Enabled"
                                }   
                            },  
                            ...
```

**After** the change, a snippet of the inventory looks like this (note the added "MACAddress" property about two-thirds of the way down):
```
{
    "ansible_facts": {
        "redfish_facts": {
            "nic": {
                "entries": [
                    [
                        {
                            "resource_uri": "/redfish/v1/Systems/437XR1138R2"
                        },
                        [
                            {
                                "Description": "System NIC 1",
                                "FQDN": "web483.contoso.com",
                                "IPv4Addresses": [
                                    {
                                        "Address": "192.168.0.10",
                                        "AddressOrigin": "Static",
                                        "Gateway": "192.168.0.1",
                                        "SubnetMask": "255.255.252.0"
                                    }
                                ],
                                "IPv6Addresses": [
                                    {
                                        "Address": "fe80::1ec1:deff:fe6f:1e24",
                                        "AddressOrigin": "Static",
                                        "AddressState": "Preferred",
                                        "PrefixLength": 64
                                    }
                                ],
                                "MACAddress": "12:44:6A:3B:04:11",
                                "NameServers": [
                                    "names.contoso.com"
                                ],
                                "PermanentMACAddress": "12:44:6A:3B:04:11",
                                "SpeedMbps": 1000,
                                "Status": {
                                    "Health": "OK",
                                    "State": "Enabled"
                                }
                            },
                            ...
```

