### PR TITLE
[2.8] [docker_network] Fix idempotency when using aux_addresses in ipam_config

### DIFF
--- a/changelogs/fragments/docker_network_aux_addresses.yml
+++ b/changelogs/fragments/docker_network_aux_addresses.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_network module - fix idempotency when using ``aux_addresses`` in ``ipam_config``.

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -346,6 +346,20 @@ def get_ip_version(cidr):
     raise ValueError('"{0}" is not a valid CIDR'.format(cidr))
 
 
+def normalize_ipam_config_key(key):
+    """Normalizes IPAM config keys returned by Docker API to match Ansible keys
+
+    :param key: Docker API key
+    :type key: str
+    :return Ansible module key
+    :rtype str
+    """
+    special_cases = {
+        'AuxiliaryAddresses': 'aux_addresses'
+    }
+    return special_cases.get(key, key.lower())
+
+
 class DockerNetworkManager(object):
 
     def __init__(self, client):
@@ -447,7 +461,7 @@ class DockerNetworkManager(object):
                             continue
                         camelkey = None
                         for net_key in net_config:
-                            if key == net_key.lower():
+                            if key == normalize_ipam_config_key(net_key):
                                 camelkey = net_key
                                 break
                         if not camelkey or net_config.get(camelkey) != value:

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -13,7 +13,7 @@
 
 #################### network-ipam-0 deprecated ####################
 
-- name: Create network with ipam_config and deprecated ipam_options
+- name: Create network with ipam_config and deprecated ipam_options (conflicting)
   docker_network:
     name: "{{ nname_ipam_0 }}"
     ipam_options:
@@ -28,32 +28,71 @@
       - network is failed
       - "network.msg == 'parameters are mutually exclusive: ipam_config|ipam_options'"
 
-- name: Create network with deprecated custom IPAM config
+- name: Create network with deprecated custom IPAM options
   docker_network:
     name: "{{ nname_ipam_0 }}"
     ipam_options:
       subnet: 172.3.29.0/24
+      gateway: 172.3.29.2
+      iprange: 172.3.29.0/26
+      aux_addresses:
+        host1: 172.3.29.3
+        host2: 172.3.29.4
   register: network
 
 - assert:
     that:
       - network is changed
 
-- name: Change subnet of network with deprecated custom IPAM config
+- name: Create network with deprecated custom IPAM options (idempotence)
   docker_network:
     name: "{{ nname_ipam_0 }}"
     ipam_options:
-      subnet: 172.3.30.0/24
+      subnet: 172.3.29.0/24
+      gateway: 172.3.29.2
+      iprange: 172.3.29.0/26
+      aux_addresses:
+        host1: 172.3.29.3
+        host2: 172.3.29.4
+  register: network
+
+- assert:
+    that:
+      - network is not changed
+
+- name: Change of network created with deprecated custom IPAM options
+  docker_network:
+    name: "{{ nname_ipam_0 }}"
+    ipam_options:
+      subnet: 172.3.28.0/24
+      gateway: 172.3.28.2
+      iprange: 172.3.28.0/26
+      aux_addresses:
+        host1: 172.3.28.3
   register: network
   diff: yes
 
 - assert:
     that:
       - network is changed
-      - network.diff.differences | length == 1
-      - network.diff.differences[0] == "ipam_config[0].subnet"
+      - network.diff.differences | length == 4
+      - '"ipam_config[0].subnet" in network.diff.differences'
+      - '"ipam_config[0].gateway" in network.diff.differences'
+      - '"ipam_config[0].iprange" in network.diff.differences'
+      - '"ipam_config[0].aux_addresses" in network.diff.differences'
 
-- name: Cleanup network with ipam_config and deprecated ipam_options
+- name: Remove gateway and iprange of network with deprecated custom IPAM options
+  docker_network:
+    name: "{{ nname_ipam_0 }}"
+    ipam_options:
+      subnet: 172.3.28.0/24
+  register: network
+
+- assert:
+    that:
+      - network is not changed
+
+- name: Cleanup network with deprecated custom IPAM options
   docker_network:
     name: "{{ nname_ipam_0 }}"
     state: absent
@@ -76,7 +115,23 @@
     that:
       - network is changed
 
-- name: Change subnet, gateway, iprange and auxiliary addresses of network with custom IPAM config
+- name: Create network with custom IPAM config (idempotence)
+  docker_network:
+    name: "{{ nname_ipam_1 }}"
+    ipam_config:
+      - subnet: 172.3.27.0/24
+        gateway: 172.3.27.2
+        iprange: 172.3.27.0/26
+        aux_addresses:
+          host1: 172.3.27.3
+          host2: 172.3.27.4
+  register: network
+
+- assert:
+    that:
+      - network is not changed
+
+- name: Change of network created with custom IPAM config
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
@@ -128,6 +183,18 @@
     that:
       - network is changed
 
+- name: Create network with IPv6 IPAM config (idempotence)
+  docker_network:
+    name: "{{ nname_ipam_2 }}"
+    enable_ipv6: yes
+    ipam_config:
+      - subnet: fdd1:ac8c:0557:7ce0::/64
+  register: network
+
+- assert:
+    that:
+      - network is not changed
+
 - name: Change subnet of network with IPv6 IPAM config
   docker_network:
     name: "{{ nname_ipam_2 }}"
@@ -178,7 +245,7 @@
     that:
       - network is changed
 
-- name: Change subnet order of network with IPv6 and custom IPv4 IPAM config
+- name: Change subnet order of network with IPv6 and custom IPv4 IPAM config (idempotence)
   docker_network:
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: yes
@@ -191,7 +258,7 @@
     that:
       - network is not changed
 
-- name: Remove IPv6 from network with custom IPv4 and IPv6 IPAM config
+- name: Remove IPv6 from network with custom IPv4 and IPv6 IPAM config (change)
   docker_network:
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: no


### PR DESCRIPTION
##### SUMMARY
Backport of #56901 to stable-2.8. Fixes idempotency for `aux_addresses`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network
