### PR TITLE
Pluribus Networks vrouter packet relay module with UT

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_vrouter_packet_relay.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_packet_relay.py
@@ -1,0 +1,200 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_vrouter_packet_relay
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.9"
+short_description: CLI command to add/remove vrouter-packet-relay
+description:
+  - This module can be used to add packet relay configuration for DHCP on vrouter
+    and remove packet relay configuration for DHCP on vrouter.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: false
+    type: str
+  state:
+    description:
+      - vrouter-packet-relay configuration command.
+    required: false
+    choices: ['present', 'absent']
+    type: str
+    default: 'present'
+  pn_forward_ip:
+    description:
+      - forwarding IP address.
+    required: false
+    choices: ['dhcp']
+    type: str
+    default: 'dhcp'
+  pn_nic:
+    description:
+      - NIC.
+    required: true
+    type: str
+  pn_forward_proto:
+    description:
+      - protocol type to forward packets.
+    required: true
+    type: str
+  pn_vrouter_name:
+    description:
+      - name of service config.
+    required: true
+    type: str
+"""
+
+EXAMPLES = """
+- name: vRouter packet relay add
+  pn_vrouter_packet_relay:
+    pn_cliswitch: "sw01"
+    pn_forward_ip: "192.168.10.1"
+    pn_nic: "eth0.4092"
+    pn_vrouter_name: "sw01-vrouter"
+
+- name: vRouter packet relay remove
+  pn_vrouter_packet_relay:
+    pn_cliswitch: "sw01"
+    state: "absent"
+    pn_forward_ip: "192.168.10.1"
+    pn_nic: "eth0.4092"
+    pn_vrouter_name: "sw01-vrouter"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the vrouter-packet-relay command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the vrouter-packet-relay command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+from ansible.module_utils.network.netvisor.netvisor import run_commands
+
+
+def check_cli(module, cli):
+    """
+    This method checks if vRouter exists on the target node.
+    This method also checks for idempotency using the vrouter-interface-show
+    command.
+    If the given vRouter exists, return VROUTER_EXISTS as True else False.
+
+    If nic_str exists on the given vRouter, return NIC_EXISTS as True else
+    False.
+
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    :return Booleans: VROUTER_EXISTS, NIC_EXISTS
+    """
+    vrouter_name = module.params['pn_vrouter_name']
+    nic_str = module.params['pn_nic']
+
+    # Check for vRouter
+    check_vrouter = 'vrouter-show format name no-show-headers'
+    out = run_commands(module, check_vrouter)[1]
+
+    if out:
+        out = out.split()
+
+    VROUTER_EXISTS = True if vrouter_name in out else False
+
+    if nic_str:
+        # Check for nic
+        show = 'vrouter-interface-show vrouter-name %s format nic no-show-headers' % vrouter_name
+        out = run_commands(module, show)[1]
+        if out:
+            out = out.split()
+
+        NIC_EXISTS = True if nic_str in out else False
+
+    return VROUTER_EXISTS, NIC_EXISTS
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        present='vrouter-packet-relay-add',
+        absent='vrouter-packet-relay-remove'
+    )
+
+    argument_spec = dict(
+        pn_cliswitch=dict(required=False, type='str'),
+        state=dict(required=False, type='str', choices=state_map.keys(), default='present'),
+        pn_forward_ip=dict(required=True, type='str'),
+        pn_nic=dict(required=True, type='str'),
+        pn_forward_proto=dict(required=False, type='str', choices=['dhcp'], default='dhcp'),
+        pn_vrouter_name=dict(required=True, type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_if=(
+            ["state", "present", ["pn_vrouter_name", "pn_forward_ip", "pn_nic", "pn_forward_proto"]],
+            ["state", "absent", ["pn_vrouter_name", "pn_forward_ip", "pn_nic", "pn_forward_proto"]],
+        ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    forward_ip = module.params['pn_forward_ip']
+    nic = module.params['pn_nic']
+    forward_proto = module.params['pn_forward_proto']
+    vrouter_name = module.params['pn_vrouter_name']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    VROUTER_EXISTS, NIC_EXISTS = check_cli(module, cli)
+
+    if VROUTER_EXISTS is False:
+        module.fail_json(
+            failed=True,
+            msg='vRouter %s does not exist' % vrouter_name
+        )
+
+    if NIC_EXISTS is False:
+        module.fail_json(
+            failed=True,
+            msg='vRouter with nic %s does not exist' % nic
+        )
+
+    if command == 'vrouter-packet-relay-add' or command == 'vrouter-packet-relay-remove':
+        cli += ' %s' % command
+        cli += ' vrouter-name %s nic %s' % (vrouter_name, nic)
+        cli += ' forward-proto %s forward-ip %s' % (forward_proto, forward_ip)
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/netvisor/pn_vrouter_packet_relay.py
+++ b/lib/ansible/modules/network/netvisor/pn_vrouter_packet_relay.py
@@ -36,10 +36,8 @@ options:
   pn_forward_ip:
     description:
       - forwarding IP address.
-    required: false
-    choices: ['dhcp']
+    required: true
     type: str
-    default: 'dhcp'
   pn_nic:
     description:
       - NIC.
@@ -48,8 +46,10 @@ options:
   pn_forward_proto:
     description:
       - protocol type to forward packets.
-    required: true
+    required: false
     type: str
+    choices: ['dhcp']
+    default: 'dhcp'
   pn_vrouter_name:
     description:
       - name of service config.

--- a/test/units/modules/network/netvisor/test_pn_vrouter_packet_relay.py
+++ b/test/units/modules/network/netvisor/test_pn_vrouter_packet_relay.py
@@ -1,0 +1,62 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_vrouter_packet_relay
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestVrouterPacketRelayModule(TestNvosModule):
+
+    module = pn_vrouter_packet_relay
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_vrouter_packet_relay.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_vrouter_packet_relay.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+        self.mock_run_check_cli.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'vrouter-packet-relay-add':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'vrouter-packet-relay-remove':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = True, True
+        if state == 'absent':
+            self.run_check_cli.return_value = True, True
+
+    def test_vrouter_packet_relay_add(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
+                         'pn_forward_ip': '192.168.1.10', 'pn_nic': 'eth0.4092', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = ' switch sw01 vrouter-packet-relay-add vrouter-name foo-vrouter nic eth0.4092 forward-proto dhcp forward-ip 192.168.1.10'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_vrouter_packet_relay_remove(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_vrouter_name': 'foo-vrouter',
+                         'pn_forward_ip': '192.168.1.10', 'pn_nic': 'eth0.4092', 'state': 'absent'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = ' switch sw01 vrouter-packet-relay-remove vrouter-name foo-vrouter nic eth0.4092 forward-proto dhcp forward-ip 192.168.1.10'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Pluribus networks module ipv6 security raguard module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Pluribus networks module vrouter packet relay module with unit test cases
module_name: pn_vrouter_packet_relay.py 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.7.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Nov 12 2018, 14:36:49) [GCC 5.4.0 20160609]
```
