### PR TITLE
rename bigiX_device_facts -> bigiX_device_info

### DIFF
--- a/changelogs/fragments/57028-facts-info-rename.yaml
+++ b/changelogs/fragments/57028-facts-info-rename.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- The ``bigip_device_facts`` module has been renamed to ``bigip_device_info``.
+- The ``bigiq_device_facts`` module has been renamed to ``bigiq_device_info``.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -73,6 +73,8 @@ Noteworthy module changes
 * The ``zabbix_group_facts`` module was renamed to :ref:`zabbix_group_info <zabbix_group_info_module>`.
 * The ``zabbix_host_facts`` module was renamed to :ref:`zabbix_host_info <zabbix_host_info_module>`.
 * The ``k8s_facts`` module was renamed to :ref:`k8s_info <k8s_info_module>`.
+* The ``bigip_device_facts`` module was renamed to :ref:`bigip_device_info <bigip_device_info_module>`.
+* The ``bigiq_device_facts`` module was renamed to :ref:`bigiq_device_info <bigiq_device_info_module>`.
 
 
 Plugins

--- a/lib/ansible/modules/network/f5/_bigip_device_facts.py
+++ b/lib/ansible/modules/network/f5/_bigip_device_facts.py
@@ -1,0 +1,1 @@
+bigip_device_info.py

--- a/lib/ansible/modules/network/f5/_bigip_facts.py
+++ b/lib/ansible/modules/network/f5/_bigip_facts.py
@@ -29,14 +29,14 @@ notes:
   - Best run as a local_action in your playbook
   - Tested with manager and above account privilege level
   - C(provision) facts were added in 2.2
-  - This module is deprecated. Use the C(bigip_device_facts) module instead.
+  - This module is deprecated. Use the C(bigip_device_info) module instead.
 deprecated:
   removed_in: '2.11'
-  alternative: bigip_device_facts
+  alternative: bigip_device_info
   why: >
     The bigip_facts module relies on SOAP to communicate with the BIG-IP,
     and has a large amount of code that does not conform to existing F5 standards.
-    The M(bigip_device_facts) module is easier to maintain and use.
+    The M(bigip_device_info) module is easier to maintain and use.
 requirements:
   - bigsuds
 options:

--- a/lib/ansible/modules/network/f5/_bigip_gtm_facts.py
+++ b/lib/ansible/modules/network/f5/_bigip_gtm_facts.py
@@ -35,14 +35,14 @@ options:
         Python's C(re) module.
 deprecated:
   removed_in: '2.11'
-  alternative: bigip_device_facts
+  alternative: bigip_device_info
   why: >
     The bigip_gtm_facts module is an outlier as all facts are being collected
-    in the bigip_device_facts module. Additionally, the M(bigip_device_facts)
+    in the bigip_device_info module. Additionally, the M(bigip_device_info)
     module is easier to maintain and use.
 extends_documentation_fragment: f5
 notes:
-  - This module is deprecated. Use the C(bigip_device_facts) module instead.
+  - This module is deprecated. Use the C(bigip_device_info) module instead.
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/lib/ansible/modules/network/f5/_bigiq_device_facts.py
+++ b/lib/ansible/modules/network/f5/_bigiq_device_facts.py
@@ -1,0 +1,1 @@
+bigiq_device_info.py

--- a/lib/ansible/modules/network/f5/bigip_device_info.py
+++ b/lib/ansible/modules/network/f5/bigip_device_info.py
@@ -15,15 +15,16 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: bigip_device_facts
-short_description: Collect facts from F5 BIG-IP devices
+module: bigip_device_info
+short_description: Collect information from F5 BIG-IP devices
 description:
-  - Collect facts from F5 BIG-IP devices.
+  - Collect information from F5 BIG-IP devices.
+  - This module was called C(bigip_device_facts) before Ansible 2.9. The usage did not change.
 version_added: 2.7
 options:
   gather_subset:
     description:
-      - When supplied, this argument will restrict the facts returned to a given subset.
+      - When supplied, this argument will restrict the information returned to a given subset.
       - Can specify a list of values to include a larger subset.
       - Values can also be used with an initial C(!) to specify that a specific subset
         should not be collected.
@@ -164,8 +165,8 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Collect BIG-IP facts
-  bigip_device_facts:
+- name: Collect BIG-IP information
+  bigip_device_info:
     gather_subset:
       - interfaces
       - vlans
