### PR TITLE
Rename ali_instance_facts -> ali_instance_info

### DIFF
--- a/changelogs/fragments/57036-facts-info-rename.yaml
+++ b/changelogs/fragments/57036-facts-info-rename.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- The ``ali_instance_facts`` module has been renamed to ``ali_instance_info``.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -78,6 +78,7 @@ Noteworthy module changes
 * The ``memset_memstore_facts`` module was renamed to :ref:`memset_memstore_info <memset_memstore_info_module>`.
 * The ``memset_server_facts`` module was renamed to :ref:`memset_server_info <memset_server_info_module>`.
 * The ``one_image_facts`` module was renamed to :ref:`one_image_info <one_image_info_module>`.
+* The ``ali_instance_facts`` module was renamed to :ref:`ali_instance_info <ali_instance_info_module>`.
 * The ``azure_rm_resourcegroup_facts`` module was renamed to :ref:`azure_rm_resourcegroup_info <azure_rm_resourcegroup_info_module>`.
 * The ``digital_ocean_account_facts`` module was renamed to :ref:`digital_ocean_account_info <digital_ocean_account_info_module>`.
 * The ``digital_ocean_certificate_facts`` module was renamed to :ref:`digital_ocean_certificate_info <digital_ocean_certificate_info_module>`.

--- a/lib/ansible/modules/cloud/alicloud/_ali_instance_facts.py
+++ b/lib/ansible/modules/cloud/alicloud/_ali_instance_facts.py
@@ -1,0 +1,1 @@
+ali_instance_info.py

--- a/lib/ansible/modules/cloud/alicloud/ali_instance_info.py
+++ b/lib/ansible/modules/cloud/alicloud/ali_instance_info.py
@@ -26,12 +26,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ali_instance_facts
+module: ali_instance_info
 version_added: "2.8"
-short_description: Gather facts on instances of Alibaba Cloud ECS.
+short_description: Gather information on instances of Alibaba Cloud ECS.
 description:
      - This module fetches data from the Open API in Alicloud.
        The module must be called from within the ECS instance itself.
+     - This module was called C(ali_instance_facts) before Ansible 2.9. The usage did not change.
 
 options:
     availability_zone:
@@ -71,14 +72,14 @@ EXAMPLES = '''
 
   tasks:
     - name: Find all instances in the specified region
-      ali_instance_facts:
+      ali_instance_info:
         alicloud_access_key: '{{ alicloud_access_key }}'
         alicloud_secret_key: '{{ alicloud_secret_key }}'
         alicloud_region: '{{ alicloud_region }}'
       register: all_instances
 
     - name: Find all instances based on the specified ids
-      ali_instance_facts:
+      ali_instance_info:
         alicloud_access_key: '{{ alicloud_access_key }}'
         alicloud_secret_key: '{{ alicloud_secret_key }}'
         alicloud_region: '{{ alicloud_region }}'
@@ -88,7 +89,7 @@ EXAMPLES = '''
       register: instances_by_ids
 
     - name: Find all instances based on the specified names/name-prefixes
-      ali_instance_facts:
+      ali_instance_info:
         alicloud_access_key: '{{ alicloud_access_key }}'
         alicloud_secret_key: '{{ alicloud_secret_key }}'
         alicloud_region: '{{ alicloud_region }}'
@@ -373,6 +374,8 @@ def main():
     )
     )
     module = AnsibleModule(argument_spec=argument_spec)
+    if module._name == 'ali_instance_facts':
+        module.deprecate("The 'ali_instance_facts' module has been renamed to 'ali_instance_info'", version='2.13')
 
     if HAS_FOOTMARK is False:
         module.fail_json(msg=missing_required_lib('footmark'), exception=FOOTMARK_IMP_ERR)


### PR DESCRIPTION
##### SUMMARY
Continues #56822. The modules do not return `ansible_facts`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ali_instance_facts
