### PR TITLE
Fortinet: fmgr_fwpol_package bug fixes

### DIFF
--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -69,7 +69,11 @@ options:
       - Delete Targets will only delete the specified scope members from installation targets.
       - Install will install the package to the assigned installation targets listed on existing package.
       - Update your installation targets BEFORE running install task.
+<<<<<<< HEAD
     choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
+=======
+    choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
+>>>>>>> Fixed issues:
     default: add
 
   name:
@@ -82,6 +86,16 @@ options:
       - Are we managing packages or package folders?
     required: True
     choices: ['pkg','folder']
+<<<<<<< HEAD
+=======
+
+  package_folder:
+    description:
+      - Name of the folder you want to put the package into.
+      - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
+      - Do not include leading or trailing forwardslashes. We take care of that for you.
+    required: false
+>>>>>>> Fixed issues:
 
   central_nat:
     description:
@@ -124,6 +138,7 @@ options:
     required: false
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
   append_scope_members:
     description:
@@ -134,6 +149,8 @@ options:
     default: 'enable'
 
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+>>>>>>> Fixed issues:
   scope_groups:
     description:
       - List of groups to add to the scope of the fw pol package
@@ -293,6 +310,9 @@ def fmgr_fwpol_package(fmgr, paramgram):
     if paramgram["mode"] in ['set', 'add']:
         url = '/pm/pkg/adom/{adom}'.format(adom=paramgram["adom"])
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Fixed issues:
         datagram = {
             "type": paramgram["object_type"],
             "name": paramgram["name"],
@@ -302,6 +322,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
                 "inspection-mode": paramgram["inspection-mode"],
                 "ngfw-mode": paramgram["ngfw-mode"],
+<<<<<<< HEAD
 =======
 
         # IF PARENT FOLDER IS NOT DEFINED
@@ -318,6 +339,8 @@ def fmgr_fwpol_package(fmgr, paramgram):
                     "ngfw-mode": paramgram["ngfw-mode"],
                 }
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+>>>>>>> Fixed issues:
             }
         }
 
@@ -328,6 +351,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
         if len(paramgram["append_members_list"]) > 0:
             datagram["scope member"] = paramgram["append_members_list"]
         elif len(paramgram["append_members_list"]) == 0:
+<<<<<<< HEAD
             datagram["scope member"] = {}
 
         # IF PARENT FOLDER IS DEFINED
@@ -380,6 +404,13 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 }]
             }
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+            datagram["scope member"] = None
+
+        # IF PARENT FOLDER IS DEFINED
+        if paramgram["parent_folder"] is not None:
+            datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
+>>>>>>> Fixed issues:
 
     # NORMAL DELETE NO PARENT
     if paramgram["mode"] == "delete" and paramgram["parent_folder"] is None:
@@ -403,6 +434,49 @@ def fmgr_fwpol_package(fmgr, paramgram):
         response = fmgr.process_request(url, datagram, FMGRMethods.EXEC)
     else:
         response = fmgr.process_request(url, datagram, paramgram["mode"])
+    return response
+
+
+def fmgr_fwpol_package_edit_targets(fmgr, paramgram):
+    """
+    This function will append scope targets to an existing policy package.
+
+    :param fmgr: The fmgr object instance from fmgr_utils.py
+    :type fmgr: class object
+    :param paramgram: The formatted dictionary of options to process
+    :type paramgram: dict
+
+    :return: The response from the FortiManager
+    :rtype: dict
+    """
+    # MERGE APPEND AND EXISTING MEMBERS LISTS BASED ON MODE
+    method = None
+    members_list = None
+    if paramgram["mode"] == "add_targets":
+        method = FMGRMethods.ADD
+        members_list = paramgram["append_members_list"]
+        for member in paramgram["existing_members_list"]:
+            if member not in members_list:
+                members_list.append(member)
+
+    elif paramgram["mode"] == "delete_targets":
+        method = FMGRMethods.DELETE
+        members_list = list()
+        for member in paramgram["append_members_list"]:
+            if member in paramgram["existing_members_list"]:
+                members_list.append(member)
+    datagram = {
+        "data": members_list
+    }
+
+    if paramgram["parent_folder"] is not None:
+        url = '/pm/pkg/adom/{adom}/{parent_folder}/{name}/scope member'.format(adom=paramgram["adom"],
+                                                                               name=paramgram["name"],
+                                                                               parent_folder=paramgram["parent_folder"])
+    elif paramgram["parent_folder"] is None:
+        url = '/pm/pkg/adom/{adom}/{name}/scope member'.format(adom=paramgram["adom"],
+                                                               name=paramgram["name"])
+    response = fmgr.process_request(url, datagram, method)
     return response
 
 
@@ -513,9 +587,12 @@ def fmgr_fwpol_package_install(fmgr, paramgram):
         "adom": paramgram["adom"],
         "pkg": paramgram["name"],
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         "scope": paramgram["assign_to_list"]
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+>>>>>>> Fixed issues:
     }
     if paramgram["parent_folder"]:
         new_path = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
@@ -643,11 +720,19 @@ def fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram):
 def main():
     argument_spec = dict(
         adom=dict(required=False, type="str", default="root"),
+<<<<<<< HEAD
         mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
+=======
+        mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
+>>>>>>> Fixed issues:
                   type="str", default="add"),
 
         name=dict(required=False, type="str"),
         object_type=dict(required=True, type="str", choices=['pkg', 'folder']),
+<<<<<<< HEAD
+=======
+        package_folder=dict(required=False, type="str"),
+>>>>>>> Fixed issues:
         central_nat=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy6_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
@@ -657,7 +742,6 @@ def main():
         scope_groups=dict(required=False, type="str"),
         scope_members=dict(required=False, type="str"),
         scope_members_vdom=dict(required=False, type="str", default="root"),
-        append_scope_members=dict(required=False, type="str", default="enable", choices=['enable', 'disable']),
         parent_folder=dict(required=False, type="str"),
         target_folder=dict(required=False, type="str"),
         target_name=dict(required=False, type="str"),
@@ -679,8 +763,8 @@ def main():
         "scope_groups": module.params["scope_groups"],
         "scope_members": module.params["scope_members"],
         "scope_members_vdom": module.params["scope_members_vdom"],
-        "append_scope_members": module.params["append_scope_members"],
         "parent_folder": module.params["parent_folder"],
+<<<<<<< HEAD
 <<<<<<< HEAD
         "target_folder": module.params["target_folder"],
         "target_name": module.params["target_name"],
@@ -690,6 +774,11 @@ def main():
 =======
         "assign_to_list": list()
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+        "append_members_list": list(),
+        "existing_members_list": list(),
+        "package_exists": None,
+>>>>>>> Fixed issues:
     }
     module.paramgram = paramgram
     fmgr = None
@@ -703,6 +792,7 @@ def main():
     # BEGIN MODULE-SPECIFIC LOGIC -- THINGS NEED TO HAPPEN DEPENDING ON THE ENDPOINT AND OPERATION
     results = DEFAULT_RESULT_OBJ
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
     paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
@@ -732,36 +822,33 @@ def main():
                 "name": member
             }
             members_list.append(scope_dict)
+=======
+    # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
+    paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
+>>>>>>> Fixed issues:
 
-    # CHECK FOR EXISTING SCOPE MEMBERS IF THAT OPTION IS ENABLED
     try:
-        if paramgram["append_scope_members"] == "enable":
-            pol_datagram = {"type": paramgram["object_type"], "name": paramgram["name"]}
-            pol_package_url = '/pm/pkg/adom/{adom}/{pkg_name}'.format(adom=paramgram["adom"],
-                                                                      pkg_name=paramgram["name"])
-            pol_package = fmgr.process_request(pol_package_url, pol_datagram, FMGRMethods.GET)
-
-            if len(pol_package) > 2:
-                raise FMGBaseException("Policy Package Name returned multiple results.")
-            if len(pol_package) == 1:
-                raise FMGBaseException("Policy Package couldn't be found, to append existing scope members")
-            if len(pol_package) == 2:
-                try:
-                    existing_members = pol_package[1]["scope member"]
-                    for member in existing_members:
-                        if member not in members_list:
-                            members_list.append(member)
-                except Exception as err:
-                    pass
+        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete"]:
+            results = fmgr_fwpol_package(fmgr, paramgram)
+            fmgr.govern_response(module=module, results=results,
+                                 ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))
     except Exception as err:
         raise FMGBaseException(err)
 
+<<<<<<< HEAD
     paramgram["assign_to_list"] = members_list
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 
     try:
         if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:
             results = fmgr_fwpol_package(fmgr, paramgram)
+=======
+    try:
+        if paramgram["object_type"] == "pkg" and paramgram["package_exists"] \
+                and len(paramgram["append_members_list"]) > 0 \
+                and paramgram["mode"] in ['add_targets', 'delete_targets']:
+            results = fmgr_fwpol_package_edit_targets(fmgr, paramgram)
+>>>>>>> Fixed issues:
             fmgr.govern_response(module=module, results=results,
                                  ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))
     except Exception as err:

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -251,6 +251,7 @@ options:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
 <<<<<<< HEAD
@@ -270,6 +271,9 @@ options:
 =======
       - Do not include leading or trailing forwardslashes. We take care of that for you.
 >>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
+=======
+      - Do not include leading or trailing forwardslashes.
+>>>>>>> Shippable cancelled for unknown reason. Doc change to restart.
     required: false
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -283,6 +287,7 @@ options:
       - Only used when mode equals move.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
 <<<<<<< HEAD
+<<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
 <<<<<<< HEAD
@@ -292,6 +297,9 @@ options:
 >>>>>>> Version_added fields missing
 =======
       - Do not include leading or trailing forwardslashes. We take care of that for you.
+=======
+      - Do not include leading or trailing forwardslashes.
+>>>>>>> Shippable cancelled for unknown reason. Doc change to restart.
     required: false
 <<<<<<< HEAD
 >>>>>>> Fixes to fmgr_fwpol_package

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -226,7 +226,11 @@ options:
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
       - Do not include leading or trailing forwardslashes. We take care of that for you.
     required: false
+<<<<<<< HEAD
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+    version_added: 2.9
+>>>>>>> Version_added fields missing
 
   target_name:
     description:
@@ -235,11 +239,15 @@ options:
       - If None, then NAME will be used.
     required: false
 <<<<<<< HEAD
+<<<<<<< HEAD
     version_added: 2.9
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+    version_added: 2.9
+>>>>>>> Version_added fields missing
 '''
 
 

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -33,23 +33,7 @@ notes:
     - Full Documentation at U(https://ftnt-ansible-docs.readthedocs.io/en/latest/).
     - Revision Comments April 2nd 2019
         - Couldn't append to installation target list, only send a complete list. We've added modes for adding and
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
           deleting targets for policy packages.
-=======
-          deleting just targets for policy packages.
->>>>>>> Added notes and documentation
-=======
-          deleting targets for policy packages.
->>>>>>> Odd error with shippable. Test was cancelled. Edited docs to re-run.
-=======
-          deleting just targets for policy packages.
->>>>>>> Added notes and documentation
-=======
-          deleting targets for policy packages.
->>>>>>> Odd error with shippable. Test was cancelled. Edited docs to re-run.
         - Install mode has been added. Scope_members is no longer taken into account when mode = install.
           Only the existing installation targets on the package will be used. Update installation targets before.
         - Nested folders and packages now work properly. Before they were not.
@@ -57,24 +41,8 @@ notes:
           what was supplied under scope_members and scope_groups. Use the add_targets or delete_targets mode first.
         - When using "add_targets" or "delete_targets" for changing installation targets, only scope_members or
           scope_groups is considered for changes to the package. To edit the package settings themselves, use "set".
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
     - Revision Comments May 21st 2019
         - Added support to move packages.
-=======
->>>>>>> Added notes and documentation
-=======
-    - Revision Comments May 21st 2019
-        - Added support to move packages.
->>>>>>> Fixes to fmgr_fwpol_package
-=======
->>>>>>> Added notes and documentation
-=======
-    - Revision Comments May 21st 2019
-        - Added support to move packages.
->>>>>>> Fixes to fmgr_fwpol_package
 author:
     - Luke Weighall (@lweighall)
     - Andrew Welsh (@Ghilli3)
@@ -101,23 +69,7 @@ options:
       - Delete Targets will only delete the specified scope members from installation targets.
       - Install will install the package to the assigned installation targets listed on existing package.
       - Update your installation targets BEFORE running install task.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
     choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
-=======
-    choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
->>>>>>> Fixed issues:
-=======
-    choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-    choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
->>>>>>> Fixed issues:
-=======
-    choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
->>>>>>> Fixes to fmgr_fwpol_package
     default: add
 
   name:
@@ -130,26 +82,7 @@ options:
       - Are we managing packages or package folders?
     required: True
     choices: ['pkg','folder']
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> Fixed issues:
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-  package_folder:
-    description:
-      - Name of the folder you want to put the package into.
-      - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
-    required: false
->>>>>>> Fixed issues:
-
-=======
->>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
-=======
->>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
   central_nat:
     description:
       - Central NAT setting.
@@ -190,48 +123,11 @@ options:
       - if policy-based ngfw-mode, refer to firewall ssl-ssh-profile.
     required: false
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-  append_scope_members:
-    description:
-      - if enabled, ansible will check for existing scope members and add those to the list before setting
-      - if disabled, ansible will simply replace the existing scope members with the list provided.
-    required: false
-    choices: ['enable', 'disable']
-    default: 'enable'
-
-<<<<<<< HEAD
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
->>>>>>> Fixed issues:
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
->>>>>>> Fixed issues:
   scope_groups:
     description:
       - List of groups to add to the scope of the fw pol package
     required: false
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
     version_added: 2.9
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
-    version_added: 2.9
->>>>>>> Quick fix to version_added for a parameter
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
-    version_added: 2.9
->>>>>>> Quick fix to version_added for a parameter
 
   scope_members:
     description:
@@ -248,64 +144,16 @@ options:
     description:
       - The parent folder name you want to add this object under.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
-<<<<<<< HEAD
-<<<<<<< HEAD
 
   target_folder:
     description:
       - Only used when mode equals move.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
       - Do not include leading or trailing forwardslashes.
-=======
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
->>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
-=======
-      - Do not include leading or trailing forwardslashes.
->>>>>>> Shippable cancelled for unknown reason. Doc change to restart.
-=======
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
->>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
-=======
-      - Do not include leading or trailing forwardslashes.
->>>>>>> Shippable cancelled for unknown reason. Doc change to restart.
     required: false
-<<<<<<< HEAD
-<<<<<<< HEAD
     version_added: 2.9
-=======
-=======
->>>>>>> Fixes to fmgr_fwpol_package
-
-  target_folder:
-    description:
-      - Only used when mode equals move.
-      - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
-<<<<<<< HEAD
-<<<<<<< HEAD
-      - Do not include leading or trailing forwardslashes.
-    required: false
-<<<<<<< HEAD
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-    version_added: 2.9
->>>>>>> Version_added fields missing
-=======
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
-=======
-      - Do not include leading or trailing forwardslashes.
->>>>>>> Shippable cancelled for unknown reason. Doc change to restart.
-    required: false
-<<<<<<< HEAD
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-    version_added: 2.9
->>>>>>> Version_added fields missing
 
   target_name:
     description:
@@ -313,25 +161,7 @@ options:
       - Only used when you want to rename the package in its new location.
       - If None, then NAME will be used.
     required: false
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
     version_added: 2.9
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-    version_added: 2.9
->>>>>>> Version_added fields missing
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-    version_added: 2.9
->>>>>>> Version_added fields missing
 '''
 
 
