### PR TITLE
docker_image: fix module failing when build option is used without specifying path

### DIFF
--- a/changelogs/fragments/56940-docker_image-fail.yml
+++ b/changelogs/fragments/56940-docker_image-fail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_image - module failed when ``source: build`` was set but ``build.path`` options not specified."

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -886,7 +886,7 @@ def main():
                                'has been renamed and will be removed in Ansible 2.12.' % (build_option, option, option))
     if client.module.params['source'] == 'build':
         if (not client.module.params['build'] or not client.module.params['build'].get('path')):
-            client.module.fail('If "source" is set to "build", the "build.path" option must be specified.')
+            client.fail('If "source" is set to "build", the "build.path" option must be specified.')
         if client.module.params['build'].get('pull') is None:
             client.module.warn("The default for build.pull is currently 'yes', but will be changed to 'no' in Ansible 2.12. "
                                "Please set build.pull explicitly to the value you need.")


### PR DESCRIPTION
##### SUMMARY
Calls the wrong fail function. Reported in #ansible-devel.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_image
