### PR TITLE
[2.8] Make second group match of ufw status output optional

### DIFF
--- a/changelogs/fragments/56678-ufw-status-change-detection.yaml
+++ b/changelogs/fragments/56678-ufw-status-change-detection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ufw - correctly check status when logging is off (https://github.com/ansible/ansible/issues/56674)

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -445,12 +445,14 @@ def main():
                 execute(cmd + [['-f'], [states[value]]])
 
         elif command == 'logging':
-            extract = re.search(r'Logging: (on|off) \(([a-z]+)\)', pre_state)
+            extract = re.search(r'Logging: (on|off)(?: \(([a-z]+)\))?', pre_state)
             if extract:
                 current_level = extract.group(2)
                 current_on_off_value = extract.group(1)
                 if value != "off":
-                    if value != "on" and (value != current_level or current_on_off_value == "off"):
+                    if current_on_off_value == "off":
+                        changed = True
+                    elif value != "on" and value != current_level:
                         changed = True
                 elif current_on_off_value != "off":
                     changed = True


### PR DESCRIPTION
##### SUMMARY
Backport of #56678 to stable-2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
