### PR TITLE
Handle binding:vnic_type as optional (#55526)

### DIFF
--- a/changelogs/fragments/55526-optional_vnic_type.yml
+++ b/changelogs/fragments/55526-optional_vnic_type.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - os_port - handle binding:vnic_type as optional
+    (https://github.com/ansible/ansible/issues/55524,
+     https://github.com/ansible/ansible/issues/55525)

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -84,7 +84,6 @@ options:
      description:
        - The type of the port that should be created
      choices: [normal, direct, direct-physical, macvtap, baremetal, virtio-forwarder]
-     default: normal
      version_added: "2.8"
    port_security_enabled:
      description:
@@ -327,7 +326,7 @@ def main():
         device_owner=dict(default=None),
         device_id=dict(default=None),
         state=dict(default='present', choices=['absent', 'present']),
-        vnic_type=dict(default='normal',
+        vnic_type=dict(default=None,
                        choices=['normal', 'direct', 'direct-physical',
                                 'macvtap', 'baremetal', 'virtio-forwarder']),
         port_security_enabled=dict(default=None, type='bool')
@@ -355,11 +354,10 @@ def main():
                 for v in module.params['security_groups']
             ]
 
-        if module.params['vnic_type']:
-            # Neutron API accept 'binding:vnic_type' as an argument
-            # for the port type.
-            module.params['binding:vnic_type'] = module.params['vnic_type']
-            module.params.pop('vnic_type', None)
+        # Neutron API accept 'binding:vnic_type' as an argument
+        # for the port type.
+        module.params['binding:vnic_type'] = module.params['vnic_type']
+        module.params.pop('vnic_type', None)
 
         port = None
         network_id = None


### PR DESCRIPTION
According to the OpenStack Networking API
the attribute binding:vnic_type of a port is optional.
This change enables the os_port module to handle
binding:vnic_type as optional.

(cherry picked from commit bc50a52ee23272fc70988139bc9a0d4b287f2cb3)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is the backport of PR #55526 to ansible-2.8 .
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #55524
Fixes #55525

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_port

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
