### PR TITLE
Use wait_for over pause for junos tests

### DIFF
--- a/test/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -8,6 +8,8 @@
   tags: netconf
 
 - name: wait for netconf server to come up
-  pause:
-    seconds: 10
-  tags: netconf
+  delegate_to: localhost
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+  with_inventory_hostnames: junos


### PR DESCRIPTION
##### SUMMARY
Optimize junos tests to remove 10 second pause

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test network-integration junos