### PR TITLE
[2.8] VMware: Fix python 3 incompatibility

### DIFF
--- a/changelogs/fragments/54123-vmware_guest-string_compat.yml
+++ b/changelogs/fragments/54123-vmware_guest-string_compat.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest now accepts Python 2 and Python 3 compatible string translate method (https://github.com/ansible/ansible/issues/54118).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1580,7 +1580,8 @@ class PyVmomiHelper(PyVmomi):
             # Setting hostName, orgName and fullName is mandatory, so we set some default when missing
             ident.userData.computerName = vim.vm.customization.FixedName()
             # computer name will be truncated to 15 characters if using VM name
-            default_name = self.params['name'].translate(None, string.punctuation)
+            default_name = self.params['name'].replace(' ', '')
+            default_name = ''.join([c for c in default_name if c not in string.punctuation])
             ident.userData.computerName.name = str(self.params['customization'].get('hostname', default_name[0:15]))
             ident.userData.fullName = str(self.params['customization'].get('fullname', 'Administrator'))
             ident.userData.orgName = str(self.params['customization'].get('orgname', 'ACME'))


### PR DESCRIPTION
##### SUMMARY
Add Python2 and Python3 compatible `string.translate` for hostname customization.

Fixes: #54118
(cherry picked from commit 8f89d1d3dae38db8273dd7a45b9320c03e347fa9)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/54123-vmware_guest-string_compat.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py