### PR TITLE
tower_job_template: implement extra_vars

### DIFF
--- a/changelogs/fragments/tower_job_template_extra_vars.yaml
+++ b/changelogs/fragments/tower_job_template_extra_vars.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- "extra_vars_path - Add deprecation warning, use ``extra_vars: \"{{ lookup('file', '/path/to/file') | from_yaml }}\"`` instead"
+- extra_vars - Set extra_vars for job template

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -77,6 +77,8 @@ Noteworthy module changes
 * The ``bigiq_device_facts`` module was renamed to :ref:`bigiq_device_info <bigiq_device_info_module>`.
 * The ``one_image_facts`` module was renamed to :ref:`one_image_info <one_image_info_module>`.
 
+* The ``tower_job_template`` module accepts `extra_vars` parameter to set extra_vars for the job template.
+* The ``tower_job_template`` module parameter `extra_vars_path` is deprecated. Use `extra_vars` parameter instead. The previos behavior can be archived with ``extra_vars: "{{ lookup('file', '/path/to/file') | from_yaml }}"``
 
 Plugins
 =======

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -78,7 +78,7 @@ Noteworthy module changes
 * The ``one_image_facts`` module was renamed to :ref:`one_image_info <one_image_info_module>`.
 
 * The ``tower_job_template`` module accepts `extra_vars` parameter to set extra_vars for the job template.
-* The ``tower_job_template`` module parameter `extra_vars_path` is deprecated. Use `extra_vars` parameter instead. The previos behavior can be archived with ``extra_vars: "{{ lookup('file', '/path/to/file') | from_yaml }}"``
+* The ``tower_job_template`` module parameter `extra_vars_path` is deprecated. Use `extra_vars` parameter instead. The previous behavior can be archived with ``extra_vars: "{{ lookup('file', '/path/to/file') | from_yaml }}"``
 
 Plugins
 =======

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -40,6 +40,14 @@ except ImportError:
     TOWER_CLI_IMP_ERR = traceback.format_exc()
     HAS_TOWER_CLI = False
 
+YAML_IMP_ERR = None
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    YAML_IMP_ERR = traceback.format_exc()
+    HAS_YAML = False
+
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
@@ -86,6 +94,11 @@ def tower_check_mode(module):
             module.fail_json(changed=False, msg='Failed check mode: {0}'.format(excinfo))
 
 
+def tower_dump_yaml(v):
+    '''Convert variable to yaml'''
+    return yaml.dump(v)
+
+
 class TowerModule(AnsibleModule):
     def __init__(self, argument_spec, **kwargs):
         args = dict(
@@ -110,3 +123,7 @@ class TowerModule(AnsibleModule):
         if not HAS_TOWER_CLI:
             self.fail_json(msg=missing_required_lib('ansible-tower-cli'),
                            exception=TOWER_CLI_IMP_ERR)
+
+        if not HAS_YAML:
+            self.fail_json(msg=missing_required_lib("PyYAML"),
+                           exception=YAML_IMP_ERR)

--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -1,3 +1,17 @@
+- name: Create a tempfile for extra_vars
+  tempfile:
+    state: file
+    suffix: .yml
+  register: extra_vars_path
+
+- name: Fill extra_vars into generated file
+  copy:
+    content: "{{ extra_vars | to_nice_yaml }}"
+    dest: "{{ extra_vars_path.path }}"
+  vars:
+    extra_vars:
+      foo: bar
+
 - name: Create an SCM Credential
   tower_credential:
     name: SCM Credential for JT
@@ -47,6 +61,40 @@
     credential: Demo Credential
     job_type: run
     state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a Job Template with extra_vars_path
+  tower_job_template:
+    name: hello-world with extra_vars_path
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: present
+    extra_vars_path: "{{ extra_vars_path.path }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "'extra_vars_path should not be used anymore.' in result.deprecations[0].msg"
+
+- name: Create a Job Template with extra_vars
+  tower_job_template:
+    name: hello-world with extra_vars
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: present
+    extra_vars:
+      foo: bar
   register: result
 
 - assert:


### PR DESCRIPTION
replace ``extra_vars_path`` by ``extra_vars``
implement integration tests for ``extra_vars_path`` and ``extra_vars``

##### SUMMARY
In the current module, extra variable for the job template can only be set via creating a YAML file and providing the path to this file via ``extra_vars_path``.
I implement the variable ``extra_vars``, where the variables can be set directly and document the way of archiving the current behavior via ``extra_vars``. Setting the variables directly is in my humble opinion the common use case, that's why I mark the ``extra_vars_path`` with a deprecation warning.
Also add tests.

Fixes #45173

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tower_job_template

##### ADDITIONAL INFORMATION
The existing behavior can be archived with by looking up the yaml file:
```
extra_vars: "{{ lookup('file', '/path/to/file') | from_yaml }}"
```

