### PR TITLE
Add support for telemetry agent install/uninstall on onyx switches

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
+++ b/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
@@ -190,6 +190,8 @@ class OnyxTelemetryAgentModule(BaseOnyxModule):
         self._commands.append(
             'docker start %s %s %s now-and-init privileged network sdk' %
             (image_name, image_version, container_name))
+        self._commands.append(
+            'docker copy-sdk %s to /' % container_name)
 
     def _check_container_exists(self, image, version):
         current_image = self._current_config.get('docker_image')

--- a/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
+++ b/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
@@ -1,0 +1,250 @@
+#!/usr/bin/python
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: onyx_telemetry_agent
+version_added: "2.9"
+author: "Samer Deeb (@samerd)"
+short_description: Manage telemetry agent on Mellanox ONYX network devices
+description:
+  - This module provides declarative management of telemetry agent
+    on Mellanox ONYX network devices.
+options:
+  name:
+    description:
+      - Name of the of the telemetry agent docker container.
+    required: true
+  state:
+    description:
+      - State of the telemetry agent agent docker container.
+    default: present
+    choices: ['present', 'absent']
+  install_mode:
+    description:
+      - Install mode of the telemetry agent, can be pull from docker hub
+        or fetch an image from given location, required if I(state)
+        is C(present).
+    choices: ['pull', 'fetch']
+  location:
+    description:
+      - location of the docker image, required if I(install_mode) is C(fetch).
+    suboptions:
+      server:
+        description:
+          - name of IP address of the server storing the image.
+        required: true
+      protocol:
+        description:
+          - protocol for fetching the image from the server.
+        choices: ['http', 'https', 'ftp', 'tftp', 'scp', 'sftp']
+        required: true
+      path:
+        description:
+          - Image absolute path within the server.
+        required: true
+      image:
+        description:
+          - Image name: default is telemetry-agent.
+        default: telemetry-agent
+      version:
+        description:
+          - Image version.
+        required: true
+      username:
+        description:
+          - username used to fetch the image.
+      password:
+        description:
+          - password used to fetch the image.
+"""
+
+EXAMPLES = """
+- name: create telemetry agent docker
+  onyx_telemetry_agent:
+    name: my_telemetry
+    install_mode: pull
+
+- name: remove telemetry agent docker
+  onyx_telemetry_agent:
+    name: my_telemetry
+    state: absent
+"""
+
+RETURN = """
+commands:
+  description: The list of configuration mode commands to send to the device
+  returned: always.
+  type: list
+  sample:
+    - no docker shutdown
+    - docker pull mellanox/telemetry_agent:latest
+    - docker start mellanox/telemetry_agent latest my_agent now-and-init privileged network sdk
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.onyx.onyx import BaseOnyxModule
+from ansible.module_utils.network.onyx.onyx import show_cmd
+
+
+class OnyxTelemetryAgentModule(BaseOnyxModule):
+    IMAGE_FILE = "ANSIBLE_DOCKER_IMAGE.img"
+
+    def init_module(self):
+        """ module initialization
+        """
+        location_spec = dict(
+            server=dict(required=True),
+            protocol=dict(
+                choices=['http', 'https', 'ftp', 'tftp', 'scp', 'sftp'],
+                required=True),
+            path=dict(required=True),
+            image=dict(default='telemetry-agent'),
+            version=dict(required=True),
+            username=dict(),
+            password=dict())
+
+        element_spec = dict(
+            name=dict(required=True),
+            install_mode=dict(choices=['pull', 'fetch']),
+            location=dict(type='dict', options=location_spec),
+            state=dict(choices=['present', 'absent'], default='present'))
+
+        argument_spec = dict()
+        argument_spec.update(element_spec)
+        self._module = AnsibleModule(
+            argument_spec=argument_spec,
+            required_if=[
+                ["state", "present", ["install_mode"]],
+                ["install_mode", "fetch", ["location"]]],
+            supports_check_mode=True)
+
+    def get_required_config(self):
+        module_params = self._module.params
+        self._required_config = dict(module_params)
+        self.validate_param_values(self._required_config)
+
+    def _get_dockers_state(self):
+        return show_cmd(self._module, "show docker")
+
+    def _get_docker_containers(self):
+        return show_cmd(self._module, "show docker containers")
+
+    def load_current_config(self):
+        # called in base class in run function
+        self._current_config = dict()
+        dockers_state = self._get_dockers_state()
+        if not dockers_state:
+            self._current_config['docker_enabled'] = False
+            return
+        docker_enabled = dockers_state.get('Dockers state')
+        self._current_config['docker_enabled'] = (docker_enabled == 'enabled')
+        if not self._current_config['docker_enabled']:
+            return
+        docker_containers = self._get_docker_containers()
+        if not docker_containers:
+            return
+        for container in docker_containers:
+            if not container:
+                continue
+            container_data = container.get(self._required_config['name'])
+            if container_data:
+                container_data = container_data[0]
+                self._current_config['docker_image'] = container_data['image']
+                self._current_config['docker_image_version'] = \
+                    container_data['version']
+                break
+
+    def generate_commands(self):
+        state = self._required_config.get("state")
+        if state == 'present':
+            self._generate_docker_commands()
+            if self._required_config.get("install_mode") == "pull":
+                self._generate_pull_container_commands()
+            else:
+                self._generate_fetch_container_commands()
+        else:
+            self._generate_remove_container_commands()
+
+    def _generate_remove_container_commands(self):
+        image = self._current_config.get('docker_image')
+        if image:
+            self._commands.append(
+                'docker no start %s' % self._required_config['name'])
+
+    def _generate_docker_commands(self):
+        if not self._current_config['docker_enabled']:
+            self._commands.append('no docker shutdown')
+
+    def _generate_start_container_commands(self, image_name, image_version,
+                                           container_name):
+        self._commands.append(
+            'docker start %s %s %s now-and-init privileged network sdk' %
+            (image_name, image_version, container_name))
+
+    def _check_container_exists(self, image, version):
+        current_image = self._current_config.get('docker_image')
+        current_version = self._current_config.get('docker_image_version')
+        if not current_image:
+            return False
+        if current_image != image:
+            msg = 'found a container with same name, but with different '\
+                'image: %s instead of %s' % (current_image, image)
+            self._module.fail_json(msg=msg)
+        return (current_version == version)
+
+    def _generate_pull_container_commands(self):
+        image_name = 'mellanox/telemetry-agent'
+        image_version = 'latest'
+        if self._check_container_exists(image_name, image_version):
+            return
+        container_name = self._required_config['name']
+        self._commands.append('docker pull mellanox/telemetry-agent:latest')
+        self._generate_start_container_commands(
+            image_name, image_version, container_name)
+
+    def _generate_fetch_container_commands(self):
+        location = self._required_config.get('location')
+        image_name = location.get('image')
+        image_version = location.get('version')
+        if self._check_container_exists(image_name, image_version):
+            return
+        url_prefix = ''
+        username = location.get('username')
+        password = location.get('password')
+        protocol = location.get('protocol')
+        image_path = location.get('path')
+
+        server = location.get('server')
+        if username:
+            url_prefix = "%s@" % username
+            if password:
+                url_prefix = "%s:%s@" % (username, password)
+        url = "%s://%s%s%s" % (protocol, url_prefix, server, image_path)
+
+        container_name = self._required_config['name']
+        self._commands.append(
+            'image fetch %s %s' % (url, self.IMAGE_FILE))
+        self._commands.append(
+            'docker load %s' % self.IMAGE_FILE)
+        self._generate_start_container_commands(
+            image_name, image_version, container_name)
+
+
+def main():
+    """ main entry point for module execution
+    """
+    OnyxTelemetryAgentModule.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
+++ b/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
@@ -54,7 +54,7 @@ options:
         required: true
       image:
         description:
-          - Image name: default is telemetry-agent.
+          - Image name, the default is telemetry-agent.
         default: telemetry-agent
       version:
         description:

--- a/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
+++ b/lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
@@ -24,10 +24,12 @@ options:
     description:
       - Name of the of the telemetry agent docker container.
     required: true
+    type: str
   state:
     description:
       - State of the telemetry agent agent docker container.
     default: present
+    type: str
     choices: ['present', 'absent']
   install_mode:
     description:
@@ -35,37 +37,46 @@ options:
         or fetch an image from given location, required if I(state)
         is C(present).
     choices: ['pull', 'fetch']
+    type: str
   location:
     description:
       - location of the docker image, required if I(install_mode) is C(fetch).
+    type: dict
     suboptions:
       server:
         description:
           - name of IP address of the server storing the image.
         required: true
+        type: str
       protocol:
         description:
           - protocol for fetching the image from the server.
         choices: ['http', 'https', 'ftp', 'tftp', 'scp', 'sftp']
         required: true
+        type: str
       path:
         description:
           - Image absolute path within the server.
         required: true
+        type: str
       image:
         description:
           - Image name, the default is telemetry-agent.
         default: telemetry-agent
+        type: str
       version:
         description:
           - Image version.
         required: true
+        type: str
       username:
         description:
           - username used to fetch the image.
