### PR TITLE
win_domain_group_membership module: Bug Fix

### DIFF
--- a/changelogs/fragments/56953-Fix-win_domain_group_membership.yml
+++ b/changelogs/fragments/56953-Fix-win_domain_group_membership.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "win_domain_group_membership - Bug fix while Adding and Deleting a group from another group(https://github.com/ansible/ansible/pull/56953)"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bug fixes while Adding and Deleting a group from another group [#56953](https://github.com/ansible/ansible/pull/56953)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_group_membership.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I was trying to add DEF group to ABC group after executing the ansible script I checked the members that are present in ABC groups, the DEF group was not added to it. As DEF group was not present in ABC group after executing the ansible script then I tried to add DEF group to ABC group using the ps1 script, after execution of the ps1 script I found that DEF is a universal group and ABC is a global group, as a global group cannot have a universal group as a member. So the ps1 script failed while executing. But while executing the ansible script it got passed, it didn't show any error while execting it.
