### PR TITLE
Allow syslog_json callback options to be set in an Ansible configurat…

### DIFF
--- a/changelogs/fragments/57232-syslog-json-configuration-options.yml
+++ b/changelogs/fragments/57232-syslog-json-configuration-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "syslog_json - Allow configuration of the syslog_json plugin via an Ansible configuration file.

--- a/changelogs/fragments/57232-syslog-json-configuration-options.yml
+++ b/changelogs/fragments/57232-syslog-json-configuration-options.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "syslog_json - Allow configuration of the syslog_json plugin via an Ansible configuration file.
+- "syslog_json - Allow configuration of the syslog_json plugin via an Ansible configuration file."

--- a/lib/ansible/plugins/callback/syslog_json.py
+++ b/lib/ansible/plugins/callback/syslog_json.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
       - This plugin logs ansible-playbook and ansible runs to a syslog server in JSON format
       - Before 2.9 only environment variables were available for configuration
     options:
-      syslog_server:
+      server:
         description: syslog server that will receive the event
         env:
         - name: SYSLOG_SERVER
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_syslog_json
             key: syslog_server
-      syslog_port:
+      port:
         description: port on which the syslog server is listening
         env:
           - name: SYSLOG_PORT
@@ -32,7 +32,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_syslog_json
             key: syslog_port
-      syslog_facility:
+      facility:
         description: syslog facility to log as
         env:
           - name: SYSLOG_FACILITY
@@ -69,9 +69,9 @@ class CallbackModule(CallbackBase):
 
         self.set_options()
 
-        syslog_host = self.get_option("syslog_server")
-        syslog_port = int(self.get_option("syslog_port"))
-        syslog_facility = self.get_option("syslog_facility")
+        syslog_host = self.get_option("server")
+        syslog_port = int(self.get_option("port"))
+        syslog_facility = self.get_option("facility")
 
         self.logger = logging.getLogger('ansible logger')
         self.logger.setLevel(logging.DEBUG)

--- a/lib/ansible/plugins/callback/syslog_json.py
+++ b/lib/ansible/plugins/callback/syslog_json.py
@@ -14,9 +14,9 @@ DOCUMENTATION = '''
     version_added: "1.9"
     description:
       - This plugin logs ansible-playbook and ansible runs to a syslog server in JSON format
-      - Before 2.4 only environment variables were available for configuration
+      - Before 2.9 only environment variables were available for configuration
     options:
-      server:
+      syslog_server:
         description: syslog server that will receive the event
         env:
         - name: SYSLOG_SERVER
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_syslog_json
             key: syslog_server
-      port:
+      syslog_port:
         description: port on which the syslog server is listening
         env:
           - name: SYSLOG_PORT
@@ -32,7 +32,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_syslog_json
             key: syslog_port
-      facility:
+      syslog_facility:
         description: syslog facility to log as
         env:
           - name: SYSLOG_FACILITY
@@ -67,12 +67,18 @@ class CallbackModule(CallbackBase):
 
         super(CallbackModule, self).__init__()
 
+        self.set_options()
+
+        syslog_host = self.get_option("syslog_server")
+        syslog_port = int(self.get_option("syslog_port"))
+        syslog_facility = self.get_option("syslog_facility")
+
         self.logger = logging.getLogger('ansible logger')
         self.logger.setLevel(logging.DEBUG)
 
         self.handler = logging.handlers.SysLogHandler(
-            address=(os.getenv('SYSLOG_SERVER', 'localhost'), int(os.getenv('SYSLOG_PORT', 514))),
-            facility=os.getenv('SYSLOG_FACILITY', logging.handlers.SysLogHandler.LOG_USER)
+            address=(syslog_host, syslog_port),
+            facility=syslog_facility
         )
         self.logger.addHandler(self.handler)
         self.hostname = socket.gethostname()


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The syslog_json documentation says that it supports options via an Ansible
configuration file. In fact, they can only be specified via environment
variables.

I've updated the module to use the standard "get_options" handling which means
that it can now support options via environment variables *or* the
configuration file.

Options can be set in the configuration file as follows:

```
callback_whitelist = syslog_json

[callback_syslog_json]
syslog_server = localhost
syslog_port = 514
syslog_facility = user
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
syslog_json callback plugin