@@ -445,14 +275,6 @@ def fmgr_fwpol_package(fmgr, paramgram):
     """
     if paramgram["mode"] in ['set', 'add']:
         url = '/pm/pkg/adom/{adom}'.format(adom=paramgram["adom"])
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Fixed issues:
-=======
->>>>>>> Fixed issues:
         datagram = {
             "type": paramgram["object_type"],
             "name": paramgram["name"],
@@ -462,30 +284,6 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
                 "inspection-mode": paramgram["inspection-mode"],
                 "ngfw-mode": paramgram["ngfw-mode"],
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-
-        # IF PARENT FOLDER IS NOT DEFINED
-        if paramgram["parent_folder"] is None:
-            datagram = {
-                "type": paramgram["object_type"],
-                "name": paramgram["name"],
-                "scope member": paramgram["assign_to_list"],
-                "package settings": {
-                    "central-nat": paramgram["central-nat"],
-                    "fwpolicy-implicit-log": paramgram["fwpolicy-implicit-log"],
-                    "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
-                    "inspection-mode": paramgram["inspection-mode"],
-                    "ngfw-mode": paramgram["ngfw-mode"],
-                }
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
->>>>>>> Fixed issues:
-=======
->>>>>>> Fixed issues:
             }
         }
 
@@ -496,110 +294,11 @@ def fmgr_fwpol_package(fmgr, paramgram):
         if len(paramgram["append_members_list"]) > 0:
             datagram["scope member"] = paramgram["append_members_list"]
         elif len(paramgram["append_members_list"]) == 0:
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
             datagram["scope member"] = {}
 
         # IF PARENT FOLDER IS DEFINED
         if paramgram["parent_folder"] is not None:
-<<<<<<< HEAD
             datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
-
-    # IF MODE IS MOVE
-    if paramgram['mode'] in ["move", "copy"]:
-        if paramgram["mode"] == "move":
-            url = '/securityconsole/package/move'
-        elif paramgram["mode"] == "copy":
-            url = '/securityconsole/package/clone'
-        if paramgram["target_name"]:
-            name = paramgram["target_name"]
-        else:
-            name = paramgram["name"]
-        datagram = {
-            "adom": paramgram["adom"],
-            "dst_name": name,
-            "dst_parent": paramgram["target_folder"],
-            "pkg": paramgram["name"]
-        }
-        if paramgram["parent_folder"]:
-            datagram["pkg"] = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
-        else:
-            datagram["pkg"] = str(paramgram["name"])
-
-        if paramgram["mode"] == "copy":
-            # SET THE SCOPE MEMBERS ACCORDING TO MODE AND WHAT WAS SUPPLIED
-            if len(paramgram["append_members_list"]) > 0:
-                datagram["scope member"] = paramgram["append_members_list"]
-            elif len(paramgram["append_members_list"]) == 0:
-                datagram["scope member"] = {}
-=======
-            datagram = {
-                "type": "folder",
-                "name": paramgram["parent_folder"],
-                "subobj": [{
-                    "name": paramgram["name"],
-                    "scope member": paramgram["assign_to_list"],
-                    "type": "pkg",
-                    "package settings": {
-                        "central-nat": paramgram["central-nat"],
-                        "fwpolicy-implicit-log": paramgram["fwpolicy-implicit-log"],
-                        "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
-                        "inspection-mode": paramgram["inspection-mode"],
-                        "ngfw-mode": paramgram["ngfw-mode"],
-                    }
-                }]
-            }
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
-            datagram["scope member"] = None
-=======
-            datagram["scope member"] = {}
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-            datagram["scope member"] = {}
->>>>>>> Fixes to fmgr_fwpol_package
-
-        # IF PARENT FOLDER IS DEFINED
-        if paramgram["parent_folder"] is not None:
-            datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
->>>>>>> Fixed issues:
-
-    # IF MODE IS MOVE
-    if paramgram['mode'] in ["move", "copy"]:
-        if paramgram["mode"] == "move":
-            url = '/securityconsole/package/move'
-        elif paramgram["mode"] == "copy":
-            url = '/securityconsole/package/clone'
-        if paramgram["target_name"]:
-            name = paramgram["target_name"]
-        else:
-            name = paramgram["name"]
-        datagram = {
-            "adom": paramgram["adom"],
-            "dst_name": name,
-            "dst_parent": paramgram["target_folder"],
-            "pkg": paramgram["name"]
-        }
-        if paramgram["parent_folder"]:
-            datagram["pkg"] = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
-        else:
-            datagram["pkg"] = str(paramgram["name"])
-
-        if paramgram["mode"] == "copy":
-            # SET THE SCOPE MEMBERS ACCORDING TO MODE AND WHAT WAS SUPPLIED
-            if len(paramgram["append_members_list"]) > 0:
-                datagram["scope member"] = paramgram["append_members_list"]
-            elif len(paramgram["append_members_list"]) == 0:
-                datagram["scope member"] = {}
-=======
-            datagram["scope member"] = None
-
-        # IF PARENT FOLDER IS DEFINED
-        if paramgram["parent_folder"] is not None:
-            datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
->>>>>>> Fixed issues:
 
     # IF MODE IS MOVE
     if paramgram['mode'] in ["move", "copy"]:
@@ -651,98 +350,6 @@ def fmgr_fwpol_package(fmgr, paramgram):
         response = fmgr.process_request(url, datagram, FMGRMethods.EXEC)
     else:
         response = fmgr.process_request(url, datagram, paramgram["mode"])
-<<<<<<< HEAD
-<<<<<<< HEAD
-    return response
-
-
-def fmgr_fwpol_package_edit_targets(fmgr, paramgram):
-    """
-    This function will append scope targets to an existing policy package.
-
-    :param fmgr: The fmgr object instance from fmgr_utils.py
-    :type fmgr: class object
-    :param paramgram: The formatted dictionary of options to process
-    :type paramgram: dict
-
-    :return: The response from the FortiManager
-    :rtype: dict
-    """
-    # MERGE APPEND AND EXISTING MEMBERS LISTS BASED ON MODE
-    method = None
-    members_list = None
-    if paramgram["mode"] == "add_targets":
-        method = FMGRMethods.ADD
-        members_list = paramgram["append_members_list"]
-        for member in paramgram["existing_members_list"]:
-            if member not in members_list:
-                members_list.append(member)
-
-    elif paramgram["mode"] == "delete_targets":
-        method = FMGRMethods.DELETE
-        members_list = list()
-        for member in paramgram["append_members_list"]:
-            if member in paramgram["existing_members_list"]:
-                members_list.append(member)
-    datagram = {
-        "data": members_list
-    }
-
-    if paramgram["parent_folder"] is not None:
-        url = '/pm/pkg/adom/{adom}/{parent_folder}/{name}/scope member'.format(adom=paramgram["adom"],
-                                                                               name=paramgram["name"],
-                                                                               parent_folder=paramgram["parent_folder"])
-    elif paramgram["parent_folder"] is None:
-        url = '/pm/pkg/adom/{adom}/{name}/scope member'.format(adom=paramgram["adom"],
-                                                               name=paramgram["name"])
-    response = fmgr.process_request(url, datagram, method)
-=======
->>>>>>> Fixes to fmgr_fwpol_package
-    return response
-
-
-def fmgr_fwpol_package_edit_targets(fmgr, paramgram):
-    """
-    This function will append scope targets to an existing policy package.
-
-    :param fmgr: The fmgr object instance from fmgr_utils.py
-    :type fmgr: class object
-    :param paramgram: The formatted dictionary of options to process
-    :type paramgram: dict
-
-    :return: The response from the FortiManager
-    :rtype: dict
-    """
-    # MERGE APPEND AND EXISTING MEMBERS LISTS BASED ON MODE
-    method = None
-    members_list = None
-    if paramgram["mode"] == "add_targets":
-        method = FMGRMethods.ADD
-        members_list = paramgram["append_members_list"]
-        for member in paramgram["existing_members_list"]:
-            if member not in members_list:
-                members_list.append(member)
-
-    elif paramgram["mode"] == "delete_targets":
-        method = FMGRMethods.DELETE
-        members_list = list()
-        for member in paramgram["append_members_list"]:
-            if member in paramgram["existing_members_list"]:
-                members_list.append(member)
-    datagram = {
-        "data": members_list
-    }
-
-    if paramgram["parent_folder"] is not None:
-        url = '/pm/pkg/adom/{adom}/{parent_folder}/{name}/scope member'.format(adom=paramgram["adom"],
-                                                                               name=paramgram["name"],
-                                                                               parent_folder=paramgram["parent_folder"])
-    elif paramgram["parent_folder"] is None:
-        url = '/pm/pkg/adom/{adom}/{name}/scope member'.format(adom=paramgram["adom"],
-                                                               name=paramgram["name"])
-    response = fmgr.process_request(url, datagram, method)
-=======
->>>>>>> Fixes to fmgr_fwpol_package
     return response
 
 
@@ -852,20 +459,6 @@ def fmgr_fwpol_package_install(fmgr, paramgram):
     datagram = {
         "adom": paramgram["adom"],
         "pkg": paramgram["name"],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        "scope": paramgram["assign_to_list"]
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
->>>>>>> Fixed issues:
-=======
-        "scope": paramgram["assign_to_list"]
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
->>>>>>> Fixed issues:
     }
     if paramgram["parent_folder"]:
         new_path = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
@@ -993,40 +586,11 @@ def fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram):
 def main():
     argument_spec = dict(
         adom=dict(required=False, type="str", default="root"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
         mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
-=======
-        mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
->>>>>>> Fixed issues:
-=======
-        mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-        mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
->>>>>>> Fixed issues:
-=======
-        mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
->>>>>>> Fixes to fmgr_fwpol_package
                   type="str", default="add"),
 
         name=dict(required=False, type="str"),
         object_type=dict(required=True, type="str", choices=['pkg', 'folder']),
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> Fixed issues:
-        package_folder=dict(required=False, type="str"),
->>>>>>> Fixed issues:
-=======
->>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
-=======
->>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
         central_nat=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy6_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
@@ -1058,41 +622,11 @@ def main():
         "scope_members": module.params["scope_members"],
         "scope_members_vdom": module.params["scope_members_vdom"],
         "parent_folder": module.params["parent_folder"],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
         "target_folder": module.params["target_folder"],
         "target_name": module.params["target_name"],
         "append_members_list": list(),
         "existing_members_list": list(),
         "package_exists": None,
-=======
-        "assign_to_list": list()
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
-=======
-        "target_folder": module.params["target_folder"],
-        "target_name": module.params["target_name"],
->>>>>>> Fixes to fmgr_fwpol_package
-=======
-        "target_folder": module.params["target_folder"],
-        "target_name": module.params["target_name"],
->>>>>>> Fixes to fmgr_fwpol_package
-        "append_members_list": list(),
-        "existing_members_list": list(),
-        "package_exists": None,
->>>>>>> Fixed issues:
-=======
-        "assign_to_list": list()
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
-        "append_members_list": list(),
-        "existing_members_list": list(),
-        "package_exists": None,
->>>>>>> Fixed issues:
     }
     module.paramgram = paramgram
     fmgr = None
@@ -1106,45 +640,8 @@ def main():
     # BEGIN MODULE-SPECIFIC LOGIC -- THINGS NEED TO HAPPEN DEPENDING ON THE ENDPOINT AND OPERATION
     results = DEFAULT_RESULT_OBJ
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
     # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
     paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
-=======
-=======
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-    # CHECK FOR SCOPE MEMBERS AND CREATE THAT MEMBERS LIST
-    members_list = list()
-    if paramgram["scope_members"] is not None and paramgram["mode"] in ['add', 'set']:
-        if isinstance(paramgram["scope_members"], list):
-            members = paramgram["scope_members"]
-        if isinstance(paramgram["scope_members"], str):
-            members = FMGRCommon.split_comma_strings_into_lists(paramgram["scope_members"])
-        for member in members:
-            scope_dict = {
-                "name": member,
-                "vdom": paramgram["scope_members_vdom"],
-            }
-            members_list.append(scope_dict)
-
-    # CHECK FOR SCOPE GROUPS AND ADD THAT TO THE MEMBERS LIST
-    if paramgram["scope_groups"] is not None and paramgram["mode"] in ['add', 'set']:
-        if isinstance(paramgram["scope_groups"], list):
-            members = paramgram["scope_groups"]
-        if isinstance(paramgram["scope_groups"], str):
-            members = FMGRCommon.split_comma_strings_into_lists(paramgram["scope_groups"])
-        for member in members:
-            scope_dict = {
-                "name": member
-            }
-            members_list.append(scope_dict)
-<<<<<<< HEAD
-=======
-    # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
-    paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
->>>>>>> Fixed issues:
 
     try:
         if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:
@@ -1154,46 +651,7 @@ def main():
     except Exception as err:
         raise FMGBaseException(err)
 
-<<<<<<< HEAD
-    paramgram["assign_to_list"] = members_list
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-=======
-=======
-    # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
-    paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
->>>>>>> Fixed issues:
-
     try:
-        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:
-            results = fmgr_fwpol_package(fmgr, paramgram)
-            fmgr.govern_response(module=module, results=results,
-                                 ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))
-    except Exception as err:
-        raise FMGBaseException(err)
-
-<<<<<<< HEAD
-    paramgram["assign_to_list"] = members_list
->>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
-
-    try:
-        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:
-            results = fmgr_fwpol_package(fmgr, paramgram)
-=======
-    try:
-        if paramgram["object_type"] == "pkg" and paramgram["package_exists"] \
-                and len(paramgram["append_members_list"]) > 0 \
-                and paramgram["mode"] in ['add_targets', 'delete_targets']:
-            results = fmgr_fwpol_package_edit_targets(fmgr, paramgram)
->>>>>>> Fixed issues:
-            fmgr.govern_response(module=module, results=results,
-                                 ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))
-    except Exception as err:
-        raise FMGBaseException(err)
-
-    try:
-=======
-    try:
->>>>>>> Fixed issues:
         if paramgram["object_type"] == "pkg" and paramgram["package_exists"] \
                 and len(paramgram["append_members_list"]) > 0 \
                 and paramgram["mode"] in ['add_targets', 'delete_targets']:

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -100,6 +100,7 @@ options:
 <<<<<<< HEAD
 =======
 
+<<<<<<< HEAD
   package_folder:
     description:
       - Name of the folder you want to put the package into.
@@ -108,6 +109,8 @@ options:
     required: false
 >>>>>>> Fixed issues:
 
+=======
+>>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
   central_nat:
     description:
       - Central NAT setting.
@@ -186,6 +189,7 @@ options:
     description:
       - The parent folder name you want to add this object under.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
+<<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
 <<<<<<< HEAD
@@ -195,6 +199,9 @@ options:
       - Only used when mode equals move.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
       - Do not include leading or trailing forwardslashes.
+=======
+      - Do not include leading or trailing forwardslashes. We take care of that for you.
+>>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
     required: false
     version_added: 2.9
 
@@ -741,9 +748,12 @@ def main():
         name=dict(required=False, type="str"),
         object_type=dict(required=True, type="str", choices=['pkg', 'folder']),
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         package_folder=dict(required=False, type="str"),
 >>>>>>> Fixed issues:
+=======
+>>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
         central_nat=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy6_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -153,6 +153,7 @@ options:
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
       - Do not include leading or trailing forwardslashes. We take care of that for you.
     required: false
+    version_added: 2.9
 
   target_name:
     description:
@@ -160,6 +161,7 @@ options:
       - Only used when you want to rename the package in its new location.
       - If None, then NAME will be used.
     required: false
+    version_added: 2.9
 '''
 
 

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -36,6 +36,7 @@ notes:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
           deleting targets for policy packages.
 =======
           deleting just targets for policy packages.
@@ -46,6 +47,9 @@ notes:
 =======
           deleting just targets for policy packages.
 >>>>>>> Added notes and documentation
+=======
+          deleting targets for policy packages.
+>>>>>>> Odd error with shippable. Test was cancelled. Edited docs to re-run.
         - Install mode has been added. Scope_members is no longer taken into account when mode = install.
           Only the existing installation targets on the package will be used. Update installation targets before.
         - Nested folders and packages now work properly. Before they were not.

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -35,6 +35,7 @@ notes:
         - Couldn't append to installation target list, only send a complete list. We've added modes for adding and
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
           deleting targets for policy packages.
 =======
           deleting just targets for policy packages.
@@ -42,6 +43,9 @@ notes:
 =======
           deleting targets for policy packages.
 >>>>>>> Odd error with shippable. Test was cancelled. Edited docs to re-run.
+=======
+          deleting just targets for policy packages.
+>>>>>>> Added notes and documentation
         - Install mode has been added. Scope_members is no longer taken into account when mode = install.
           Only the existing installation targets on the package will be used. Update installation targets before.
         - Nested folders and packages now work properly. Before they were not.
@@ -49,6 +53,7 @@ notes:
           what was supplied under scope_members and scope_groups. Use the add_targets or delete_targets mode first.
         - When using "add_targets" or "delete_targets" for changing installation targets, only scope_members or
           scope_groups is considered for changes to the package. To edit the package settings themselves, use "set".
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
     - Revision Comments May 21st 2019
@@ -59,6 +64,8 @@ notes:
     - Revision Comments May 21st 2019
         - Added support to move packages.
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+>>>>>>> Added notes and documentation
 author:
     - Luke Weighall (@lweighall)
     - Andrew Welsh (@Ghilli3)

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -179,9 +179,13 @@ options:
       - List of groups to add to the scope of the fw pol package
     required: false
 <<<<<<< HEAD
+<<<<<<< HEAD
     version_added: 2.9
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+    version_added: 2.9
+>>>>>>> Quick fix to version_added for a parameter
 
   scope_members:
     description:

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -123,11 +123,25 @@ options:
       - if policy-based ngfw-mode, refer to firewall ssl-ssh-profile.
     required: false
 
+<<<<<<< HEAD
+=======
+  append_scope_members:
+    description:
+      - if enabled, ansible will check for existing scope members and add those to the list before setting
+      - if disabled, ansible will simply replace the existing scope members with the list provided.
+    required: false
+    choices: ['enable', 'disable']
+    default: 'enable'
+
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
   scope_groups:
     description:
       - List of groups to add to the scope of the fw pol package
     required: false
+<<<<<<< HEAD
     version_added: 2.9
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 
   scope_members:
     description:
@@ -146,6 +160,7 @@ options:
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
       - Do not include leading or trailing forwardslashes.
     required: false
+<<<<<<< HEAD
 
   target_folder:
     description:
@@ -162,6 +177,8 @@ options:
       - If None, then NAME will be used.
     required: false
     version_added: 2.9
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 '''
 
 
@@ -275,6 +292,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
     """
     if paramgram["mode"] in ['set', 'add']:
         url = '/pm/pkg/adom/{adom}'.format(adom=paramgram["adom"])