+        type: str
       password:
         description:
           - password used to fetch the image.
+        type: str
 """
 
 EXAMPLES = """

--- a/test/units/modules/network/onyx/fixtures/onyx_show_docker_containers.cfg
+++ b/test/units/modules/network/onyx/fixtures/onyx_show_docker_containers.cfg
@@ -1,0 +1,32 @@
+[
+    {
+        "telemetry-test": [
+            {
+                "status": "running",
+                "cpu limit": "-",
+                "image": "mellanox/telemetry-agent",
+                "labels": "-",
+                "version": "latest",
+                "memory limit": "-",
+                "start point": "init",
+                "usb mount": "disabled",
+                "privileges": "network, sdk"
+            }
+        ]
+    },
+    {
+        "ubuntu1": [
+            {
+                "status": "running",
+                "cpu limit": "-",
+                "image": "ubuntu",
+                "labels": "-",
+                "version": "latest",
+                "memory limit": "-",
+                "start point": "init",
+                "usb mount": "disabled",
+                "privileges": "network, sdk"
+            }
+        ]
+    }
+]

--- a/test/units/modules/network/onyx/fixtures/onyx_show_docker_state.cfg
+++ b/test/units/modules/network/onyx/fixtures/onyx_show_docker_state.cfg
@@ -1,0 +1,3 @@
+{
+    "Dockers state": "enabled"
+}

