### PR TITLE
Add support for vlan update on ovs bridges

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -140,6 +140,12 @@ def map_obj_to_commands(want, have, module):
                                 or want['external_ids'][k] != have['external_ids'][k]):
                             command += " " + k + " " + v
                             commands.append(command)
+
+            if want['vlan'] and want['vlan'] != have['vlan']:
+                templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"
+                                       " set port %(bridge)s tag=%(vlan)s")
+                command = templatized_command % module.params
+                commands.append(command)
         else:
             templatized_command = ("%(ovs-vsctl)s -t %(timeout)s add-br"
                                    " %(bridge)s")
@@ -169,6 +175,7 @@ def map_obj_to_commands(want, have, module):
                     command = templatized_command % module.params
                     command += " " + k + " " + v
                     commands.append(command)
+
     return commands
 
 

--- a/test/integration/targets/openvswitch_bridge/tests/basic.yaml
+++ b/test/integration/targets/openvswitch_bridge/tests/basic.yaml
@@ -11,7 +11,7 @@
 
 - assert:
     that:
-      - "result.changed == true"
+      - result is changed
 
 - name: Create bridge again (idempotent)
   openvswitch_bridge:
@@ -20,7 +20,29 @@
 
 - assert:
     that:
-      - "result.changed == false"
+      - result is not changed
 
-- name: Tear down test bridge
+- name: Add fake bridge
+  openvswitch_bridge:
+    bridge: fake-br-test
+    parent: br-test
+    vlan: 100
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Change fake bridge vlan
+  openvswitch_bridge:
+    bridge: fake-br-test
+    parent: br-test
+    vlan: 300
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Tear down test bridges
   command: ovs-vsctl del-br br-test


### PR DESCRIPTION
##### SUMMARY
Add support for vlan update on ovs bridges

This commit adds support for updating vlan to an existing openvswitch bridge,
which was previously ignored-

Fixes #57018

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openvswitch_brige