### PR TITLE
Fix preset rs template

### DIFF
--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_preset.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_preset.py
@@ -129,8 +129,11 @@ class KubeVirtVMPreset(KubeVirtRawModule):
         # attributes there, remove when we do:
         definition['spec']['domain']['devices'] = dict()
 
+        # defaults for template
+        defaults = {'disks': [], 'volumes': [], 'interfaces': [], 'networks': []}
+
         # Execute the CURD of VM:
-        dummy, definition = self.construct_vm_definition(KIND, definition, definition)
+        dummy, definition = self.construct_vm_definition(KIND, definition, definition, defaults)
         result_crud = self.execute_crud(KIND, definition)
         changed = result_crud['changed']
         result = result_crud.pop('result')

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_rs.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_rs.py
@@ -173,9 +173,12 @@ class KubeVirtVMIRS(KubeVirtRawModule):
         if replicas is not None:
             definition['spec']['replicas'] = replicas
 
+        # defaults for template
+        defaults = {'disks': [], 'volumes': [], 'interfaces': [], 'networks': []}
+
         # Execute the CURD of VM:
         template = definition['spec']['template']
-        dummy, definition = self.construct_vm_definition(KIND, definition, template)
+        dummy, definition = self.construct_vm_definition(KIND, definition, template, defaults)
         result_crud = self.execute_crud(KIND, definition)
         changed = result_crud['changed']
         result = result_crud.pop('result')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Introducing template support in kubevirt.py module introduced regressinon in kubevirt_rs and kubevirt_preset modules, this PR is fixing it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kubevirt_rs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
