### PR TITLE
Adding Port Security Timeout option in Interface Policy Port Security

### DIFF
--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -16,7 +16,7 @@ module: aci_interface_policy_port_security
 short_description: Manage port security (l2:PortSecurityPol)
 description:
 - Manage port security on Cisco ACI fabrics.
-version_added: '2.9'
+version_added: '2.4'
 options:
   port_security:
     description:
@@ -36,6 +36,7 @@ options:
     - The APIC defaults to C(0) when unset during creation.
     type: int
   port_security_timeout:
+    version_added: '2.9'
     description:
     - The delay time in seconds before MAC learning is re-enabled
     - Accepted values range between C(60) and C(3600)

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -16,7 +16,7 @@ module: aci_interface_policy_port_security
 short_description: Manage port security (l2:PortSecurityPol)
 description:
 - Manage port security on Cisco ACI fabrics.
-version_added: '2.4'
+version_added: '2.9'
 options:
   port_security:
     description:
@@ -204,7 +204,7 @@ def main():
     port_security_timeout = module.params['port_security_timeout']
     if max_end_points is not None and max_end_points not in range(12001):
         module.fail_json(msg='The "max_end_points" must be between 0 and 12000')
-    if port_security_timeout is not None and port_security_timeout not in range(60,3601):
+    if port_security_timeout is not None and port_security_timeout not in range(60, 3601):
         module.fail_json(msg='The "port_security_timeout" must be between 60 and 3600')
     state = module.params['state']
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -35,6 +35,12 @@ options:
     - Accepted values range between C(0) and C(12000).
     - The APIC defaults to C(0) when unset during creation.
     type: int
+  port_security_timeout:
+    description:
+    - The delay time in seconds before MAC learning is re-enabled
+    - Accepted values range between C(60) and C(3600)
+    - The APIC defaults to C(60) when unset during creation
+    type: int
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -60,6 +66,7 @@ EXAMPLES = r'''
     port_security: '{{ port_security }}'
     description: '{{ descr }}'
     max_end_points: '{{ max_end_points }}'
+    port_security_timeout: '{{ port_security_timeout }}
   delegate_to: localhost
 '''
 
@@ -178,6 +185,7 @@ def main():
         port_security=dict(type='str', aliases=['name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         max_end_points=dict(type='int'),
+        port_security_timeout=dict(type='int'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
 
@@ -193,8 +201,11 @@ def main():
     port_security = module.params['port_security']
     description = module.params['description']
     max_end_points = module.params['max_end_points']
+    port_security_timeout = module.params['port_security_timeout']
     if max_end_points is not None and max_end_points not in range(12001):
         module.fail_json(msg='The "max_end_points" must be between 0 and 12000')
+    if port_security_timeout is not None and port_security_timeout not in range(60,3601):
+        module.fail_json(msg='The "port_security_timeout" must be between 60 and 3600')
     state = module.params['state']
 
     aci = ACIModule(module)

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -66,7 +66,7 @@ EXAMPLES = r'''
     port_security: '{{ port_security }}'
     description: '{{ descr }}'
     max_end_points: '{{ max_end_points }}'
-    port_security_timeout: '{{ port_security_timeout }}
+    port_security_timeout: '{{ port_security_timeout }}'
   delegate_to: localhost
 '''
 


### PR DESCRIPTION
##### SUMMARY
Add support for port security timeout for ACI Interface Policy Port Security 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Network Module ACI 
Library : _aci_intf_policy_port_security

#### ADDITIONAL INFORMATION
- aci_interface_policy_port_security:
    host: '{{ inventory_hostname }}'
    username: '{{ username }}'
    password: '{{ password }}'
    port_security: '{{ port_security }}'
    description: '{{ descr }}'
    max_end_points: '{{ max_end_points }}'
    port_security_timeout: '{{ port_security_timeout }}' .   <-- New option added
  delegate_to: localhost
