### PR TITLE
ec2_group: Copy to new list from dict.items() return

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -938,7 +938,7 @@ def get_diff_final_resource(client, module, security_group):
                     'vpc_id': rule_sg.get('vpc_id', module.params['vpc_id']),
                     'vpc_peering_connection_id': rule_sg.get('vpc_peering_connection_id')
                 }]
-                for k, v in format_rule['user_id_group_pairs'][0].items():
+                for k, v in list(format_rule['user_id_group_pairs'][0].items()):
                     if v is None:
                         format_rule['user_id_group_pairs'][0].pop(k)
             final_rules.append(format_rule)


### PR DESCRIPTION
dict.items() in pytho2 returns a list of tuples which can be iterated
while modifying the dict. In python 3 it returns a view which is tied to
the underlying dict, meaning the modifications to the dict while
iterating are unsafe.

This commit generates new list containing the tuples from the iterator
in python 3 which breaks the link to the dict, allowing the dict to be
modified while iterating the list.

In python 2 it would simply copy the list.

Fixes #56902

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
dict.items() in pytho2 returns a list of tuples which can be iterated
while modifying the dict. In python 3 it returns a view which is tied to
the underlying dict, meaning the modifications to the dict while
iterating are unsafe.

This commit generates new list containing the tuples from the iterator
in python 3 which breaks the link to the dict, allowing the dict to be
modified while iterating the list.

In python 2 it would simply copy the list.


<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
