### PR TITLE
tower_credential: 'ssh_key_data' parameter isn't a path anymore

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -168,7 +168,7 @@ EXAMPLES = '''
 - name: Add Credential Into Tower
   tower_credential:
     name: Workshop Credential
-    ssh_key_data: "/home/{{ansible_user}}/.ssh/aws-private.pem"
+    ssh_key_data: "{{ lookup('file', '/home/' ~ {{ansible_user}} ~ '/.ssh/aws-private.pem') }}"
     kind: ssh
     organization: Default
     tower_username: admin


### PR DESCRIPTION
##### SUMMARY
`tower_credential`:  update example, `ssh_key_data` parameter should not be a path (since 2.8, see #45158)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
tower_credential

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