--- a/test/units/modules/network/onyx/test_onyx_telemetry_agent.py
+++ b/test/units/modules/network/onyx/test_onyx_telemetry_agent.py
@@ -1,0 +1,214 @@
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat.mock import patch
+from ansible.modules.network.onyx import onyx_telemetry_agent
+from units.modules.utils import set_module_args
+from .onyx_module import TestOnyxModule, load_fixture
+
+
+class TestOnyxTelemetryAgentModule(TestOnyxModule):
+
+    module = onyx_telemetry_agent
+    docker_enabled = True
+    container_exists = True
+    CONTAINER_NAME = "telemetry-test"
+    CONTAINER_IMAGE = "mellanox/telemetry-agent"
+    CONTAINER_IMAGE_VER = "latest"
+    FAKE_USER = 'user'
+    FAKE_PWD = 'pwd'
+    FAKE_SERVER = 'server'
+    PROTOCOL = 'http'
+    IMAGE_PATH = '/path'
+    NO_USR_URL = '%s://%s%s' % (PROTOCOL, FAKE_SERVER, IMAGE_PATH)
+    USR_URL = '%s://%s@%s%s' % (PROTOCOL, FAKE_USER, FAKE_SERVER, IMAGE_PATH)
+    USR_PWD_URL = '%s://%s:%s@%s%s' % (PROTOCOL, FAKE_USER, FAKE_PWD,
+                                       FAKE_SERVER, IMAGE_PATH)
+
+    LOCATION = dict(
+        server=FAKE_SERVER,
+        protocol=PROTOCOL,
+        path=IMAGE_PATH,
+        image=CONTAINER_IMAGE,
+        version=CONTAINER_IMAGE_VER,
+        username=FAKE_USER,
+        password=FAKE_PWD)
+
+    CMD_NO_DOCKER_START = 'docker no start %s' % CONTAINER_NAME
+    CMD_DOCKER_PULL = "docker pull %s:%s" % (
+        CONTAINER_IMAGE, CONTAINER_IMAGE_VER)
+    CMD_DOCKER_START = "docker start %s %s %s now-and-init privileged network sdk" % (
+        CONTAINER_IMAGE, CONTAINER_IMAGE_VER, CONTAINER_NAME)
+    CMD_NO_DOCKER_SHUTDOWN = "no docker shutdown"
+    CMD_IMAGE_FETCH = 'image fetch %s {0}'.format(
+        module.OnyxTelemetryAgentModule.IMAGE_FILE)
+    CMD_IMAGE_LOAD = 'docker load %s' % module.OnyxTelemetryAgentModule.IMAGE_FILE
+
+    def setUp(self):
+        super(TestOnyxTelemetryAgentModule, self).setUp()
+        self.docker_enabled = True
+        self.container_exists = True
+
+        self.mock_get_dockers_state = patch.object(
+            self.module.OnyxTelemetryAgentModule,
+            '_get_dockers_state')
+        self.get_dockers_state = self.mock_get_dockers_state.start()
+
+        self.mock_load_config = patch(
+            'ansible.module_utils.network.onyx.onyx.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_get_docker_containers = patch.object(
+            self.module.OnyxTelemetryAgentModule, '_get_docker_containers')
+        self.get_docker_containers = self.mock_get_docker_containers.start()
+
+    def tearDown(self):
+        super(TestOnyxTelemetryAgentModule, self).tearDown()
+        self.mock_get_docker_containers.stop()
+        self.mock_load_config.stop()
+        self.mock_get_dockers_state.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        docker_state_cfg = 'onyx_show_docker_state.cfg'
+        docker_state_data = load_fixture(docker_state_cfg)
+        if not self.docker_enabled:
+            docker_state_data = dict(docker_state_data)
+            docker_state_data["Dockers state"] = "disabled"
+        docker_containers_cfg = 'onyx_show_docker_containers.cfg'
+        docker_containers_data = load_fixture(docker_containers_cfg)
+        if not self.container_exists:
+            docker_containers_data = list(docker_containers_data)
+            del docker_containers_data[0]
+
+        self.get_dockers_state.return_value = docker_state_data
+        self.get_docker_containers.return_value = docker_containers_data
+        self.load_config.return_value = None
+
+    def test_pull_no_change(self):
+        self.docker_enabled = True
+        self.container_exists = True
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='pull'))
+        self.execute_module(changed=False)
+
+    def test_pull_docker_enabled(self):
+        self.docker_enabled = True
+        self.container_exists = False
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='pull'))
+        commands = [
+            self.CMD_DOCKER_PULL,
+            self.CMD_DOCKER_START
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_pull_docker_disabled(self):
+        self.docker_enabled = False
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='pull'))
+        commands = [
+            self.CMD_NO_DOCKER_SHUTDOWN,
+            self.CMD_DOCKER_PULL,
+            self.CMD_DOCKER_START
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_remove_docker(self):
+        self.docker_enabled = True
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 state='absent'))
+        commands = [
+            self.CMD_NO_DOCKER_START
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_remove_docker_no_change(self):
+        self.docker_enabled = True
+        self.container_exists = False
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 state='absent'))
+        self.execute_module(changed=False)
+
+    def test_fetch_no_change(self):
+        self.docker_enabled = True
+        self.container_exists = True
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='fetch',
+                 location=self.LOCATION))
+        self.execute_module(changed=False)
+
+    def test_fetch_docker_enabled(self):
+        self.docker_enabled = True
+        self.container_exists = False
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='fetch',
+                 location=self.LOCATION))
+        url = self.USR_PWD_URL
+        commands = [
+            self.CMD_IMAGE_FETCH % url,
+            self.CMD_IMAGE_LOAD,
+            self.CMD_DOCKER_START
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_fetch_docker_no_usr(self):
+        self.docker_enabled = True
+        self.container_exists = False
+        location = dict(self.LOCATION)
+        del location['username']
+        del location['password']
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='fetch',
+                 location=location))
+        url = self.NO_USR_URL
+        commands = [
+            self.CMD_IMAGE_FETCH % url,
+            self.CMD_IMAGE_LOAD,
+            self.CMD_DOCKER_START
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_fetch_docker_no_pwd(self):
+        self.docker_enabled = True
+        self.container_exists = False
+        location = dict(self.LOCATION)
+        del location['password']
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='fetch',
+                 location=location))
+        url = self.USR_URL
+        commands = [
+            self.CMD_IMAGE_FETCH % url,
+            self.CMD_IMAGE_LOAD,
+            self.CMD_DOCKER_START
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_fetch_docker_disabled(self):
+        self.docker_enabled = False
+        set_module_args(
+            dict(name=self.CONTAINER_NAME,
+                 install_mode='fetch',
+                 location=self.LOCATION))
+        url = self.USR_PWD_URL
+        commands = [
+            self.CMD_NO_DOCKER_SHUTDOWN,
+            self.CMD_IMAGE_FETCH % url,
+            self.CMD_IMAGE_LOAD,
+            self.CMD_DOCKER_START
+        ]
+        self.execute_module(changed=True, commands=commands)

--- a/test/units/modules/network/onyx/test_onyx_telemetry_agent.py
+++ b/test/units/modules/network/onyx/test_onyx_telemetry_agent.py
@@ -44,6 +44,7 @@ class TestOnyxTelemetryAgentModule(TestOnyxModule):
         CONTAINER_IMAGE, CONTAINER_IMAGE_VER)
     CMD_DOCKER_START = "docker start %s %s %s now-and-init privileged network sdk" % (
         CONTAINER_IMAGE, CONTAINER_IMAGE_VER, CONTAINER_NAME)
