### PR TITLE
k8s: Fix .to_dict not needed (#56147)

### DIFF
--- a/changelogs/fragments/56147-k8s-update-with-force.yaml
+++ b/changelogs/fragments/56147-k8s-update-with-force.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s - resource updates applied with force work correctly now

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -318,7 +318,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                 result['result'] = k8s_obj
                 if wait:
                     success, result['result'], result['duration'] = self.wait(resource, definition, wait_timeout, condition=wait_condition)
-                match, diffs = self.diff_objects(existing.to_dict(), result['result'].to_dict())
+                match, diffs = self.diff_objects(existing.to_dict(), result['result'])
                 result['changed'] = not match
                 result['method'] = 'replace'
                 result['diff'] = diffs


### PR DESCRIPTION
##### SUMMARY

* k8s: Fix .to_dict not needed

* Add changelog fragment

(cherry picked from commit 7364e79c0db232e1317ae57051ab6068885f8f30)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s

