### PR TITLE
[2.8] docker conncetion plugin: accept 'dev' as 'newest version'

### DIFF
--- a/changelogs/fragments/56947-docker-dev.yml
+++ b/changelogs/fragments/56947-docker-dev.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker connection plugin - accept version ``dev`` as 'newest version' and print warning."

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -84,7 +84,9 @@ class Connection(ConnectionBase):
                 raise AnsibleError("docker command not found in PATH")
 
         docker_version = self._get_docker_version()
-        if LooseVersion(docker_version) < LooseVersion(u'1.3'):
+        if docker_version == u'dev':
+            display.warning(u'Docker version number is "dev". Will assume latest version.')
+        if docker_version != u'dev' and LooseVersion(docker_version) < LooseVersion(u'1.3'):
             raise AnsibleError('docker connection type requires docker 1.3 or higher')
 
         # The remote user we will request from docker (if supported)
@@ -93,7 +95,7 @@ class Connection(ConnectionBase):
         self.actual_user = None
 
         if self._play_context.remote_user is not None:
-            if LooseVersion(docker_version) >= LooseVersion(u'1.7'):
+            if docker_version == u'dev' or LooseVersion(docker_version) >= LooseVersion(u'1.7'):
                 # Support for specifying the exec user was added in docker 1.7
                 self.remote_user = self._play_context.remote_user
                 self.actual_user = self.remote_user


### PR DESCRIPTION
##### SUMMARY
Backport of #56947 to stable-2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/docker.py
