### PR TITLE
win_chocolatey - honour version when bootstrapping chocolatey and fix package listing

### DIFF
--- a/changelogs/fragments/win_chocolatey-version.yaml
+++ b/changelogs/fragments/win_chocolatey-version.yaml
@@ -1,2 +1,3 @@
 bugfixes:
 - win_chocolatey - Install the specific Chocolatey version if the ``version`` option is set.
+- win_chocolatey - Better support detecting multiple packages installed at different versions on newer Chocolatey releases

--- a/changelogs/fragments/win_chocolatey-version.yaml
+++ b/changelogs/fragments/win_chocolatey-version.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_chocolatey - Install the specific Chocolatey version if the ``version`` option is set.

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -211,6 +211,9 @@ options:
     - Provide as a string (e.g. C('6.1')), otherwise it is considered to be
       a floating-point number and depending on the locale could become C(6,1),
       which will cause a failure.
+    - If I(name) is set to C(chocolatey) and Chocolatey is not installed on the
+      host, this will be the version of Chocolatey that is installed. You can
+      also set the C(chocolateyVersion) environment var.
     type: str
 notes:
 - This module will install or upgrade Chocolatey when needed.

--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-# We've been burned too many times with a new version breaking CI, fix the version in our tests.
-- name: ensure Chocolatey is installed
-  win_chocolatey:
-    name: chocolatey
-    version: 0.10.13
-    state: present
-
 - name: ensure test package is uninstalled
   win_chocolatey:
     name: '{{ test_choco_packages }}'

--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+# We've been burned too many times with a new version breaking CI, fix the version in our tests.
+- name: ensure Chocolatey is installed
+  win_chocolatey:
+    name: chocolatey
+    version: 0.10.13
+    state: present
+
 - name: ensure test package is uninstalled
   win_chocolatey:
     name: '{{ test_choco_packages }}'

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -468,14 +468,15 @@
   register: allow_multiple
 
 - name: get result of install older package with allow_multiple
-  win_command: choco.exe list --local-only --limit-output --all-versions --exact {{ test_choco_package1|quote }}
+  win_command: choco.exe list --local-only --limit-output --all-versions
   register: allow_multiple_actual
 
 - name: assert install older package with allow_multiple
   assert:
     that:
     - allow_multiple is changed
-    - allow_multiple_actual.stdout == "ansible|0.1.0\r\nansible|0.0.1\r\n"
+    - '"ansible|0.1.0" in allow_multiple_actual.stdout_lines'
+    - '"ansible|0.0.1" in allow_multiple_actual.stdout_lines'
 
 - name: pin 2 packages (check mode)
   win_chocolatey:
@@ -593,11 +594,12 @@
   register: remove_multiple
 
 - name: get result of uninstall specific version installed with allow_multiple
-  win_command: choco.exe list --local-only --limit-output --all-versions --exact {{ test_choco_package1|quote }}
+  win_command: choco.exe list --local-only --limit-output --all-versions
   register: remove_multiple_actual
 
 - name: assert uninstall specific version installed with allow_multiple
   assert:
     that:
     - remove_multiple is changed
-    - remove_multiple_actual.stdout == "ansible|0.1.0\r\n"
+    - '"ansible|0.0.1" not in remove_multiple_actual.stdout_lines'
+    - '"ansible|0.1.0" in remove_multiple_actual.stdout_lines'

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -438,21 +438,22 @@
     state: downgrade
     version: 0.0.1
 
-- name: upgrade all packages
-  win_chocolatey:
-    name: all
-    state: latest
-  register: all_latest
-
-- name: get result of upgrade all packages
-  win_command: choco.exe list --local-only --limit-output --exact {{ test_choco_package1|quote }}
-  register: all_latest_actual
-
-- name: assert upgrade all packages
-  assert:
-    that:
-    - all_latest is changed
-    - all_latest_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
+# TODO: Re-enable once https://github.com/chocolatey/choco/issues/1837 is fixed and in a new release
+#- name: upgrade all packages
+#  win_chocolatey:
+#    name: all
+#    state: latest
+#  register: all_latest
+#
+#- name: get result of upgrade all packages
+#  win_command: choco.exe list --local-only --limit-output --exact {{ test_choco_package1|quote }}
+#  register: all_latest_actual
+#
+#- name: assert upgrade all packages
+#  assert:
+#    that:
+#    - all_latest is changed
+#    - all_latest_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
 
 - name: install newer version of package
   win_chocolatey:

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -458,7 +458,7 @@
 - name: install newer version of package
   win_chocolatey:
     name: '{{ test_choco_package1 }}'
-    state: present
+    state: latest
 
 - name: install older package with allow_multiple
   win_chocolatey:

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -438,27 +438,26 @@
     state: downgrade
     version: 0.0.1
 
-# TODO: Re-enable once https://github.com/chocolatey/choco/issues/1837 is fixed and in a new release
-#- name: upgrade all packages
-#  win_chocolatey:
-#    name: all
-#    state: latest
-#  register: all_latest
-#
-#- name: get result of upgrade all packages
-#  win_command: choco.exe list --local-only --limit-output --exact {{ test_choco_package1|quote }}
-#  register: all_latest_actual
-#
-#- name: assert upgrade all packages
-#  assert:
-#    that:
-#    - all_latest is changed
-#    - all_latest_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
+- name: upgrade all packages
+  win_chocolatey:
+    name: all
+    state: latest
+  register: all_latest
+
+- name: get result of upgrade all packages
+  win_command: choco.exe list --local-only --limit-output --exact {{ test_choco_package1|quote }}
+  register: all_latest_actual
+
+- name: assert upgrade all packages
+  assert:
+    that:
+    - all_latest is changed
+    - all_latest_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
 
 - name: install newer version of package
   win_chocolatey:
     name: '{{ test_choco_package1 }}'
-    state: latest
+    state: present
 
 - name: install older package with allow_multiple
   win_chocolatey:


### PR DESCRIPTION
##### SUMMARY
Adds the ability to specify the version of Chocolatey that will be bootstrapped onto the host by using the `version` parameter. This is still technically possible today by doing the below but that requires knowledge about Chocolatey we can't expect users to know.

```
- win_chocolatey:
    name: chocolatey
    state: present
  environment:
    chocolateyVersion: 0.10.13
```

~~This also pins our CI version as 0.10.14 causes issues in Ansible due to https://github.com/chocolatey/choco/issues/1837.~~

We also change the package detection logic based on https://github.com/chocolatey/choco/issues/1843. This should be more resilient going forwards.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey