### PR TITLE
Update intro_installation.rst

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -119,7 +119,7 @@ To enable the Ansible Engine repository for RHEL 8, run the following command:
 
 .. code-block:: bash
 
-    $ sudo subscription-manager repos --enable rhel-8-server-ansible-2.8-rpms
+    $ sudo subscription-manager repos --enable ansible-2.8-for-rhel-8-x86_64-rpms
 
 To enable the Ansible Engine repository for RHEL 7, run the following command:
 


### PR DESCRIPTION
##### SUMMARY
Updated RHEL 8 Repository Name

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
Installation Guide

##### ADDITIONAL INFORMATION
```
PS /home/joshua> sudo subscription-manager repos --enable rhel-8-server-ansible-2.8-rpms
Error: 'rhel-8-server-ansible-2.8-rpms' does not match a valid repository ID. Use "subscription-manager repos --list" to see valid repositories.
PS /home/joshua> sudo subscription-manager repos --enable ansible-2.8-for-rhel-8-x86_64-rpms
Repository 'ansible-2.8-for-rhel-8-x86_64-rpms' is enabled for this system.
```
