### PR TITLE
option is marked as required but specifies a default

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -36,7 +36,7 @@ options:
     type: bool
   save_config:
     description:
-        - Flag indicating whether to save the configuration.
+      - Flag indicating whether to save the configuration.
     type: bool
     default: False
 '''
@@ -63,10 +63,10 @@ EXAMPLES = '''
 
 RETURN = '''
 rebooted:
-    description: Whether the device was instructed to reboot.
-    returned: success
-    type: bool
-    sample: true
+  description: Whether the device was instructed to reboot.
+  returned: success
+  type: bool
+  sample: true
 '''
 
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -134,7 +134,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool', default='false'),
+        confirm=dict(required=True, type='bool'),
         save_config=dict(required=False, type='bool', default='false')
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,6 +34,7 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
+        required: false
         default: false
     save_config:
         description:
@@ -134,7 +135,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool', default='false'),
+        confirm=dict(required=False, type='bool', default='false'),
         save_config=dict(required=False, type='bool', default='false')
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,7 +34,6 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        required: false
         default: false
     save_config:
         description:
@@ -135,7 +134,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=False, type='bool', default='false'),
+        confirm=dict(required=True, type='bool', default='false'),
         save_config=dict(required=False, type='bool', default='false')
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,7 +34,6 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        required: True
     save_config:
         description:
             - Flag indicating whether to save the configuration.

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,6 +34,7 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
+        required: true
     save_config:
         description:
             - Flag indicating whether to save the configuration.

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -38,7 +38,6 @@ options:
     save_config:
         description:
             - Flag indicating whether to save the configuration.
-        required: False
         type: bool
         default: False
 '''

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -33,13 +33,10 @@ options:
     confirm:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
-        type: bool
-        default: false
+        required: true
     save_config:
         description:
             - Flag indicating whether to save the configuration.
-        type: bool
-        default: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -30,15 +30,15 @@ description:
 author: Gong Jianjun (@QijunPan)
 requirements: ["ncclient"]
 options:
-    confirm:
-        description:
-            - Safeguard boolean. Set to true if you're sure you want to reboot.
-        type: bool
-    save_config:
-        description:
-            - Flag indicating whether to save the configuration.
-        type: bool
-        default: False
+  confirm:
+    description:
+      - Safeguard boolean. Set to true if you're sure you want to reboot.
+    type: bool
+  save_config:
+    description:
+        - Flag indicating whether to save the configuration.
+    type: bool
+    default: False
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -33,9 +33,14 @@ options:
     confirm:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
+        type: bool
+        default: false
     save_config:
         description:
             - Flag indicating whether to save the configuration.
+        required: false
+        type: bool
+        default: false
 '''
 
 EXAMPLES = '''
@@ -50,6 +55,7 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
       transport: cli
+
   tasks:
   - name: Reboot the device
     ce_reboot:
@@ -60,10 +66,10 @@ EXAMPLES = '''
 
 RETURN = '''
 rebooted:
-  description: Whether the device was instructed to reboot.
-  returned: success
-  type: bool
-  sample: true
+    description: Whether the device was instructed to reboot.
+    returned: success
+    type: bool
+    sample: true
 '''
 
 
@@ -128,8 +134,8 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(type='bool', default=False, required=False),
-        save_config=dict(type='bool', default=False, required=False)
+        confirm=dict(required=True, type='bool', default='false'),
+        save_config=dict(required=False, type='bool', default='false')
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,7 +34,7 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        required: false
+        required: true
         default: false
     save_config:
         description:
@@ -135,7 +135,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(default=False, type='bool'),
+        confirm=dict(required=True, type='bool'),
         save_config=dict(default=False, type='bool')
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,7 +34,6 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        default: false
     save_config:
         description:
             - Flag indicating whether to save the configuration.
@@ -134,7 +133,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool', default='false'),
+        confirm=dict(required=True, type='bool'),
         save_config=dict(required=False, type='bool', default='false')
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -30,15 +30,16 @@ description:
 author: Gong Jianjun (@QijunPan)
 requirements: ["ncclient"]
 options:
