### PR TITLE
Always keep subset data for callbacks (#56881)

### DIFF
--- a/changelogs/fragments/always_keep_subset.yml
+++ b/changelogs/fragments/always_keep_subset.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - keep results subset also when not no_log.

--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -119,6 +119,15 @@ class TaskResult:
         else:
             ignore = _IGNORE
 
+        subset = {}
+        # preserve subset for later
+        for sub in _SUB_PRESERVE:
+            if sub in self._result:
+                subset[sub] = {}
+                for key in _SUB_PRESERVE[sub]:
+                    if key in self._result[sub]:
+                        subset[sub][key] = self._result[sub][key]
+
         if isinstance(self._task.no_log, bool) and self._task.no_log or self._result.get('_ansible_no_log', False):
             x = {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}
 
@@ -126,14 +135,6 @@ class TaskResult:
             for preserve in _PRESERVE:
                 if preserve in self._result:
                     x[preserve] = self._result[preserve]
-
-            # preserve subset
-            for sub in _SUB_PRESERVE:
-                if sub in self._result:
-                    x[sub] = {}
-                    for key in _SUB_PRESERVE[sub]:
-                        if key in self._result[sub]:
-                            x[sub][key] = self._result[sub][key]
 
             result._result = x
         elif self._result:
@@ -146,5 +147,8 @@ class TaskResult:
 
             # remove almost ALL internal keys, keep ones relevant to callback
             strip_internal_keys(result._result, exceptions=CLEAN_EXCEPTIONS)
+
+        # keep subset
+        result._result.update(subset)
 
         return result


### PR DESCRIPTION
results were only being preserved during no_log
  fixes #56704

(cherry picked from commit 4adb7cfb5f5e04aca29c7fd95f52e48901629c86)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
task_result