### PR TITLE
[stable-2.8] Don't validate ip address for mgmt interface (#56136)

### DIFF
--- a/test/integration/targets/eos_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/default_facts.yaml
@@ -23,7 +23,7 @@
       # Items from those subsets are present
       - "result.ansible_facts.ansible_net_filesystems is defined" #hw
       - "result.ansible_facts.ansible_net_memtotal_mb > 10" #hw
-      - "result.ansible_facts.ansible_net_interfaces.Management1.ipv4.masklen > 1" # interfaces
+      - "result.ansible_facts.ansible_net_interfaces.Management1" # interfaces
 
       # ... and not present
       - "result.ansible_facts.ansible_net_config is not defined" # config

--- a/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
@@ -23,7 +23,7 @@
       - "'hardware' not in result.ansible_facts.ansible_net_gather_subset"
 
       # Items from those subsets are present
-      - "result.ansible_facts.ansible_net_interfaces.Management1.ipv4.masklen > 1" # interfaces
+      - "result.ansible_facts.ansible_net_interfaces.Management1" # interfaces
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
 

--- a/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
@@ -27,7 +27,7 @@
       # Items from those subsets are present
       - "result.ansible_facts.ansible_net_filesystems is defined" #hw
       - "result.ansible_facts.ansible_net_memtotal_mb > 10" #hw
-      - "result.ansible_facts.ansible_net_interfaces.Management1.ipv4.masklen > 1" # interfaces
+      - "result.ansible_facts.ansible_net_interfaces.Management1" # interfaces
 
       # ... and not present
       - "result.ansible_facts.ansible_net_config is not defined" # config

--- a/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
@@ -27,7 +27,7 @@
       - "'hardware' not in result.ansible_facts.ansible_net_gather_subset"
 
       # Items from those subsets are present
-      - "result.ansible_facts.ansible_net_interfaces.Management1.ipv4.masklen > 1" # interfaces
+      - "result.ansible_facts.ansible_net_interfaces.Management1" # interfaces
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
 


### PR DESCRIPTION
##### SUMMARY
It is possible the EOS appliance doesn't have an IP address on the
management1 interface, instead just check we have found that interface.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>
(cherry picked from commit f9589bd)

Co-authored-by: Paul Belanger <pabelanger@redhat.com>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_facts