### PR TITLE
Fix syntax issue with ios_ntp tests

### DIFF
--- a/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
+++ b/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
@@ -1,6 +1,6 @@
 ---
 - name: remove NTP (if set)
-  ios_ntp:
+  ios_ntp: &remove
     server: 10.75.32.5
     source_int: Loopback0
     acl: NTP_ACL


### PR DESCRIPTION
##### SUMMARY
Fix syntax issue with ios_ntp testing. This was exposed when moving to zuul.ansible.com

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test ios_ntp