### PR TITLE
[2.8] VMware: Use short unique task name for schedule task

### DIFF
--- a/changelogs/fragments/56987-vmware_guest_powerstate-fix_task_name.yml
+++ b/changelogs/fragments/56987-vmware_guest_powerstate-fix_task_name.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Use shorter and unique random task name for scheduled task created by vmware_guest_powerstate (https://github.com/ansible/ansible/issues/56987).


### PR DESCRIPTION
##### SUMMARY
* Updated documentation
* Updated task name logic

Fixes: #56987

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/56987-vmware_guest_powerstate-fix_task_name.yml
lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml
