### PR TITLE
Adds visibility parameter to gitlab group creation

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -188,7 +188,8 @@ class GitLabGroup(object):
             group = self.createGroup({
                 'name': name,
                 'path': options['path'],
-                'parent_id': parent_id})
+                'parent_id': parent_id,
+                'visibility': options['visibility']})
             changed = True
         else:
             changed, group = self.updateGroup(self.groupObject, {


### PR DESCRIPTION
##### SUMMARY

Adds `visibility` as a parameter to gitlab group creation

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
gitlab_group

##### ADDITIONAL INFORMATION

The `visibility` parameter was not being used when a group is being created, only when a group was getting updated. This patch adds it into the group creation as well. The following ansible created a group with private visibility settings before the patch, and public visibility after the patch.

```
- name: Add website group
  gitlab_group:
    server_url: URL
    login_token: TOKEN
    name: example_group
    visibility: public
```