### PR TITLE
[docker_network] Fix idempotency when using aux_addresses in ipam_config

### DIFF
--- a/changelogs/fragments/docker_network_aux_addresses.yml
+++ b/changelogs/fragments/docker_network_aux_addresses.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_network module - fix idempotency when using aux_addresses in ipam_config

--- a/changelogs/fragments/docker_network_aux_addresses.yml
+++ b/changelogs/fragments/docker_network_aux_addresses.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - docker_network module - fix idempotency when using aux_addresses in ipam_config
+  - docker_network module - fix idempotency when using ``aux_addresses`` in ``ipam_config``.

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -346,6 +346,20 @@ def get_ip_version(cidr):
     raise ValueError('"{0}" is not a valid CIDR'.format(cidr))
 
 
+def normalize_ipam_config_key(key):
+    """Normalizes IPAM config keys returned by Docker API to match Ansible keys
+
+    :param key: Docker API key
+    :type key: str
+    :return Ansible module key
+    :rtype str
+    """
+    special_cases = {
+        'AuxiliaryAddresses': 'aux_addresses'
+    }
+    return special_cases.get(key, key.lower())
+
+
 class DockerNetworkManager(object):
 
     def __init__(self, client):
@@ -447,7 +461,7 @@ class DockerNetworkManager(object):
                             continue
                         camelkey = None
                         for net_key in net_config:
-                            if key == net_key.lower():
+                            if key == normalize_ipam_config_key(net_key):
                                 camelkey = net_key
                                 break
                         if not camelkey or net_config.get(camelkey) != value:


### PR DESCRIPTION
##### SUMMARY
Mismatch between keys returned by Docker API (AuxilliaryAddresses) vs
expected by Ansible module (aux_addresses) resulted in tasks always
have status 'changed'. The existing code normalizing one set of
keys to another missed this special case where converting
CamelCase to lowercase is not sufficent.

Please see
https://github.com/moby/moby/blob/master/api/types/network/network.go
for reference.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ADDITIONAL INFORMATION
Example task that exposed the flaw:
```
- name: internal docker network
  docker_network:
    name: underbr
    driver_options:
      com.docker.network.bridge.name: underbr
    internal: yes
    ipam_config:
      - subnet: 172.22.0.0/24
        gateway: 172.22.0.254
        aux_addresses:
          DefaultGatewayIPv4: 172.22.0.1
    state: present
```
Running it repeatedly caused the task to be always reported as 'changed'
```
Docker version 18.09.6
Python version 3.6.8 (on remote system)
Docker SDK version 3.7.2 (on remote system)
```