+<<<<<<< HEAD
         datagram = {
             "type": paramgram["object_type"],
             "name": paramgram["name"],
@@ -284,6 +302,22 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
                 "inspection-mode": paramgram["inspection-mode"],
                 "ngfw-mode": paramgram["ngfw-mode"],
+=======
+
+        # IF PARENT FOLDER IS NOT DEFINED
+        if paramgram["parent_folder"] is None:
+            datagram = {
+                "type": paramgram["object_type"],
+                "name": paramgram["name"],
+                "scope member": paramgram["assign_to_list"],
+                "package settings": {
+                    "central-nat": paramgram["central-nat"],
+                    "fwpolicy-implicit-log": paramgram["fwpolicy-implicit-log"],
+                    "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
+                    "inspection-mode": paramgram["inspection-mode"],
+                    "ngfw-mode": paramgram["ngfw-mode"],
+                }
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
             }
         }
 
@@ -298,6 +332,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
 
         # IF PARENT FOLDER IS DEFINED
         if paramgram["parent_folder"] is not None:
+<<<<<<< HEAD
             datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
 
     # IF MODE IS MOVE
@@ -327,6 +362,24 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 datagram["scope member"] = paramgram["append_members_list"]
             elif len(paramgram["append_members_list"]) == 0:
                 datagram["scope member"] = {}
+=======
+            datagram = {
+                "type": "folder",
+                "name": paramgram["parent_folder"],
+                "subobj": [{
+                    "name": paramgram["name"],
+                    "scope member": paramgram["assign_to_list"],
+                    "type": "pkg",
+                    "package settings": {
+                        "central-nat": paramgram["central-nat"],
+                        "fwpolicy-implicit-log": paramgram["fwpolicy-implicit-log"],
+                        "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
+                        "inspection-mode": paramgram["inspection-mode"],
+                        "ngfw-mode": paramgram["ngfw-mode"],
+                    }
+                }]
+            }
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 
     # NORMAL DELETE NO PARENT
     if paramgram["mode"] == "delete" and paramgram["parent_folder"] is None:
@@ -459,6 +512,10 @@ def fmgr_fwpol_package_install(fmgr, paramgram):
     datagram = {
         "adom": paramgram["adom"],
         "pkg": paramgram["name"],
+<<<<<<< HEAD
+=======
+        "scope": paramgram["assign_to_list"]
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
     }
     if paramgram["parent_folder"]:
         new_path = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
@@ -600,6 +657,7 @@ def main():
         scope_groups=dict(required=False, type="str"),
         scope_members=dict(required=False, type="str"),
         scope_members_vdom=dict(required=False, type="str", default="root"),
+        append_scope_members=dict(required=False, type="str", default="enable", choices=['enable', 'disable']),
         parent_folder=dict(required=False, type="str"),
         target_folder=dict(required=False, type="str"),
         target_name=dict(required=False, type="str"),
@@ -621,12 +679,17 @@ def main():
         "scope_groups": module.params["scope_groups"],
         "scope_members": module.params["scope_members"],
         "scope_members_vdom": module.params["scope_members_vdom"],
+        "append_scope_members": module.params["append_scope_members"],
         "parent_folder": module.params["parent_folder"],
+<<<<<<< HEAD
         "target_folder": module.params["target_folder"],
         "target_name": module.params["target_name"],
         "append_members_list": list(),
         "existing_members_list": list(),
         "package_exists": None,
+=======
+        "assign_to_list": list()
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
     }
     module.paramgram = paramgram
     fmgr = None
@@ -640,8 +703,61 @@ def main():
     # BEGIN MODULE-SPECIFIC LOGIC -- THINGS NEED TO HAPPEN DEPENDING ON THE ENDPOINT AND OPERATION
     results = DEFAULT_RESULT_OBJ
 
+<<<<<<< HEAD
     # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
     paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
+=======
+    # CHECK FOR SCOPE MEMBERS AND CREATE THAT MEMBERS LIST
+    members_list = list()
+    if paramgram["scope_members"] is not None and paramgram["mode"] in ['add', 'set']:
+        if isinstance(paramgram["scope_members"], list):
+            members = paramgram["scope_members"]
+        if isinstance(paramgram["scope_members"], str):
+            members = FMGRCommon.split_comma_strings_into_lists(paramgram["scope_members"])
+        for member in members:
+            scope_dict = {
+                "name": member,
+                "vdom": paramgram["scope_members_vdom"],
+            }
+            members_list.append(scope_dict)
+
+    # CHECK FOR SCOPE GROUPS AND ADD THAT TO THE MEMBERS LIST
+    if paramgram["scope_groups"] is not None and paramgram["mode"] in ['add', 'set']:
+        if isinstance(paramgram["scope_groups"], list):
+            members = paramgram["scope_groups"]
+        if isinstance(paramgram["scope_groups"], str):
+            members = FMGRCommon.split_comma_strings_into_lists(paramgram["scope_groups"])
+        for member in members:
+            scope_dict = {
+                "name": member
+            }
+            members_list.append(scope_dict)
+
+    # CHECK FOR EXISTING SCOPE MEMBERS IF THAT OPTION IS ENABLED
+    try:
+        if paramgram["append_scope_members"] == "enable":
+            pol_datagram = {"type": paramgram["object_type"], "name": paramgram["name"]}
+            pol_package_url = '/pm/pkg/adom/{adom}/{pkg_name}'.format(adom=paramgram["adom"],
+                                                                      pkg_name=paramgram["name"])
+            pol_package = fmgr.process_request(pol_package_url, pol_datagram, FMGRMethods.GET)
+
+            if len(pol_package) > 2:
+                raise FMGBaseException("Policy Package Name returned multiple results.")
+            if len(pol_package) == 1:
+                raise FMGBaseException("Policy Package couldn't be found, to append existing scope members")
+            if len(pol_package) == 2:
+                try:
+                    existing_members = pol_package[1]["scope member"]
+                    for member in existing_members:
+                        if member not in members_list:
+                            members_list.append(member)
+                except Exception as err:
+                    pass
+    except Exception as err:
+        raise FMGBaseException(err)
+
+    paramgram["assign_to_list"] = members_list
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 
     try:
         if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -203,6 +203,7 @@ options:
       - The parent folder name you want to add this object under.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
 <<<<<<< HEAD
+<<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
 <<<<<<< HEAD
@@ -215,6 +216,9 @@ options:
 =======
       - Do not include leading or trailing forwardslashes. We take care of that for you.
 >>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
+=======
+      - Do not include leading or trailing forwardslashes.
+>>>>>>> Shippable cancelled for unknown reason. Doc change to restart.
     required: false
 <<<<<<< HEAD
     version_added: 2.9
@@ -224,7 +228,7 @@ options:
     description:
       - Only used when mode equals move.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
+      - Do not include leading or trailing forwardslashes.
     required: false
 <<<<<<< HEAD
 >>>>>>> Fixes to fmgr_fwpol_package

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -33,7 +33,7 @@ notes:
     - Full Documentation at U(https://ftnt-ansible-docs.readthedocs.io/en/latest/).
     - Revision Comments April 2nd 2019
         - Couldn't append to installation target list, only send a complete list. We've added modes for adding and
-          deleting just targets for policy packages.
+          deleting targets for policy packages.
         - Install mode has been added. Scope_members is no longer taken into account when mode = install.
           Only the existing installation targets on the package will be used. Update installation targets before.
         - Nested folders and packages now work properly. Before they were not.

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -41,6 +41,8 @@ notes:
           what was supplied under scope_members and scope_groups. Use the add_targets or delete_targets mode first.
         - When using "add_targets" or "delete_targets" for changing installation targets, only scope_members or
           scope_groups is considered for changes to the package. To edit the package settings themselves, use "set".
+    - Revision Comments May 21st 2019
+        - Added support to move packages.
 author:
     - Luke Weighall (@lweighall)
     - Andrew Welsh (@Ghilli3)
@@ -67,7 +69,7 @@ options:
       - Delete Targets will only delete the specified scope members from installation targets.
       - Install will install the package to the assigned installation targets listed on existing package.
       - Update your installation targets BEFORE running install task.
-    choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
+    choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
     default: add
 
   name:
@@ -142,6 +144,20 @@ options:
       - The parent folder name you want to add this object under.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
       - Do not include leading or trailing forwardslashes. We take care of that for you.
+    required: false
+
+  target_folder:
+    description:
+      - Only used when mode equals move.
+      - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
+      - Do not include leading or trailing forwardslashes. We take care of that for you.
+    required: false
+
+  target_name:
+    description:
+      - Only used when mode equals move.
+      - Only used when you want to rename the package in its new location.
+      - If None, then NAME will be used.
     required: false
 '''
 
@@ -223,6 +239,7 @@ EXAMPLES = '''
     name: "ansibleTestFolder1"
     object_type: "folder"
 '''
+
 RETURN = """
 api_result:
   description: full API response, includes status code and message
@@ -274,11 +291,39 @@ def fmgr_fwpol_package(fmgr, paramgram):
         if len(paramgram["append_members_list"]) > 0:
             datagram["scope member"] = paramgram["append_members_list"]
         elif len(paramgram["append_members_list"]) == 0:
-            datagram["scope member"] = None
+            datagram["scope member"] = {}
 
         # IF PARENT FOLDER IS DEFINED
         if paramgram["parent_folder"] is not None:
             datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
+
+    # IF MODE IS MOVE
+    if paramgram['mode'] in ["move", "copy"]:
+        if paramgram["mode"] == "move":
+            url = '/securityconsole/package/move'
+        elif paramgram["mode"] == "copy":
+            url = '/securityconsole/package/clone'
+        if paramgram["target_name"]:
+            name = paramgram["target_name"]
+        else:
+            name = paramgram["name"]
+        datagram = {
+            "adom": paramgram["adom"],
+            "dst_name": name,
+            "dst_parent": paramgram["target_folder"],
+            "pkg": paramgram["name"]
+        }
+        if paramgram["parent_folder"]:
+            datagram["pkg"] = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
+        else:
+            datagram["pkg"] = str(paramgram["name"])
+
+        if paramgram["mode"] == "copy":
+            # SET THE SCOPE MEMBERS ACCORDING TO MODE AND WHAT WAS SUPPLIED
+            if len(paramgram["append_members_list"]) > 0:
+                datagram["scope member"] = paramgram["append_members_list"]
+            elif len(paramgram["append_members_list"]) == 0:
+                datagram["scope member"] = {}
 
     # NORMAL DELETE NO PARENT
     if paramgram["mode"] == "delete" and paramgram["parent_folder"] is None:
@@ -298,7 +343,10 @@ def fmgr_fwpol_package(fmgr, paramgram):
                                                                   name=paramgram["name"],
                                                                   parent_folder=paramgram["parent_folder"])
 
-    response = fmgr.process_request(url, datagram, paramgram["mode"])
+    if paramgram['mode'] in ["move", "copy"]:
+        response = fmgr.process_request(url, datagram, FMGRMethods.EXEC)
+    else:
+        response = fmgr.process_request(url, datagram, paramgram["mode"])
     return response
 
 
@@ -535,7 +583,7 @@ def fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram):
 def main():
     argument_spec = dict(
         adom=dict(required=False, type="str", default="root"),
-        mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
+        mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
                   type="str", default="add"),
 
         name=dict(required=False, type="str"),
@@ -550,6 +598,8 @@ def main():
         scope_members=dict(required=False, type="str"),
         scope_members_vdom=dict(required=False, type="str", default="root"),
         parent_folder=dict(required=False, type="str"),
+        target_folder=dict(required=False, type="str"),
+        target_name=dict(required=False, type="str"),
 
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,)
@@ -569,6 +619,8 @@ def main():
         "scope_members": module.params["scope_members"],
         "scope_members_vdom": module.params["scope_members_vdom"],
         "parent_folder": module.params["parent_folder"],
+        "target_folder": module.params["target_folder"],
+        "target_name": module.params["target_name"],
         "append_members_list": list(),
         "existing_members_list": list(),
         "package_exists": None,
@@ -589,7 +641,7 @@ def main():
     paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
 
     try:
-        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete"]:
+        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:
             results = fmgr_fwpol_package(fmgr, paramgram)
             fmgr.govern_response(module=module, results=results,
                                  ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -220,6 +220,7 @@ options:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     version_added: 2.9
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
@@ -228,6 +229,9 @@ options:
 >>>>>>> Quick fix to version_added for a parameter
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+    version_added: 2.9
+>>>>>>> Quick fix to version_added for a parameter
 
   scope_members:
     description:

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -128,6 +128,7 @@ options:
 >>>>>>> Fixed issues:
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   package_folder:
     description:
       - Name of the folder you want to put the package into.
@@ -136,6 +137,8 @@ options:
     required: false
 >>>>>>> Fixed issues:
 
+=======
+>>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
 =======
 >>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
   central_nat:
@@ -234,6 +237,7 @@ options:
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
 <<<<<<< HEAD
@@ -250,6 +254,9 @@ options:
 =======
       - Do not include leading or trailing forwardslashes.
 >>>>>>> Shippable cancelled for unknown reason. Doc change to restart.
+=======
+      - Do not include leading or trailing forwardslashes. We take care of that for you.
+>>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
     required: false
 <<<<<<< HEAD
     version_added: 2.9
@@ -931,11 +938,14 @@ def main():
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 =======
 >>>>>>> Fixed issues:
         package_folder=dict(required=False, type="str"),
 >>>>>>> Fixed issues:
+=======
+>>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
 =======
 >>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
         central_nat=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -162,7 +162,10 @@ options:
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
   append_scope_members:
     description:
       - if enabled, ansible will check for existing scope members and add those to the list before setting
@@ -171,13 +174,17 @@ options:
     choices: ['enable', 'disable']
     default: 'enable'
 
+<<<<<<< HEAD
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
 >>>>>>> Fixed issues:
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
   scope_groups:
     description:
       - List of groups to add to the scope of the fw pol package
     required: false
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
     version_added: 2.9
@@ -186,6 +193,8 @@ options:
 =======
     version_added: 2.9
 >>>>>>> Quick fix to version_added for a parameter
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 
   scope_members:
     description:
@@ -206,6 +215,7 @@ options:
 <<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
+<<<<<<< HEAD
 <<<<<<< HEAD
 
   target_folder:
@@ -252,6 +262,8 @@ options:
 =======
     version_added: 2.9
 >>>>>>> Version_added fields missing
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 '''
 
 
@@ -367,6 +379,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
         url = '/pm/pkg/adom/{adom}'.format(adom=paramgram["adom"])
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 >>>>>>> Fixed issues:
         datagram = {
@@ -380,6 +393,8 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 "ngfw-mode": paramgram["ngfw-mode"],
 <<<<<<< HEAD
 =======
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 
         # IF PARENT FOLDER IS NOT DEFINED
         if paramgram["parent_folder"] is None:
@@ -679,11 +694,15 @@ def fmgr_fwpol_package_install(fmgr, paramgram):
         "pkg": paramgram["name"],
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         "scope": paramgram["assign_to_list"]
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
 >>>>>>> Fixed issues:
+=======
+        "scope": paramgram["assign_to_list"]
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
     }
     if paramgram["parent_folder"]:
         new_path = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
@@ -840,6 +859,7 @@ def main():
         scope_groups=dict(required=False, type="str"),
         scope_members=dict(required=False, type="str"),
         scope_members_vdom=dict(required=False, type="str", default="root"),
+        append_scope_members=dict(required=False, type="str", default="enable", choices=['enable', 'disable']),
         parent_folder=dict(required=False, type="str"),
         target_folder=dict(required=False, type="str"),
         target_name=dict(required=False, type="str"),
@@ -861,7 +881,9 @@ def main():
         "scope_groups": module.params["scope_groups"],
         "scope_members": module.params["scope_members"],
         "scope_members_vdom": module.params["scope_members_vdom"],
+        "append_scope_members": module.params["append_scope_members"],
         "parent_folder": module.params["parent_folder"],
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -882,6 +904,9 @@ def main():
         "existing_members_list": list(),
         "package_exists": None,
 >>>>>>> Fixed issues:
+=======
+        "assign_to_list": list()
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
     }
     module.paramgram = paramgram
     fmgr = None
