### PR TITLE
win_format - Add allocation_unit_size

### DIFF
--- a/changelogs/fragments/56966-win_format-allocation-unit-size.yml
+++ b/changelogs/fragments/56966-win_format-allocation-unit-size.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_format - fixed issue where module would not change allocation unit size (https://github.com/ansible/ansible/issues/56961)

--- a/lib/ansible/modules/windows/win_format.ps1
+++ b/lib/ansible/modules/windows/win_format.ps1
@@ -108,7 +108,8 @@ function Format-AnsibleVolume {
         $Full,
         $UseLargeFRS,
         $Compress,
-        $SetIntegrityStreams
+        $SetIntegrityStreams,
+        $AllocationUnitSize
     )
     $parameters = @{
         Path = $Path
@@ -128,6 +129,9 @@ function Format-AnsibleVolume {
     }
     if ($null -ne $FileSystem) {
         $parameters.Add("FileSystem", $FileSystem)
+    }
+    if ($null -ne $AllocationUnitSize) {
+        $parameters.Add("AllocationUnitSize", $AllocationUnitSize)
     }
 
     Format-Volume @parameters -Confirm:$false | Out-Null
@@ -161,7 +165,7 @@ foreach ($access_path in $ansible_partition.AccessPaths) {
 
 if ($force_format) {
     if (-not $module.CheckMode) {
-        Format-AnsibleVolume -Path $ansible_volume.Path -Full $full_format -Label $new_label -FileSystem $file_system -SetIntegrityStreams $integrity_streams -UseLargeFRS $large_frs -Compress $compress_volume
+        Format-AnsibleVolume -Path $ansible_volume.Path -Full $full_format -Label $new_label -FileSystem $file_system -SetIntegrityStreams $integrity_streams -UseLargeFRS $large_frs -Compress $compress_volume -AllocationUnitSize $allocation_unit_size
     }
     $module.Result.changed = $true
 }
@@ -174,7 +178,7 @@ else {
         if ($ansible_volume_size -eq 0 -or
             $ansible_volume.FileSystemLabel -ne $new_label) {
             if (-not $module.CheckMode) {
-                Format-AnsibleVolume -Path $ansible_volume.Path -Full $full_format -Label $new_label -FileSystem $file_system -SetIntegrityStreams $integrity_streams -UseLargeFRS $large_frs -Compress $compress_volume
+                Format-AnsibleVolume -Path $ansible_volume.Path -Full $full_format -Label $new_label -FileSystem $file_system -SetIntegrityStreams $integrity_streams -UseLargeFRS $large_frs -Compress $compress_volume -AllocationUnitSize $allocation_unit_size
             }
             $module.Result.changed = $true
         }

--- a/lib/ansible/modules/windows/win_format.ps1
+++ b/lib/ansible/modules/windows/win_format.ps1
@@ -141,8 +141,16 @@ function Format-AnsibleVolume {
 $ansible_volume = Get-AnsibleVolume -DriveLetter $drive_letter -Path $path -Label $label
 $ansible_file_system = $ansible_volume.FileSystem
 $ansible_volume_size = $ansible_volume.Size
+$ansible_volume_alu = $ansible_volume.AllocationUnitSize
 
 $ansible_partition = Get-Partition -Volume $ansible_volume
+
+if (-not $force_format -and
+    $null -ne $allocation_unit_size -and
+    $ansible_volume_alu -ne 0 -and
+    $allocation_unit_size -ne $ansible_volume_alu) {
+    $module.FailJson("Force format must be specified since target allocation unit size: $($allocation_unit_size) is different from the current allocation unit size of the volume: $($ansible_volume_alu)")
+}
 
 foreach ($access_path in $ansible_partition.AccessPaths) {
     if ($access_path -ne $Path) {

--- a/lib/ansible/modules/windows/win_format.ps1
+++ b/lib/ansible/modules/windows/win_format.ps1
@@ -141,11 +141,11 @@ function Format-AnsibleVolume {
 $ansible_volume = Get-AnsibleVolume -DriveLetter $drive_letter -Path $path -Label $label
 $ansible_file_system = $ansible_volume.FileSystem
 $ansible_volume_size = $ansible_volume.Size
-$ansible_volume_alu = $ansible_volume.AllocationUnitSize
+$ansible_volume_alu = (Get-CimInstance -ClassName Win32_Volume | Where-Object { $_.DeviceId -eq $ansible_volume.Path } | Select-Object BlockSize).BlockSize
 
 $ansible_partition = Get-Partition -Volume $ansible_volume
 
-if (-not $force_format -and $null -ne $allocation_unit_size -and $ansible_volume_alu -ne 0 -and $allocation_unit_size -ne $ansible_volume_alu) {
+if (-not $force_format -and $null -ne $allocation_unit_size -and $ansible_volume_alu -ne 0 -and $null -ne $ansible_volume_alu -and $allocation_unit_size -ne $ansible_volume_alu) {
         $module.FailJson("Force format must be specified since target allocation unit size: $($allocation_unit_size) is different from the current allocation unit size of the volume: $($ansible_volume_alu)")
 }
 

--- a/lib/ansible/modules/windows/win_format.ps1
+++ b/lib/ansible/modules/windows/win_format.ps1
@@ -145,11 +145,8 @@ $ansible_volume_alu = $ansible_volume.AllocationUnitSize
 
 $ansible_partition = Get-Partition -Volume $ansible_volume
 
-if (-not $force_format -and
-    $null -ne $allocation_unit_size -and
-    $ansible_volume_alu -ne 0 -and
-    $allocation_unit_size -ne $ansible_volume_alu) {
-    $module.FailJson("Force format must be specified since target allocation unit size: $($allocation_unit_size) is different from the current allocation unit size of the volume: $($ansible_volume_alu)")
+if (-not $force_format -and $null -ne $allocation_unit_size -and $ansible_volume_alu -ne 0 -and $allocation_unit_size -ne $ansible_volume_alu) {
+        $module.FailJson("Force format must be specified since target allocation unit size: $($allocation_unit_size) is different from the current allocation unit size of the volume: $($ansible_volume_alu)")
 }
 
 foreach ($access_path in $ansible_partition.AccessPaths) {

--- a/lib/ansible/modules/windows/win_format.ps1
+++ b/lib/ansible/modules/windows/win_format.ps1
@@ -141,7 +141,7 @@ function Format-AnsibleVolume {
 $ansible_volume = Get-AnsibleVolume -DriveLetter $drive_letter -Path $path -Label $label
 $ansible_file_system = $ansible_volume.FileSystem
 $ansible_volume_size = $ansible_volume.Size
-$ansible_volume_alu = (Get-CimInstance -ClassName Win32_Volume | Where-Object { $_.DeviceId -eq $ansible_volume.Path } | Select-Object BlockSize).BlockSize
+$ansible_volume_alu = (Get-CimInstance -ClassName Win32_Volume -Filter "DeviceId = '$($ansible_volume.path.replace('\','\\'))'" -Property BlockSize).BlockSize
 
 $ansible_partition = Get-Partition -Volume $ansible_volume
 

--- a/lib/ansible/modules/windows/win_format.py
+++ b/lib/ansible/modules/windows/win_format.py
@@ -43,6 +43,7 @@ options:
       - Specifies the cluster size to use when formatting the volume.
       - If no cluster size is specified when you format a partition, defaults are selected based on
         the size of the partition.
+      - This value must be a multiple of the physical sector size of the disk.
     type: int
   large_frs:
     description:

--- a/test/integration/targets/win_format/tasks/tests.yml
+++ b/test/integration/targets/win_format/tasks/tests.yml
@@ -35,8 +35,6 @@
 - win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$($AnsiVol.AllocationUnitSize)"
   register: formatted_value_result_check
 
-- debug: var=formatted_value_result_check
-
 - name: Fully format volume and assign label
   win_format:
     drive_letter: T

--- a/test/integration/targets/win_format/tasks/tests.yml
+++ b/test/integration/targets/win_format/tasks/tests.yml
@@ -28,28 +28,32 @@
     drive_letter: T
     new_label: Formatted
     full: True
+    allocation_unit_size: 8192
   register: format_result_check
   check_mode: True
 
-- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel)"
+- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$($AnsiVol.AllocationUnitSize)"
   register: formatted_value_result_check
+
+- debug: var=formatted_value_result_check
 
 - name: Fully format volume and assign label
   win_format:
     drive_letter: T
     new_label: Formatted
     full: True
+    allocation_unit_size: 8192
   register: format_result
 
-- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel)"
+- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$($AnsiVol.AllocationUnitSize)"
   register: formatted_value_result
 
 - assert:
     that:
       - format_result_check is changed
       - format_result is changed
-      - formatted_value_result_check.stdout | trim == "2096037888,0,"
-      - formatted_value_result.stdout | trim == "2096037888,2096033792,Formatted"
+      - formatted_value_result_check.stdout | trim == "2096037888,0,,0"
+      - formatted_value_result.stdout | trim == "2096037888,2096029696,Formatted,8192"
 
 - name: Format NTFS volume with integrity streams enabled
   win_format:
@@ -136,3 +140,24 @@
       - format_volume_without_force is failed
       - 'format_volume_without_force.msg == "Force format must be specified to format non-pristine volumes"'
       - format_volume_with_force is changed
+
+- name: Reformat using different alu without force format
+  win_format:
+    path: "{{ shell_partition_result.stdout | trim }}"
+    allocation_unit_size: 8192
+    file_system: ntfs
+  register: reformat_using_alu_without_force
+  ignore_errors: True
+
+- name: Reformat using different alu using force format
+  win_format:
+    path: "{{ shell_partition_result.stdout | trim }}"
+    allocation_unit_size: 8192
+    file_system: ntfs
+    force: True
+  register: reformat_using_alu_with_force
+
+- assert:
+    that:
+      - reformat_using_alu_without_force is failed
+      - reformat_using_alu_with_force is changed

--- a/test/integration/targets/win_format/tasks/tests.yml
+++ b/test/integration/targets/win_format/tasks/tests.yml
@@ -31,9 +31,8 @@
     allocation_unit_size: 8192
   register: format_result_check
   check_mode: True
-  ignore_errors: True
 
-- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$((Get-CimInstance -ClassName Win32_Volume | Where-Object { $_.DriveLetter -eq 'T:' } | Select-Object BlockSize).BlockSize)"
+- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$((Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = 'T:'" -Property BlockSize).BlockSize)"
   register: formatted_value_result_check
 
 - name: Fully format volume and assign label
@@ -44,7 +43,7 @@
     allocation_unit_size: 8192
   register: format_result
 
-- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$((Get-CimInstance -ClassName Win32_Volume | Where-Object { $_.DriveLetter -eq 'T:' } | Select-Object BlockSize).BlockSize)"
+- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$((Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = 'T:'" -Property BlockSize).BlockSize)"
   register: formatted_value_result
 
 - assert:
@@ -148,6 +147,10 @@
   register: reformat_using_alu_without_force
   ignore_errors: True
 
+- assert:
+    that:
+      - reformat_using_alu_without_force is failed
+
 - name: Reformat using different alu using force format
   win_format:
     path: "{{ shell_partition_result.stdout | trim }}"
@@ -158,5 +161,4 @@
 
 - assert:
     that:
-      - reformat_using_alu_without_force is failed
       - reformat_using_alu_with_force is changed

--- a/test/integration/targets/win_format/tasks/tests.yml
+++ b/test/integration/targets/win_format/tasks/tests.yml
@@ -31,8 +31,9 @@
     allocation_unit_size: 8192
   register: format_result_check
   check_mode: True
+  ignore_errors: True
 
-- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$($AnsiVol.AllocationUnitSize)"
+- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$((Get-CimInstance -ClassName Win32_Volume | Where-Object { $_.DriveLetter -eq 'T:' } | Select-Object BlockSize).BlockSize)"
   register: formatted_value_result_check
 
 - name: Fully format volume and assign label
@@ -43,14 +44,14 @@
     allocation_unit_size: 8192
   register: format_result
 
-- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$($AnsiVol.AllocationUnitSize)"
+- win_shell: $AnsiPart = Get-Partition -DriveLetter T; $AnsiVol = Get-Volume -DriveLetter T; "$($AnsiPart.Size),$($AnsiVol.Size),$($AnsiVol.FileSystemLabel),$((Get-CimInstance -ClassName Win32_Volume | Where-Object { $_.DriveLetter -eq 'T:' } | Select-Object BlockSize).BlockSize)"
   register: formatted_value_result
 
 - assert:
     that:
       - format_result_check is changed
       - format_result is changed
-      - formatted_value_result_check.stdout | trim == "2096037888,0,,0"
+      - formatted_value_result_check.stdout | trim == "2096037888,0,,"
       - formatted_value_result.stdout | trim == "2096037888,2096029696,Formatted,8192"
 
 - name: Format NTFS volume with integrity streams enabled


### PR DESCRIPTION
##### SUMMARY
Fixes #56961 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_format

##### ADDITIONAL INFORMATION
Added `allocation_unit_size` support for `win_format`. Was added initially then removed after the re-write. Putting it back in with this.

Added a note in the docs to specify usage of physical sector size as well.