-  confirm:
-    description:
-      - Safeguard boolean. Set to true if you're sure you want to reboot.
-    type: bool
-  save_config:
-    description:
-      - Flag indicating whether to save the configuration.
-    type: bool
-    default: False
+    confirm:
+        description:
+            - Safeguard boolean. Set to true if you're sure you want to reboot.
+        type: bool
+        default: false
+    save_config:
+        description:
+            - Flag indicating whether to save the configuration.
+        type: bool
+        default: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -35,6 +35,7 @@ options:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
         required: true
+        default: false
     save_config:
         description:
             - Flag indicating whether to save the configuration.

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,7 +34,8 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        required: true
+        required: false
+        default: false
     save_config:
         description:
             - Flag indicating whether to save the configuration.
@@ -134,8 +135,8 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool'),
-        save_config=dict(required=False, type='bool', default='false')
+        confirm=dict(default=False, type='bool'),
+        save_config=dict(default=False, type='bool')
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -131,7 +131,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool'),
+        confirm=dict(type='bool', default=False),
         save_config=dict(type='bool', default=False)
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -33,7 +33,6 @@ options:
     confirm:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
-        required: true
     save_config:
         description:
             - Flag indicating whether to save the configuration.
@@ -129,8 +128,8 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(type='bool', default=False),
-        save_config=dict(type='bool', default=False)
+        confirm=dict(type='bool', default=False, required=False),
+        save_config=dict(type='bool', default=False, required=False)
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -35,7 +35,6 @@ options:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
         required: true
-        default: false
     save_config:
         description:
             - Flag indicating whether to save the configuration.

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,13 +34,13 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        default: false
+        default: False
     save_config:
         description:
             - Flag indicating whether to save the configuration.
-        required: false
+        required: False
         type: bool
-        default: false
+        default: False
 '''
 
 EXAMPLES = '''
@@ -55,7 +55,6 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
       transport: cli
-
   tasks:
   - name: Reboot the device
     ce_reboot:
@@ -134,8 +133,8 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool'),
-        save_config=dict(required=False, type='bool', default='false')
+        confirm=dict(required=True, type='bool', default=False),
+        save_config=dict(required=False, type='bool', default=False)
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,7 +34,7 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        default: False
+        required: True
     save_config:
         description:
             - Flag indicating whether to save the configuration.

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -133,7 +133,7 @@ def main():
 
     argument_spec = dict(
         confirm=dict(required=True, type='bool'),
-        save_config=dict(required=False, type='bool', default=False)
+        save_config=dict(type='bool', default=False)
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -133,7 +133,7 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool', default=False),
+        confirm=dict(required=True, type='bool'),
         save_config=dict(required=False, type='bool', default=False)
     )
 

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -450,7 +450,6 @@ lib/ansible/modules/network/cloudengine/ce_ntp.py E322
 lib/ansible/modules/network/cloudengine/ce_ntp_auth.py E322
 lib/ansible/modules/network/cloudengine/ce_ospf.py E322
 lib/ansible/modules/network/cloudengine/ce_ospf_vrf.py E322
-lib/ansible/modules/network/cloudengine/ce_reboot.py E317
 lib/ansible/modules/network/cloudengine/ce_reboot.py E322
 lib/ansible/modules/network/cloudengine/ce_rollback.py E322
 lib/ansible/modules/network/cloudengine/ce_sflow.py E322


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
option is marked as required but specifies a default 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_reboot.py
test/sanity/validate-modules/ignore.txt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

1. Option is marked as required but specifies a default. Arguments with a default should not be marked as required. [E317](https://docs.ansible.com/ansible/devel/dev_guide/testing_validate-modules.html)
2. As I shipit the PR,it failed again and again. E317 passed test in fact. So  update ignore.txt and remove line 453.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```