### PR TITLE
removed_module func: removed extra spaces from msg and docstring

### DIFF
--- a/changelogs/fragments/57209-removed_module_remove_extra_spaces.yml
+++ b/changelogs/fragments/57209-removed_module_remove_extra_spaces.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - removed_module - remove extra spaces from msg and docstring (https://github.com/ansible/ansible/pull/57209)

--- a/lib/ansible/module_utils/common/removed.py
+++ b/lib/ansible/module_utils/common/removed.py
@@ -7,13 +7,13 @@ import sys
 from ansible.module_utils._text import to_native
 
 
-def removed_module(removed_in, msg='This module has been removed.  The module documentation for'
+def removed_module(removed_in, msg='This module has been removed. The module documentation for'
                                    ' Ansible-%(version)s may contain hints for porting'):
     """
     Returns module failure along with a message about the module being removed
 
     :arg removed_in: The version that the module was removed in
-    :kwarg msg: Message to use in the module's failure message.  The default says that the module
+    :kwarg msg: Message to use in the module's failure message. The default says that the module
         has been removed and what version of the Ansible documentation to search for porting help.
 
     Remove the actual code and instead have boilerplate like this::


### PR DESCRIPTION
##### SUMMARY
removed_module func: removed extra spaces from msg and docstring.
Two spaces between "removed." and "The module"
```
fatal: [spblnx125]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false, 
    "msg": "This module has been removed.  The module documentation for Ansible-2.8 may contain hints for porting"
}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

+label: small_patch