### PR TITLE
[test] Change profile name in dnf/modularity integration test

### DIFF
--- a/test/integration/targets/dnf/tasks/modularity.yml
+++ b/test/integration/targets/dnf/tasks/modularity.yml
@@ -1,7 +1,7 @@
 # FUTURE - look at including AppStream support in our local repo
 - name: set package for RHEL
   set_fact:
-    astream_name: '@swig:3.0/default'
+    astream_name: '@swig:3.0/common'
   when: ansible_distribution == 'RedHat'
 
 - name: set package for Fedora


### PR DESCRIPTION
jj##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On RHEL 8, there is no profile of swig:3.0 module stream named "default". Only "common" and "complete" profiles are available. This results in failing dnf integration tests on RHEL 8 (ansible-test integration dnf --allow-destructive)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
