### PR TITLE
apt_repository: support repos as list

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -24,10 +24,12 @@ notes:
     - This module works on Debian, Ubuntu and their derivatives.
     - This module supports Debian Squeeze (version 6) as well as its successors.
 options:
-    repo:
+    repos:
         description:
-            - A source string for the repository.
+            - A list of source strings for the repository.
         required: true
+        type: list
+        aliases: [ repo ]
     state:
         description:
             - A source string state.
@@ -40,7 +42,7 @@ options:
         version_added: "1.6"
     update_cache:
         description:
-            - Run the equivalent of C(apt-get update) when a change occurs.  Cache updates are run after making changes.
+            - Run the equivalent of C(apt-get update) when a change occurs. Cache updates are run after making changes.
         type: bool
         default: "yes"
     validate_certs:
@@ -70,36 +72,63 @@ requirements:
 '''
 
 EXAMPLES = '''
-# Add specified repository into sources list.
-- apt_repository:
+---
+- name: Add specified repository into sources list.
+  apt_repository:
     repo: deb http://archive.canonical.com/ubuntu hardy partner
     state: present
 
-# Add specified repository into sources list using specified filename.
-- apt_repository:
+- name: Add a list of specified repositories into sources list. Update cache is running once.
+  apt_repository:
+    repos:
+      - deb http://archive.canonical.com/ubuntu hardy partner
+      - deb-src http://archive.canonical.com/ubuntu hardy partner
+    state: present
+
+- name: Add specified repository into sources list using specified filename.
+  apt_repository:
     repo: deb http://dl.google.com/linux/chrome/deb/ stable main
     state: present
     filename: google-chrome
 
-# Add source repository into sources list.
-- apt_repository:
+- name: Add source repository into sources list.
+  apt_repository:
     repo: deb-src http://archive.canonical.com/ubuntu hardy partner
     state: present
 
-# Remove specified repository from sources list.
-- apt_repository:
+- name: Remove specified repository from sources list.
+  apt_repository:
     repo: deb http://archive.canonical.com/ubuntu hardy partner
     state: absent
 
-# Add nginx stable repository from PPA and install its signing key.
 # On Ubuntu target:
-- apt_repository:
+- name: Add nginx stable repository from PPA and install its signing key.
+  apt_repository:
     repo: ppa:nginx/stable
 
 # On Debian target
-- apt_repository:
-    repo: 'ppa:nginx/stable'
+- name: Add nginx stable repository from PPA and install its signing key.
+  apt_repository:
+    repo: ppa:nginx/stable
     codename: trusty
