### PR TITLE
Update /plugins/inventory/__init__.py - Removed redundant "_" separator when prefix is an empty string

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -402,7 +402,10 @@ class Constructable(object):
 
                     if key:
                         prefix = keyed.get('prefix', '')
-                        sep = keyed.get('separator', '_')
+                        if prefix = '':
+                            sep = ''
+                        else:
+                            sep = keyed.get('separator', '_')
                         raw_parent_name = keyed.get('parent_group', None)
                         if raw_parent_name:
                             try:

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -402,7 +402,7 @@ class Constructable(object):
 
                     if key:
                         prefix = keyed.get('prefix', '')
-                        if prefix = '':
+                        if prefix == '':
                             sep = ''
                         else:
                             sep = keyed.get('separator', '_')


### PR DESCRIPTION
##### SUMMARY
GCP dynamic inventory - removed separator in case prefix is an empty string.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugin

##### ADDITIONAL INFORMATION
Added conditional before setting the separator (default '_') which sets it to '' in case prefix is '' as well.

**Before change**
```
 "all": {
     "children": [
         "__built_in_method_items_of_dict_object_at_0x2bc4db0_",
         "_analytics",
         "_consul_server",
         "_dashboardapi",
         "_elasticsearch",
         "_http_server",
         "_https_server",
         "_inventory",
         "_k2bq",
         "_kafka",
         "_kibana",
         "_logstash_k2bq",
         "_logstash_k2es",
         "_mysql",
         "_neo4j",
         "_ssl_offload",
         "_zookeeper",
         "ungrouped"
     ]
```
**After change**
```
 "all": {
     "children": [
         "_built_in_method_items_of_dict_object_at_0x2bc4db0_",
         "analytics",
         "consul_server",
         "dashboardapi",
         "elasticsearch",
         "http_server",
         "https_server",
         "inventory",
         "k2bq",
         "kafka",
         "kibana",
         "logstash_k2bq",
         "logstash_k2es",
         "mysql",
         "neo4j",
         "ssl_offload",
         "zookeeper",
         "ungrouped"
     ]
```
