### PR TITLE
fix rabbitmq_user to correctly deal with removing non existent user

### DIFF
--- a/test/integration/targets/rabbitmq_user/tasks/tests.yml
+++ b/test/integration/targets/rabbitmq_user/tasks/tests.yml
@@ -125,6 +125,19 @@
         that:
           - remove_user.changed == true
 
+- name: Test remove user that is not present
+  block:
+    - name: Remove user
+      rabbitmq_user:
+        user: notpresent
+        state: absent
+      register: remove_user_not_present
+
+    - name: Check that user removing succeeds with a change
+      assert:
+        that:
+          - remove_user_not_present.changed == true
+
 - name: Test remove user idempotence
   block:
     - name: Remove user


### PR DESCRIPTION
##### SUMMARY
Verifying and fixing bug #57040

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ADDITIONAL INFORMATION
Rabbitmqctl returns an error when a user is removed that is not present. See bug report.