+    CMD_COPY_SDK = 'docker copy-sdk %s to /' % CONTAINER_NAME
     CMD_NO_DOCKER_SHUTDOWN = "no docker shutdown"
     CMD_IMAGE_FETCH = 'image fetch %s {0}'.format(
         module.OnyxTelemetryAgentModule.IMAGE_FILE)
@@ -105,7 +106,8 @@ class TestOnyxTelemetryAgentModule(TestOnyxModule):
                  install_mode='pull'))
         commands = [
             self.CMD_DOCKER_PULL,
-            self.CMD_DOCKER_START
+            self.CMD_DOCKER_START,
+            self.CMD_COPY_SDK
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -117,7 +119,8 @@ class TestOnyxTelemetryAgentModule(TestOnyxModule):
         commands = [
             self.CMD_NO_DOCKER_SHUTDOWN,
             self.CMD_DOCKER_PULL,
-            self.CMD_DOCKER_START
+            self.CMD_DOCKER_START,
+            self.CMD_COPY_SDK
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -159,7 +162,8 @@ class TestOnyxTelemetryAgentModule(TestOnyxModule):
         commands = [
             self.CMD_IMAGE_FETCH % url,
             self.CMD_IMAGE_LOAD,
-            self.CMD_DOCKER_START
+            self.CMD_DOCKER_START,
+            self.CMD_COPY_SDK
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -177,7 +181,8 @@ class TestOnyxTelemetryAgentModule(TestOnyxModule):
         commands = [
             self.CMD_IMAGE_FETCH % url,
             self.CMD_IMAGE_LOAD,
-            self.CMD_DOCKER_START
+            self.CMD_DOCKER_START,
+            self.CMD_COPY_SDK
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -194,7 +199,8 @@ class TestOnyxTelemetryAgentModule(TestOnyxModule):
         commands = [
             self.CMD_IMAGE_FETCH % url,
             self.CMD_IMAGE_LOAD,
-            self.CMD_DOCKER_START
+            self.CMD_DOCKER_START,
+            self.CMD_COPY_SDK
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -209,6 +215,7 @@ class TestOnyxTelemetryAgentModule(TestOnyxModule):
             self.CMD_NO_DOCKER_SHUTDOWN,
             self.CMD_IMAGE_FETCH % url,
             self.CMD_IMAGE_LOAD,
-            self.CMD_DOCKER_START
+            self.CMD_DOCKER_START,
+            self.CMD_COPY_SDK
         ]
         self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
Signed-off-by: Samer Deeb samerd@mellanox.com

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support for managing telemetry agent docker container on mellanox network devices.
This module will support pulling for container hub, fetching from container image, and removing container
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/onyx/onyx_telemetry_agent.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
