### PR TITLE
Rename xenserver_guest_facts -> xenserver_guest_info

### DIFF
--- a/changelogs/fragments/57032-facts-info-rename.yaml
+++ b/changelogs/fragments/57032-facts-info-rename.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- The ``xenserver_guest_facts`` module has been renamed to ``xenserver_guest_info``.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -82,6 +82,7 @@ Noteworthy module changes
 * The ``memset_server_facts`` module was renamed to :ref:`memset_server_info <memset_server_info_module>`.
 * The ``one_image_facts`` module was renamed to :ref:`one_image_info <one_image_info_module>`.
 * The ``ali_instance_facts`` module was renamed to :ref:`ali_instance_info <ali_instance_info_module>`.
+* The ``xenserver_guest_facts`` module was renamed to :ref:`xenserver_guest_info <xenserver_guest_info_module>`.
 * The ``azure_rm_resourcegroup_facts`` module was renamed to :ref:`azure_rm_resourcegroup_info <azure_rm_resourcegroup_info_module>`.
 * The ``digital_ocean_account_facts`` module was renamed to :ref:`digital_ocean_account_info <digital_ocean_account_info_module>`.
 * The ``digital_ocean_certificate_facts`` module was renamed to :ref:`digital_ocean_certificate_info <digital_ocean_certificate_info_module>`.

--- a/lib/ansible/modules/cloud/xenserver/_xenserver_guest_facts.py
+++ b/lib/ansible/modules/cloud/xenserver/_xenserver_guest_facts.py
@@ -1,0 +1,1 @@
+xenserver_guest_info.py

--- a/lib/ansible/modules/cloud/xenserver/xenserver_guest_info.py
+++ b/lib/ansible/modules/cloud/xenserver/xenserver_guest_info.py
@@ -13,8 +13,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: xenserver_guest_facts
-short_description: Gathers facts for virtual machines running on Citrix XenServer host or pool
+module: xenserver_guest_info
+short_description: Gathers information for virtual machines running on Citrix XenServer host or pool
 description: >
    This module can be used to gather essential VM facts.
 version_added: '2.8'
@@ -30,6 +30,7 @@ notes:
    accessing XenServer host in trusted environment or use C(https://) scheme explicitly.'
 - 'To use C(https://) scheme for C(hostname) you have to either import host certificate to your OS certificate store or use C(validate_certs: no)
    which requires XenAPI library from XenServer 7.2 SDK or newer and Python 2.7.9 or newer.'
+- This module was called C(xenserver_guest_facts) before Ansible 2.9. The usage did not change.
 requirements:
 - python >= 2.6
 - XenAPI
@@ -53,7 +54,7 @@ extends_documentation_fragment: xenserver.documentation
 
 EXAMPLES = r'''
 - name: Gather facts
-  xenserver_guest_facts:
+  xenserver_guest_info:
     hostname: "{{ xenserver_hostname }}"
     username: "{{ xenserver_username }}"
     password: "{{ xenserver_password }}"
@@ -205,6 +206,8 @@ def main():
                                ['name', 'uuid'],
                            ],
                            )
+    if module._name == 'xenserver_guest_facts':
+        module.deprecate("The 'xenserver_guest_facts' module has been renamed to 'xenserver_guest_info'", version='2.13')
 
     result = {'failed': False, 'changed': False}
 

--- a/test/units/modules/cloud/xenserver/conftest.py
+++ b/test/units/modules/cloud/xenserver/conftest.py
@@ -50,16 +50,16 @@ def XenAPI():
 
 
 @pytest.fixture
-def xenserver_guest_facts(XenAPI):
-    """Imports and returns xenserver_guest_facts module."""
+def xenserver_guest_info(XenAPI):
+    """Imports and returns xenserver_guest_info module."""
 
     # Since we are wrapping fake XenAPI module inside a fixture, all modules
     # that depend on it have to be imported inside a test function. To make
     # this easier to handle and remove some code repetition, we wrap the import
-    # of xenserver_guest_facts module with a fixture.
-    from ansible.modules.cloud.xenserver import xenserver_guest_facts
+    # of xenserver_guest_info module with a fixture.
+    from ansible.modules.cloud.xenserver import xenserver_guest_info
 
-    return xenserver_guest_facts
+    return xenserver_guest_info
 
 
 @pytest.fixture

--- a/test/units/modules/cloud/xenserver/test_xenserver_guest_info.py
+++ b/test/units/modules/cloud/xenserver/test_xenserver_guest_info.py
@@ -46,16 +46,16 @@ testcase_module_params = {
 
 
 @pytest.mark.parametrize('patch_ansible_module', testcase_module_params['params'], ids=testcase_module_params['ids'], indirect=True)
-def test_xenserver_guest_facts(mocker, capfd, XenAPI, xenserver_guest_facts):
+def test_xenserver_guest_info(mocker, capfd, XenAPI, xenserver_guest_info):
     """
     Tests regular module invocation including parsing and propagation of
     module params and module output.
     """
     fake_vm_facts = {"fake-vm-fact": True}
 
-    mocker.patch('ansible.modules.cloud.xenserver.xenserver_guest_facts.get_object_ref', return_value=None)
-    mocker.patch('ansible.modules.cloud.xenserver.xenserver_guest_facts.gather_vm_params', return_value=None)
-    mocker.patch('ansible.modules.cloud.xenserver.xenserver_guest_facts.gather_vm_facts', return_value=fake_vm_facts)
+    mocker.patch('ansible.modules.cloud.xenserver.xenserver_guest_info.get_object_ref', return_value=None)
+    mocker.patch('ansible.modules.cloud.xenserver.xenserver_guest_info.gather_vm_params', return_value=None)
+    mocker.patch('ansible.modules.cloud.xenserver.xenserver_guest_info.gather_vm_facts', return_value=fake_vm_facts)
 
     mocked_xenapi = mocker.patch.object(XenAPI.Session, 'xenapi', create=True)
 
@@ -69,7 +69,7 @@ def test_xenserver_guest_facts(mocker, capfd, XenAPI, xenserver_guest_facts):
     mocker.patch('ansible.module_utils.xenserver.get_xenserver_version', return_value=[7, 2, 0])
 
     with pytest.raises(SystemExit):
-        xenserver_guest_facts.main()
+        xenserver_guest_info.main()
 
     out, err = capfd.readouterr()
     result = json.loads(out)


### PR DESCRIPTION
##### SUMMARY
Continues #56822. The modules do not return `ansible_facts`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xenserver_guest_facts
