### PR TITLE
Use correct variable for run_once regardless of batch example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -273,7 +273,7 @@ As always with delegation, the action will be executed on the delegated host, bu
 .. note::
      When used together with "serial", tasks marked as "run_once" will be run on one host in *each* serial batch.
      If it's crucial that the task is run only once regardless of "serial" mode, use
-     :code:`when: inventory_hostname == ansible_play_hosts[0]` construct.
+     :code:`when: inventory_hostname == ansible_play_hosts_all[0]` construct.
 
 .. note::
     Any conditional (i.e `when:`) will use the variables of the 'first host' to decide if the task runs or not, no other hosts will be tested.


### PR DESCRIPTION
##### SUMMARY
The previous `when: inventory_hostname == ansible_play_hosts[0]` was
actually exactly the same as run_once, as it only includes hosts of
the current batch.

To really run run_once regardless of serial, `ansible_play_hosts_all`
must be used.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Playbooks delegation
