### PR TITLE
kubevirt_pvc: improve failure handling

### DIFF
--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_pvc.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_pvc.py
@@ -391,6 +391,8 @@ class KubevirtPVC(KubernetesRawModule):
                     if import_status == desired_cdi_status:
                         return_obj = entity
                         break
+                    elif import_status == 'Failed':
+                        raise CreatePVCFailed("PVC creation incomplete; importing data failed")
                 else:
                     return_obj = entity
                     break


### PR DESCRIPTION
##### SUMMARY
The module did not handle CDI reporting failure when waiting for the importer to finish. Now it does.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/cloud/kubevirt_pvc

