### PR TITLE
VMware: Updates the DRS rule without deletion

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_vm_drs_rule.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_vm_drs_rule.py
@@ -99,7 +99,6 @@ EXAMPLES = r'''
         - vm1
         - vm2
     drs_rule_name: vm1-vm2-affinity-rule-001
-    enabled: True
     mandatory: True
     affinity_rule: False
   delegate_to: localhost
@@ -241,9 +240,9 @@ class VmwareDrs(PyVmomi):
         if rule_obj is not None:
             existing_rule = self.normalize_rule_spec(rule_obj=rule_obj)
             if ((sorted(existing_rule['rule_vms']) == sorted(self.vm_list)) and
-                (existing_rule['rule_enabled'] == self.enabled) and
-                (existing_rule['rule_mandatory'] == self.mandatory) and
-                (existing_rule['rule_affinity'] == self.affinity_rule)):
+                    (existing_rule['rule_enabled'] == self.enabled) and
+                    (existing_rule['rule_mandatory'] == self.mandatory) and
+                    (existing_rule['rule_affinity'] == self.affinity_rule)):
                 self.module.exit_json(changed=False, result=existing_rule, msg="Rule already exists with the same configuration")
             else:
                 changed, result = self.update_rule_spec(rule_obj)
@@ -284,17 +283,17 @@ class VmwareDrs(PyVmomi):
 
         return changed, result
 
-    def update_rule_spec(self,rule_obj=None):
+    def update_rule_spec(self, rule_obj=None):
         """
         Function to update DRS rule
         """
         changed = False
 
         rule_obj.vm = self.vm_obj_list
-        
+
         if (rule_obj.mandatory != self.mandatory):
             rule_obj.mandatory = self.mandatory
-        
+
         if (rule_obj.enabled != self.enabled):
             rule_obj.enabled = self.enabled
 

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_vm_drs_rule.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_vm_drs_rule.py
@@ -169,7 +169,7 @@ class VmwareDrs(PyVmomi):
     # Getter
     def get_all_vms_info(self, vms_list=None):
         """
-        Function to get all VM objects using name from given cluster
+        Get all VM objects using name from given cluster
         Args:
             vms_list: List of VM names
 
@@ -192,7 +192,7 @@ class VmwareDrs(PyVmomi):
 
     def get_rule_key_by_name(self, cluster_obj=None, rule_name=None):
         """
-        Function to get a specific DRS rule key by name
+        Get a specific DRS rule key by name
         Args:
             rule_name: Name of rule
             cluster_obj: Cluster managed object
@@ -213,7 +213,7 @@ class VmwareDrs(PyVmomi):
     @staticmethod
     def normalize_rule_spec(rule_obj=None):
         """
-        Function to return human readable rule spec
+        Return human readable rule spec
         Args:
             rule_obj: Rule managed object
 
@@ -234,7 +234,7 @@ class VmwareDrs(PyVmomi):
     # Create
     def create(self):
         """
-        Function to create a DRS rule if rule does not exist
+        Create a DRS rule if rule does not exist
         """
         rule_obj = self.get_rule_key_by_name(rule_name=self.rule_name)
         if rule_obj is not None:
@@ -253,7 +253,7 @@ class VmwareDrs(PyVmomi):
 
     def create_rule_spec(self):
         """
-        Function to create DRS rule
+        Create DRS rule
         """
         changed = False
         if self.affinity_rule:
@@ -285,7 +285,7 @@ class VmwareDrs(PyVmomi):
 
     def update_rule_spec(self, rule_obj=None):
         """
-        Function to update DRS rule
+        Update DRS rule
         """
         changed = False
 
@@ -317,7 +317,7 @@ class VmwareDrs(PyVmomi):
     # Delete
     def delete(self, rule_name=None):
         """
-        Function to delete DRS rule using name
+        Delete DRS rule using name
         """
         changed = False
         if rule_name is None:

--- a/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
@@ -11,7 +11,9 @@
         setup_attach_host: true
         setup_datastore: true
         setup_virtualmachines: true
-    - name: Create a DRS Affinity rule for vms
+
+    - &create_drs_rule
+      name: Create a DRS Affinity rule for vms
       vmware_vm_vm_drs_rule:
         validate_certs: False
         hostname: "{{ vcenter_hostname }}"
@@ -24,12 +26,24 @@
         affinity_rule: True
         mandatory: True
       register: drs_rule_0001_results
-    - debug: var=drs_rule_0001_results
-    - assert:
-        that:
-            - "{{ drs_rule_0001_results.changed }}"
 
-    - name: Create a DRS Anti-Affinity rule for vms
+    - debug: var=drs_rule_0001_results
+
+    - name: Check if changes are made
+      assert:
+        that:
+          - drs_rule_0001_results.changed
+
+    - <<: *create_drs_rule
+      name: Create a DRS Affinity rule for vms again
+
+    - name: Check if no changes are made if drs rule is created again
+      assert:
+        that:
+          - not drs_rule_0001_results.changed
+
+    - &update_drs_rule
+      name: Update a DRS Affinity rule for vms
       vmware_vm_vm_drs_rule:
         validate_certs: False
         hostname: "{{ vcenter_hostname }}"
@@ -37,12 +51,94 @@
         password: "{{ vcenter_password }}"
         drs_rule_name: drs_rule_0001
         cluster_name: "{{ ccr1 }}"
-        vms: "{{ virtual_machines | map(attribute='name') | list }}"
+        vms: "{{ virtual_machines_in_cluster | map(attribute='name') | list }}"
         enabled: False
+        affinity_rule: True
+        mandatory: False
+      register: drs_rule_0001_results
+
+    - name: Check if changes are made if drs rule is created
+      assert:
+        that:
+            - drs_rule_0001_results.changed
+
+    - <<: *update_drs_rule
+      name: Update a DRS Affinity rule for vms again
+
+    - name: Check if no changes are made if drs rule is created again
+      assert:
+        that:
+            - not drs_rule_0001_results.changed
+
+    - &delete_drs_rule
+      name: Delete a DRS Affinity rule for vms
+      vmware_vm_vm_drs_rule:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_0001
+        cluster_name: "{{ ccr1 }}"
+        state: absent
+      register: drs_rule_0001_results
+
+    - name: Check if DRS rule is delete
+      assert:
+        that:
+            - drs_rule_0001_results.changed
+
+    - <<: *delete_drs_rule
+      name: Delete a DRS Affinity rule for vms again
+
+    - name: Check if DRS rule is not delete again
+      assert:
+        that:
+            - not drs_rule_0001_results.changed
+
+    - &create_anti_drs_rule
+      name: Create a DRS Anti-Affinity rule for vms
+      vmware_vm_vm_drs_rule:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_0002
+        cluster_name: "{{ ccr1 }}"
+        vms: "{{ virtual_machines_in_cluster | map(attribute='name') | list }}"
+        enabled: True
         affinity_rule: False
         mandatory: False
       register: drs_rule_0002_results
+
     - debug: var=drs_rule_0002_results
-    - assert:
+
+    - name: Check if DRS Anti-Affinity rule is created
+      assert:
         that:
-            - "{{ drs_rule_0002_results.changed }}"
+            - drs_rule_0002_results.changed
+
+    - <<: *create_anti_drs_rule
+      name: Create a DRS Anti-Affinity rule for vms again
+
+    - debug: var=drs_rule_0002_results
+
+    - name: Check if no changes are made if DRS Anti-Affinity rule is created again
+      assert:
+        that:
+            - not drs_rule_0002_results.changed
+
+    - name: Delete a DRS Anti-Affinity rule for vms
+      vmware_vm_vm_drs_rule:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_0002
+        cluster_name: "{{ ccr1 }}"
+        state: absent
+      register: drs_rule_0002_results
+
+    - name: Check if DRS rule is not delete
+      assert:
+        that:
+            - drs_rule_0002_results.changed


### PR DESCRIPTION
The DRS rule will be updated if any changes in the configuration without deleting the existing rule.
The rule itself is updated by the given configuration.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The DRS rule will be updated to the new given configuration if the **STATE** is **present**
and the DRS rule already exists. There will be no deletion of the DRS rule. The rule will be updated
directly.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_vm_drs_rule
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The given list of VMs will override the VMs list in the DRS rule provided. So to update the DRS rule,
provide with the existing VMs in the list along with the new VMs to add. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
