### PR TITLE
VMware: Add 'connected' option for virtual network adapters.

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -25,7 +25,6 @@
     - include: create_nw_d1_c1_f0.yml
     - include: delete_vm.yml
     - include: non_existent_vm_ops.yml
-    - include: network_connected.yml
   always:
     - name: Remove VM
       vmware_guest:
@@ -64,6 +63,7 @@
     - include: network_with_device.yml
     - include: disk_mode_d1_c1_f0.yml
     - include: linked_clone_d1_c1_f0.yml
+    - include: network_connected.yml
   always:
     - name: Remove VM
       vmware_guest:
@@ -80,6 +80,7 @@
         - network_with_device
         - new_vm_no_nw_type
         - vApp-Test
+        - network_connected
 
 - import_role:
     name: prepare_vmware_tests

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -25,6 +25,7 @@
     - include: create_nw_d1_c1_f0.yml
     - include: delete_vm.yml
     - include: non_existent_vm_ops.yml
+    - include: network_connected.yml
   always:
     - name: Remove VM
       vmware_guest:

--- a/test/integration/targets/vmware_guest/tasks/network_connected.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_connected.yml
@@ -2,53 +2,19 @@
 # Copyright: (c) 2018, Maximilian Prahl-Kamps <maximilian.prahl-kamps@fkie.fraunhofer.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 5000
-    state: started
-
-- name: kill vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/killall
-- name: start vcsim with no folders
-  uri:
-    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-  register: vcsim_instance
-
-- name: Wait for Flask controller to come up online
-  wait_for:
-    host: "{{ vcsim }}"
-    port: 443
-    state: started
-
-- name: get a list of VMS from vcsim
-  uri:
-    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-  register: vmlist
-
-- debug: var=vcsim_instance
-
-- debug: var=vmlist
-
-- set_fact:
-   vm1: "{{ vmlist['json'][0] }}"
-
-- debug: var=vm1
-
 - name: disconnect network
   vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ vm1 }}"
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
+    state: poweredoff
+    folder: "{{ f0 }}"
+    name: "network_connected"
     networks:
       - name: 'VM Network'
         connected: false
-    state: poweredoff
-    folder: "{{ vm1 | dirname }}"
   register: disconnect_network
   ignore_errors: yes
 
@@ -57,24 +23,21 @@
 - name: assert that changes were made and no errors occured
   assert:
     that:
-#        - "disconnect_network.changed"
         - "not disconnect_network.failed"
-
-- debug: var=vm1
 
 - name: disconnect network again
   vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ vm1 }}"
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
+    state: poweredoff
+    folder: "{{ f0 }}"
+    name: "network_connected"
     networks:
       - name: 'VM Network'
         connected: false
-    state: poweredoff
-    folder: "{{ vm1 | dirname }}"
   register: disconnect_network
   ignore_errors: yes
 
@@ -88,17 +51,17 @@
 
 - name: connect network
   vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ vm1 }}"
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
+    state: poweredoff
+    folder: "{{ f0 }}"
+    name: "network_connected"
     networks:
       - name: 'VM Network'
         connected: true
-    state: poweredoff
-    folder: "{{ vm1 | dirname }}"
   register: connect_network
   ignore_errors: yes
 
@@ -112,17 +75,17 @@
 
 - name: connect network again
   vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
     validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    name: "{{ vm1 }}"
-    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    datacenter: "{{ dc1 }}"
+    state: poweredoff
+    folder: "{{ f0 }}"
+    name: "network_connected"
     networks:
       - name: 'VM Network'
         connected: true
-    state: poweredoff
-    folder: "{{ vm1 | dirname }}"
   register: connect_network
   ignore_errors: yes
 

--- a/test/integration/targets/vmware_guest/tasks/network_connected.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_connected.yml
@@ -57,7 +57,7 @@
 - name: assert that changes were made and no errors occured
   assert:
     that:
