### PR TITLE
Creation of Team SUSE


### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -427,6 +427,7 @@ files:
     maintainers: $team_ansible kustodian
     ignored: skvidal
   $modules/packaging/os/zypper.py:
+    maintainers: $team_suse
     ignored: dirtyharrycallahan robinro
   $modules/remote_management/foreman/: $team_foreman
   $modules/remote_management/hpilo/:
@@ -1620,6 +1621,7 @@ macros:
   team_rhn: alikins barnabycourt FlossWare vritant
   team_scaleway: remyleone abarbare DenBeke jerome-quere kindermoumoute QuentinBrosse
   team_solaris: bcoca dagwieers danowar2k fishman jpdasma jasperla mator scathatheworm troy2914 xen0l
+  team_suse: evrardjp
   team_tower: ghjm matburt ryanpetrello rooftopcellist AlanCoding jladdjr kdelee chrismeyersfsu
   team_ucs: dsoper2 movinalot SDBrett vallard vvb
   team_vmware: Akasurde warthog9 Tomorrow9 goneri pgbidkar


### PR DESCRIPTION
#### ISSUE TYPE
feature pull request

#### SUMMARY
I hope, in the future, that a team of SUSE employees and openSUSE
community members will be stepping up to help maintain not
only zypper modules, but other modules impacting (open)SUSE.

For this, it makes sense to create a team.

I will be the first person of this organisation, and I hope I
will be joined by my colleagues soon.

