### PR TITLE
nxos_snmp_user, nxos_snmp_host integration test fixes.

### DIFF
--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
@@ -1,7 +1,7 @@
 ---
 - set_fact: snmp_type="inform"
 - set_fact: snmp_version="v3"
-- set_fact: snmp_auth="noauth"
+- set_fact: snmp_auth="priv"
 
 - debug: msg="START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test"
 - debug: msg="Using provider={{ connection.transport }}"

--- a/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -3,6 +3,12 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: delete_last_user_allowed='true'
+- set_fact: delete_last_user_allowed='false'
+  when: imagetag and (imagetag is version_compare('9.3', 'ge'))
+- set_fact: delete_last_user_allowed='false'
+  when: platform is search('N5K|N6K|N9K-F')
+
 - name: Remove snmp user
   nxos_snmp_user: &remove_snmp_user
     user: ntc
@@ -95,7 +101,7 @@
       register: result
 
     - assert: *false
-    when: platform is not search('N5K|N6K|N9K-F')
+    when: delete_last_user_allowed
 
   always:
     - name: delete snmp user

--- a/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -5,7 +5,7 @@
 
 - set_fact: delete_last_user_allowed='true'
 - set_fact: delete_last_user_allowed='false'
-  when: imagetag and (imagetag is version_compare('9.3', 'ge'))
+  when: imagetag and (imagetag is version_compare('9.1', 'ge'))
 - set_fact: delete_last_user_allowed='false'
   when: platform is search('N5K|N6K|N9K-F')
 


### PR DESCRIPTION
##### SUMMARY
Fixes a few bugs in the nxos_snmp* tests:
  * Only priv users are allowed for snmp v3
  * Some nxos platforms/images don't allow the last user to be removed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_snmp_host
nxos_snmp_user

##### ADDITIONAL INFORMATION
Tests pass on n3k, n6k, n7k, n9k