### PR TITLE
Remove wwitzel3 from BOTMETA

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1516,7 +1516,7 @@ macros:
   team_rhn: alikins barnabycourt FlossWare vritant
   team_scaleway: remyleone abarbare DenBeke jerome-quere kindermoumoute QuentinBrosse
   team_solaris: bcoca dagwieers danowar2k fishman jpdasma jasperla mator scathatheworm troy2914 xen0l
-  team_tower: ghjm matburt wwitzel3 ryanpetrello rooftopcellist AlanCoding jladdjr kdelee
+  team_tower: ghjm matburt ryanpetrello rooftopcellist AlanCoding jladdjr kdelee
   team_ucs: dsoper2 movinalot SDBrett vallard vvb
   team_vmware: Akasurde dav1x warthog9 Tomorrow9 goneri
   team_virt: joshainglis karmab


### PR DESCRIPTION
##### SUMMARY
@wwitzel3 is no longer on the tower team. Removing from BOTMETA.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
BOTMETA
