### PR TITLE
docker_image.py: fix attribute error when image.build.path is missing

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -886,7 +886,7 @@ def main():
                                'has been renamed and will be removed in Ansible 2.12.' % (build_option, option, option))
     if client.module.params['source'] == 'build':
         if (not client.module.params['build'] or not client.module.params['build'].get('path')):
-            client.module.fail('If "source" is set to "build", the "build.path" option must be specified.')
+            client.fail('If "source" is set to "build", the "build.path" option must be specified.')
         if client.module.params['build'].get('pull') is None:
             client.module.warn("The default for build.pull is currently 'yes', but will be changed to 'no' in Ansible 2.12. "
                                "Please set build.pull explicitly to the value you need.")


### PR DESCRIPTION
##### SUMMARY
A wrong failure function is called when image.build.path is missing. This causes an attributeerror and difficulties to debug what is actually going on.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker module docker_image component

##### ADDITIONAL INFORMATION
Call the docker_image component with `source: build` property but no `build.path` property. This causes an attributeerror python exception. It should instead inform the user that a required property is missing.