### PR TITLE
Correct typo in playbooks_intro.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -512,7 +512,7 @@ For example, if you run ``ansible-lint`` on the :ref:`verify-apache.yml playbook
 
 .. code-block:: bash
 
-    $ ansible-lint veryify-apache.yml
+    $ ansible-lint verify-apache.yml
     [403] Package installs should not use latest
     verify-apache.yml:8
     Task/Handler: ensure apache is at the latest version


### PR DESCRIPTION
##### SUMMARY
Typo in code block line:
ansible-lint veryify-apache.yml

should be
ansible-lint verify-apache.yml

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
Introductory documentation on Playbooks

