### PR TITLE
Fix: OpenBSD syspatch module bug

### DIFF
--- a/lib/ansible/modules/system/syspatch.py
+++ b/lib/ansible/modules/system/syspatch.py
@@ -141,11 +141,11 @@ def syspatch_run(module):
             # Kernel update applied
             reboot_needed = True
         elif out.lower().find('syspatch updated itself'):
-            warnings.append['Syspatch was updated. Please run syspatch again.']
+            warnings.append('Syspatch was updated. Please run syspatch again.')
 
         # If no stdout, then warn user
-        if len(out) > 0:
-            warnings.append['syspatch had suggested changes, but stdout was empty.']
+        if len(out) == 0:
+            warnings.append('syspatch had suggested changes, but stdout was empty.')
 
         changed = True
     else:

--- a/lib/ansible/modules/system/syspatch.py
+++ b/lib/ansible/modules/system/syspatch.py
@@ -147,10 +147,10 @@ def syspatch_run(module):
         # http://openbsd-archive.7691.n7.nabble.com/Warning-applying-latest-syspatch-td354250.html
         if rc != 0 and err != 'ln: /usr/X11R6/bin/X: No such file or directory\n':
             module.fail_json(msg="Command %s failed rc=%d, out=%s, err=%s" % (cmd, rc, out, err))
-        elif out.lower().find('create unique kernel'):
+        elif out.lower().find('create unique kernel') > 0:
             # Kernel update applied
             reboot_required = True
-        elif out.lower().find('syspatch updated itself'):
+        elif out.lower().find('syspatch updated itself') > 0:
             warnings.append('Syspatch was updated. Please run syspatch again.')
 
         # If no stdout, then warn user

--- a/lib/ansible/modules/system/syspatch.py
+++ b/lib/ansible/modules/system/syspatch.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 # NOTE: You can reboot automatically if a patch requires it:
 - name: Apply all patches and store result
   syspatch:
-    revert: all
+    apply: true
   register: syspatch
 
 - name: Reboot if patch requires it


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes bug with OpenBSD syspatch module. Meant to push it to my branch before was pulled in today: https://github.com/ansible/ansible/pull/55561

Also adds a new playbook example. Renames a variable to be more consistent with other Ansible modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
syspatch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This fixes a logic issue and issue where append was being used incorrectly.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
FAILED! => {"changed": false, "module_stderr": "Shared connection to 127.0.0.1 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1559353159.453823-221920894433339/AnsiballZ_syspatch.py\", line 114, in <module>\r\n    _ansiballz_main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1559353159.453823-221920894433339/AnsiballZ_syspatch.py\", line 106, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1559353159.453823-221920894433339/AnsiballZ_syspatch.py\", line 49, in invoke_module\r\n    imp.load_module('__main__', mod, module, MOD_DESC)\r\n  File \"/usr/local/lib/python3.6/imp.py\", line 235, in load_module\r\n    return load_source(name, filename, file)\r\n  File \"/usr/local/lib/python3.6/imp.py\", line 170, in load_source\r\n    module = _exec(spec, sys.modules[name])\r\n  File \"<frozen importlib._bootstrap>\", line 618, in _exec\r\n  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module\r\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\r\n  File \"/tmp/ansible_syspatch_payload_i0tv3135/__main__.py\", line 175, in <module>\r\n  File \"/tmp/ansible_syspatch_payload_i0tv3135/__main__.py\", line 171, in main\r\n  File \"/tmp/ansible_syspatch_payload_i0tv3135/__main__.py\", line 95, in run_module\r\n  File \"/tmp/ansible_syspatch_payload_i0tv3135/__main__.py\", line 149, in syspatch_run\r\nTypeError: 'builtin_function_or_method' object is not subscriptable\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

Sorry about that @bcoca !