### PR TITLE
Fix junos_facts test

### DIFF
--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -354,7 +354,8 @@ def main():
 
         if subset not in VALID_SUBSETS:
             module.fail_json(msg='Subset must be one of [%s], got %s' %
-                             (', '.join(VALID_SUBSETS), subset))
+                             (', '.join(sorted([subset for subset in
+                                                VALID_SUBSETS])), subset))
 
         if exclude:
             exclude_subsets.add(subset)

--- a/test/integration/targets/junos_facts/tests/netconf/facts.yaml
+++ b/test/integration/targets/junos_facts/tests/netconf/facts.yaml
@@ -50,7 +50,7 @@
 - assert:
     that:
       - "result.failed == true"
-      - "result.msg == 'Subset must be one of [hardware, default, ofacts, config, interfaces], got test'"
+      - "result.msg == 'Subset must be one of [config, default, hardware, interfaces, ofacts], got test'"
 
 - name: Collect config facts from device in set format
   junos_facts:


### PR DESCRIPTION
##### SUMMARY
Fixes an issue with the junos_facts testing

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos_facts

##### ADDITIONAL INFORMATION
The test expected a fixed string in order to assert it where it had a random
order. This change makes it so the msg is sorted out.

```
-      - "result.msg == 'Subset must be one of [hardware, default, ofacts, config, interfaces], got test'"
+      - "result.msg == 'Subset must be one of [config, default, hardware, interfaces, ofacts], got test'"
```