### PR TITLE
win_scheduled_task: Fix start/end boundry triggers to allow for timezone sync

### DIFF
--- a/changelogs/fragments/win_scheduled_task-Fix-Timezone-in-start-boundry.yml
+++ b/changelogs/fragments/win_scheduled_task-Fix-Timezone-in-start-boundry.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "win_scheduled_task - Fix start/end bountry triggers to allow for timezone sync (https://github.com/ansible/ansible/issues/49327)"

--- a/lib/ansible/modules/windows/win_scheduled_task.ps1
+++ b/lib/ansible/modules/windows/win_scheduled_task.ps1
@@ -746,7 +746,7 @@ for ($i = 0; $i -lt $triggers.Count; $i++) {
         if ($trigger.ContainsKey($property_name)) {
             $date_value = $trigger.$property_name
             try {
-                $date = Get-Date -Date $date_value -Format s
+                $date = Get-Date -Date $date_value -Format "yyyy-MM-dd'T'HH:mm:ssK"
                 # make sure we convert it to the full string format
                 $trigger.$property_name = $date.ToString()
             } catch [System.Management.Automation.ParameterBindingException] {

--- a/test/integration/targets/win_scheduled_task/tasks/triggers.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/triggers.yml
@@ -321,7 +321,7 @@
     - create_trigger_repetition_result_check.triggers|count == 1
     - create_trigger_repetition_result_check.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
     - create_trigger_repetition_result_check.triggers[0].enabled == True
-    - create_trigger_repetition_result_check.triggers[0].start_boundary == "2000-01-01T00:00:01"
+    - create_trigger_repetition_result_check.triggers[0].start_boundary == "1999-12-31T21:00:01+00:00"
     - create_trigger_repetition_result_check.triggers[0].end_boundary == None
     - create_trigger_repetition_result_check.triggers[0].weeks_of_month == "1,2"
     - create_trigger_repetition_result_check.triggers[0].days_of_week == "monday,wednesday"

--- a/test/integration/targets/win_scheduled_task/tasks/triggers.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/triggers.yml
@@ -246,7 +246,7 @@
     - path: cmd.exe
     triggers:
     - type: monthlydow
-      start_boundary: '2000-01-01T00:00:01'
+      start_boundary: '2000-01-01T00:00:01+03:00'
       weeks_of_month: 1,2
       days_of_week: [ "monday", "wednesday" ]
   register: trigger_monthlydow
@@ -265,7 +265,7 @@
     - trigger_monthlydow_result.triggers|count == 1
     - trigger_monthlydow_result.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
     - trigger_monthlydow_result.triggers[0].enabled == True
-    - trigger_monthlydow_result.triggers[0].start_boundary == "2000-01-01T00:00:01"
+    - trigger_monthlydow_result.triggers[0].start_boundary == "1999-12-31T21:00:01+00:00"
     - trigger_monthlydow_result.triggers[0].end_boundary == None
     - trigger_monthlydow_result.triggers[0].weeks_of_month == "1,2"
     - trigger_monthlydow_result.triggers[0].days_of_week == "monday,wednesday"
@@ -780,40 +780,6 @@
     - remove_triggers_result_check.triggers[0].enabled == False
     - remove_triggers_result_check.triggers[0].start_boundary == None
     - remove_triggers_result_check.triggers[0].end_boundary == None
-
-# Check timezone in start_boundry
-- name: create monthly dow trigger - timezoned
-  win_scheduled_task:
-    name: '{{test_scheduled_task_name}}'
-    state: present
-    actions:
-    - path: cmd.exe
-    triggers:
-    - type: monthlydow
-      start_boundary: '2000-01-01T00:00:01+03:00'
-      weeks_of_month: 1,2
-      days_of_week: [ "monday", "wednesday" ]
-  register: trigger_monthlydow_timezonde
-
-- name: get result of create monthly dow trigger - timezoned
-  win_scheduled_task_stat:
-    path: \
-    name: '{{test_scheduled_task_name}}'
-  register: trigger_monthlydow_timezonde_result
-
-- name: assert results of create monthly dow trigger - timezoned
-  assert:
-    that:
-    - trigger_monthlydow_timezonde is changed
-    - trigger_monthlydow_timezonde_result.task_exists == True
-    - trigger_monthlydow_timezonde_result.triggers|count == 1
-    - trigger_monthlydow_timezonde_result.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
-    - trigger_monthlydow_timezonde_result.triggers[0].enabled == True
-    - trigger_monthlydow_timezonde_result.triggers[0].start_boundary == "2000-01-01T00:00:01+03:00"
-    - trigger_monthlydow_timezonde_result.triggers[0].end_boundary == None
-    - trigger_monthlydow_timezonde_result.triggers[0].weeks_of_month == "1,2"
-    - trigger_monthlydow_timezonde_result.triggers[0].days_of_week == "monday,wednesday"
-
 
 - name: remove all triggers
   win_scheduled_task:

--- a/test/integration/targets/win_scheduled_task/tasks/triggers.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/triggers.yml
@@ -781,6 +781,40 @@
     - remove_triggers_result_check.triggers[0].start_boundary == None
     - remove_triggers_result_check.triggers[0].end_boundary == None
 
+# Check timezone in start_boundry
+- name: create monthly dow trigger - timezoned
+  win_scheduled_task:
+    name: '{{test_scheduled_task_name}}'
+    state: present
+    actions:
+    - path: cmd.exe
+    triggers:
+    - type: monthlydow
+      start_boundary: '2000-01-01T00:00:01+03:00'
+      weeks_of_month: 1,2
+      days_of_week: [ "monday", "wednesday" ]
+  register: trigger_monthlydow_timezonde
+
+- name: get result of create monthly dow trigger - timezoned
+  win_scheduled_task_stat:
+    path: \
+    name: '{{test_scheduled_task_name}}'
+  register: trigger_monthlydow_timezonde_result
+
+- name: assert results of create monthly dow trigger - timezoned
+  assert:
+    that:
+    - trigger_monthlydow_timezonde is changed
+    - trigger_monthlydow_timezonde_result.task_exists == True
+    - trigger_monthlydow_timezonde_result.triggers|count == 1
+    - trigger_monthlydow_timezonde_result.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
+    - trigger_monthlydow_timezonde_result.triggers[0].enabled == True
+    - trigger_monthlydow_timezonde_result.triggers[0].start_boundary == "2000-01-01T00:00:01+03:00"
+    - trigger_monthlydow_timezonde_result.triggers[0].end_boundary == None
+    - trigger_monthlydow_timezonde_result.triggers[0].weeks_of_month == "1,2"
+    - trigger_monthlydow_timezonde_result.triggers[0].days_of_week == "monday,wednesday"
+
+
 - name: remove all triggers
   win_scheduled_task:
     name: '{{test_scheduled_task_name}}'

--- a/test/integration/targets/win_scheduled_task/tasks/triggers.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/triggers.yml
@@ -278,7 +278,7 @@
     - path: cmd.exe
     triggers:
     - type: monthlydow
-      start_boundary: '2000-01-01T00:00:01'
+      start_boundary: '2000-01-01T00:00:01+03:00'
       weeks_of_month: 1,2
       days_of_week: [ "monday", "wednesday" ]
   register: trigger_monthlydow_again


### PR DESCRIPTION
##### SUMMARY
Fixes #49327 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
win_scheduled_task.ps1

##### ADDITIONAL INFORMATION