@@ -897,9 +922,12 @@ def main():
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
     paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
 =======
+=======
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
     # CHECK FOR SCOPE MEMBERS AND CREATE THAT MEMBERS LIST
     members_list = list()
     if paramgram["scope_members"] is not None and paramgram["mode"] in ['add', 'set']:
@@ -925,6 +953,7 @@ def main():
                 "name": member
             }
             members_list.append(scope_dict)
+<<<<<<< HEAD
 =======
     # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
     paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
@@ -939,6 +968,33 @@ def main():
         raise FMGBaseException(err)
 
 <<<<<<< HEAD
+    paramgram["assign_to_list"] = members_list
+>>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+
+    # CHECK FOR EXISTING SCOPE MEMBERS IF THAT OPTION IS ENABLED
+    try:
+        if paramgram["append_scope_members"] == "enable":
+            pol_datagram = {"type": paramgram["object_type"], "name": paramgram["name"]}
+            pol_package_url = '/pm/pkg/adom/{adom}/{pkg_name}'.format(adom=paramgram["adom"],
+                                                                      pkg_name=paramgram["name"])
+            pol_package = fmgr.process_request(pol_package_url, pol_datagram, FMGRMethods.GET)
+
+            if len(pol_package) > 2:
+                raise FMGBaseException("Policy Package Name returned multiple results.")
+            if len(pol_package) == 1:
+                raise FMGBaseException("Policy Package couldn't be found, to append existing scope members")
+            if len(pol_package) == 2:
+                try:
+                    existing_members = pol_package[1]["scope member"]
+                    for member in existing_members:
+                        if member not in members_list:
+                            members_list.append(member)
+                except Exception as err:
+                    pass
+    except Exception as err:
+        raise FMGBaseException(err)
+
     paramgram["assign_to_list"] = members_list
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -127,6 +127,7 @@ options:
     description:
       - List of groups to add to the scope of the fw pol package
     required: false
+    version_added: 2.9
 
   scope_members:
     description:

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -60,6 +60,7 @@ notes:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     - Revision Comments May 21st 2019
         - Added support to move packages.
 =======
@@ -70,6 +71,10 @@ notes:
 >>>>>>> Fixes to fmgr_fwpol_package
 =======
 >>>>>>> Added notes and documentation
+=======
+    - Revision Comments May 21st 2019
+        - Added support to move packages.
+>>>>>>> Fixes to fmgr_fwpol_package
 author:
     - Luke Weighall (@lweighall)
     - Andrew Welsh (@Ghilli3)
@@ -99,6 +104,7 @@ options:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
 =======
     choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
@@ -109,6 +115,9 @@ options:
 =======
     choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
 >>>>>>> Fixed issues:
+=======
+    choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
+>>>>>>> Fixes to fmgr_fwpol_package
     default: add
 
   name:
@@ -259,13 +268,17 @@ options:
 >>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
     required: false
 <<<<<<< HEAD
+<<<<<<< HEAD
     version_added: 2.9
 =======
+=======
+>>>>>>> Fixes to fmgr_fwpol_package
 
   target_folder:
     description:
       - Only used when mode equals move.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
+<<<<<<< HEAD
       - Do not include leading or trailing forwardslashes.
     required: false
 <<<<<<< HEAD
@@ -273,6 +286,10 @@ options:
 =======
     version_added: 2.9
 >>>>>>> Version_added fields missing
+=======
+      - Do not include leading or trailing forwardslashes. We take care of that for you.
+    required: false
+>>>>>>> Fixes to fmgr_fwpol_package
 
   target_name:
     description:
@@ -282,6 +299,7 @@ options:
     required: false
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     version_added: 2.9
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
@@ -292,6 +310,8 @@ options:
 >>>>>>> Version_added fields missing
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+>>>>>>> Fixes to fmgr_fwpol_package
 '''
 
 
@@ -459,6 +479,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
             datagram["scope member"] = {}
 
         # IF PARENT FOLDER IS DEFINED
@@ -516,6 +537,9 @@ def fmgr_fwpol_package(fmgr, paramgram):
 =======
             datagram["scope member"] = {}
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+            datagram["scope member"] = {}
+>>>>>>> Fixes to fmgr_fwpol_package
 
         # IF PARENT FOLDER IS DEFINED
         if paramgram["parent_folder"] is not None:
@@ -557,6 +581,34 @@ def fmgr_fwpol_package(fmgr, paramgram):
             datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
 >>>>>>> Fixed issues:
 
+    # IF MODE IS MOVE
+    if paramgram['mode'] in ["move", "copy"]:
+        if paramgram["mode"] == "move":
+            url = '/securityconsole/package/move'
+        elif paramgram["mode"] == "copy":
+            url = '/securityconsole/package/clone'
+        if paramgram["target_name"]:
+            name = paramgram["target_name"]
+        else:
+            name = paramgram["name"]
+        datagram = {
+            "adom": paramgram["adom"],
+            "dst_name": name,
+            "dst_parent": paramgram["target_folder"],
+            "pkg": paramgram["name"]
+        }
+        if paramgram["parent_folder"]:
+            datagram["pkg"] = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
+        else:
+            datagram["pkg"] = str(paramgram["name"])
+
+        if paramgram["mode"] == "copy":
+            # SET THE SCOPE MEMBERS ACCORDING TO MODE AND WHAT WAS SUPPLIED
+            if len(paramgram["append_members_list"]) > 0:
+                datagram["scope member"] = paramgram["append_members_list"]
+            elif len(paramgram["append_members_list"]) == 0:
+                datagram["scope member"] = {}
+
     # NORMAL DELETE NO PARENT
     if paramgram["mode"] == "delete" and paramgram["parent_folder"] is None:
         datagram = {
@@ -579,6 +631,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
         response = fmgr.process_request(url, datagram, FMGRMethods.EXEC)
     else:
         response = fmgr.process_request(url, datagram, paramgram["mode"])
+<<<<<<< HEAD
 <<<<<<< HEAD
     return response
 
@@ -668,6 +721,8 @@ def fmgr_fwpol_package_edit_targets(fmgr, paramgram):
         url = '/pm/pkg/adom/{adom}/{name}/scope member'.format(adom=paramgram["adom"],
                                                                name=paramgram["name"])
     response = fmgr.process_request(url, datagram, method)
+=======
+>>>>>>> Fixes to fmgr_fwpol_package
     return response
 
 
@@ -921,6 +976,7 @@ def main():
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
 =======
         mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
@@ -931,6 +987,9 @@ def main():
 =======
         mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
 >>>>>>> Fixed issues:
+=======
+        mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
+>>>>>>> Fixes to fmgr_fwpol_package
                   type="str", default="add"),
 
         name=dict(required=False, type="str"),
@@ -984,6 +1043,7 @@ def main():
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         "target_folder": module.params["target_folder"],
         "target_name": module.params["target_name"],
         "append_members_list": list(),
@@ -993,6 +1053,10 @@ def main():
         "assign_to_list": list()
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
+=======
+        "target_folder": module.params["target_folder"],
+        "target_name": module.params["target_name"],
+>>>>>>> Fixes to fmgr_fwpol_package
 =======
         "target_folder": module.params["target_folder"],
         "target_name": module.params["target_name"],
@@ -1080,7 +1144,7 @@ def main():
 >>>>>>> Fixed issues:
 
     try:
-        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete"]:
+        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:
             results = fmgr_fwpol_package(fmgr, paramgram)
             fmgr.govern_response(module=module, results=results,
                                  ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -34,10 +34,14 @@ notes:
     - Revision Comments April 2nd 2019
         - Couldn't append to installation target list, only send a complete list. We've added modes for adding and
 <<<<<<< HEAD
+<<<<<<< HEAD
           deleting targets for policy packages.
 =======
           deleting just targets for policy packages.
 >>>>>>> Added notes and documentation
+=======
+          deleting targets for policy packages.
+>>>>>>> Odd error with shippable. Test was cancelled. Edited docs to re-run.
         - Install mode has been added. Scope_members is no longer taken into account when mode = install.
           Only the existing installation targets on the package will be used. Update installation targets before.
         - Nested folders and packages now work properly. Before they were not.

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -81,13 +81,6 @@ options:
     required: True
     choices: ['pkg','folder']
 
-  package_folder:
-    description:
-      - Name of the folder you want to put the package into.
-      - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
-    required: false
-
   central_nat:
     description:
       - Central NAT setting.
@@ -147,6 +140,8 @@ options:
   parent_folder:
     description:
       - The parent folder name you want to add this object under.
+      - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
+      - Do not include leading or trailing forwardslashes. We take care of that for you.
     required: false
 '''
 
@@ -545,7 +540,6 @@ def main():
 
         name=dict(required=False, type="str"),
         object_type=dict(required=True, type="str", choices=['pkg', 'folder']),
-        package_folder=dict(required=False, type="str"),
         central_nat=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
         fwpolicy6_implicit_log=dict(required=False, type="str", default="disable", choices=['enable', 'disable']),
@@ -565,7 +559,6 @@ def main():
         "name": module.params["name"],
         "mode": module.params["mode"],
         "object_type": module.params["object_type"],
-        "package-folder": module.params["package_folder"],
         "central-nat": module.params["central_nat"],
         "fwpolicy-implicit-log": module.params["fwpolicy_implicit_log"],
         "fwpolicy6-implicit-log": module.params["fwpolicy6_implicit_log"],

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -33,7 +33,11 @@ notes:
     - Full Documentation at U(https://ftnt-ansible-docs.readthedocs.io/en/latest/).
     - Revision Comments April 2nd 2019
         - Couldn't append to installation target list, only send a complete list. We've added modes for adding and
+<<<<<<< HEAD
           deleting targets for policy packages.
+=======
+          deleting just targets for policy packages.
+>>>>>>> Added notes and documentation
         - Install mode has been added. Scope_members is no longer taken into account when mode = install.
           Only the existing installation targets on the package will be used. Update installation targets before.
         - Nested folders and packages now work properly. Before they were not.
@@ -41,8 +45,11 @@ notes:
           what was supplied under scope_members and scope_groups. Use the add_targets or delete_targets mode first.
         - When using "add_targets" or "delete_targets" for changing installation targets, only scope_members or
           scope_groups is considered for changes to the package. To edit the package settings themselves, use "set".
+<<<<<<< HEAD
     - Revision Comments May 21st 2019
         - Added support to move packages.
+=======
+>>>>>>> Added notes and documentation
 author:
     - Luke Weighall (@lweighall)
     - Andrew Welsh (@Ghilli3)

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -87,6 +87,7 @@ options:
       - Update your installation targets BEFORE running install task.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
 =======
     choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
@@ -94,6 +95,9 @@ options:
 =======
     choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+    choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
+>>>>>>> Fixed issues:
     default: add
 
   name:
@@ -107,7 +111,10 @@ options:
     required: True
     choices: ['pkg','folder']
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> Fixed issues:
 
 <<<<<<< HEAD
   package_folder:
@@ -163,6 +170,7 @@ options:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
@@ -180,6 +188,8 @@ options:
 >>>>>>> Fixed issues:
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+>>>>>>> Fixed issues:
   scope_groups:
     description:
       - List of groups to add to the scope of the fw pol package
@@ -380,6 +390,9 @@ def fmgr_fwpol_package(fmgr, paramgram):
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Fixed issues:
 =======
 >>>>>>> Fixed issues:
         datagram = {
@@ -391,6 +404,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 "fwpolicy6-implicit-log": paramgram["fwpolicy6-implicit-log"],
                 "inspection-mode": paramgram["inspection-mode"],
                 "ngfw-mode": paramgram["ngfw-mode"],
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 =======
@@ -412,6 +426,8 @@ def fmgr_fwpol_package(fmgr, paramgram):
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
 >>>>>>> Fixed issues:
+=======
+>>>>>>> Fixed issues:
             }
         }
 