@@ -175,8 +176,8 @@ EXAMPLES = r'''
       password: secret
   delegate_to: localhost
 
-- name: Collect all BIG-IP facts
-  bigip_device_facts:
+- name: Collect all BIG-IP information
+  bigip_device_info:
     gather_subset:
       - all
     provider:
@@ -185,8 +186,8 @@ EXAMPLES = r'''
       password: secret
   delegate_to: localhost
 
-- name: Collect all BIG-IP facts except trunks
-  bigip_device_facts:
+- name: Collect all BIG-IP information except trunks
+  bigip_device_info:
     gather_subset:
       - all
       - "!trunks"
@@ -199,7 +200,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 asm_policy_stats:
-  description: Miscellaneous ASM policy related facts.
+  description: Miscellaneous ASM policy related information.
   returned: When C(asm-policy-stats) is specified in C(gather_subset).
   type: complex
   contains:
@@ -235,7 +236,7 @@ asm_policy_stats:
       sample: 3
   sample: hash/dictionary of values
 asm_policies:
-  description: Detailed facts for ASM policies present on device.
+  description: Detailed information for ASM policies present on device.
   returned: When C(asm-policies) is specified in C(gather_subset).
   type: complex
   contains:
@@ -474,7 +475,7 @@ asm_policies:
           sample: 1
   sample: hash/dictionary of values
 asm_server_technologies:
-  description: Detailed facts for ASM server technologies present on device.
+  description: Detailed information for ASM server technologies present on device.
   returned: When C(asm-server-technologies) is specified in C(gather_subset).
   type: complex
   contains:
@@ -502,7 +503,7 @@ asm_server_technologies:
       sample: https://localhost/mgmt/tm/asm/server-technologies/NQG7CT02OBC2cQWbnP7T-A?ver=13.1.0
   sample: hash/dictionary of values
 asm_signature_sets:
-  description: Detailed facts for ASM signature sets present on device.
+  description: Detailed information for ASM signature sets present on device.
   returned: When C(asm-signature-sets) is specified in C(gather_subset).
   type: complex
   contains:
@@ -565,7 +566,7 @@ asm_signature_sets:
       sample: yes
   sample: hash/dictionary of values
 client_ssl_profiles:
