### PR TITLE
modules/cloud/google: add service_account_contents

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -357,6 +357,7 @@ def prefetch_soa_resource(module):
             'service_account_file': module.params['service_account_file'],
             'auth_kind': module.params['auth_kind'],
             'service_account_email': module.params['service_account_email'],
+            'service_account_contents': module.params['service_account_contents'],
         },
         module,
     )


### PR DESCRIPTION
##### SUMMARY
The new `service_account_contents` field don't works per the doc, `service_account_contents` is missing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloud/google