### PR TITLE
DNS Made Easy: Fixed monitor (DNS failover) record property handling

### DIFF
--- a/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
+++ b/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - correctly handle monitor (DNS failover) record property
+minor_changes:
+  - systemDescription parameter requirement now enforced as required by DNSMadeEasy API

--- a/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
+++ b/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - correctly handle monitor (DNS failover) record property
 minor_changes:
-  - systemDescription parameter requirement now enforced as required by DNSMadeEasy API
+  - "dnsmadeeasy - systemDescription parameter requirement now enforced as required by DNSMadeEasy API."

--- a/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
+++ b/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - correctly handle monitor (DNS failover) record property
+  - "dnsmadeeasy - correctly handle monitor (DNS failover) record property."
 minor_changes:
   - "dnsmadeeasy - systemDescription parameter requirement now enforced as required by DNSMadeEasy API."

--- a/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
+++ b/changelogs/fragments/56880-dnsmadeeasy-fix_monitor_handling.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - "dnsmadeeasy - correctly handle monitor (DNS failover) record property."
 minor_changes:
-  - "dnsmadeeasy - systemDescription parameter requirement now enforced as required by DNSMadeEasy API."
+  - "dnsmadeeasy - ``systemDescription`` parameter requirement now enforced as required by DNSMadeEasy API."

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -94,7 +94,6 @@ options:
   systemDescription:
     description:
       - Description used by the monitor.
-    required: true
     version_added: 2.4
 
   maxEmails:

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -626,8 +626,8 @@ def main():
     # monitor creation
     monitor_changed = False
     new_monitor = dict()
-    # if monitor param is passed, we need to build object with necessary parameters
-    if module.params["monitor"] is not None:
+    # if record_type param matches A or CNAME, we need to build monitor with necessary parameters
+    if module.params['record_type'] in ['A', 'CNAME']:
         # Build the monitor
         for i in ['monitor', 'systemDescription', 'protocol', 'port', 'sensitivity', 'maxEmails',
                   'contactList', 'httpFqdn', 'httpFile', 'httpQueryString',
@@ -675,7 +675,6 @@ def main():
                 record_changed = True
         new_record['id'] = str(current_record['id'])
 
-    monitor_changed = False
     if current_monitor:
         for i in new_monitor:
             if str(current_monitor.get(i)) != str(new_monitor[i]):
@@ -693,8 +692,8 @@ def main():
         # create record and monitor as the record does not exist
         if not current_record:
             record = DME.createRecord(DME.prepareRecord(new_record))
-            monitor = DME.updateMonitor(record['id'], DME.prepareMonitor(new_monitor))
-            module.exit_json(changed=True, result=dict(record=record, monitor=monitor))
+            DME.updateMonitor(record['id'], DME.prepareMonitor(new_monitor))
+            module.exit_json(changed=True, result=dict(record=record, monitor=new_monitor))
 
         # update the record
         updated = False

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -623,23 +623,9 @@ def main():
         new_record["port"] = new_record["value"].split(" ")[2]
         new_record["value"] = new_record["value"].split(" ")[3]
 
-    # Fetch existing monitor if the A record indicates it should exist and build the new monitor
-    current_monitor = dict()
-    new_monitor = dict()
+    # monitor creation
     monitor_changed = False
-    if current_record and current_record['type'] in ['A', 'CNAME']:
-        # mark monitor as changed if passed parameter does not match current value
-        if current_record['monitor'] != module.params['monitor']:
-            monitor_changed = True
-
-        if current_record['monitor']:
-            current_monitor = DME.getMonitor(current_record['id'])
-
-            # Compare new monitor against existing one
-            for i in new_monitor:
-                if str(current_monitor.get(i)) != str(new_monitor[i]):
-                    monitor_changed = True
-
+    new_monitor = dict()
     # if record_type param matches A or CNAME, we need to build monitor with necessary parameters
     if module.params['record_type'] in ['A', 'CNAME']:
         # Build the monitor
@@ -665,6 +651,21 @@ def main():
                 else:
                     # The module option names match the API field names
                     new_monitor[i] = module.params[i]
+
+    # Fetch existing monitor if the A record indicates it should exist and build the new monitor
+    current_monitor = dict()
+    if current_record and current_record['type'] in ['A', 'CNAME']:
+        # mark monitor as changed if passed parameter does not match current value
+        if current_record['monitor'] != module.params['monitor']:
+            monitor_changed = True
+
+        if current_record['monitor']:
+            current_monitor = DME.getMonitor(current_record['id'])
+
+            # Compare new monitor against existing one
+            for i in new_monitor:
+                if str(current_monitor.get(i)) != str(new_monitor[i]):
+                    monitor_changed = True
 
     # Compare new record against existing one
     record_changed = False

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -623,9 +623,23 @@ def main():
         new_record["port"] = new_record["value"].split(" ")[2]
         new_record["value"] = new_record["value"].split(" ")[3]
 
-    # monitor creation
-    monitor_changed = False
+    # Fetch existing monitor if the A record indicates it should exist and build the new monitor
+    current_monitor = dict()
     new_monitor = dict()
+    monitor_changed = False
+    if current_record and current_record['type'] in ['A', 'CNAME']:
+        # mark monitor as changed if passed parameter does not match current value
+        if current_record['monitor'] != module.params['monitor']:
+            monitor_changed = True
+
+        if current_record['monitor']:
+            current_monitor = DME.getMonitor(current_record['id'])
+
+            # Compare new monitor against existing one
+            for i in new_monitor:
+                if str(current_monitor.get(i)) != str(new_monitor[i]):
+                    monitor_changed = True
+
     # if record_type param matches A or CNAME, we need to build monitor with necessary parameters
     if module.params['record_type'] in ['A', 'CNAME']:
         # Build the monitor
@@ -651,21 +665,6 @@ def main():
                 else:
                     # The module option names match the API field names
                     new_monitor[i] = module.params[i]
-
-    # Fetch existing monitor if the A record indicates it should exist and build the new monitor
-    current_monitor = dict()
-    if current_record and current_record['type'] in ['A', 'CNAME']:
-        # mark monitor as changed if passed parameter does not match current value
-        if current_record['monitor'] != module.params['monitor']:
-            monitor_changed = True
-
-        if current_record['monitor']:
-            current_monitor = DME.getMonitor(current_record['id'])
-
-            # Compare new monitor against existing one
-            for i in new_monitor:
-                if str(current_monitor.get(i)) != str(new_monitor[i]):
-                    monitor_changed = True
 
     # Compare new record against existing one
     record_changed = False


### PR DESCRIPTION
##### SUMMARY
The handling of failover record property has been corrected. These changes ensure that the monitor property is only applied for the applicable DNS records (A and CNAME in this case). In the process, the handling has been made idempotent.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dnsmadeeasy

##### ADDITIONAL INFORMATION
While doing other development work (TXT record handling), the monitor would also try to apply to such records. This lead to the initial investigation and root cause analysis. Once that was fixed, the modification of the records itself was not working correctly and throwing 404s from the API.
Hence the following:
- Monitor property creation has been separated out as it is needed whenever monitor parameter is specified.
- CNAME record type has been added as a further failover candidate
