### PR TITLE
[backport] Copyright fix for 2018 (#56860)

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/footer.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/footer.html
@@ -23,6 +23,6 @@
 
   <p>
   {%- if last_updated %}{% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}<br/>{% endif %}
-  Copyright © 2018 Red Hat, Inc. <br/>
+  Copyright © 2019 Red Hat, Inc. <br/>
   </p>
 </footer>

--- a/docs/templates/cli_rst.j2
+++ b/docs/templates/cli_rst.j2
@@ -128,12 +128,9 @@ See the `AUTHORS` file for a complete list of contributors.
 Copyright
 =========
 
-Copyright © 2017 Red Hat, Inc | Ansible.
-
 Ansible is released under the terms of the GPLv3 License.
 
 See also
 ========
 
 {% for other in cli_bin_name_list|sort %}:manpage:`{{other}}(1)`,  {% endfor %}
-


### PR DESCRIPTION
* update copyright in footer

* remove extraneous copyright from cli commands

(cherry picked from commit f9b43a0f6843bc8651c914b0b5619ac4f62fa241)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