+'''
+
+RETURN = '''
+---
+repos:
+  description: List of source repos
+  returned: success
+  type: list
+  version_added: "2.9"
+repo:
+  description: The source repo
+  returned: if only one repo given
+  type: str
+state:
+  description: State of the source repos
+  returned: success
+  type: str
+  sample: present
 '''
 
 import glob
@@ -481,7 +510,7 @@ def get_add_ppa_signing_key_callback(module):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            repo=dict(type='str', required=True),
+            repos=dict(type='list', required=True, aliases=['repo']),
             state=dict(type='str', default='present', choices=['absent', 'present']),
             mode=dict(type='raw'),
             update_cache=dict(type='bool', default=True, aliases=['update-cache']),
@@ -495,7 +524,7 @@ def main():
     )
 
     params = module.params
-    repo = module.params['repo']
+    repos = module.params['repos']
     state = module.params['state']
     update_cache = module.params['update_cache']
     # Note: mode is referenced in SourcesList class via the passed in module (self here)
@@ -508,8 +537,8 @@ def main():
         else:
             module.fail_json(msg='%s is not installed, and install_python_apt is False' % PYTHON_APT)
 
-    if not repo:
-        module.fail_json(msg='Please set argument \'repo\' to a non-empty value')
+    if not repos or not any(repos):
+        module.fail_json(msg="Please set argument 'repos' to a non-empty value")
 
     if isinstance(distro, aptsources_distro.Distribution):
         sourceslist = UbuntuSourcesList(module, add_ppa_signing_keys_callback=get_add_ppa_signing_key_callback(module))
@@ -521,9 +550,11 @@ def main():
 
     try:
         if state == 'present':
-            sourceslist.add_source(repo)
+            for repo in repos:
+                sourceslist.add_source(repo)
         elif state == 'absent':
-            sourceslist.remove_source(repo)
+            for repo in repos:
+                sourceslist.remove_source(repo)
     except InvalidSource as err:
         module.fail_json(msg='Invalid repository string: %s' % to_native(err))
 
@@ -557,7 +588,13 @@ def main():
             # Return an error message.
             module.fail_json(msg='apt cache update failed')
 
-    module.exit_json(changed=changed, repo=repo, state=state, diff=diff)
+    result = dict(changed=changed, repos=repos, state=state, diff=diff)
+
+    # For backwards compatibilty return also "repo" if only one or less is given
+    if len(repos) == 1:
+        result['repo'] = repos[0]
+
+    module.exit_json(**result)
 
 
 if __name__ == '__main__':

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -1,13 +1,15 @@
 ---
-
-- set_fact:
+- name: set test vars
+  set_fact:
     test_ppa_name: 'ppa:git-core/ppa'
     test_ppa_filename: 'git-core'
-    test_ppa_spec: 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu {{ansible_distribution_release}} main'
+    test_ppa_spec: 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu {{ ansible_distribution_release }} main'
+    test_ppa_spec_src: 'deb-src http://ppa.launchpad.net/git-core/ppa/ubuntu {{ ansible_distribution_release }} main'
     test_ppa_key: 'E1DF1F24' # http://keyserver.ubuntu.com:11371/pks/lookup?search=0xD06AAF4C11DAB86DF421421EFE6B20ECA7AD98A1&op=index
 
 - name: show python version
-  debug: var=ansible_python_version
+  debug:
+    var: ansible_python_version
 
 - name: use python-apt
   set_fact:
@@ -20,102 +22,125 @@
   when: ansible_python_version is version('3', '>=')
 
 # UNINSTALL 'python-apt'
-#  The `apt_repository` module has the smarts to auto-install `python-apt`.  To
-# test, we will first uninstall `python-apt`.
+# The `apt_repository` module has the smarts to auto-install `python-apt`.
+# To test, we will first uninstall `python-apt`.
 - name: check {{ python_apt }} with dpkg
   shell: dpkg -s {{ python_apt }}
   register: dpkg_result
   ignore_errors: true
 
 - name: uninstall {{ python_apt }} with apt
-  apt: pkg={{ python_apt }} state=absent purge=yes
+  apt:
+    pkg: '{{ python_apt }}'
+    state: absent
+    purge: yes
   register: apt_result
   when: dpkg_result is successful
 
 #
 # TEST: apt_repository: repo=<name>
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: 'name=<name> (expect: pass)'
-  apt_repository: repo='{{test_ppa_name}}' state=present
+  apt_repository:
+    repo: '{{ test_ppa_name }}'
+    state: present
   register: result
 
-- name: 'assert the apt cache did *NOT* change'
+- name: assert the apt cache did *NOT* change
   assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_name}}"'
+      - 'result.repo == "{{ test_ppa_name }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did change'
+- name: assert the apt cache did change
   assert:
     that:
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 - name: 'ensure ppa key is installed (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=present
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: present
 
 #
 # TEST: apt_repository: repo=<name> update_cache=no
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: 'name=<name> update_cache=no (expect: pass)'
-  apt_repository: repo='{{test_ppa_name}}' state=present update_cache=no
+  apt_repository:
+    repo: '{{ test_ppa_name }}'
+    state: present
+    update_cache: no
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_name}}"'
+      - 'result.repo == "{{ test_ppa_name }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did *NOT* change'
+- name: assert the apt cache did *NOT* change
   assert:
     that:
       - 'cache_before.stat.mtime == cache_after.stat.mtime'
 
 - name: 'ensure ppa key is installed (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=present
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: present
 
 #
 # TEST: apt_repository: repo=<name> update_cache=yes
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: 'name=<name> update_cache=yes (expect: pass)'
-  apt_repository: repo='{{test_ppa_name}}' state=present update_cache=yes
+  apt_repository:
+    repo: '{{ test_ppa_name }}'
+    state: present
+    update_cache: yes
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_name}}"'
+      - 'result.repo == "{{ test_ppa_name }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
 - name: 'assert the apt cache did change'
@@ -124,86 +149,157 @@
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 - name: 'ensure ppa key is installed (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=present
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: present
 
 #
 # TEST: apt_repository: repo=<spec>
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: ensure ppa key is present before adding repo that requires authentication
-  apt_key: keyserver=keyserver.ubuntu.com id='{{test_ppa_key}}' state=present
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: '{{ test_ppa_key }}'
+    state: present
 
 - name: 'name=<spec> (expect: pass)'
-  apt_repository: repo='{{test_ppa_spec}}' state=present
+  apt_repository:
+    repo: '{{ test_ppa_spec }}'
+    state: present
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_spec}}"'
+      - 'result.repo == "{{ test_ppa_spec }}"'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did change'
+- name: assert the apt cache did change
   assert:
     that:
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 # When installing a repo with the spec, the key is *NOT* added
 - name: 'ensure ppa key is absent (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=absent
+  apt_key:
+    id: '{{ test_ppa_key }}'
+    state: absent
+
+#
+# TEST: apt_repository: repo=<spec>,<spec>
+#
+- include: cleanup.yml
+
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
+  register: cache_before
+
+- name: ensure ppa key is present before adding repo that requires authentication
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: '{{ test_ppa_key }}'
+    state: present
+
+- name: 'test repos as list (expect: pass)'
+  apt_repository:
+    repos:
+    - '{{ test_ppa_spec }}'
+    - '{{ test_ppa_spec_src }}'
+    state: present
+  register: result
+
+- name: verify
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+      - 'result.repos == [ test_ppa_spec, test_ppa_spec_src ]'
+
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
+  register: cache_after
+
+- name: assert the apt cache did change
+  assert:
+    that:
+      - 'cache_before.stat.mtime != cache_after.stat.mtime'
+
+# When installing a repo with the spec, the key is *NOT* added
+- name: 'ensure ppa key is absent (expect: pass)'
+  apt_key:
+    id: '{{ test_ppa_key }}'
+    state: absent
 
 #
 # TEST: apt_repository: repo=<spec> filename=<filename>
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml
 
-- name: 'record apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: record apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_before
 
 - name: ensure ppa key is present before adding repo that requires authentication
-  apt_key: keyserver=keyserver.ubuntu.com id='{{test_ppa_key}}' state=present
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: '{{ test_ppa_key }}'
+    state: present
 
 - name: 'name=<spec> filename=<filename> (expect: pass)'
-  apt_repository: repo='{{test_ppa_spec}}' filename='{{test_ppa_filename}}' state=present
+  apt_repository:
+    repo: '{{ test_ppa_spec }}'
+    filename: '{{ test_ppa_filename }}'
+    state: present
   register: result
 
-- assert:
+- name: verify
+  assert:
     that:
       - 'result.changed'
       - 'result.state == "present"'
-      - 'result.repo == "{{test_ppa_spec}}"'
+      - 'result.repo == "{{ test_ppa_spec }}"'
 
-- name: 'examine source file'
-  stat: path='/etc/apt/sources.list.d/{{test_ppa_filename}}.list'
+- name: examine source file
+  stat:
+    path: /etc/apt/sources.list.d/{{ test_ppa_filename }}.list
   register: source_file
 
-- name: 'assert source file exists'
+- name: assert source file exists
   assert:
     that:
       - 'source_file.stat.exists == True'
 
-- name: 'examine apt cache mtime'
-  stat: path='/var/cache/apt/pkgcache.bin'
+- name: examine apt cache mtime
+  stat:
+    path: /var/cache/apt/pkgcache.bin
   register: cache_after
 
-- name: 'assert the apt cache did change'
+- name: assert the apt cache did change
   assert:
     that:
       - 'cache_before.stat.mtime != cache_after.stat.mtime'
 
 # When installing a repo with the spec, the key is *NOT* added
 - name: 'ensure ppa key is absent (expect: pass)'
-  apt_key: id='{{test_ppa_key}}' state=absent
+  apt_key:
+    id: "{{ test_ppa_key }}"
+    state: absent
 
 - name: Test apt_repository with a null value for repo
   apt_repository:
@@ -211,7 +307,8 @@
   register: result
   ignore_errors: yes
 
-- assert:
+- name: verify
+  assert:
     that:
       - result is failed
       - result.msg == "Please set argument 'repos' to a non-empty value"
@@ -222,7 +319,8 @@
   register: result
   ignore_errors: yes
 
-- assert:
+- name: verify
+  assert:
     that:
       - result is failed
       - result.msg == "Please set argument 'repos' to a non-empty value"
@@ -230,4 +328,4 @@
 #
 # TEARDOWN
 #
-- include: 'cleanup.yml'
+- include: cleanup.yml

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -214,7 +214,7 @@
 - assert:
     that:
       - result is failed
-      - result.msg == 'Please set argument \'repo\' to a non-empty value'
+      - result.msg == "Please set argument 'repos' to a non-empty value"
 
 - name: Test apt_repository with an empty value for repo
   apt_repository:
@@ -225,7 +225,7 @@
 - assert:
     that:
       - result is failed
-      - result.msg == 'Please set argument \'repo\' to a non-empty value'
+      - result.msg == "Please set argument 'repos' to a non-empty value"
 
 #
 # TEARDOWN


### PR DESCRIPTION
##### SUMMARY
Currently the update cache runs once for every repo added. This simple change allows to add multiple repos and running the cache once.

This is a re-submission of #56564 because the following suggested alternate solution does not work as expected and the PR was closed without giving any chance to clarify.

This was the suggestion:

~~~yaml
update_cache: "{{ansible_loop.last|bool}}"
~~~

Response: the hint with the ansible_loop.last is nice, however, the result in this use case might not the one expected.

from the docs:

~~~yaml
    update_cache:
        description:
            - Run the equivalent of C(apt-get update) when a change occurs. Cache updates are run after making changes.
        type: bool
        default: yes
~~~
apt_repository only updates cache on change, if the last item is unchanged. cache won't be updated.

related #36605

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt_repository

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
