### PR TITLE
add terminal initial prompt for initial connection

### DIFF
--- a/lib/ansible/plugins/terminal/ce.py
+++ b/lib/ansible/plugins/terminal/ce.py
@@ -31,7 +31,13 @@ class TerminalModule(TerminalBase):
         re.compile(br'[\r\n]?<.+>(?:\s*)$'),
         re.compile(br'[\r\n]?\[.+\](?:\s*)$'),
     ]
+    #: terminal initial prompt
+    #: The password needs to be changed. Change now? [Y/N]:
+    terminal_initial_prompt = br'Change\s*now\s*\?\s*\[Y\/N\]\s*:'
 
+    #: terminal initial answer
+    #: do not change password when it is asked to change with initial connection.
+    terminal_initial_answer = b'N'
     terminal_stderr_re = [
         re.compile(br"% ?Error: "),
         re.compile(br"^% \w+", re.M),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add terminal initial prompt for initial connection
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/terminal/ce.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
When CE establishes an initial connection, it may prompt that passwords need to be changed.If there is no anser until time is out , the connection will be failed.So create this PR to fix it.
```
