### PR TITLE
Remove usage of global var log_path for win_domain_* modules

### DIFF
--- a/changelogs/fragments/57092-PSLint-fixes-globalvars.yml
+++ b/changelogs/fragments/57092-PSLint-fixes-globalvars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Fix PSLint errors regarding global vars (PSAvoidGlobalVars)"

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -106,7 +106,7 @@ $read_only = Get-AnsibleParam -obj $params -name "read_only" -type "bool" -defau
 $site_name = Get-AnsibleParam -obj $params -name "site_name" -type "str" -failifempty $read_only
 
 $state = Get-AnsibleParam -obj $params -name "state" -validateset ("domain_controller", "member_server") -failifempty $result
-$log_path = Get-AnsibleParam -obj $params -name "log_path" -default $null
+$log_path = Get-AnsibleParam -obj $params -name "log_path"
 $_ansible_check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
 
 Try {

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -10,8 +10,6 @@ Set-StrictMode -Version 2
 $ErrorActionPreference = "Stop"
 $ConfirmPreference = "None"
 
-$log_path = $null
-
 Function Write-DebugLog {
     Param(
         [string]$msg
@@ -108,10 +106,8 @@ $read_only = Get-AnsibleParam -obj $params -name "read_only" -type "bool" -defau
 $site_name = Get-AnsibleParam -obj $params -name "site_name" -type "str" -failifempty $read_only
 
 $state = Get-AnsibleParam -obj $params -name "state" -validateset ("domain_controller", "member_server") -failifempty $result
-$log_path = Get-AnsibleParam -obj $params -name "log_path"
+$log_path = Get-AnsibleParam -obj $params -name "log_path" -default $null
 $_ansible_check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
-
-$global:log_path = $log_path
 
 Try {
     # ensure target OS support; < 2012 doesn't have cmdlet support for DC promotion

--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -197,7 +197,7 @@ $domain_admin_user = Get-AnsibleParam $params "domain_admin_user" -failifempty $
 $domain_admin_password = Get-AnsibleParam $params "domain_admin_password" -failifempty $result
 $domain_ou_path = Get-AnsibleParam $params "domain_ou_path"
 
-$log_path = Get-AnsibleParam $params "log_path" -default $null
+$log_path = Get-AnsibleParam $params "log_path"
 $_ansible_check_mode = Get-AnsibleParam $params "_ansible_check_mode" -default $false
 
 If ($state -eq "domain") {

--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -9,8 +9,6 @@ Set-StrictMode -Version 2
 
 $ErrorActionPreference = "Stop"
 
-$log_path = $null
-
 Function Write-DebugLog {
     Param(
     [string]$msg
@@ -199,7 +197,7 @@ $domain_admin_user = Get-AnsibleParam $params "domain_admin_user" -failifempty $
 $domain_admin_password = Get-AnsibleParam $params "domain_admin_password" -failifempty $result
 $domain_ou_path = Get-AnsibleParam $params "domain_ou_path"
 
-$log_path = Get-AnsibleParam $params "log_path"
+$log_path = Get-AnsibleParam $params "log_path" -default $null
 $_ansible_check_mode = Get-AnsibleParam $params "_ansible_check_mode" -default $false
 
 If ($state -eq "domain") {
@@ -212,9 +210,6 @@ Else { # workgroup
         Fail-Json @{} "workgroup_name is required when state is 'workgroup'"
     }
 }
-
-
-$global:log_path = $log_path
 
 Try {
 

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -91,7 +91,7 @@ if ($state -eq "absent") {
     }
 
     # Make sure drive is accessible
-    if (($testPath) -and (-not (Test-Path "${drive}:"))) {
+    if (($test_path) -and (-not (Test-Path "${drive}:"))) {
         Fail-Json $result "Unable to access '${drive}:' drive"
     }
 

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -91,7 +91,7 @@ if ($state -eq "absent") {
     }
 
     # Make sure drive is accessible
-    if (($test_path) -and (-not (Test-Path "${drive}:"))) {
+    if (($testPath) -and (-not (Test-Path "${drive}:"))) {
         Fail-Json $result "Unable to access '${drive}:' drive"
     }
 

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -98,6 +98,7 @@ lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingWMICmdlet
 lib/ansible/modules/windows/win_pagefile.ps1 PSCustomUseLiteralPath
+lib/ansible/modules/windows/win_pagefile.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_pagefile.ps1 PSUseSupportsShouldProcess
 lib/ansible/modules/windows/win_pester.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_product_facts.ps1 PSAvoidTrailingWhitespace

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -48,7 +48,6 @@ lib/ansible/modules/windows/win_dns_client.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_dns_client.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_domain.ps1 PSAvoidUsingEmptyCatchBlock
 lib/ansible/modules/windows/win_domain.ps1 PSUseApprovedVerbs
-lib/ansible/modules/windows/win_domain.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_domain_controller.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_domain_controller.ps1 PSAvoidUsingWMICmdlet
 lib/ansible/modules/windows/win_domain_controller.ps1 PSCustomUseLiteralPath

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -48,14 +48,13 @@ lib/ansible/modules/windows/win_dns_client.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_dns_client.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_domain.ps1 PSAvoidUsingEmptyCatchBlock
 lib/ansible/modules/windows/win_domain.ps1 PSUseApprovedVerbs
-lib/ansible/modules/windows/win_domain_controller.ps1 PSAvoidGlobalVars
+lib/ansible/modules/windows/win_domain.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_domain_controller.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_domain_controller.ps1 PSAvoidUsingWMICmdlet
 lib/ansible/modules/windows/win_domain_controller.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_domain_controller.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_domain_controller.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_domain_group.ps1 PSAvoidTrailingWhitespace
-lib/ansible/modules/windows/win_domain_membership.ps1 PSAvoidGlobalVars
 lib/ansible/modules/windows/win_domain_membership.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_domain_membership.ps1 PSAvoidUsingWMICmdlet
 lib/ansible/modules/windows/win_domain_membership.ps1 PSCustomUseLiteralPath

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -98,7 +98,6 @@ lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_pagefile.ps1 PSAvoidUsingWMICmdlet
 lib/ansible/modules/windows/win_pagefile.ps1 PSCustomUseLiteralPath
-lib/ansible/modules/windows/win_pagefile.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_pagefile.ps1 PSUseSupportsShouldProcess
 lib/ansible/modules/windows/win_pester.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_product_facts.ps1 PSAvoidTrailingWhitespace


### PR DESCRIPTION
##### SUMMARY
In continuation to #55862 
Remove the declaration of log_path as global

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_membership.ps1
win_domain_controller.ps1

##### ADDITIONAL INFORMATION
