### PR TITLE
Sort out None results from Consul client

### DIFF
--- a/changelogs/fragments/56969-sort_out_none_objects_from_consul_client_inventory.yml
+++ b/changelogs/fragments/56969-sort_out_none_objects_from_consul_client_inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "consul_io.py: fix appends of None objects to some list variables (see https://github.com/ansible/ansible/pull/56969 and https://github.com/ansible/ansible/issues/56732)"

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -237,9 +237,9 @@ class ConsulInventory(object):
         index, groups_list = self.consul_api.kv.get(self.config.kv_groups, recurse=True, dc=datacenter)
         index, metadata_list = self.consul_api.kv.get(self.config.kv_metadata, recurse=True, dc=datacenter)
         index, nodes = self.consul_api.catalog.nodes(dc=datacenter)
-        self.inmemory_kv += groups_list
-        self.inmemory_kv += metadata_list
-        self.inmemory_nodes += nodes
+        self.inmemory_kv += groups_list if groups_list else []
+        self.inmemory_kv += metadata_list if metadata_list else []
+        self.inmemory_nodes += nodes if nodes else []
 
     def load_all_data_consul(self):
         ''' cycle through each of the datacenters in the consul catalog and process
@@ -529,8 +529,6 @@ class ConsulConfig(dict):
 
         if hasattr(self, 'token'):
             token = self.token
-            if not token:
-                token = 'anonymous'
         return consul.Consul(host=host, port=port, token=token, scheme=scheme)
 
 


### PR DESCRIPTION
[CHANGED]
* Some requests to Consul return a None value that was added to a list.
Now it's added only if it returns a value.
* Token value was set to 'anonymous' by default and raised errors.
Now is set to None and left untouched. This allows Consul client to
finish requests properly.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