@@ -422,6 +438,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
         if len(paramgram["append_members_list"]) > 0:
             datagram["scope member"] = paramgram["append_members_list"]
         elif len(paramgram["append_members_list"]) == 0:
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
             datagram["scope member"] = {}
@@ -514,6 +531,13 @@ def fmgr_fwpol_package(fmgr, paramgram):
                 datagram["scope member"] = paramgram["append_members_list"]
             elif len(paramgram["append_members_list"]) == 0:
                 datagram["scope member"] = {}
+=======
+            datagram["scope member"] = None
+
+        # IF PARENT FOLDER IS DEFINED
+        if paramgram["parent_folder"] is not None:
+            datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
+>>>>>>> Fixed issues:
 
     # NORMAL DELETE NO PARENT
     if paramgram["mode"] == "delete" and paramgram["parent_folder"] is None:
@@ -629,6 +653,49 @@ def fmgr_fwpol_package_edit_targets(fmgr, paramgram):
     return response
 
 
+def fmgr_fwpol_package_edit_targets(fmgr, paramgram):
+    """
+    This function will append scope targets to an existing policy package.
+
+    :param fmgr: The fmgr object instance from fmgr_utils.py
+    :type fmgr: class object
+    :param paramgram: The formatted dictionary of options to process
+    :type paramgram: dict
+
+    :return: The response from the FortiManager
+    :rtype: dict
+    """
+    # MERGE APPEND AND EXISTING MEMBERS LISTS BASED ON MODE
+    method = None
+    members_list = None
+    if paramgram["mode"] == "add_targets":
+        method = FMGRMethods.ADD
+        members_list = paramgram["append_members_list"]
+        for member in paramgram["existing_members_list"]:
+            if member not in members_list:
+                members_list.append(member)
+
+    elif paramgram["mode"] == "delete_targets":
+        method = FMGRMethods.DELETE
+        members_list = list()
+        for member in paramgram["append_members_list"]:
+            if member in paramgram["existing_members_list"]:
+                members_list.append(member)
+    datagram = {
+        "data": members_list
+    }
+
+    if paramgram["parent_folder"] is not None:
+        url = '/pm/pkg/adom/{adom}/{parent_folder}/{name}/scope member'.format(adom=paramgram["adom"],
+                                                                               name=paramgram["name"],
+                                                                               parent_folder=paramgram["parent_folder"])
+    elif paramgram["parent_folder"] is None:
+        url = '/pm/pkg/adom/{adom}/{name}/scope member'.format(adom=paramgram["adom"],
+                                                               name=paramgram["name"])
+    response = fmgr.process_request(url, datagram, method)
+    return response
+
+
 def fmgr_fwpol_package_folder(fmgr, paramgram):
     """
     This function will create folders for firewall packages. It can create down to two levels deep.
@@ -695,6 +762,7 @@ def fmgr_fwpol_package_install(fmgr, paramgram):
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         "scope": paramgram["assign_to_list"]
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
@@ -703,6 +771,8 @@ def fmgr_fwpol_package_install(fmgr, paramgram):
 =======
         "scope": paramgram["assign_to_list"]
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+>>>>>>> Fixed issues:
     }
     if paramgram["parent_folder"]:
         new_path = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
@@ -832,6 +902,7 @@ def main():
         adom=dict(required=False, type="str", default="root"),
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
 =======
         mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
@@ -839,13 +910,19 @@ def main():
 =======
         mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+        mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
+>>>>>>> Fixed issues:
                   type="str", default="add"),
 
         name=dict(required=False, type="str"),
         object_type=dict(required=True, type="str", choices=['pkg', 'folder']),
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> Fixed issues:
         package_folder=dict(required=False, type="str"),
 >>>>>>> Fixed issues:
 =======
@@ -859,7 +936,6 @@ def main():
         scope_groups=dict(required=False, type="str"),
         scope_members=dict(required=False, type="str"),
         scope_members_vdom=dict(required=False, type="str", default="root"),
-        append_scope_members=dict(required=False, type="str", default="enable", choices=['enable', 'disable']),
         parent_folder=dict(required=False, type="str"),
         target_folder=dict(required=False, type="str"),
         target_name=dict(required=False, type="str"),
@@ -881,8 +957,8 @@ def main():
         "scope_groups": module.params["scope_groups"],
         "scope_members": module.params["scope_members"],
         "scope_members_vdom": module.params["scope_members_vdom"],
-        "append_scope_members": module.params["append_scope_members"],
         "parent_folder": module.params["parent_folder"],
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -907,6 +983,11 @@ def main():
 =======
         "assign_to_list": list()
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+        "append_members_list": list(),
+        "existing_members_list": list(),
+        "package_exists": None,
+>>>>>>> Fixed issues:
     }
     module.paramgram = paramgram
     fmgr = None
@@ -920,6 +1001,7 @@ def main():
     # BEGIN MODULE-SPECIFIC LOGIC -- THINGS NEED TO HAPPEN DEPENDING ON THE ENDPOINT AND OPERATION
     results = DEFAULT_RESULT_OBJ
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -971,30 +1053,20 @@ def main():
     paramgram["assign_to_list"] = members_list
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
+=======
+    # QUERY FORTIMANAGER FOR EXISTING PACKAGE DETAILS AND UPDATE PARAMGRAM
+    paramgram = fmgr_fwpol_package_get_details(fmgr, paramgram)
+>>>>>>> Fixed issues:
 
-    # CHECK FOR EXISTING SCOPE MEMBERS IF THAT OPTION IS ENABLED
     try:
-        if paramgram["append_scope_members"] == "enable":
-            pol_datagram = {"type": paramgram["object_type"], "name": paramgram["name"]}
-            pol_package_url = '/pm/pkg/adom/{adom}/{pkg_name}'.format(adom=paramgram["adom"],
-                                                                      pkg_name=paramgram["name"])
-            pol_package = fmgr.process_request(pol_package_url, pol_datagram, FMGRMethods.GET)
-
-            if len(pol_package) > 2:
-                raise FMGBaseException("Policy Package Name returned multiple results.")
-            if len(pol_package) == 1:
-                raise FMGBaseException("Policy Package couldn't be found, to append existing scope members")
-            if len(pol_package) == 2:
-                try:
-                    existing_members = pol_package[1]["scope member"]
-                    for member in existing_members:
-                        if member not in members_list:
-                            members_list.append(member)
-                except Exception as err:
-                    pass
+        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete"]:
+            results = fmgr_fwpol_package(fmgr, paramgram)
+            fmgr.govern_response(module=module, results=results,
+                                 ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))
     except Exception as err:
         raise FMGBaseException(err)
 
+<<<<<<< HEAD
     paramgram["assign_to_list"] = members_list
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 
@@ -1014,6 +1086,9 @@ def main():
         raise FMGBaseException(err)
 
     try:
+=======
+    try:
+>>>>>>> Fixed issues:
         if paramgram["object_type"] == "pkg" and paramgram["package_exists"] \
                 and len(paramgram["append_members_list"]) > 0 \
                 and paramgram["mode"] in ['add_targets', 'delete_targets']:

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -144,14 +144,14 @@ options:
     description:
       - The parent folder name you want to add this object under.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
+      - Do not include leading or trailing forwardslashes.
     required: false
 
   target_folder:
     description:
       - Only used when mode equals move.
       - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
-      - Do not include leading or trailing forwardslashes. We take care of that for you.
+      - Do not include leading or trailing forwardslashes.
     required: false
     version_added: 2.9
 

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -31,6 +31,16 @@ module: fmgr_fwpol_package
 version_added: "2.8"
 notes:
     - Full Documentation at U(https://ftnt-ansible-docs.readthedocs.io/en/latest/).
+    - Revision Comments April 2nd 2019
+        - Couldn't append to installation target list, only send a complete list. We've added modes for adding and
+          deleting just targets for policy packages.
+        - Install mode has been added. Scope_members is no longer taken into account when mode = install.
+          Only the existing installation targets on the package will be used. Update installation targets before.
+        - Nested folders and packages now work properly. Before they were not.
+        - When using modes "add" or "set" with object_type = "pkg" the installation targets are STILL OVERWRITTEN with
+          what was supplied under scope_members and scope_groups. Use the add_targets or delete_targets mode first.
+        - When using "add_targets" or "delete_targets" for changing installation targets, only scope_members or
+          scope_groups is considered for changes to the package. To edit the package settings themselves, use "set".
 author:
     - Luke Weighall (@lweighall)
     - Andrew Welsh (@Ghilli3)

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -50,10 +50,15 @@ notes:
         - When using "add_targets" or "delete_targets" for changing installation targets, only scope_members or
           scope_groups is considered for changes to the package. To edit the package settings themselves, use "set".
 <<<<<<< HEAD
+<<<<<<< HEAD
     - Revision Comments May 21st 2019
         - Added support to move packages.
 =======
 >>>>>>> Added notes and documentation
+=======
+    - Revision Comments May 21st 2019
+        - Added support to move packages.
+>>>>>>> Fixes to fmgr_fwpol_package
 author:
     - Luke Weighall (@lweighall)
     - Andrew Welsh (@Ghilli3)
@@ -81,10 +86,14 @@ options:
       - Install will install the package to the assigned installation targets listed on existing package.
       - Update your installation targets BEFORE running install task.
 <<<<<<< HEAD
+<<<<<<< HEAD
     choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
 =======
     choices: ['add', 'set', 'delete', 'add_targets', 'delete_targets', 'install']
 >>>>>>> Fixed issues:
+=======
+    choices: ['add', 'set', 'delete', 'move', 'copy', 'add_targets', 'delete_targets', 'install']
+>>>>>>> Fixes to fmgr_fwpol_package
     default: add
 
   name:
@@ -203,7 +212,17 @@ options:
       - Do not include leading or trailing forwardslashes. We take care of that for you.
 >>>>>>> Removed un-used parameter package_folder. Replaced by parent_folder.
     required: false
+<<<<<<< HEAD
     version_added: 2.9
+=======
+
+  target_folder:
+    description:
+      - Only used when mode equals move.
+      - Nested folders are supported with forwardslashes. i.e. ansibleTestFolder1/ansibleTestFolder2/etc...
+      - Do not include leading or trailing forwardslashes. We take care of that for you.
+    required: false
+>>>>>>> Fixes to fmgr_fwpol_package
 
   target_name:
     description:
@@ -211,9 +230,12 @@ options:
       - Only used when you want to rename the package in its new location.
       - If None, then NAME will be used.
     required: false
+<<<<<<< HEAD
     version_added: 2.9
 =======
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
+=======
+>>>>>>> Fixes to fmgr_fwpol_package
 '''
 
 
@@ -370,6 +392,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
             datagram["scope member"] = paramgram["append_members_list"]
         elif len(paramgram["append_members_list"]) == 0:
 <<<<<<< HEAD
+<<<<<<< HEAD
             datagram["scope member"] = {}
 
         # IF PARENT FOLDER IS DEFINED
@@ -424,11 +447,42 @@ def fmgr_fwpol_package(fmgr, paramgram):
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
             datagram["scope member"] = None
+=======
+            datagram["scope member"] = {}
+>>>>>>> Fixes to fmgr_fwpol_package
 
         # IF PARENT FOLDER IS DEFINED
         if paramgram["parent_folder"] is not None:
             datagram = fmgr_fwpol_package_create_parent_folder_objects(paramgram, datagram)
 >>>>>>> Fixed issues:
+
+    # IF MODE IS MOVE
+    if paramgram['mode'] in ["move", "copy"]:
+        if paramgram["mode"] == "move":
+            url = '/securityconsole/package/move'
+        elif paramgram["mode"] == "copy":
+            url = '/securityconsole/package/clone'
+        if paramgram["target_name"]:
+            name = paramgram["target_name"]
+        else:
+            name = paramgram["name"]
+        datagram = {
+            "adom": paramgram["adom"],
+            "dst_name": name,
+            "dst_parent": paramgram["target_folder"],
+            "pkg": paramgram["name"]
+        }
+        if paramgram["parent_folder"]:
+            datagram["pkg"] = str(paramgram["parent_folder"]) + "/" + str(paramgram["name"])
+        else:
+            datagram["pkg"] = str(paramgram["name"])
+
+        if paramgram["mode"] == "copy":
+            # SET THE SCOPE MEMBERS ACCORDING TO MODE AND WHAT WAS SUPPLIED
+            if len(paramgram["append_members_list"]) > 0:
+                datagram["scope member"] = paramgram["append_members_list"]
+            elif len(paramgram["append_members_list"]) == 0:
+                datagram["scope member"] = {}
 
     # NORMAL DELETE NO PARENT
     if paramgram["mode"] == "delete" and paramgram["parent_folder"] is None:
@@ -452,6 +506,7 @@ def fmgr_fwpol_package(fmgr, paramgram):
         response = fmgr.process_request(url, datagram, FMGRMethods.EXEC)
     else:
         response = fmgr.process_request(url, datagram, paramgram["mode"])
+<<<<<<< HEAD
     return response
 
 
@@ -495,6 +550,8 @@ def fmgr_fwpol_package_edit_targets(fmgr, paramgram):
         url = '/pm/pkg/adom/{adom}/{name}/scope member'.format(adom=paramgram["adom"],
                                                                name=paramgram["name"])
     response = fmgr.process_request(url, datagram, method)
+=======
+>>>>>>> Fixes to fmgr_fwpol_package
     return response
 
 
@@ -739,10 +796,14 @@ def main():
     argument_spec = dict(
         adom=dict(required=False, type="str", default="root"),
 <<<<<<< HEAD
+<<<<<<< HEAD
         mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
 =======
         mode=dict(choices=["add", "set", "delete", "add_targets", "delete_targets", "install"],
 >>>>>>> Fixed issues:
+=======
+        mode=dict(choices=["add", "set", "delete", "move", "copy", "add_targets", "delete_targets", "install"],
+>>>>>>> Fixes to fmgr_fwpol_package
                   type="str", default="add"),
 
         name=dict(required=False, type="str"),
@@ -787,6 +848,7 @@ def main():
         "parent_folder": module.params["parent_folder"],
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         "target_folder": module.params["target_folder"],
         "target_name": module.params["target_name"],
         "append_members_list": list(),
@@ -796,6 +858,10 @@ def main():
         "assign_to_list": list()
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
+=======
+        "target_folder": module.params["target_folder"],
+        "target_name": module.params["target_name"],
+>>>>>>> Fixes to fmgr_fwpol_package
         "append_members_list": list(),
         "existing_members_list": list(),
         "package_exists": None,
@@ -849,7 +915,7 @@ def main():
 >>>>>>> Fixed issues:
 
     try:
-        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete"]:
+        if paramgram["object_type"] == "pkg" and paramgram["mode"] in ["add", "set", "delete", "move", "copy"]:
             results = fmgr_fwpol_package(fmgr, paramgram)
             fmgr.govern_response(module=module, results=results,
                                  ansible_facts=fmgr.construct_ansible_facts(results, module.params, paramgram))

--- a/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -293,7 +293,11 @@ options:
 =======
       - Do not include leading or trailing forwardslashes. We take care of that for you.
     required: false
+<<<<<<< HEAD
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+    version_added: 2.9
+>>>>>>> Version_added fields missing
 
   target_name:
     description:
@@ -301,6 +305,7 @@ options:
       - Only used when you want to rename the package in its new location.
       - If None, then NAME will be used.
     required: false
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -316,6 +321,9 @@ options:
 >>>>>>> Added Append_scope_members list. Defaults to enable, but if you disable it, it will still allow the overwriting of members.
 =======
 >>>>>>> Fixes to fmgr_fwpol_package
+=======
+    version_added: 2.9
+>>>>>>> Version_added fields missing
 '''
 
 

--- a/test/units/modules/network/fortimanager/fixtures/test_fmgr_device.json
+++ b/test/units/modules/network/fortimanager/fixtures/test_fmgr_device.json
@@ -1,5 +1,8 @@
 {
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Auto Commit for: fmgr_device
     "add_device": [
         {
             "url": "/dvm/cmd/add/device/",
@@ -932,6 +935,7 @@
             "post_method": "exec"
         }
     ]
+<<<<<<< HEAD
 =======
    "add_device": [
       {
@@ -1865,5 +1869,7 @@
          "post_method": "exec"
       }
    ]
+>>>>>>> Auto Commit for: fmgr_device
+=======
 >>>>>>> Auto Commit for: fmgr_device
 }

--- a/test/units/modules/network/fortimanager/fixtures/test_fmgr_device.json
+++ b/test/units/modules/network/fortimanager/fixtures/test_fmgr_device.json
@@ -1,4 +1,5 @@
 {
+<<<<<<< HEAD
     "add_device": [
         {
             "url": "/dvm/cmd/add/device/",
@@ -931,4 +932,938 @@
             "post_method": "exec"
         }
     ]
+=======
+   "add_device": [
+      {
+         "url": "/dvm/cmd/add/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "os_ver": 6, 
+               "ip": "10.7.220.151", 
+               "mgmt.__data[6]": 1, 
+               "vm_mem": 1003, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "platform_id": 112, 
+               "branch_pt": 231, 
+               "hostname": "ansible-fgt01", 
+               "source": 1, 
+               "mgmt_id": 1014939351, 
+               "version": 600, 
+               "build": 231, 
+               "mgmt_mode": 3, 
+               "adm_usr": "admin", 
+               "av_ver": "1.00000(2018-04-09 18:07)", 
+               "mgmt.__data[4]": 1052262400, 
+               "oid": 403, 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1550698141, 
+               "vm_mem_limit": 6144, 
+               "mgmt.__data[0]": 3870643, 
+               "name": "FGT1", 
+               "tab_status": "<unknown>", 
+               "patch": 4, 
+               "vm_cpu_limit": 4, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097169, 
+               "sn": "FGVM04TM18000391", 
+               "mr": 0, 
+               "os_type": 0, 
+               "vm_cpu": 1
+            }
+         }, 
+         "datagram_sent": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "name": "FGT1", 
+               "ip": "10.7.220.151", 
+               "flags": 24, 
+               "sn": null, 
+               "mgmt_mode": "fmgfaz", 
+               "adm_usr": "admin"
+            }, 
+            "flags": [
+               "create_task", 
+               "nonblocking"
+            ], 
+            "odd_request_form": "True", 
+            "adom": "ansible"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "device_unique_name": "FGT1", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "exec"
+      }, 
+      {
+         "url": "/dvm/cmd/add/device/", 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "device_unique_name": "FGT2", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "datagram_sent": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "name": "FGT2", 
+               "ip": "10.7.220.152", 
+               "flags": 24, 
+               "sn": null, 
+               "mgmt_mode": "fmgfaz", 
+               "adm_usr": "admin"
+            }, 
+            "flags": [
+               "create_task", 
+               "nonblocking"
+            ], 
+            "odd_request_form": "True", 
+            "adom": "ansible"
+         }, 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.152", 
+               "mgmt.__data[6]": 1, 
+               "vm_mem": 1003, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 4, 
+               "vm_cpu": 1, 
+               "branch_pt": 231, 
+               "hostname": "ansible-fgt02", 
+               "source": 1, 
+               "mgmt_id": 1879100317, 
+               "version": 600, 
+               "build": 231, 
+               "mgmt_mode": 3, 
+               "adm_usr": "admin", 
+               "av_ver": "1.00000(2018-04-09 18:07)", 
+               "oid": 415, 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1550698177, 
+               "patch": 4, 
+               "vm_mem_limit": 6144, 
+               "mgmt.__data[0]": 3870643, 
+               "name": "FGT2", 
+               "tab_status": "<unknown>", 
+               "mgmt.__data[4]": 1052262400, 
+               "platform_id": 112, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097169, 
+               "sn": "FGVM04TM18000392", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "post_method": "exec"
+      }, 
+      {
+         "url": "/dvm/cmd/add/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "os_ver": 6, 
+               "ip": "10.7.220.153", 
+               "mgmt.__data[6]": 1, 
+               "vm_mem": 1003, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "platform_id": 112, 
+               "branch_pt": 231, 
+               "hostname": "ansible-fgt03", 
+               "source": 1, 
+               "mgmt_id": 104863251, 
+               "version": 600, 
+               "build": 231, 
+               "mgmt_mode": 3, 
+               "adm_usr": "admin", 
+               "av_ver": "1.00000(2018-04-09 18:07)", 
+               "mgmt.__data[4]": 1052262400, 
+               "oid": 427, 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1550698204, 
+               "vm_mem_limit": 6144, 
+               "mgmt.__data[0]": 3870643, 
+               "name": "FGT3", 
+               "tab_status": "<unknown>", 
+               "patch": 4, 
+               "vm_cpu_limit": 4, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097169, 
+               "sn": "FGVM04TM18000393", 
+               "mr": 0, 
+               "os_type": 0, 
+               "vm_cpu": 1
+            }
+         }, 
+         "datagram_sent": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "name": "FGT3", 
+               "ip": "10.7.220.153", 
+               "flags": 24, 
+               "sn": null, 
+               "mgmt_mode": "fmgfaz", 
+               "adm_usr": "admin"
+            }, 
+            "flags": [
+               "create_task", 
+               "nonblocking"
+            ], 
+            "odd_request_form": "True", 
+            "adom": "ansible"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "device_unique_name": "FGT3", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "exec"
+      }
+   ], 
+   "discover_device": [
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "device_unique_name": "FGT1", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "datagram_sent": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.151", 
+               "adm_usr": "admin"
+            }, 
+            "odd_request_form": "True"
+         }, 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.151", 
+               "vm_mem": 1003, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 4, 
+               "vm_cpu": 1, 
+               "branch_pt": 231, 
+               "hostname": "ansible-fgt01", 
+               "source": 1, 
+               "version": 600, 
+               "build": 231, 
+               "adm_usr": "admin", 
+               "av_ver": "1.00000(2018-04-09 18:07)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1550698136, 
+               "vm_mem_limit": 6144, 
+               "name": "ansible-fgt01", 
+               "tab_status": "<unknown>", 
+               "patch": 4, 
+               "platform_id": 112, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM04TM18000391", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "post_method": "exec"
+      }, 
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "os_ver": 6, 
+               "ip": "10.7.220.152", 
+               "vm_mem": 1003, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "platform_id": 112, 
+               "branch_pt": 231, 
+               "hostname": "ansible-fgt02", 
+               "source": 1, 
+               "version": 600, 
+               "build": 231, 
+               "adm_usr": "admin", 
+               "av_ver": "1.00000(2018-04-09 18:07)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1550698173, 
+               "vm_mem_limit": 6144, 
+               "name": "ansible-fgt02", 
+               "tab_status": "<unknown>", 
+               "patch": 4, 
+               "vm_cpu_limit": 4, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM04TM18000392", 
+               "mr": 0, 
+               "os_type": 0, 
+               "vm_cpu": 1
+            }
+         }, 
+         "datagram_sent": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.152", 
+               "adm_usr": "admin"
+            }, 
+            "odd_request_form": "True"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "device_unique_name": "FGT2", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "exec"
+      }, 
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "device_unique_name": "FGT3", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "datagram_sent": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.153", 
+               "adm_usr": "admin"
+            }, 
+            "odd_request_form": "True"
+         }, 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.153", 
+               "vm_mem": 1003, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 4, 
+               "vm_cpu": 1, 
+               "branch_pt": 231, 
+               "hostname": "ansible-fgt03", 
+               "source": 1, 
+               "version": 600, 
+               "build": 231, 
+               "adm_usr": "admin", 
+               "av_ver": "1.00000(2018-04-09 18:07)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1550698200, 
+               "vm_mem_limit": 6144, 
+               "name": "ansible-fgt03", 
+               "tab_status": "<unknown>", 
+               "patch": 4, 
+               "platform_id": 112, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM04TM18000393", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "post_method": "exec"
+      }
+   ], 
+   "get_device": [
+      {
+         "url": "/dvmdb/adom/ansible/device/FGT1", 
+         "raw_response": {
+            "adm_pass": [
+               "ENC", 
+               "tUEPOPpQM6XsNwOPcWyrWoPoKo2DMjtFqOYEzLfF+99FpTkDmKa+GTmwBMLV1ns0OYrNgWnk6RPbRjSZSvu2LPYvCcWfQONLEZ1HlczZ00kEtDRCvRxG6l7FGtcj1Pl7QO9khy2lKWx4/lbPmLNqCzwCmlkAO5fGXR3nCbWPXH5BrRwO"
+            ], 
+            "faz.perm": 0, 
+            "foslic_ram": 0, 
+            "foslic_type": "temporary", 
+            "last_checked": 1550635232, 
+            "psk": "", 
+            "opts": 0, 
+            "ip": "10.7.220.151", 
+            "foslic_utm": null, 
+            "logdisk_size": 30235, 
+            "mgmt.__data[6]": 1, 
+            "foslic_last_sync": 0, 
+            "app_ver": "", 
+            "ips_ext": 0, 
+            "vm_mem": 1003, 
+            "mgmt.__data[4]": 1052262400, 
+            "maxvdom": 10, 
+            "conn_mode": "passive", 
+            "location_from": "GUI(10.0.0.151)", 
+            "mgmt.__data[1]": 0, 
+            "mgmt.__data[2]": 0, 
+            "faz.full_act": 0, 
+            "os_ver": "6.0", 
+            "node_flags": 0, 
+            "hostname": "ansible-fgt01", 
+            "mgmt.__data[5]": 0, 
+            "mgmt_id": 2076985412, 
+            "hw_rev_minor": 0, 
+            "mgmt_if": "port1", 
+            "source": "faz", 
+            "ha_mode": "standalone", 
+            "version": 600, 
+            "build": 231, 
+            "latitude": "47.473991", 
+            "foslic_cpu": 0, 
+            "last_resync": 1550634702, 
+            "desc": "", 
+            "adm_usr": "admin", 
+            "vm_lic_expire": 0, 
+            "ha_slave": null, 
+            "av_ver": "1.00000(2018-04-09 18:07)", 
+            "fsw_cnt": 0, 
+            "tunnel_cookie": "", 
+            "foslic_inst_time": 0, 
+            "lic_flags": 0, 
+            "checksum": "89 1f b7 b7 2a a6 af 54 c5 a5 aa e3 32 92 c7 55", 
+            "oid": 366, 
+            "conn_status": "up", 
+            "fex_cnt": 0, 
+            "mgmt.__data[3]": 0, 
+            "beta": -1, 
+            "ha_group_name": "", 
+            "dev_status": "installed", 
+            "platform_str": "FortiGate-VM64", 
+            "mgmt.__data[7]": 0, 
+            "faz.used": 0, 
+            "fap_cnt": 0, 
+            "foslic_dr_site": "disable", 
+            "mgmt_mode": "fmgfaz", 
+            "vdom": [
+               {
+                  "status": null, 
+                  "oid": 3, 
+                  "name": "root", 
+                  "node_flags": 0, 
+                  "devid": "FGT1", 
+                  "tab_status": null, 
+                  "comments": "", 
+                  "flags": null, 
+                  "opmode": "nat", 
+                  "ext_flags": 1, 
+                  "rtm_prof_id": 0
+               }
+            ], 
+            "hdisk_size": 30720, 
+            "vm_mem_limit": 6144, 
+            "mgmt.__data[0]": 3870643, 
+            "ha_group_id": 0, 
+            "name": "FGT1", 
+            "faz.quota": 0, 
+            "mgt_vdom": "root", 
+            "tab_status": "", 
+            "tunnel_ip": "169.254.0.5", 
+            "longitude": "-122.260963", 
+            "patch": 4, 
+            "vm_cpu_limit": 4, 
+            "vm_status": 3, 
+            "lic_region": "", 
+            "hw_rev_major": 0, 
+            "flags": [
+               "has_hdd", 
+               "reload"
+            ], 
+            "sn": "FGVM04TM18000391", 
+            "mr": 0, 
+            "conf_status": "insync", 
+            "os_type": "fos", 
+            "ips_ver": "6.00741(2015-12-01 02:30)", 
+            "db_status": "nomod", 
+            "branch_pt": 231, 
+            "vm_cpu": 1
+         }, 
+         "datagram_sent": {
+            "filter": [
+               "name", 
+               "==", 
+               "FGT1"
+            ], 
+            "adom": "ansible"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "device_unique_name": "FGT1", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "get"
+      }, 
+      {
+         "url": "/dvmdb/adom/ansible/device/FGT2", 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "device_unique_name": "FGT2", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "datagram_sent": {
+            "filter": [
+               "name", 
+               "==", 
+               "FGT2"
+            ], 
+            "adom": "ansible"
+         }, 
+         "raw_response": {
+            "adm_pass": [
+               "ENC", 
+               "F27zJSIl5O8O5rlXIi7BzHIUO5d3ZAuNxoniR42zOxGHyqZCx1OyA81b7v6dNwE30nBhjqfD+IDRmSPEW6qxKIQ2UV5eh8zgDNj8i5lj5gTvbLN5A4BR4CMLQo7nYTTomHUJQrGPfYskuxm74JGik+di9TrqOhvpZL8d1zj3XHx5pq+d"
+            ], 
+            "faz.perm": 0, 
+            "hostname": "ansible-fgt02", 
+            "foslic_type": "temporary", 
+            "mgmt.__data[7]": 0, 
+            "av_ver": "1.00000(2018-04-09 18:07)", 
+            "ip": "10.7.220.152", 
+            "foslic_utm": null, 
+            "logdisk_size": 30235, 
+            "mgmt.__data[6]": 1, 
+            "fsw_cnt": 0, 
+            "app_ver": "", 
+            "ips_ext": 0, 
+            "vm_mem": 1003, 
+            "maxvdom": 10, 
+            "conn_mode": "passive", 
+            "mgt_vdom": "root", 
+            "mgmt.__data[1]": 0, 
+            "hw_rev_major": 0, 
+            "name": "FGT2", 
+            "node_flags": 0, 
+            "foslic_ram": 0, 
+            "mgmt.__data[5]": 0, 
+            "ha_mode": "standalone", 
+            "hw_rev_minor": 0, 
+            "mgmt_if": "port1", 
+            "source": "faz", 
+            "mgmt_id": 1555154046, 
+            "version": 600, 
+            "build": 231, 
+            "latitude": "47.473991", 
+            "foslic_cpu": 0, 
+            "last_resync": 1550634728, 
+            "hdisk_size": 30720, 
+            "adm_usr": "admin", 
+            "vm_lic_expire": 0, 
+            "sn": "FGVM04TM18000392", 
+            "ha_slave": null, 
+            "psk": "", 
+            "foslic_last_sync": 0, 
+            "tunnel_cookie": "", 
+            "vm_mem_limit": 6144, 
+            "mr": 0, 
+            "lic_flags": 0, 
+            "oid": 378, 
+            "conn_status": "up", 
+            "fex_cnt": 0, 
+            "vm_cpu": 1, 
+            "beta": -1, 
+            "ha_group_name": "", 
+            "dev_status": "retrieved", 
+            "platform_str": "FortiGate-VM64", 
+            "last_checked": 1550634728, 
+            "branch_pt": 231, 
+            "faz.used": 0, 
+            "patch": 4, 
+            "fap_cnt": 0, 
+            "foslic_dr_site": "disable", 
+            "mgmt_mode": "fmgfaz", 
+            "vdom": [
+               {
+                  "status": null, 
+                  "oid": 3, 
+                  "name": "root", 
+                  "node_flags": 4, 
+                  "devid": "FGT2", 
+                  "tab_status": null, 
+                  "comments": "", 
+                  "flags": null, 
+                  "opmode": "nat", 
+                  "ext_flags": 1, 
+                  "rtm_prof_id": 0
+               }
+            ], 
+            "desc": "", 
+            "foslic_inst_time": 0, 
+            "mgmt.__data[0]": 3870643, 
+            "ha_group_id": 0, 
+            "location_from": "GUI(10.0.0.151)", 
+            "faz.quota": 0, 
+            "faz.full_act": 0, 
+            "tab_status": "", 
+            "tunnel_ip": "169.254.0.3", 
+            "longitude": "-122.260963", 
+            "mgmt.__data[4]": 1052262400, 
+            "vm_cpu_limit": 4, 
+            "vm_status": 3, 
+            "lic_region": "", 
+            "mgmt.__data[2]": 0, 
+            "flags": [
+               "has_hdd", 
+               "reload"
+            ], 
+            "opts": 0, 
+            "checksum": "56 e9 a7 14 e2 61 05 f9 ec 2b 00 1e 36 bc af c8", 
+            "conf_status": "insync", 
+            "os_type": "fos", 
+            "ips_ver": "6.00741(2015-12-01 02:30)", 
+            "db_status": "mod", 
+            "mgmt.__data[3]": 0, 
+            "os_ver": "6.0"
+         }, 
+         "post_method": "get"
+      }, 
+      {
+         "url": "/dvmdb/adom/ansible/device/FGT3", 
+         "raw_response": {
+            "adm_pass": [
+               "ENC", 
+               "F27zJSIl5O8O5rlXIi7BzHIUO5d3ZAuNxoniR42zOxGHyqZCx1OyA81b7v6dNwE30nBhjqfD+IDRmSPEW6qxKIQ2UV5eh8zgDNj8i5lj5gTvbLN5A4BR4CMLQo7nYTTomHUJQrGPfYskuxm74JGik+di9TrqOhvpZL8d1zj3XHx5pq+d"
+            ], 
+            "faz.perm": 0, 
+            "foslic_ram": 0, 
+            "foslic_type": "temporary", 
+            "last_checked": 1550634754, 
+            "psk": "", 
+            "opts": 0, 
+            "ip": "10.7.220.153", 
+            "foslic_utm": null, 
+            "logdisk_size": 30235, 
+            "mgmt.__data[6]": 1, 
+            "foslic_last_sync": 0, 
+            "app_ver": "", 
+            "ips_ext": 0, 
+            "vm_mem": 1003, 
+            "mgmt.__data[4]": 1052262400, 
+            "desc": "", 
+            "maxvdom": 10, 
+            "conn_mode": "passive", 
+            "location_from": "GUI(10.0.0.151)", 
+            "mgmt.__data[1]": 0, 
+            "os_ver": "6.0", 
+            "faz.full_act": 0, 
+            "node_flags": 0, 
+            "hostname": "ansible-fgt03", 
+            "mgmt.__data[5]": 0, 
+            "mgmt_id": 1175062219, 
+            "hw_rev_minor": 0, 
+            "mgmt_if": "port1", 
+            "source": "faz", 
+            "ha_mode": "standalone", 
+            "version": 600, 
+            "build": 231, 
+            "latitude": "47.473991", 
+            "foslic_cpu": 0, 
+            "last_resync": 1550634754, 
+            "hdisk_size": 30720, 
+            "adm_usr": "admin", 
+            "vm_lic_expire": 0, 
+            "conf_status": "insync", 
+            "ha_slave": null, 
+            "av_ver": "1.00000(2018-04-09 18:07)", 
+            "fsw_cnt": 0, 
+            "tunnel_cookie": "", 
+            "foslic_inst_time": 0, 
+            "lic_flags": 0, 
+            "oid": 390, 
+            "conn_status": "up", 
+            "fex_cnt": 0, 
+            "mgmt.__data[3]": 0, 
+            "beta": -1, 
+            "ha_group_name": "", 
+            "dev_status": "retrieved", 
+            "platform_str": "FortiGate-VM64", 
+            "mgmt.__data[7]": 0, 
+            "faz.used": 0, 
+            "fap_cnt": 0, 
+            "foslic_dr_site": "disable", 
+            "mgmt_mode": "fmgfaz", 
+            "vdom": [
+               {
+                  "status": null, 
+                  "oid": 3, 
+                  "name": "root", 
+                  "node_flags": 4, 
+                  "devid": "FGT3", 
+                  "tab_status": null, 
+                  "comments": "", 
+                  "flags": null, 
+                  "opmode": "nat", 
+                  "ext_flags": 1, 
+                  "rtm_prof_id": 0
+               }
+            ], 
+            "name": "FGT3", 
+            "vm_mem_limit": 6144, 
+            "mgmt.__data[0]": 3870643, 
+            "ha_group_id": 0, 
+            "mgmt.__data[2]": 0, 
+            "faz.quota": 0, 
+            "checksum": "30 fc af f5 58 e4 1e 2d 46 c0 07 4b b6 4b c2 1b", 
+            "tab_status": "", 
+            "tunnel_ip": "169.254.0.4", 
+            "longitude": "-122.260963", 
+            "patch": 4, 
+            "vm_cpu_limit": 4, 
+            "vm_status": 3, 
+            "lic_region": "", 
+            "mgt_vdom": "root", 
+            "flags": [
+               "has_hdd", 
+               "reload"
+            ], 
+            "sn": "FGVM04TM18000393", 
+            "mr": 0, 
+            "hw_rev_major": 0, 
+            "os_type": "fos", 
+            "ips_ver": "6.00741(2015-12-01 02:30)", 
+            "db_status": "mod", 
+            "branch_pt": 231, 
+            "vm_cpu": 1
+         }, 
+         "datagram_sent": {
+            "filter": [
+               "name", 
+               "==", 
+               "FGT3"
+            ], 
+            "adom": "ansible"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "device_unique_name": "FGT3", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "get"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "Object does not exist", 
+               "code": -3
+            }, 
+            "url": "/dvmdb/adom/ansible/device/FGT1"
+         }, 
+         "datagram_sent": {
+            "filter": [
+               "name", 
+               "==", 
+               "FGT1"
+            ], 
+            "adom": "ansible"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "device_unique_name": "FGT1", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "get"
+      }, 
+      {
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "device_unique_name": "FGT2", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "datagram_sent": {
+            "filter": [
+               "name", 
+               "==", 
+               "FGT2"
+            ], 
+            "adom": "ansible"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "Object does not exist", 
+               "code": -3
+            }, 
+            "url": "/dvmdb/adom/ansible/device/FGT2"
+         }, 
+         "post_method": "get"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "Object does not exist", 
+               "code": -3
+            }, 
+            "url": "/dvmdb/adom/ansible/device/FGT3"
+         }, 
+         "datagram_sent": {
+            "filter": [
+               "name", 
+               "==", 
+               "FGT3"
+            ], 
+            "adom": "ansible"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "device_unique_name": "FGT3", 
+            "mode": "add", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "get"
+      }
+   ], 
+   "delete_device": [
+      {
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "root", 
+            "device_ip": "10.7.220.151", 
+            "device_unique_name": "FGT1", 
+            "mode": "delete", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "datagram_sent": {
+            "device": "FGT1", 
+            "flags": [
+               "create_task", 
+               "nonblocking"
+            ], 
+            "adom": "root"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvm/cmd/del/device/"
+         }, 
+         "post_method": "exec"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvm/cmd/del/device/"
+         }, 
+         "datagram_sent": {
+            "device": "FGT2", 
+            "flags": [
+               "create_task", 
+               "nonblocking"
+            ], 
+            "adom": "ansible"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "device_unique_name": "FGT2", 
+            "mode": "delete", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "exec"
+      }, 
+      {
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "device_unique_name": "FGT3", 
+            "mode": "delete", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "datagram_sent": {
+            "device": "FGT3", 
+            "flags": [
+               "create_task", 
+               "nonblocking"
+            ], 
+            "adom": "ansible"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvm/cmd/del/device/"
+         }, 
+         "post_method": "exec"
+      }
+   ]
+>>>>>>> Auto Commit for: fmgr_device
 }

--- a/test/units/modules/network/fortimanager/fixtures/test_fmgr_fwpol_package.json
+++ b/test/units/modules/network/fortimanager/fixtures/test_fmgr_fwpol_package.json
@@ -1,279 +1,1860 @@
 {
-    "fmgr_fwpol_package_folder": [
-        {
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible"
+   "fmgr_fwpol_package_folder": [
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "datagram_sent": {
-                "type": "folder",
-                "name": "ansibleTestFolder1"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestFolder4"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder4",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "paramgram_used": {
-                "ssl-ssh-profile": null,
-                "name": "ansibleTestFolder1",
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "folder",
-                "fwpolicy-implicit-log": "disable",
-                "package-folder": null,
-                "inspection-mode": "flow",
-                "scope_members": null,
-                "mode": "set",
-                "parent_folder": null,
-                "scope_members_vdom": "root",
-                "central-nat": "disable",
-                "ngfw-mode": "profile-based"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestFolder3"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder3",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "post_method": "set"
-        },
-        {
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestFolder2"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder2",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "datagram_sent": {
-                "subobj": [
-                    {
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "set",
+            "scope_groups": null,
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "subobj": [
+               {
+                  "type": "folder",
+                  "name": "ansibleTestFolder2"
+               }
+            ],
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder2",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "set",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "subobj": [
+               {
+                  "subobj": [
+                     {
                         "type": "folder",
-                        "name": "ansibleTestFolder2"
-                    }
-                ],
-                "type": "folder",
-                "name": "ansibleTestFolder1"
+                        "name": "ansibleTestFolder3"
+                     }
+                  ],
+                  "type": "folder",
+                  "name": "ansibleTestFolder2"
+               }
+            ],
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder3",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "set",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "paramgram_used": {
-                "ssl-ssh-profile": null,
-                "name": "ansibleTestFolder2",
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "folder",
-                "fwpolicy-implicit-log": "disable",
-                "package-folder": null,
-                "inspection-mode": "flow",
-                "scope_members": null,
-                "mode": "set",
-                "parent_folder": "ansibleTestFolder1",
-                "scope_members_vdom": "root",
-                "central-nat": "disable",
-                "ngfw-mode": "profile-based"
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "subobj": [
+               {
+                  "subobj": [
+                     {
+                        "subobj": [
+                           {
+                              "type": "folder",
+                              "name": "ansibleTestFolder4"
+                           }
+                        ],
+                        "type": "folder",
+                        "name": "ansibleTestFolder3"
+                     }
+                  ],
+                  "type": "folder",
+                  "name": "ansibleTestFolder2"
+               }
+            ],
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestFolder4",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "folder",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "set",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      }
+   ],
+   "fmgr_fwpol_package_edit_targets": [
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "post_method": "set"
-        },
-        {
-            "paramgram_used": {
-                "ssl-ssh-profile": null,
-                "scope_members_vdom": "root",
-                "name": "ansibleTestFolder2",
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "folder",
-                "fwpolicy-implicit-log": "disable",
-                "central-nat": "disable",
-                "inspection-mode": "flow",
-                "scope_members": null,
-                "mode": "delete",
-                "parent_folder": "ansibleTestFolder1",
-                "package-folder": null,
-                "ngfw-mode": "profile-based"
+            "url": "/pm/pkg/adom/ansible/ansibleTestPackage1/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT1",
+            "mode": "add_targets",
+            "scope_groups": "testtest",
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "add"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "datagram_sent": {
-                "name": "ansibleTestFolder2"
+            "url": "/pm/pkg/adom/ansible/ansibleTestPackage1/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2",
+            "mode": "delete_targets",
+            "scope_groups": "TestGroup",
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestPackage2/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage2",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT1, FGT2, FGT3",
+            "mode": "add_targets",
+            "scope_groups": "testtest, TestGroup",
+            "parent_folder": "ansibleTestFolder1",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "add"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "post_method": "delete"
-        },
-        {
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible/ansibleTestFolder1"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestPackage2/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage2",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2",
+            "mode": "delete_targets",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "datagram_sent": {
-                "name": "ansibleTestFolder1"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestPackage3/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage3",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT1, FGT2, FGT3",
+            "mode": "add_targets",
+            "scope_groups": "testtest, TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "add"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "paramgram_used": {
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "folder",
-                "inspection-mode": "flow",
-                "parent_folder": null,
-                "ngfw-mode": "profile-based",
-                "ssl-ssh-profile": null,
-                "name": "ansibleTestFolder1",
-                "central-nat": "disable",
-                "fwpolicy-implicit-log": "disable",
-                "package-folder": null,
-                "scope_members": null,
-                "mode": "delete",
-                "scope_members_vdom": "root"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestPackage3/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage3",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2",
+            "mode": "delete_targets",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "post_method": "delete"
-        }
-    ],
-    "fmgr_fwpol_package": [
-        {
-            "paramgram_used": {
-                "ssl-ssh-profile": null,
-                "name": "ansibleTestPackage1",
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "pkg",
-                "fwpolicy-implicit-log": "disable",
-                "package-folder": null,
-                "inspection-mode": "flow",
-                "scope_members": "FGT2, FGT3",
-                "mode": "set",
-                "parent_folder": null,
-                "scope_members_vdom": "root",
-                "central-nat": "disable",
-                "ngfw-mode": "profile-based"
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestPackage4/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage4",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT1, FGT2, FGT3",
+            "mode": "add_targets",
+            "scope_groups": "testtest, TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "add"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "datagram_sent": {
-                "type": "pkg",
-                "name": "ansibleTestPackage1",
-                "scope member": [
-                    {
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestPackage4/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage4",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2",
+            "mode": "delete_targets",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4/ansibleTestPackage5/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage5",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT1, FGT2, FGT3",
+            "mode": "add_targets",
+            "scope_groups": "testtest, TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "add"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4/ansibleTestPackage5/scope member"
+         },
+         "datagram_sent": {
+            "data": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ]
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               },
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage5",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2",
+            "mode": "delete_targets",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      }
+   ],
+   "fmgr_fwpol_package": [
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible/ansibleTestPackage1"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestPackage1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "name": "ansibleTestPackage1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestPackage2"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestPackage2"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage2",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestPackage3"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestPackage3"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage3",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestPackage4"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestPackage4"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage4",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4/ansibleTestPackage5"
+         },
+         "datagram_sent": {
+            "name": "ansibleTestPackage5"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage5",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "delete",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "delete"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "type": "pkg",
+            "name": "ansibleTestPackage1",
+            "scope member": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "package settings": {
+               "inspection-mode": "flow",
+               "central-nat": "disable",
+               "fwpolicy-implicit-log": "disable",
+               "fwpolicy6-implicit-log": "disable",
+               "ngfw-mode": "profile-based"
+            }
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestPackage1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2, FGT3",
+            "mode": "add",
+            "scope_groups": "TestGroup",
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "add"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "type": "pkg",
+            "name": "ansibleTestPackage1",
+            "scope member": [
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "package settings": {
+               "inspection-mode": "flow",
+               "central-nat": "disable",
+               "fwpolicy-implicit-log": "disable",
+               "fwpolicy6-implicit-log": "disable",
+               "ngfw-mode": "profile-based"
+            }
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "set",
+            "scope_groups": "TestGroup",
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
+            },
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "subobj": [
+               {
+                  "type": "pkg",
+                  "name": "ansibleTestPackage2",
+                  "scope member": [
+                     {
                         "name": "FGT2",
                         "vdom": "root"
-                    },
-                    {
+                     },
+                     {
                         "name": "FGT3",
                         "vdom": "root"
-                    }
-                ],
-                "package settings": {
-                    "inspection-mode": "flow",
-                    "central-nat": "disable",
-                    "fwpolicy-implicit-log": "disable",
-                    "fwpolicy6-implicit-log": "disable",
-                    "ngfw-mode": "profile-based"
-                }
+                     },
+                     {
+                        "name": "TestGroup"
+                     }
+                  ],
+                  "package settings": {
+                     "inspection-mode": "flow",
+                     "central-nat": "disable",
+                     "fwpolicy-implicit-log": "disable",
+                     "fwpolicy6-implicit-log": "disable",
+                     "ngfw-mode": "profile-based"
+                  }
+               }
+            ],
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestPackage2",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2, FGT3",
+            "mode": "set",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible"
-            },
-            "post_method": "set"
-        },
-        {
-            "paramgram_used": {
-                "ssl-ssh-profile": null,
-                "name": "ansibleTestPackage2",
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "pkg",
-                "fwpolicy-implicit-log": "disable",
-                "package-folder": null,
-                "inspection-mode": "flow",
-                "scope_members": null,
-                "mode": "set",
-                "parent_folder": "ansibleTestFolder1",
-                "scope_members_vdom": "root",
-                "central-nat": "disable",
-                "ngfw-mode": "profile-based"
-            },
-            "datagram_sent": {
-                "subobj": [
-                    {
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "subobj": [
+               {
+                  "subobj": [
+                     {
                         "type": "pkg",
-                        "name": "ansibleTestPackage2",
-                        "scope member": [],
+                        "name": "ansibleTestPackage3",
+                        "scope member": [
+                           {
+                              "name": "FGT2",
+                              "vdom": "root"
+                           },
+                           {
+                              "name": "FGT3",
+                              "vdom": "root"
+                           },
+                           {
+                              "name": "TestGroup"
+                           }
+                        ],
                         "package settings": {
-                            "inspection-mode": "flow",
-                            "central-nat": "disable",
-                            "fwpolicy-implicit-log": "disable",
-                            "fwpolicy6-implicit-log": "disable",
-                            "ngfw-mode": "profile-based"
+                           "inspection-mode": "flow",
+                           "central-nat": "disable",
+                           "fwpolicy-implicit-log": "disable",
+                           "fwpolicy6-implicit-log": "disable",
+                           "ngfw-mode": "profile-based"
                         }
-                    }
-                ],
-                "type": "folder",
-                "name": "ansibleTestFolder1"
+                     }
+                  ],
+                  "type": "folder",
+                  "name": "ansibleTestFolder2"
+               }
+            ],
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestPackage3",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2, FGT3",
+            "mode": "set",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible"
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "subobj": [
+               {
+                  "subobj": [
+                     {
+                        "subobj": [
+                           {
+                              "type": "pkg",
+                              "name": "ansibleTestPackage4",
+                              "scope member": [
+                                 {
+                                    "name": "FGT2",
+                                    "vdom": "root"
+                                 },
+                                 {
+                                    "name": "FGT3",
+                                    "vdom": "root"
+                                 },
+                                 {
+                                    "name": "TestGroup"
+                                 }
+                              ],
+                              "package settings": {
+                                 "inspection-mode": "flow",
+                                 "central-nat": "disable",
+                                 "fwpolicy-implicit-log": "disable",
+                                 "fwpolicy6-implicit-log": "disable",
+                                 "ngfw-mode": "profile-based"
+                              }
+                           }
+                        ],
+                        "type": "folder",
+                        "name": "ansibleTestFolder3"
+                     }
+                  ],
+                  "type": "folder",
+                  "name": "ansibleTestFolder2"
+               }
+            ],
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestPackage4",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2, FGT3",
+            "mode": "set",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      },
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK",
+               "code": 0
             },
-            "post_method": "set"
-        },
-        {
-            "paramgram_used": {
-                "ssl-ssh-profile": null,
-                "name": "ansibleTestPackage1",
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "pkg",
-                "fwpolicy-implicit-log": "disable",
-                "package-folder": null,
-                "inspection-mode": "flow",
-                "scope_members": null,
-                "mode": "delete",
-                "parent_folder": null,
-                "scope_members_vdom": "root",
-                "central-nat": "disable",
-                "ngfw-mode": "profile-based"
-            },
-            "datagram_sent": {
-                "name": "ansibleTestPackage1"
-            },
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible/ansibleTestPackage1"
-            },
-            "post_method": "delete"
-        },
-        {
-            "raw_response": {
-                "status": {
-                    "message": "OK",
-                    "code": 0
-                },
-                "url": "/pm/pkg/adom/ansible/ansibleTestFolder1/ansibleTestPackage2"
-            },
-            "datagram_sent": {
-                "name": "ansibleTestPackage2"
-            },
-            "paramgram_used": {
-                "ssl-ssh-profile": null,
-                "name": "ansibleTestPackage2",
-                "adom": "ansible",
-                "fwpolicy6-implicit-log": "disable",
-                "object_type": "pkg",
-                "fwpolicy-implicit-log": "disable",
-                "package-folder": null,
-                "inspection-mode": "flow",
-                "scope_members": null,
-                "mode": "delete",
-                "parent_folder": "ansibleTestFolder1",
-                "scope_members_vdom": "root",
-                "central-nat": "disable",
-                "ngfw-mode": "profile-based"
-            },
-            "post_method": "delete"
-        }
-    ]
+            "url": "/pm/pkg/adom/ansible"
+         },
+         "datagram_sent": {
+            "subobj": [
+               {
+                  "subobj": [
+                     {
+                        "subobj": [
+                           {
+                              "subobj": [
+                                 {
+                                    "type": "pkg",
+                                    "name": "ansibleTestPackage5",
+                                    "scope member": [
+                                       {
+                                          "name": "FGT2",
+                                          "vdom": "root"
+                                       },
+                                       {
+                                          "name": "FGT3",
+                                          "vdom": "root"
+                                       },
+                                       {
+                                          "name": "TestGroup"
+                                       }
+                                    ],
+                                    "package settings": {
+                                       "inspection-mode": "flow",
+                                       "central-nat": "disable",
+                                       "fwpolicy-implicit-log": "disable",
+                                       "fwpolicy6-implicit-log": "disable",
+                                       "ngfw-mode": "profile-based"
+                                    }
+                                 }
+                              ],
+                              "type": "folder",
+                              "name": "ansibleTestFolder4"
+                           }
+                        ],
+                        "type": "folder",
+                        "name": "ansibleTestFolder3"
+                     }
+                  ],
+                  "type": "folder",
+                  "name": "ansibleTestFolder2"
+               }
+            ],
+            "type": "folder",
+            "name": "ansibleTestFolder1"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [],
+            "name": "ansibleTestPackage5",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [
+               {
+                  "name": "FGT2",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               },
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "inspection-mode": "flow",
+            "scope_members": "FGT2, FGT3",
+            "mode": "set",
+            "scope_groups": "TestGroup",
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestFolder3/ansibleTestFolder4",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "set"
+      }
+   ],
+   "fmgr_fwpol_package_install": [
+      {
+         "url": "/securityconsole/install/package",
+         "raw_response": {
+            "task": 288
+         },
+         "datagram_sent": {
+            "pkg": "ansibleTestPackage1",
+            "adom": "ansible"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "TestGroup"
+               }
+            ],
+            "name": "ansibleTestPackage1",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "install",
+            "scope_groups": null,
+            "parent_folder": null,
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "exec"
+      },
+      {
+         "url": "/securityconsole/install/package",
+         "raw_response": {
+            "task": 289
+         },
+         "datagram_sent": {
+            "pkg": "ansibleTestFolder1/ansibleTestPackage2",
+            "adom": "ansible"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage2",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "install",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "exec"
+      },
+      {
+         "url": "/securityconsole/install/package",
+         "raw_response": {
+            "message": "session id(43584) username(ansible)",
+            "task": 290
+         },
+         "datagram_sent": {
+            "pkg": "ansibleTestFolder1/ansibleTestFolder2/ansibleTestPackage3",
+            "adom": "ansible"
+         },
+         "paramgram_used": {
+            "ssl-ssh-profile": null,
+            "existing_members_list": [
+               {
+                  "name": "testtest"
+               },
+               {
+                  "name": "FGT1",
+                  "vdom": "root"
+               },
+               {
+                  "name": "FGT3",
+                  "vdom": "root"
+               }
+            ],
+            "name": "ansibleTestPackage3",
+            "adom": "ansible",
+            "package_exists": true,
+            "central-nat": "disable",
+            "object_type": "pkg",
+            "fwpolicy-implicit-log": "disable",
+            "package-folder": null,
+            "append_members_list": [],
+            "inspection-mode": "flow",
+            "scope_members": null,
+            "mode": "install",
+            "scope_groups": null,
+            "parent_folder": "ansibleTestFolder1/ansibleTestFolder2",
+            "scope_members_vdom": "root",
+            "fwpolicy6-implicit-log": "disable",
+            "ngfw-mode": "profile-based"
+         },
+         "post_method": "exec"
+      }
+   ]
 }

--- a/test/units/modules/network/fortimanager/test_fmgr_device.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device.py
@@ -62,9 +62,13 @@ fmg_instance = FortiManagerHandler(connection_mock, module_mock)
 
 def test_discover_device(fixture_data, mocker):
 <<<<<<< HEAD
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 =======
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 >>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################
@@ -110,9 +114,13 @@ def test_discover_device(fixture_data, mocker):
 
 def test_add_device(fixture_data, mocker):
 <<<<<<< HEAD
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 =======
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 >>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################
@@ -158,9 +166,13 @@ def test_add_device(fixture_data, mocker):
 
 def test_delete_device(fixture_data, mocker):
 <<<<<<< HEAD
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 =======
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 >>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################
@@ -206,9 +218,13 @@ def test_delete_device(fixture_data, mocker):
 
 def test_get_device(fixture_data, mocker):
 <<<<<<< HEAD
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 =======
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
 >>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################

--- a/test/units/modules/network/fortimanager/test_fmgr_device.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device.py
@@ -61,7 +61,11 @@ fmg_instance = FortiManagerHandler(connection_mock, module_mock)
 
 
 def test_discover_device(fixture_data, mocker):
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################
 
@@ -105,7 +109,11 @@ def test_discover_device(fixture_data, mocker):
 
 
 def test_add_device(fixture_data, mocker):
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################
 
@@ -149,7 +157,11 @@ def test_add_device(fixture_data, mocker):
 
 
 def test_delete_device(fixture_data, mocker):
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################
 
@@ -193,7 +205,11 @@ def test_delete_device(fixture_data, mocker):
 
 
 def test_get_device(fixture_data, mocker):
+<<<<<<< HEAD
     mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
+=======
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request", 
+>>>>>>> Auto Commit for: fmgr_device
                  side_effect=fixture_data)
     #  Fixture sets used:###########################
 

--- a/test/units/modules/network/fortimanager/test_fmgr_fwpol_package.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_fwpol_package.py
@@ -15,7 +15,6 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
-
 __metaclass__ = type
 
 import os
@@ -77,6 +76,63 @@ def test_fmgr_fwpol_package(fixture_data, mocker):
     # Test using fixture 4 #
     output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[3]['paramgram_used'])
     assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 5 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[4]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 6 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[5]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 7 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[6]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 8 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[7]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 9 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[8]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 10 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[9]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 11 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package(fmg_instance, fixture_data[10]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+
+
+def test_fmgr_fwpol_package_edit_targets(fixture_data, mocker):
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
+                 side_effect=fixture_data)
+
+    # Test using fixture 1 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[0]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 2 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[1]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 3 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[2]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 4 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[3]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 5 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[4]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 6 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[5]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 7 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[6]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 8 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[7]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 9 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[8]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 10 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_edit_targets(fmg_instance, fixture_data[9]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
 
 
 def test_fmgr_fwpol_package_folder(fixture_data, mocker):
@@ -95,3 +151,30 @@ def test_fmgr_fwpol_package_folder(fixture_data, mocker):
     # Test using fixture 4 #
     output = fmgr_fwpol_package.fmgr_fwpol_package_folder(fmg_instance, fixture_data[3]['paramgram_used'])
     assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 5 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_folder(fmg_instance, fixture_data[4]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 6 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_folder(fmg_instance, fixture_data[5]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 7 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_folder(fmg_instance, fixture_data[6]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+    # Test using fixture 8 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_folder(fmg_instance, fixture_data[7]['paramgram_used'])
+    assert output['raw_response']['status']['code'] == 0
+
+
+def test_fmgr_fwpol_package_install(fixture_data, mocker):
+    mocker.patch("ansible.module_utils.network.fortimanager.fortimanager.FortiManagerHandler.process_request",
+                 side_effect=fixture_data)
+
+    # Test using fixture 1 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_install(fmg_instance, fixture_data[0]['paramgram_used'])
+    assert isinstance(output['raw_response'], dict) is True
+    # Test using fixture 2 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_install(fmg_instance, fixture_data[1]['paramgram_used'])
+    assert isinstance(output['raw_response'], dict) is True
+    # Test using fixture 3 #
+    output = fmgr_fwpol_package.fmgr_fwpol_package_install(fmg_instance, fixture_data[2]['paramgram_used'])
+    assert isinstance(output['raw_response'], dict) is True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A number of bugs were fixed with fmgr_fwpol_package regarding the parameter "parent_folder". Also added ability to move/copy packages between folders.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
fmgr_fwpol_package.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
