### PR TITLE
hostname - Correct distribution for various Linux distros based on output from distro library

### DIFF
--- a/changelogs/fragments/hostname-update-distros.yaml
+++ b/changelogs/fragments/hostname-update-distros.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - make module work on CoreOS, Oracle Linux, Clear Linux, OpenSUSE Leap, ArchARM (https://github.com/ansible/ansible/issues/42726)

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -583,9 +583,21 @@ class OpenSUSEHostname(Hostname):
     strategy_class = SystemdStrategy
 
 
+class OpenSUSELeapHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Opensuse-leap'
+    strategy_class = SystemdStrategy
+
+
 class ArchHostname(Hostname):
     platform = 'Linux'
     distribution = 'Arch'
+    strategy_class = SystemdStrategy
+
+
+class ArchARMHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Archarm'
     strategy_class = SystemdStrategy
 
 
@@ -615,7 +627,7 @@ class ScientificHostname(Hostname):
 
 class OracleLinuxHostname(Hostname):
     platform = 'Linux'
-    distribution = 'Oracle'
+    distribution = 'Ol'
     strategy_class = RedHatStrategy
 
 

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -613,10 +613,22 @@ class CentOSHostname(Hostname):
     strategy_class = RedHatStrategy
 
 
+class ClearLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Clear-linux-os'
+    strategy_class = SystemdStrategy
+
+
 class CloudlinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Cloudlinux'
     strategy_class = RedHatStrategy
+
+
+class CoreosHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Coreos'
+    strategy_class = SystemdStrategy
 
 
 class ScientificHostname(Hostname):


### PR DESCRIPTION
##### SUMMARY
Fixes #42726

Makes `hostname` work again on the following distributions:
- OpenSUSE Leap
- ArchARM
- Oracle Linux
- CoreOS

We switched to using `distro.id()` in Ansible 2.8 for identifying the distribution. Add new classes to fix distributions that were currently unsupported. Adjust the distribution string in existing classes to match the new output.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/modules/system/hostname.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```