### PR TITLE
Fix lvg default parameter

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -143,7 +143,7 @@ def main():
         argument_spec=dict(
             vg=dict(type='str', required=True),
             pvs=dict(type='list'),
-            pesize=dict(type='str', default=4),
+            pesize=dict(type='str', default='4'),
             pv_options=dict(type='str', default=''),
             vg_options=dict(type='str', default=''),
             state=dict(type='str', default='present', choices=['absent', 'present']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When using lvg_module with default variable of `pesize`, the following warning statement is always output. This p-r fix this problem.

```
[WARNING]: The value 4 (type int) in a string field was converted to '4' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

lvg module

<!--- ##### ADDITIONAL INFORMATION --->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!---
```paste below

```
--->