### PR TITLE
Added support for VM and VM interface addition

### DIFF
--- a/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
+++ b/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
@@ -100,6 +100,8 @@ NO_DEFAULT_ID = set(
 
 DEVICE_STATUS = dict(offline=0, active=1, planned=2, staged=3, failed=4, inventory=5)
 
+VM_STATUS = dict(offline=0, active=1, staged=3)
+
 IP_ADDRESS_STATUS = dict(active=1, reserved=2, deprecated=3, dhcp=5)
 
 IP_ADDRESS_ROLE = dict(

--- a/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
+++ b/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
@@ -22,7 +22,7 @@ API_APPS_ENDPOINTS = dict(
     ipam=["ip_addresses", "prefixes", "roles", "vlans", "vlan_groups", "vrfs"],
     secrets=[],
     tenancy=["tenants", "tenant_groups"],
-    virtualization=["clusters"],
+    virtualization=["clusters","interfaces","virtual_machines"],
 )
 
 QUERY_TYPES = dict(
@@ -47,6 +47,7 @@ QUERY_TYPES = dict(
     vlan="name",
     vlan_group="slug",
     vrf="name",
+    virtual_machine="name",
 )
 
 CONVERT_TO_ID = dict(
@@ -73,6 +74,7 @@ CONVERT_TO_ID = dict(
     vlan="vlans",
     vlan_group="vlan_groups",
     vrf="vrfs",
+    virtual_machine="virtual_machines",
 )
 
 FACE_ID = dict(front=0, rear=1)
@@ -174,7 +176,7 @@ INTF_FORM_FACTOR = {
 INTF_MODE = {"access": 100, "tagged": 200, "tagged all": 300}
 
 ALLOWED_QUERY_PARAMS = {
-    "interface": set(["name", "device"]),
+    "interface": set(["name", "device", "virtual_machine"]),
     "lag": set(["name"]),
     "nat_inside": set(["vrf", "address"]),
     "vlan": set(["name", "site", "vlan_group", "tenant"]),

--- a/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
+++ b/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
@@ -22,7 +22,7 @@ API_APPS_ENDPOINTS = dict(
     ipam=["ip_addresses", "prefixes", "roles", "vlans", "vlan_groups", "vrfs"],
     secrets=[],
     tenancy=["tenants", "tenant_groups"],
-    virtualization=["clusters","interfaces","virtual_machines"],
+    virtualization=["clusters", "interfaces", "virtual_machines"],
 )
 
 QUERY_TYPES = dict(

--- a/lib/ansible/modules/net_tools/netbox/netbox_interface.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_interface.py
@@ -44,7 +44,7 @@ options:
       device:
         description:
           - |
-            Name of the device the interface will be associated with (case-sensitive). 
+            Name of the device the interface will be associated with (case-sensitive).
             Required when app parameter is not specified or is set as "dcim".
         required: true
         type: str

--- a/lib/ansible/modules/net_tools/netbox/netbox_interface.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_interface.py
@@ -218,8 +218,7 @@ msg:
 import json
 import traceback
 
-#from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.net_tools.netbox.netbox_utils import (
     find_ids,
     normalize_data,
@@ -261,8 +260,7 @@ def main():
 
     # Fail module if pynetbox is not installed
     if not HAS_PYNETBOX:
-        module.fail_json(msg="missing required lib pynetbox", exception=PYNETBOX_IMP_ERR)
-        #module.fail_json(msg=missing_required_lib('pynetbox'), exception=PYNETBOX_IMP_ERR)
+        module.fail_json(msg=missing_required_lib('pynetbox'), exception=PYNETBOX_IMP_ERR)
     # Assign variables to be used with module
     app = module.params["app"]
     endpoint = "interfaces"

--- a/lib/ansible/modules/net_tools/netbox/netbox_interface.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_interface.py
@@ -114,6 +114,7 @@ options:
     choices: [ dcim, virtualization ]
     default: dcim
     type: str
+    version_added: "2.9"
   validate_certs:
     description:
       - |

--- a/lib/ansible/modules/net_tools/netbox/netbox_interface.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_interface.py
@@ -22,6 +22,7 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
+  - Alvaro Arriola (@axarriola)
 requirements:
   - pynetbox
 version_added: "2.8"
@@ -42,9 +43,18 @@ options:
     suboptions:
       device:
         description:
-          - Name of the device the interface will be associated with (case-sensitive)
+          - |
+            Name of the device the interface will be associated with (case-sensitive). 
+            Required when app parameter is not specified or is set as "dcim".
         required: true
         type: str
+      virtual_machine:
+        description:
+          - |
+            Name of the virtual machine the interface will be associated with (case-sensitive).
+            Required when app parameter is set to "virtualization".
+        type: str
+        version_added: "2.9"
       name:
         description:
           - Name of the interface to be created

--- a/lib/ansible/modules/net_tools/netbox/netbox_vm.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_vm.py
@@ -1,0 +1,319 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Mikhail Yohman (@FragmentedPacket) <mikhail.yohman@gmail.com>
+# Copyright: (c) 2018, David Gomez (@amb1s1) <david.gomez@networktocode.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: netbox_vm
+short_description: Create, update or delete devices within Netbox
+description:
+  - Creates, updates or removes devices from Netbox
+notes:
+  - Tags should be defined as a YAML list
+  - This should be ran with connection C(local) and hosts C(localhost)
+author:
+  - Mikhail Yohman (@FragmentedPacket)
+  - David Gomez (@amb1s1)
+  - Alvaro Arriola (@axarriola)
+requirements:
+  - pynetbox
+version_added: '2.8'
+options:
+  netbox_url:
+    description:
+      - URL of the Netbox instance resolvable by Ansible control host
+    required: true
+  netbox_token:
+    description:
+      - The token created within Netbox to authorize API access
+    required: true
+  data:
+    description:
+      - Defines the device configuration
+    suboptions:
+      name:
+        description:
+          - The name of the VM
+        required: true
+      role:
+        description:
+          - Required if I(state=present) and the device does not exist yet
+      tenant:
+        description:
+          - The tenant that the device will be assigned to
+      platform:
+        description:
+          - The platform of the device
+      serial:
+        description:
+          - Serial number of the device
+      primary_ip:
+        description:
+          - Primary IP of the VM
+        type: string
+      primary_ip4:
+        description:
+          - Primary IPv4 of the VM
+        type: string
+      primary_ip6:
+        description:
+          - Primary IPv6 of the VM
+        type: string
+      vcpus:
+        description:
+          - Number of vcpus assigned to VM
+        type: integer
+      memory:
+        description:
+          - Memory assigned to VM in MB
+        type: integer
+      disk:
+        description:
+          - Disk size in GB
+        type: integer
+      status:
+        description:
+          - The status of the device
+        choices:
+          - Active
+          - Offline
+          - Planned
+          - Staged
+          - Failed
+          - Inventory
+      cluster:
+        description:
+          - Cluster that the device will be assigned to
+      comments:
+        description:
+          - Comments that may include additional information in regards to the device
+      tags:
+        description:
+          - Any tags that the device may need to be associated with
+      custom_fields:
+        description:
+          - must exist in Netbox
+    required: true
+  state:
+    description:
+      - Use C(present) or C(absent) for adding or removing.
+    choices: [ absent, present ]
+    default: present
+  validate_certs:
+    description:
+      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+    default: 'yes'
+    type: bool
+'''
+
+EXAMPLES = r'''
+- name: "Test Netbox modules"
+  connection: local
+  hosts: localhost
+  gather_facts: False
+
+  tasks:
+    - name: Create device within Netbox with only required information
+      netbox_device:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test Device
+          device_type: C9410R
+          device_role: Core Switch
+          site: Main
+        state: present
+
+    - name: Delete device within netbox
+      netbox_device:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test Device
+        state: absent
+
+    - name: Create device with tags
+      netbox_device:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Another Test Device
+          device_type: C9410R
+          device_role: Core Switch
+          site: Main
+          tags:
+            - Schnozzberry
+        state: present
+
+    - name: Update the rack and position of an existing device
+      netbox_device:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test Device
+          rack: Test Rack
+          position: 10
+          face: Front
+        state: present
+'''
+
+RETURN = r'''
+device:
+  description: Serialized object as created or already existent within Netbox
+  returned: success (when I(state=present))
+  type: dict
+msg:
+  description: Message indicating failure or info about what has been achieved
+  returned: always
+  type: str
+'''
+
+import json
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.net_tools.netbox.netbox_utils import (
+    find_ids,
+    normalize_data,
+    create_netbox_object,
+    delete_netbox_object,
+    update_netbox_object,
+    DEVICE_STATUS,
+    FACE_ID
+)
+
+PYNETBOX_IMP_ERR = None
+try:
+    import pynetbox
+    HAS_PYNETBOX = True
+except ImportError:
+    PYNETBOX_IMP_ERR = traceback.format_exc()
+    HAS_PYNETBOX = False
+
+
+def main():
+    '''
+    Main entry point for module execution
+    '''
+    argument_spec = dict(
+        netbox_url=dict(type="str", required=True),
+        netbox_token=dict(type="str", required=True, no_log=True),
+        data=dict(type="dict", required=True),
+        state=dict(required=False, default='present', choices=['present', 'absent']),
+        validate_certs=dict(type="bool", default=True)
+    )
+
+    global module
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    # Fail module if pynetbox is not installed
+    if not HAS_PYNETBOX:
+        module.fail_json(msg=missing_required_lib('pynetbox'), exception=PYNETBOX_IMP_ERR)
+
+    # Fail if device name or cluster is not given
+    if not module.params["data"].get("name") or not module.params["data"].get("cluster"):
+        module.fail_json(msg="missing device name/cluster")
+
+    # Assign variables to be used with module
+    app = 'virtualization'
+    endpoint = 'virtual_machines'
+    url = module.params["netbox_url"]
+    token = module.params["netbox_token"]
+    data = module.params["data"]
+    state = module.params["state"]
+    validate_certs = module.params["validate_certs"]
+
+    # Attempt to create Netbox API object
+    try:
+        nb = pynetbox.api(url, token=token, ssl_verify=validate_certs)
+    except Exception:
+        module.fail_json(msg="Failed to establish connection to Netbox API")
+    try:
+        nb_app = getattr(nb, app)
+    except AttributeError:
+        module.fail_json(msg="Incorrect application specified: %s" % (app))
+
+    nb_endpoint = getattr(nb_app, endpoint)
+    norm_data = normalize_data(data)
+    try:
+        if 'present' in state:
+            result = ensure_device_present(nb, nb_endpoint, norm_data)
+        else:
+            result = ensure_device_absent(nb_endpoint, norm_data)
+        return module.exit_json(**result)
+    except pynetbox.RequestError as e:
+        return module.fail_json(msg=json.loads(e.error))
+    except ValueError as e:
+        return module.fail_json(msg=str(e))
+
+
+def _find_ids(nb, data):
+    if data.get("status"):
+        data["status"] = DEVICE_STATUS.get(data["status"].lower())
+    if data.get("face"):
+        data["face"] = FACE_ID.get(data["face"].lower())
+    return find_ids(nb, data)
+
+
+def ensure_device_present(nb, nb_endpoint, normalized_data):
+    '''
+    :returns dict(device, msg, changed, diff): dictionary resulting of the request,
+        where `device` is the serialized device fetched or newly created in
+        Netbox
+    '''
+    data = _find_ids(nb, normalized_data)
+    nb_device = nb_endpoint.get(name=data["name"])
+    result = {}
+    if not nb_device:
+        device, diff = create_netbox_object(nb_endpoint, data, module.check_mode)
+        msg = "Device %s created" % (data["name"])
+        changed = True
+        result["diff"] = diff
+    else:
+        device, diff = update_netbox_object(nb_device, data, module.check_mode)
+        if device is False:
+            module.fail_json(
+                msg="Request failed, couldn't update device: %s" % data["name"]
+            )
+        if diff:
+            msg = "Device %s updated" % (data["name"])
+            changed = True
+            result["diff"] = diff
+        else:
+            msg = "Device %s already exists" % (data["name"])
+            changed = False
+    result.update({"device": device, "changed": changed, "msg": msg})
+    return result
+
+
+def ensure_device_absent(nb_endpoint, data):
+    '''
+    :returns dict(msg, changed, diff)
+    '''
+    nb_device = nb_endpoint.get(name=data["name"])
+    result = {}
+    if nb_device:
+        dummy, diff = delete_netbox_object(nb_device, module.check_mode)
+        msg = 'Device %s deleted' % (data["name"])
+        changed = True
+        result["diff"] = diff
+    else:
+        msg = 'Device %s already absent' % (data["name"])
+        changed = False
+
+    result.update({"changed": changed, "msg": msg})
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/net_tools/netbox/netbox_vm.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_vm.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2018, Mikhail Yohman (@FragmentedPacket) <mikhail.yohman@gmail.com>
 # Copyright: (c) 2018, David Gomez (@amb1s1) <david.gomez@networktocode.com>
+# Copyright: (c) 2019, Alvaro Arriola (@axarriola) <alvaroxarriola@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -26,7 +27,7 @@ author:
   - Alvaro Arriola (@axarriola)
 requirements:
   - pynetbox
-version_added: '2.8'
+version_added: '2.9'
 options:
   netbox_url:
     description:
@@ -53,33 +54,24 @@ options:
       platform:
         description:
           - The platform of the device
-      serial:
-        description:
-          - Serial number of the device
       primary_ip:
         description:
           - Primary IP of the VM
-        type: string
       primary_ip4:
         description:
           - Primary IPv4 of the VM
-        type: string
       primary_ip6:
         description:
           - Primary IPv6 of the VM
-        type: string
       vcpus:
         description:
           - Number of vcpus assigned to VM
-        type: integer
       memory:
         description:
           - Memory assigned to VM in MB
-        type: integer
       disk:
         description:
           - Disk size in GB
-        type: integer
       status:
         description:
           - The status of the device

--- a/lib/ansible/modules/net_tools/netbox/netbox_vm.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_vm.py
@@ -91,8 +91,7 @@ options:
       - Use C(present) or C(absent) for adding or removing.
     choices: [ absent, present ]
     default: present
-    type: string
-    default: 'present'
+    type: str
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.

--- a/lib/ansible/modules/net_tools/netbox/netbox_vm.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_vm.py
@@ -45,24 +45,15 @@ options:
         description:
           - The name of the virtual machine
         required: true
-      role:
+      device_role:
         description:
-          - Required if I(state=present) and the virtual machine does not exist yet
+          - Required if I(state=present) and the virtual machine does not exist yet. The device_role should be enabled for VM use.
       tenant:
         description:
           - The tenant that the virtual machine will be assigned to
       platform:
         description:
           - The platform of the virtual machine
-      primary_ip:
-        description:
-          - Primary IP of the VM
-      primary_ip4:
-        description:
-          - Primary IPv4 of the VM
-      primary_ip6:
-        description:
-          - Primary IPv6 of the VM
       vcpus:
         description:
           - Number of vcpus assigned to VM

--- a/lib/ansible/modules/net_tools/netbox/netbox_vm.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_vm.py
@@ -33,10 +33,12 @@ options:
     description:
       - URL of the Netbox instance resolvable by Ansible control host
     required: true
+    type: str
   netbox_token:
     description:
       - The token created within Netbox to authorize API access
     required: true
+    type: str
   data:
     description:
       - Defines the virtual machine configuration
@@ -83,11 +85,14 @@ options:
         description:
           - must exist in Netbox
     required: true
+    type: dict
   state:
     description:
       - Use C(present) or C(absent) for adding or removing.
     choices: [ absent, present ]
     default: present
+    type: string
+    default: 'present'
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.


### PR DESCRIPTION
##### SUMMARY
Added support for VM and VM interface creation.
VM addition was added in a new module called netbox_vm.
VM interface addition is under the same netbox_interface module. A new parameter called app was added to specify "dcim" or "virtualization".
The module_util netbox_utils had additions to support the search of interface by virtual_machine.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
netbox_utils.py
netbox_vm.py
netbox_interface.py

##### ADDITIONAL INFORMATION
Tested on Netbox v2.5.12