-  description: Client SSL Profile related facts.
+  description: Client SSL Profile related information.
   returned: When C(client-ssl-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -816,7 +817,7 @@ client_ssl_profiles:
       type: str
   sample: hash/dictionary of values
 devices:
-  description: Device related facts.
+  description: Device related information.
   returned: When C(devices) is specified in C(gather_subset).
   type: complex
   contains:
@@ -960,7 +961,7 @@ devices:
       sample: 2.2.2.2
     self:
       description:
-        - Whether this device is the one that was queried for facts, or not.
+        - Whether this device is the one that was queried for information, or not.
       returned: queried
       type: bool
       sample: yes
@@ -1014,7 +1015,7 @@ devices:
           sample: 1026
   sample: hash/dictionary of values
 device_groups:
-  description: Device group related facts.
+  description: Device group related information.
   returned: When C(device-groups) is specified in C(gather_subset).
   type: complex
   contains:
@@ -1081,7 +1082,7 @@ device_groups:
       sample: yes
   sample: hash/dictionary of values
 external_monitors:
-  description: External monitor related facts.
+  description: External monitor related information.
   returned: When C(external-monitors) is specified in C(gather_subset).
   type: complex
   contains:
@@ -1171,7 +1172,7 @@ external_monitors:
       sample: 0
   sample: hash/dictionary of values
 fasthttp_profiles:
-  description: FastHTTP profile related facts.
+  description: FastHTTP profile related information.
   returned: When C(fasthttp-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -1343,7 +1344,7 @@ fasthttp_profiles:
       sample: enabled
   sample: hash/dictionary of values
 fastl4_profiles:
-  description: FastL4 profile related facts.
+  description: FastL4 profile related information.
   returned: When C(fastl4-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -1720,7 +1721,7 @@ fastl4_profiles:
       sample: fallback
   sample: hash/dictionary of values
 gateway_icmp_monitors:
-  description: Gateway ICMP monitor related facts.
+  description: Gateway ICMP monitor related information.
   returned: When C(gateway-icmp-monitors) is specified in C(gather_subset).
   type: complex
   contains:
@@ -1834,9 +1835,9 @@ gateway_icmp_monitors:
   sample: hash/dictionary of values
 gtm_pools:
   description:
-    - GTM pool related facts.
-    - Every "type" of pool has the exact same list of possible facts. Therefore,
-      the list of facts here is presented once instead of 6 times.
+    - GTM pool related information.
+    - Every "type" of pool has the exact same list of possible information. Therefore,
+      the list of information here is presented once instead of 6 times.
   returned: When any of C(gtm-pools) or C(gtm-*-pools) is specified in C(gather_subset).
   type: complex
   contains:
@@ -1977,7 +1978,7 @@ gtm_pools:
   sample: hash/dictionary of values
 gtm_servers:
   description:
-    - GTM server related facts.
+    - GTM server related information.
   returned: When C(gtm-servers) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2142,9 +2143,9 @@ gtm_servers:
   sample: hash/dictionary of values
 gtm_wide_ips:
   description:
-    - GTM Wide IP related facts.
-    - Every "type" of wide-ip has the exact same list of possible facts. Therefore,
-      the list of facts here is presented once instead of 6 times.
+    - GTM Wide IP related information.
+    - Every "type" of wide-ip has the exact same list of possible information. Therefore,
+      the list of information here is presented once instead of 6 times.
   returned: When any of C(gtm-wide-ips) or C(gtm-*-wide-ips) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2233,7 +2234,7 @@ gtm_wide_ips:
       type: complex
   sample: hash/dictionary of values
 http_monitors:
-  description: HTTP monitor related facts.
+  description: HTTP monitor related information.
   returned: When C(http-monitors) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2389,7 +2390,7 @@ http_monitors:
       sample: user1
   sample: hash/dictionary of values
 https_monitors:
-  description: HTTPS monitor related facts.
+  description: HTTPS monitor related information.
   returned: When C(https-monitors) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2551,7 +2552,7 @@ https_monitors:
       sample: user1
   sample: hash/dictionary of values
 http_profiles:
-  description: HTTP profile related facts.
+  description: HTTP profile related information.
   returned: When C(http-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2767,7 +2768,7 @@ http_profiles:
       sample: preserve
   sample: hash/dictionary of values
 iapp_services:
-  description: iApp v1 service related facts.
+  description: iApp v1 service related information.
   returned: When C(iapp-services) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2852,7 +2853,7 @@ iapp_services:
       sample: My service
   sample: hash/dictionary of values
 icmp_monitors:
-  description: ICMP monitor related facts.
+  description: ICMP monitor related information.
   returned: When C(icmp-monitors) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2964,7 +2965,7 @@ icmp_monitors:
       sample: 0
   sample: hash/dictionary of values
 interfaces:
-  description: Interface related facts.
+  description: Interface related information.
   returned: When C(interfaces) is specified in C(gather_subset).
   type: complex
   contains:
@@ -3093,7 +3094,7 @@ interfaces:
       sample: auto
   sample: hash/dictionary of values
 irules:
-  description: iRule related facts.
+  description: iRule related information.
   returned: When C(irules) is specified in C(gather_subset).
   type: complex
   contains:
@@ -3738,7 +3739,7 @@ ltm_policies:
       sample: hash/dictionary of values
   sample: hash/dictionary of values
 nodes:
-  description: Node related facts.
+  description: Node related information.
   returned: When C(nodes) is specified in C(gather_subset).
   type: complex
   contains:
@@ -3842,7 +3843,7 @@ nodes:
       sample: and_list
   sample: hash/dictionary of values
 oneconnect_profiles:
-  description: OneConnect profile related facts.
+  description: OneConnect profile related information.
   returned: When C(oneconnect-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -4010,7 +4011,7 @@ provision_info:
       sample: 0
   sample: hash/dictionary of values
 self_ips:
-  description: Self-IP related facts.
+  description: Self-IP related information.
   returned: When C(self-ips) is specified in C(gather_subset).
   type: complex
   contains:
@@ -4085,7 +4086,7 @@ self_ips:
       sample: no
   sample: hash/dictionary of values
 server_ssl_profiles:
-  description: Server SSL related facts.
+  description: Server SSL related information.
   returned: When C(server-ssl-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -4638,7 +4639,7 @@ software_volumes:
       sample: 13.1.0.4
   sample: hash/dictionary of values
 ssl_certs:
-  description: SSL certificate related facts.
+  description: SSL certificate related information.
   returned: When C(ssl-certs) is specified in C(gather_subset).
   type: complex
   contains:
@@ -4732,7 +4733,7 @@ ssl_certs:
       sample: "2018-05-15T21:11:15Z"
   sample: hash/dictionary of values
 ssl_keys:
-  description: SSL certificate related facts.
+  description: SSL certificate related information.
   returned: When C(ssl-certs) is specified in C(gather_subset).
   type: complex
   contains:
@@ -4782,7 +4783,7 @@ ssl_keys:
       sample: 1fcf7de3dd8e834d613099d8e10b2060cd9ecc9f
   sample: hash/dictionary of values
 system_db:
-  description: System DB related facts.
+  description: System DB related information.
   returned: When C(system-db) is specified in C(gather_subset).
   type: complex
   contains:
@@ -4824,7 +4825,7 @@ system_db:
       sample: string
   sample: hash/dictionary of values
 system_info:
-  description: Traffic group related facts.
+  description: Traffic group related information.
   returned: When C(traffic-groups) is specified in C(gather_subset).
   type: complex
   contains:
@@ -5018,7 +5019,7 @@ system_info:
       sample: 603202
   sample: hash/dictionary of values
 tcp_monitors:
-  description: TCP monitor related facts.
+  description: TCP monitor related information.
   returned: When C(tcp-monitors) is specified in C(gather_subset).
   type: complex
   contains:
@@ -5145,7 +5146,7 @@ tcp_monitors:
       sample: 0
   sample: hash/dictionary of values
 tcp_half_open_monitors:
-  description: TCP Half-open monitor related facts.
+  description: TCP Half-open monitor related information.
   returned: When C(tcp-half-open-monitors) is specified in C(gather_subset).
   type: complex
   contains:
@@ -5224,7 +5225,7 @@ tcp_half_open_monitors:
       sample: 0
   sample: hash/dictionary of values
 tcp_profiles:
-  description: TCP profile related facts.
+  description: TCP profile related information.
   returned: When C(tcp-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -5798,7 +5799,7 @@ tcp_profiles:
       sample: 2000
   sample: hash/dictionary of values
 traffic_groups:
-  description: Traffic group related facts.
+  description: Traffic group related information.
   returned: When C(traffic-groups) is specified in C(gather_subset).
   type: complex
   contains:
@@ -5863,7 +5864,7 @@ traffic_groups:
       sample: "00:98:76:54:32:10"
   sample: hash/dictionary of values
 trunks:
-  description: Trunk related facts.
+  description: Trunk related information.
   returned: When C(trunks) is specified in C(gather_subset).
   type: complex
   contains:
@@ -5956,7 +5957,7 @@ trunks:
       sample: 1
   sample: hash/dictionary of values
 udp_profiles:
-  description: UDP profile related facts.
+  description: UDP profile related information.
   returned: When C(udp-profiles) is specified in C(gather_subset).
   type: complex
   contains:
@@ -6088,7 +6089,7 @@ udp_profiles:
       sample: yes
   sample: hash/dictionary of values
 vcmp_guests:
-  description: vCMP related facts.
+  description: vCMP related information.
   returned: When C(vcmp-guests) is specified in C(gather_subset).
   type: complex
   contains:
@@ -6199,7 +6200,7 @@ vcmp_guests:
       sample: guest1.img
   sample: hash/dictionary of values
 virtual_addresses:
-  description: Virtual address related facts.
+  description: Virtual address related information.
   returned: When C(virtual-addresses) is specified in C(gather_subset).
   type: complex
   contains:
@@ -6299,7 +6300,7 @@ virtual_addresses:
       sample: no
   sample: hash/dictionary of values
 virtual_servers:
-  description: Virtual address related facts.
+  description: Virtual address related information.
   returned: When C(virtual-addresses) is specified in C(gather_subset).
   type: complex
   contains:
@@ -6788,7 +6789,7 @@ virtual_servers:
       sample: 8
   sample: hash/dictionary of values
 vlans:
-  description: List of VLAN facts.
+  description: List of VLAN information.
   returned: When C(vlans) is specified in C(gather_subset).
   type: complex
   contains:
@@ -6969,7 +6970,7 @@ class BaseManager(object):
         # A list of modules currently provisioned on the device.
         #
         # This list is used by different fact managers to check to see
-        # if they should even attempt to gather facts. If the module is
+        # if they should even attempt to gather information. If the module is
         # not provisioned, then it is likely that the REST API will not
         # return valid data.
         #
@@ -16044,6 +16045,8 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
+    if module._name == 'bigip_device_facts':
+        module.deprecate("The 'bigip_device_facts' module has been renamed to 'bigip_device_info'", version='2.13')
 
     try:
         mm = ModuleManager(module=module)

--- a/lib/ansible/modules/network/f5/bigiq_device_info.py
+++ b/lib/ansible/modules/network/f5/bigiq_device_info.py
@@ -14,15 +14,16 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: bigiq_device_facts
-short_description: Collect facts from F5 BIG-IQ devices
+module: bigiq_device_info
+short_description: Collect information from F5 BIG-IQ devices
 description:
-  - Collect facts from F5 BIG-IQ devices.
+  - Collect information from F5 BIG-IQ devices.
+  - This module was called C(bigiq_device_facts) before Ansible 2.9. The usage did not change.
 version_added: 2.8
 options:
   gather_subset:
     description:
-      - When supplied, this argument will restrict the facts returned to a given subset.
+      - When supplied, this argument will restrict the information returned to a given subset.
       - Can specify a list of values to include a larger subset.
       - Values can also be used with an initial C(!) to specify that a specific subset
         should not be collected.
@@ -49,8 +50,8 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Collect BIG-IQ facts
-  bigiq_device_facts:
+- name: Collect BIG-IQ information
+  bigiq_device_info:
     gather_subset:
       - system-info
       - vlans
@@ -60,8 +61,8 @@ EXAMPLES = r'''
       password: secret
   delegate_to: localhost
 
-- name: Collect all BIG-IQ facts
-  bigiq_device_facts:
+- name: Collect all BIG-IQ information
+  bigiq_device_info:
     gather_subset:
       - all
     provider:
@@ -70,8 +71,8 @@ EXAMPLES = r'''
       password: secret
   delegate_to: localhost
 
-- name: Collect all BIG-IP facts except trunks
-  bigiq_device_facts:
+- name: Collect all BIG-IP information except trunks
+  bigiq_device_info:
     gather_subset:
       - all
       - "!trunks"
@@ -84,7 +85,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 applications:
-  description: Application related facts
+  description: Application related information
   returned: When C(managed-devices) is specified in C(gather_subset).
   type: complex
   contains:
@@ -169,7 +170,7 @@ applications:
       sample: no
   sample: hash/dictionary of values
 managed_devices:
-  description: Managed device related facts.
+  description: Managed device related information.
   returned: When C(managed-devices) is specified in C(gather_subset).
   type: complex
   contains:
@@ -307,7 +308,7 @@ managed_devices:
       sample: 13.1.1
   sample: hash/dictionary of values
 purchased_pool_licenses:
-  description: Purchased Pool License related facts.
+  description: Purchased Pool License related information.
   returned: When C(purchased-pool-licenses) is specified in C(gather_subset).
   type: complex
   contains:
@@ -403,7 +404,7 @@ purchased_pool_licenses:
       sample: XXXXX-XXXXX-XXXXX-XXXXX-XXXXXXX
   sample: hash/dictionary of values
 regkey_pools:
-  description: Regkey Pool related facts.
+  description: Regkey Pool related information.
   returned: When C(regkey-pools) is specified in C(gather_subset).
   type: complex
   contains:
@@ -492,7 +493,7 @@ regkey_pools:
       sample: hash/dictionary of values
   sample: hash/dictionary of values
 system_info:
-  description: System info related facts.
+  description: System info related information.
   returned: When C(system-info) is specified in C(gather_subset).
   type: complex
   contains:
@@ -683,7 +684,7 @@ system_info:
       sample: 603202
   sample: hash/dictionary of values
 vlans:
-  description: List of VLAN facts.
+  description: List of VLAN information.
   returned: When C(vlans) is specified in C(gather_subset).
   type: complex
   contains:
@@ -2297,6 +2298,8 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
+    if module._name == 'bigiq_device_facts':
+        module.deprecate("The 'bigiq_device_facts' module has been renamed to 'bigiq_device_info'", version='2.13')
 
     try:
         mm = ModuleManager(module=module)

--- a/test/units/modules/network/f5/test_bigip_device_info.py
+++ b/test/units/modules/network/f5/test_bigip_device_info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright: (c) 2018, F5 Networks Inc.
+# Copyright (c) 2017 F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -15,12 +15,14 @@ if sys.version_info < (2, 7):
     pytestmark = pytest.mark.skip("F5 Ansible modules require Python >= 2.7")
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
 
 try:
-    from library.modules.bigiq_device_facts import Parameters
-    from library.modules.bigiq_device_facts import SystemInfoFactManager
-    from library.modules.bigiq_device_facts import ModuleManager
-    from library.modules.bigiq_device_facts import ArgumentSpec
+    from library.modules.bigip_device_info import Parameters
+    from library.modules.bigip_device_info import VirtualAddressesFactManager
+    from library.modules.bigip_device_info import VirtualAddressesParameters
+    from library.modules.bigip_device_info import ArgumentSpec
+    from library.modules.bigip_device_info import ModuleManager
 
     # In Ansible 2.8, Ansible changed import paths.
     from test.units.compat import unittest
@@ -29,10 +31,11 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    from ansible.modules.network.f5.bigiq_device_facts import Parameters
-    from ansible.modules.network.f5.bigiq_device_facts import SystemInfoFactManager
-    from ansible.modules.network.f5.bigiq_device_facts import ModuleManager
-    from ansible.modules.network.f5.bigiq_device_facts import ArgumentSpec
+    from ansible.modules.network.f5.bigip_device_info import Parameters
+    from ansible.modules.network.f5.bigip_device_info import VirtualAddressesFactManager
+    from ansible.modules.network.f5.bigip_device_info import VirtualAddressesParameters
+    from ansible.modules.network.f5.bigip_device_info import ArgumentSpec
+    from ansible.modules.network.f5.bigip_device_info import ModuleManager
 
     # Ansible 2.8 imports
     from units.compat import unittest
@@ -64,13 +67,20 @@ def load_fixture(name):
     return data
 
 
+class FakeVirtualAddress:
+    def __init__(self, *args, **kwargs):
+        attrs = kwargs.pop('params', {})
+        for key, value in iteritems(attrs):
+            setattr(self, key, value)
+
+
 class TestParameters(unittest.TestCase):
     def test_module_parameters(self):
         args = dict(
-            gather_subset=['system-info'],
+            gather_subset=['virtual-servers'],
         )
         p = Parameters(params=args)
-        assert p.gather_subset == ['system-info']
+        assert p.gather_subset == ['virtual-servers']
 
 
 class TestManager(unittest.TestCase):
@@ -78,9 +88,21 @@ class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
 
-    def test_get_facts(self, *args):
+        try:
+            self.p1 = patch('library.modules.bigip_device_info.modules_provisioned')
+            self.m1 = self.p1.start()
+            self.m1.return_value = ['ltm', 'gtm', 'asm']
+        except Exception:
+            self.p1 = patch('ansible.modules.network.f5.bigip_device_info.modules_provisioned')
+            self.m1 = self.p1.start()
+            self.m1.return_value = ['ltm', 'gtm', 'asm']
+
+    def tearDown(self):
+        self.p1.stop()
+
+    def test_get_trunk_facts(self, *args):
         set_module_args(dict(
-            gather_subset=['system-info'],
+            gather_subset=['virtual-addresses'],
             provider=dict(
                 server='localhost',
                 password='password',
@@ -88,15 +110,16 @@ class TestManager(unittest.TestCase):
             )
         ))
 
-        fixture1 = load_fixture('load_shared_system_setup_1.json')
+        fixture1 = load_fixture('load_ltm_virtual_address_collection_1.json')
+        collection = fixture1['items']
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
             supports_check_mode=self.spec.supports_check_mode
         )
 
-        tm = SystemInfoFactManager(module=module)
-        tm.read_collection_from_device = Mock(return_value=fixture1)
+        tm = VirtualAddressesFactManager(module=module)
+        tm.read_collection_from_device = Mock(return_value=collection)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -104,5 +127,6 @@ class TestManager(unittest.TestCase):
 
         results = mm.exec_module()
 
-        assert results['changed'] is True
-        assert 'system_info' in results
+        assert results['queried'] is True
+        assert 'virtual_addresses' in results
+        assert len(results['virtual_addresses']) > 0

--- a/test/units/modules/network/f5/test_bigiq_device_info.py
+++ b/test/units/modules/network/f5/test_bigiq_device_info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 F5 Networks Inc.
+# Copyright: (c) 2018, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -15,14 +15,12 @@ if sys.version_info < (2, 7):
     pytestmark = pytest.mark.skip("F5 Ansible modules require Python >= 2.7")
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 
 try:
-    from library.modules.bigip_device_facts import Parameters
-    from library.modules.bigip_device_facts import VirtualAddressesFactManager
-    from library.modules.bigip_device_facts import VirtualAddressesParameters
-    from library.modules.bigip_device_facts import ArgumentSpec
-    from library.modules.bigip_device_facts import ModuleManager
+    from library.modules.bigiq_device_info import Parameters
+    from library.modules.bigiq_device_info import SystemInfoFactManager
+    from library.modules.bigiq_device_info import ModuleManager
+    from library.modules.bigiq_device_info import ArgumentSpec
 
     # In Ansible 2.8, Ansible changed import paths.
     from test.units.compat import unittest
@@ -31,11 +29,10 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    from ansible.modules.network.f5.bigip_device_facts import Parameters
-    from ansible.modules.network.f5.bigip_device_facts import VirtualAddressesFactManager
-    from ansible.modules.network.f5.bigip_device_facts import VirtualAddressesParameters
-    from ansible.modules.network.f5.bigip_device_facts import ArgumentSpec
-    from ansible.modules.network.f5.bigip_device_facts import ModuleManager
+    from ansible.modules.network.f5.bigiq_device_info import Parameters
+    from ansible.modules.network.f5.bigiq_device_info import SystemInfoFactManager
+    from ansible.modules.network.f5.bigiq_device_info import ModuleManager
+    from ansible.modules.network.f5.bigiq_device_info import ArgumentSpec
 
     # Ansible 2.8 imports
     from units.compat import unittest
@@ -67,20 +64,13 @@ def load_fixture(name):
     return data
 
 
-class FakeVirtualAddress:
-    def __init__(self, *args, **kwargs):
-        attrs = kwargs.pop('params', {})
-        for key, value in iteritems(attrs):
-            setattr(self, key, value)
-
-
 class TestParameters(unittest.TestCase):
     def test_module_parameters(self):
         args = dict(
-            gather_subset=['virtual-servers'],
+            gather_subset=['system-info'],
         )
         p = Parameters(params=args)
-        assert p.gather_subset == ['virtual-servers']
+        assert p.gather_subset == ['system-info']
 
 
 class TestManager(unittest.TestCase):
@@ -88,21 +78,9 @@ class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
 
-        try:
-            self.p1 = patch('library.modules.bigip_device_facts.modules_provisioned')
-            self.m1 = self.p1.start()
-            self.m1.return_value = ['ltm', 'gtm', 'asm']
-        except Exception:
-            self.p1 = patch('ansible.modules.network.f5.bigip_device_facts.modules_provisioned')
-            self.m1 = self.p1.start()
-            self.m1.return_value = ['ltm', 'gtm', 'asm']
-
-    def tearDown(self):
-        self.p1.stop()
-
-    def test_get_trunk_facts(self, *args):
+    def test_get_facts(self, *args):
         set_module_args(dict(
-            gather_subset=['virtual-addresses'],
+            gather_subset=['system-info'],
             provider=dict(
                 server='localhost',
                 password='password',
@@ -110,16 +88,15 @@ class TestManager(unittest.TestCase):
             )
         ))
 
-        fixture1 = load_fixture('load_ltm_virtual_address_collection_1.json')
-        collection = fixture1['items']
+        fixture1 = load_fixture('load_shared_system_setup_1.json')
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
             supports_check_mode=self.spec.supports_check_mode
         )
 
-        tm = VirtualAddressesFactManager(module=module)
-        tm.read_collection_from_device = Mock(return_value=collection)
+        tm = SystemInfoFactManager(module=module)
+        tm.read_collection_from_device = Mock(return_value=fixture1)
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(module=module)
@@ -127,6 +104,5 @@ class TestManager(unittest.TestCase):
 
         results = mm.exec_module()
 
-        assert results['queried'] is True
-        assert 'virtual_addresses' in results
-        assert len(results['virtual_addresses']) > 0
+        assert results['changed'] is True
+        assert 'system_info' in results


### PR DESCRIPTION
##### SUMMARY
Renames `bigip_device_facts` and `bigiq_device_facts` to `_info` since they do not return `ansible_facts`. Continues #56822.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bigip_device_facts
bigiq_device_facts
