### PR TITLE
nxos_pim_interface: Add 'bfd' support

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -173,10 +173,10 @@ PARAM_TO_DEFAULT_KEYMAP = {
 }
 
 BFD_KEYMAP = {
-   None: None,
-   'default': 'no ip pim bfd-instance',
-   False: 'ip pim bfd-instance disable',
-   True: 'ip pim bfd-instance',
+    None: None,
+    'default': 'no ip pim bfd-instance',
+    False: 'ip pim bfd-instance disable',
+    True: 'ip pim bfd-instance',
 }
 
 
@@ -461,6 +461,7 @@ def config_pim_interface_defaults(existing, jp_bidir, isauth):
             command.append(each)
 
     return command
+
 
 def normalize_proposed_values(proposed):
     keys = proposed.keys()

--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -43,10 +43,11 @@ options:
   bfd:
     description:
       - Enables BFD for PIM at the interface level. This overrides the bfd variable set at the pim global level.
-      - Valid values are true, false (disables bfd on the interface), or 'default'.
+      - Valid values are 'enable', 'disable' or 'default'.
       - "Dependency: 'feature bfd'"
     version_added: "2.9"
     type: str
+    choices: ['enable', 'disable', 'default']
   dr_prio:
     description:
       - Configures priority for PIM DR election on interface.
@@ -122,7 +123,7 @@ EXAMPLES = r'''
 - name: disable bfd on the interface
   nxos_pim_interface:
     interface: eth1/33
-    bfd: false
+    bfd: disable
 
 - name: Ensure defaults are in place
   nxos_pim_interface:
@@ -135,8 +136,11 @@ commands:
     description: command sent to the device
     returned: always
     type: list
-    sample: ["interface eth1/33", "ip pim neighbor-policy test",
-            "ip pim neighbor-policy test"]
+    sample: ["interface eth1/33",
+             "ip pim neighbor-policy test",
+             "ip pim bfd-instance disable",
+             "ip pim neighbor-policy test"
+            ]
 '''
 
 import re
