### PR TITLE
Split Avi Credentials into two parts - secrets and login_info

### DIFF
--- a/lib/ansible/module_utils/network/avi/ansible_utils.py
+++ b/lib/ansible/module_utils/network/avi/ansible_utils.py
@@ -552,5 +552,6 @@ def avi_common_argument_spec():
         tenant_uuid=dict(default=''),
         api_version=dict(default='16.4.4', type='str'),
         avi_credentials=dict(default=None, no_log=True, type='dict'),
+        avi_login_info=dict(default=None, type='dict'),
         api_context=dict(type='dict'),
         avi_disable_session_cache_as_fact=dict(default=False, type='bool'))

--- a/lib/ansible/module_utils/network/avi/avi_api.py
+++ b/lib/ansible/module_utils/network/avi/avi_api.py
@@ -192,6 +192,10 @@ class AviCredentials(object):
             self.session_id = m.params['session_id']
         if m.params.get('csrftoken'):
             self.csrftoken = m.params['csrftoken']
+        if m.params.get('avi_login_info'):
+            for k, v in m.params['avi_login_info'].items():
+                if v:
+                    setattr(self, k, v)
 
     def __str__(self):
         return 'controller %s user %s api %s tenant %s' % (

--- a/lib/ansible/plugins/doc_fragments/avi.py
+++ b/lib/ansible/plugins/doc_fragments/avi.py
@@ -42,7 +42,10 @@ options:
         default: 16.4.4
     avi_credentials:
         description:
-            - Avi Credentials dictionary which can be used in lieu of enumerating Avi Controller login details.
+            - Avi Credentials dictionary which can be used in lieu of enumerating Avi Controller login secrets.
+            - info of this dict will not be logged.
+            - THis dict will contain only the login secrets like password.
+            - Ansible dose complete search and replace of no log params so all controller information should go in avi_login_info
         type: dict
         version_added: "2.5"
     api_context:
@@ -56,6 +59,13 @@ options:
             - It disables avi session information to be cached as a fact.
         type: bool
         version_added: "2.6"
+    avi_login_info:
+         description:       
+            - Avi login info dictionary which can be used in lieu of enumerating Avi Controller login details.
+            - This dictionary should not contain login secrets avi_credentials should be used for login secrets.
+            - This should contain information like controller, username, tenant, api_version
+        type: dict
+        version_added: "2.9"
 notes:
   - For more information on using Ansible to manage Avi Network devices see U(https://www.ansible.com/ansible-avi-networks).
 '''

--- a/lib/ansible/plugins/doc_fragments/avi.py
+++ b/lib/ansible/plugins/doc_fragments/avi.py
@@ -60,7 +60,7 @@ options:
         type: bool
         version_added: "2.6"
     avi_login_info:
-         description:       
+        description:       
             - Avi login info dictionary which can be used in lieu of enumerating Avi Controller login details.
             - This dictionary should not contain login secrets avi_credentials should be used for login secrets.
             - This should contain information like controller, username, tenant, api_version

--- a/lib/ansible/plugins/doc_fragments/avi.py
+++ b/lib/ansible/plugins/doc_fragments/avi.py
@@ -60,7 +60,7 @@ options:
         type: bool
         version_added: "2.6"
     avi_login_info:
-        description:       
+        description:
             - Avi login info dictionary which can be used in lieu of enumerating Avi Controller login details.
             - This dictionary should not contain login secrets avi_credentials should be used for login secrets.
             - This should contain information like controller, username, tenant, api_version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Split Avi Credentials into two parts - secrets and login_info
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- module_utils/network/avi/ansible_utils.py 
- module_utils/network/avi/avi_api.py
- plugins/doc_fragments/avi.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
