### PR TITLE
vmware: fix python 2.7.9 < with if validate_certs false

### DIFF
--- a/changelogs/fragments/57185-fix_vmware_modules_py_pre2.79.yaml
+++ b/changelogs/fragments/57185-fix_vmware_modules_py_pre2.79.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware - Ensure we can use the modules with Python < 2.7.9 or RHEL/CentOS < 7.4, this as soon as ``validate_certs`` is disabled.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -526,12 +526,17 @@ def connect_to_api(module, disconnect_atexit=True, return_si=False):
     if validate_certs and not hasattr(ssl, 'SSLContext'):
         module.fail_json(msg='pyVim does not support changing verification mode with python < 2.7.9. Either update '
                              'python or use validate_certs=false.')
-
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-    if validate_certs:
+    elif validate_certs:
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         ssl_context.verify_mode = ssl.CERT_REQUIRED
         ssl_context.check_hostname = True
         ssl_context.load_default_certs()
+    elif hasattr(ssl, 'SSLContext'):
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        ssl_context.verify_mode = ssl.CERT_NONE
+        ssl_context.check_hostname = False
+    else:  # Python < 2.7.9 or RHEL/Centos < 7.4
+        ssl_context = None
 
     service_instance = None
     proxy_host = module.params.get('proxy_host')


### PR DESCRIPTION
##### SUMMARY

Python < 2.7.9 does not have the ssl.SSLContext attribute.
ssl.SSLContext is only required when we want to validate the SSL
connection. If `validate_certs` is false, we don't initialize the
`ssl_context` variable.

closes: #57072

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware