### PR TITLE
Backport/2.8/57135

### DIFF
--- a/changelogs/fragments/57135-netapp_e_iscsi_target-fix-chap-secret-size-and-clearing.yaml
+++ b/changelogs/fragments/57135-netapp_e_iscsi_target-fix-chap-secret-size-and-clearing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - netapp_e_iscsi_target - fix netapp_e_iscsi_target chap secret size and clearing functionality

--- a/lib/ansible/modules/storage/netapp/netapp_e_iscsi_target.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_iscsi_target.py
@@ -39,7 +39,8 @@ options:
             - When this value is specified, we will always trigger an update (changed=True). We have no way of verifying
               whether or not the password has changed.
             - The chap secret may only use ascii characters with values between 32 and 126 decimal.
-            - The chap secret must be no less than 12 characters, but no more than 16 characters in length.
+            - The chap secret must be no less than 12 characters, but no greater than 57 characters in length.
+            - The chap secret is cleared when not specified or an empty string.
         aliases:
             - chap
             - password
@@ -158,9 +159,9 @@ class IscsiTarget(object):
         if not self.url.endswith('/'):
             self.url += '/'
 
-        if self.chap_secret is not None:
-            if len(self.chap_secret) < 12 or len(self.chap_secret) > 16:
-                self.module.fail_json(msg="The provided CHAP secret is not valid, it must be between 12 and 16"
+        if self.chap_secret:
+            if len(self.chap_secret) < 12 or len(self.chap_secret) > 57:
+                self.module.fail_json(msg="The provided CHAP secret is not valid, it must be between 12 and 57"
                                           " characters in length.")
 
             for c in self.chap_secret:
@@ -226,7 +227,7 @@ class IscsiTarget(object):
             body['alias'] = self.name
 
         # If the CHAP secret was provided, we trigger an update.
-        if self.chap_secret is not None:
+        if self.chap_secret:
             update = True
             body.update(dict(enableChapAuthentication=True,
                              chapSecret=self.chap_secret))

--- a/test/units/modules/storage/netapp/test_netapp_e_iscsi_target.py
+++ b/test/units/modules/storage/netapp/test_netapp_e_iscsi_target.py
@@ -35,13 +35,13 @@ class IscsiTargetTest(ModuleTestCase):
 
     def test_validate_params(self):
         """Ensure we can pass valid parameters to the module"""
-        for i in range(12, 16):
+        for i in range(12, 57):
             secret = 'a' * i
             self._set_args(dict(chap=secret))
             tgt = IscsiTarget()
 
     def test_invalid_chap_secret(self):
-        for secret in [11 * 'a', 17 * 'a', u'©' * 12]:
+        for secret in [11 * 'a', 58 * 'a']:
             with self.assertRaisesRegexp(AnsibleFailJson, r'.*?CHAP secret is not valid.*') as result:
                 self._set_args(dict(chap=secret))
                 tgt = IscsiTarget()


### PR DESCRIPTION
##### SUMMARY
Fix CHAP secret allowable length and ability to clear the password.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_iscsi_target
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
iSCSI CHAP secret is prevented from being up to 57 characters and the modules fails when empty string is passed to clear the password.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.9.0.dev0
  config file = None
  configured module search path = [u'/home/swartzn/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/ansible-dev/lib/ansible
  executable location = /home/swartzn/ansible-dev/bin/ansible
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
```
