### PR TITLE
Validate types before asserting lengths

### DIFF
--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -25,13 +25,13 @@ def sequence_of_sequences(min=None, max=None):
     return All(
         Any(
             None,
-            [Length(min=min, max=max)],
-            tuple([Length(min=min, max=max)]),
+            [Any(list, tuple)],
+            tuple([Any(list, tuple)]),
         ),
         Any(
             None,
-            [Any(list, tuple)],
-            tuple([Any(list, tuple)]),
+            [Length(min=min, max=max)],
+            tuple([Length(min=min, max=max)]),
         ),
     )
 


### PR DESCRIPTION
##### SUMMARY
Validate types before asserting lengths

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules/schema.py

##### ADDITIONAL INFORMATION
before
```
00:58 Traceback (most recent call last):
00:58   File "test/sanity/validate-modules/validate-modules", line 846, in _validate_docs_schema
00:58     schema(doc)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 267, in __call__
00:58     return self._compiled([], data)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 589, in validate_dict
00:58     return base_validate(path, iteritems(data), out)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 381, in validate_mapping
00:58     cval = cvalue(key_path, value)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/validators.py", line 204, in _run
00:58     return self._exec(self._compiled, value, path)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/validators.py", line 284, in _exec
00:58     v = func(path, v)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/validators.py", line 204, in _run
00:58     return self._exec(self._compiled, value, path)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/validators.py", line 249, in _exec
00:58     return func(path, v)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 630, in validate_sequence
00:58     cval = validate(index_path, value)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 811, in validate_callable
00:58     return schema(data)
00:58   File "/usr/local/lib/python3.6/dist-packages/voluptuous/validators.py", line 601, in __call__
00:58     if self.min is not None and len(v) < self.min:
00:58 TypeError: object of type 'bool' has no len()
00:58 
00:58 During handling of the above exception, another exception occurred:
00:58 
00:58 Traceback (most recent call last):
00:58   File "test/sanity/validate-modules/validate-modules", line 1745, in <module>
00:58     main()
00:58   File "test/sanity/validate-modules/validate-modules", line 1644, in main
00:58     mv.validate()
00:58   File "test/sanity/validate-modules/validate-modules", line 1525, in validate
00:58     self._validate_ansible_module_call(docs)
00:58   File "test/sanity/validate-modules/validate-modules", line 1142, in _validate_ansible_module_call
00:58     self._validate_docs_schema(kwargs, ansible_module_kwargs_schema, 'AnsibleModule', 332)
00:58   File "test/sanity/validate-modules/validate-modules", line 848, in _validate_docs_schema
00:58     for error in e.errors:
00:58 AttributeError: 'TypeError' object has no attribute 'errors'
```

after
```
lib/ansible/modules/cloud/memset/memset_memstore_user.py:0:0: E332 AnsibleModule.required_if.0: expected list @ data['required_if'][0]. Got 'update_password'
lib/ansible/modules/cloud/memset/memset_memstore_user.py:0:0: E332 AnsibleModule.required_if.1: expected list @ data['required_if'][1]. Got True
```