### PR TITLE
Correct repository name to install

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -119,7 +119,7 @@ To enable the Ansible Engine repository for RHEL 8, run the following command:
 
 .. code-block:: bash
 
-    $ sudo subscription-manager repos --enable rhel-8-server-ansible-2.8-rpms
+    $ sudo subscription-manager repos --enable ansible-2.8-for-rhel-8-x86_64-rpms
 
 To enable the Ansible Engine repository for RHEL 7, run the following command:
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The name of repository is not correct to install.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
On RHEL8, these are the list of ansible repos:

```
# LANG=C subscription-manager repos --list | grep ansible
Repo ID:   ansible-2-for-rhel-8-x86_64-source-rpms
Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/source/SRPMS
Repo ID:   ansible-2.8-for-rhel-8-x86_64-source-rpms
Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.8/source/SRPMS
Repo ID:   ansible-2-for-rhel-8-x86_64-debug-rpms
Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/debug
Repo ID:   ansible-2-for-rhel-8-x86_64-rpms
Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os
Repo ID:   ansible-2.8-for-rhel-8-x86_64-debug-rpms
Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.8/debug
Repo ID:   ansible-2.8-for-rhel-8-x86_64-rpms
Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.8/os
```