@@ -175,8 +179,8 @@ PARAM_TO_DEFAULT_KEYMAP = {
 BFD_KEYMAP = {
     None: None,
     'default': 'no ip pim bfd-instance',
-    False: 'ip pim bfd-instance disable',
-    True: 'ip pim bfd-instance',
+    'disable': 'ip pim bfd-instance disable',
+    'enable': 'ip pim bfd-instance',
 }
 
 
@@ -286,9 +290,10 @@ def get_pim_interface(module, interface):
             elif 'sparse-mode' in each:
                 pim_interface['sparse'] = True
             elif 'bfd-instance' in each:
+                value = 'default'
                 m = re.search(r'ip pim bfd-instance(?P<disable> disable)?', each)
                 if m:
-                    pim_interface['bfd'] = False if m.group('disable') else True
+                    pim_interface['bfd'] = 'disable' if m.group('disable') else 'enable'
             elif 'border' in each:
                 pim_interface['border'] = True
             elif 'hello-interval' in each:
@@ -466,13 +471,8 @@ def config_pim_interface_defaults(existing, jp_bidir, isauth):
 def normalize_proposed_values(proposed):
     keys = proposed.keys()
     if 'bfd' in keys:
-        # bfd is a tri-state string: False, True, default
-        v = proposed['bfd'].lower()
-        if v == 'false':
-            v = False
-        elif v == 'true':
-            v = True
-        proposed['bfd'] = v
+        # bfd is a tri-state string: enable, disable, default
+        proposed['bfd'] = proposed['bfd'].lower()
     if 'hello_interval' in keys:
         proposed['hello_interval'] = str(proposed['hello_interval'] * 1000)
 
@@ -488,7 +488,7 @@ def main():
         jp_policy_in=dict(type='str'),
         jp_type_out=dict(type='str', choices=['prefix', 'routemap']),
         jp_type_in=dict(type='str', choices=['prefix', 'routemap']),
-        bfd=dict(type='str'),
+        bfd=dict(type='str', choices=['enable', 'disable', 'default']),
         border=dict(type='bool', default=False),
         neighbor_policy=dict(type='str'),
         neighbor_type=dict(type='str', choices=['prefix', 'routemap']),

--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -40,6 +40,13 @@ options:
       - Enable/disable sparse-mode on the interface.
     type: bool
     default: no
+  bfd:
+    description:
+      - Enables BFD for PIM at the interface level. This overrides the bfd variable set at the pim global level.
+      - Valid values are true, false (disables bfd on the interface), or 'default'.
+      - "Dependency: 'feature bfd'"
+    version_added: "2.9"
+    type: str
   dr_prio:
     description:
       - Configures priority for PIM DR election on interface.
@@ -112,6 +119,11 @@ EXAMPLES = r'''
     jp_type_in: routemap
     jp_type_out: routemap
 
+- name: disable bfd on the interface
+  nxos_pim_interface:
+    interface: eth1/33
+    bfd: false
+
 - name: Ensure defaults are in place
   nxos_pim_interface:
     interface: eth1/33
@@ -137,6 +149,7 @@ from ansible.module_utils.six import string_types
 
 PARAM_TO_COMMAND_KEYMAP = {
     'interface': '',
+    'bfd': 'ip pim bfd-instance',
     'sparse': 'ip pim sparse-mode',
     'dr_prio': 'ip pim dr-priority {0}',
     'hello_interval': 'ip pim hello-interval {0}',
@@ -151,11 +164,19 @@ PARAM_TO_COMMAND_KEYMAP = {
 }
 
 PARAM_TO_DEFAULT_KEYMAP = {
+    'bfd': 'default',
     'dr_prio': '1',
     'hello_interval': '30000',
     'sparse': False,
     'border': False,
     'hello_auth_key': False,
+}
+
+BFD_KEYMAP = {
+   None: None,
+   'default': 'no ip pim bfd-instance',
+   False: 'ip pim bfd-instance disable',
+   True: 'ip pim bfd-instance',
 }
 
 
@@ -222,6 +243,7 @@ def get_pim_interface(module, interface):
     pim_interface = {}
     body = get_config(module, flags=['interface {0}'.format(interface)])
 
+    pim_interface['bfd'] = 'default'
     pim_interface['neighbor_type'] = None
     pim_interface['neighbor_policy'] = None
     pim_interface['jp_policy_in'] = None
@@ -263,6 +285,10 @@ def get_pim_interface(module, interface):
                 pim_interface['isauth'] = True
             elif 'sparse-mode' in each:
                 pim_interface['sparse'] = True
+            elif 'bfd-instance' in each:
+                m = re.search(r'ip pim bfd-instance(?P<disable> disable)?', each)
+                if m:
+                    pim_interface['bfd'] = False if m.group('disable') else True
             elif 'border' in each:
                 pim_interface['border'] = True
             elif 'hello-interval' in each:
@@ -299,9 +325,11 @@ def config_pim_interface(delta, existing, jp_bidir, isauth):
                 commands.append(command)
 
     for k, v in delta.items():
-        if k in ['dr_prio', 'hello_interval', 'hello_auth_key', 'border',
+        if k in ['bfd', 'dr_prio', 'hello_interval', 'hello_auth_key', 'border',
                  'sparse']:
-            if v:
+            if k == 'bfd':
+                command = BFD_KEYMAP[v]
+            elif v:
                 command = PARAM_TO_COMMAND_KEYMAP.get(k).format(v)
             elif k == 'hello_auth_key':
                 if isauth:
@@ -350,12 +378,17 @@ def config_pim_interface(delta, existing, jp_bidir, isauth):
                 commands.append(command)
         command = None
 
+    if 'no ip pim sparse-mode' in commands:
+        # sparse is long-running on some platforms, process it last
+        commands.remove('no ip pim sparse-mode')
+        commands.append('no ip pim sparse-mode')
     return commands
 
 
 def get_pim_interface_defaults():
 
     args = dict(dr_prio=PARAM_TO_DEFAULT_KEYMAP.get('dr_prio'),
+                bfd=PARAM_TO_DEFAULT_KEYMAP.get('bfd'),
                 border=PARAM_TO_DEFAULT_KEYMAP.get('border'),
                 sparse=PARAM_TO_DEFAULT_KEYMAP.get('sparse'),
                 hello_interval=PARAM_TO_DEFAULT_KEYMAP.get('hello_interval'),
@@ -429,6 +462,19 @@ def config_pim_interface_defaults(existing, jp_bidir, isauth):
 
     return command
 
+def normalize_proposed_values(proposed):
+    keys = proposed.keys()
+    if 'bfd' in keys:
+        # bfd is a tri-state string: False, True, default
+        v = proposed['bfd'].lower()
+        if v == 'false':
+            v = False
+        elif v == 'true':
+            v = True
+        proposed['bfd'] = v
+    if 'hello_interval' in keys:
+        proposed['hello_interval'] = str(proposed['hello_interval'] * 1000)
+
 
 def main():
     argument_spec = dict(
@@ -441,6 +487,7 @@ def main():
         jp_policy_in=dict(type='str'),
         jp_type_out=dict(type='str', choices=['prefix', 'routemap']),
         jp_type_in=dict(type='str', choices=['prefix', 'routemap']),
+        bfd=dict(type='str'),
         border=dict(type='bool', default=False),
         neighbor_policy=dict(type='str'),
         neighbor_type=dict(type='str', choices=['prefix', 'routemap']),
@@ -484,9 +531,7 @@ def main():
     args = PARAM_TO_COMMAND_KEYMAP.keys()
     proposed = dict((k, v) for k, v in module.params.items()
                     if v is not None and k in args)
-
-    if hello_interval:
-        proposed['hello_interval'] = str(proposed['hello_interval'] * 1000)
+    normalize_proposed_values(proposed)
 
     delta = dict(set(proposed.items()).difference(existing.items()))
 

--- a/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
@@ -3,17 +3,20 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
-- name: "Disable feature PIM"
+- name: "Setup: Disable features"
   nxos_feature: &disable_feature
-    feature: pim
+    feature: "{{ item }}"
     provider: "{{ connection }}"
     state: disabled
+  loop: ['pim', 'bfd']
+  ignore_errors: yes
 
-- name: "Enable feature PIM"
+- name: "Setup: Enable features"
   nxos_feature:
-    feature: pim
+    feature: "{{ item }}"
     provider: "{{ connection }}"
     state: enabled
+  loop: ['pim', 'bfd']
 
 - set_fact: testint="{{ nxos_int1 }}"
 
@@ -115,6 +118,7 @@
       hello_interval: 40
       sparse: True
       border: True
+      bfd: True
       provider: "{{ connection }}"
       state: present
     register: result
@@ -132,6 +136,7 @@
       interface: "{{ testint }}"
       sparse: False
       border: False
+      bfd: False
       provider: "{{ connection }}"
       state: present
     register: result
@@ -193,5 +198,6 @@
   always:
   - name: "Disable feature PIM"
     nxos_feature: *disable_feature
+    loop: ['pim', 'bfd']
 
 - debug: msg="END connection={{ ansible_connection }} nxos_pim_interface sanity test"

--- a/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
@@ -118,7 +118,7 @@
       hello_interval: 40
       sparse: True
       border: True
-      bfd: True
+      bfd: enable
       provider: "{{ connection }}"
       state: present
     register: result
@@ -136,7 +136,7 @@
       interface: "{{ testint }}"
       sparse: False
       border: False
-      bfd: False
+      bfd: disable
       provider: "{{ connection }}"
       state: present
     register: result

--- a/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
+++ b/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
@@ -54,9 +54,9 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
         self.load_config.return_value = None
 
     def test_bfd_1(self):
-        # default (None) -> True
+        # default (None) -> enable
         self.get_config.return_value = None
-        set_module_args(dict(interface='eth2/1', bfd=True))
+        set_module_args(dict(interface='eth2/1', bfd='enable'))
         self.execute_module(
             changed=True,
             commands=[
@@ -64,8 +64,8 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
                 'ip pim bfd-instance',
             ])
 
-        # default (None) -> False (disable)
-        set_module_args(dict(interface='eth2/1', bfd=False))
+        # default (None) -> disable
+        set_module_args(dict(interface='eth2/1', bfd='disable'))
         self.execute_module(
             changed=True,
             commands=[
@@ -86,13 +86,13 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
         self.execute_module(changed=False,)
 
     def test_bfd_2(self):
-        # From False (disabled)
+        # From disable
         self.get_config.return_value = '''
             interface Ethernet9/2
               ip pim bfd-instance disable
         '''
-        # False (disabled) -> True
-        set_module_args(dict(interface='Ethernet9/2', bfd='true'))
+        # disable -> enable
+        set_module_args(dict(interface='Ethernet9/2', bfd='enable'))
         self.execute_module(
             changed=True,
             commands=[
@@ -100,11 +100,11 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
                 'ip pim bfd-instance',
             ])
 
-        # False (disable) -> False (disable) (idempotence)
-        set_module_args(dict(interface='Ethernet9/2', bfd='false'))
+        # disable -> disable (idempotence)
+        set_module_args(dict(interface='Ethernet9/2', bfd='disable'))
         self.execute_module(changed=False,)
 
-        # False (disable) -> default (None)
+        # disable -> default (None)
         set_module_args(dict(interface='Ethernet9/2', bfd='default'))
         self.execute_module(
             changed=True,
@@ -112,7 +112,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
                 'interface Ethernet9/2',
                 'no ip pim bfd-instance',
             ])
-        # False (disable) -> interface state 'default'
+        # disable -> interface state 'default'
         set_module_args(dict(interface='Ethernet9/3', state='default'))
         self.execute_module(
             changed=True,
@@ -121,7 +121,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
                 'no ip pim bfd-instance',
             ])
 
-        # False (disable) -> interface state 'absent'
+        # disable -> interface state 'absent'
         set_module_args(dict(interface='Ethernet9/3', state='absent'))
         self.execute_module(
             changed=True,
@@ -131,13 +131,13 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             ])
 
     def test_bfd_3(self):
-        # From True
+        # From enable
         self.get_config.return_value = '''
             interface Ethernet9/2
               ip pim bfd-instance
         '''
-        # True -> False (disabled)
-        set_module_args(dict(interface='Ethernet9/3', bfd='false'))
+        # enable -> disabled
+        set_module_args(dict(interface='Ethernet9/3', bfd='disable'))
         self.execute_module(
             changed=True,
             commands=[
@@ -145,11 +145,11 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
                 'ip pim bfd-instance disable',
             ])
 
-        # True -> True (idempotence)
-        set_module_args(dict(interface='Ethernet9/3', bfd='true'))
+        # enable -> enable (idempotence)
+        set_module_args(dict(interface='Ethernet9/3', bfd='enable'))
         self.execute_module(changed=False,)
 
-        # True -> default (None)
+        # enable -> default (None)
         set_module_args(dict(interface='Ethernet9/3', bfd='default'))
         self.execute_module(
             changed=True,
@@ -158,7 +158,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
                 'no ip pim bfd-instance',
             ])
 
-        # True -> interface state 'default'
+        # enable -> interface state 'default'
         set_module_args(dict(interface='Ethernet9/3', state='default'))
         self.execute_module(
             changed=True,
@@ -167,7 +167,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
                 'no ip pim bfd-instance',
             ])
 
-        # True -> interface state 'absent'
+        # enable -> interface state 'absent'
         set_module_args(dict(interface='Ethernet9/3', state='absent'))
         self.execute_module(
             changed=True,

--- a/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
+++ b/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
@@ -23,6 +23,7 @@ from units.compat.mock import patch
 from ansible.modules.network.nxos import nxos_pim_interface
 from .nxos_module import TestNxosModule, load_fixture, set_module_args
 
+
 class TestNxosPimInterfaceBfdModule(TestNxosModule):
 
     module = nxos_pim_interface
@@ -61,7 +62,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface eth2/1',
                 'ip pim bfd-instance',
-        ])
+            ])
 
         # default (None) -> False (disable)
         set_module_args(dict(interface='eth2/1', bfd=False))
@@ -70,7 +71,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface eth2/1',
                 'ip pim bfd-instance disable',
-        ])
+            ])
 
         # default (None) -> default (None) (idempotence)
         set_module_args(dict(interface='eth2/1', bfd='default'))
@@ -97,7 +98,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/2',
                 'ip pim bfd-instance',
-        ])
+            ])
 
         # False (disable) -> False (disable) (idempotence)
         set_module_args(dict(interface='Ethernet9/2', bfd='false'))
@@ -110,7 +111,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/2',
                 'no ip pim bfd-instance',
-        ])
+            ])
         # False (disable) -> interface state 'default'
         set_module_args(dict(interface='Ethernet9/3', state='default'))
         self.execute_module(
@@ -118,7 +119,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/3',
                 'no ip pim bfd-instance',
-        ])
+            ])
 
         # False (disable) -> interface state 'absent'
         set_module_args(dict(interface='Ethernet9/3', state='absent'))
@@ -127,7 +128,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/3',
                 'no ip pim bfd-instance',
-        ])
+            ])
 
     def test_bfd_3(self):
         # From True
@@ -142,7 +143,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/3',
                 'ip pim bfd-instance disable',
-        ])
+            ])
 
         # True -> True (idempotence)
         set_module_args(dict(interface='Ethernet9/3', bfd='true'))
@@ -155,7 +156,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/3',
                 'no ip pim bfd-instance',
-        ])
+            ])
 
         # True -> interface state 'default'
         set_module_args(dict(interface='Ethernet9/3', state='default'))
@@ -164,7 +165,7 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/3',
                 'no ip pim bfd-instance',
-        ])
+            ])
 
         # True -> interface state 'absent'
         set_module_args(dict(interface='Ethernet9/3', state='absent'))
@@ -173,4 +174,4 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             commands=[
                 'interface Ethernet9/3',
                 'no ip pim bfd-instance',
-        ])
+            ])

--- a/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
+++ b/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
@@ -1,4 +1,4 @@
-# (c) 2016 Red Hat Inc.
+# (c) 2019 Red Hat Inc.
 #
 # This file is part of Ansible
 #

--- a/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
+++ b/test/units/modules/network/nxos/test_nxos_pim_interface_bfd.py
@@ -1,0 +1,176 @@
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat.mock import patch
+from ansible.modules.network.nxos import nxos_pim_interface
+from .nxos_module import TestNxosModule, load_fixture, set_module_args
+
+class TestNxosPimInterfaceBfdModule(TestNxosModule):
+
+    module = nxos_pim_interface
+
+    def setUp(self):
+        super(TestNxosPimInterfaceBfdModule, self).setUp()
+
+        self.mock_get_interface_mode = patch('ansible.modules.network.nxos.nxos_pim_interface.get_interface_mode')
+        self.get_interface_mode = self.mock_get_interface_mode.start()
+
+        self.mock_get_config = patch('ansible.modules.network.nxos.nxos_pim_interface.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.nxos.nxos_pim_interface.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_run_commands = patch('ansible.modules.network.nxos.nxos_pim_interface.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        super(TestNxosPimInterfaceBfdModule, self).tearDown()
+        self.mock_get_interface_mode.stop()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None, device=''):
+        self.load_config.return_value = None
+
+    def test_bfd_1(self):
+        # default (None) -> True
+        self.get_config.return_value = None
+        set_module_args(dict(interface='eth2/1', bfd=True))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface eth2/1',
+                'ip pim bfd-instance',
+        ])
+
+        # default (None) -> False (disable)
+        set_module_args(dict(interface='eth2/1', bfd=False))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface eth2/1',
+                'ip pim bfd-instance disable',
+        ])
+
+        # default (None) -> default (None) (idempotence)
+        set_module_args(dict(interface='eth2/1', bfd='default'))
+        self.execute_module(changed=False,)
+
+        # default (None) -> interface state 'default'
+        set_module_args(dict(interface='Ethernet9/3', state='default'))
+        self.execute_module(changed=False,)
+
+        # default (None) -> interface state 'absent'
+        set_module_args(dict(interface='Ethernet9/3', state='absent'))
+        self.execute_module(changed=False,)
+
+    def test_bfd_2(self):
+        # From False (disabled)
+        self.get_config.return_value = '''
+            interface Ethernet9/2
+              ip pim bfd-instance disable
+        '''
+        # False (disabled) -> True
+        set_module_args(dict(interface='Ethernet9/2', bfd='true'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/2',
+                'ip pim bfd-instance',
+        ])
+
+        # False (disable) -> False (disable) (idempotence)
+        set_module_args(dict(interface='Ethernet9/2', bfd='false'))
+        self.execute_module(changed=False,)
+
+        # False (disable) -> default (None)
+        set_module_args(dict(interface='Ethernet9/2', bfd='default'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/2',
+                'no ip pim bfd-instance',
+        ])
+        # False (disable) -> interface state 'default'
+        set_module_args(dict(interface='Ethernet9/3', state='default'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/3',
+                'no ip pim bfd-instance',
+        ])
+
+        # False (disable) -> interface state 'absent'
+        set_module_args(dict(interface='Ethernet9/3', state='absent'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/3',
+                'no ip pim bfd-instance',
+        ])
+
+    def test_bfd_3(self):
+        # From True
+        self.get_config.return_value = '''
+            interface Ethernet9/2
+              ip pim bfd-instance
+        '''
+        # True -> False (disabled)
+        set_module_args(dict(interface='Ethernet9/3', bfd='false'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/3',
+                'ip pim bfd-instance disable',
+        ])
+
+        # True -> True (idempotence)
+        set_module_args(dict(interface='Ethernet9/3', bfd='true'))
+        self.execute_module(changed=False,)
+
+        # True -> default (None)
+        set_module_args(dict(interface='Ethernet9/3', bfd='default'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/3',
+                'no ip pim bfd-instance',
+        ])
+
+        # True -> interface state 'default'
+        set_module_args(dict(interface='Ethernet9/3', state='default'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/3',
+                'no ip pim bfd-instance',
+        ])
+
+        # True -> interface state 'absent'
+        set_module_args(dict(interface='Ethernet9/3', state='absent'))
+        self.execute_module(
+            changed=True,
+            commands=[
+                'interface Ethernet9/3',
+                'no ip pim bfd-instance',
+        ])


### PR DESCRIPTION
##### SUMMARY
*edit: Updated to reflect new tri-stage values*

Add support for `bfd` state in `nxos_pim_interface`

- `bfd` is a tri-state value because it nvgens a `disable` state:
 - `enable`  = `ip ospf bfd`
 - `disable` = `ip ospf bfd disable`
 - `default` = `None`   

(note: `no ip ospf bfd` removes both forms of the enable/disable states)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`nxos_pim_interface`

##### ADDITIONAL INFORMATION
Tested on all NXOS regression platforms: `N3K, N6K, N7K, N9K, N3K-F, N9K-F`
