### PR TITLE
[2.8] route53_facts: add check mode support

### DIFF
--- a/changelogs/fragments/56900-route53-facts-check-mode.yaml
+++ b/changelogs/fragments/56900-route53-facts-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - route53_facts - the module did not advertise check mode support, causing it not to be run in check mode.

--- a/lib/ansible/modules/cloud/amazon/route53_facts.py
+++ b/lib/ansible/modules/cloud/amazon/route53_facts.py
@@ -432,6 +432,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        supports_check_mode=True,
         mutually_exclusive=[
             ['hosted_zone_method', 'health_check_method'],
         ],


### PR DESCRIPTION
##### SUMMARY

This backports #56900 to the current 2.8.x stable series.

* route53_facts: add check mode support
* route53_facts: add changelog fragment mentioning check mode support

Co-Authored-By: Felix Fontein <felix@fontein.de>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
route53_facts