### PR TITLE
meraki_content_filtering - Add support for querying

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_content_filtering.py
+++ b/lib/ansible/modules/network/meraki/meraki_content_filtering.py
@@ -46,7 +46,7 @@ options:
     state:
         description:
         - States that a policy should be created or modified.
-        choices: [present]
+        choices: [present, query]
         default: present
         type: str
     allowed_urls:
@@ -67,7 +67,11 @@ options:
         - Determines whether a network filters fo rall URLs in a category or only the list of top blocked sites.
         choices: [ top sites, full list ]
         type: str
-
+    subset:
+        description:
+        - Display only certain facts.
+        choices: [categories, policy]
+        type: str
 author:
     - Kevin Breit (@kbreit)
 extends_documentation_fragment: meraki
@@ -192,8 +196,8 @@ def main():
             path = meraki.construct_path('categories', net_id=net_id)
             response_data['categories'] = meraki.request(path, method='GET')
             path = meraki.construct_path('policy', net_id=net_id)
-            response_data['policy'] = meraki.request(path, method='GET')    
-            meraki.result['data']     = response_data
+            response_data['policy'] = meraki.request(path, method='GET')
+            meraki.result['data'] = response_data
     if module.params['state'] == 'present':
         payload = dict()
         if meraki.params['allowed_urls']:

--- a/lib/ansible/modules/network/meraki/meraki_content_filtering.py
+++ b/lib/ansible/modules/network/meraki/meraki_content_filtering.py
@@ -17,7 +17,7 @@ DOCUMENTATION = r'''
 ---
 module: meraki_content_filtering
 short_description: Edit Meraki MX content filtering policies
-version_added: "2.9"
+version_added: "2.8"
 description:
 - Allows for setting policy on content filtering.
 
@@ -72,6 +72,7 @@ options:
         - Display only certain facts.
         choices: [categories, policy]
         type: str
+        version_added: '2.9'
 author:
     - Kevin Breit (@kbreit)
 extends_documentation_fragment: meraki

--- a/lib/ansible/modules/network/meraki/meraki_content_filtering.py
+++ b/lib/ansible/modules/network/meraki/meraki_content_filtering.py
@@ -17,7 +17,7 @@ DOCUMENTATION = r'''
 ---
 module: meraki_content_filtering
 short_description: Edit Meraki MX content filtering policies
-version_added: "2.8"
+version_added: "2.9"
 description:
 - Allows for setting policy on content filtering.
 

--- a/test/integration/targets/meraki_content_filtering/tasks/main.yml
+++ b/test/integration/targets/meraki_content_filtering/tasks/main.yml
@@ -127,6 +127,60 @@
         - blocked_cateogry.data.blockedUrlCategories | length == 1
         - blocked_cateogry.data.urlCategoryListSize == "fullList"
 
+  - name: Query all content filtering information
+    meraki_content_filtering:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      state: query
+    delegate_to: localhost
+    register: query_all
+
+  - debug:
+      var: query_all
+
+  - name: Query all content filtering assertion
+    assert:
+      that:
+        - query_all.data.categories is defined
+        - query_all.data.policy is defined
+
+  - name: Query categories
+    meraki_content_filtering:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      state: query
+      subset: categories
+    delegate_to: localhost
+    register: query_categories
+
+  - debug:
+      var: query_categories
+
+  - name: Query categories assertion
+    assert:
+      that:
+        - query_categories.data is defined
+
+  - name: Query content filtering policies
+    meraki_content_filtering:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      subset: policy
+      state: query
+    delegate_to: localhost
+    register: query_policy
+
+  - debug:
+      var: query_policy
+
+  - name: Query contnet filtering policy assertion
+    assert:
+      that:
+        - query_policy.data is defined
+
   always:
     - name: Reset policies
       meraki_content_filtering:


### PR DESCRIPTION
##### SUMMARY
The `meraki_content_filtering` module has support for modifying content filtering rules but not querying rules or the categories. 

This replaces https://github.com/ansible/ansible/pull/51191.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
meraki_content_filtering
