### PR TITLE
Set community support for NetApp unit tests in BOTMETA

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1448,6 +1448,9 @@ files:
   test/units/modules/network/nso: *nso
   test/units/modules/network/nxos: *nxos
   test/units/modules/storage/hpe3par: *hpe3par
+  test/units/modules/storage/netapp:
+    maintainers: $team_netapp
+    support: community
   test/utils/shippable/:
     notified: mattclay
   hacking/report.py:


### PR DESCRIPTION
##### SUMMARY

This will prevent PRs that touch those unit tests for being label as `support: core`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
BOTMETA.yml