### PR TITLE
Add find module `patterns` option use cases documentation

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -37,7 +37,7 @@ options:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
             - The patterns restrict the list of files to be returned to those whose basenames match at
               least one of the patterns specified. Multiple patterns can be specified using a list.
-            - The pattern is matched against the file base name, excluding the directory the file is in
+            - The pattern is matched against the file base name, excluding the directory.
             - When using regexen, the pattern MUST match the ENTIRE file name, not just parts of it. So
               if you are looking to match all files ending in .default, you'd need to use '.*\.default'
               as a regexp and not just '\.default'.

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -37,6 +37,10 @@ options:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
             - The patterns restrict the list of files to be returned to those whose basenames match at
               least one of the patterns specified. Multiple patterns can be specified using a list.
+            - The pattern is matched against the file base name, excluding the directory the file is in
+            - When using regexen, the pattern MUST match the ENTIRE file name, not just parts of it. So
+              if you are looking to match all files ending in .default, you'd need to use '.*\.default'
+              as a regexp and not just '\.default'.
             - This parameter expects a list, which can be either comma separated or YAML. If any of the
               patterns contain a comma, make sure to put them in a list to avoid splitting the patterns
               in undesirable ways.


### PR DESCRIPTION
##### SUMMARY
* Specify that the pattern is matched against the dirent basename
* Specify that regexen must match the whole name of the dirent. It has been a pitfall for me.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr