### PR TITLE
Update win_domain_group_membership.ps1

### DIFF
--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -69,7 +69,7 @@ foreach ($member in $members) {
         }
     }
 
-    if ($state -in @("present", "pure") -and !$user_in_group) {       
+    if ($state -in @("present", "pure") -and !$user_in_group) {
         try {
             Add-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args
         } catch {

--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -69,7 +69,7 @@ foreach ($member in $members) {
         }
     }
 
-    if ($state -in @("present", "pure") -and !$user_in_group) {        
+    if ($state -in @("present", "pure") -and !$user_in_group) {       
         try {
             Add-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args
         } catch {
@@ -82,7 +82,7 @@ foreach ($member in $members) {
             Remove-ADGroupMember -Identity $name -Members $group_member -WhatIf:$check_mode @extra_args -Confirm:$False
         } catch {
             Fail-Json $result "Failed to remove a group $($group_member): $($_.Exception.Message)"
-        }    
+        }
         $result.removed.Add($group_member.SamAccountName)
         $result.changed = $true
     }


### PR DESCRIPTION
Bug fixes while Adding and Deleting a group from another group

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I was trying to add DEF group to ABC group after executing the ansible script I checked the members that are present in ABC groups, the DEF group was not added to it. As DEF group was not present in ABC group after executing the ansible script then I tried to add DEF group to ABC group using the ps1 script, after execution of the ps1 script I found that DEF is a universal group and ABC is a global group, as a global group cannot have a universal group as a member. So the ps1 script failed while executing. But while executing the ansible script it got passed, it didn't show any error while execting it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_group_membership
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

**STEPS TO REPRODUCE**
This can be reproduced by running the following playbook

```
---
- hosts: nodes
  vars:
    domain_user_name: '************************'                                                           # Service Account Username
    domain_user_password: '********************'                                                           # Service Account Password                                                                         
    domain_name: '**********************'                                                                      # Zone of the DNS

  tasks:
  - name: Add a domain group to a domain group
    win_domain_group_membership:
      name: "ABC"
      members:
        - "DEF"
      domain_username: "{{ domain_user_name }}"
      domain_password: "{{ domain_user_password }}"
      domain_server: "{{ domain_name }}"
      state: present
```
**EXPECTED RESULTS**

```
TASK [Add a domain group to a domain group] *************************************************************************************************************************************************************************************************
task path: /home/test.yml:12
Using module file /usr/lib/python2.7/site-packages/ansible/modules/windows/win_domain_group_membership.ps1
<xx.xx.xx.xx> ESTABLISH WINRM CONNECTION FOR USER: test on PORT 5986 TO xx.xx.xx.xx
checking if winrm_host xx.xx.xx.xx is an IPv6 address
EXEC (via pipeline wrapper)
fatal: [xx.xx.xx.xx]: FAILED! => {
    "added": [],
    "changed": false,
    "msg": "Failed to add a group CN=DEF: A global group cannot have a universal group as a member",
    "removed": []
}
```
**ACTUAL RESULTS**

```
TASK [Add a domain group to a domain group] *************************************************************************************************************************************************************************************************
task path: /home/test.yml:12
Using module file /usr/lib/python2.7/site-packages/ansible/modules/windows/win_domain_group_membership.ps1
<xx.xx.xx.xx> ESTABLISH WINRM CONNECTION FOR USER: test on PORT 5986 TO xx.xx.xx.xx
checking if winrm_host xx.xx.xx.xx is an IPv6 address
EXEC (via pipeline wrapper)
changed: [xx.xx.xx.xx] => {
    "added": [
        "DEF"
    ],
    "changed": true,
    "members": [
        "XYZ"
    ],
    "removed": []
}
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```