### PR TITLE
CLI docs include license not copyright (#56871)

### DIFF
--- a/docs/templates/cli_rst.j2
+++ b/docs/templates/cli_rst.j2
@@ -125,10 +125,10 @@ Ansible was originally written by Michael DeHaan.
 See the `AUTHORS` file for a complete list of contributors.
 
 
-Copyright
-=========
+License
+=======
 
-Ansible is released under the terms of the GPLv3 License.
+Ansible is released under the terms of the GPLv3+ License.
 
 See also
 ========


### PR DESCRIPTION
(cherry picked from commit fc94d79c47a2f47f52f8cc8a20d8c94fd2238619)

##### SUMMARY
Backports #56871. Follows up on #56860 and #56869.

Now that we have consolidated the copyright notice into the footer for all pages on the docsite, this header should not refer to Copyright.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
