### PR TITLE
kubevirt: Add hostname and subdomain parameters

### DIFF
--- a/changelogs/fragments/kubevirt_add_hostname_and_subdomain_parameters.yml
+++ b/changelogs/fragments/kubevirt_add_hostname_and_subdomain_parameters.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added new parameters hostname and subdomain to kubevirt_vm module.

--- a/lib/ansible/module_utils/kubevirt.py
+++ b/lib/ansible/module_utils/kubevirt.py
@@ -49,6 +49,8 @@ VM_SPEC_DEF_ARG_SPEC = {
 VM_COMMON_ARG_SPEC = {
     'name': {'required': True},
     'namespace': {'required': True},
+    'hostname': {'type': 'str'},
+    'subdomain': {'type': 'str'},
     'state': {
         'default': 'present',
         'choices': ['present', 'absent'],
@@ -329,6 +331,8 @@ class KubeVirtRawModule(KubernetesRawModule):
         node_affinity = params.get('node_affinity')
         vm_affinity = params.get('affinity')
         vm_anti_affinity = params.get('anti_affinity')
+        hostname = params.get('hostname')
+        subdomain = params.get('subdomain')
         template_spec = template['spec']
 
         # Merge additional flat parameters:
@@ -417,6 +421,12 @@ class KubeVirtRawModule(KubernetesRawModule):
                 template_spec['affinity']['nodeAffinity']['requiredDuringSchedulingIgnoredDuringExecution']['nodeSelectorTerms'].append({
                     'matchExpressions': affinity.get('term').get('match_expressions'),
                 })
+
+        if hostname:
+            template_spec['hostname'] = hostname
+
+        if subdomain:
+            template_spec['subdomain'] = subdomain
 
         # Define disks
         self._define_disks(disks, template_spec, defaults)

--- a/lib/ansible/plugins/doc_fragments/kubevirt_common_options.py
+++ b/lib/ansible/plugins/doc_fragments/kubevirt_common_options.py
@@ -106,6 +106,17 @@ options:
         description:
             - "Specify tablets to be used as input devices"
         type: list
+    hostname:
+        description:
+            - "Specifies the hostname of the virtual machine. The hostname will be set either by dhcp, cloud-init if configured or virtual machine
+               name will be used."
+        version_added: 2.9
+    subdomain:
+        description:
+            - "If specified, the fully qualified virtual machine hostname will be hostname.subdomain.namespace.svc.cluster_domain. If not specified,
+               the virtual machine will not have a domain name at all. The DNS entry will resolve to the virtual machine, no matter if the virtual machine
+               itself can pick up a hostname."
+        version_added: 2.9
 requirements:
     - python >= 2.7
     - openshift >= 0.8.2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR add two new parameters to `kubevirt_vm` module called `hostname` and `subdomain` to manage DNS of the VM. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kubevirt_vm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
