### PR TITLE
mongodb add support for certificate authority file

### DIFF
--- a/changelogs/fragments/56911-mongodb.yaml
+++ b/changelogs/fragments/56911-mongodb.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mongodb_user, mongodb_replicaset - Introduce ``ssl_ca_certs`` to specify the certificate authority .pem file for verification of the certificate presented by the server

--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -64,6 +64,10 @@ options:
     - Whether to use an SSL connection when connecting to the database
     type: bool
     default: no
+  ssl_ca_certs:
+    version_added: "2.9"
+    description:
+    - Specifies the Certificate Authority (CA) .pem file which contains root certificate chain for verification of the certificate presented by the server
   ssl_cert_reqs:
     description:
     - Specifies whether a certificate is required from the other side of the connection, and whether it will be validated if provided.
@@ -303,6 +307,7 @@ def main():
             arbiter_at_index=dict(type='int'),
             validate=dict(type='bool', default=True),
             ssl=dict(type='bool', default=False),
+            ssl_ca_certs=dict(default=None),
             ssl_cert_reqs=dict(type='str', default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),
             protocol_version=dict(type='int', default=1, choices=[0, 1]),
             chaining_allowed=dict(type='bool', default=True),
@@ -348,6 +353,7 @@ def main():
 
     if ssl:
         connection_params["ssl"] = ssl
+        connection_params["ssl_ca_certs"] = module.params['ssl_ca_certs']
         connection_params["ssl_cert_reqs"] = getattr(ssl_lib, module.params['ssl_cert_reqs'])
 
     try:

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -62,6 +62,12 @@ options:
         description:
             - Whether to use an SSL connection when connecting to the database
         type: bool
+    ssl_ca_certs:
+        version_added: "2.9"
+        description:
+            - >
+              Specifies the Certificate Authority (CA) .pem file which contains root certificate chain
+              for verification of the certificate presented by the server
     ssl_cert_reqs:
         version_added: "2.2"
         description:
@@ -345,6 +351,7 @@ def main():
             roles=dict(default=None, type='list'),
             state=dict(default='present', choices=['absent', 'present']),
             update_password=dict(default="always", choices=["always", "on_create"]),
+            ssl_ca_certs=dict(default=None),
             ssl_cert_reqs=dict(default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),
         ),
         supports_check_mode=True
@@ -379,6 +386,7 @@ def main():
 
         if ssl:
             connection_params["ssl"] = ssl
+            connection_params["ssl_ca_certs"] = module.params['ssl_ca_certs']
             connection_params["ssl_cert_reqs"] = getattr(ssl_lib, module.params['ssl_cert_reqs'])
 
         client = MongoClient(**connection_params)


### PR DESCRIPTION
##### SUMMARY
Add support for setting up certificate authority file to allow client validation of certificate provided by server.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_user
mongodb_replicaset
