### PR TITLE
[WIP] validate-modules: 'choices' disable string conversion

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -110,9 +110,9 @@ options:
             - The Azure managed disk's zone.
             - Allowed values are C(1), C(2), C(3) and C(' ').
         choices:
-            - 1
-            - 2
-            - 3
+            - '1'
+            - '2'
+            - '3'
             - ''
         version_added: "2.8"
 

--- a/lib/ansible/modules/cloud/centurylink/clc_loadbalancer.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_loadbalancer.py
@@ -720,7 +720,7 @@ class ClcLoadBalancer:
                 msg='Unable to fetch the load balancer pools for for load balancer id: {0}. {1}'.format(
                     lb_id, str(e.response_text)))
         for pool in pool_list:
-            if int(pool.get('port')) == int(port):
+            if int(pool.get('port')) == port:
                 result = pool.get('id')
         return result
 
@@ -862,7 +862,7 @@ class ClcLoadBalancer:
             description=dict(default=None),
             location=dict(required=True),
             alias=dict(required=True),
-            port=dict(choices=[80, 443]),
+            port=dict(type='int', choices=[80, 443]),
             method=dict(choices=['leastConnection', 'roundRobin']),
             persistence=dict(choices=['standard', 'sticky']),
             nodes=dict(type='list', default=[]),

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -30,7 +30,7 @@ options:
    protocol:
       description:
         - IP protocols TCP UDP ICMP 112 (VRRP) 132 (SCTP)
-      choices: ['tcp', 'udp', 'icmp', '112', '132', None]
+      choices: ['tcp', 'udp', 'icmp', '112', '132', null]
    port_range_min:
       description:
         - Starting port

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -143,7 +143,7 @@ options:
       - Determines how yum resolves host names.
       - C(4) or C(IPv4) - resolve to IPv4 addresses only.
       - C(6) or C(IPv6) - resolve to IPv6 addresses only.
-    choices: [4, 6, IPv4, IPv6, whatever]
+    choices: ['4', '6', IPv4, IPv6, whatever]
     default: whatever
   keepalive:
     description:

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1169,6 +1169,7 @@ class ModuleValidator(Validator):
 
         # Use this to access type checkers later
         module = NoArgsAnsibleModule({})
+        module._string_conversion_action = 'error'
 
         provider_args = set()
         args_from_argspec = set()

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1341,40 +1341,47 @@ class ModuleValidator(Validator):
             doc_choices = []
             try:
                 for choice in docs.get('options', {}).get(arg, {}).get('choices', []):
-                    try:
-                        with CaptureStd():
-                            doc_choices.append(_type_checker(choice))
-                    except (Exception, SystemExit):
-                        msg = "Argument '%s' in documentation" % arg
-                        if context:
-                            msg += " found in %s" % " -> ".join(context)
-                        msg += " defines choices as (%r) but this is incompatible with argument type %r" % (choice, _type)
-                        self.reporter.error(
-                            path=self.object_path,
-                            code='doc-choices-incompatible-type',
-                            msg=msg
-                        )
-                        raise StopIteration()
+                    if choice is None:
+                        doc_choices.append(choice)
+                    else:
+                        try:
+                            with CaptureStd():
+                                doc_choices.append(_type_checker(choice))
+                        except (Exception, SystemExit):
+                            msg = "Argument '%s' in documentation" % arg
+                            if context:
+                                msg += " found in %s" % " -> ".join(context)
+                            msg += " defines choices as (%r) but this is incompatible with argument type %r" % (choice, _type)
+
+                            self.reporter.error(
+                                path=self.object_path,
+                                code='doc-choices-incompatible-type',
+                                msg=msg
+                            )
+                            raise StopIteration()
             except StopIteration:
                 continue
 
             arg_choices = []
             try:
                 for choice in data.get('choices', []):
-                    try:
-                        with CaptureStd():
-                            arg_choices.append(_type_checker(choice))
-                    except (Exception, SystemExit):
-                        msg = "Argument '%s' in argument_spec" % arg
-                        if context:
-                            msg += " found in %s" % " -> ".join(context)
-                        msg += " defines choices as (%r) but this is incompatible with argument type %r" % (choice, _type)
-                        self.reporter.error(
-                            path=self.object_path,
-                            code='incompatible-choices',
-                            msg=msg
-                        )
-                        raise StopIteration()
+                    if choice is None:
+                        arg_choices.append(choice)
+                    else:
+                        try:
+                            with CaptureStd():
+                                arg_choices.append(_type_checker(choice))
+                        except (Exception, SystemExit):
+                            msg = "Argument '%s' in argument_spec" % arg
+                            if context:
+                                msg += " found in %s" % " -> ".join(context)
+                            msg += " defines choices as (%r) but this is incompatible with argument type %r" % (choice, _type)
+                            self.reporter.error(
+                                path=self.object_path,
+                                code='incompatible-choices',
+                                msg=msg
+                            )
+                            raise StopIteration()
             except StopIteration:
                 continue
 


### PR DESCRIPTION
##### SUMMARY
`validate-modules` sanity check: 
* disable string conversion
* allow to explicitly use `None` in `choices`

Fix E328 errors:
* `azure_rm_manageddisk`: `zone` param: values are `str`
* `clc_loadbalancer`: `port` parameter is an `int`
* `yum_repository`: `ip_resolve` parameter: fix doc (values are strings)
* `os_security_group_rule.py`: `protocol` parameter: `None` (Python)/`null` (YAML)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
validate-modules

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
