### PR TITLE
Nxos facts fix backport 27

### DIFF
--- a/changelogs/fragments/nxos_facts_fix_backport27_fix.yaml
+++ b/changelogs/fragments/nxos_facts_fix_backport27_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_facts fix <https://github.com/ansible/ansible/pull/57009>

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -861,7 +861,7 @@ class Legacy(FactsBase):
     def parse_module(self, data):
         objects = list()
         for line in data.splitlines():
-            if line == '':
+            if line == '' or re.search(r'\b' + 'Sw' + r'\b', line):
                 break
             if line[0].isdigit():
                 obj = {}
@@ -881,7 +881,7 @@ class Legacy(FactsBase):
                     if items:
                         obj['type'] = items[0]
                         obj['model'] = items[1]
-                        obj['status'] = items[2]
+                        obj['status'] = items[-1]
 
                 objects.append(obj)
         return objects
@@ -895,9 +895,11 @@ class Legacy(FactsBase):
             line = l.split()
             if len(line) > 1:
                 obj = {}
+                if re.search(r'Direction', data, re.M):
+                    obj['direction'] = line[-2]
                 obj['name'] = line[0]
                 obj['model'] = line[1]
-                obj['hw_ver'] = line[-2]
+                obj['hw_ver'] = line[2]
                 obj['status'] = line[-1]
                 objects.append(obj)
         return objects


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- related to #56057
- when running nxos_facts task (text format) against a Nexus 7009 running 6.2(16) fails with indexing error.
- when getting (fan info) facts for text format command output , directions not getting displayed instead wrongly assigned to hw_ver.
```yaml
     "fan_info": [
            {
                "hw_ver": "front-to-back", 
                "model": "N9K-9000v-FAN", 
                "name": "Fan1(sys_fan1)", 
                "status": "Ok"
            }, 
            {
                "hw_ver": "front-to-back", 
                "model": "N9K-9000v-FAN", 
                "name": "Fan2(sys_fan2)", 
                "status": "Ok"
            }, 
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
