### PR TITLE
 win_domain_computer module:  Fix idempotence when name != sam_account_name 

### DIFF
--- a/changelogs/fragments/win_domain_computer-idempotence.yaml
+++ b/changelogs/fragments/win_domain_computer-idempotence.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_computer - Fix idempotence checks when ``sAMAccountName`` is different from ``name``

--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -59,6 +59,7 @@ If ($state -eq "present") {
 } Else {
   $desired_state = [ordered]@{
     name = $name
+    sam_account_name = $sam_account_name
     state = $state
   }
 }
@@ -68,7 +69,7 @@ Function Get-InitialState($desired_state) {
   # Test computer exists
   $computer = Try {
     Get-ADComputer `
-      -Identity $desired_state.name `
+      -Identity $desired_state.sam_account_name `
       -Properties DistinguishedName,DNSHostName,Enabled,Name,SamAccountName,Description,ObjectClass `
       @extra_args
   } Catch { $null }
@@ -87,6 +88,7 @@ Function Get-InitialState($desired_state) {
   } Else {
     $initial_state = [ordered]@{
       name = $desired_state.name
+      sam_account_name = $desired_state.sam_account_name
       state = "absent"
     }
   }
@@ -112,7 +114,7 @@ Function Set-ConstructedState($initial_state, $desired_state) {
   If ($initial_state.distinguished_name -cne $desired_state.distinguished_name) {
     # Move computer to OU
     Try {
-      Get-ADComputer -Identity $desired_state.name @extra_args |
+      Get-ADComputer -Identity $desired_state.sam_account_name @extra_args |
           Move-ADObject `
             -TargetPath $desired_state.ou `
             -Confirm:$False `
@@ -147,7 +149,7 @@ Function Add-ConstructedState($desired_state) {
 # ------------------------------------------------------------------------------
 Function Remove-ConstructedState($initial_state) {
   Try {
-    Get-ADComputer -Identity $initial_state.name @extra_args |
+    Get-ADComputer -Identity $initial_state.sam_account_name @extra_args |
       Remove-ADObject `
         -Recursive `
         -Confirm:$False `

--- a/lib/ansible/modules/windows/win_domain_computer.py
+++ b/lib/ansible/modules/windows/win_domain_computer.py
@@ -104,7 +104,7 @@ EXAMPLES = r'''
   - name: Add linux computer to Active Directory OU using a windows machine
     win_domain_computer:
       name: one_linux_server.my_org.local
-      sam_account_name: linux_server
+      sam_account_name: linux_server$
       dns_hostname: one_linux_server.my_org.local
       ou: "OU=servers,DC=my_org,DC=local"
       description: Example of linux server

--- a/test/integration/targets/win_domain_computer/aliases
+++ b/test/integration/targets/win_domain_computer/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/win_domain_computer/tasks/main.yml
+++ b/test/integration/targets/win_domain_computer/tasks/main.yml
@@ -1,0 +1,71 @@
+# this won't run in Ansible's integration tests until we get a domain set up
+# these are here if someone wants to run the module tests locally on their own
+# domain.
+# Requirements:
+#   LDAP Base path set in defaults/main.yml like DC=ansible,DC=local
+#   Custom OU path set in defaults/main.yml like OU=ou1,DC=ansible,DC=local
+---
+- name: run win_domain_users test
+  hosts: win_domain_computer_testing_host
+  vars:
+    test_win_domain_computer_ldap_base: "{{ test_ad_ou }}"
+    test_win_domain_computer_ou_path: "{{ test_ad_group_ou }}"
+    test_win_domain_computer_name: "test_computer.{{ test_domain_name }}"
+  tasks:
+
+    - name: ensure the computer is deleted before the test
+      win_domain_computer:
+        name: '{{ test_win_domain_computer_name }}'
+        state: absent
+
+    # --------------------------------------------------------------------------
+
+    - name: Test computer with long name and distinct sam_account_name
+      vars:
+        test_win_domain_computer_long_name: '{{ test_win_domain_computer_name }}_with_long_name'
+        test_win_domain_computer_sam_account_name: '{{ test_win_domain_computer_name }}$'
+      block:
+
+        # ----------------------------------------------------------------------
+        - name: create computer with long name and distinct sam_account_name
+          win_domain_computer:
+            name: '{{ test_win_domain_computer_long_name }}'
+            sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+            enabled: yes
+            state: present
+          register: create_distinct_sam_account_name
+          check_mode: yes
+
+        - name: get actual computer with long name and distinct sam_account_name
+          win_command: powershell.exe "Import-Module ActiveDirectory; Get-ADComputer -Identity '{{ test_win_domain_computer_sam_account_name }}'"
+          register: create_distinct_sam_account_name_check
+          ignore_errors: True
+
+        - name: assert create computer with long name and distinct sam_account_name
+          assert:
+            that:
+            - create_distinct_sam_account_name is changed
+            - create_distinct_sam_account_name_check.rc == 1
+
+        - name: (Idempotence) create computer with long name and distinct sam_account_name
+          win_domain_computer:
+            name: '{{ test_win_domain_computer_long_name }}'
+            sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+            enabled: yes
+            state: present
+          register: create_distinct_sam_account_name_idempotence
+          check_mode: yes
+
+        - name: (Idempotence) assert create computer with long name and distinct sam_account_name
+          assert:
+            that:
+            - create_distinct_sam_account_name_idempotence is not changed
+
+        - name: ensure the test group is deleted after the test
+          win_domain_computer:
+            name: '{{ test_win_domain_computer_long_name }}'
+            sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+            state: absent
+            ignore_protection: True
+
+        # ----------------------------------------------------------------------


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Creating a computer with distinct `name` and `sam_account_name` makes idempotence fail.
Running the test provided `test/integration/targets/win_domain_computer/tasks/main.yml` (tried to follow the examples but surely will need adaptations)  shows the mentioned idempotence fail.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_computer

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Inside the module we ask for the AD computer object by `sam_account_name` instead of `name`, fixing the issue.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change 
```paste below

```
-->
