### PR TITLE
changed update_pgroup so that volumes get appended to volume members …

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_pg.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pg.py
@@ -351,9 +351,10 @@ def update_pgroup(module, array):
             except Exception:
                 module.fail_json(msg='Adding volumes to pgroup {0} failed.'.format(module.params['pgroup']))
         else:
-            if not all(x in get_pgroup(module, array)['volumes'] for x in module.params['volume']):
+            addvollist = [x for x in module.params['volume'] if x not in get_pgroup(module, array)['volumes']]
+            if addvollist:
                 try:
-                    array.set_pgroup(module.params['pgroup'], vollist=module.params['volume'])
+                    array.set_pgroup(module.params['pgroup'], addvollist=addvollist)
                     changed = True
                 except Exception:
                     module.fail_json(msg='Changing volumes in pgroup {0} failed.'.format(module.params['pgroup']))


### PR DESCRIPTION
…list instead of replacing volume members list

##### SUMMARY
Fixes an issue when adding volumes to an existing protection group that has existing volume members, the list of new volumes would replace the existing protection group members instead of appending to the members list.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pg

##### ADDITIONAL INFORMATION
Create a protection group (testpg) on your flash array and add a single volume (testvol1) to it
create second vol (testvol2) that ansible will use for adding to protection group
run the following ansible playbook task against that flash array:
```
  - name: Add volume to protection group
    purefa_pg:
      pgroup: testpg
      state: present
      volume:
        - testvol2
```

The protection group will end up having only testvol2 as a member.

The issue is related to the use of vollist parameter as opposed to the addvollist parameter provided as part of the flasharray API.