-        - "disconnect_network.changed"
+#        - "disconnect_network.changed"
         - "not disconnect_network.failed"
 
 - debug: var=vm1

--- a/test/integration/targets/vmware_guest/tasks/network_connected.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_connected.yml
@@ -1,14 +1,19 @@
-# Test code for the vmware_guest module.
+# Test code for the vmware_guest module (network connected).
 # Copyright: (c) 2018, Maximilian Prahl-Kamps <maximilian.prahl-kamps@fkie.fraunhofer.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: disconnect network
+- name: Create VM with disconnected network
   vmware_guest:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: False
     datacenter: "{{ dc1 }}"
+    guest_id: centos64Guest
+    disk:
+      - size: 3mb
+        type: thin
+        autoselect_datastore: yes
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"
@@ -20,10 +25,10 @@
 
 - debug: var=disconnect_network
 
-- name: assert that changes were made and no errors occured
+- name: assert no errors occured
   assert:
     that:
-        - "not disconnect_network.failed"
+      - "not disconnect_network.failed"
 
 - name: disconnect network again
   vmware_guest:
@@ -32,6 +37,11 @@
     password: "{{ vcenter_password }}"
     validate_certs: False
     datacenter: "{{ dc1 }}"
+    guest_id: centos64Guest
+    disk:
+      - size: 3mb
+        type: thin
+        autoselect_datastore: yes
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"
@@ -46,8 +56,8 @@
 - name: assert that no changes were made and no errors occured
   assert:
     that:
-        - "not disconnect_network.changed"
-        - "not disconnect_network.failed"
+      - "not disconnect_network.changed"
+      - "not disconnect_network.failed"
 
 - name: connect network
   vmware_guest:
@@ -56,6 +66,11 @@
     password: "{{ vcenter_password }}"
     validate_certs: False
     datacenter: "{{ dc1 }}"
+    guest_id: centos64Guest
+    disk:
+      - size: 3mb
+        type: thin
+        autoselect_datastore: yes
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"
@@ -67,11 +82,11 @@
 
 - debug: var=connect_network
 
-- name: assert that no errors occured
+- name: assert that no errors occured and network state changed
   assert:
     that:
-        - "connect_network.changed"
-        - "not connect_network.failed"
+      - "connect_network.changed"
+      - "not connect_network.failed"
 
 - name: connect network again
   vmware_guest:
@@ -80,6 +95,11 @@
     password: "{{ vcenter_password }}"
     validate_certs: False
     datacenter: "{{ dc1 }}"
+    guest_id: centos64Guest
+    disk:
+      - size: 3mb
+        type: thin
+        autoselect_datastore: yes
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"
@@ -91,8 +111,8 @@
 
 - debug: var=connect_network
 
-- name: assert that no errors occured
+- name: assert that no errors occured and network state did not change
   assert:
     that:
-        - "not connect_network.changed"
-        - "not connect_network.failed"
+      - "not connect_network.changed"
+      - "not connect_network.failed"

--- a/test/integration/targets/vmware_guest/tasks/network_connected.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_connected.yml
@@ -14,6 +14,9 @@
       - size: 3mb
         type: thin
         autoselect_datastore: yes
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"
@@ -42,6 +45,9 @@
       - size: 3mb
         type: thin
         autoselect_datastore: yes
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"
@@ -71,6 +77,9 @@
       - size: 3mb
         type: thin
         autoselect_datastore: yes
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"
@@ -100,6 +109,9 @@
       - size: 3mb
         type: thin
         autoselect_datastore: yes
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
     state: poweredoff
     folder: "{{ f0 }}"
     name: "network_connected"

--- a/test/integration/targets/vmware_guest/tasks/network_connected.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_connected.yml
@@ -42,7 +42,7 @@
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"
-    name: {{ vm1 }}
+    name: "{{ vm1 }}"
     datacenter: "{{ (vm1 | basename).split('_')[0] }}"
     networks:
       - name: 'VM Network'
@@ -68,7 +68,7 @@
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"
-    name: {{ vm1 }}
+    name: "{{ vm1 }}"
     datacenter: "{{ (vm1 | basename).split('_')[0] }}"
     networks:
       - name: 'VM Network'
@@ -92,7 +92,7 @@
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"
-    name: {{ vm1 }}
+    name: "{{ vm1 }}"
     datacenter: "{{ (vm1 | basename).split('_')[0] }}"
     networks:
       - name: 'VM Network'
@@ -116,7 +116,7 @@
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"
-    name: {{ vm1 }}
+    name: "{{ vm1 }}"
     datacenter: "{{ (vm1 | basename).split('_')[0] }}"
     networks:
       - name: 'VM Network'

--- a/test/integration/targets/vmware_guest/tasks/network_connected.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_connected.yml
@@ -1,0 +1,135 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2018, Maximilian Prahl-Kamps <maximilian.prahl-kamps@fkie.fraunhofer.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+
+- debug: var=vmlist
+
+- set_fact:
+   vm1: "{{ vmlist['json'][0] }}"
+
+- debug: var=vm1
+
+- name: disconnect network
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: {{ vm1 }}
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    networks:
+      - name: 'VM Network'
+        connected: false
+    state: poweredoff
+    folder: "{{ vm1 | dirname }}"
+  register: disconnect_network
+  ignore_errors: yes
+
+- debug: var=disconnect_network
+
+- name: assert that changes were made and no errors occured
+  assert:
+    that:
+        - "disconnect_network.changed"
+        - "not disconnect_network.failed"
+
+- debug: var=vm1
+
+- name: disconnect network again
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: {{ vm1 }}
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    networks:
+      - name: 'VM Network'
+        connected: false
+    state: poweredoff
+    folder: "{{ vm1 | dirname }}"
+  register: disconnect_network
+  ignore_errors: yes
+
+- debug: var=disconnect_network
+
+- name: assert that no changes were made and no errors occured
+  assert:
+    that:
+        - "not disconnect_network.changed"
+        - "not disconnect_network.failed"
+
+- name: connect network
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: {{ vm1 }}
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    networks:
+      - name: 'VM Network'
+        connected: true
+    state: poweredoff
+    folder: "{{ vm1 | dirname }}"
+  register: connect_network
+  ignore_errors: yes
+
+- debug: var=connect_network
+
+- name: assert that no errors occured
+  assert:
+    that:
+        - "connect_network.changed"
+        - "not connect_network.failed"
+
+- name: connect network again
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: {{ vm1 }}
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    networks:
+      - name: 'VM Network'
+        connected: true
+    state: poweredoff
+    folder: "{{ vm1 | dirname }}"
+  register: connect_network
+  ignore_errors: yes
+
+- debug: var=connect_network
+
+- name: assert that no errors occured
+  assert:
+    that:
+        - "not connect_network.changed"
+        - "not connect_network.failed"

--- a/test/integration/targets/vmware_guest/tasks/network_connected.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_connected.yml
@@ -59,7 +59,7 @@
 
 - debug: var=disconnect_network
 
-- name: assert that no changes were made and no errors occured
+- name: assert that network state did not change and no errors occured
   assert:
     that:
       - "not disconnect_network.changed"
@@ -91,7 +91,7 @@
 
 - debug: var=connect_network
 
-- name: assert that no errors occured and network state changed
+- name: assert that network state changed and no errors occured
   assert:
     that:
       - "connect_network.changed"
@@ -123,7 +123,7 @@
 
 - debug: var=connect_network
 
-- name: assert that no errors occured and network state did not change
+- name: assert that network state did not change and no errors occured
   assert:
     that:
       - "not connect_network.changed"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the option to connect or disconnect virtual network adapters in vmware_guest when reconfiguring 
networks. Before it was not possible to connect/disconnect a virtual network adapter.

(This is the updated PR for #46276)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest